### PR TITLE
Add support for prefix and suffix filter to the DAL

### DIFF
--- a/changelog/_unreleased/2021-02-17-add-prefix-and-suffix-filter-to-the-dal.md
+++ b/changelog/_unreleased/2021-02-17-add-prefix-and-suffix-filter-to-the-dal.md
@@ -1,0 +1,11 @@
+---
+title: Add prefix and suffix filter to the DAL
+issue: NEXT-13886
+author: Felix Brucker
+author_email: felix@felixbrucker.com
+author_github: felixbrucker
+---
+# Core
+* Added `Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter` and `Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter`.
+# Administration
+* Added static `prefix()` and `suffix()` filter methods to the `Criteria` class (`src/Administration/Resources/app/administration/src/core/data/criteria.data.js`).

--- a/src/Administration/Resources/app/administration/src/core/data/criteria.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data/criteria.data.js
@@ -451,6 +451,36 @@ export default class Criteria {
     }
 
     /**
+     * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter.
+     * This allows to filter documents where the value marks the beginning of the provided field.
+     *
+     * Sql representation: `{field} LIKE {value}%`
+     *
+     * @param {string} field
+     * @param {string} value
+     *
+     * @returns {Object}
+     */
+    static prefix(field, value) {
+        return { type: 'prefix', field, value };
+    }
+
+    /**
+     * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter.
+     * This allows to filter documents where the value marks the end of the provided field.
+     *
+     * Sql representation: `{field} LIKE %{value}`
+     *
+     * @param {string} field
+     * @param {string} value
+     *
+     * @returns {Object}
+     */
+    static suffix(field, value) {
+        return { type: 'suffix', field, value };
+    }
+
+    /**
      * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter.
      * This allows to filter documents where the field matches one of the provided values
      *

--- a/src/Core/Framework/DataAbstractionLayer/Search/Filter/PrefixFilter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Filter/PrefixFilter.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Search\Filter;
+
+class PrefixFilter extends SingleFieldFilter
+{
+    /**
+     * @var string
+     */
+    protected $field;
+
+    /**
+     * @var string|float|int|null
+     */
+    protected $value;
+
+    public function __construct(string $field, $value)
+    {
+        $this->field = $field;
+        $this->value = $value;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getFields(): array
+    {
+        return [$this->field];
+    }
+}

--- a/src/Core/Framework/DataAbstractionLayer/Search/Filter/SuffixFilter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Filter/SuffixFilter.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Search\Filter;
+
+class SuffixFilter extends SingleFieldFilter
+{
+    /**
+     * @var string
+     */
+    protected $field;
+
+    /**
+     * @var string|float|int|null
+     */
+    protected $value;
+
+    public function __construct(string $field, $value)
+    {
+        $this->field = $field;
+        $this->value = $value;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getFields(): array
+    {
+        return [$this->field];
+    }
+}

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParser.php
@@ -11,7 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 
 class QueryStringParser
 {
@@ -61,6 +63,26 @@ class QueryStringParser
                 }
 
                 return new ContainsFilter(self::buildFieldName($definition, $query['field']), $query['value']);
+            case 'prefix':
+                if (empty($query['field'])) {
+                    throw new InvalidFilterQueryException('Parameter "field" for prefix filter is missing.', $path . '/field');
+                }
+
+                if (!isset($query['value']) || $query['value'] === '') {
+                    throw new InvalidFilterQueryException('Parameter "value" for prefix filter is missing.', $path . '/value');
+                }
+
+                return new PrefixFilter(self::buildFieldName($definition, $query['field']), $query['value']);
+            case 'suffix':
+                if (empty($query['field'])) {
+                    throw new InvalidFilterQueryException('Parameter "field" for suffix filter is missing.', $path . '/field');
+                }
+
+                if (!isset($query['value']) || $query['value'] === '') {
+                    throw new InvalidFilterQueryException('Parameter "value" for suffix filter is missing.', $path . '/value');
+                }
+
+                return new SuffixFilter(self::buildFieldName($definition, $query['field']), $query['value']);
             case 'not':
                 return new NotFilter(
                     $query['operator'] ?? 'AND',
@@ -126,6 +148,18 @@ class QueryStringParser
             case $query instanceof ContainsFilter:
                 return [
                     'type' => 'contains',
+                    'field' => $query->getField(),
+                    'value' => $query->getValue(),
+                ];
+            case $query instanceof PrefixFilter:
+                return [
+                    'type' => 'prefix',
+                    'field' => $query->getField(),
+                    'value' => $query->getValue(),
+                ];
+            case $query instanceof SuffixFilter:
+                return [
+                    'type' => 'suffix',
                     'field' => $query->getField(),
                     'value' => $query->getValue(),
                 ];

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
@@ -17,8 +17,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SingleFieldFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -105,6 +107,10 @@ class SqlQueryParser
                 return $this->parseEqualsAnyFilter($query, $definition, $root, $context);
             case $query instanceof ContainsFilter:
                 return $this->parseContainsFilter($query, $definition, $root, $context);
+            case $query instanceof PrefixFilter:
+                return $this->parsePrefixFilter($query, $definition, $root, $context);
+            case $query instanceof SuffixFilter:
+                return $this->parseSuffixFilter($query, $definition, $root, $context);
             case $query instanceof RangeFilter:
                 return $this->parseRangeFilter($query, $definition, $root, $context);
             case $query instanceof NotFilter:
@@ -167,6 +173,36 @@ class SqlQueryParser
 
         $escaped = addcslashes($query->getValue(), '\\_%');
         $result->addParameter($key, '%' . $escaped . '%');
+
+        return $result;
+    }
+
+    private function parsePrefixFilter(PrefixFilter $query, EntityDefinition $definition, string $root, Context $context): ParseResult
+    {
+        $key = $this->getKey();
+
+        $field = $this->queryHelper->getFieldAccessor($query->getField(), $definition, $root, $context);
+
+        $result = new ParseResult();
+        $result->addWhere($field . ' LIKE :' . $key);
+
+        $escaped = addcslashes($query->getValue(), '\\_%');
+        $result->addParameter($key, $escaped . '%');
+
+        return $result;
+    }
+
+    private function parseSuffixFilter(SuffixFilter $query, EntityDefinition $definition, string $root, Context $context): ParseResult
+    {
+        $key = $this->getKey();
+
+        $field = $this->queryHelper->getFieldAccessor($query->getField(), $definition, $root, $context);
+
+        $result = new ParseResult();
+        $result->addWhere($field . ' LIKE :' . $key);
+
+        $escaped = addcslashes($query->getValue(), '\\_%');
+        $result->addParameter($key, '%' . $escaped);
 
         return $result;
     }

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/Parser/QueryStringParserTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/Parser/QueryStringParserTest.php
@@ -9,6 +9,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Exception\SearchRequestExceptio
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\QueryStringParser;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 
@@ -91,6 +93,72 @@ class QueryStringParserTest extends TestCase
             [['type' => 'contains', 'field' => 'foo', 'value' => false], false],
             [['type' => 'contains', 'field' => 'foo', 'value' => 1], false],
             [['type' => 'contains', 'field' => 'foo', 'value' => 0], false],
+        ];
+    }
+
+    /**
+     * @dataProvider prefixFilterDataProvider
+     */
+    public function testPrefixFilter(array $filter, bool $expectException): void
+    {
+        if ($expectException) {
+            $this->expectException(InvalidFilterQueryException::class);
+        }
+
+        /** @var EqualsFilter $result */
+        $result = QueryStringParser::fromArray($this->getContainer()->get(ProductDefinition::class), $filter, new SearchRequestException());
+
+        static::assertInstanceOf(PrefixFilter::class, $result);
+
+        static::assertEquals($result->getField(), 'product.' . $filter['field']);
+        static::assertEquals($result->getValue(), $filter['value']);
+    }
+
+    public function prefixFilterDataProvider(): array
+    {
+        return [
+            [['type' => 'prefix', 'field' => 'foo', 'value' => 'bar'], false],
+            [['type' => 'prefix', 'field' => 'foo', 'value' => ''], true],
+            [['type' => 'prefix', 'field' => '', 'value' => 'bar'], true],
+            [['type' => 'prefix', 'field' => 'foo'], true],
+            [['type' => 'prefix', 'value' => 'bar'], true],
+            [['type' => 'prefix', 'field' => 'foo', 'value' => true], false],
+            [['type' => 'prefix', 'field' => 'foo', 'value' => false], false],
+            [['type' => 'prefix', 'field' => 'foo', 'value' => 1], false],
+            [['type' => 'prefix', 'field' => 'foo', 'value' => 0], false],
+        ];
+    }
+
+    /**
+     * @dataProvider suffixFilterDataProvider
+     */
+    public function testSuffixFilter(array $filter, bool $expectException): void
+    {
+        if ($expectException) {
+            $this->expectException(InvalidFilterQueryException::class);
+        }
+
+        /** @var EqualsFilter $result */
+        $result = QueryStringParser::fromArray($this->getContainer()->get(ProductDefinition::class), $filter, new SearchRequestException());
+
+        static::assertInstanceOf(SuffixFilter::class, $result);
+
+        static::assertEquals($result->getField(), 'product.' . $filter['field']);
+        static::assertEquals($result->getValue(), $filter['value']);
+    }
+
+    public function suffixFilterDataProvider(): array
+    {
+        return [
+            [['type' => 'suffix', 'field' => 'foo', 'value' => 'bar'], false],
+            [['type' => 'suffix', 'field' => 'foo', 'value' => ''], true],
+            [['type' => 'suffix', 'field' => '', 'value' => 'bar'], true],
+            [['type' => 'suffix', 'field' => 'foo'], true],
+            [['type' => 'suffix', 'value' => 'bar'], true],
+            [['type' => 'suffix', 'field' => 'foo', 'value' => true], false],
+            [['type' => 'suffix', 'field' => 'foo', 'value' => false], false],
+            [['type' => 'suffix', 'field' => 'foo', 'value' => 1], false],
+            [['type' => 'suffix', 'field' => 'foo', 'value' => 0], false],
         ];
     }
 

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
@@ -7,6 +7,8 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -55,6 +57,72 @@ class SqlQueryParserTest extends TestCase
 
         static::assertContains($targetId, $foundIds->getIds());
         static::assertNotContains($errournousId, $foundIds->getIds());
+    }
+
+    public function testPrefixFilterFindUnderscore(): void
+    {
+        $targetId = $this->createManufacturer(['link' => 'target_to_find']);
+        $erroneousId = $this->createManufacturer(['link' => 'target to find']);
+        $criteria = (new Criteria())->addFilter(new PrefixFilter('link', 'target_to'));
+        $foundIds = $this->manufacturerRepository->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertContains($targetId, $foundIds->getIds());
+        static::assertNotContains($erroneousId, $foundIds->getIds());
+    }
+
+    public function testPrefixFilterFindPercentageSign(): void
+    {
+        $targetId = $this->createManufacturer(['link' => 'target%find']);
+        $erroneousId = $this->createManufacturer(['link' => 'target to find']);
+        $criteria = (new Criteria())->addFilter(new PrefixFilter('link', 'target%fi'));
+        $foundIds = $this->manufacturerRepository->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertContains($targetId, $foundIds->getIds());
+        static::assertNotContains($erroneousId, $foundIds->getIds());
+    }
+
+    public function testPrefixFilterFindBackslash(): void
+    {
+        $targetId = $this->createManufacturer(['link' => '\\ target find']);
+        $erroneousId = $this->createManufacturer(['link' => '\\target find']);
+        $criteria = (new Criteria())->addFilter(new PrefixFilter('link', '\\ '));
+        $foundIds = $this->manufacturerRepository->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertContains($targetId, $foundIds->getIds());
+        static::assertNotContains($erroneousId, $foundIds->getIds());
+    }
+
+    public function testSuffixFilterFindUnderscore(): void
+    {
+        $targetId = $this->createManufacturer(['link' => 'target_to_find']);
+        $erroneousId = $this->createManufacturer(['link' => 'target to find']);
+        $criteria = (new Criteria())->addFilter(new SuffixFilter('link', 'to_find'));
+        $foundIds = $this->manufacturerRepository->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertContains($targetId, $foundIds->getIds());
+        static::assertNotContains($erroneousId, $foundIds->getIds());
+    }
+
+    public function testSuffixFilterFindPercentageSign(): void
+    {
+        $targetId = $this->createManufacturer(['link' => 'target%find']);
+        $erroneousId = $this->createManufacturer(['link' => 'target to find']);
+        $criteria = (new Criteria())->addFilter(new SuffixFilter('link', 'et%find'));
+        $foundIds = $this->manufacturerRepository->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertContains($targetId, $foundIds->getIds());
+        static::assertNotContains($erroneousId, $foundIds->getIds());
+    }
+
+    public function testSuffixFilterFindBackslash(): void
+    {
+        $targetId = $this->createManufacturer(['link' => 'target find \\']);
+        $erroneousId = $this->createManufacturer(['link' => 'target find\\']);
+        $criteria = (new Criteria())->addFilter(new SuffixFilter('link', ' \\'));
+        $foundIds = $this->manufacturerRepository->searchIds($criteria, Context::createDefaultContext());
+
+        static::assertContains($targetId, $foundIds->getIds());
+        static::assertNotContains($erroneousId, $foundIds->getIds());
     }
 
     private function createManufacturer(array $parameters = []): string

--- a/src/Docs/Resources/current/60-references-internals/10-core/130-dal.md
+++ b/src/Docs/Resources/current/60-references-internals/10-core/130-dal.md
@@ -9,6 +9,8 @@
 | equals      | Exact match for the given value  |
 | equalsAny   | At least one exact match for a value of the given list |
 | contains    | Before and after wildcard search for the given value |
+| prefix      | After wildcard search for the given value |
+| suffix      | Before wildcard search for the given value |
 | range       | For range compatible fields like numbers or dates |
 | not         | Allows to negate a filter |
 | multi       | Allows to combine different filters |
@@ -104,6 +106,66 @@ The following SQL statement is executed in the background: `WHERE name LIKE '%Li
             }    
         ]
     }    
+    </code></pre></section>
+  </div>
+</div>
+
+### Prefix
+The `Prefix` Filter allows you to filter a field to an approximate value, where the passed value must be the start of a full value.
+The following SQL statement is executed in the background: `WHERE name LIKE 'Lightweight%'`.
+
+<div class="tabs">
+  <nav>
+    <a href="#">PHP</a>
+    <a href="#">API</a>
+  </nav>
+  <div class="tabs-container">
+    <section><pre><code>
+    $criteria = new Criteria();
+    $criteria->addFilter(new PrefixFilter('name', 'Lightweight'));
+    </code></pre></section>
+
+    <section><pre><code>
+    POST /api/v3/search/product
+    {
+        "filter": [
+            {
+                "type": "prefix",
+                "field": "name",
+                "value": "Lightweight"
+            }
+        ]
+    }
+    </code></pre></section>
+  </div>
+</div>
+
+### Suffix
+The `Suffix` Filter allows you to filter a field to an approximate value, where the passed value must be the end of a full value.
+The following SQL statement is executed in the background: `WHERE name LIKE '%Lightweight'`.
+
+<div class="tabs">
+  <nav>
+    <a href="#">PHP</a>
+    <a href="#">API</a>
+  </nav>
+  <div class="tabs-container">
+    <section><pre><code>
+    $criteria = new Criteria();
+    $criteria->addFilter(new SuffixFilter('name', 'Lightweight'));
+    </code></pre></section>
+
+    <section><pre><code>
+    POST /api/v3/search/product
+    {
+        "filter": [
+            {
+                "type": "suffix",
+                "field": "name",
+                "value": "Lightweight"
+            }
+        ]
+    }
     </code></pre></section>
   </div>
 </div>

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -12,6 +12,7 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\Joining\NestedQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\ExistsQuery;
+use ONGR\ElasticsearchDSL\Query\TermLevel\PrefixQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\RangeQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
 use ONGR\ElasticsearchDSL\Query\TermLevel\TermsQuery;
@@ -44,7 +45,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\XOrFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Feature;
@@ -158,6 +161,12 @@ class CriteriaParser
 
             case $filter instanceof ContainsFilter:
                 return $this->parseContainsFilter($filter, $definition, $context);
+
+            case $filter instanceof PrefixFilter:
+                return $this->parsePrefixFilter($filter, $definition, $context);
+
+            case $filter instanceof SuffixFilter:
+                return $this->parseSuffixFilter($filter, $definition, $context);
 
             case $filter instanceof RangeFilter:
                 return $this->parseRangeFilter($filter, $definition, $context);
@@ -431,6 +440,34 @@ class CriteriaParser
 
         return $this->createNestedQuery(
             new WildcardQuery($accessor, '*' . $value . '*'),
+            $definition,
+            $filter->getField()
+        );
+    }
+
+    private function parsePrefixFilter(PrefixFilter $filter, EntityDefinition $definition, Context $context): BuilderInterface
+    {
+        $accessor = $this->buildAccessor($definition, $filter->getField(), $context);
+
+        /** @var string $value */
+        $value = $filter->getValue();
+
+        return $this->createNestedQuery(
+            new PrefixQuery($accessor, $value),
+            $definition,
+            $filter->getField()
+        );
+    }
+
+    private function parseSuffixFilter(SuffixFilter $filter, EntityDefinition $definition, Context $context): BuilderInterface
+    {
+        $accessor = $this->buildAccessor($definition, $filter->getField(), $context);
+
+        /** @var string $value */
+        $value = $filter->getValue();
+
+        return $this->createNestedQuery(
+            new WildcardQuery($accessor, '*' . $value),
             $definition,
             $filter->getField()
         );

--- a/src/Elasticsearch/Test/Product/ElasticsearchProductTest.php
+++ b/src/Elasticsearch/Test/Product/ElasticsearchProductTest.php
@@ -41,7 +41,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NandFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\OrFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Grouping\FieldGrouping;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Feature;
@@ -456,6 +458,94 @@ class ElasticsearchProductTest extends TestCase
             static::assertCount(1, $products->getIds());
             static::assertSame(1, $products->getTotal());
             static::assertContains($data->get('product-2'), $products->getIds());
+        } catch (\Exception $e) {
+            static::tearDown();
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @depends testIndexing
+     */
+    public function testPrefixFilter(IdsCollection $data): void
+    {
+        try {
+            $searcher = $this->createEntitySearcher();
+            $criteria = new Criteria();
+            $criteria->addFilter(new PrefixFilter('product.name', 'Sti'));
+
+            $products = $searcher->search($this->productDefinition, $criteria, $data->getContext());
+            static::assertCount(1, $products->getIds());
+            static::assertSame(1, $products->getTotal());
+            static::assertContains($data->get('product-3'), $products->getIds());
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new PrefixFilter('product.name', 'subber'));
+
+            $products = $searcher->search($this->productDefinition, $criteria, $data->getContext());
+            static::assertCount(0, $products->getIds());
+            static::assertSame(0, $products->getTotal());
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new PrefixFilter('product.name', 'Rubb'));
+
+            $products = $searcher->search($this->productDefinition, $criteria, $data->getContext());
+            static::assertCount(1, $products->getIds());
+            static::assertSame(1, $products->getTotal());
+            static::assertContains($data->get('product-2'), $products->getIds());
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new PrefixFilter('product.name', 'Spacht'));
+
+            $products = $searcher->search($this->productDefinition, $criteria, $data->getContext());
+            static::assertCount(1, $products->getIds());
+            static::assertSame(1, $products->getTotal());
+            static::assertContains($data->get('product-6'), $products->getIds());
+        } catch (\Exception $e) {
+            static::tearDown();
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @depends testIndexing
+     */
+    public function testSuffixFilter(IdsCollection $data): void
+    {
+        try {
+            $searcher = $this->createEntitySearcher();
+            $criteria = new Criteria();
+            $criteria->addFilter(new SuffixFilter('product.name', 'tilk'));
+
+            $products = $searcher->search($this->productDefinition, $criteria, $data->getContext());
+            static::assertCount(1, $products->getIds());
+            static::assertSame(1, $products->getTotal());
+            static::assertContains($data->get('product-3'), $products->getIds());
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new SuffixFilter('product.name', 'subber'));
+
+            $products = $searcher->search($this->productDefinition, $criteria, $data->getContext());
+            static::assertCount(0, $products->getIds());
+            static::assertSame(0, $products->getTotal());
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new SuffixFilter('product.name', 'bber'));
+
+            $products = $searcher->search($this->productDefinition, $criteria, $data->getContext());
+            static::assertCount(1, $products->getIds());
+            static::assertSame(1, $products->getTotal());
+            static::assertContains($data->get('product-2'), $products->getIds());
+
+            $criteria = new Criteria();
+            $criteria->addFilter(new SuffixFilter('product.name', 'company'));
+
+            $products = $searcher->search($this->productDefinition, $criteria, $data->getContext());
+            static::assertCount(1, $products->getIds());
+            static::assertSame(1, $products->getTotal());
+            static::assertContains($data->get('product-6'), $products->getIds());
         } catch (\Exception $e) {
             static::tearDown();
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently it is impossible to filter by prefix or suffix, only infix (`contains`).

### 2. What does this change do, exactly?
This PR adds support for prefix and suffix filter to the DAL.

### 3. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
