### PR TITLE
Include options in product exports

### DIFF
--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -142,6 +142,7 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             ->addAssociation('manufacturer')
             ->addAssociation('media')
             ->addAssociation('prices')
+            ->addAssociation('options.group')
             ->addAssociation('properties.group');
 
         $iterator = new SalesChannelRepositoryIterator($this->productRepository, $context, $criteria);


### PR DESCRIPTION
### 1. Why is this change necessary?

Because `product.options` is not available in the product exports.

### 2. What does this change do, exactly?

Add the association to be loaded.
