### PR TITLE
Make file systems public in the dependency injection container

### DIFF
--- a/changelog/_unreleased/2021-03-09-make-filesyste-services-public-in-container.md
+++ b/changelog/_unreleased/2021-03-09-make-filesyste-services-public-in-container.md
@@ -1,0 +1,9 @@
+---
+title: Make filesystem services public in dependency injection container
+author: Manuel Kress
+author_email: 6232639+windaishi@users.noreply.github.com
+author_github: windaishi
+---
+# Core
+* All file system services (e.g. `shopware.filesystem.private`) are now public in the dependency injection container.
+  * This makes them directly available via `$container->get()` without the necessity to inject them as service.

--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -128,6 +128,7 @@ abstract class Bundle extends SymfonyBundle
                 'plugins/' . $containerPrefix,
             ]
         );
+        $filesystem->setPublic(true);
 
         $container->setDefinition($serviceId, $filesystem);
     }

--- a/src/Core/Framework/DependencyInjection/filesystem.xml
+++ b/src/Core/Framework/DependencyInjection/filesystem.xml
@@ -11,32 +11,32 @@
             <argument type="tagged" tag="shopware.filesystem.plugin"/>
         </service>
 
-        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.public">
+        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.public" public="true">
             <factory service="Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory" method="factory"/>
             <argument>%shopware.filesystem.public%</argument>
         </service>
 
-        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.private">
+        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.private" public="true">
             <factory service="Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory" method="factory"/>
             <argument>%shopware.filesystem.private%</argument>
         </service>
 
-        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.temp">
+        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.temp" public="true">
             <factory service="Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory" method="factory"/>
             <argument>%shopware.filesystem.temp%</argument>
         </service>
 
-        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.theme">
+        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.theme" public="true">
             <factory service="Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory" method="factory"/>
             <argument>%shopware.filesystem.theme%</argument>
         </service>
 
-        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.sitemap">
+        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.sitemap" public="true">
             <factory service="Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory" method="factory"/>
             <argument>%shopware.filesystem.sitemap%</argument>
         </service>
 
-        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.asset">
+        <service class="League\Flysystem\FilesystemInterface" id="shopware.filesystem.asset" public="true">
             <factory service="Shopware\Core\Framework\Adapter\Filesystem\FilesystemFactory" method="factory"/>
             <argument>%shopware.filesystem.asset%</argument>
         </service>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Sometimes you need to access the filesystem of Shopware and don't have the possibility to inject it via dependency injection. One use-case for example is when uninstalling or updating a disabled plugin. When the plugin is disabled, no plugin services are loaded. When you need to access the file-system in an update/uninstall-routine, you can't do it via `$this->container->get('shopware.filesystem.private')`.

### 2. What does this change do, exactly?
This changes all filesystem services to be public in the container.

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
