### PR TITLE
NEXT-13579:Added return statement into LineItemCustomFieldRule for mi…

### DIFF
--- a/changelog/_unreleased/2021-02-08-fix-fatal-error-with-missing-custom-fields.md
+++ b/changelog/_unreleased/2021-02-08-fix-fatal-error-with-missing-custom-fields.md
@@ -1,0 +1,9 @@
+---
+title: fix-fatal-error-with-missing-custom-fields
+issue: NEXT-13579
+author: Tobias Kluth
+author_email: t_kluth@gmx.de 
+author_github: @tobiaskluth
+---
+# Core
+*  Changed `src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php` function `isCustomFieldValid` to evaluate missing custom fields to a false statement instead of throwing fatal error.

--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -85,6 +85,10 @@ class LineItemCustomFieldRule extends Rule
     {
         $customFields = $lineItem->getPayloadValue('customFields');
 
+        if ($customFields === null) {
+            return false;
+        }
+
         $actual = $this->getValue($customFields, $this->renderedField);
         if ($actual === null) {
             return false;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

The usage of customfield rules breaks cart functionalities.

### 2. What does this change do, exactly?

Before accessing the payloadValue "customFields" it checks whether the payload exists and if not, results in a false result.

### 3. Describe each step to reproduce the issue or behaviour.

1. create a LineItem Customfield Rule ("LineItem with attribute")
2. create a Promotion
3. Entering the promotion code results in a 500 Error Response

### 4. Please link to the relevant issues (if any).

[NEXT-13579](https://issues.shopware.com/issues/NEXT-13579)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.