### PR TITLE
Fix error in certain products w/o variants

### DIFF
--- a/changelog/_unreleased/2021-02-09-fix-invalid-check-for-product-variants.md
+++ b/changelog/_unreleased/2021-02-09-fix-invalid-check-for-product-variants.md
@@ -1,0 +1,9 @@
+---
+title: Fix invalid check for product variants
+issue: 123
+author: Ingo Weseloh
+author_email: it@exanto.de
+author_github: novalis111
+---
+# Core
+* Fix invalid check for missing/no product variants in Product Listing

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
@@ -391,7 +391,7 @@ class ProductListingFeaturesSubscriber implements EventSubscriberInterface
             return false;
         }
 
-        if ($product->getOptions() === null) {
+        if ($product->getOptionIds() === null) {
             return true;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Bug in frontend display.

### 2. What does this change do, exactly?

After migration from Shopware 5, this error occurs on several products which don't have variants assigned. The check $product->getOptions() always returns an array, so the check can never be null, which leads to the following error down the line:

count(): Parameter must be an array or an object that implements Countable

The right check is to check $product->getOptionIds() against null, which in fact does happen.

### 3. Describe each step to reproduce the issue or behaviour.

Happened after migration from a Shopware 5 instance.

### 4. Please link to the relevant issues (if any).

[Issue 1554 filed on Dec 7](https://github.com/shopware/platform/issues/1554)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
