### PR TITLE
External URLs in sw-image-slider vue Component

### DIFF
--- a/changelog/_unreleased/2021-03-09-fix-external-image-url-in-sw-image-slider.md
+++ b/changelog/_unreleased/2021-03-09-fix-external-image-url-in-sw-image-slider.md
@@ -1,0 +1,9 @@
+---
+title: Fix external image URLs in sw-image-slider
+issue: 
+author: Sebastian Diez
+author_email: s.diez@seidemann-web.com
+author_github: @s-diez
+---
+# Administration
+* Fixed the call of the URL constructor in the sw-image-slider vue component. This will allow usage of sw-image-slider with media or external URLs again.

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-image-slider/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-image-slider/index.js
@@ -132,7 +132,8 @@ Component.register('sw-image-slider', {
             const link = this.isImageObject(image) ? image.src : image;
 
             try {
-                URL(link);
+                // eslint-disable-next-line no-new
+                new URL(link);
             } catch (e) {
                 return Filter.getByName('asset')(link);
             }

--- a/src/Administration/Resources/app/administration/test/app/component/media/sw-image-slider.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/component/media/sw-image-slider.spec.js
@@ -51,12 +51,13 @@ describe('src/app/component/base/sw-image-slider', () => {
     it('should display every image, even in an object, independent if the link is external or not', () => {
         const wrapper = createWrapper();
         const containerScrollable = wrapper.find('.sw-image-slider__image-container-scrollable');
-        const elementWrappers = wrapper.findAll(
-            '.sw-image-slider__image-container-scrollable > .sw-image-slider__image-container-element-wrapper'
+        const actualImages = wrapper.findAll(
+            '.sw-image-slider__image-container-scrollable .sw-image-slider__image-container-element-image'
         );
 
         expect(containerScrollable.exists()).toBeTruthy();
-        expect(elementWrappers.length).toBe(images.length);
+        expect(actualImages.length).toBe(images.length);
+        expect(actualImages.at(1).attributes().src).toBe(images[1]);
     });
 
     it('should display descriptions, if enabled and existing', () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

External image urls are processed incorrectly in the administration vue component sw-image-slider. They are handled as if they were incomplete asset urls.

### 2. What does this change do, exactly?

Fixes the call to the constructor `URL` without `new`.

### 3. Describe each step to reproduce the issue or behaviour.

- Write a administration plugin which uses the vue component sw-image-slider.
- `<sw-image-slider :images=['https://assets.shopware.com/media/logos/shopware_logo_blue.svg'] :canvasWidth="200" :canvasHeight="200" />
- Look at the result in the administration and inspect the generated image src.
- The image src is corrupted.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
