### PR TITLE
enable custom component config options to be mixed with native fields (custom sort order)

### DIFF
--- a/src/Core/System/SystemConfig/Schema/config.xsd
+++ b/src/Core/System/SystemConfig/Schema/config.xsd
@@ -12,13 +12,13 @@
         </xs:unique>
     </xs:element>
     <xs:complexType name="card">
-        <xs:sequence>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
             <xs:element name="title" type="translatableString" maxOccurs="unbounded"/>
             <xs:element name="name" type="xs:string" minOccurs="0"/>
             <xs:element name="input-field" type="input-field" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="component" type="component" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="flag" type="xs:string" minOccurs="0"/>
-        </xs:sequence>
+        </xs:choice>
     </xs:complexType>
     <xs:complexType name="component">
         <xs:sequence>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Currently if multiple config options are defined as mixed "input-field" and "component", "component"'s always have to be at the end of each card due to the constraints of `<xsd:sequence>`

### 2. What does this change do, exactly?

The change enables plugin developers to define components and input-fields in arbitrary order.

### 3. Describe each step to reproduce the issue or behaviour.

Define the following config options:

    <card>
        <title lang="de-DE">Card Title</title>

        <input-field type="bool">
            <name>firstOption</name>
        </input-field>

        <component name="my-component">
            <name>secondOption</name>
        </component>
        
        <input-field type="bool">
            <name>thirdOption</name>
        </input-field>
    </card>

You will get the following error:

Encountered an error while loading the configuration:Unable to parse file ".../config.xml". Message: [ERROR 1871] Element 'input-field': This element is not expected. Expected is ( component ). (in /var/www/shopware/public/ - line 93, column 0)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [] I have written or adjusted the documentation according to my changes
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
