### PR TITLE
fix: fix rich snippet error in offcanvas nav show all link

### DIFF
--- a/changelog/_unreleased/2021-03-12-fix-rich-snippet-error-in-offcanvas-nav.md
+++ b/changelog/_unreleased/2021-03-12-fix-rich-snippet-error-in-offcanvas-nav.md
@@ -1,0 +1,11 @@
+title: Fix rich snippet error in offcanvas nav
+issue:
+author: Leon Weickert
+author_email: shopware@devert.net
+author_github: @DevertNet
+
+---
+
+# Storefront
+
+-   Fixed a rich snippets error in the show all link of the offcanvas navigation (storefront/layout/navigation/offcanvas/show-all-link.html.twig)

--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/show-all-link.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/show-all-link.html.twig
@@ -7,7 +7,7 @@
             <span class="navigation-offcanvas-link-icon js-navigation-offcanvas-loading-icon">
                 {% sw_icon 'stack' %}
             </span>
-            <span itemprop="{{ "general.mainMenu"|trans|striptags }}">
+            <span itemprop="name">
                 {{ "general.mainMenu"|trans|sw_sanitize }}
             </span>
         {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
There was an rich snippet error in the show-all-link in the offcanvas navigation on all category and details pages.

### 2. What does this change do, exactly?
Fix the itemprop-attribute which was responsible for the error.

### 3. Describe each step to reproduce the issue or behaviour.
Check rich snippets for a category page.

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
