### PR TITLE
NTR: Fix ConfigSet on CLI for bool values

### DIFF
--- a/src/Core/System/SystemConfig/SystemConfigService.php
+++ b/src/Core/System/SystemConfig/SystemConfigService.php
@@ -233,6 +233,21 @@ class SystemConfigService
      */
     public function set(string $key, $value, ?string $salesChannelId = null): void
     {
+        if (\is_string($value)) {
+            // incoming data is actually string
+            // so we define 2 string words and convert it into a real bool
+            // otherwise the internal storage will always use TRUE on a value
+            // and setting of FALSE will thus never work
+            if (strtolower($value) === 'true') {
+                $value = true;
+            }
+
+            if (strtolower($value) === 'false') {
+                $value = false;
+            }
+        }
+
+
         // reset internal cache
         $this->configs = [];
 

--- a/src/Core/System/Test/SystemConfig/SystemConfigServiceTest.php
+++ b/src/Core/System/Test/SystemConfig/SystemConfigServiceTest.php
@@ -218,6 +218,30 @@ class SystemConfigServiceTest extends TestCase
         static::assertTrue($actual);
     }
 
+    /**
+     * This test verifies that a STRING bool value is also correctly interpreted.
+     * The actual type that is being used in CLI is string and not bool.
+     * So we convert "true" and "false" to true and false
+     */
+    public function testSetGetSalesChannelBoolWithStringTypes(): void
+    {
+        $this->systemConfigService->set('foo.bar', 'false');
+        $actual = $this->systemConfigService->get('foo.bar', Defaults::SALES_CHANNEL);
+        static::assertFalse($actual);
+
+        $this->systemConfigService->set('foo.bar', 'FALSE');
+        $actual = $this->systemConfigService->get('foo.bar', Defaults::SALES_CHANNEL);
+        static::assertFalse($actual);
+
+        $this->systemConfigService->set('foo.bar', 'true', Defaults::SALES_CHANNEL);
+        $actual = $this->systemConfigService->get('foo.bar', Defaults::SALES_CHANNEL);
+        static::assertTrue($actual);
+
+        $this->systemConfigService->set('foo.bar', 'TRUE', Defaults::SALES_CHANNEL);
+        $actual = $this->systemConfigService->get('foo.bar', Defaults::SALES_CHANNEL);
+        static::assertTrue($actual);
+    }
+
     public function testGetDomainNoData(): void
     {
         $actual = $this->systemConfigService->getDomain('foo');


### PR DESCRIPTION
### 1. Why is this change necessary?
i found out that setting of a bool value FALSE does not work with the CLI
because for me all values are interpreted as a string type and thus are always true.
therefore setting of FALSE does never work

### 2. Describe each step to reproduce the issue or behaviour.
create a plugin with a bool config (like testMode TRUE/FALSE)
and try to set both on CLI
only true works, false does not


PLEASE VERIFY if its also the case for you,
if so and if you are happy with the request, I'd be happy about a merge
