### PR TITLE
NEXT-13735 Fix DBAL Entity Hydration when one entity is hydrated multiple times with different associations loaded

### DIFF
--- a/changelog/_unreleased/2021-02-15-remove-entity-caching-in-dbal-entity-hydrator.md
+++ b/changelog/_unreleased/2021-02-15-remove-entity-caching-in-dbal-entity-hydrator.md
@@ -1,0 +1,9 @@
+---
+title: remove entity caching in DBAL Entity Hydrator
+issue: NEXT-13735
+author: Alexander Bachmann
+author_email: email.bachmann@gmail.com
+author_github: AlexBachmann
+---
+# Core
+* Removed entity caching in DBAL Entity Hydrator to avoid conflicts when hydrating the same identity with differently loaded associations

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -32,19 +32,12 @@ use Shopware\Core\Framework\Struct\ArrayStruct;
 class EntityHydrator
 {
     /**
-     * @var Entity[] internal object cache to prevent duplicate hydration for exact same objects
-     */
-    private $objects = [];
-
-    /**
      * @var Entity[] internal constructor cache
      */
     private $instances = [];
 
     public function hydrate(EntityCollection $collection, string $entityClass, EntityDefinition $definition, array $rows, string $root, Context $context): EntityCollection
     {
-        $this->objects = [];
-
         foreach ($rows as $row) {
             $collection->add($this->hydrateEntity($this->createClass($entityClass), $definition, $row, $root, $context));
         }
@@ -116,11 +109,6 @@ class EntityHydrator
 
         $entity->setUniqueIdentifier($identifier);
         $entity->internalSetEntityName($definition->getEntityName());
-
-        $cacheKey = $definition->getEntityName() . '::' . $identifier;
-        if (isset($this->objects[$cacheKey])) {
-            return $this->objects[$cacheKey];
-        }
 
         /** @var ArrayStruct $mappingStorage */
         $mappingStorage = $this->createClass(ArrayStruct::class);
@@ -214,11 +202,6 @@ class EntityHydrator
             } else {
                 $entity->assign([$propertyName => $decoded]);
             }
-        }
-
-        //write object cache key to prevent multiple hydration for the same entity
-        if ($cacheKey) {
-            $this->objects[$cacheKey] = $entity;
         }
 
         return $entity;

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/SingleEntityDependencyTestDependencyDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/SingleEntityDependencyTestDependencyDefinition.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class SingleEntityDependencyTestDependencyDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = '_test_zipcode';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function since(): ?string
+    {
+        return '6.0.0.0';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+            (new StringField('zipcode', 'zipcode'))->addFlags(new Required()),
+            (new FkField('country_id', 'countryId', SingleEntityDependencyTestDependencySubDefinition::class, 'id'))->addFlags(new Required()),
+
+            new ManyToOneAssociationField('country', 'country_id', SingleEntityDependencyTestDependencySubDefinition::class, 'id'),
+        ]);
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/SingleEntityDependencyTestDependencySubDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/SingleEntityDependencyTestDependencySubDefinition.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class SingleEntityDependencyTestDependencySubDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = '_test_country';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function since(): ?string
+    {
+        return '6.0.0.0';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+            (new StringField('iso', 'iso'))->addFlags(new Required()),
+        ]);
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/SingleEntityDependencyTestRootDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/SingleEntityDependencyTestRootDefinition.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class SingleEntityDependencyTestRootDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = '_test_pickup_point';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function since(): ?string
+    {
+        return '6.0.0.0';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+            (new StringField('name', 'name'))->addFlags(new Required()),
+            (new FkField('warehouse_id', 'warehouseId', SingleEntityDependencyTestSubDefinition::class, 'id'))->addFlags(new Required()),
+            (new FkField('zipcode_id', 'zipcodeId', SingleEntityDependencyTestDependencyDefinition::class, 'id'))->addFlags(new Required()),
+
+            new ManyToOneAssociationField('warehouse', 'warehouse_id', SingleEntityDependencyTestSubDefinition::class, 'id'),
+            new ManyToOneAssociationField('zipcode', 'zipcode_id', SingleEntityDependencyTestDependencyDefinition::class, 'id'),
+        ]);
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/SingleEntityDependencyTestSubDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/SingleEntityDependencyTestSubDefinition.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+class SingleEntityDependencyTestSubDefinition extends EntityDefinition
+{
+    public const ENTITY_NAME = '_test_warehouse';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function since(): ?string
+    {
+        return '6.0.0.0';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+            (new StringField('name', 'name'))->addFlags(new Required()),
+            (new FkField('zipcode_id', 'zipcodeId', SingleEntityDependencyTestDependencyDefinition::class, 'id'))->addFlags(new Required()),
+
+            new ManyToOneAssociationField('zipcode', 'zipcode_id', SingleEntityDependencyTestDependencyDefinition::class, 'id'),
+        ]);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

It is possible that one entity is being hydrated multiple times with differently loaded associations. In these cases the current caching strategy fails to hydrate the entities correctly, because it caches the hydrated entities ONLY by its unique identifier, DISREGARDING the loaded associations of the entity. In situations, where we hydrate the same entity (same ID) two ore more times with the different associations, the entity of the first hydration is REUSED. This can lead to missing association data in the loaded entity.

### Use Case ###

Think of the following situation
```
PickupPoint
|- id
|- warehouseId
|- warehouse
|- |- id
|- |- zipcodeId
|- |- zipcode
|- |- |- id <--- ID 123
|- |- |- countryId
|- zipcodeId
|- zipcode
|- |- id <--- ID 123
|- |- countryId
|- |- country
|- |- |- id
|- |- |- iso
```

In the use case above the pickup point and the warehouse share the same zipcode (which in this use case is an entity, not a string). While the Search Query DOES NOT LOAD the country association of the zipcode entity associated with the warehouse, it does load the associated country of the zipcode entity associated with the pickup point.

The above use case is currently not hydrated correctly, since the first time the zipcode is being hydrated, the country data is missing, the country data is also missing for the second zipcode entity, since it is being reused, using the current caching strategy.

### 2. What does this change do, exactly?

The change changes the way we generate the caching key within the entity hydrator, differentiating between entities that have loaded associations and those who do not.

### 3. Describe each step to reproduce the issue or behaviour.

See supplied Unit Test

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13735

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
