### PR TITLE
(Bugfix) Make sure one to one entities are encoded correctly by the JsonApiEncoder

### DIFF
--- a/changelog/_unreleased/2021-02-16-fix-caching-of-json-api-encoding-result.md
+++ b/changelog/_unreleased/2021-02-16-fix-caching-of-json-api-encoding-result.md
@@ -1,0 +1,9 @@
+---
+title: Fix caching of JsonApiEncodingResult
+issue: NEXT-13701
+author: Alexander Bachmann
+author_email: email.bachmann@gmail.com
+author_github: @AlexBachmann
+---
+# Core
+* Changed caching strategy in JsonApiEncodingResult for the `included` section. Use a merging strategy for existing entities.

--- a/src/Core/Framework/Api/Serializer/JsonApiEncodingResult.php
+++ b/src/Core/Framework/Api/Serializer/JsonApiEncodingResult.php
@@ -78,6 +78,8 @@ class JsonApiEncodingResult implements \JsonSerializable
         $key = $entity->getId() . '-' . $entity->getType();
 
         if ($this->contains($entity->getId(), $entity->getType())) {
+            $this->mergeRecords($this->included[$key], $entity);
+
             return;
         }
 
@@ -144,5 +146,34 @@ class JsonApiEncodingResult implements \JsonSerializable
     public function getApiVersion(): int
     {
         return $this->apiVersion;
+    }
+
+    protected function mergeRecords(Record $recordA, Record $recordB): void
+    {
+        foreach ($recordB->getAttributes() as $key => $value) {
+            if (!empty($value)) {
+                $recordA->setAttribute($key, $value);
+            }
+        }
+
+        foreach ($recordB->getRelationships() as $key => $value) {
+            if ($value['data'] === null) {
+                continue;
+            }
+            $recordA->addRelationship($key, $value);
+        }
+
+        foreach ($recordB->getExtensions() as $key => $value) {
+            if ($value['data'] === null) {
+                continue;
+            }
+            $recordA->addExtension($key, $value);
+        }
+
+        foreach ($recordB->getLinks() as $key => $value) {
+            if (!empty($value)) {
+                $recordA->addLink($key, $value);
+            }
+        }
     }
 }

--- a/src/Core/Framework/Test/Api/Serializer/JsonApiEncoderTest.php
+++ b/src/Core/Framework/Test/Api/Serializer/JsonApiEncoderTest.php
@@ -2,15 +2,20 @@
 
 namespace Shopware\Core\Framework\Test\Api\Serializer;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderDefinition;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Rule\RuleDefinition;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Exception\UnsupportedEncoderInputException;
 use Shopware\Core\Framework\Api\Serializer\JsonApiEncoder;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\Api\Serializer\fixtures\SerializationFixture;
 use Shopware\Core\Framework\Test\Api\Serializer\fixtures\TestBasicStruct;
@@ -26,14 +31,72 @@ use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayer
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\AssociationExtension;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ExtendableDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ExtendedDefinition;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ExtendedProductDefinition;
+use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ProductExtension;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ScalarRuntimeExtension;
-use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\User\UserDefinition;
 
 class JsonApiEncoderTest extends TestCase
 {
-    use KernelTestBehaviour;
+    use IntegrationTestBehaviour;
     use DataAbstractionLayerFieldTestBehaviour;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * @var EntityRepositoryInterface
+     */
+    private $productRepository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = $this->getContainer()->get(Connection::class);
+
+        $this->registerDefinition(ExtendedProductDefinition::class);
+        $this->registerDefinitionWithExtensions(
+            ProductDefinition::class,
+            ProductExtension::class
+        );
+
+        $this->productRepository = $this->getContainer()->get('product.repository');
+
+        $this->connection->rollBack();
+
+        $this->connection->executeUpdate('
+            DROP TABLE IF EXISTS `extended_product`;
+            CREATE TABLE `extended_product` (
+                `id` BINARY(16) NOT NULL,
+                `name` VARCHAR(255) NULL,
+                `product_id` BINARY(16) NULL,
+                `language_id` BINARY(16) NULL,
+                `created_at` DATETIME(3) NOT NULL,
+                `updated_at` DATETIME(3) NULL,
+                PRIMARY KEY (`id`),
+                CONSTRAINT `fk.extended_product.id` FOREIGN KEY (`product_id`) REFERENCES `product` (`id`),
+                CONSTRAINT `fk.extended_product.language_id` FOREIGN KEY (`language_id`) REFERENCES `language` (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+        ');
+
+        $this->connection->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->connection->rollBack();
+
+        $this->connection->executeUpdate('DROP TABLE `extended_product`');
+        $this->connection->beginTransaction();
+
+        $this->removeExtension(ProductExtension::class);
+
+        parent::tearDown();
+    }
 
     public function emptyInputProvider(): array
     {
@@ -138,6 +201,100 @@ class JsonApiEncoderTest extends TestCase
         static::assertStringContainsString('"attributes":{}', $actual);
 
         $this->assertValues($fixture->getAdminJsonApiFixtures(), json_decode($actual, true));
+    }
+
+    public function testEncodeEntityWithToOneEntityExtension(): void
+    {
+        $productId = Uuid::randomHex();
+
+        $this->productRepository->create([
+            [
+                'id' => $productId,
+                'productNumber' => Uuid::randomHex(),
+                'stock' => 1,
+                'name' => 'Test product',
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 8.10, 'linked' => false]],
+                'tax' => ['name' => 'test', 'taxRate' => 5],
+                'manufacturer' => [
+                    'id' => Uuid::randomHex(),
+                    'name' => 'shopware AG',
+                    'link' => 'https://shopware.com',
+                ],
+                'toOne' => [
+                    'name' => 'test',
+                ],
+            ],
+        ], Context::createDefaultContext());
+
+        $criteria = new Criteria([$productId]);
+        $criteria->addAssociation('toOne');
+
+        $productDefinition = $this->getContainer()->get(ProductDefinition::class);
+
+        /** @var ProductEntity $product */
+        $product = $this->productRepository->search($criteria, Context::createDefaultContext())->get($productId);
+        $encoder = $this->getContainer()->get(JsonApiEncoder::class);
+        $encodedResponse = $encoder->encode(new Criteria(), $productDefinition, $product, SerializationFixture::API_BASE_URL);
+        $actual = \json_decode($encodedResponse, true);
+
+        foreach ($actual['included'] as $included) {
+            if ($included['type'] !== 'extension') {
+                continue;
+            }
+            static::assertNotEmpty($included['relationships']['toOne']['data'], 'The relationship data to the loaded extension association is missing');
+            static::assertEquals('extended_product', $included['relationships']['toOne']['data']['type']);
+            static::assertNotEmpty($included['relationships']['toOne']['data']['id']);
+        }
+    }
+
+    public function testEncodeEntityWithToManyEntityExtension(): void
+    {
+        $productId = Uuid::randomHex();
+
+        $this->productRepository->create([
+            [
+                'id' => $productId,
+                'productNumber' => Uuid::randomHex(),
+                'stock' => 1,
+                'name' => 'Test product',
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 8.10, 'linked' => false]],
+                'tax' => ['name' => 'test', 'taxRate' => 5],
+                'manufacturer' => [
+                    'id' => Uuid::randomHex(),
+                    'name' => 'shopware AG',
+                    'link' => 'https://shopware.com',
+                ],
+                'oneToMany' => [
+                    [
+                        'name' => 'toMany01',
+                    ],
+                    [
+                        'name' => 'toMany02',
+                    ]
+                ],
+            ],
+        ], Context::createDefaultContext());
+
+        $criteria = new Criteria([$productId]);
+        $criteria->addAssociation('oneToMany');
+
+        $productDefinition = $this->getContainer()->get(ProductDefinition::class);
+
+        /** @var ProductEntity $product */
+        $product = $this->productRepository->search($criteria, Context::createDefaultContext())->get($productId);
+        $encoder = $this->getContainer()->get(JsonApiEncoder::class);
+        $encodedResponse = $encoder->encode(new Criteria(), $productDefinition, $product, SerializationFixture::API_BASE_URL);
+        $actual = \json_decode($encodedResponse, true);
+
+        foreach ($actual['included'] as $included) {
+            if ($included['type'] !== 'extension') {
+                continue;
+            }
+            static::assertNotEmpty($included['relationships']['oneToMany']['data'], 'The relationship data to the loaded extension association is missing');
+            static::assertCount(2, $included['relationships']['oneToMany']['data']);
+            static::assertEquals('extended_product', $included['relationships']['oneToMany']['data'][0]['type']);
+            static::assertNotEmpty($included['relationships']['oneToMany']['data'][0]['id']);
+        }
     }
 
     private function arrayRemove($haystack, string $keyToRemove): array


### PR DESCRIPTION
### 1. Why is this change necessary?
If one of our entities (Entity A) has a one to one association with a different entity (Entity B), it is very likely that
this entity has a relationship back to the first entity.

Entity A  < ------ > Entity B

Searching for Entity A, while also loading Entity B ($criteria->addAssociation('entityB') would result in a result like this

$entiyA
|-- $entiyB
|-- |-- $entityA
|-- |-- |-- $entityB = null

Or, if $entityB is implemented via an entity extension:

$entityA
|-- $extensions
|-- |-- $entityB
|-- |-- |-- $entityA
|-- |-- |-- |-- $extensions
|-- |-- |-- |-- |-- $entiyB = null

The problem we have in these situations is the following, entity A is serialized first in the process of serializing entityB:

Process:
Serialize Entity A --> Serialize Relationships / Extensions of Entity A --> Serialize Entity B (which is related / an extension of Entity A) --> Serialize relationships / Extensions of Entity B --> Serialize Entity A (which is a related / an extension of Entity B)

This process naturally ends at some point, as we are walking down the tree. HOWEVER, we do have a problem once we add the serialized data to the included section of the record.
Since we include All relationships / extensions of Entity A the first time in the process of serializing Entity B, we do not add the data again when we come back to Entity A when we walk back up the tree. This results in the fact that the data value of Entity B remains NULL in the included part, even though the association has been loaded in the search query.

This phenomenon is easier understood running the unit test, which i provided with this commit. Without the fix, the toOne Relationship is not correctly serialized.

### 2. What does this change do, exactly?

This change merges entity data of entities that have been previously added instead of ignoring the entity. By merging the entity data, we make sure that those entities that have been hydrated the most are included in the response.

### 3. Describe each step to reproduce the issue or behaviour.

See #1


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
