### PR TITLE
Clear cache and reload page after updating plugin in the updates-list-view

### DIFF
--- a/changelog/_unreleased/2021-03-04-clear-cache-and-reload-page-after-plugin-update.md
+++ b/changelog/_unreleased/2021-03-04-clear-cache-and-reload-page-after-plugin-update.md
@@ -1,0 +1,8 @@
+---
+title: Clear cache and reload page after updating a plugin
+issue: NEXT-8900, NEXT-10204
+flag: 
+---
+# Administration
+* Changed `sw-plugin-updates-grid/index.js` so that the cache is cleared, and the page is reloaded after updating a
+plugin in the plugin-updates-grid.


### PR DESCRIPTION
### 1. Why is this change necessary?

When updating a plugin via the _plugin list view_ (i.e. the code was already updated on the file system), the cache is cleared and the page is reloaded so that all cached files and controller routes are up to date. 
When updating a plugin via the _plugin update list view_ (i.e. the code must be downloaded first), the cache is _not_ cleared and the page is _not_ reloaded. The cache is now stale.

When a plugin update changes a controller route, the old route is still in the cache and cannot be found. We had this problem when an update of the DHL plugin changed one of its routes. The customers contacted us because of errors after the update:
```
Beim Starten des Vorgangs ist ein Fehler aufgetreten:
No route found for "POST /api/v2/_action/order/e34147b44d0d45d5ad1dea2d69bbb590/create-shipment-blueprint" (from " ..shop url.. /admin")
```

### 2. What does this change do, exactly?

This PR changes the behaviour in the `sw-plugin-updates-grid` so that the cache is cleared and the page is reloaded after a plugin update. This is basically the same as what is already happening in the `sw-plugin-list` view.


### 3. Describe each step to reproduce the issue or behaviour.

Downgrade any plugin to a version before a route change. Update that plugin in the `sw-plugin-updates-grid`. Use the administration action that uses that route. The request will fail.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-8900
https://issues.shopware.com/issues/NEXT-10204

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
