### PR TITLE
NEXT-13729: Fix sending emails did not use language chain fallback for header and footer mail templates

### DIFF
--- a/changelog/_unreleased/2021-02-14-fix-sending-emails-did-not-use-language-chain-fallback-for-header-and-footer-mail-templates.md
+++ b/changelog/_unreleased/2021-02-14-fix-sending-emails-did-not-use-language-chain-fallback-for-header-and-footer-mail-templates.md
@@ -1,0 +1,6 @@
+---
+title: Fix sending emails did not use language chain fallback for header and footer mail templates
+issue: NEXT-13729
+---
+# Core
+* Changed mail service to use language chain fallback upon retrieving header and footer mail template content.

--- a/src/Core/Content/Mail/Service/MailService.php
+++ b/src/Core/Content/Mail/Service/MailService.php
@@ -258,8 +258,8 @@ class MailService extends AbstractMailService
     {
         if ($salesChannel && $mailHeaderFooter = $salesChannel->getMailHeaderFooter()) {
             return [
-                'text/plain' => $mailHeaderFooter->getHeaderPlain() . $data['contentPlain'] . $mailHeaderFooter->getFooterPlain(),
-                'text/html' => $mailHeaderFooter->getHeaderHtml() . $data['contentHtml'] . $mailHeaderFooter->getFooterHtml(),
+                'text/plain' => ($mailHeaderFooter->getTranslation('headerPlain') ?? '') . $data['contentPlain'] . ($mailHeaderFooter->getTranslation('footerPlain') ?? ''),
+                'text/html' => ($mailHeaderFooter->getTranslation('headerHtml') ?? '') . $data['contentHtml'] . ($mailHeaderFooter->getTranslation('footerHtml') ?? ''),
             ];
         }
 


### PR DESCRIPTION
Fixes: NEXT-13729

### 1. Why is this change necessary?
To fix the issue  NEXT-13729

### 2. What does this change do, exactly?
Se changelog entry.

### 3. Describe each step to reproduce the issue or behaviour.
Send an e-mail from the non system default language and use a header and footer template that only exists in the system default language.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13729

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change: ***Not sure how to best write a test for it within your test framework, especially as there does not seem to be one that alredy tackles header and foorter email template. If necessary please write them yourselves.***
- [X] I have squashed any insignificant commits
- [X] I have created a changelog file with all necessary information about my changes: 
- [ ] I have written or adjusted the documentation according to my changes: ***not necessary as a bugfix***
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code: ***not necessary as nothing requires those***
- [X] I have read the contribution requirements and fulfil them.
