### PR TITLE
add hint about docker resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ A full installation guide covering different dev environments is available in th
 
 *For the impatient reader, here is a tl;dr using docker.*
 
+Make sure to assign enough resources, especially memory, to Docker to make this work. 
+
 Let's start by cloning the development template:
 
 ```bash


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

It took me one day to install the Shopware development environment because it always stopped on step 32. After some experimentation I found out that I had the default resource settings for Docker, i.e. 1 GB of memory (RAM). Because of that the ElasticSearch and MySQL container where killed due to OOM issues and the Shopware installation stopped.

### 2. What does this change do, exactly?

It will give a hint to assign enough resources, especially memory, to Docker.

### 3. Describe each step to reproduce the issue or behaviour.

- configure Docker to only use 1 GB of memory
- install the Shopware development environment via Docker

### 4. Please link to the relevant issues (if any).

- none

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
