### PR TITLE
Fix disabled theme manager fields

### DIFF
--- a/changelog/_unreleased/2021-04-16-parameter-editable-in-theme.json-does-not-work-consistently.md
+++ b/changelog/_unreleased/2021-04-16-parameter-editable-in-theme.json-does-not-work-consistently.md
@@ -1,0 +1,6 @@
+---
+title: Parameter "editable" in theme.json doesn't work consistently
+issue: NEXT-14550
+---
+# Administration
+* Adjusted the conditions to disable configuration fields which are set to `editable = false` within theme.json in `src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig`

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -197,7 +197,7 @@
                                                                         :options="field.options"
                                                                         :label="!field.label ? '' : field.label"
                                                                         :helpText="!field.helpText ? null : field.helpText"
-                                                                        :disabled="!acl.can('theme.editor')"
+                                                                        :disabled="!acl.can('theme.editor') || themeConfig[fieldName].editable === false"
                                                                         v-model="themeConfig[fieldName].value">
                                                                     </sw-field>
 
@@ -206,7 +206,7 @@
                                                                         type="url"
                                                                         :label="!field.label ? '' : field.label"
                                                                         :helpText="!field.helpText ? null : field.helpText"
-                                                                        :disabled="!acl.can('theme.editor')"
+                                                                        :disabled="!acl.can('theme.editor') || themeConfig[fieldName].editable === false"
                                                                         v-model="themeConfig[fieldName].value">
                                                                     </sw-field>
 
@@ -243,10 +243,10 @@
                                                                     </sw-field>
 
                                                                     <sw-form-field-renderer
-                                                                        v-else-if="themeConfig[fieldName].editable !== false"
+                                                                        v-else
                                                                         v-bind="getBind(field)"
                                                                         v-model="themeConfig[fieldName].value"
-                                                                        :disabled="!acl.can('theme.editor')">
+                                                                        :disabled="!acl.can('theme.editor') || themeConfig[fieldName].editable === false">
                                                                     </sw-form-field-renderer>
                                                                 </template>
                                                             </div>


### PR DESCRIPTION
## Parameter "editable" in theme.json doesn't work consistently
Thank you very much for helping us with solving our issues regarding the "editable=false" parameter in the theme.json. We appreciate it very much! Unfortunately, both fixes doesn't work consistently.

![current](https://user-images.githubusercontent.com/82637348/115006982-c8c5cd00-9ea9-11eb-92d0-52921a570207.png)
![fixed](https://user-images.githubusercontent.com/82637348/115006989-ca8f9080-9ea9-11eb-9ee2-01021ac9fca7.png)



### 1. Why is this change necessary?
Currently some configuration fields are hidden but leave a blank space in the theme configuration, other theme configuration fields are beeing disabled. Since theme configuration fields cannot be removed without residue, it would be great if this can be aligned.

### 2. What does this change do, exactly?
The adjustment doesn't hide some "editable=false" configuration fields anymore instead it disables all theme configuration fields with the parameter "editable=false".

### 3. Describe each step to reproduce the issue or behaviour.
Add different config fields and set the parameter 'editable' to 'false'. There are some fields available so we've tested the filed types: text, number, color, media, url, textarea, custom, datetime. Some theme configuration fields will be hidden, some will be disabled the url type isn't affected at all.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13834
https://issues.shopware.com/issues/NEXT-14550

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
