### PR TITLE
Set criteria limit null

### DIFF
--- a/changelog/_unreleased/2021-03-25-product-listing-criteria-limit-fix.md
+++ b/changelog/_unreleased/2021-03-25-product-listing-criteria-limit-fix.md
@@ -1,0 +1,8 @@
+---
+title: Fix limit of fetched property groups in product listing filter
+issue: /
+author: Ruben Jacobs
+author_email: ruben6jacobs@gmail.com
+---
+# Administrationt
+* Added `criteria.setLimit(null);` in `src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/index.js` to fetch all property groups

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/index.js
@@ -75,6 +75,7 @@ Component.register('sw-cms-el-config-product-listing', {
 
             criteria.addSorting(Criteria.sort('name', 'ASC', false));
             criteria.addFilter(Criteria.equals('filterable', true));
+            criteria.setLimit(null);
 
             return criteria;
         },


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When configuring the filtering of the product listing in a category, only 25 first properties are fetched and used for the listing. 

### 2. What does this change do, exactly?
It puts the limit in the criteria used to fetch the property groups to `null` so all property groups are fetched.

### 3. Describe each step to reproduce the issue or behaviour.
Create more than 25 different property groups and check if they are all listed in the product listing filtering grid in category edit.

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
