### PR TITLE
Move outer padding into inner in sw-url-field secure prefix

### DIFF
--- a/changelog/_unreleased/2021-04-19-sw-url-field-secure-prefix-fully-clickable.md
+++ b/changelog/_unreleased/2021-04-19-sw-url-field-secure-prefix-fully-clickable.md
@@ -1,0 +1,8 @@
+---
+title: Make sw-url-field secure prefix fully clickable
+author: Joshua Behrens
+author_email: behrens@heptacom.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added SCSS that moves the padding of the sw-url-field prefix element into the inner text to make it fully clickable

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field/sw-url-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field/sw-url-field.scss
@@ -6,6 +6,8 @@ $sw-field-color-secure: $color-emerald-500;
         display: inline-flex;
         cursor: pointer;
         user-select: none;
+        margin: -12px -15px;
+        padding: 12px 15px;
 
         &.is--ssl {
             color: $sw-field-color-secure;


### PR DESCRIPTION
### 1. Why is this change necessary?
Improved admin UX for sw-url-field. See comparison:

Before
![sw-url-field-hover-before](https://user-images.githubusercontent.com/1133593/115174399-795de780-a0c9-11eb-9e9b-48482a32fe2c.gif)
After
![sw-url-field-hover-after](https://user-images.githubusercontent.com/1133593/115174409-7bc04180-a0c9-11eb-8240-8623f216b8f6.gif)

### 2. What does this change do, exactly?
It uses the padding the prefix area in the outer component has and uses the negative margin solution to remove that padding. To keep the padding on the element itself to make it look like before it is applied to the secure text. Effectively this makes the secure text bigger in mouse interaction.

### 3. Describe each step to reproduce the issue or behaviour.
1. Be in a hurry
2. Go on a journey to activate https on a sales channel domain
3. Misclick and do not activate https
4. Be confused
5. Concentrate
6. Click again and activate https
7. Click again to ensure you are not within the matrix
8. Save
9. Reload storefront
10. Get a 500 for a missing sales channel domain
11. Recognize you are still left with an http domain out of curiosity

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Appendix
According to a [research](https://www.youtube.com/watch?v=r2CbbBLVaPk) @jkrzefski has found, a user does not need to be in a hurry. Drunk is also a suitable state to fall for this design flaw.