### PR TITLE
Add datetime-local and time-local to system-config

### DIFF
--- a/changelog/_unreleased/2021-03-25-add-datetime-local-to-system-config.md
+++ b/changelog/_unreleased/2021-03-25-add-datetime-local-to-system-config.md
@@ -1,0 +1,10 @@
+---
+title: Add datetime-local to SystemConfig field types
+author: Maximilian Ruesch
+author_email: maximilian.ruesch@pickware.de
+---
+# Core
+* Added datetime-local to config field types in SystemConfig
+---
+# Administration
+* Added datetime-local type to `sw-form-field-renderer`

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-datepicker/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-datepicker/index.js
@@ -66,9 +66,9 @@ Component.register('sw-datepicker', {
         dateType: {
             type: String,
             default: 'date',
-            validValues: ['time', 'date', 'datetime', 'datetime-local'],
+            validValues: ['time', 'time-local', 'date', 'datetime', 'datetime-local'],
             validator(value) {
-                return ['time', 'date', 'datetime', 'datetime-local'].includes(value);
+                return ['time', 'time-local', 'date', 'datetime', 'datetime-local'].includes(value);
             }
         },
 
@@ -131,7 +131,7 @@ Component.register('sw-datepicker', {
         },
 
         noCalendar() {
-            return this.dateType === 'time';
+            return this.dateType === 'time' || this.dateType === 'time-local';
         },
 
         enableTime() {
@@ -409,6 +409,16 @@ Component.register('sw-datepicker', {
 
             if (this.dateType === 'time') {
                 dateFormat = 'H:i:S+00:00';
+                altFormat = 'H:i';
+            }
+
+            if (this.dateType === 'time-local') {
+                const currentOffset = -1 * new Date().getTimezoneOffset();
+                const hours = Math.floor(currentOffset / 60);
+                const minutes = currentOffset - (hours * 60);
+                const offsetString = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+
+                dateFormat = `H:i:S+${offsetString}`;
                 altFormat = 'H:i';
             }
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-form-field-renderer/index.js
@@ -152,12 +152,20 @@ Component.register('sw-form-field-renderer', {
                 return { type: 'date', dateType: 'datetime' };
             }
 
+            if (this.type === 'datetime-local') {
+                return { type: 'date', dateType: 'datetime-local' };
+            }
+
             if (this.type === 'date') {
                 return { type: 'date', dateType: 'date' };
             }
 
             if (this.type === 'time') {
                 return { type: 'date', dateType: 'time' };
+            }
+
+            if (this.type === 'time-local') {
+                return { type: 'date', dateType: 'time-local' };
             }
 
             return { type: this.type };

--- a/src/Core/System/SystemConfig/Schema/config.xsd
+++ b/src/Core/System/SystemConfig/Schema/config.xsd
@@ -54,8 +54,10 @@
             <xs:enumeration value="bool"/>
             <xs:enumeration value="checkbox"/>
             <xs:enumeration value="datetime"/>
+            <xs:enumeration value="datetime-local"/>
             <xs:enumeration value="date"/>
             <xs:enumeration value="time"/>
+            <xs:enumeration value="time-local"/>
             <xs:enumeration value="colorpicker"/>
             <xs:enumeration value="single-select"/>
             <xs:enumeration value="multi-select"/>


### PR DESCRIPTION
### 1. Why is this change necessary?
The localized datetime field `datetime-local` was added in the commit ce3d73d99c061c77420c9183dbe289b545871e89 . This field type is not available in SystemConfig and the respective `sw-form-field-renderer` in the administration.
A new time-local field was also missing in the commit.

### 2. What does this change do, exactly?
It adds the `datetime-local` and `time-local` types to the SystemConfig and the `sw-form-field-renderer` and the `time-local` logic to the `sw-datepicker` component.

Below is a view of the changes in the administration and the respective values database:
![image](https://user-images.githubusercontent.com/78490564/113838859-7b51ad80-978f-11eb-9125-4b337aaaf7b2.png)
![image](https://user-images.githubusercontent.com/78490564/113838898-83115200-978f-11eb-899c-e20c4c3028b0.png)


### 3. Describe each step to reproduce the issue or behaviour.
1. In a plugin config file of choice, create an `input-field` with type `datetime-local` or `time-local`
2. Log in administration and go to the config of the selected plugin
3. Shopware will show an error notification saying that the `datetime-local` (or `time-local`) type is not registered

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.