### PR TITLE
Switch priority of configured email addresses

### DIFF
--- a/src/Core/Content/MailTemplate/Service/MailService.php
+++ b/src/Core/Content/MailTemplate/Service/MailService.php
@@ -230,11 +230,11 @@ class MailService implements MailServiceInterface
         $senderEmail = $data['senderEmail'] ?? null;
 
         if ($senderEmail === null || trim($senderEmail) === '') {
-            $senderEmail = $this->systemConfigService->get('core.basicInformation.email', $salesChannelId);
+            $senderEmail = $this->systemConfigService->get('core.mailerSettings.senderAddress', $salesChannelId);
         }
 
         if ($senderEmail === null || trim($senderEmail) === '') {
-            $senderEmail = $this->systemConfigService->get('core.mailerSettings.senderAddress', $salesChannelId);
+            $senderEmail = $this->systemConfigService->get('core.basicInformation.email', $salesChannelId);
         }
 
         if ($senderEmail === null || trim($senderEmail) === '') {


### PR DESCRIPTION
### 1. Why is this change necessary?
When both the shop owner's email in basic information and the sender address in the mailer settings are configured, the first one takes precedence. Depending on the two addresses and the used mail server this can cause the emails to be rejected

### 2. What does this change do, exactly?
Change the order in which the configuration is checked to make sure the mailer settings take precedence.

### 3. Describe each step to reproduce the issue or behaviour.
* configure shop owner's email address in basic information
* configure sender address in mailer settings
* if the domain is different the mail server will most likely deny the send request

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1639

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
