### PR TITLE
Make empty array Criteria parameters invalid

### DIFF
--- a/changelog/release-6-3-2-0/2020-10-07-fix-criteria-parameter-with-empty-ids.md
+++ b/changelog/release-6-3-2-0/2020-10-07-fix-criteria-parameter-with-empty-ids.md
@@ -1,0 +1,8 @@
+---
+title:  Make empty array Criteria parameters invalid
+author:             Hendrik Söbbing
+author_email:       hendrik@soebbing.de
+author_github:      @soebbing
+---
+# Core
+* Changed default constructor parameter `\Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria` to `null`

--- a/src/Core/Checkout/Test/Cart/Promotion/Integration/DeliveryPromotionCalculationTest.php
+++ b/src/Core/Checkout/Test/Cart/Promotion/Integration/DeliveryPromotionCalculationTest.php
@@ -687,7 +687,7 @@ class DeliveryPromotionCalculationTest extends TestCase
      */
     private function deletePromotions(): void
     {
-        $idSearchResult = $this->promotionRepository->searchIds(new Criteria([]), $this->context->getContext());
+        $idSearchResult = $this->promotionRepository->searchIds(new Criteria(), $this->context->getContext());
         $data = [];
         foreach ($idSearchResult->getIds() as $id) {
             $data[]['id'] = $id;

--- a/src/Core/Content/ProductExport/Service/ProductExporter.php
+++ b/src/Core/Content/ProductExport/Service/ProductExporter.php
@@ -47,7 +47,8 @@ class ProductExporter implements ProductExporterInterface
         ExportBehavior $behavior,
         ?string $productExportId = null
     ): void {
-        $criteria = new Criteria(array_filter([$productExportId]));
+        $ids = array_filter([$productExportId]);
+        $criteria = new Criteria(empty($ids) ? null : $ids);
         $criteria
             ->addAssociation('salesChannel')
             ->addAssociation('salesChannelDomain.salesChannel')

--- a/src/Core/Content/Seo/Api/SeoActionController.php
+++ b/src/Core/Content/Seo/Api/SeoActionController.php
@@ -170,7 +170,7 @@ class SeoActionController extends AbstractController
 
         /** @var Entity|null $entity */
         $entity = $repository
-            ->search((new Criteria($fk ? [$fk] : []))->setLimit(1), $context)
+            ->search((new Criteria($fk ? [$fk] : null))->setLimit(1), $context)
             ->first();
 
         if (!$entity) {

--- a/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
@@ -95,6 +95,12 @@ class EntityRepository implements EntityRepositoryInterface
 
         $ids = $this->searchIds($criteria, $context);
 
+        if (empty($ids->getIds())) {
+            $collectionClass = $this->definition->getCollectionClass();
+
+            return new EntitySearchResult(0, new $collectionClass(), $aggregations, $criteria, $context);
+        }
+
         $readCriteria = $criteria->cloneForRead($ids->getIds());
 
         $entities = $this->read($readCriteria, $context);

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -109,13 +109,19 @@ class Criteria extends Struct
     protected $title;
 
     /**
-     * @param string[]|array<int, string[]> $ids
+     * @param string[]|array<int, string[]>|null $ids
      *
      * @throws InconsistentCriteriaIdsException
      */
-    public function __construct(array $ids = [])
+    public function __construct(?array $ids = null)
     {
-        if (\count($ids) > \count(array_filter($ids))) {
+        if ($ids === null) {
+            $this->ids = [];
+
+            return;
+        }
+
+        if (empty($ids) || \count($ids) > \count(array_filter($ids))) {
             throw new InconsistentCriteriaIdsException();
         }
 
@@ -467,10 +473,15 @@ class Criteria extends Struct
     }
 
     /**
-     * @param string[]|array<int, string[]> $ids
+     * @param string[]|array<int, string[]>|null $ids
      */
-    public function cloneForRead(array $ids = []): Criteria
+    public function cloneForRead(?array $ids = null): Criteria
     {
+        if (\is_array($ids)
+            && (\count($ids) === 0 || \count($ids) > \count(array_filter($ids)))) {
+            throw new InconsistentCriteriaIdsException();
+        }
+
         $self = new self($ids);
         $self->setTitle($this->getTitle());
 

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/CriteriaTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/CriteriaTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Search;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+
+class CriteriaTest extends TestCase
+{
+    public function testMissingConstructorParameterSetsEmptyIds(): void
+    {
+        $criteria = new Criteria();
+
+        static::assertEquals([], $criteria->getIds());
+    }
+
+    public function testNullConstructorParameterSetsEmptyIds(): void
+    {
+        $criteria = new Criteria(null);
+
+        static::assertEquals([], $criteria->getIds());
+    }
+
+    public function testInconsistentIdsExceptionIsThrown(): void
+    {
+        $this->expectException(InconsistentCriteriaIdsException::class);
+
+        new Criteria([
+            null,
+            'foo',
+        ]);
+    }
+
+    public function testEmptyArrayThrowsException(): void
+    {
+        $this->expectException(InconsistentCriteriaIdsException::class);
+
+        new Criteria([]);
+    }
+
+    public function testNullInCloneForReadSetsEmptyIds(): void
+    {
+        $criteria = new Criteria();
+
+        $cloned = $criteria->cloneForRead(null);
+
+        static::assertEquals([], $cloned->getIds());
+    }
+
+    public function testInconsistentIdsInCloneForReadExceptionIsThrown(): void
+    {
+        $this->expectException(InconsistentCriteriaIdsException::class);
+
+        (new Criteria())->cloneForRead([
+            null,
+            'foo',
+        ]);
+    }
+
+    public function testCloneFromWithEmptyArrayThrowsException(): void
+    {
+        $this->expectException(InconsistentCriteriaIdsException::class);
+
+        (new Criteria())->cloneForRead([]);
+    }
+}

--- a/src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+++ b/src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
@@ -93,6 +93,12 @@ class SalesChannelRepository implements SalesChannelRepositoryInterface
 
         $ids = $this->doSearch($criteria, $salesChannelContext);
 
+        if (empty($ids->getIds())) {
+            $collectionClass = $this->definition->getCollectionClass();
+
+            return new EntitySearchResult(0, new $collectionClass(), $aggregations, $criteria, $salesChannelContext->getContext());
+        }
+
         $readCriteria = $criteria->cloneForRead($ids->getIds());
 
         $entities = $this->read($readCriteria, $salesChannelContext);

--- a/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php
@@ -124,11 +124,11 @@ class AccountEditOrderPageLoader
 
     private function createCriteria(Request $request, SalesChannelContext $context): Criteria
     {
+        $criteria = new Criteria();
         if ($request->get('orderId')) {
             $criteria = new Criteria([$request->get('orderId')]);
-        } else {
-            $criteria = new Criteria([]);
         }
+
         $criteria->addAssociation('lineItems.cover')
             ->addAssociation('transactions.paymentMethod')
             ->addAssociation('deliveries.shippingMethod');
@@ -148,7 +148,7 @@ class AccountEditOrderPageLoader
 
     private function getPaymentMethods(SalesChannelContext $context, Request $request): PaymentMethodCollection
     {
-        $criteria = new Criteria([]);
+        $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('afterOrderEnabled', true));
 
         $routeRequest = new Request();

--- a/src/Storefront/Test/Framework/Seo/MainCategory/MainCategoryExtensionTest.php
+++ b/src/Storefront/Test/Framework/Seo/MainCategory/MainCategoryExtensionTest.php
@@ -64,7 +64,7 @@ class MainCategoryExtensionTest extends TestCase
         static::assertEmpty($product->getMainCategories());
 
         // update main category
-        $categories = $this->categoryRepository->searchIds(new Criteria([]), Context::createDefaultContext());
+        $categories = $this->categoryRepository->searchIds(new Criteria(), Context::createDefaultContext());
 
         $this->productRepository->update([
             [


### PR DESCRIPTION
Clone of PR #1400

### 1. Why is this change necessary?

Consider the following code:
```php
/** @var string[] $ids */
$ids = $this->getIds();
$result = $this->productRepository->search(new Criteria($ids), $context):
// do something with results
```
This code seems rather unsuspicious, until `$ids` is an empty array. In that case, ALL entities are loaded.  This shows that it currently is easy to load all entities without actually planning to, resulting in unexpected behaviour.

![Obligatory meme](https://i.imgflip.com/4hm5hb.jpg)

### 2. What does this change do, exactly?

This change distinguishes between an implicit not-setting some ids, and an explicit setting of an empty id array. The former makes `Criteria`s behave like before, just calling `new Criteria()` doesn't change any behaviour.

### 3. Describe each step to reproduce the issue or behaviour.

What changes is the behaviour when doing something like `new Criteria([])`. Up to now, this is equivalent to `new Criteria()`, my change will throw an `InconsistentCriteriaIdsException` in that case - just like it currently would in case of `new Criteria([null])`.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
