### PR TITLE
URGENT: consider criteria ids for aggregation cache key generation

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
@@ -89,7 +89,7 @@ class EntityCacheKeyGenerator
         $keys = [
             md5(json_encode($aggregation)),
             $this->getDefinitionCacheKey($definition),
-            $this->getAggregationHash($criteria),
+            $this->getCriteriaHash($criteria),
             $this->getContextHash($context),
             $this->cacheHash,
         ];

--- a/src/Core/Framework/Test/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\CountAggregation;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\EntityAggregation;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
@@ -153,5 +154,27 @@ class EntityCacheKeyGeneratorTest extends TestCase
         static::assertContains('media_translation.title', $tags);
 
         static::assertCount(9, $tags, print_r($tags, true));
+    }
+
+    public function testGenerateAggregationCacheTags(): void
+    {
+        $context = Context::createDefaultContext();
+        $id = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+
+        $criteria1 = new Criteria([$id]);
+        $aggregation1 = new CountAggregation('productCount', 'product.id');
+        $criteria1->addAggregation($aggregation1);
+
+        $criteria2 = new Criteria([$id2]);
+        $aggregation2 = new CountAggregation('productCount', 'product.id');
+        $criteria2->addAggregation($aggregation2);
+
+        $key1 = $this->generator->getAggregationCacheKey($aggregation1,
+            $this->getContainer()->get(ProductDefinition::class), $criteria1, $context);
+        $key2 = $this->generator->getAggregationCacheKey($aggregation2,
+            $this->getContainer()->get(ProductDefinition::class), $criteria2, $context);
+
+        static::assertNotEquals($key1, $key2);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
At the moment, queries containing aggregations get cached even if the id's of the criteria has changed. This can lead to unpredictable behavior and wrong results for aggregation.

```php
$this->productRepository->search($criteria, $context)
        ->getAggregations()
        ->get($aggregationName);
// This might return a cached result from a different criteria!!
```

**At the moment: at any time an aggregation is queried it might return a wrong result! So this PR is urgent. Please assign a high priority to it**.

### 2. What does this change do, exactly?
It adds the criteria to the aggregation's cache key. 

### 3. Describe each step to reproduce the issue or behaviour.
I created an example plugin which shows the bug in action:
https://github.com/wesionaire/WesioCacheBugDemo

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13961

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
