### PR TITLE
ProductConfiguratorSettingEntity mediaId null type

### DIFF
--- a/changelog/_unreleased/2020-02-16-Allow-Null-Type-In-ProductConfiguratorSettingEntity-MediaId.md
+++ b/changelog/_unreleased/2020-02-16-Allow-Null-Type-In-ProductConfiguratorSettingEntity-MediaId.md
@@ -1,0 +1,10 @@
+---
+title: Allow null type in ProductConfiguratorSettingEntity mediaId
+author: Sebastian Diez
+author_email: s.diez@seidemann-web.com
+author_github: @s-diez 
+---
+# Core
+
+Fixes the type of the property mediaId in ProductConfiguratorSettingEntity from string to string|null. It could always be null.
+

--- a/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingEntity.php
@@ -23,7 +23,7 @@ class ProductConfiguratorSettingEntity extends Entity
     protected $optionId;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $mediaId;
 
@@ -102,12 +102,12 @@ class ProductConfiguratorSettingEntity extends Entity
         $this->option = $option;
     }
 
-    public function getMediaId(): string
+    public function getMediaId(): ?string
     {
         return $this->mediaId;
     }
 
-    public function setMediaId(string $mediaId): void
+    public function setMediaId(?string $mediaId): void
     {
         $this->mediaId = $mediaId;
     }


### PR DESCRIPTION
Fixes the type of the property mediaId in ProductConfiguratorSettingEntity. It can actually be null.

### 1. Why is this change necessary?

The property mediaId in ProductConfiguratorSettingEntity can actually be null. But its type annotation and return type does not allow this.

### 2. What does this change do, exactly?

Changes mediaId to string|null from string.

### 3. Describe each step to reproduce the issue or behaviour.

Load a ProductConfiguratorSettingEntity with no assigned media from the repository and call getMediaId

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
