### PR TITLE
Fix hot proxy server for shared instances

### DIFF
--- a/changelog/_unreleased/2021-02-12-fix-hot-proxy-for-shared-instances.md
+++ b/changelog/_unreleased/2021-02-12-fix-hot-proxy-for-shared-instances.md
@@ -1,0 +1,9 @@
+---
+title: Fix hot proxy server for shared instances
+author: Wolf Wortmann
+author_email: wortmann@icue-medien.de
+---
+# Storefront
+* Allow the hot proxy server to be used in shared (multi-domain) environments
+    * Added rejection of requests to the hot proxy from the wrong host
+    * Added proper error handling inside the hot-proxy-request


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, the hot-proxy fails to work in shared instances e.g. when using on an internal development server where multiple web application get built at the same time with different domains.
This allows the hot-proxy to get used in a way more widespread environment since many people are not used to local-machine development environments or restricted by company rules to internal development servers.

### 2. What does this change do, exactly?
This change fixes multiple things
1. errors inside the lifecycle of a request are now handled properly instead of crashing the whole hot-proxy
1. port-binds are now bound to the host which eliminates unforeseen binding behavior (e.g. binding to the default `::` host [may result in only a IPv6 bind](https://nodejs.org/docs/latest-v15.x/api/net.html#net_server_listen_port_host_backlog_callback))
1. the request is now piped to a specific host instead of the internal loopback address, which allows any domain-based routers to work properly (e.g. apache/nginx)
1. reject requests from the wrong host to prevent domain specific content to be served on another domain

### 3. Describe each step to reproduce the issue or behaviour.
* Accessing the Hot-Proxy won't work when using IPv4 because of the IPv6-only bind
```
$ lsof -i :9998
COMMAND TYPE NODE NAME
node    IPv6 TCP :9998 (LISTEN)
```
* When able to access the Hot-Proxy the pipe won't work due an error: `connect ECONNREFUSED 127.0.0.1:80`

### 4. Please link to the relevant issues (if any).
n/a

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
