### PR TITLE
Fix performance issue with incomplete theme config

### DIFF
--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -211,6 +211,11 @@ class ThemeService
 
         /** @var string[] $mediaIds */
         $mediaIds = array_keys($mediaItems);
+
+        if (count($mediaIds) === 0) {
+            return $resolvedConfig;
+        }
+
         $criteria = new Criteria($mediaIds);
         $criteria->setTitle('theme-service::resolve-media');
         $result = $this->mediaRepository->search($criteria, $context);


### PR DESCRIPTION
### 1. Why is this change necessary?
* Can cause big performance issues when your theme config contains no valid media entries
* It was very hard to debug, because DAL caching prevents tools like Tideways from discovering such an issue

### 2. What does this change do, exactly?
* In case your theme config contains no valid media entries, this fix will prevent shopware from reading ALL media items from DAL

### 3. Describe each step to reproduce the issue or behaviour.
* Change the UUIDs for logos in theme config to `null` and try to browse the storefront

### 4. Please link to the relevant issues (if any).
* None yet (please tell me if required)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

I am sure whether tests or documentation needs to be written for this minor change (code seems to be refactored in `trunk` anyway).