### PR TITLE
Initialize session properly even when response is coming from the cache.

### DIFF
--- a/changelog/_unreleased/2021-02-17-initialize-session-even-when-response-is-coming-from-the-cache..md
+++ b/changelog/_unreleased/2021-02-17-initialize-session-even-when-response-is-coming-from-the-cache..md
@@ -1,0 +1,10 @@
+---
+title: Initialize session even when response is coming from the cache.
+issue: NEXT-13808
+author: Tommy Quissens
+author_email: tommy.quissens@gmail.com 
+author_github: Tommy Quissens
+___
+# Storefront
+*  Added `startSession` before sending the response, to make sure there is a proper session 
+___

--- a/src/Storefront/Framework/Routing/StorefrontSubscriber.php
+++ b/src/Storefront/Framework/Routing/StorefrontSubscriber.php
@@ -138,6 +138,9 @@ class StorefrontSubscriber implements EventSubscriberInterface
                 'updateSessionAfterLogout',
             ],
             BeforeSendResponseEvent::class => [
+                // make sure the session is started in the shopware manner
+                // even if the request is handled by the \Symfony\Component\HttpKernel\HttpCache\HttpCache
+                ['startSession', 9000],
                 ['replaceCsrfToken'],
                 ['setCanonicalUrl'],
             ],


### PR DESCRIPTION

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Fixes https://issues.shopware.com/issues/NEXT-10238 and https://issues.shopware.com/issues/NEXT-7081. And far more possible issues when having forms in cached pages.


### 2. What does this change do, exactly?
Initialize the session the shopware way (using `session-` as a key instead of `PHPSESSID`), which currently does not happen on cached pages because the `KernelEvents::REQUEST` is not triggered when the request is handled by the `\Symfony\Component\HttpKernel\HttpCache\HttpCache`


### 3. Describe each step to reproduce the issue or behaviour.
Can be found in https://issues.shopware.com/issues/NEXT-10238 and https://issues.shopware.com/issues/NEXT-7081

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-10238
https://issues.shopware.com/issues/NEXT-7081

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
