### PR TITLE
Fix EntityHydration to declare toOne Association Extensions, even if the value is NULL

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/data-new/entity-hydrator.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data-new/entity-hydrator.data.js
@@ -243,7 +243,11 @@ export default class EntityHydrator {
 
                 if (nestedEntity) {
                     data[property] = nestedEntity;
+                } else {
+                    data[property] = null;
                 }
+            } else {
+                data[property] = null;
             }
 
             return true;


### PR DESCRIPTION
Declare data property in toOne Associations, even if the value is NULL

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
If we associate entity extensions in the administration, and the association is a toOne association, we currently
do NOT declare the property in the data object, if the joined entity is missing (the value is NULL). I argue, that
the developer expects the property to be declared in the data object, even if no joined entity exists. In
just cases the data property should be declared with the value NULL.

### 2. What does this change do, exactly?
It declares the associated entity in the data properties and gives it the value NULL.

### 3. Describe each step to reproduce the issue or behaviour.
Create an Entity Extension, that creates a OneToOne association to a new entity. Now you want to load this associated entity, by extending the criteria: `criteria.addAssociation('newEntity');` The problem arises, if the joined entity currently has no entry for this entity, so the association returns NULL. Instead of declaring the associated entity with the value NULL, currently the association is ignored entirely.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
