### PR TITLE
add twig-blocks to pseudo-modal

### DIFF
--- a/changelog/_unreleased/2021-04-19-add-twig-blocks-to-pseudo-modal.md
+++ b/changelog/_unreleased/2021-04-19-add-twig-blocks-to-pseudo-modal.md
@@ -1,0 +1,9 @@
+---
+title: add twig-blocks to pseudo-modal
+issue: -
+author: Leon Weickert
+author_email: leon@devert.net 
+author_github: DevertNet
+---
+# Storefront
+* add twig blocks to `src/Storefront/Resources/views/storefront/component/pseudo-modal.html.twig` to improve customizability through plugins and themes.

--- a/src/Storefront/Resources/views/storefront/component/pseudo-modal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/pseudo-modal.html.twig
@@ -1,26 +1,40 @@
-<div class="js-pseudo-modal-template">
-    <div class="modal fade"
-         tabindex="-1"
-         role="dialog">
-        <div class="modal-dialog"
-             role="document">
-            <div class="modal-content">
-                <div class="modal-header only-close">
-                    <h5 class="modal-title js-pseudo-modal-template-title-element"></h5>
-                    <button type="button"
-                            class="modal-close close"
-                            data-dismiss="modal"
-                            aria-label="Close">
-                        {% block product_detail_zoom_modal_close_button_content %}
-                            <span aria-hidden="true">
-                                {% sw_icon 'x' style { 'size': 'sm' } %}
-                            </span>
+{% block component_pseudo_modal %}
+    <div class="js-pseudo-modal-template">
+        <div class="modal fade"
+            tabindex="-1"
+            role="dialog">
+            {% block component_pseudo_modal_dialog %}
+                <div class="modal-dialog"
+                    role="document">
+                    <div class="modal-content">
+                        {% block component_pseudo_modal_header %}
+                            <div class="modal-header only-close">
+                                {% block component_pseudo_modal_header_title %}
+                                    <div class="modal-title js-pseudo-modal-template-title-element h5"></div>
+                                {% endblock %}
+                                {% block component_pseudo_modal_header_close_button %}
+                                    <button type="button"
+                                            class="modal-close close"
+                                            data-dismiss="modal"
+                                            aria-label="Close">
+                                        {% block component_pseudo_modal_header_close_button_content %}
+                                            <span aria-hidden="true">
+                                                {% sw_icon 'x' style { 'size': 'sm' } %}
+                                            </span>
+                                        {% endblock %}
+                                    </button>
+                                {% endblock %}
+                            </div>
                         {% endblock %}
-                    </button>
+                        {% block component_pseudo_modal_body %}
+                            <div class="modal-body js-pseudo-modal-template-content-element">
+                                {% block component_pseudo_modal_body_cotent %}
+                                {% endblock %}
+                            </div>
+                        {% endblock %}
+                    </div>
                 </div>
-                <div class="modal-body js-pseudo-modal-template-content-element">
-                </div>
-            </div>
+            {% endblock %}
         </div>
     </div>
-</div>
+{% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
So far it is not well possible to customize the pseudo-modal.html.twig template.

### 2. What does this change do, exactly?
Add some twig blocks to the template.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
