### PR TITLE
Improvement: Add twig blocks to metatag templates

### DIFF
--- a/changelog/_unreleased/2021-03-18-add-twig-blocks-to-meta.md
+++ b/changelog/_unreleased/2021-03-18-add-twig-blocks-to-meta.md
@@ -1,0 +1,25 @@
+---
+title: Add twig blocks to metatag template
+author: Rune Laenen
+author_email: rune@laenen.me
+author_github: @runelaenen
+---
+# Storefront
+* Added the following twig blocks in `meta.html.twig`:
+    * `layout_head_meta_tags_general_author`
+    * `layout_head_meta_tags_robots`
+    * `layout_head_meta_tags_general_revisit`
+    * `layout_head_meta_tags_keywords`
+    * `layout_head_meta_tags_description`
+    * `layout_head_meta_tags_type_og`
+    * `layout_head_meta_tags_sitename_og`
+    * `layout_head_meta_tags_title_og`
+    * `layout_head_meta_tags_image_og`
+    * `layout_head_meta_tags_card_twitter`
+    * `layout_head_meta_tags_sitename_twitter`
+    * `layout_head_meta_tags_title_twitter`
+    * `layout_head_meta_tags_image_twitter`
+    * `layout_head_meta_tags_copyright_holder`
+    * `layout_head_meta_tags_copyright_year`
+    * `layout_head_meta_tags_family_friendly`
+    * `layout_head_meta_tags_image_meta`

--- a/src/Storefront/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/meta.html.twig
@@ -19,11 +19,11 @@
 
             {% block layout_head_meta_tags_general %}
                 <meta name="author"
-                      content="{{ metaInformation.author|striptags }}"/>
+                      content="{% block layout_head_meta_tags_general_author %}{{ metaInformation.author|striptags }}{% endblock %}"/>
                 <meta name="robots"
                       content="{% block layout_head_meta_tags_robots %}{{ metaInformation.robots }}{% endblock %}"/>
                 <meta name="revisit-after"
-                      content="{{ metaInformation.revisit|striptags }}"/>
+                      content="{% block layout_head_meta_tags_general_revisit %}{{ metaInformation.revisit|striptags }}{% endblock %}"/>
                 <meta name="keywords"
                       content="{% block layout_head_meta_tags_keywords %}{{ metaKeywords }}{% endblock %}"/>
                 <meta name="description"
@@ -32,37 +32,37 @@
 
             {% block layout_head_meta_tags_opengraph %}
                 <meta property="og:type"
-                      content="website"/>
+                      content="{% block layout_head_meta_tags_type_og %}website{% endblock %}"/>
                 <meta property="og:site_name"
-                      content="{{ basicConfig.shopName }}"/>
+                      content="{% block layout_head_meta_tags_sitename_og %}{{ basicConfig.shopName }}{% endblock %}"/>
                 <meta property="og:title"
-                      content="{{ metaTitle }}"/>
+                      content="{% block layout_head_meta_tags_title_og %}{{ metaTitle }}{% endblock %}"/>
                 <meta property="og:description"
                       content="{% block layout_head_meta_tags_description_og %}{{ metaDescription }}{% endblock %}"/>
                 <meta property="og:image"
-                      content="{{ theme_config('sw-logo-desktop') }}"/>
+                      content="{% block layout_head_meta_tags_image_og %}{{ theme_config('sw-logo-desktop') }}{% endblock %}"/>
 
                 <meta name="twitter:card"
-                      content="summary"/>
+                      content="{% block layout_head_meta_tags_card_twitter %}summary{% endblock %}"/>
                 <meta name="twitter:site"
-                      content="{{ basicConfig.shopName }}"/>
+                      content="{% block layout_head_meta_tags_sitename_twitter %}{{ basicConfig.shopName }}{% endblock %}"/>
                 <meta name="twitter:title"
-                      content="{{ metaTitle }}"/>
+                      content="{% block layout_head_meta_tags_title_twitter %}{{ metaTitle }}{% endblock %}"/>
                 <meta name="twitter:description"
                       content="{% block layout_head_meta_tags_description_twitter %}{{ metaDescription }}{% endblock %}"/>
                 <meta name="twitter:image"
-                      content="{{ theme_config('sw-logo-desktop') }}"/>
+                      content="{% block layout_head_meta_tags_image_twitter %}{{ theme_config('sw-logo-desktop') }}{% endblock %}"/>
             {% endblock %}
 
             {% block layout_head_meta_tags_schema_webpage %}
                 <meta itemprop="copyrightHolder"
-                      content="{{ basicConfig.shopName }}"/>
+                      content="{% block layout_head_meta_tags_copyright_holder %}{{ basicConfig.shopName }}{% endblock %}"/>
                 <meta itemprop="copyrightYear"
-                      content="{{ metaInformation.copyrightYear|striptags }}"/>
+                      content="{% block layout_head_meta_tags_copyright_year %}{{ metaInformation.copyrightYear|striptags }}{% endblock %}"/>
                 <meta itemprop="isFamilyFriendly"
-                      content="{% if basicConfig.familyFriendly %}true{% else %}false{% endif %}"/>
+                      content="{% block layout_head_meta_tags_family_friendly %}{% if basicConfig.familyFriendly %}true{% else %}false{% endif %}{% endblock %}"/>
                 <meta itemprop="image"
-                      content="{{ theme_config('sw-logo-desktop') }}"/>
+                      content="{% block layout_head_meta_tags_image_meta %}{{ theme_config('sw-logo-desktop') }}{% endblock %}"/>
             {% endblock %}
 
             {% block layout_head_meta_tags_hreflangs %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Allows developers to override single meta fields, instead of all the meta tags. Before this change all you can do is override the block which has all meta tags, even if you only need to change 1 value.

### 2. What does this change do, exactly?
Add twig blocks around the meta- and og-tag values.

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
