### PR TITLE
Change active date range filter to also take time into account

### DIFF
--- a/changelog/_unreleased/2020-02-21-fix-date-time-filtering-on-promotions.md
+++ b/changelog/_unreleased/2020-02-21-fix-date-time-filtering-on-promotions.md
@@ -1,0 +1,11 @@
+---
+title: Fix date time filtering on promotions
+issue: NEXT-13790
+author: Leon Rustmeier
+author_email: l.rustmeier@heptacom.de
+author_github: leonrustmeier
+---
+# Core
+* Changed `ActiveDateRange` filter in `Checkout/Promotion/Gateway/Template/ActiveDateRange.php`to take set time of a promotion into account.
+___
+

--- a/src/Core/Checkout/Promotion/Gateway/Template/ActiveDateRange.php
+++ b/src/Core/Checkout/Promotion/Gateway/Template/ActiveDateRange.php
@@ -19,8 +19,8 @@ class ActiveDateRange extends MultiFilter
         $today = new \DateTime();
         $today = $today->setTimezone(new \DateTimeZone('UTC'));
 
-        $todayStart = $today->format('Y-m-d 0:0:0');
-        $todayEnd = $today->format('Y-m-d 23:59:59');
+        $todayStart = $today->format('Y-m-d H:s:i');
+        $todayEnd = $today->format('Y-m-d H:s:i');
 
         $filterNoDateRange = new MultiFilter(
             MultiFilter::CONNECTION_AND,
@@ -42,7 +42,7 @@ class ActiveDateRange extends MultiFilter
             MultiFilter::CONNECTION_AND,
             [
                 new EqualsFilter('validFrom', null),
-                new RangeFilter('validUntil', ['gte' => $todayEnd]),
+                new RangeFilter('validUntil', ['gt' => $todayEnd]),
             ]
         );
 
@@ -50,7 +50,7 @@ class ActiveDateRange extends MultiFilter
             MultiFilter::CONNECTION_AND,
             [
                 new RangeFilter('validFrom', ['lte' => $todayStart]),
-                new RangeFilter('validUntil', ['gte' => $todayEnd]),
+                new RangeFilter('validUntil', ['gt' => $todayEnd]),
             ]
         );
 

--- a/src/Core/Checkout/Test/Cart/Promotion/Unit/Gateway/Template/ActiveDateRangeTest.php
+++ b/src/Core/Checkout/Test/Cart/Promotion/Unit/Gateway/Template/ActiveDateRangeTest.php
@@ -48,8 +48,8 @@ class ActiveDateRangeTest extends TestCase
         $today = new \DateTime();
         $today = $today->setTimezone(new \DateTimeZone('UTC'));
 
-        $todayStart = $today->format('Y-m-d 0:0:0');
-        $todayEnd = $today->format('Y-m-d 23:59:59');
+        $todayStart = $today->format('Y-m-d H:s:i');
+        $todayEnd = $today->format('Y-m-d H:s:i');
 
         $filterNoDateRange = new MultiFilter(
             MultiFilter::CONNECTION_AND,
@@ -71,7 +71,7 @@ class ActiveDateRangeTest extends TestCase
             MultiFilter::CONNECTION_AND,
             [
                 new EqualsFilter('validFrom', null),
-                new RangeFilter('validUntil', ['gte' => $todayEnd]),
+                new RangeFilter('validUntil', ['gt' => $todayEnd]),
             ]
         );
 
@@ -79,7 +79,7 @@ class ActiveDateRangeTest extends TestCase
             MultiFilter::CONNECTION_AND,
             [
                 new RangeFilter('validFrom', ['lte' => $todayStart]),
-                new RangeFilter('validUntil', ['gte' => $todayEnd]),
+                new RangeFilter('validUntil', ['gt' => $todayEnd]),
             ]
         );
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When you create a new promotion over the administration you have a date-time picker for the start and end date.
Since time is not taken into account in the promotion filter, promotions that are created with the current date will be invalid until the next day.

### 2. What does this change do, exactly?
This change fixes the active date range promotion filter to take the set time off valid from and until into account.

### 3. Describe each step to reproduce the issue or behaviour.
1. Login to the administration
2. Go to `Marketing > Promotions`
3. Click on `Add Promotion`
4. For `Valid from` choose the current date with a timestamp that already passed
5. Set promotion as active, setup a promotion code, and add a discount
6. Try to redeem the promotion code in the checkout
7. Get error: error.promotion-not-eligible

### 4. Please link to the relevant issues (if any).
None

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
