### PR TITLE
feature: allow to control template targets trough StorefrontRenderEvent

### DIFF
--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -34,7 +34,7 @@ abstract class StorefrontController extends AbstractController
         $event = new StorefrontRenderEvent($view, $parameters, $request, $salesChannelContext);
         $this->get('event_dispatcher')->dispatch($event);
 
-        $response = $this->render($view, $event->getParameters(), new StorefrontResponse());
+        $response = $this->render($event->getView(), $event->getParameters(), new StorefrontResponse());
 
         if (!$response instanceof StorefrontResponse) {
             throw new \RuntimeException('Symfony render implementation changed. Providing a response is no longer supported');

--- a/src/Storefront/Event/StorefrontRenderEvent.php
+++ b/src/Storefront/Event/StorefrontRenderEvent.php
@@ -67,4 +67,9 @@ class StorefrontRenderEvent extends NestedEvent implements ShopwareSalesChannelE
     {
         $this->parameters[$key] = $value;
     }
+
+    public function setView(string $view): void
+    {
+        $this->view = $view;
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

When I wanted to swap out a template within event subscriber just to keep the business logic out of templates I noticed that this is currently not possible.

Right now on controller actions templates are assigned trough Shopware\Storefront\Controller\StorefrontController renderStorefront method that dispatches event "StorefrontRenderEvent" before template is rendered but keeps the $view string as protected and without using it from event on actual render call. 

This effectively stops you to create logic around template assignments and forces you to write business logic to templates (instead of keeping templates stupid and more simple) . You are forced to write business logic based conditions directly to templates and provide objects/data to meet all conditions beforehand. If page is more complex and contains a lot of data that can also affect performance. Cognitive load to create, understand and edit the templates is also higher. 

### 2. What does this change do, exactly?

Change introduced would allow to use StorefrontRenderEvent setView() method to change a template target before response is rendered. 

This gives a way for a developer to keep business logic written in php separately from a template. On condition A use template T1 and on condition B use template T2. 

### 3. Describe each step to reproduce the issue or behaviour.

not a issue =>  feature 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
