### PR TITLE
bug Invoice/DeliveryNote generation

### DIFF
--- a/src/Core/Framework/Resources/views/documents/base.html.twig
+++ b/src/Core/Framework/Resources/views/documents/base.html.twig
@@ -53,7 +53,7 @@ merge 16.11.2020
 
             {% block document_font_links %}
                 <link href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900&display=swap" rel="stylesheet">
-            {% endblock %}document_body
+            {% endblock %}
 
             {% if config.custom.pageOrientation == 'landscape' %}
                 {% sw_include '@Framework/documents/style_base_landscape.css.twig' %}


### PR DESCRIPTION
fixed bug in Invoice/DeliveryNote generation
removed document_body from line 56

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Because Invoice and Delivery Note have a wrong text

### 2. What does this change do, exactly?

removed wrong text

### 3. Describe each step to reproduce the issue or behaviour.

generate a invoice or a delivery note and look at smale business adress

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
