### PR TITLE
Make name column nullable

### DIFF
--- a/changelog/_unreleased/2021-04-08-cms-page-translation-name-nullable.md
+++ b/changelog/_unreleased/2021-04-08-cms-page-translation-name-nullable.md
@@ -1,0 +1,9 @@
+---
+title: Cms Page Translation Name Nullable
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.me 
+author_github: runelaenen
+---
+# Core
+* Added migration to make `name` column in `cms_page_translation` nullable.

--- a/src/Core/Migration/Migration1617896006MakeNameNullable.php
+++ b/src/Core/Migration/Migration1617896006MakeNameNullable.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @deprecated tag:v6.5.0 - Will be deleted. Migrations are now namespaced by major version
+ */
+class Migration1617896006MakeNameNullable extends \Shopware\Core\Migration\V6_4\Migration1617896006MakeNameNullable
+{}

--- a/src/Core/Migration/V6_4/Migration1617896006MakeNameNullable.php
+++ b/src/Core/Migration/V6_4/Migration1617896006MakeNameNullable.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_4;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1617896006MakeNameNullable extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1617896006;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $sql = <<<SQL
+ALTER TABLE `cms_page_translation` MODIFY COLUMN `name` VARCHAR(255) NULL;
+SQL;
+
+        $connection->executeUpdate($sql);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
When saving a CMS page, which has custom fields, in a different (non default) language, shopware returns an 500.

### 2. What does this change do, exactly?
Allow null for name, as it should fall back on the main language.

### 3. Describe each step to reproduce the issue or behaviour.
- Save a cms page (with custom fields, as you cannot save the name itself and there are no other fields)
- Get 500 error: `detail: "An exception occurred while executing 'INSERT INTO `cms_page_translation` (`cms_page_id`, `language_id`, `name`, `custom_fields`, `created_at`) VALUES (?, ?, ?, ?, ?)' with params ["\xc2\x03\x2d\x35\x3e\x80\x46\xa4\xae\xa4\x5e\xdd\x69\xaa\xd0\x56", "\x56\x9f\xf2\x9d\xee\x9b\x40\xd9\xb0\x46\x80\x7f\x02\x3f\xe2\x9c", null, "{\"custom_field\":false}", "2021-03-17 09:06:32.771"]:↵↵SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'name' cannot be null"`

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1712

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
