### PR TITLE
Support IdStruct in TransactionTransformer, so primary keys can be pre-determined

### DIFF
--- a/src/Core/Checkout/Cart/Order/Transformer/TransactionTransformer.php
+++ b/src/Core/Checkout/Cart/Order/Transformer/TransactionTransformer.php
@@ -2,9 +2,12 @@
 
 namespace Shopware\Core\Checkout\Cart\Order\Transformer;
 
+use Shopware\Core\Checkout\Cart\Order\IdStruct;
+use Shopware\Core\Checkout\Cart\Order\OrderConverter;
 use Shopware\Core\Checkout\Cart\Transaction\Struct\Transaction;
 use Shopware\Core\Checkout\Cart\Transaction\Struct\TransactionCollection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Struct\Struct;
 
 class TransactionTransformer
 {
@@ -27,9 +30,21 @@ class TransactionTransformer
         Context $context
     ): array {
         return [
+            'id' => self::getId($transaction),
             'paymentMethodId' => $transaction->getPaymentMethodId(),
             'amount' => $transaction->getAmount(),
             'stateId' => $stateId,
         ];
+    }
+
+    private static function getId(Struct $struct): ?string
+    {
+        /** @var IdStruct|null $idStruct */
+        $idStruct = $struct->getExtensionOfType(OrderConverter::ORIGINAL_ID, IdStruct::class);
+        if ($idStruct !== null) {
+            return $idStruct->getId();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

When creating an order via the OrderPersister, it is easier to keep track of transaction entities when the primary key is pre-determined instead of arbitrarily generated. The same principle is already possible with deliveries, so this should be no problem, I guess.

### 2. What does this change do, exactly?

When you create an order via the OrderPersister with transactions, you can now attach an IdStruct to the transactions that will determine their primary key.

### 3. Describe each step to reproduce the issue or behaviour.

1. Prepare a cart.
2. Add a transaction to the cart.
3. Attach an IdStruct to the transaction with your desired primary key.
4. Pass the cart to the OrderPersister.
5. Find your transaction by its primary key.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
