### PR TITLE
Fix fullscreen modals without Bootstrap Shopware skin

### DIFF
--- a/changelog/_unreleased/2021-04-19-fullscreen-modal-without-bootstrap-shopware-skin.md
+++ b/changelog/_unreleased/2021-04-19-fullscreen-modal-without-bootstrap-shopware-skin.md
@@ -1,0 +1,8 @@
+---
+title: Fullscreen modal is displayed without Bootstrap Shopware skin
+author: Joshua Behrens
+author_email: behrens@heptacom.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Moved `.is-fullscreen` modifier class for `.modal`from Bootstrap Shopware skin into modal component style

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_modal.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_modal.scss
@@ -16,4 +16,28 @@ https://getbootstrap.com/docs/4.3/components/modal/
     .modal-close:focus {
         outline: 0;
     }
+
+    &.is-fullscreen {
+        .modal-dialog,
+        .modal-content {
+            width: 100%;
+            height: 100%;
+            min-height: 100%;
+            position: absolute;
+            max-width: 100%;
+            top: 0;
+            left: 0;
+            margin: 0;
+            overflow-y: scroll;
+            box-shadow: none;
+        }
+
+        .modal-dialog,
+        .modal-content,
+        .modal-header,
+        .modal-body,
+        .modal-footer {
+            border-radius: 0;
+        }
+    }
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_modal.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_modal.scss
@@ -14,29 +14,3 @@ https://getbootstrap.com/docs/4.3/components/modal/
         margin: 0;
     }
 }
-
-.modal {
-    &.is-fullscreen {
-        .modal-dialog,
-        .modal-content {
-            width: 100%;
-            height: 100%;
-            min-height: 100%;
-            position: absolute;
-            max-width: 100%;
-            top: 0;
-            left: 0;
-            margin: 0;
-            overflow-y: scroll;
-            box-shadow: none;
-        }
-
-        .modal-dialog,
-        .modal-content,
-        .modal-header,
-        .modal-body,
-        .modal-footer {
-            border-radius: 0;
-        }
-    }
-}


### PR DESCRIPTION
### 1. Why is this change necessary?
When the Bootstrap Shopware skin is dropped in favor for a custom skin, the `.is-fullscreen` modifier class is missing. But we need it for e.g. the product image gallery.

### 2. What does this change do, exactly?
Move the `.is-fullscreen` class from the skin to the component.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a theme that has `@StorefrontBootstrap` instead of `@Storefront` as reference
2. Run `bin/console theme:compile`
3. Open a product with an image in the storefront
4. Click on the image to open a fullscreen gallery
5. You only see a gray thick line (which is just the border of the modal)
<img width="1434" alt="grafik" src="https://user-images.githubusercontent.com/1133593/115168254-86270f00-a0ba-11eb-8858-97cd05d233e1.png">

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Appendix

You do not have to create custom theme. You can simply remove the skin reference for testing:

<img width="444" alt="grafik" src="https://user-images.githubusercontent.com/1133593/115168062-ff723200-a0b9-11eb-8d4e-a0e1cda98563.png">
