### PR TITLE
PageLoader in ErrorController

### DIFF
--- a/changelog/_unreleased/2021-04-08-page-load-event-on-404-error.md
+++ b/changelog/_unreleased/2021-04-08-page-load-event-on-404-error.md
@@ -1,0 +1,10 @@
+---
+title: Page load event on 404 error
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.me 
+author_github: runelaenen
+---
+# Storefront
+* Changed the `ErrorController` to use the ErrorPageLoader for every error and template.
+* `PageLoadedEvents` will be triggered also when no 404 template is configured.

--- a/src/Storefront/Controller/ErrorController.php
+++ b/src/Storefront/Controller/ErrorController.php
@@ -66,24 +66,20 @@ class ErrorController extends StorefrontController
             $request->attributes->set('navigationId', $context->getSalesChannel()->getNavigationCategoryId());
 
             $salesChannelId = $context->getSalesChannel()->getId();
-            $cmsErrorLayoutId = $this->systemConfigService->getString('core.basicInformation.http404Page', $salesChannelId);
-            if ($cmsErrorLayoutId !== '' && $is404StatusCode) {
-                $errorPage = $this->errorPageLoader->load($cmsErrorLayoutId, $request, $context);
+            $cms404ErrorLayoutId = $this->systemConfigService->getString('core.basicInformation.http404Page', $salesChannelId);
 
-                $response = $this->renderStorefront(
-                    '@Storefront/storefront/page/content/index.html.twig',
-                    ['page' => $errorPage]
-                );
+            if ($cms404ErrorLayoutId !== '' ) {
+                $errorPage = $this->errorPageLoader->load($cms404ErrorLayoutId, $request, $context);
+                $errorTemplate = '@Storefront/storefront/page/content/index.html.twig';
             } else {
-                $errorTemplate = $this->errorTemplateResolver->resolve($exception, $request);
-
-                if (!$request->isXmlHttpRequest()) {
-                    $header = $this->headerPageletLoader->load($request, $context);
-                    $errorTemplate->setHeader($header);
-                }
-
-                $response = $this->renderStorefront($errorTemplate->getTemplateName(), ['page' => $errorTemplate]);
+                $errorPage = $this->errorPageLoader->load(null, $request, $context);
+                $errorTemplate = $this->errorTemplateResolver->resolve($exception, $request)->getTemplateName();
             }
+
+            $response = $this->renderStorefront(
+                $errorTemplate,
+                ['page' => $errorPage]
+            );
 
             if ($exception instanceof HttpException) {
                 $response->setStatusCode($exception->getStatusCode());

--- a/src/Storefront/Page/Navigation/Error/ErrorPageLoader.php
+++ b/src/Storefront/Page/Navigation/Error/ErrorPageLoader.php
@@ -50,18 +50,18 @@ class ErrorPageLoader implements ErrorPageLoaderInterface
      * @throws MissingRequestParameterException
      * @throws PageNotFoundException
      */
-    public function load(string $cmsErrorLayoutId, Request $request, SalesChannelContext $context): ErrorPage
+    public function load(?string $cms404ErrorLayoutId, Request $request, SalesChannelContext $context): ErrorPage
     {
         $page = $this->genericLoader->load($request, $context);
         $page = ErrorPage::createFrom($page);
 
-        $pages = $this->cmsPageLoader->load($request, new Criteria([$cmsErrorLayoutId]), $context);
+        if ($cms404ErrorLayoutId) {
+            $pages = $this->cmsPageLoader->load($request, new Criteria([$cms404ErrorLayoutId]), $context);
 
-        if (!$pages->has($cmsErrorLayoutId)) {
-            throw new PageNotFoundException($cmsErrorLayoutId);
+            if ($pages->has($cms404ErrorLayoutId)) {
+                $page->setCmsPage($pages->get($cms404ErrorLayoutId));
+            }
         }
-
-        $page->setCmsPage($pages->get($cmsErrorLayoutId));
 
         $this->eventDispatcher->dispatch(new ErrorPageLoadedEvent($page, $context, $request));
 

--- a/src/Storefront/Page/Navigation/Error/ErrorPageLoaderInterface.php
+++ b/src/Storefront/Page/Navigation/Error/ErrorPageLoaderInterface.php
@@ -11,5 +11,5 @@ use Symfony\Component\HttpFoundation\Request;
  */
 interface ErrorPageLoaderInterface
 {
-    public function load(string $cmsErrorLayoutId, Request $request, SalesChannelContext $context): ErrorPage;
+    public function load(?string $cms404ErrorLayoutId, Request $request, SalesChannelContext $context): ErrorPage;
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
In the ErrorController, the GenericPageLoadedEvent is not dispatched when a 404 page is rendered and no CMS Layout is configured as error page.

### 2. What does this change do, exactly?
Always use the ErrorPageLoader, also when no CmsLayout is configured.

### 3. Describe each step to reproduce the issue or behaviour.
 - Do not configure a 404 error page.
 - Go to a non-existent page
 - The ErrorLoader will not be used, causing no PageLoaded events to be dispatched (Which can cause broken headers & footers in projects if custom code relies on these events)

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1762

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
