### PR TITLE
Allow a guest account to set the payment for an order

### DIFF
--- a/changelog/_unreleased/2021-04-12-allow-guest-account-to-set-payment-for-order.md
+++ b/changelog/_unreleased/2021-04-12-allow-guest-account-to-set-payment-for-order.md
@@ -1,0 +1,8 @@
+---
+title: Allows a guest account to set the payment for an order
+author: Steven de Vries
+author_email: steven@enrise.com
+author_github: @StevendeVries
+---
+# API
+* Changed annotation for `setPayment()` in `Core/Checkout/Order/SalesChannel/SetPaymentOrderRoute.php` to allow a guest account to reinitialize payment when the previous payment failed

--- a/src/Core/Checkout/Order/SalesChannel/SetPaymentOrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/SetPaymentOrderRoute.php
@@ -74,7 +74,7 @@ class SetPaymentOrderRoute extends AbstractSetPaymentOrderRoute
      *          @OA\JsonContent(ref="#/components/schemas/SuccessResponse")
      *     )
      * )
-     * @LoginRequired()
+     * @LoginRequired(allowGuest=true)
      * @Route(path="/store-api/order/payment", name="store-api.order.set-payment", methods={"POST"})
      */
     public function setPayment(Request $request, SalesChannelContext $context): SetPaymentOrderRouteResponse


### PR DESCRIPTION
### 1. Why is this change necessary?
When going through the checkout flow with a guest account and the payment fails (aborting for instance), it's not possible to restart the payment. 

### 2. What does this change do, exactly?
It allows to set the payment for an order using a guest account

### 3. Describe each step to reproduce the issue or behavior.
When a payment fails you want to set the payment again for this order using the Store API, for a guest account this call is prohibited since it requires a "full" account

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
