### PR TITLE
do not assume address exists

### DIFF
--- a/changelog/_unreleased/2021-04-17-fix-missing-null-check-for-customer-addresses-which-prevented-login.md
+++ b/changelog/_unreleased/2021-04-17-fix-missing-null-check-for-customer-addresses-which-prevented-login.md
@@ -1,0 +1,6 @@
+---
+title: Run app registration during app update if necessary
+issue: -
+---
+# Core
+* Made `SalesChannelContextFactory` more resilient with regards to missing customer addresses.

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
@@ -464,8 +464,14 @@ class SalesChannelContextFactory extends AbstractSalesChannelContextFactory
 
         $addresses = $this->addressRepository->search($criteria, $context);
 
-        $customer->setActiveBillingAddress($addresses->get($billingAddressId));
-        $customer->setActiveShippingAddress($addresses->get($shippingAddressId));
+        $billingAddress = $addresses->get($billingAddressId);
+        if (null !== $billingAddress) {
+            $customer->setActiveBillingAddress($billingAddress);
+        }
+        $shippingAddress = $addresses->get($shippingAddressId);
+        if (null !== $shippingAddress) {
+            $customer->setActiveShippingAddress($shippingAddress);
+        }
 
         return $customer;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
During our tests exceptions occured during login because the `SalesChannelContextRestorer` couldn't properly resolve the address again.

### 2. What does this change do, exactly?
This change checks if an address really exists before trying to set it to the customer. Therewith it makes the whole process a bit more resilient.

### 3. Describe each step to reproduce the issue or behaviour.
Unfortunately I couldn't reproduce it for myself. Instead I activated the debug mode and asked my client to retry so he could send me the stack trace:

![image](https://user-images.githubusercontent.com/277531/115122154-b8e7df00-9fb6-11eb-8197-5b8ea6ee5ed2.png)

I can't rule out the possibility that a plugin is involved in the problem, but I thought it wouldn't hurt to check for the existence of the objects before passing them to a setter that expects a non-nullable argument.

### 4. Please link to the relevant issues (if any).
no issue found

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
