### PR TITLE
* fix the command exit code to be int (required by symfony)

### DIFF
--- a/src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
+++ b/src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
@@ -110,6 +110,8 @@ class SitemapGenerateCommand extends Command
                 $languageIds = $salesChannel->getDomains()->map(function (SalesChannelDomainEntity $salesChannelDomain) {
                     return $salesChannelDomain->getLanguageId();
                 });
+
+                $languageIds = array_unique($languageIds);
             }
 
             foreach ($languageIds as $languageId) {
@@ -126,7 +128,7 @@ class SitemapGenerateCommand extends Command
 
         $output->writeln('done!');
 
-        return null;
+        return 0;
     }
 
     private function generateSitemap(SalesChannelContext $salesChannelContext, bool $force, ?string $lastProvider = null, ?int $offset = null): void

--- a/src/Core/Content/Sitemap/Service/SitemapHandle.php
+++ b/src/Core/Content/Sitemap/Service/SitemapHandle.php
@@ -112,7 +112,7 @@ class SitemapHandle implements SitemapHandleInterface
 
     private function getFileName(SalesChannelContext $salesChannelContext, ?int $index = null): string
     {
-        return sprintf($salesChannelContext->getSalesChannel()->getId() . '-' . self::SITEMAP_NAME_PATTERN, $index ?? $this->index);
+        return sprintf($salesChannelContext->getSalesChannel()->getId() . '-' . $salesChannelContext->getSalesChannel()->getLanguageId() . '-' . self::SITEMAP_NAME_PATTERN, $index ?? $this->index);
     }
 
     private function printHeader(): void


### PR DESCRIPTION
* fix the sitemap languageIds to be unique to prevent double generation of the same sitemap
* fix the tmp file name to be unique to avoid tmp file name collision

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Sitemap Generation is broken when used via the queue because of errors

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
