### PR TITLE
NEXT-14444 Add Criteria to OrderRouteRequestEvent call

### DIFF
--- a/changelog/_unreleased/2021-03-24-add-criteria-to-order-loaded-event.md
+++ b/changelog/_unreleased/2021-03-24-add-criteria-to-order-loaded-event.md
@@ -1,0 +1,9 @@
+---
+title: Add Criteria to OrderRouteRequestEvent call
+issue: NEXT-14444
+author: Component K Corp
+author_email: k@componentk.com
+author_github: @augsteyer
+---
+# Storefront
+* Changed method `loadNewestOrder` in `Storefront/Page/Account/Overview/AccountOverviewPageLoader.php` to provide Criteria class to the dispatched `OrderRouteRequestEvent` event

--- a/src/Storefront/Page/Account/Overview/AccountOverviewPageLoader.php
+++ b/src/Storefront/Page/Account/Overview/AccountOverviewPageLoader.php
@@ -98,7 +98,7 @@ class AccountOverviewPageLoader
 
         $apiRequest = new Request();
 
-        $event = new OrderRouteRequestEvent($request, $apiRequest, $context);
+        $event = new OrderRouteRequestEvent($request, $apiRequest, $context, $criteria);
         $this->eventDispatcher->dispatch($event);
 
         $responseStruct = $this->orderRoute


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To provide consistency across the platform. Criteria is normally passed in Events so that associations or additional filtering can be added by custom event subscribers. This is already done in another call located at `Storefront\Page\Account\Order\AccountEditOrderPageLoader.php`, [Line 117](https://github.com/shopware/platform/blob/v6.3.5.2/src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php#L117)

### 2. What does this change do, exactly?
Add criteria object to an event being called on the Customer Overview page. Specifically the "Last Order" block.

### 3. Describe each step to reproduce the issue or behaviour.
Since `OrderRouteRequestEvent` omits the criteria, a new one gets created every time the event is called. Which prevents customization.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-14444

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
