### PR TITLE
Nullable product display group

### DIFF
--- a/src/Core/Content/Product/ProductEntity.php
+++ b/src/Core/Content/Product/ProductEntity.php
@@ -69,7 +69,7 @@ class ProductEntity extends Entity
     protected $active;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $displayGroup;
 
@@ -1119,12 +1119,12 @@ class ProductEntity extends Entity
         $this->ratingAverage = $ratingAverage;
     }
 
-    public function getDisplayGroup(): string
+    public function getDisplayGroup(): ?string
     {
         return $this->displayGroup;
     }
 
-    public function setDisplayGroup(string $displayGroup): void
+    public function setDisplayGroup(?string $displayGroup): void
     {
         $this->displayGroup = $displayGroup;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The Field display_group is set to null (in VariantListingUpdater) the entity needs to reflect that.

### 2. What does this change do, exactly?
sets a field to nullable

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

