### PR TITLE
NEXT-14586 Resolve Symfony 5.1 deprecations

### DIFF
--- a/changelog/_unreleased/2021-04-01-resolve-symfony-5-1-deprecations.md
+++ b/changelog/_unreleased/2021-04-01-resolve-symfony-5-1-deprecations.md
@@ -1,0 +1,9 @@
+---
+title: Resolve Symfony 5.1 deprecations
+issue: NEXT-14586
+author: Dominik Brader
+author_email: dominik@brader.co.at
+author_github: @TheKeymaster
+---
+# Core
+* Changed `Core/Framework/Resources/config/packages/dev/routing.yaml` and `Core/Framework/Resources/config/packages/routing.yaml` to address the Symfony 5.1 routing deprecation, by explicitly setting `framework.router.utf8` to `true`.

--- a/src/Core/Framework/Resources/config/packages/dev/routing.yaml
+++ b/src/Core/Framework/Resources/config/packages/dev/routing.yaml
@@ -1,3 +1,4 @@
 framework:
     router:
         strict_requirements: true
+        utf8: true

--- a/src/Core/Framework/Resources/config/packages/routing.yaml
+++ b/src/Core/Framework/Resources/config/packages/routing.yaml
@@ -1,3 +1,4 @@
 framework:
     router:
         strict_requirements: ~
+        utf8: true


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Since Symfony 5.1 **not** setting the `framework.router.utf8` option is considered deprecated. See:

* https://github.com/symfony/framework-bundle/blob/5.x/CHANGELOG.md#510
* https://github.com/symfony/framework-bundle/commit/f7019239da09fe5f98bec7b2afebb01cf16a8816

Without these change my plugin tests fail, as the Symfony Deprecation Helper gets mad at me :(.

![image](https://user-images.githubusercontent.com/20555112/113322716-55eb1c80-9315-11eb-9e09-16165b6b2bb5.png)


### 2. What does this change do, exactly?
Set the `utf8` option to be `true`.

### 3. Describe each step to reproduce the issue or behaviour.
Run tests that interact with the Symfony/Shopware router.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-14586

### 5. Checklist

- [ ] ~~I have written tests and verified that they fail without my change~~ => => Not applicable
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] ~~I have written or adjusted the documentation according to my changes~~ => Not applicable
- [ ] ~~This change has comments for package types, values, functions, and non-obvious lines of code~~ => Not applicable
- [x] I have read the contribution requirements and fulfil them.
