### PR TITLE
Add action modal template for order-line-items-grid component

### DIFF
--- a/changelog/_unreleased/2021-03-22-action-modal-template-for-order-line-item-grid.md
+++ b/changelog/_unreleased/2021-03-22-action-modal-template-for-order-line-item-grid.md
@@ -1,0 +1,14 @@
+---
+title: Add action-modals template for order-line-items-grid 
+issue: NA 
+flag: NA
+author: Huzaifa Mustafa 
+author_email: hello@huzaifamustafa.com 
+author_github: @zaifastafa
+---
+
+# Administration
+
+* Added action-modals template and corresponding blocks
+  in  `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig`
+  so that plugins can add their own `sw-modal` implementations for this component. 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
@@ -221,6 +221,12 @@
                         </template>
                     {% endblock %}
 
+                    {% block sw_order_line_items_grid_grid_actions_modals %}
+                        <template #action-modals="{ item }">
+                            {% block sw_order_line_items_grid_grid_actions_modals_items %}{% endblock %}
+                        </template>
+                    {% endblock %}
+
                     {% block sw_order_line_items_grid_bulk_actions %}
                         <template #bulk>
                             {% block sw_order_line_items_grid_bulk_actions_delete %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
As plugin developers, we do not have the option of setting modal boxes for the `order-line-items-grid` component. If a plugin exists and it has create its own action template, it is not possible to extend it in another plugin anymore.

### 2. What does this change do, exactly?
This provides a block for plugin developers to use similar to other components where they can write their own implementation of action modals. 

### 3. Describe each step to reproduce the issue or behaviour.
1. Install a plugin which overrides `{% block sw_order_line_items_grid_grid_actions %}` block with their own implementation of `<template #action-modals="{ item }">` template.
2. Install another plugin which does the same thing. The first plugin's implementation does not work anymore even with the `{% parent %}` as there is no block for it.

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
