### PR TITLE
Fix exact matches on plugin name

### DIFF
--- a/changelog/_unreleased/2021-04-08-create-migration-plugin-name-exact-match.md
+++ b/changelog/_unreleased/2021-04-08-create-migration-plugin-name-exact-match.md
@@ -1,0 +1,9 @@
+---
+title: Create migration plugin name exact match
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.me 
+author_github: runelaenen
+---
+# Core
+* Added a check to allow exact matches if multiple plugins are found.

--- a/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
@@ -90,13 +90,19 @@ class CreateMigrationCommand extends Command
             }
 
             if (\count($pluginBundles) > 1) {
-                throw new \RuntimeException(
-                    sprintf(
-                        'More than one pluginname starting with "%s" was found: %s',
-                        $pluginName,
-                        implode(';', array_keys($pluginBundles))
-                    )
-                );
+                $pluginBundles = array_filter($pluginBundles, static function (Plugin $value) use ($pluginName) {
+                    return $pluginName === $value->getName();
+                });
+
+                if (\count($pluginBundles) > 1) {
+                    throw new \RuntimeException(
+                        sprintf(
+                            'More than one pluginname starting with "%s" was found: %s',
+                            $pluginName,
+                            implode(';', array_keys($pluginBundles))
+                        )
+                    );
+                }
             }
 
             $pluginBundle = array_values($pluginBundles)[0];


### PR DESCRIPTION
### 1. Why is this change necessary?
When running the following command, it triggers the error from the title. When a perfect match is available, it should not trigger the error.

### 2. What does this change do, exactly?
Add a second check if there is 1 plugin with an exact match. If there is, proceed with this plugin.
Partial plugin check stays possible. (If only 1 plugin starting with 'SwagAbc' is available, this plugin will still be selected correctly)

### 3. Describe each step to reproduce the issue or behaviour.
- Have 2 plugins: SwagTest and SwagTestPlugin
- Run the command `bin/console database:create-migration --plugin SwagTest --name TestMigration`
You would expect the command to choose the correct plugin, however both the plugins are selected and the command fails. The PR fixes this.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1719

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
