### PR TITLE
Fix to exception in cart when a promotion is applied

### DIFF
--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -85,6 +85,10 @@ class LineItemCustomFieldRule extends Rule
     {
         $customFields = $lineItem->getPayloadValue('customFields');
 
+        if (is_null($customFields)) {
+            return false;
+        }
+
         $actual = $this->getValue($customFields, $this->renderedField);
         if ($actual === null) {
             return false;


### PR DESCRIPTION
### 1. Why is this change necessary?
An exception is thrown when an item is added to the cart if both a promotion and a line item custom field rule are applied at the same time. Promotion line items don't have customFields in their payload causing the following exception to occur:
request.CRITICAL: Uncaught PHP Exception TypeError: "Argument 1 passed to Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule::getValue() must be of the type array, null given, called in /vendor/shopware/core/Checkout/Cart/Rule/LineItemCustomFieldRule.php on line 84" at /vendor/shopware/core/Checkout/Cart/Rule/LineItemCustomFieldRule.php line 134 {"exception":"[object] (TypeError(code: 0): Argument 1 passed to Shopware\\Core\\Checkout\\Cart\\Rule\\LineItemCustomFieldRule::getValue() must be of the type array, null given, called in /vendor/shopware/core/Checkout/Cart/Rule/LineItemCustomFieldRule.php on line 84 at /vendor/shopware/core/Checkout/Cart/Rule/LineItemCustomFieldRule.php:134)"} []

### 2. What does this change do, exactly?
It catches cases where $lineItem->getPayloadValue('customFields') returns null by returning false to the check isCustomFieldValid().

### 3. Describe each step to reproduce the issue or behaviour.
Create a rule using the LineItemCustomFieldRule.
Create a promotion applying to the product you test this issue with.
Apply rule to shipping or payment method.
Add a product to the cart triggering this rule and configured promotion.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13892

### 5. Checklist

- [] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
