### PR TITLE
Added events for concatenated styles/scripts in theme compiler

### DIFF
--- a/changelog/_unreleased/2021-03-09-added-events-for-concatenated-styles-scripts-in-theme-compiler.md
+++ b/changelog/_unreleased/2021-03-09-added-events-for-concatenated-styles-scripts-in-theme-compiler.md
@@ -1,0 +1,10 @@
+---
+title: Added events for concatenated styles/scripts in theme compiler
+issue: NEXT-14227
+author: David Neustadt
+author_email: kontakt@davidneustadt.de
+author_github: dneustadt
+---
+# Storefront
+* Added `Symfony\Contracts\EventDispatcher\Event\ThemeCompilerConcatenatedStylesEvent` and `Symfony\Contracts\EventDispatcher\Event\ThemeCompilerConcatenatedScriptsEvent`.
+* Pass concatenated styles and scripts through dedicated events before further compilation

--- a/src/Storefront/Event/ThemeCompilerConcatenatedScriptsEvent.php
+++ b/src/Storefront/Event/ThemeCompilerConcatenatedScriptsEvent.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ThemeCompilerConcatenatedScriptsEvent extends Event
+{
+    /**
+     * @var string
+     */
+    private $concatenatedScripts;
+
+    /**
+     * @var string
+     */
+    private $salesChannelId;
+
+    public function __construct(string $concatenatedScripts, string $salesChannelId)
+    {
+        $this->concatenatedScripts = $concatenatedScripts;
+        $this->salesChannelId = $salesChannelId;
+    }
+
+    public function getConcatenatedScripts(): string
+    {
+        return $this->concatenatedScripts;
+    }
+
+    public function setConcatenatedScripts(string $concatenatedScripts): void
+    {
+        $this->concatenatedScripts = $concatenatedScripts;
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelId;
+    }
+}

--- a/src/Storefront/Event/ThemeCompilerConcatenatedStylesEvent.php
+++ b/src/Storefront/Event/ThemeCompilerConcatenatedStylesEvent.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ThemeCompilerConcatenatedStylesEvent extends Event
+{
+    /**
+     * @var string
+     */
+    private $concatenatedStyles;
+
+    /**
+     * @var string
+     */
+    private $salesChannelId;
+
+    public function __construct(string $concatenatedStyles, string $salesChannelId)
+    {
+        $this->concatenatedStyles = $concatenatedStyles;
+        $this->salesChannelId = $salesChannelId;
+    }
+
+    public function getConcatenatedStyles(): string
+    {
+        return $this->concatenatedStyles;
+    }
+
+    public function setConcatenatedStyles(string $concatenatedStyles): void
+    {
+        $this->concatenatedStyles = $concatenatedStyles;
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelId;
+    }
+}

--- a/src/Storefront/Test/Theme/ThemeCompilerTest.php
+++ b/src/Storefront/Test/Theme/ThemeCompilerTest.php
@@ -9,7 +9,10 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Storefront\Event\ThemeCompilerConcatenatedScriptsEvent;
+use Shopware\Storefront\Event\ThemeCompilerConcatenatedStylesEvent;
 use Shopware\Storefront\Event\ThemeCompilerEnrichScssVariablesEvent;
+use Shopware\Storefront\Test\Theme\fixtures\MockThemeCompilerConcatenatedSubscriber;
 use Shopware\Storefront\Test\Theme\fixtures\MockThemeVariablesSubscriber;
 use Shopware\Storefront\Theme\ThemeCompiler;
 use Shopware\Storefront\Theme\ThemeFileImporter;
@@ -298,6 +301,36 @@ PHP_EOL;
         ];
 
         static::assertSame($expected, $actual);
+    }
+
+    public function testConcanatedStylesEventPassThru(): void
+    {
+        $subscriber = new MockThemeCompilerConcatenatedSubscriber();
+
+        $styles = 'body {}';
+
+        $event = new ThemeCompilerConcatenatedStylesEvent($styles, $this->mockSalesChannelId);
+        $subscriber->onGetConcatenatedStyles($event);
+        $actual = $event->getConcatenatedStyles();
+
+        $expected = $styles . MockThemeCompilerConcatenatedSubscriber::STYLES_CONCAT;
+
+        static::assertEquals($expected, $actual);
+    }
+
+    public function testConcanatedScriptsEventPassThrough(): void
+    {
+        $subscriber = new MockThemeCompilerConcatenatedSubscriber();
+
+        $scripts = 'console.log(\'foo\');';
+
+        $event = new ThemeCompilerConcatenatedScriptsEvent($scripts, $this->mockSalesChannelId);
+        $subscriber->onGetConcatenatedScripts($event);
+        $actual = $event->getConcatenatedScripts();
+
+        $expected = $scripts . MockThemeCompilerConcatenatedSubscriber::SCRIPTS_CONCAT;
+
+        static::assertEquals($expected, $actual);
     }
 
     public function testMediaIdsInThemeConfigGetResolvedToPaths(): void

--- a/src/Storefront/Test/Theme/fixtures/MockThemeCompilerConcatenatedSubscriber.php
+++ b/src/Storefront/Test/Theme/fixtures/MockThemeCompilerConcatenatedSubscriber.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Test\Theme\fixtures;
+
+use Shopware\Storefront\Event\ThemeCompilerConcatenatedScriptsEvent;
+use Shopware\Storefront\Event\ThemeCompilerConcatenatedStylesEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class MockThemeCompilerConcatenatedSubscriber implements EventSubscriberInterface
+{
+    public const STYLES_CONCAT = '.mock-selector {}';
+    public const SCRIPTS_CONCAT = 'console.log(\'bar\');';
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            ThemeCompilerConcatenatedStylesEvent::class => 'onGetConcatenatedStyles',
+            ThemeCompilerConcatenatedScriptsEvent::class => 'onGetConcatenatedScripts',
+        ];
+    }
+
+    public function onGetConcatenatedStyles(ThemeCompilerConcatenatedStylesEvent $event): void
+    {
+        $event->setConcatenatedStyles($event->getConcatenatedStyles() . self::STYLES_CONCAT);
+    }
+
+    public function onGetConcatenatedScripts(ThemeCompilerConcatenatedScriptsEvent $event): void
+    {
+        $event->setConcatenatedScripts($event->getConcatenatedScripts() . self::SCRIPTS_CONCAT);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
There is currently no way to alter the contents of previously concatenated SCSS/scripts immediately before they are being passed to the compiler or put into the filesystem respectively. By using dispatched events contents may be enriched or altered independently of plugin context.

### 2. What does this change do, exactly?
Adds two events for concatenated SCSS/JS respectively, dispatched immediately before compilation/being written to the filesystem and retrieves the final respective value from each event.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
