### PR TITLE
Fix default sender email address

### DIFF
--- a/changelog/_unreleased/2020-03-26-change-order-of-email-sender-addresses.md
+++ b/changelog/_unreleased/2020-03-26-change-order-of-email-sender-addresses.md
@@ -1,0 +1,8 @@
+---
+title: Change order of email sender addresses
+author: Paul von Allwörden
+author_email: paul.von.allwoerden@pickware.de
+author_github: paulvonallwoerden
+---
+# Core
+*  Changed method `getSender()` in `Core/Content/Mail/Service/MailService.php` to prioritize the sender address from `core.mailerSettings.senderAddress`.

--- a/src/Core/Content/Mail/Service/MailService.php
+++ b/src/Core/Content/Mail/Service/MailService.php
@@ -226,11 +226,11 @@ class MailService extends AbstractMailService
         $senderEmail = $data['senderEmail'] ?? null;
 
         if ($senderEmail === null || trim($senderEmail) === '') {
-            $senderEmail = $this->systemConfigService->get('core.basicInformation.email', $salesChannelId);
+            $senderEmail = $this->systemConfigService->get('core.mailerSettings.senderAddress', $salesChannelId);
         }
 
         if ($senderEmail === null || trim($senderEmail) === '') {
-            $senderEmail = $this->systemConfigService->get('core.mailerSettings.senderAddress', $salesChannelId);
+            $senderEmail = $this->systemConfigService->get('core.basicInformation.email', $salesChannelId);
         }
 
         if ($senderEmail === null || trim($senderEmail) === '') {

--- a/src/Core/Content/Test/MailTemplate/Service/MailServiceTest.php
+++ b/src/Core/Content/Test/MailTemplate/Service/MailServiceTest.php
@@ -28,7 +28,7 @@ class MailServiceTest extends TestCase
         return [
             ['basic@example.com', 'basic@example.com', null, null],
             ['config@example.com', null, 'config@example.com', null],
-            ['basic@example.com', 'basic@example.com', 'config@example.com', null],
+            ['config@example.com', 'basic@example.com', 'config@example.com', null],
             ['data@example.com', 'basic@example.com', 'config@example.com', 'data@example.com'],
             ['data@example.com', 'basic@example.com', null, 'data@example.com'],
             ['data@example.com', null, 'config@example.com', 'data@example.com'],


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

When both the shop owner's email in basic information and the sender address in the mailer settings are configured, the first one takes precedence. Depending on the two addresses and the used mail server this can cause the emails to be rejected.

### 2. What does this change do, exactly?

Change the order in which the configuration is checked to make sure the mailer settings take precedence.

### 3. Describe each step to reproduce the issue or behaviour.

- configure shop owner's email address in basic information
- configure sender address in mailer settings
- if the domain is different the mail server will most likely deny the send request

### 4. Please link to the relevant issues (if any).

- #1639

(Also, this PR builds upon https://github.com/shopware/platform/pull/1640)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
