### PR TITLE
NEXT-13629 - Add Information about currently running Profile name

### DIFF
--- a/changelog/_unreleased/2021-02-05-add-info-about-import-profile.md
+++ b/changelog/_unreleased/2021-02-05-add-info-about-import-profile.md
@@ -1,0 +1,9 @@
+---
+title: Add Information about currently running Profile name
+issue: NEXT-13629
+author: Björn Herzke 
+author_github: @wrongspot
+---
+# Core
+* `Shopware\Core\Content\ImportExport\Struct\Config` will provide profile Information about currently running Profile name
+

--- a/src/Core/Content/ImportExport/ImportExportProfileEntity.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileEntity.php
@@ -11,7 +11,7 @@ class ImportExportProfileEntity extends Entity
     use EntityIdTrait;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $name;
 
@@ -65,7 +65,7 @@ class ImportExportProfileEntity extends Entity
      */
     protected $translations;
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }

--- a/src/Core/Content/ImportExport/Service/ImportExportService.php
+++ b/src/Core/Content/ImportExport/Service/ImportExportService.php
@@ -288,6 +288,7 @@ class ImportExportService
         $parameters['enclosure'] = $profileEntity->getEnclosure();
         $parameters['sourceEntity'] = $profileEntity->getSourceEntity();
         $parameters['fileType'] = $profileEntity->getFileType();
+        $parameters['profileName'] = $profileEntity->getName();
 
         return [
             'mapping' => $config['mapping'] ?? $profileEntity->getMapping(),

--- a/src/Core/Content/Test/ImportExport/Service/ImportExportServiceTest.php
+++ b/src/Core/Content/Test/ImportExport/Service/ImportExportServiceTest.php
@@ -179,6 +179,7 @@ class ImportExportServiceTest extends TestCase
         static::assertSame($profile['enclosure'], $actualConfig->get('enclosure'));
         static::assertSame($profile['sourceEntity'], $actualConfig->get('sourceEntity'));
         static::assertSame($profile['fileType'], $actualConfig->get('fileType'));
+        static::assertSame($profile['name'], $actualConfig->get('profileName'));
 
         $expectedMapping = MappingCollection::fromIterable($profile['mapping']);
         static::assertEquals($expectedMapping, $actualConfig->getMapping());


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When manipulating data in import/export proccess, it is sometimes necessary to know which profile is currently being used.

### 2. What does this change do, exactly?
With this adjustment, the profile name can be read from the `Shopware\Core\Content\ImportExport\Struct\Config` 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13629

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
