### PR TITLE
Adding salutation and title to address

### DIFF
--- a/src/Core/Checkout/Customer/SalesChannel/ListAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ListAddressRoute.php
@@ -65,6 +65,7 @@ class ListAddressRoute extends AbstractListAddressRoute
     {
         $criteria
             ->addAssociation('country')
+            ->addAssociation('salutation')
             ->addFilter(new EqualsFilter('customer_address.customerId', $customer->getId()));
 
         $this->eventDispatcher->dispatch(

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -462,6 +462,7 @@ class RegisterRoute extends AbstractRegisterRoute
         $mappedData = $addressData->only(
             'firstName',
             'lastName',
+            'title',
             'salutationId',
             'street',
             'zipcode',

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
@@ -432,8 +432,10 @@ class SalesChannelContextFactory extends AbstractSalesChannelContextFactory
         $criteria->setTitle('context-factory::customer');
         $criteria->addAssociation('salutation');
         $criteria->addAssociation('defaultPaymentMethod');
+        $criteria->addAssociation('defaultBillingAddress.salutation');
         $criteria->addAssociation('defaultBillingAddress.country');
         $criteria->addAssociation('defaultBillingAddress.countryState');
+        $criteria->addAssociation('defaultShippingAddress.salutation');
         $criteria->addAssociation('defaultShippingAddress.country');
         $criteria->addAssociation('defaultShippingAddress.countryState');
 
@@ -459,6 +461,7 @@ class SalesChannelContextFactory extends AbstractSalesChannelContextFactory
 
         $criteria = new Criteria($addressIds);
         $criteria->setTitle('context-factory::addresses');
+        $criteria->addAssociation('salutation');
         $criteria->addAssociation('country');
         $criteria->addAssociation('countryState');
 


### PR DESCRIPTION
### 1. Why is this change necessary?
- address.salutation is empty in storefront/component/address/address.html.twig
- title from the registration is not saved in the address during registration 

### 2. What does this change do, exactly?
- adding salutation it to the address
- adding title to the mapped data in RegisterRoute

### 3. Describe each step to reproduce the issue or behaviour.
- adding an address and missing the salutation and title in the checkout.
- register with a title and missing it in the address after registration
