### PR TITLE
feat: Reformat output of system:config:get

### DIFF
--- a/changelog/_unreleased/2021-03-30-add-better-output-format-to-system-config-get.md
+++ b/changelog/_unreleased/2021-03-30-add-better-output-format-to-system-config-get.md
@@ -1,0 +1,8 @@
+---
+title: Better output format for system-config-get
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Format output of the command `system:config:get` as "key => entry"

--- a/src/Core/System/SystemConfig/Command/ConfigGet.php
+++ b/src/Core/System/SystemConfig/Command/ConfigGet.php
@@ -34,17 +34,30 @@ class ConfigGet extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $configKey = $input->getArgument('key');
         $value = $this->systemConfigService->get(
-            $input->getArgument('key'),
+            $configKey,
             $input->getOption('salesChannelId')
         );
 
-        if (\is_array($value)) {
-            $output->writeln($value);
-        } else {
-            $output->writeln((string) $value);
+        if (!\is_array($value)) {
+            $value = [$configKey => $value];
         }
 
+        $this->writeConfig($output, $value);
+
         return 0;
+    }
+
+    private function writeConfig(OutputInterface $output, array $config, int $level = 0): void
+    {
+        foreach ($config as $key => $entry) {
+            if (\is_array($entry)) {
+                $output->writeln($key);
+                $this->writeConfig($output, $entry, $level + 1);
+            } else {
+                $output->writeln(str_repeat(' ', $level * 2) . "{$key} => {$entry}");
+            }
+        }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
I just discovered the command `system:config:get` but I find its usage very difficult if you fetch several entries, so it is now formatted such that the config key is visible.

### 2. What does this change do, exactly?
Reformat output of system:config:get

### 3. Describe each step to reproduce the issue or behaviour.
`php bin/console system:config:get core`

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
