### PR TITLE
Remove sidebar flash on cookie accept all

### DIFF
--- a/changelog/_unreleased/2021-04-08-sidebar-flash-on-cookie-accept-all.md
+++ b/changelog/_unreleased/2021-04-08-sidebar-flash-on-cookie-accept-all.md
@@ -1,0 +1,10 @@
+---
+title: Sidebar flash on cookie accept all
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.me 
+author_github: runelaenen
+---
+# Storefront
+* Changed `cookie-configuration.plugin.js` to not flash the cookie sidebar when Accept All is clicked from the cookie bar.
+* Added `loadIntoMemory` to the `acceptAllCookies` method. If passed true, the off canvas menu will not be opened, and the DOM will be loaded into memory.


### PR DESCRIPTION
### 1. Why is this change necessary?
When clicking the Accept All button, the sidebar flashes in for a small moment. This should not happen.
The loader should be on the cookie bar, and the sidebar should never be seen by the visitor.

### 2. What does this change do, exactly?
Change the javascript plugin to not show the sidebar when Accept All is clicked from the cookie bar.

### 3. Describe each step to reproduce the issue or behaviour.
- Click Accept All. The sidebar will flash for a second

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1641

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
