### PR TITLE
Remove the word honeypot from its div class to remove ability for bot…

### DIFF
--- a/changelog/_unreleased/2021-04-06-honeypots-remove-label.md
+++ b/changelog/_unreleased/2021-04-06-honeypots-remove-label.md
@@ -7,4 +7,4 @@ author_github: @juripetersen
 ---
 # Storefront
 * Changed class from ```div class="captcha--honeypot"``` to ```div class="register-shopware-surname"``` to remove the appearance of the word honeypot
-since it labels the honeypot and bots can ignore this field just by reading this string.
+since it labels the honeypot and bots can ignore this field just by reading this string. Otherwise bots can still register users programmatically while ignoring the honeypot

--- a/changelog/_unreleased/2021-04-06-honeypots-remove-label.md
+++ b/changelog/_unreleased/2021-04-06-honeypots-remove-label.md
@@ -6,5 +6,5 @@ author_email: juri.petersen@visuellverstehen.de
 author_github: @juripetersen
 ---
 # Storefront
-* Changed class from ```div class="captcha--honeypot"``` to ```div class="register-shopware-surname"``` to remove the appearance of the word honeypot
+* Changed class from `div class="captcha--honeypot"` to `div class="register-shopware-surname"` to remove the appearance of the word honeypot
 since it labels the honeypot and bots can ignore this field just by reading this string. Otherwise bots can still register users programmatically while ignoring the honeypot

--- a/changelog/_unreleased/2021-04-06-honeypots-remove-label.md
+++ b/changelog/_unreleased/2021-04-06-honeypots-remove-label.md
@@ -1,0 +1,10 @@
+---
+title: Honeypots can be ignored by bots since its labeled
+issue: NEXT-14628
+author: Juri Petersen
+author_email: juri.petersen@visuellverstehen.de
+author_github: @juripetersen
+---
+# Storefront
+* Changed class from ```div class="captcha--honeypot"``` to ```div class="register-shopware-surname"``` to remove the appearance of the word honeypot
+since it labels the honeypot and bots can ignore this field just by reading this string.

--- a/src/Storefront/Resources/views/storefront/component/captcha/honeypot.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/honeypot.html.twig
@@ -1,5 +1,5 @@
 {% block component_captcha_honeypot %}
-    <div class="captcha--honeypot">
+    <div class="register-shopware-surname">
         {% block component_captcha_honeypot_input %}
             <input type="text"
                    name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\HoneypotCaptcha::CAPTCHA_REQUEST_PARAMETER') }}"

--- a/src/Storefront/Resources/views/storefront/component/captcha/honeypot.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/honeypot.html.twig
@@ -1,5 +1,5 @@
 {% block component_captcha_honeypot %}
-    <div class="register-shopware-surname">
+    <div class="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\HoneypotCaptcha::CAPTCHA_REQUEST_PARAMETER') }}">
         {% block component_captcha_honeypot_input %}
             <input type="text"
                    name="{{ constant('Shopware\\Storefront\\Framework\\Captcha\\HoneypotCaptcha::CAPTCHA_REQUEST_PARAMETER') }}"


### PR DESCRIPTION
…s to ignore this field

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The word honeypot is existant as a class for the wrapper div in ```honeypot.html.twig```. 
Bots or scrapers use labels and classes to identify honeypots and we had occurences where the Shopware Honeypot does not work because it is ignored.

### 2. What does this change do, exactly?
Change the class of div in ```honeypot.html.twig``` from ```captcha--honeypot``` to ```register-shopware-surname```

### 3. Describe each step to reproduce the issue or behaviour.
Hard to reproduce because you will need a bot that registers accounts and uses a mechanism to identify honeypots by labels and classes.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-14628
https://github.com/shopware/platform/issues/1760

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
