### PR TITLE
Added previous Throwable argument to StoreApiException, ThemeCompileException and friends

### DIFF
--- a/changelog/_unreleased/2021-04-20-add-more-ocassions-with-shopware-http-exception-previous-exception.md
+++ b/changelog/_unreleased/2021-04-20-add-more-ocassions-with-shopware-http-exception-previous-exception.md
@@ -1,0 +1,9 @@
+---
+title: Add and fill "previous exception" parameter to multiple exception types
+author: Joshua Behrens
+author_email: behrens@heptacom.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added an optional `\Throwable $previous` parameter to constructors of child classes of the `ShopwareHttpException` when missing
+* Changed calls to Exception constructors that have an additional parameter for the previous exception

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3436,11 +3436,6 @@ parameters:
 			path: src/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPass.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Language\\\\Exception\\\\LanguageForeignKeyDeleteException\\:\\:__construct\\(\\) has parameter \\$e with no typehint specified\\.$#"
-			count: 1
-			path: src/Core/System/Language/Exception/LanguageForeignKeyDeleteException.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\System\\\\Language\\\\LanguageValidator\\:\\:buildViolation\\(\\) has parameter \\$root with no typehint specified\\.$#"
 			count: 1
 			path: src/Core/System/Language/LanguageValidator.php
@@ -3496,9 +3491,64 @@ parameters:
 			path: src/Core/System/SalesChannel/Api/StructEncoder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Exception\\\\LanguageOfSalesChannelDomainDeleteException\\:\\:__construct\\(\\) has parameter \\$e with no typehint specified\\.$#"
+			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\DataAbstractionLayer\\\\SalesChannelIndexer\\:\\:iterate\\(\\) has parameter \\$offset with no typehint specified\\.$#"
 			count: 1
-			path: src/Core/System/SalesChannel/Exception/LanguageOfSalesChannelDomainDeleteException.php
+			path: src/Core/System/SalesChannel/DataAbstractionLayer/SalesChannelIndexer.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of static method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\RepositorySearchDetector\\:\\:isSearchRequired\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntitySearchResultLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelEntitySearchResultLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\EntityAggregatorInterface\\:\\:aggregate\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityAggregationResultLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Read\\\\EntityReaderInterface\\:\\:read\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelEntityLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\EntitySearcherInterface\\:\\:search\\(\\) expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Parameter \\#1 \\$definition of class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelEntityIdSearchResultLoadedEvent constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityDefinition\\|Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Entity\\\\SalesChannelDefinitionInterface given\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			count: 1
+			path: src/Core/System/SalesChannel/SalesChannel/ContextSwitchRoute.php
 
 		-
 			message: "#^Property Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity\\:\\:\\$maintenanceIpWhitelist \\(string\\) does not accept string\\|null\\.$#"

--- a/src/Core/Checkout/Cart/Address/Error/AddressValidationError.php
+++ b/src/Core/Checkout/Cart/Address/Error/AddressValidationError.php
@@ -24,7 +24,7 @@ class AddressValidationError extends Error
      */
     private $violations;
 
-    public function __construct(bool $isBillingAddress, ConstraintViolationList $violations)
+    public function __construct(bool $isBillingAddress, ConstraintViolationList $violations, ?\Throwable $previous = null)
     {
         $this->isBillingAddress = $isBillingAddress;
         $this->violations = $violations;
@@ -33,7 +33,7 @@ class AddressValidationError extends Error
             $isBillingAddress ? 'billing' : 'shipping'
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getId(): string

--- a/src/Core/Checkout/Cart/Address/Error/BillingAddressBlockedError.php
+++ b/src/Core/Checkout/Cart/Address/Error/BillingAddressBlockedError.php
@@ -13,7 +13,7 @@ class BillingAddressBlockedError extends Error
      */
     private $name;
 
-    public function __construct(string $name)
+    public function __construct(string $name, ?\Throwable $previous = null)
     {
         $this->name = $name;
 
@@ -22,7 +22,7 @@ class BillingAddressBlockedError extends Error
             $name
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getName(): string

--- a/src/Core/Checkout/Cart/Address/Error/ShippingAddressBlockedError.php
+++ b/src/Core/Checkout/Cart/Address/Error/ShippingAddressBlockedError.php
@@ -13,7 +13,7 @@ class ShippingAddressBlockedError extends Error
      */
     private $name;
 
-    public function __construct(string $name)
+    public function __construct(string $name, ?\Throwable $previous = null)
     {
         $this->name = $name;
 
@@ -22,7 +22,7 @@ class ShippingAddressBlockedError extends Error
             $name
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getName(): string

--- a/src/Core/Checkout/Cart/Error/IncompleteLineItemError.php
+++ b/src/Core/Checkout/Cart/Error/IncompleteLineItemError.php
@@ -15,13 +15,13 @@ class IncompleteLineItemError extends Error
      */
     private $property;
 
-    public function __construct(string $key, string $property)
+    public function __construct(string $key, string $property, ?\Throwable $previous = null)
     {
         $this->key = $key;
         $this->property = $property;
         $this->message = sprintf('Line item "%s" incomplete. Property "%s" missing.', $key, $property);
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getParameters(): array

--- a/src/Core/Checkout/Cart/Exception/CartDeserializeFailedException.php
+++ b/src/Core/Checkout/Cart/Exception/CartDeserializeFailedException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class CartDeserializeFailedException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Failed to deserialize cart.');
+        parent::__construct('Failed to deserialize cart.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Cart/Exception/CartTokenNotFoundException.php
+++ b/src/Core/Checkout/Cart/Exception/CartTokenNotFoundException.php
@@ -12,11 +12,11 @@ class CartTokenNotFoundException extends ShopwareHttpException
      */
     private $token;
 
-    public function __construct(string $token)
+    public function __construct(string $token, ?\Throwable $previous = null)
     {
         $this->token = $token;
 
-        parent::__construct('Cart with token {{ token }} not found.', ['token' => $token]);
+        parent::__construct('Cart with token {{ token }} not found.', ['token' => $token], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Cart/Exception/CustomerNotLoggedInException.php
+++ b/src/Core/Checkout/Cart/Exception/CustomerNotLoggedInException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CustomerNotLoggedInException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Customer is not logged in.');
+        parent::__construct('Customer is not logged in.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Cart/Exception/InsufficientPermissionException.php
+++ b/src/Core/Checkout/Cart/Exception/InsufficientPermissionException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InsufficientPermissionException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Insufficient permission exception.');
+        parent::__construct('Insufficient permission exception.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Cart/Exception/InvalidCartException.php
+++ b/src/Core/Checkout/Cart/Exception/InvalidCartException.php
@@ -13,13 +13,14 @@ class InvalidCartException extends ShopwareHttpException
      */
     private $cartErrors;
 
-    public function __construct(ErrorCollection $errors)
+    public function __construct(ErrorCollection $errors, ?\Throwable $previous = null)
     {
         $this->cartErrors = $errors;
 
         parent::__construct(
             'The cart is invalid, got {{ errorCount }} error(s).',
-            ['errorCount' => $errors->count()]
+            ['errorCount' => $errors->count()],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/Exception/InvalidChildQuantityException.php
+++ b/src/Core/Checkout/Cart/Exception/InvalidChildQuantityException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidChildQuantityException extends ShopwareHttpException
 {
-    public function __construct(int $childQuantity, int $parentQuantity)
+    public function __construct(int $childQuantity, int $parentQuantity, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The quantity of a child "{{ childQuantity }}" must be a multiple of the parent quantity "{{ parentQuantity }}"',
-            ['childQuantity' => $childQuantity, 'parentQuantity' => $parentQuantity]
+            ['childQuantity' => $childQuantity, 'parentQuantity' => $parentQuantity],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/Exception/InvalidPayloadException.php
+++ b/src/Core/Checkout/Cart/Exception/InvalidPayloadException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidPayloadException extends ShopwareHttpException
 {
-    public function __construct(string $id, string $lineItemId)
+    public function __construct(string $id, string $lineItemId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Unable to save payload with id `{{ id }}` on line item `{{ lineItemId }}`. Only scalar data types are allowed.',
-            ['id' => $id, 'lineItemId' => $lineItemId]
+            ['id' => $id, 'lineItemId' => $lineItemId],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/Exception/InvalidQuantityException.php
+++ b/src/Core/Checkout/Cart/Exception/InvalidQuantityException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidQuantityException extends ShopwareHttpException
 {
-    public function __construct(int $quantity)
+    public function __construct(int $quantity, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The quantity must be a positive integer. Given: "{{ quantity }}"',
-            ['quantity' => $quantity]
+            ['quantity' => $quantity],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/Exception/LineItemCoverNotFoundException.php
+++ b/src/Core/Checkout/Cart/Exception/LineItemCoverNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LineItemCoverNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $coverId, string $lineItemKey)
+    public function __construct(string $coverId, string $lineItemKey, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Line item cover with identifier "{{ lineItemId }}" for line item "{{ coverId }}" not found',
-            ['coverId' => $coverId, 'lineItemId' => $lineItemKey]
+            ['coverId' => $coverId, 'lineItemId' => $lineItemKey],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/Exception/LineItemNotFoundException.php
+++ b/src/Core/Checkout/Cart/Exception/LineItemNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LineItemNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $identifier)
+    public function __construct(string $identifier, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Line item with identifier {{ identifier }} not found.',
-            ['identifier' => $identifier]
+            ['identifier' => $identifier],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/Exception/LineItemNotRemovableException.php
+++ b/src/Core/Checkout/Cart/Exception/LineItemNotRemovableException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LineItemNotRemovableException extends ShopwareHttpException
 {
-    public function __construct(string $identifier)
+    public function __construct(string $identifier, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Line item with identifier {{ identifier }} cannot be removed.',
-            ['identifier' => $identifier]
+            ['identifier' => $identifier],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/Exception/LineItemNotStackableException.php
+++ b/src/Core/Checkout/Cart/Exception/LineItemNotStackableException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LineItemNotStackableException extends ShopwareHttpException
 {
-    public function __construct(string $identifier)
+    public function __construct(string $identifier, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Line item with identifier "{{ identifier }}" is not stackable and the quantity cannot be changed.',
-            ['identifier' => $identifier]
+            ['identifier' => $identifier],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/Exception/LineItemTypeNotSupportedException.php
+++ b/src/Core/Checkout/Cart/Exception/LineItemTypeNotSupportedException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LineItemTypeNotSupportedException extends ShopwareHttpException
 {
-    public function __construct(string $type)
+    public function __construct(string $type, ?\Throwable $previous = null)
     {
-        parent::__construct(sprintf('LineItem with type is not supported %s', $type), [], null);
+        parent::__construct(sprintf('LineItem with type is not supported %s', $type), [], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Checkout/Cart/Exception/MissingLineItemPriceException.php
+++ b/src/Core/Checkout/Cart/Exception/MissingLineItemPriceException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MissingLineItemPriceException extends ShopwareHttpException
 {
-    public function __construct(string $identifier)
+    public function __construct(string $identifier, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Line item {{ identifier }} contains no price definition or already calculated price.',
-            ['identifier' => $identifier]
+            ['identifier' => $identifier],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/Exception/MissingOrderRelationException.php
+++ b/src/Core/Checkout/Cart/Exception/MissingOrderRelationException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MissingOrderRelationException extends ShopwareHttpException
 {
-    public function __construct(string $relation)
+    public function __construct(string $relation, ?\Throwable $previous = null)
     {
-        parent::__construct('The required relation "{{ relation }}" is missing .', ['relation' => $relation]);
+        parent::__construct('The required relation "{{ relation }}" is missing .', ['relation' => $relation], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Cart/Exception/MixedLineItemTypeException.php
+++ b/src/Core/Checkout/Cart/Exception/MixedLineItemTypeException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MixedLineItemTypeException extends ShopwareHttpException
 {
-    public function __construct(string $id, string $type)
+    public function __construct(string $id, string $type, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Line item with id {{ id }} already exists with different type {{ type }}.',
-            ['id' => $id, 'type' => $type]
+            ['id' => $id, 'type' => $type],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/Exception/OrderDeliveryNotFoundException.php
+++ b/src/Core/Checkout/Cart/Exception/OrderDeliveryNotFoundException.php
@@ -12,11 +12,12 @@ class OrderDeliveryNotFoundException extends ShopwareHttpException
      */
     private $orderDeliveryId;
 
-    public function __construct(string $orderDeliveryId)
+    public function __construct(string $orderDeliveryId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Order delivery with id "{{ orderDeliveryId }}" not found.',
-            ['orderDeliveryId' => $orderDeliveryId]
+            ['orderDeliveryId' => $orderDeliveryId],
+            $previous
         );
 
         $this->orderDeliveryId = $orderDeliveryId;

--- a/src/Core/Checkout/Cart/Exception/OrderInconsistentException.php
+++ b/src/Core/Checkout/Cart/Exception/OrderInconsistentException.php
@@ -12,11 +12,12 @@ class OrderInconsistentException extends ShopwareHttpException
      */
     private $orderId;
 
-    public function __construct(string $orderId, string $reason)
+    public function __construct(string $orderId, string $reason, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Inconsistent order with id "{{ orderId }}". Reason: {{ reason }}',
-            ['orderId' => $orderId, 'reason' => $reason]
+            ['orderId' => $orderId, 'reason' => $reason],
+            $previous
         );
 
         $this->orderId = $orderId;

--- a/src/Core/Checkout/Cart/Exception/OrderNotFoundException.php
+++ b/src/Core/Checkout/Cart/Exception/OrderNotFoundException.php
@@ -12,11 +12,12 @@ class OrderNotFoundException extends ShopwareHttpException
      */
     private $orderId;
 
-    public function __construct(string $orderId)
+    public function __construct(string $orderId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Order with id "{{ orderId }}" not found.',
-            ['orderId' => $orderId]
+            ['orderId' => $orderId],
+            $previous
         );
 
         $this->orderId = $orderId;

--- a/src/Core/Checkout/Cart/Exception/OrderPaidException.php
+++ b/src/Core/Checkout/Cart/Exception/OrderPaidException.php
@@ -12,11 +12,12 @@ class OrderPaidException extends ShopwareHttpException
      */
     private $orderId;
 
-    public function __construct(string $orderId)
+    public function __construct(string $orderId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Order with id "{{ orderId }}" was already paid and cannot be edited afterwards.',
-            ['orderId' => $orderId]
+            ['orderId' => $orderId],
+            $previous
         );
 
         $this->orderId = $orderId;

--- a/src/Core/Checkout/Cart/Exception/OrderRecalculationException.php
+++ b/src/Core/Checkout/Cart/Exception/OrderRecalculationException.php
@@ -12,11 +12,12 @@ class OrderRecalculationException extends ShopwareHttpException
      */
     protected $orderId;
 
-    public function __construct(string $orderId, string $details)
+    public function __construct(string $orderId, string $details, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Order with id "{{ orderId }}" could not be recalculated. {{ details }}',
-            ['orderId' => $orderId, 'details' => $details]
+            ['orderId' => $orderId, 'details' => $details],
+            $previous
         );
 
         $this->orderId = $orderId;

--- a/src/Core/Checkout/Cart/Exception/OrderTransactionNotFoundException.php
+++ b/src/Core/Checkout/Cart/Exception/OrderTransactionNotFoundException.php
@@ -12,11 +12,12 @@ class OrderTransactionNotFoundException extends ShopwareHttpException
      */
     private $orderTransactionId;
 
-    public function __construct(string $orderTransactionId)
+    public function __construct(string $orderTransactionId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Order transaction with id "{{ orderTransactionId }}" not found.',
-            ['orderTransactionId' => $orderTransactionId]
+            ['orderTransactionId' => $orderTransactionId],
+            $previous
         );
 
         $this->orderTransactionId = $orderTransactionId;

--- a/src/Core/Checkout/Cart/Exception/PayloadKeyNotFoundException.php
+++ b/src/Core/Checkout/Cart/Exception/PayloadKeyNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PayloadKeyNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $id, string $lineItemId)
+    public function __construct(string $id, string $lineItemId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Payload key "{{ payloadKey }}" in line item "{{ id }}" not found.',
-            ['payloadKey' => $id, 'id' => $lineItemId]
+            ['payloadKey' => $id, 'id' => $lineItemId],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Cart/LineItem/Group/Exception/LineItemGroupPackagerNotFoundException.php
+++ b/src/Core/Checkout/Cart/LineItem/Group/Exception/LineItemGroupPackagerNotFoundException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LineItemGroupPackagerNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $key)
+    public function __construct(string $key, ?\Throwable $previous = null)
     {
-        parent::__construct('Packager "{{ key }}" has not been found!', ['key' => $key]);
+        parent::__construct('Packager "{{ key }}" has not been found!', ['key' => $key], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Cart/LineItem/Group/Exception/LineItemGroupSorterNotFoundException.php
+++ b/src/Core/Checkout/Cart/LineItem/Group/Exception/LineItemGroupSorterNotFoundException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LineItemGroupSorterNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $key)
+    public function __construct(string $key, ?\Throwable $previous = null)
     {
-        parent::__construct('Sorter "{{ key }}" has not been found!', ['key' => $key]);
+        parent::__construct('Sorter "{{ key }}" has not been found!', ['key' => $key], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Customer/DataAbstractionLayer/CustomerWishlistProductExceptionHandler.php
+++ b/src/Core/Checkout/Customer/DataAbstractionLayer/CustomerWishlistProductExceptionHandler.php
@@ -25,7 +25,7 @@ class CustomerWishlistProductExceptionHandler implements ExceptionHandlerInterfa
         if (preg_match('/SQLSTATE\[23000\]:.*1062 Duplicate.*uniq.customer_wishlist.sales_channel_id__customer_id\'/', $e->getMessage())) {
             $payload = $command->getPayload();
 
-            return new DuplicateWishlistProductException(!empty($payload['product_id']) ? Uuid::fromBytesToHex($payload['product_id']) : '');
+            return new DuplicateWishlistProductException(!empty($payload['product_id']) ? Uuid::fromBytesToHex($payload['product_id']) : '', $e);
         }
 
         return null;

--- a/src/Core/Checkout/Customer/Exception/AddressNotFoundException.php
+++ b/src/Core/Checkout/Customer/Exception/AddressNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class AddressNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Customer address with id "{{ addressId }}" not found.',
-            ['addressId' => $id]
+            ['addressId' => $id],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/BadCredentialsException.php
+++ b/src/Core/Checkout/Customer/Exception/BadCredentialsException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class BadCredentialsException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Invalid username and/or password.');
+        parent::__construct('Invalid username and/or password.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Customer/Exception/CannotDeleteDefaultAddressException.php
+++ b/src/Core/Checkout/Customer/Exception/CannotDeleteDefaultAddressException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CannotDeleteDefaultAddressException extends ShopwareHttpException
 {
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Customer address with id "{{ addressId }}" is a default address and cannot be deleted.',
-            ['addressId' => $id]
+            ['addressId' => $id],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/CustomerAlreadyConfirmedException.php
+++ b/src/Core/Checkout/Customer/Exception/CustomerAlreadyConfirmedException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CustomerAlreadyConfirmedException extends ShopwareHttpException
 {
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The customer with the id "{{ customerId }}" is already confirmed.',
-            ['customerId' => $id]
+            ['customerId' => $id],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/CustomerGroupRegistrationConfigurationNotFound.php
+++ b/src/Core/Checkout/Customer/Exception/CustomerGroupRegistrationConfigurationNotFound.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CustomerGroupRegistrationConfigurationNotFound extends ShopwareHttpException
 {
-    public function __construct(string $customerGroupId)
+    public function __construct(string $customerGroupId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Customer group registration for id {{ customerGroupId }} not found.',
-            ['customerGroupId' => $customerGroupId]
+            ['customerGroupId' => $customerGroupId],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/CustomerNotFoundByHashException.php
+++ b/src/Core/Checkout/Customer/Exception/CustomerNotFoundByHashException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CustomerNotFoundByHashException extends ShopwareHttpException
 {
-    public function __construct(string $hash)
+    public function __construct(string $hash, ?\Throwable $previous = null)
     {
         parent::__construct(
             'No matching customer for the hash "{{ hash }}" was found.',
-            ['hash' => $hash]
+            ['hash' => $hash],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/CustomerNotFoundException.php
+++ b/src/Core/Checkout/Customer/Exception/CustomerNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CustomerNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $email)
+    public function __construct(string $email, ?\Throwable $previous = null)
     {
         parent::__construct(
             'No matching customer for the email "{{ email }}" was found.',
-            ['email' => $email]
+            ['email' => $email],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/CustomerRecoveryHashExpiredException.php
+++ b/src/Core/Checkout/Customer/Exception/CustomerRecoveryHashExpiredException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CustomerRecoveryHashExpiredException extends ShopwareHttpException
 {
-    public function __construct(string $hash)
+    public function __construct(string $hash, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The hash "{{ hash }}" is expired.',
-            ['hash' => $hash]
+            ['hash' => $hash],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/CustomerWishlistNotActivatedException.php
+++ b/src/Core/Checkout/Customer/Exception/CustomerWishlistNotActivatedException.php
@@ -7,10 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CustomerWishlistNotActivatedException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
         parent::__construct(
-            'Wishlist is not activated!'
+            'Wishlist is not activated!',
+            [],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/CustomerWishlistNotFoundException.php
+++ b/src/Core/Checkout/Customer/Exception/CustomerWishlistNotFoundException.php
@@ -7,10 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CustomerWishlistNotFoundException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
         parent::__construct(
-            'Wishlist for this customer was not found.'
+            'Wishlist for this customer was not found.',
+            [],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/DuplicateWishlistProductException.php
+++ b/src/Core/Checkout/Customer/Exception/DuplicateWishlistProductException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DuplicateWishlistProductException extends ShopwareHttpException
 {
-    public function __construct(string $productId)
+    public function __construct(string $productId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Product with id {{ productId }} already added in wishlist',
-            ['productId' => $productId]
+            ['productId' => $productId],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/InactiveCustomerException.php
+++ b/src/Core/Checkout/Customer/Exception/InactiveCustomerException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InactiveCustomerException extends ShopwareHttpException
 {
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The customer with the id "{{ customerId }}" is inactive.',
-            ['customerId' => $id]
+            ['customerId' => $id],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/LegacyPasswordEncoderNotFoundException.php
+++ b/src/Core/Checkout/Customer/Exception/LegacyPasswordEncoderNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LegacyPasswordEncoderNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $encoder)
+    public function __construct(string $encoder, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Encoder with name "{{ encoder }}" not found.',
-            ['encoder' => $encoder]
+            ['encoder' => $encoder],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/NoHashProvidedException.php
+++ b/src/Core/Checkout/Customer/Exception/NoHashProvidedException.php
@@ -7,10 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class NoHashProvidedException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
         parent::__construct(
-            'The given hash is empty.'
+            'The given hash is empty.',
+            [],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/Exception/WishlistProductNotFoundException.php
+++ b/src/Core/Checkout/Customer/Exception/WishlistProductNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class WishlistProductNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $productId)
+    public function __construct(string $productId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Wishlist product with id {{ productId }} not found',
-            ['productId' => $productId]
+            ['productId' => $productId],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
@@ -120,7 +120,7 @@ class LoginRoute extends AbstractLoginRoute
                 $context
             );
         } catch (CustomerNotFoundException | BadCredentialsException $exception) {
-            throw new UnauthorizedHttpException('json', $exception->getMessage());
+            throw new UnauthorizedHttpException('json', $exception->getMessage(), $exception);
         }
 
         if (!$customer->getActive()) {

--- a/src/Core/Checkout/Document/Exception/DocumentGenerationException.php
+++ b/src/Core/Checkout/Document/Exception/DocumentGenerationException.php
@@ -7,10 +7,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DocumentGenerationException extends ShopwareHttpException
 {
-    public function __construct(string $message = '')
+    public function __construct(string $message = '', ?\Throwable $previous = null)
     {
         $message = sprintf('Unable to generate document. ' . $message);
-        parent::__construct($message);
+        parent::__construct($message, [], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Checkout/Document/Exception/DocumentNumberAlreadyExistsException.php
+++ b/src/Core/Checkout/Document/Exception/DocumentNumberAlreadyExistsException.php
@@ -7,11 +7,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DocumentNumberAlreadyExistsException extends ShopwareHttpException
 {
-    public function __construct(?string $number)
+    public function __construct(?string $number, ?\Throwable $previous = null)
     {
         parent::__construct('Document number {{number}} has already been allocated.', [
             'number' => $number,
-        ]);
+        ], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Checkout/Document/Exception/InvalidDocumentException.php
+++ b/src/Core/Checkout/Document/Exception/InvalidDocumentException.php
@@ -7,10 +7,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidDocumentException extends ShopwareHttpException
 {
-    public function __construct(string $documentId)
+    public function __construct(string $documentId, ?\Throwable $previous = null)
     {
         $message = sprintf('The document with id "%s" is invalid or could not be found.', $documentId);
-        parent::__construct($message);
+        parent::__construct($message, [], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Checkout/Document/Exception/InvalidDocumentGeneratorTypeException.php
+++ b/src/Core/Checkout/Document/Exception/InvalidDocumentGeneratorTypeException.php
@@ -7,10 +7,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidDocumentGeneratorTypeException extends ShopwareHttpException
 {
-    public function __construct(string $type)
+    public function __construct(string $type, ?\Throwable $previous = null)
     {
         $message = sprintf('Unable to find a document generator with type "%s"', $type);
-        parent::__construct($message);
+        parent::__construct($message, [], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Checkout/Document/Exception/InvalidFileGeneratorTypeException.php
+++ b/src/Core/Checkout/Document/Exception/InvalidFileGeneratorTypeException.php
@@ -7,10 +7,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidFileGeneratorTypeException extends ShopwareHttpException
 {
-    public function __construct(string $type)
+    public function __construct(string $type, ?\Throwable $previous = null)
     {
         $message = sprintf('Unable to find a file generator with type "%s"', $type);
-        parent::__construct($message);
+        parent::__construct($message, [], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Checkout/Order/Exception/DeliveryWithoutAddressException.php
+++ b/src/Core/Checkout/Order/Exception/DeliveryWithoutAddressException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DeliveryWithoutAddressException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Delivery contains no shipping address');
+        parent::__construct('Delivery contains no shipping address', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Order/Exception/EmptyCartException.php
+++ b/src/Core/Checkout/Order/Exception/EmptyCartException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EmptyCartException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Cart is empty');
+        parent::__construct('Cart is empty', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Order/Exception/GuestNotAuthenticatedException.php
+++ b/src/Core/Checkout/Order/Exception/GuestNotAuthenticatedException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class GuestNotAuthenticatedException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Guest not authenticated.');
+        parent::__construct('Guest not authenticated.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Order/Exception/LanguageOfOrderDeleteException.php
+++ b/src/Core/Checkout/Order/Exception/LanguageOfOrderDeleteException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LanguageOfOrderDeleteException extends ShopwareHttpException
 {
-    public function __construct(string $language, ?\Throwable $e = null)
+    public function __construct(string $language, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The language "{{ language }}" cannot be deleted because Orders with this language exist.',
             ['language' => $language],
-            $e
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Order/Exception/PaymentMethodNotAvailableException.php
+++ b/src/Core/Checkout/Order/Exception/PaymentMethodNotAvailableException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PaymentMethodNotAvailableException extends ShopwareHttpException
 {
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The order has no active payment method - {{ id }}',
-            ['id' => $id]
+            ['id' => $id],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Order/Exception/WrongGuestCredentialsException.php
+++ b/src/Core/Checkout/Order/Exception/WrongGuestCredentialsException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class WrongGuestCredentialsException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Wrong credentials for guest authentication.');
+        parent::__construct('Wrong credentials for guest authentication.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Payment/Cart/Error/PaymentMethodBlockedError.php
+++ b/src/Core/Checkout/Payment/Cart/Error/PaymentMethodBlockedError.php
@@ -13,7 +13,7 @@ class PaymentMethodBlockedError extends Error
      */
     private $name;
 
-    public function __construct(string $name)
+    public function __construct(string $name, ?\Throwable $previous = null)
     {
         $this->name = $name;
         $this->message = sprintf(
@@ -21,7 +21,7 @@ class PaymentMethodBlockedError extends Error
             $name
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getParameters(): array

--- a/src/Core/Checkout/Payment/Cart/Token/JWTFactoryV2.php
+++ b/src/Core/Checkout/Payment/Cart/Token/JWTFactoryV2.php
@@ -48,7 +48,7 @@ class JWTFactoryV2 implements TokenFactoryInterfaceV2
             /** @var UnencryptedToken $jwtToken */
             $jwtToken = $this->configuration->parser()->parse($token);
         } catch (\Throwable $e) {
-            throw new InvalidTokenException($token);
+            throw new InvalidTokenException($token, $e);
         }
 
         if (!$this->configuration->validator()->validate($jwtToken, ...$this->configuration->validationConstraints())) {

--- a/src/Core/Checkout/Payment/Exception/AsyncPaymentFinalizeException.php
+++ b/src/Core/Checkout/Payment/Exception/AsyncPaymentFinalizeException.php
@@ -4,12 +4,13 @@ namespace Shopware\Core\Checkout\Payment\Exception;
 
 class AsyncPaymentFinalizeException extends PaymentProcessException
 {
-    public function __construct(string $orderTransactionId, string $errorMessage)
+    public function __construct(string $orderTransactionId, string $errorMessage, ?\Throwable $previous = null)
     {
         parent::__construct(
             $orderTransactionId,
             'The asynchronous payment finalize was interrupted due to the following error:' . \PHP_EOL . '{{ errorMessage }}',
-            ['errorMessage' => $errorMessage]
+            ['errorMessage' => $errorMessage],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Payment/Exception/AsyncPaymentProcessException.php
+++ b/src/Core/Checkout/Payment/Exception/AsyncPaymentProcessException.php
@@ -4,12 +4,13 @@ namespace Shopware\Core\Checkout\Payment\Exception;
 
 class AsyncPaymentProcessException extends PaymentProcessException
 {
-    public function __construct(string $orderTransactionId, string $errorMessage)
+    public function __construct(string $orderTransactionId, string $errorMessage, ?\Throwable $previous = null)
     {
         parent::__construct(
             $orderTransactionId,
             'The asynchronous payment process was interrupted due to the following error:' . \PHP_EOL . '{{ errorMessage }}',
-            ['errorMessage' => $errorMessage]
+            ['errorMessage' => $errorMessage],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Payment/Exception/CustomerCanceledAsyncPaymentException.php
+++ b/src/Core/Checkout/Payment/Exception/CustomerCanceledAsyncPaymentException.php
@@ -4,12 +4,13 @@ namespace Shopware\Core\Checkout\Payment\Exception;
 
 class CustomerCanceledAsyncPaymentException extends PaymentProcessException
 {
-    public function __construct(string $orderTransactionId, string $additionalInformation = '')
+    public function __construct(string $orderTransactionId, string $additionalInformation = '', ?\Throwable $previous = null)
     {
         parent::__construct(
             $orderTransactionId,
             'The customer canceled the external payment process. {{ additionalInformation }}',
-            ['additionalInformation' => $additionalInformation]
+            ['additionalInformation' => $additionalInformation],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Payment/Exception/InvalidOrderException.php
+++ b/src/Core/Checkout/Payment/Exception/InvalidOrderException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidOrderException extends ShopwareHttpException
 {
-    public function __construct(string $orderId)
+    public function __construct(string $orderId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The order with id {{ orderId }} is invalid or could not be found.',
-            ['orderId' => $orderId]
+            ['orderId' => $orderId],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Payment/Exception/InvalidTokenException.php
+++ b/src/Core/Checkout/Payment/Exception/InvalidTokenException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidTokenException extends ShopwareHttpException
 {
-    public function __construct(string $token)
+    public function __construct(string $token, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The provided token {{ token }} is invalid and the payment could not be processed.',
-            ['token' => $token]
+            ['token' => $token],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Payment/Exception/InvalidTransactionException.php
+++ b/src/Core/Checkout/Payment/Exception/InvalidTransactionException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidTransactionException extends ShopwareHttpException
 {
-    public function __construct(string $transactionId)
+    public function __construct(string $transactionId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The transaction with id {{ transactionId }} is invalid or could not be found.',
-            ['transactionId' => $transactionId]
+            ['transactionId' => $transactionId],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Payment/Exception/PaymentProcessException.php
+++ b/src/Core/Checkout/Payment/Exception/PaymentProcessException.php
@@ -12,11 +12,11 @@ abstract class PaymentProcessException extends ShopwareHttpException
      */
     private $orderTransactionId;
 
-    public function __construct(string $orderTransactionId, string $message, array $parameters = [])
+    public function __construct(string $orderTransactionId, string $message, array $parameters = [], ?\Throwable $previous = null)
     {
         $this->orderTransactionId = $orderTransactionId;
 
-        parent::__construct($message, $parameters);
+        parent::__construct($message, $parameters, $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Checkout/Payment/Exception/PluginPaymentMethodsDeleteRestrictionException.php
+++ b/src/Core/Checkout/Payment/Exception/PluginPaymentMethodsDeleteRestrictionException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PluginPaymentMethodsDeleteRestrictionException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Plugin payment methods can not be deleted via API.');
+        parent::__construct('Plugin payment methods can not be deleted via API.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Payment/Exception/SyncPaymentProcessException.php
+++ b/src/Core/Checkout/Payment/Exception/SyncPaymentProcessException.php
@@ -4,12 +4,13 @@ namespace Shopware\Core\Checkout\Payment\Exception;
 
 class SyncPaymentProcessException extends PaymentProcessException
 {
-    public function __construct(string $orderTransactionId, string $errorMessage)
+    public function __construct(string $orderTransactionId, string $errorMessage, ?\Throwable $previous = null)
     {
         parent::__construct(
             $orderTransactionId,
             'The synchronous payment process was interrupted due to the following error:' . \PHP_EOL . '{{ errorMessage }}',
-            ['errorMessage' => $errorMessage]
+            ['errorMessage' => $errorMessage],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Payment/Exception/TokenExpiredException.php
+++ b/src/Core/Checkout/Payment/Exception/TokenExpiredException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TokenExpiredException extends ShopwareHttpException
 {
-    public function __construct(string $token)
+    public function __construct(string $token, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The provided token {{ token }} is expired and the payment could not be processed.',
-            ['token' => $token]
+            ['token' => $token],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Payment/Exception/UnknownPaymentMethodException.php
+++ b/src/Core/Checkout/Payment/Exception/UnknownPaymentMethodException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class UnknownPaymentMethodException extends ShopwareHttpException
 {
-    public function __construct(string $paymentMethodId)
+    public function __construct(string $paymentMethodId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The payment method {{ paymentMethodId }} could not be found.',
-            ['paymentMethodId' => $paymentMethodId]
+            ['paymentMethodId' => $paymentMethodId],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Promotion/Cart/Discount/Filter/Exception/FilterPickerNotFoundException.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/Filter/Exception/FilterPickerNotFoundException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FilterPickerNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $key)
+    public function __construct(string $key, ?\Throwable $previous = null)
     {
-        parent::__construct('Picker "{{ key }}" has not been found!', ['key' => $key]);
+        parent::__construct('Picker "{{ key }}" has not been found!', ['key' => $key], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Promotion/Cart/Discount/Filter/Exception/FilterSorterNotFoundException.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/Filter/Exception/FilterSorterNotFoundException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FilterSorterNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $key)
+    public function __construct(string $key, ?\Throwable $previous = null)
     {
-        parent::__construct('Sorter "{{ key }}" has not been found!', ['key' => $key]);
+        parent::__construct('Sorter "{{ key }}" has not been found!', ['key' => $key], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Promotion/Cart/Error/AutoPromotionNotFoundError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/AutoPromotionNotFoundError.php
@@ -13,13 +13,13 @@ class AutoPromotionNotFoundError extends Error
      */
     protected $name;
 
-    public function __construct(string $name)
+    public function __construct(string $name, ?\Throwable $previous = null)
     {
         $this->name = $name;
 
         $this->message = sprintf('Promotion %s was no longer valid!', $this->name);
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getParameters(): array

--- a/src/Core/Checkout/Promotion/Cart/Error/PromotionNotEligibleError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/PromotionNotEligibleError.php
@@ -13,13 +13,13 @@ class PromotionNotEligibleError extends Error
      */
     protected $name;
 
-    public function __construct(string $name)
+    public function __construct(string $name, ?\Throwable $previous = null)
     {
         $this->name = $name;
 
         $this->message = sprintf('Promotion %s not eligible for cart!', $this->name);
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function isPersistent(): bool

--- a/src/Core/Checkout/Promotion/Cart/Error/PromotionNotFoundError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/PromotionNotFoundError.php
@@ -13,13 +13,13 @@ class PromotionNotFoundError extends Error
      */
     protected $promotionCode;
 
-    public function __construct(string $promotionCode)
+    public function __construct(string $promotionCode, ?\Throwable $previous = null)
     {
         $this->promotionCode = $promotionCode;
 
         $this->message = sprintf('Promotion with code %s not found!', $this->promotionCode);
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getId(): string

--- a/src/Core/Checkout/Promotion/Cart/PromotionCartAddedInformationError.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCartAddedInformationError.php
@@ -19,7 +19,7 @@ class PromotionCartAddedInformationError extends Error
      */
     private $discountLineItemId;
 
-    public function __construct(LineItem $discountLineItem)
+    public function __construct(LineItem $discountLineItem, ?\Throwable $previous = null)
     {
         $this->name = $discountLineItem->getLabel();
         $this->discountLineItemId = $discountLineItem->getId();
@@ -27,7 +27,7 @@ class PromotionCartAddedInformationError extends Error
             'Discount %s has been added',
             $this->name
         );
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function isPersistent(): bool

--- a/src/Core/Checkout/Promotion/Cart/PromotionCartDeletedInformationError.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCartDeletedInformationError.php
@@ -19,7 +19,7 @@ class PromotionCartDeletedInformationError extends Error
      */
     private $discountLineItemId;
 
-    public function __construct(LineItem $discountLineItem)
+    public function __construct(LineItem $discountLineItem, ?\Throwable $previous = null)
     {
         $this->name = $discountLineItem->getLabel();
         $this->discountLineItemId = $discountLineItem->getId();
@@ -27,7 +27,7 @@ class PromotionCartDeletedInformationError extends Error
             'Discount %s has been added',
             $this->name
         );
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getMessageKey(): string

--- a/src/Core/Checkout/Promotion/Exception/CodeAlreadyRedeemedException.php
+++ b/src/Core/Checkout/Promotion/Exception/CodeAlreadyRedeemedException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CodeAlreadyRedeemedException extends ShopwareHttpException
 {
-    public function __construct(string $code)
+    public function __construct(string $code, ?\Throwable $previous = null)
     {
-        parent::__construct('Promotion with code "{{ code }}" has already been marked as redeemed!', ['code' => $code]);
+        parent::__construct('Promotion with code "{{ code }}" has already been marked as redeemed!', ['code' => $code], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Promotion/Exception/DiscountCalculatorNotFoundException.php
+++ b/src/Core/Checkout/Promotion/Exception/DiscountCalculatorNotFoundException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DiscountCalculatorNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $type)
+    public function __construct(string $type, ?\Throwable $previous = null)
     {
-        parent::__construct('Promotion Discount Calculator "{{ type }}" has not been found!', ['type' => $type]);
+        parent::__construct('Promotion Discount Calculator "{{ type }}" has not been found!', ['type' => $type], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Promotion/Exception/InvalidPriceDefinitionException.php
+++ b/src/Core/Checkout/Promotion/Exception/InvalidPriceDefinitionException.php
@@ -7,12 +7,13 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidPriceDefinitionException extends ShopwareHttpException
 {
-    public function __construct(string $label, ?string $code)
+    public function __construct(string $label, ?string $code, ?\Throwable $previous = null)
     {
         if ($code === null) {
             parent::__construct(
                 'Invalid discount price definition for automated promotion "{{ label }}"',
-                ['label' => $label]
+                ['label' => $label],
+                $previous
             );
 
             return;
@@ -20,7 +21,8 @@ class InvalidPriceDefinitionException extends ShopwareHttpException
 
         parent::__construct(
             'Invalid discount price definition for promotion line item with code "{{ code }}"',
-            ['code' => $code]
+            ['code' => $code],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Promotion/Exception/InvalidScopeDefinitionException.php
+++ b/src/Core/Checkout/Promotion/Exception/InvalidScopeDefinitionException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidScopeDefinitionException extends ShopwareHttpException
 {
-    public function __construct(string $scope)
+    public function __construct(string $scope, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Invalid discount calculator scope definition "{{ label }}"',
-            ['label' => $scope]
+            ['label' => $scope],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Promotion/Exception/PatternAlreadyInUseException.php
+++ b/src/Core/Checkout/Promotion/Exception/PatternAlreadyInUseException.php
@@ -9,10 +9,12 @@ class PatternAlreadyInUseException extends ShopwareHttpException
 {
     public const ERROR_CODE = 'PROMOTION__INDIVIDUAL_CODES_PATTERN_ALREADY_IN_USE';
 
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
         parent::__construct(
-            'Code pattern already exists in another promotion. Please provide a different pattern.'
+            'Code pattern already exists in another promotion. Please provide a different pattern.',
+            [],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Promotion/Exception/PatternNotComplexEnoughException.php
+++ b/src/Core/Checkout/Promotion/Exception/PatternNotComplexEnoughException.php
@@ -9,10 +9,12 @@ class PatternNotComplexEnoughException extends ShopwareHttpException
 {
     public const ERROR_CODE = 'PROMOTION__INDIVIDUAL_CODES_PATTERN_INSUFFICIENTLY_COMPLEX';
 
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
         parent::__construct(
-            'The amount of possible codes is too low for the current pattern. Make sure your pattern is sufficiently complex.'
+            'The amount of possible codes is too low for the current pattern. Make sure your pattern is sufficiently complex.',
+            [],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Promotion/Exception/PriceDefinitionNotValidForDiscountTypeException.php
+++ b/src/Core/Checkout/Promotion/Exception/PriceDefinitionNotValidForDiscountTypeException.php
@@ -7,11 +7,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PriceDefinitionNotValidForDiscountTypeException extends ShopwareHttpException
 {
-    public function __construct(string $message)
-    {
-        parent::__construct($message);
-    }
-
     public function getErrorCode(): string
     {
         return 'CHECKOUT__INVALID_PRICE_DEFINITION_FOR_DISCOUNT_TYPE';

--- a/src/Core/Checkout/Promotion/Exception/PriceNotFoundException.php
+++ b/src/Core/Checkout/Promotion/Exception/PriceNotFoundException.php
@@ -8,9 +8,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PriceNotFoundException extends ShopwareHttpException
 {
-    public function __construct(LineItem $item)
+    public function __construct(LineItem $item, ?\Throwable $previous = null)
     {
-        parent::__construct('No calculated price found for item ' . $item->getId());
+        parent::__construct('No calculated price found for item ' . $item->getId(), [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Promotion/Exception/PromotionCodeNotFoundException.php
+++ b/src/Core/Checkout/Promotion/Exception/PromotionCodeNotFoundException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PromotionCodeNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $code)
+    public function __construct(string $code, ?\Throwable $previous = null)
     {
-        parent::__construct('Promotion Code "{{ code }}" has not been found!', ['code' => $code]);
+        parent::__construct('Promotion Code "{{ code }}" has not been found!', ['code' => $code], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Promotion/Exception/SetGroupNotFoundException.php
+++ b/src/Core/Checkout/Promotion/Exception/SetGroupNotFoundException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SetGroupNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $groupId)
+    public function __construct(string $groupId, ?\Throwable $previous = null)
     {
-        parent::__construct('Promotion SetGroup "{{ id }}" has not been found!', ['id' => $groupId]);
+        parent::__construct('Promotion SetGroup "{{ id }}" has not been found!', ['id' => $groupId], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Checkout/Promotion/Exception/UnknownPromotionDiscountTypeException.php
+++ b/src/Core/Checkout/Promotion/Exception/UnknownPromotionDiscountTypeException.php
@@ -8,11 +8,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class UnknownPromotionDiscountTypeException extends ShopwareHttpException
 {
-    public function __construct(PromotionDiscountEntity $discount)
+    public function __construct(PromotionDiscountEntity $discount, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Unknown promotion discount type detected: {{ type }}',
-            ['type' => $discount->getType()]
+            ['type' => $discount->getType()],
+            $previous
         );
     }
 

--- a/src/Core/Checkout/Shipping/Cart/Error/ShippingMethodBlockedError.php
+++ b/src/Core/Checkout/Shipping/Cart/Error/ShippingMethodBlockedError.php
@@ -13,7 +13,7 @@ class ShippingMethodBlockedError extends Error
      */
     private $name;
 
-    public function __construct(string $name)
+    public function __construct(string $name, ?\Throwable $previous = null)
     {
         $this->name = $name;
         $this->message = sprintf(
@@ -21,7 +21,7 @@ class ShippingMethodBlockedError extends Error
             $name
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function isPersistent(): bool

--- a/src/Core/Checkout/Shipping/Exception/ShippingMethodNotFoundException.php
+++ b/src/Core/Checkout/Shipping/Exception/ShippingMethodNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ShippingMethodNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Shipping method with id "{{ shippingMethodId }}" not found.',
-            ['shippingMethodId' => $id]
+            ['shippingMethodId' => $id],
+            $previous
         );
     }
 

--- a/src/Core/Content/Category/Exception/CategoryNotFoundException.php
+++ b/src/Core/Content/Category/Exception/CategoryNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CategoryNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $categoryId)
+    public function __construct(string $categoryId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Category "{{ categoryId }}" not found.',
-            ['categoryId' => $categoryId]
+            ['categoryId' => $categoryId],
+            $previous
         );
     }
 

--- a/src/Core/Content/Cms/Exception/DuplicateCriteriaKeyException.php
+++ b/src/Core/Content/Cms/Exception/DuplicateCriteriaKeyException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class DuplicateCriteriaKeyException extends ShopwareHttpException
 {
-    public function __construct(string $key)
+    public function __construct(string $key, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The key "{{ key }}" is duplicated in the criteria collection.',
-            ['key' => $key]
+            ['key' => $key],
+            $previous
         );
     }
 

--- a/src/Core/Content/Cms/Exception/PageNotFoundException.php
+++ b/src/Core/Content/Cms/Exception/PageNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PageNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $pageId)
+    public function __construct(string $pageId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Page with id "{{ pageId }}" was not found.',
-            ['pageId' => $pageId]
+            ['pageId' => $pageId],
+            $previous
         );
     }
 

--- a/src/Core/Content/ImportExport/Exception/DeleteDefaultProfileException.php
+++ b/src/Core/Content/ImportExport/Exception/DeleteDefaultProfileException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DeleteDefaultProfileException extends ShopwareHttpException
 {
-    public function __construct(array $ids)
+    public function __construct(array $ids, ?\Throwable $previous = null)
     {
-        parent::__construct('Cannot delete system default import_export_profile', ['ids' => $ids]);
+        parent::__construct('Cannot delete system default import_export_profile', ['ids' => $ids], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/ImportExport/Exception/FileNotFoundException.php
+++ b/src/Core/Content/ImportExport/Exception/FileNotFoundException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FileNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $fileId)
+    public function __construct(string $fileId, ?\Throwable $previous = null)
     {
-        parent::__construct('Cannot find import/export file with id {{ fileId }}', ['fileId' => $fileId]);
+        parent::__construct('Cannot find import/export file with id {{ fileId }}', ['fileId' => $fileId], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Content/ImportExport/Exception/FileNotReadableException.php
+++ b/src/Core/Content/ImportExport/Exception/FileNotReadableException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FileNotReadableException extends ShopwareHttpException
 {
-    public function __construct(string $path)
+    public function __construct(string $path, ?\Throwable $previous = null)
     {
-        parent::__construct('Import file is not readable at {{ path }}.', ['path' => $path]);
+        parent::__construct('Import file is not readable at {{ path }}.', ['path' => $path], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/ImportExport/Exception/InvalidFileAccessTokenException.php
+++ b/src/Core/Content/ImportExport/Exception/InvalidFileAccessTokenException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidFileAccessTokenException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Access to file denied due to invalid access token', []);
+        parent::__construct('Access to file denied due to invalid access token', [], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Content/ImportExport/Exception/LogNotWritableException.php
+++ b/src/Core/Content/ImportExport/Exception/LogNotWritableException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LogNotWritableException extends ShopwareHttpException
 {
-    public function __construct(array $ids)
+    public function __construct(array $ids, ?\Throwable $previous = null)
     {
-        parent::__construct('Entity import_export_log is write-protected if not in system scope', ['ids' => $ids]);
+        parent::__construct('Entity import_export_log is write-protected if not in system scope', ['ids' => $ids], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/ImportExport/Exception/ProfileNotFoundException.php
+++ b/src/Core/Content/ImportExport/Exception/ProfileNotFoundException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProfileNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $profileId)
+    public function __construct(string $profileId, ?\Throwable $previous = null)
     {
-        parent::__construct('Cannot find import/export profile with id {{ profileId }}', ['profileId' => $profileId]);
+        parent::__construct('Cannot find import/export profile with id {{ profileId }}', ['profileId' => $profileId], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Content/ImportExport/Exception/UnexpectedFileTypeException.php
+++ b/src/Core/Content/ImportExport/Exception/UnexpectedFileTypeException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class UnexpectedFileTypeException extends ShopwareHttpException
 {
-    public function __construct(?string $givenType, string $expectedType)
+    public function __construct(?string $givenType, string $expectedType, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Given file does not match MIME-Type for selected profile. Given: {{ given }}. Expected: {{ expected }}',
-            ['given' => $givenType, 'expected' => $expectedType]
+            ['given' => $givenType, 'expected' => $expectedType],
+            $previous
         );
     }
 

--- a/src/Core/Content/LandingPage/Exception/LandingPageNotFoundException.php
+++ b/src/Core/Content/LandingPage/Exception/LandingPageNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LandingPageNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $landingPageId)
+    public function __construct(string $landingPageId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Landing page "{{ landingPageId }}" not found.',
-            ['landingPageId' => $landingPageId]
+            ['landingPageId' => $landingPageId],
+            $previous
         );
     }
 

--- a/src/Core/Content/MailTemplate/Exception/MailEventConfigurationException.php
+++ b/src/Core/Content/MailTemplate/Exception/MailEventConfigurationException.php
@@ -7,14 +7,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MailEventConfigurationException extends ShopwareHttpException
 {
-    public function __construct(string $message, string $eventClass)
+    public function __construct(string $message, string $eventClass, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Failed processing the mail event: {{ errorMessage }}. {{ eventClass }}',
             [
                 'errorMessage' => $message,
                 'eventClass' => $eventClass,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/Content/MailTemplate/Exception/MailTemplateRendererException.php
+++ b/src/Core/Content/MailTemplate/Exception/MailTemplateRendererException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MailTemplateRendererException extends ShopwareHttpException
 {
-    public function __construct(string $twigMessage)
+    public function __construct(string $twigMessage, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Failed rendering mail template using Twig: {{ errorMessage }}',
-            ['errorMessage' => $twigMessage]
+            ['errorMessage' => $twigMessage],
+            $previous
         );
     }
 

--- a/src/Core/Content/MailTemplate/Exception/MailTransportFailedException.php
+++ b/src/Core/Content/MailTemplate/Exception/MailTransportFailedException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MailTransportFailedException extends ShopwareHttpException
 {
-    public function __construct(array $failedRecipients, ?\Throwable $e = null)
+    public function __construct(array $failedRecipients, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Failed sending mail to following recipients: {{ recipients }} with Error: {{ errorMessage }}',
-            ['recipients' => $failedRecipients, 'recipientsString' => implode(', ', $failedRecipients), 'errorMessage' => $e ? $e->getMessage() : 'Unknown error'],
-            $e
+            ['recipients' => $failedRecipients, 'recipientsString' => implode(', ', $failedRecipients), 'errorMessage' => $previous ? $previous->getMessage() : 'Unknown error'],
+            $previous
         );
     }
 

--- a/src/Core/Content/MailTemplate/Exception/SalesChannelNotFoundException.php
+++ b/src/Core/Content/MailTemplate/Exception/SalesChannelNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SalesChannelNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $salesChannelId)
+    public function __construct(string $salesChannelId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Sales channel with id "{{ salesChannelId }}" was not found.',
-            ['salesChannelId' => $salesChannelId]
+            ['salesChannelId' => $salesChannelId],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/CouldNotRenameFileException.php
+++ b/src/Core/Content/Media/Exception/CouldNotRenameFileException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class CouldNotRenameFileException extends ShopwareHttpException
 {
-    public function __construct(string $mediaId, string $oldFileName)
+    public function __construct(string $mediaId, string $oldFileName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Could not rename File for media with id: {{ mediaId }}. Rollback to filename: "{{ oldFileName }}"',
-            ['mediaId' => $mediaId, 'oldFileName' => $oldFileName]
+            ['mediaId' => $mediaId, 'oldFileName' => $oldFileName],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/DisabledUrlUploadFeatureException.php
+++ b/src/Core/Content/Media/Exception/DisabledUrlUploadFeatureException.php
@@ -6,10 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class DisabledUrlUploadFeatureException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
         parent::__construct(
-            'The feature to upload a media via URL is disabled.'
+            'The feature to upload a media via URL is disabled.',
+            [],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/DuplicatedMediaFileNameException.php
+++ b/src/Core/Content/Media/Exception/DuplicatedMediaFileNameException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class DuplicatedMediaFileNameException extends ShopwareHttpException
 {
-    public function __construct(string $fileName, string $fileExtension)
+    public function __construct(string $fileName, string $fileExtension, ?\Throwable $previous = null)
     {
         parent::__construct(
             'A file with the name "{{ fileName }}.{{ fileExtension }}" already exists.',
-            ['fileName' => $fileName, 'fileExtension' => $fileExtension]
+            ['fileName' => $fileName, 'fileExtension' => $fileExtension],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/EmptyMediaFilenameException.php
+++ b/src/Core/Content/Media/Exception/EmptyMediaFilenameException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EmptyMediaFilenameException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('A valid Filename must be provided.');
+        parent::__construct('A valid Filename must be provided.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/Media/Exception/EmptyMediaIdException.php
+++ b/src/Core/Content/Media/Exception/EmptyMediaIdException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EmptyMediaIdException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('A media id must be provided.');
+        parent::__construct('A media id must be provided.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/Media/Exception/FileTypeNotSupportedException.php
+++ b/src/Core/Content/Media/Exception/FileTypeNotSupportedException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FileTypeNotSupportedException extends ShopwareHttpException
 {
-    public function __construct(string $mediaId)
+    public function __construct(string $mediaId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The File for media object with id: {{ mediaId }} is not supported for creating thumbnails.',
-            ['mediaId' => $mediaId]
+            ['mediaId' => $mediaId],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/IllegalFileNameException.php
+++ b/src/Core/Content/Media/Exception/IllegalFileNameException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class IllegalFileNameException extends ShopwareHttpException
 {
-    public function __construct(string $filename, string $cause)
+    public function __construct(string $filename, string $cause, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Provided filename "{{ fileName }}" is not permitted: {{ cause }}',
-            ['fileName' => $filename, 'cause' => $cause]
+            ['fileName' => $filename, 'cause' => $cause],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/IllegalUrlException.php
+++ b/src/Core/Content/Media/Exception/IllegalUrlException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class IllegalUrlException extends ShopwareHttpException
 {
-    public function __construct(string $url)
+    public function __construct(string $url, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Provided URL "{{ url }}" is not allowed.',
-            ['url' => $url]
+            ['url' => $url],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/MediaFolderNotFoundException.php
+++ b/src/Core/Content/Media/Exception/MediaFolderNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MediaFolderNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $folderId)
+    public function __construct(string $folderId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Could not find media folder with id: "{{ folderId }}"',
-            ['folderId' => $folderId]
+            ['folderId' => $folderId],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/MediaNotFoundException.php
+++ b/src/Core/Content/Media/Exception/MediaNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MediaNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $mediaId)
+    public function __construct(string $mediaId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Media for id {{ mediaId }} not found.',
-            ['mediaId' => $mediaId]
+            ['mediaId' => $mediaId],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/MissingFileException.php
+++ b/src/Core/Content/Media/Exception/MissingFileException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MissingFileException extends ShopwareHttpException
 {
-    public function __construct(string $mediaId)
+    public function __construct(string $mediaId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Could not find file for media with id: "{{ mediaId }}"',
-            ['mediaId' => $mediaId]
+            ['mediaId' => $mediaId],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/MissingFileExtensionException.php
+++ b/src/Core/Content/Media/Exception/MissingFileExtensionException.php
@@ -4,8 +4,8 @@ namespace Shopware\Core\Content\Media\Exception;
 
 class MissingFileExtensionException extends UploadException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('No file extension provided. Please use the "extension" query parameter to specify the extension of the uploaded File');
+        parent::__construct('No file extension provided. Please use the "extension" query parameter to specify the extension of the uploaded File', $previous);
     }
 }

--- a/src/Core/Content/Media/Exception/StrategyNotFoundException.php
+++ b/src/Core/Content/Media/Exception/StrategyNotFoundException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class StrategyNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $strategyName)
+    public function __construct(string $strategyName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'No Strategy with name "{{ strategyName }}" found.',
-            ['strategyName' => $strategyName]
+            ['strategyName' => $strategyName],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/ThumbnailCouldNotBeSavedException.php
+++ b/src/Core/Content/Media/Exception/ThumbnailCouldNotBeSavedException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class ThumbnailCouldNotBeSavedException extends ShopwareHttpException
 {
-    public function __construct(string $url)
+    public function __construct(string $url, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Thumbnail could not be saved to location: {{ location }}',
-            ['location' => $url]
+            ['location' => $url],
+            $previous
         );
     }
 

--- a/src/Core/Content/Media/Exception/UploadException.php
+++ b/src/Core/Content/Media/Exception/UploadException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class UploadException extends ShopwareHttpException
 {
-    public function __construct(string $message = '')
+    public function __construct(string $message = '', ?\Throwable $previous = null)
     {
-        parent::__construct('{{ message }}', ['message' => $message]);
+        parent::__construct('{{ message }}', ['message' => $message], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/Media/File/FileFetcher.php
+++ b/src/Core/Content/Media/File/FileFetcher.php
@@ -155,7 +155,7 @@ class FileFetcher
         try {
             $inputStream = @fopen($url, 'rb', false, $streamContext);
         } catch (\Throwable $e) {
-            throw new UploadException("Could not open source stream from {$url}");
+            throw new UploadException("Could not open source stream from {$url}", $e);
         }
 
         if ($inputStream === false) {
@@ -175,7 +175,7 @@ class FileFetcher
         try {
             $inputStream = @fopen($filename, 'wb');
         } catch (\Throwable $e) {
-            throw new UploadException("Could not open Stream to write upload data: ${filename}");
+            throw new UploadException("Could not open Stream to write upload data: ${filename}", $e);
         }
 
         if ($inputStream === false) {

--- a/src/Core/Content/Media/File/FileSaver.php
+++ b/src/Core/Content/Media/File/FileSaver.php
@@ -210,7 +210,7 @@ class FileSaver
                 $this->getFileSystem($currentMedia)
             );
         } catch (\Exception $e) {
-            throw new CouldNotRenameFileException($currentMedia->getId(), $currentMedia->getFileName());
+            throw new CouldNotRenameFileException($currentMedia->getId(), $currentMedia->getFileName(), $e);
         }
 
         foreach ($currentMedia->getThumbnails() as $thumbnail) {

--- a/src/Core/Content/Newsletter/Exception/LanguageOfNewsletterDeleteException.php
+++ b/src/Core/Content/Newsletter/Exception/LanguageOfNewsletterDeleteException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LanguageOfNewsletterDeleteException extends ShopwareHttpException
 {
-    public function __construct(string $language, ?\Throwable $e = null)
+    public function __construct(string $language, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The language "{{ language }}" cannot be deleted because newsletter recipients with this language exist.',
             ['language' => $language],
-            $e
+            $previous
         );
     }
 

--- a/src/Core/Content/Newsletter/Exception/NewsletterRecipientNotFoundException.php
+++ b/src/Core/Content/Newsletter/Exception/NewsletterRecipientNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class NewsletterRecipientNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $identifier, string $value)
+    public function __construct(string $identifier, string $value, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The NewsletterRecipient with the identifier "{{ identifier }}" - {{ value }} was not found.',
-            ['identifier' => $identifier, 'value' => $value]
+            ['identifier' => $identifier, 'value' => $value],
+            $previous
         );
     }
 

--- a/src/Core/Content/Newsletter/Exception/SalesChannelDomainNotFoundException.php
+++ b/src/Core/Content/Newsletter/Exception/SalesChannelDomainNotFoundException.php
@@ -7,11 +7,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
 class SalesChannelDomainNotFoundException extends ShopwareHttpException
 {
-    public function __construct(SalesChannelEntity $salesChannel)
+    public function __construct(SalesChannelEntity $salesChannel, ?\Throwable $previous = null)
     {
         parent::__construct(
             'No domain found for sales channel {{ salesChannel }}',
-            ['salesChannel' => $salesChannel->getTranslation('name')]
+            ['salesChannel' => $salesChannel->getTranslation('name')],
+            $previous
         );
     }
 

--- a/src/Core/Content/Product/Cart/ProductNotFoundError.php
+++ b/src/Core/Content/Product/Cart/ProductNotFoundError.php
@@ -12,11 +12,11 @@ class ProductNotFoundError extends Error
      */
     protected $id;
 
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
         $this->id = $id;
 
-        parent::__construct('The product %s could not be found');
+        parent::__construct('The product %s could not be found', 0, $previous);
     }
 
     public function getParameters(): array

--- a/src/Core/Content/Product/Cart/ProductOutOfStockError.php
+++ b/src/Core/Content/Product/Cart/ProductOutOfStockError.php
@@ -17,13 +17,13 @@ class ProductOutOfStockError extends Error
      */
     protected $name;
 
-    public function __construct(string $id, string $name)
+    public function __construct(string $id, string $name, ?\Throwable $previous = null)
     {
         $this->id = $id;
 
         $this->message = sprintf('The product %s is no longer available', $name);
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
         $this->name = $name;
     }
 

--- a/src/Core/Content/Product/Cart/ProductStockReachedError.php
+++ b/src/Core/Content/Product/Cart/ProductStockReachedError.php
@@ -22,7 +22,7 @@ class ProductStockReachedError extends Error
      */
     protected $quantity;
 
-    public function __construct(string $id, string $name, int $quantity)
+    public function __construct(string $id, string $name, int $quantity, ?\Throwable $previous = null)
     {
         $this->id = $id;
 
@@ -32,7 +32,7 @@ class ProductStockReachedError extends Error
             $quantity
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
         $this->name = $name;
         $this->quantity = $quantity;
     }

--- a/src/Core/Content/Product/Cart/PurchaseStepsError.php
+++ b/src/Core/Content/Product/Cart/PurchaseStepsError.php
@@ -22,7 +22,7 @@ class PurchaseStepsError extends Error
      */
     protected $quantity;
 
-    public function __construct(string $id, string $name, int $quantity)
+    public function __construct(string $id, string $name, int $quantity, ?\Throwable $previous = null)
     {
         $this->id = $id;
 
@@ -32,7 +32,7 @@ class PurchaseStepsError extends Error
             $quantity
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
         $this->name = $name;
         $this->quantity = $quantity;
     }

--- a/src/Core/Content/Product/Exception/DuplicateProductNumberException.php
+++ b/src/Core/Content/Product/Exception/DuplicateProductNumberException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DuplicateProductNumberException extends ShopwareHttpException
 {
-    public function __construct(string $number, ?\Throwable $e = null)
+    public function __construct(string $number, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Product with number "{{ number }}" already exists.',
             ['number' => $number],
-            $e
+            $previous
         );
     }
 

--- a/src/Core/Content/Product/Exception/DuplicateProductSearchConfigFieldException.php
+++ b/src/Core/Content/Product/Exception/DuplicateProductSearchConfigFieldException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DuplicateProductSearchConfigFieldException extends ShopwareHttpException
 {
-    public function __construct(string $fieldName, \Throwable $e)
+    public function __construct(string $fieldName, \Throwable $previous)
     {
         parent::__construct(
             'Product search config with field {{ fieldName }} already exists.',
             ['fieldName' => $fieldName],
-            $e
+            $previous
         );
     }
 

--- a/src/Core/Content/Product/Exception/DuplicateProductSearchConfigLanguageException.php
+++ b/src/Core/Content/Product/Exception/DuplicateProductSearchConfigLanguageException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DuplicateProductSearchConfigLanguageException extends ShopwareHttpException
 {
-    public function __construct(string $languageId, \Throwable $e)
+    public function __construct(string $languageId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Product search config with language_id {{ languageId }} already exists.',
             ['languageId' => $languageId],
-            $e
+            $previous
         );
     }
 

--- a/src/Core/Content/Product/Exception/DuplicateProductSortingKeyException.php
+++ b/src/Core/Content/Product/Exception/DuplicateProductSortingKeyException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DuplicateProductSortingKeyException extends ShopwareHttpException
 {
-    public function __construct(string $key, \Throwable $e)
+    public function __construct(string $key, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Sorting with key "{{ key }}" already exists.',
             ['key' => $key],
-            $e
+            $previous
         );
     }
 

--- a/src/Core/Content/Product/Exception/LanguageOfProductReviewDeleteException.php
+++ b/src/Core/Content/Product/Exception/LanguageOfProductReviewDeleteException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LanguageOfProductReviewDeleteException extends ShopwareHttpException
 {
-    public function __construct(string $language, ?\Throwable $e = null)
+    public function __construct(string $language, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The language "{{ language }}" cannot be deleted because product reviews with this language exist.',
             ['language' => $language],
-            $e
+            $previous
         );
     }
 

--- a/src/Core/Content/Product/Exception/NoConfiguratorFoundException.php
+++ b/src/Core/Content/Product/Exception/NoConfiguratorFoundException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class NoConfiguratorFoundException extends ShopwareHttpException
 {
-    public function __construct(string $productId)
+    public function __construct(string $productId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Product with id {{ productId }} has no configuration.',
-            ['productId' => $productId]
+            ['productId' => $productId],
+            $previous
         );
     }
 

--- a/src/Core/Content/Product/Exception/ProductLineItemDifferentIdException.php
+++ b/src/Core/Content/Product/Exception/ProductLineItemDifferentIdException.php
@@ -7,10 +7,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProductLineItemDifferentIdException extends ShopwareHttpException
 {
-    public function __construct(string $lineItemId)
+    public function __construct(string $lineItemId, ?\Throwable $previous = null)
     {
         $message = sprintf('The `productId` and `referencedId` of the line item %s are not identical.', $lineItemId);
-        parent::__construct($message);
+        parent::__construct($message, [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/Product/Exception/ProductLineItemInconsistentException.php
+++ b/src/Core/Content/Product/Exception/ProductLineItemInconsistentException.php
@@ -7,14 +7,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProductLineItemInconsistentException extends ShopwareHttpException
 {
-    public function __construct(string $lineItemId)
+    public function __construct(string $lineItemId, ?\Throwable $previous = null)
     {
         $message = sprintf(
             'To change the product of line item (%s), the following properties must also be updated: `productId`, `referenceId`, `payload.productNumber`.',
             $lineItemId
         );
 
-        parent::__construct($message);
+        parent::__construct($message, [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/Product/Exception/ProductNotFoundException.php
+++ b/src/Core/Content/Product/Exception/ProductNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProductNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $productId)
+    public function __construct(string $productId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Product for id {{ productId }} not found.',
-            ['productId' => $productId]
+            ['productId' => $productId],
+            $previous
         );
     }
 

--- a/src/Core/Content/Product/Exception/ProductNumberNotFoundException.php
+++ b/src/Core/Content/Product/Exception/ProductNumberNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProductNumberNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $number)
+    public function __construct(string $number, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Product with number "{{ number }}" not found.',
-            ['number' => $number]
+            ['number' => $number],
+            $previous
         );
     }
 

--- a/src/Core/Content/Product/Exception/ReviewNotActiveExeption.php
+++ b/src/Core/Content/Product/Exception/ReviewNotActiveExeption.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ReviewNotActiveExeption extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Reviews not activated');
+        parent::__construct('Reviews not activated', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/Product/SalesChannel/Exception/ProductSortingNotFoundException.php
+++ b/src/Core/Content/Product/SalesChannel/Exception/ProductSortingNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ProductSortingNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $key)
+    public function __construct(string $key, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Product sorting with key {{ key }} not found.',
-            ['key' => $key]
+            ['key' => $key],
+            $previous
         );
     }
 

--- a/src/Core/Content/ProductExport/Error/XmlValidationError.php
+++ b/src/Core/Content/ProductExport/Error/XmlValidationError.php
@@ -22,7 +22,7 @@ class XmlValidationError extends Error
     /**
      * @param \LibXMLError[] $errors
      */
-    public function __construct(string $id, array $errors = [])
+    public function __construct(string $id, array $errors = [], ?\Throwable $previous = null)
     {
         $this->id = $id;
         $this->errors = $errors;
@@ -43,7 +43,7 @@ class XmlValidationError extends Error
 
         $this->message = 'The export did not generate a valid XML file';
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getId(): string

--- a/src/Core/Content/ProductExport/Exception/DuplicateFileNameException.php
+++ b/src/Core/Content/ProductExport/Exception/DuplicateFileNameException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class DuplicateFileNameException extends ShopwareHttpException
 {
-    public function __construct(string $number, ?\Throwable $e = null)
+    public function __construct(string $number, ?\Throwable $previous = null)
     {
         parent::__construct(
             'File name "{{ fileName }}" already exists.',
             ['fileName' => $number],
-            $e
+            $previous
         );
     }
 

--- a/src/Core/Content/ProductExport/Exception/EmptyExportException.php
+++ b/src/Core/Content/ProductExport/Exception/EmptyExportException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EmptyExportException extends ShopwareHttpException
 {
-    public function __construct(?string $id = null)
+    public function __construct(?string $id = null, ?\Throwable $previous = null)
     {
         if (empty($id)) {
-            parent::__construct('No products for export found');
+            parent::__construct('No products for export found', [], $previous);
         } else {
-            parent::__construct('No products for export with ID {{ id }} found', ['id' => $id]);
+            parent::__construct('No products for export with ID {{ id }} found', ['id' => $id], $previous);
         }
     }
 

--- a/src/Core/Content/ProductExport/Exception/ExportInvalidException.php
+++ b/src/Core/Content/ProductExport/Exception/ExportInvalidException.php
@@ -17,7 +17,7 @@ class ExportInvalidException extends ShopwareHttpException
     /**
      * @param Error[] $errors
      */
-    public function __construct(ProductExportEntity $productExportEntity, array $errors)
+    public function __construct(ProductExportEntity $productExportEntity, array $errors, ?\Throwable $previous = null)
     {
         $errorMessages = array_merge(
             ...array_map(
@@ -36,7 +36,8 @@ class ExportInvalidException extends ShopwareHttpException
                 $productExportEntity->getId(),
                 $productExportEntity->getFileName()
             ),
-            ['errors' => $errors, 'errorMessages' => $errorMessages]
+            ['errors' => $errors, 'errorMessages' => $errorMessages],
+            $previous
         );
     }
 

--- a/src/Core/Content/ProductExport/Exception/ExportNotFoundException.php
+++ b/src/Core/Content/ProductExport/Exception/ExportNotFoundException.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ExportNotFoundException extends ShopwareHttpException
 {
-    public function __construct(?string $id = null, ?string $fileName = null)
+    public function __construct(?string $id = null, ?string $fileName = null, ?\Throwable $previous = null)
     {
         $message = 'No product exports found';
 
@@ -17,7 +17,7 @@ class ExportNotFoundException extends ShopwareHttpException
             $message = 'Product export with file name {{ fileName }} not found. Please check your access key.';
         }
 
-        parent::__construct($message, ['id' => $id, 'fileName' => $fileName]);
+        parent::__construct($message, ['id' => $id, 'fileName' => $fileName], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Content/ProductExport/Exception/ExportNotGeneratedException.php
+++ b/src/Core/Content/ProductExport/Exception/ExportNotGeneratedException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ExportNotGeneratedException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Export file has not been generated yet. Please make sure that the scheduled task are working or run the command manually.');
+        parent::__construct('Export file has not been generated yet. Please make sure that the scheduled task are working or run the command manually.', [], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Content/ProductExport/Exception/MissingRootFilterException.php
+++ b/src/Core/Content/ProductExport/Exception/MissingRootFilterException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class MissingRootFilterException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Missing root filter ');
+        parent::__construct('Missing root filter ', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/ProductExport/Exception/SalesChannelDomainNotFoundException.php
+++ b/src/Core/Content/ProductExport/Exception/SalesChannelDomainNotFoundException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class SalesChannelDomainNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
-        parent::__construct('Sales channel domain with ID {{ id }} not found', ['id' => $id]);
+        parent::__construct('Sales channel domain with ID {{ id }} not found', ['id' => $id], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
@@ -67,7 +67,7 @@ class ProductExportRenderer implements ProductExportRendererInterface
 
             return $this->replaceSeoUrlPlaceholder($content, $productExport, $salesChannelContext);
         } catch (StringTemplateRenderingException $exception) {
-            $renderHeaderException = new RenderHeaderException($exception->getMessage());
+            $renderHeaderException = new RenderHeaderException($exception->getMessage(), $exception);
             $this->logException($salesChannelContext->getContext(), $renderHeaderException);
 
             throw $renderHeaderException;
@@ -100,7 +100,7 @@ class ProductExportRenderer implements ProductExportRendererInterface
 
             return $this->replaceSeoUrlPlaceholder($content, $productExport, $salesChannelContext);
         } catch (StringTemplateRenderingException $exception) {
-            $renderFooterException = new RenderFooterException($exception->getMessage());
+            $renderFooterException = new RenderFooterException($exception->getMessage(), $exception);
             $this->logException($salesChannelContext->getContext(), $renderFooterException);
 
             throw $renderFooterException;
@@ -121,7 +121,7 @@ class ProductExportRenderer implements ProductExportRendererInterface
 
             return $this->replaceSeoUrlPlaceholder($content, $productExport, $salesChannelContext);
         } catch (StringTemplateRenderingException $exception) {
-            $renderProductException = new RenderProductException($exception->getMessage());
+            $renderProductException = new RenderProductException($exception->getMessage(), $exception);
             $this->logException($salesChannelContext->getContext(), $renderProductException);
 
             throw $renderProductException;

--- a/src/Core/Content/ProductStream/Exception/FilterNotFoundException.php
+++ b/src/Core/Content/ProductStream/Exception/FilterNotFoundException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class FilterNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $type)
+    public function __construct(string $type, ?\Throwable $previous = null)
     {
-        parent::__construct('Filter for type {{ type}} not found', ['type' => $type]);
+        parent::__construct('Filter for type {{ type}} not found', ['type' => $type], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/ProductStream/Exception/NoFilterException.php
+++ b/src/Core/Content/ProductStream/Exception/NoFilterException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class NoFilterException extends ShopwareHttpException
 {
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
-        parent::__construct('Product stream with ID {{ id }} has no filters', ['id' => $id]);
+        parent::__construct('Product stream with ID {{ id }} has no filters', ['id' => $id], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/Seo/Exception/InvalidSeoUrlException.php
+++ b/src/Core/Content/Seo/Exception/InvalidSeoUrlException.php
@@ -7,11 +7,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidSeoUrlException extends ShopwareHttpException
 {
-    public function __construct(string $message)
-    {
-        parent::__construct($message);
-    }
-
     public function getStatusCode(): int
     {
         return Response::HTTP_BAD_REQUEST;

--- a/src/Core/Content/Seo/Exception/InvalidTemplateException.php
+++ b/src/Core/Content/Seo/Exception/InvalidTemplateException.php
@@ -9,11 +9,6 @@ class InvalidTemplateException extends ShopwareHttpException
 {
     public const ERROR_CODE = 'FRAMEWORK__INVALID_SEO_TEMPLATE';
 
-    public function __construct(string $message)
-    {
-        parent::__construct($message);
-    }
-
     public function getStatusCode(): int
     {
         return Response::HTTP_BAD_REQUEST;

--- a/src/Core/Content/Seo/Exception/NoEntitiesForPreviewException.php
+++ b/src/Core/Content/Seo/Exception/NoEntitiesForPreviewException.php
@@ -9,11 +9,12 @@ class NoEntitiesForPreviewException extends ShopwareHttpException
 {
     public const ERROR_CODE = 'FRAMEWORK__NO_ENTRIES_FOR_SEO_URL_PREVIEW';
 
-    public function __construct(string $entityName, string $routeName)
+    public function __construct(string $entityName, string $routeName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'No entites of type {{ entityName }} could be found to create a preview for route {{ routeName }}',
-            ['entityName' => $entityName, 'routeName' => $routeName]
+            ['entityName' => $entityName, 'routeName' => $routeName],
+            $previous
         );
     }
 

--- a/src/Core/Content/Seo/Exception/SeoUrlRouteNotFoundException.php
+++ b/src/Core/Content/Seo/Exception/SeoUrlRouteNotFoundException.php
@@ -9,9 +9,9 @@ class SeoUrlRouteNotFoundException extends ShopwareHttpException
 {
     public const ERROR_CODE = 'FRAMEWORK__SEO_URL_ROUTE_NOT_FOUND';
 
-    public function __construct(string $routeName)
+    public function __construct(string $routeName, ?\Throwable $previous = null)
     {
-        parent::__construct('seo url route"{{ routeName }}" not found.', ['routeName' => $routeName]);
+        parent::__construct('seo url route"{{ routeName }}" not found.', ['routeName' => $routeName], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Content/Sitemap/Exception/AlreadyLockedException.php
+++ b/src/Core/Content/Sitemap/Exception/AlreadyLockedException.php
@@ -7,12 +7,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class AlreadyLockedException extends ShopwareHttpException
 {
-    public function __construct(SalesChannelContext $salesChannelContext)
+    public function __construct(SalesChannelContext $salesChannelContext, ?\Throwable $previous = null)
     {
         parent::__construct('Cannot acquire lock for sales channel {{salesChannelId}} and language {{languageId}}', [
             'salesChannelId' => $salesChannelContext->getSalesChannel()->getId(),
             'languageId' => $salesChannelContext->getSalesChannel()->getLanguageId(),
-        ]);
+        ], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/Sitemap/Exception/InvalidSitemapKey.php
+++ b/src/Core/Content/Sitemap/Exception/InvalidSitemapKey.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class InvalidSitemapKey extends ShopwareHttpException
 {
-    public function __construct(string $sitemapKey)
+    public function __construct(string $sitemapKey, ?\Throwable $previous = null)
     {
-        parent::__construct('Invalid sitemap config key: "{{ sitemapKey }}"', ['sitemapKey' => $sitemapKey]);
+        parent::__construct('Invalid sitemap config key: "{{ sitemapKey }}"', ['sitemapKey' => $sitemapKey], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Content/Sitemap/Exception/UrlProviderNotFound.php
+++ b/src/Core/Content/Sitemap/Exception/UrlProviderNotFound.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class UrlProviderNotFound extends ShopwareHttpException
 {
-    public function __construct(string $provider)
+    public function __construct(string $provider, ?\Throwable $previous = null)
     {
-        parent::__construct('provider "{{ provider }}" not found.', ['provider' => $provider]);
+        parent::__construct('provider "{{ provider }}" not found.', ['provider' => $provider], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Adapter/Filesystem/Exception/AdapterFactoryNotFoundException.php
+++ b/src/Core/Framework/Adapter/Filesystem/Exception/AdapterFactoryNotFoundException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class AdapterFactoryNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $type)
+    public function __construct(string $type, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Adapter factory for type "{{ type }}" was not found.',
-            ['type' => $type]
+            ['type' => $type],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Adapter/Filesystem/Exception/DuplicateFilesystemFactoryException.php
+++ b/src/Core/Framework/Adapter/Filesystem/Exception/DuplicateFilesystemFactoryException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class DuplicateFilesystemFactoryException extends ShopwareHttpException
 {
-    public function __construct(string $type)
+    public function __construct(string $type, ?\Throwable $previous = null)
     {
-        parent::__construct('The type of factory "{{ type }}" must be unique.', ['type' => $type]);
+        parent::__construct('The type of factory "{{ type }}" must be unique.', ['type' => $type], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Adapter/Twig/Exception/StringTemplateRenderingException.php
+++ b/src/Core/Framework/Adapter/Twig/Exception/StringTemplateRenderingException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StringTemplateRenderingException extends ShopwareHttpException
 {
-    public function __construct(string $twigMessage)
+    public function __construct(string $twigMessage, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Failed rendering string template using Twig: {{ message }}',
-            ['message' => $twigMessage]
+            ['message' => $twigMessage],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Adapter/Twig/StringTemplateRenderer.php
+++ b/src/Core/Framework/Adapter/Twig/StringTemplateRenderer.php
@@ -64,7 +64,7 @@ class StringTemplateRenderer
         try {
             return $this->twig->render($name, $data);
         } catch (Error $error) {
-            throw new StringTemplateRenderingException($error->getMessage());
+            throw new StringTemplateRenderingException($error->getMessage(), $error);
         }
     }
 

--- a/src/Core/Framework/Api/ApiDefinition/ApiDefinitionGeneratorNotFoundException.php
+++ b/src/Core/Framework/Api/ApiDefinition/ApiDefinitionGeneratorNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ApiDefinitionGeneratorNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $format)
+    public function __construct(string $format, ?\Throwable $previous = null)
     {
         parent::__construct(
             'A definition generator for format "{{ format }}" was not found.',
-            ['format' => $format]
+            ['format' => $format],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Api/ApiDefinition/ApiTypeNotFoundException.php
+++ b/src/Core/Framework/Api/ApiDefinition/ApiTypeNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ApiTypeNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $type)
+    public function __construct(string $type, ?\Throwable $previous = null)
     {
         parent::__construct(
             'A api type "{{ type }}" was not found.',
-            ['type' => $type]
+            ['type' => $type],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Api/Context/Exception/InvalidContextSourceException.php
+++ b/src/Core/Framework/Api/Context/Exception/InvalidContextSourceException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class InvalidContextSourceException extends ShopwareHttpException
 {
-    public function __construct(string $expected, string $actual)
+    public function __construct(string $expected, string $actual, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Expected ContextSource of "{{expected}}", but got "{{actual}}".',
-            ['expected' => $expected, 'actual' => $actual]
+            ['expected' => $expected, 'actual' => $actual],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Api/Context/Exception/InvalidContextSourceUserException.php
+++ b/src/Core/Framework/Api/Context/Exception/InvalidContextSourceUserException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class InvalidContextSourceUserException extends ShopwareHttpException
 {
-    public function __construct(string $contextSource)
+    public function __construct(string $contextSource, ?\Throwable $previous = null)
     {
         parent::__construct(
             '{{ contextSource }} does not have a valid user ID',
-            ['contextSource' => $contextSource]
+            ['contextSource' => $contextSource],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Api/Controller/Exception/ExpectedUserHttpException.php
+++ b/src/Core/Framework/Api/Controller/Exception/ExpectedUserHttpException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ExpectedUserHttpException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('For this interaction an authenticated user login is required.');
+        parent::__construct('For this interaction an authenticated user login is required.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Api/Controller/Exception/PermissionDeniedException.php
+++ b/src/Core/Framework/Api/Controller/Exception/PermissionDeniedException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PermissionDeniedException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('The user does not have the permission to do this action.');
+        parent::__construct('The user does not have the permission to do this action.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Api/Converter/Exceptions/ApiConversionException.php
+++ b/src/Core/Framework/Api/Converter/Exceptions/ApiConversionException.php
@@ -17,7 +17,11 @@ class ApiConversionException extends ShopwareHttpException
     {
         $this->exceptions = $exceptions;
 
-        parent::__construct('Api Version conversion failed, got {{ numberOfFailures }} failure(s).', ['numberOfFailures' => \count($exceptions)]);
+        parent::__construct(
+            'Api Version conversion failed, got {{ numberOfFailures }} failure(s).',
+            ['numberOfFailures' => \count($exceptions)],
+            \current(\array_filter($exceptions, 'is_object')) ?: null
+        );
     }
 
     public function add(\Throwable $exception, string $pointer): void

--- a/src/Core/Framework/Api/Exception/ExceptionFailedException.php
+++ b/src/Core/Framework/Api/Exception/ExceptionFailedException.php
@@ -9,9 +9,9 @@ class ExceptionFailedException extends ShopwareHttpException
 {
     private array $fails = [];
 
-    public function __construct(array $failedExpectations)
+    public function __construct(array $failedExpectations, ?\Throwable $previous = null)
     {
-        parent::__construct('API Expectations failed', []);
+        parent::__construct('API Expectations failed', [], $previous);
         $this->fails = $failedExpectations;
     }
 

--- a/src/Core/Framework/Api/Exception/IncompletePrimaryKeyException.php
+++ b/src/Core/Framework/Api/Exception/IncompletePrimaryKeyException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class IncompletePrimaryKeyException extends ShopwareHttpException
 {
-    public function __construct(array $primaryKeyFields)
+    public function __construct(array $primaryKeyFields, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The primary key consists of {{ fieldCount }} fields. Please provide values for the following fields: {{ fieldsString }}',
-            ['fieldCount' => \count($primaryKeyFields), 'fields' => $primaryKeyFields, 'fieldsString' => implode(', ', $primaryKeyFields)]
+            ['fieldCount' => \count($primaryKeyFields), 'fields' => $primaryKeyFields, 'fieldsString' => implode(', ', $primaryKeyFields)],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Api/Exception/InvalidSalesChannelIdException.php
+++ b/src/Core/Framework/Api/Exception/InvalidSalesChannelIdException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidSalesChannelIdException extends ShopwareHttpException
 {
-    public function __construct(string $salesChannelId)
+    public function __construct(string $salesChannelId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The provided salesChannelId "{{ salesChannelId }}" is invalid.',
-            ['salesChannelId' => $salesChannelId]
+            ['salesChannelId' => $salesChannelId],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Api/Exception/InvalidVersionNameException.php
+++ b/src/Core/Framework/Api/Exception/InvalidVersionNameException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidVersionNameException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Invalid version name given. Only alphanumeric characters are allowed');
+        parent::__construct('Invalid version name given. Only alphanumeric characters are allowed', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Api/Exception/LiveVersionDeleteException.php
+++ b/src/Core/Framework/Api/Exception/LiveVersionDeleteException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class LiveVersionDeleteException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Live version can not be deleted. Delete entity instead.');
+        parent::__construct('Live version can not be deleted. Delete entity instead.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Api/Exception/MissingPrivilegeException.php
+++ b/src/Core/Framework/Api/Exception/MissingPrivilegeException.php
@@ -9,14 +9,14 @@ class MissingPrivilegeException extends ShopwareHttpException
 {
     public const MISSING_PRIVILEGE_ERROR = 'FRAMEWORK__MISSING_PRIVILEGE_ERROR';
 
-    public function __construct(array $privilege = [])
+    public function __construct(array $privilege = [], ?\Throwable $previous = null)
     {
         $errorMessage = json_encode([
             'message' => 'Missing privilege',
             'missingPrivileges' => $privilege,
         ]);
 
-        parent::__construct($errorMessage ?: '');
+        parent::__construct($errorMessage ?: '', [], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Framework/Api/Exception/NoEntityClonedException.php
+++ b/src/Core/Framework/Api/Exception/NoEntityClonedException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class NoEntityClonedException extends ShopwareHttpException
 {
-    public function __construct(string $entity, string $id)
+    public function __construct(string $entity, string $id, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Could not clone entity {{ entity }} with id {{ id }}.',
-            ['entity' => $entity, 'id' => $id]
+            ['entity' => $entity, 'id' => $id],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Api/Exception/ResourceNotFoundException.php
+++ b/src/Core/Framework/Api/Exception/ResourceNotFoundException.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ResourceNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $resourceType, array $primaryKey)
+    public function __construct(string $resourceType, array $primaryKey, ?\Throwable $previous = null)
     {
         $resourceIds = [];
         foreach ($primaryKey as $key => $value) {
@@ -16,7 +16,8 @@ class ResourceNotFoundException extends ShopwareHttpException
 
         parent::__construct(
             'The {{ type }} resource with the following primary key was not found: {{ primaryKeyString }}',
-            ['type' => $resourceType, 'primaryKey' => $primaryKey, 'primaryKeyString' => implode(' ', $resourceIds)]
+            ['type' => $resourceType, 'primaryKey' => $primaryKey, 'primaryKeyString' => implode(' ', $resourceIds)],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Api/Exception/UnsupportedEncoderInputException.php
+++ b/src/Core/Framework/Api/Exception/UnsupportedEncoderInputException.php
@@ -9,9 +9,9 @@ class UnsupportedEncoderInputException extends ShopwareHttpException
     /**
      * {@inheritdoc}
      */
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Unsupported encoder data provided. Only entities and entity collections are supported');
+        parent::__construct('Unsupported encoder data provided. Only entities and entity collections are supported', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/App/ActionButton/AppActionLoader.php
+++ b/src/Core/Framework/App/ActionButton/AppActionLoader.php
@@ -55,7 +55,7 @@ class AppActionLoader
         try {
             $shopId = $this->shopIdProvider->getShopId();
         } catch (AppUrlChangeDetectedException $e) {
-            throw new ActionNotFoundException();
+            throw new ActionNotFoundException($e);
         }
 
         /** @var string $secret */

--- a/src/Core/Framework/App/Exception/ActionNotFoundException.php
+++ b/src/Core/Framework/App/Exception/ActionNotFoundException.php
@@ -10,9 +10,9 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ActionNotFoundException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('The requested app action does not exist');
+        parent::__construct('The requested app action does not exist', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/App/Exception/AppAlreadyInstalledException.php
+++ b/src/Core/Framework/App/Exception/AppAlreadyInstalledException.php
@@ -7,8 +7,8 @@ namespace Shopware\Core\Framework\App\Exception;
  */
 class AppAlreadyInstalledException extends \Exception
 {
-    public function __construct(string $appName)
+    public function __construct(string $appName, ?\Throwable $previous = null)
     {
-        parent::__construct(sprintf('App with name "%s" is already installed.', $appName));
+        parent::__construct(sprintf('App with name "%s" is already installed.', $appName), 0, $previous);
     }
 }

--- a/src/Core/Framework/App/Exception/AppNotFoundException.php
+++ b/src/Core/Framework/App/Exception/AppNotFoundException.php
@@ -7,8 +7,8 @@ namespace Shopware\Core\Framework\App\Exception;
  */
 class AppNotFoundException extends \Exception
 {
-    public function __construct(string $appId)
+    public function __construct(string $appId, ?\Throwable $previous = null)
     {
-        parent::__construct(sprintf('App for ID: "%s" could not be found.', $appId));
+        parent::__construct(sprintf('App for ID: "%s" could not be found.', $appId), 0, $previous);
     }
 }

--- a/src/Core/Framework/App/Exception/AppUrlChangeDetectedException.php
+++ b/src/Core/Framework/App/Exception/AppUrlChangeDetectedException.php
@@ -7,8 +7,8 @@ namespace Shopware\Core\Framework\App\Exception;
  */
 class AppUrlChangeDetectedException extends \Exception
 {
-    public function __construct(string $previousUrl, string $currentUrl)
+    public function __construct(string $previousUrl, string $currentUrl, ?\Throwable $previous = null)
     {
-        parent::__construct(sprintf('Detected APP_URL change, was "%s" and is now "%s".', $previousUrl, $currentUrl));
+        parent::__construct(sprintf('Detected APP_URL change, was "%s" and is now "%s".', $previousUrl, $currentUrl), 0, $previous);
     }
 }

--- a/src/Core/Framework/App/Exception/AppUrlChangeStrategyNotFoundException.php
+++ b/src/Core/Framework/App/Exception/AppUrlChangeStrategyNotFoundException.php
@@ -7,8 +7,8 @@ namespace Shopware\Core\Framework\App\Exception;
  */
 class AppUrlChangeStrategyNotFoundException extends \RuntimeException
 {
-    public function __construct(string $strategyName)
+    public function __construct(string $strategyName, ?\Throwable $previous = null)
     {
-        parent::__construct('Unable to find AppUrlChangeResolver with name: "' . $strategyName . '".');
+        parent::__construct('Unable to find AppUrlChangeResolver with name: "' . $strategyName . '".', 0, $previous);
     }
 }

--- a/src/Core/Framework/App/Exception/InvalidAppConfigurationException.php
+++ b/src/Core/Framework/App/Exception/InvalidAppConfigurationException.php
@@ -9,8 +9,8 @@ use Shopware\Core\Framework\App\Validation\Error\Error;
  */
 class InvalidAppConfigurationException extends \RuntimeException
 {
-    public function __construct(Error $error)
+    public function __construct(Error $previous)
     {
-        parent::__construct($error->getMessage());
+        parent::__construct($previous->getMessage(), $previous->getCode(), $previous);
     }
 }

--- a/src/Core/Framework/App/Exception/NoAppUrlChangeDetectedException.php
+++ b/src/Core/Framework/App/Exception/NoAppUrlChangeDetectedException.php
@@ -7,8 +7,8 @@ namespace Shopware\Core\Framework\App\Exception;
  */
 class NoAppUrlChangeDetectedException extends \RuntimeException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('No APP_URL change was detected, cannot run AppUrlChange strategies.');
+        parent::__construct('No APP_URL change was detected, cannot run AppUrlChange strategies.', 0, $previous);
     }
 }

--- a/src/Core/Framework/App/Manifest/Exception/ManifestNotFoundException.php
+++ b/src/Core/Framework/App/Manifest/Exception/ManifestNotFoundException.php
@@ -7,11 +7,11 @@ namespace Shopware\Core\Framework\App\Manifest\Exception;
  */
 class ManifestNotFoundException extends \RuntimeException
 {
-    public function __construct(string $path)
+    public function __construct(string $path, ?\Throwable $previous = null)
     {
         parent::__construct(sprintf(
             'No "manifest.xml" file in path "%s" found. (The file must be placed in the app root folder.)',
             $path
-        ));
+        ), 0, $previous);
     }
 }

--- a/src/Core/Framework/App/Manifest/Manifest.php
+++ b/src/Core/Framework/App/Manifest/Manifest.php
@@ -110,7 +110,7 @@ class Manifest
             $payments = $doc->getElementsByTagName('payments')->item(0);
             $payments = $payments === null ? null : Payments::fromXml($payments);
         } catch (\Exception $e) {
-            throw new XmlParsingException($xmlFile, $e->getMessage());
+            throw new XmlParsingException($xmlFile, $e->getMessage(), $e);
         }
 
         return new self(\dirname($xmlFile), $metadata, $setup, $admin, $permissions, $customFields, $webhooks, $cookies, $payments);

--- a/src/Core/Framework/App/Payment/Handler/AppAsyncPaymentHandler.php
+++ b/src/Core/Framework/App/Payment/Handler/AppAsyncPaymentHandler.php
@@ -43,7 +43,7 @@ class AppAsyncPaymentHandler extends AbstractAppPaymentHandler implements Asynch
         try {
             $response = $this->payloadService->request($url, $payload, $app, AsyncPayResponse::class);
         } catch (ClientExceptionInterface $exception) {
-            throw new AsyncPaymentProcessException($transaction->getOrderTransaction()->getId(), sprintf('App error: %s', $exception->getMessage()));
+            throw new AsyncPaymentProcessException($transaction->getOrderTransaction()->getId(), \sprintf('App error: %s', $exception->getMessage()), $exception);
         }
 
         if (!$response instanceof AsyncPayResponse) {
@@ -85,7 +85,7 @@ class AppAsyncPaymentHandler extends AbstractAppPaymentHandler implements Asynch
         try {
             $response = $this->payloadService->request($url, $payload, $app, AsyncFinalizeResponse::class);
         } catch (ClientExceptionInterface $exception) {
-            throw new AsyncPaymentFinalizeException($transaction->getOrderTransaction()->getId(), sprintf('App error: %s', $exception->getMessage()));
+            throw new AsyncPaymentFinalizeException($transaction->getOrderTransaction()->getId(), \sprintf('App error: %s', $exception->getMessage()), $exception);
         }
 
         if (!$response instanceof AsyncFinalizeResponse) {

--- a/src/Core/Framework/App/Payment/Handler/AppSyncPaymentHandler.php
+++ b/src/Core/Framework/App/Payment/Handler/AppSyncPaymentHandler.php
@@ -36,7 +36,7 @@ class AppSyncPaymentHandler extends AbstractAppPaymentHandler implements Synchro
         try {
             $response = $this->payloadService->request($payUrl, $payload, $app, SyncPayResponse::class);
         } catch (ClientExceptionInterface $exception) {
-            throw new AsyncPaymentProcessException($transaction->getOrderTransaction()->getId(), sprintf('App error: %s', $exception->getMessage()));
+            throw new AsyncPaymentProcessException($transaction->getOrderTransaction()->getId(), \sprintf('App error: %s', $exception->getMessage()), $exception);
         }
 
         if (!$response instanceof SyncPayResponse) {

--- a/src/Core/Framework/App/Validation/Error/AppNameError.php
+++ b/src/Core/Framework/App/Validation/Error/AppNameError.php
@@ -9,14 +9,14 @@ class AppNameError extends Error
 {
     private const KEY = 'invalid-app-name';
 
-    public function __construct(string $appName)
+    public function __construct(string $appName, ?\Throwable $previous = null)
     {
         $this->message = sprintf(
             'The technical app name "%s" in the "manifest.xml" and the folder name must be equal.',
             $appName
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getMessageKey(): string

--- a/src/Core/Framework/App/Validation/Error/ConfigurationError.php
+++ b/src/Core/Framework/App/Validation/Error/ConfigurationError.php
@@ -9,14 +9,14 @@ class ConfigurationError extends Error
 {
     private const KEY = 'manifest-invalid-config';
 
-    public function __construct(array $violations)
+    public function __construct(array $violations, ?\Throwable $previous = null)
     {
         $this->message = sprintf(
             "The following custom components are not allowed to be used in app configuration:\n- %s",
             implode("\n- ", $violations)
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getMessageKey(): string

--- a/src/Core/Framework/App/Validation/Error/MissingPermissionError.php
+++ b/src/Core/Framework/App/Validation/Error/MissingPermissionError.php
@@ -9,14 +9,14 @@ class MissingPermissionError extends Error
 {
     private const KEY = 'manifest-missing-permission';
 
-    public function __construct(array $violations)
+    public function __construct(array $violations, ?\Throwable $previous = null)
     {
         $this->message = sprintf(
             "The following permissions are missing:\n- %s",
             implode("\n- ", $violations)
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getMessageKey(): string

--- a/src/Core/Framework/App/Validation/Error/MissingTranslationError.php
+++ b/src/Core/Framework/App/Validation/Error/MissingTranslationError.php
@@ -9,7 +9,7 @@ class MissingTranslationError extends Error
 {
     private const KEY = 'manifest-missing-translation';
 
-    public function __construct(string $xmlElementClass, array $missingTranslations)
+    public function __construct(string $xmlElementClass, array $missingTranslations, ?\Throwable $previous = null)
     {
         $path = explode('\\', $xmlElementClass);
         $xmlClassName = array_pop($path);
@@ -25,7 +25,7 @@ class MissingTranslationError extends Error
             implode("\n- ", $validations)
         );
 
-        parent::__construct($message);
+        parent::__construct($message, 0, $previous);
     }
 
     public function getMessageKey(): string

--- a/src/Core/Framework/App/Validation/Error/NotHookableError.php
+++ b/src/Core/Framework/App/Validation/Error/NotHookableError.php
@@ -9,14 +9,14 @@ class NotHookableError extends Error
 {
     private const KEY = 'manifest-not-hookable';
 
-    public function __construct(array $violations)
+    public function __construct(array $violations, ?\Throwable $previous = null)
     {
         $this->message = sprintf(
             "The following webhooks are not hookable:\n- %s",
             implode("\n- ", $violations)
         );
 
-        parent::__construct($this->message);
+        parent::__construct($this->message, 0, $previous);
     }
 
     public function getMessageKey(): string

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Exception/FieldAccessorBuilderNotFoundException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Exception/FieldAccessorBuilderNotFoundException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class FieldAccessorBuilderNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $field)
+    public function __construct(string $field, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The field accessor builder for field {{ field }} was not found.',
-            ['field' => $field]
+            ['field' => $field],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Exception/FieldNotStorageAwareException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Exception/FieldNotStorageAwareException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FieldNotStorageAwareException extends ShopwareHttpException
 {
-    public function __construct(string $field)
+    public function __construct(string $field, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The field {{ field }} must implement the StorageAware interface to be accessible.',
-            ['field' => $field]
+            ['field' => $field],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Exception/InvalidSortingDirectionException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Exception/InvalidSortingDirectionException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidSortingDirectionException extends ShopwareHttpException
 {
-    public function __construct(string $direction)
+    public function __construct(string $direction, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The given sort direction "{{ direction }}" is invalid.',
-            ['direction' => $direction]
+            ['direction' => $direction],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Exception/ParentAssociationCanNotBeFetched.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Exception/ParentAssociationCanNotBeFetched.php
@@ -7,10 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ParentAssociationCanNotBeFetched extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
         parent::__construct(
-            'It is not possible to read the parent association directly. Please read the parents via a separate call over the repository'
+            'It is not possible to read the parent association directly. Please read the parents via a separate call over the repository',
+            [],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Exception/UnmappedFieldException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Exception/UnmappedFieldException.php
@@ -8,14 +8,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class UnmappedFieldException extends ShopwareHttpException
 {
-    public function __construct(string $field, EntityDefinition $definition)
+    public function __construct(string $field, EntityDefinition $definition, ?\Throwable $previous = null)
     {
         $fieldParts = explode('.', $field);
         $name = array_pop($fieldParts);
 
         parent::__construct(
             'Field "{{ field }}" in entity "{{ entity }}" was not found.',
-            ['field' => $name, 'entity' => $definition->getEntityName()]
+            ['field' => $name, 'entity' => $definition->getEntityName()],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/DefinitionInstanceRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/DefinitionInstanceRegistry.php
@@ -82,7 +82,7 @@ class DefinitionInstanceRegistry
         try {
             return $this->get($definitionClass);
         } catch (ServiceNotFoundException $e) {
-            throw new DefinitionNotFoundException($entityName);
+            throw new DefinitionNotFoundException($entityName, $e);
         }
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/ApiProtectionException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/ApiProtectionException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class ApiProtectionException extends ShopwareHttpException
 {
-    public function __construct(string $accessor)
+    public function __construct(string $accessor, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Accessor {{ accessor }} is not allowed in this api scope',
-            ['accessor' => $accessor]
+            ['accessor' => $accessor],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/AssociationNotFoundException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/AssociationNotFoundException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class AssociationNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $field)
+    public function __construct(string $field, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Can not find association by name {{ association }}',
-            ['association' => $field]
+            ['association' => $field],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/CanNotFindParentStorageFieldException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/CanNotFindParentStorageFieldException.php
@@ -7,11 +7,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class CanNotFindParentStorageFieldException extends ShopwareHttpException
 {
-    public function __construct(EntityDefinition $definition)
+    public function __construct(EntityDefinition $definition, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Can not find FkField for parent property definition {{ definition }}',
-            ['definition' => $definition->getClass()]
+            ['definition' => $definition->getClass()],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/DecodeByHydratorException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/DecodeByHydratorException.php
@@ -8,11 +8,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class DecodeByHydratorException extends ShopwareHttpException
 {
-    public function __construct(Field $field)
+    public function __construct(Field $field, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Decoding of {{ fieldClass }} is handled by the entity hydrator.',
-            ['fieldClass' => \get_class($field)]
+            ['fieldClass' => \get_class($field)],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/DefinitionNotFoundException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/DefinitionNotFoundException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class DefinitionNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $entity)
+    public function __construct(string $entity, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Definition for entity "{{ entityName }}" does not exist.',
-            ['entityName' => $entity]
+            ['entityName' => $entity],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/EntityNotFoundException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/EntityNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EntityNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $entity, string $identifier)
+    public function __construct(string $entity, string $identifier, ?\Throwable $previous = null)
     {
         parent::__construct(
             '{{ entity }} for id {{ identifier }} not found.',
-            ['entity' => $entity, 'identifier' => $identifier]
+            ['entity' => $entity, 'identifier' => $identifier],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/EntityRepositoryNotFoundException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/EntityRepositoryNotFoundException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class EntityRepositoryNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $entity)
+    public function __construct(string $entity, ?\Throwable $previous = null)
     {
         parent::__construct(
             'EntityRepository for entity "{{ entityName }}" does not exist.',
-            ['entityName' => $entity]
+            ['entityName' => $entity],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/ImpossibleWriteOrderException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/ImpossibleWriteOrderException.php
@@ -7,11 +7,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class ImpossibleWriteOrderException extends ShopwareHttpException
 {
-    public function __construct(array $remaining)
+    public function __construct(array $remaining, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Can not resolve write order for provided data. Remaining write order classes: {{ classesString }}',
-            ['classes' => $remaining, 'classesString' => implode(', ', $remaining)]
+            ['classes' => $remaining, 'classesString' => implode(', ', $remaining)],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/InconsistentCriteriaIdsException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/InconsistentCriteriaIdsException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class InconsistentCriteriaIdsException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Inconsistent argument for Criteria. Please filter all invalid values first.');
+        parent::__construct('Inconsistent argument for Criteria. Please filter all invalid values first.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/DataAbstractionLayer/Exception/InvalidAggregationQueryException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/InvalidAggregationQueryException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidAggregationQueryException extends ShopwareHttpException
 {
-    public function __construct(string $message)
+    public function __construct(string $message, ?\Throwable $previous = null)
     {
-        parent::__construct('{{ message }}', ['message' => $message]);
+        parent::__construct('{{ message }}', ['message' => $message], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Framework/DataAbstractionLayer/Exception/InvalidFilterQueryException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/InvalidFilterQueryException.php
@@ -12,11 +12,11 @@ class InvalidFilterQueryException extends ShopwareHttpException
      */
     private $path;
 
-    public function __construct(string $message, string $path = '')
+    public function __construct(string $message, string $path = '', ?\Throwable $previous = null)
     {
         $this->path = $path;
 
-        parent::__construct('{{ message }}', ['message' => $message]);
+        parent::__construct('{{ message }}', ['message' => $message], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Framework/DataAbstractionLayer/Exception/InvalidLimitQueryException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/InvalidLimitQueryException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidLimitQueryException extends ShopwareHttpException
 {
-    public function __construct($limit)
+    public function __construct($limit, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The limit parameter must be a positive integer greater or equals than 1. Given: {{ limit }}',
-            ['limit' => $limit]
+            ['limit' => $limit],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/InvalidPageQueryException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/InvalidPageQueryException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidPageQueryException extends ShopwareHttpException
 {
-    public function __construct($page)
+    public function __construct($page, ?\Throwable $previous = null)
     {
-        parent::__construct('The page parameter must be a positive integer. Given: {{ page }}', ['page' => $page]);
+        parent::__construct('The page parameter must be a positive integer. Given: {{ page }}', ['page' => $page], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Framework/DataAbstractionLayer/Exception/InvalidParentAssociationException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/InvalidParentAssociationException.php
@@ -8,11 +8,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class InvalidParentAssociationException extends ShopwareHttpException
 {
-    public function __construct(EntityDefinition $definition, Field $parentField)
+    public function __construct(EntityDefinition $definition, Field $parentField, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Parent property for {{ definition }} expected to be an ManyToOneAssociationField got {{ fieldDefinition }}',
-            ['definition' => $definition->getClass(), 'fieldDefinition' => \get_class($parentField)]
+            ['definition' => $definition->getClass(), 'fieldDefinition' => \get_class($parentField)],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/InvalidPriceFieldTypeException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/InvalidPriceFieldTypeException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class InvalidPriceFieldTypeException extends ShopwareHttpException
 {
-    public function __construct(string $type)
+    public function __construct(string $type, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The price field does not contain a valid "type" value. Received {{ type }} ',
-            ['type' => $type]
+            ['type' => $type],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/InvalidSerializerFieldException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/InvalidSerializerFieldException.php
@@ -19,11 +19,12 @@ class InvalidSerializerFieldException extends ShopwareHttpException
      */
     private $field;
 
-    public function __construct(string $expectedClass, Field $field)
+    public function __construct(string $expectedClass, Field $field, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Expected field of type "{{ expectedField }}" got "{{ field }}".',
-            ['expectedField' => $expectedClass, 'field' => \get_class($field)]
+            ['expectedField' => $expectedClass, 'field' => \get_class($field)],
+            $previous
         );
 
         $this->expectedClass = $expectedClass;

--- a/src/Core/Framework/DataAbstractionLayer/Exception/InvalidSortQueryException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/InvalidSortQueryException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidSortQueryException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('A value for the sort parameter is required.');
+        parent::__construct('A value for the sort parameter is required.', [], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Framework/DataAbstractionLayer/Exception/MappingEntityClassesException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/MappingEntityClassesException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class MappingEntityClassesException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Mapping definition neither have entities nor collection.');
+        parent::__construct('Mapping definition neither have entities nor collection.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/DataAbstractionLayer/Exception/MissingFieldSerializerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/MissingFieldSerializerException.php
@@ -8,9 +8,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class MissingFieldSerializerException extends ShopwareHttpException
 {
-    public function __construct(Field $field)
+    public function __construct(Field $field, ?\Throwable $previous = null)
     {
-        parent::__construct('No field serializer class found for field class "{{ class }}".', ['class' => \get_class($field)]);
+        parent::__construct('No field serializer class found for field class "{{ class }}".', ['class' => \get_class($field)], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/DataAbstractionLayer/Exception/MissingReverseAssociation.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/MissingReverseAssociation.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class MissingReverseAssociation extends ShopwareHttpException
 {
-    public function __construct(string $source, string $target)
+    public function __construct(string $source, string $target, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Can not find reverse association in entity {{ source }} which should have an association to entity {{ target }}',
-            ['source' => $source, 'target' => $target]
+            ['source' => $source, 'target' => $target],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/MissingSystemTranslationException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/MissingSystemTranslationException.php
@@ -6,6 +6,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Exception;
 
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 
@@ -13,7 +14,7 @@ class MissingSystemTranslationException extends WriteConstraintViolationExceptio
 {
     public const VIOLATION_MISSING_SYSTEM_TRANSLATION = 'MISSING-SYSTEM-TRANSLATION';
 
-    public function __construct(string $path = '')
+    public function __construct(string $path = '', ?\Throwable $previous = null)
     {
         $template = 'Translation required for system language {{ systemLanguage }}';
         $parameters = ['{{ systemLanguage }}' => Defaults::LANGUAGE_SYSTEM];
@@ -29,6 +30,6 @@ class MissingSystemTranslationException extends WriteConstraintViolationExceptio
                 self::VIOLATION_MISSING_SYSTEM_TRANSLATION
             ),
         ]);
-        parent::__construct($constraintViolationList, $path);
+        parent::__construct($constraintViolationList, $path, Response::HTTP_BAD_REQUEST, $previous);
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Exception/MissingTranslationLanguageException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/MissingTranslationLanguageException.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\System\Exception;
 namespace Shopware\Core\Framework\DataAbstractionLayer\Exception;
 
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 
@@ -12,7 +13,7 @@ class MissingTranslationLanguageException extends WriteConstraintViolationExcept
 {
     public const VIOLATION_MISSING_TRANSLATION_LANGUAGE = 'MISSING-TRANSLATION-LANGUAGE';
 
-    public function __construct(string $path, int $translationIndex)
+    public function __construct(string $path, int $translationIndex, ?\Throwable $previous = null)
     {
         $template = 'Translation requires a language id.';
         $constraintViolationList = new ConstraintViolationList([
@@ -27,6 +28,6 @@ class MissingTranslationLanguageException extends WriteConstraintViolationExcept
                 self::VIOLATION_MISSING_TRANSLATION_LANGUAGE
             ),
         ]);
-        parent::__construct($constraintViolationList, $path);
+        parent::__construct($constraintViolationList, $path, Response::HTTP_BAD_REQUEST, $previous);
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Exception/ParentFieldForeignKeyConstraintMissingException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/ParentFieldForeignKeyConstraintMissingException.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class ParentFieldForeignKeyConstraintMissingException extends ShopwareHttpException
 {
-    public function __construct(EntityDefinition $definition, Field $parentField)
+    public function __construct(EntityDefinition $definition, Field $parentField, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Foreign key property {{ propertyName }} of parent association in definition {{ definition }} expected to be an FkField got %s',
@@ -16,7 +16,8 @@ class ParentFieldForeignKeyConstraintMissingException extends ShopwareHttpExcept
                 'definition' => $definition->getClass(),
                 'propertyName' => $parentField->getPropertyName(),
                 'propertyClass' => \get_class($parentField),
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/ParentFieldNotFoundException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/ParentFieldNotFoundException.php
@@ -7,11 +7,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class ParentFieldNotFoundException extends ShopwareHttpException
 {
-    public function __construct(EntityDefinition $definition)
+    public function __construct(EntityDefinition $definition, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Can not find parent property \'parent\' field for definition {{ definition }',
-            ['definition' => $definition->getClass()]
+            ['definition' => $definition->getClass()],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/PrimaryKeyNotProvidedException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/PrimaryKeyNotProvidedException.php
@@ -8,11 +8,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class PrimaryKeyNotProvidedException extends ShopwareHttpException
 {
-    public function __construct(EntityDefinition $definition, Field $field)
+    public function __construct(EntityDefinition $definition, Field $field, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Expected primary key field {{ propertyName }} for definition {{ definition }} not provided',
-            ['definition' => $definition->getClass(), 'propertyName' => $field->getPropertyName()]
+            ['definition' => $definition->getClass(), 'propertyName' => $field->getPropertyName()],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/QueryLimitExceededException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/QueryLimitExceededException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class QueryLimitExceededException extends ShopwareHttpException
 {
-    public function __construct($maxLimit, $limit)
+    public function __construct($maxLimit, $limit, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The limit must be lower than or equal to MAX_LIMIT(={{ maxLimit }}). Given: {{ limit }}',
-            ['maxLimit' => $maxLimit, 'limit' => $limit]
+            ['maxLimit' => $maxLimit, 'limit' => $limit],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/ReadProtectedException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/ReadProtectedException.php
@@ -7,14 +7,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ReadProtectedException extends ShopwareHttpException
 {
-    public function __construct(string $field, string $scope)
+    public function __construct(string $field, string $scope, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The field/association "{{ field }}" is read protected for your scope "{{ scope }}"',
             [
                 'field' => $field,
                 'scope' => $scope,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/RepositoryNotFoundException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/RepositoryNotFoundException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class RepositoryNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $entity)
+    public function __construct(string $entity, ?\Throwable $previous = null)
     {
-        parent::__construct('Repository for entity "{{ entityName }}" does not exist.', ['entityName' => $entity]);
+        parent::__construct('Repository for entity "{{ entityName }}" does not exist.', ['entityName' => $entity], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/DataAbstractionLayer/Exception/SearchRequestException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/SearchRequestException.php
@@ -13,11 +13,11 @@ class SearchRequestException extends ShopwareHttpException
      */
     private $exceptions;
 
-    public function __construct(array $exceptions = [])
+    public function __construct(array $exceptions = [], ?\Throwable $previous = null)
     {
         $this->exceptions = $exceptions;
 
-        parent::__construct('Mapping failed, got {{ numberOfFailures }} failure(s).', ['numberOfFailures' => \count($exceptions)]);
+        parent::__construct('Mapping failed, got {{ numberOfFailures }} failure(s).', ['numberOfFailures' => \count($exceptions)], $previous);
     }
 
     public function add(\Throwable $exception, string $pointer): void

--- a/src/Core/Framework/DataAbstractionLayer/Exception/UnsupportedCommandTypeException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/UnsupportedCommandTypeException.php
@@ -7,11 +7,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class UnsupportedCommandTypeException extends ShopwareHttpException
 {
-    public function __construct(WriteCommand $command)
+    public function __construct(WriteCommand $command, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Command of class {{ command }} is not supported by {{ definition }}',
-            ['command' => \get_class($command), 'definition' => $command->getDefinition()->getClass()]
+            ['command' => \get_class($command), 'definition' => $command->getDefinition()->getClass()],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Exception/WriteNotSupportedException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Exception/WriteNotSupportedException.php
@@ -14,11 +14,12 @@ class WriteNotSupportedException extends ShopwareHttpException
      */
     private $field;
 
-    public function __construct(Field $field)
+    public function __construct(Field $field, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Writing to ReadOnly field "{{ field }}" is not supported.',
-            ['field' => \get_class($field)]
+            ['field' => \get_class($field)],
+            $previous
         );
 
         $this->field = $field;

--- a/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteTypeIntendException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteTypeIntendException.php
@@ -7,11 +7,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class WriteTypeIntendException extends ShopwareHttpException
 {
-    public function __construct(EntityDefinition $definition, string $expectedClass, string $actualClass)
+    public function __construct(EntityDefinition $definition, string $expectedClass, string $actualClass, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Expected command for "{{ definition }}" to be "{{ expectedClass }}". (Got: {{ actualClass }})',
-            ['definition' => $definition->getClass(), 'expectedClass' => $expectedClass, 'actualClass' => $actualClass]
+            ['definition' => $definition->getClass(), 'expectedClass' => $expectedClass, 'actualClass' => $actualClass],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Write/FieldException/ExpectedArrayException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/FieldException/ExpectedArrayException.php
@@ -12,9 +12,9 @@ class ExpectedArrayException extends ShopwareHttpException implements WriteField
      */
     private $path;
 
-    public function __construct(string $path)
+    public function __construct(string $path, ?\Throwable $previous = null)
     {
-        parent::__construct('Expected data to be array.');
+        parent::__construct('Expected data to be array.', [], $previous);
 
         $this->path = $path;
     }

--- a/src/Core/Framework/DataAbstractionLayer/Write/FieldException/UnexpectedFieldException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/FieldException/UnexpectedFieldException.php
@@ -17,11 +17,12 @@ class UnexpectedFieldException extends ShopwareHttpException implements WriteFie
      */
     private $fieldName;
 
-    public function __construct(string $path, string $fieldName)
+    public function __construct(string $path, string $fieldName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Unexpected field: {{ field }}',
-            ['field' => $fieldName]
+            ['field' => $fieldName],
+            $previous
         );
 
         $this->path = $path;

--- a/src/Core/Framework/DataAbstractionLayer/Write/Validation/RestrictDeleteViolationException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Validation/RestrictDeleteViolationException.php
@@ -16,7 +16,7 @@ class RestrictDeleteViolationException extends ShopwareHttpException
     /**
      * @param RestrictDeleteViolation[] $restrictions
      */
-    public function __construct(EntityDefinition $definition, array $restrictions)
+    public function __construct(EntityDefinition $definition, array $restrictions, ?\Throwable $previous = null)
     {
         $restriction = $restrictions[0];
         $usages = [];
@@ -37,7 +37,8 @@ class RestrictDeleteViolationException extends ShopwareHttpException
 
         parent::__construct(
             'The delete request for {{ entity }} was denied due to a conflict. The entity is currently in use by: {{ usagesString }}',
-            ['entity' => $definition->getEntityName(), 'usagesString' => implode(', ', $usagesStrings), 'usages' => $usages]
+            ['entity' => $definition->getEntityName(), 'usagesString' => implode(', ', $usagesStrings), 'usages' => $usages],
+            $previous
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteException.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteException.php
@@ -15,9 +15,9 @@ class WriteException extends ShopwareHttpException
      */
     private $exceptions = [];
 
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct(self::MESSAGE, ['errorCount' => 0]);
+        parent::__construct(self::MESSAGE, ['errorCount' => 0], $previous);
     }
 
     public function add(\Throwable $exception): WriteException

--- a/src/Core/Framework/Migration/Exception/InvalidMigrationClassException.php
+++ b/src/Core/Framework/Migration/Exception/InvalidMigrationClassException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class InvalidMigrationClassException extends ShopwareHttpException
 {
-    public function __construct(string $class, string $path)
+    public function __construct(string $class, string $path, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Unable to load migration {{ class }} at path {{ path }}',
-            ['class' => $class, 'path' => $path]
+            ['class' => $class, 'path' => $path],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Migration/Exception/MigrateException.php
+++ b/src/Core/Framework/Migration/Exception/MigrateException.php
@@ -6,7 +6,7 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class MigrateException extends ShopwareHttpException
 {
-    public function __construct(string $message, \Exception $previous)
+    public function __construct(string $message, ?\Throwable $previous = null)
     {
         parent::__construct('Migration error: {{ errorMessage }}', ['errorMessage' => $message], $previous);
     }

--- a/src/Core/Framework/Migration/Exception/UnknownMigrationSourceException.php
+++ b/src/Core/Framework/Migration/Exception/UnknownMigrationSourceException.php
@@ -15,13 +15,14 @@ if (class_exists(HttpException::class)) {
          */
         private $name;
 
-        public function __construct(string $name)
+        public function __construct(string $name, ?\Throwable $previous = null)
         {
             $this->name = $name;
 
             parent::__construct(
                 'No source registered for "{{ name }}"',
-                ['name' => $name]
+                ['name' => $name],
+                $previous
             );
         }
 
@@ -45,9 +46,9 @@ if (class_exists(HttpException::class)) {
          */
         private $name;
 
-        public function __construct(string $name)
+        public function __construct(string $name, ?\Throwable $previous = null)
         {
-            parent::__construct('No source registered for "' . $name . '"');
+            parent::__construct('No source registered for "' . $name . '"', 0, $previous);
             $this->name = $name;
         }
 

--- a/src/Core/Framework/Plugin/Composer/PackageProvider.php
+++ b/src/Core/Framework/Plugin/Composer/PackageProvider.php
@@ -31,7 +31,7 @@ class PackageProvider
         try {
             return Factory::createComposer($pluginPath, $composerIO)->getPackage();
         } catch (\InvalidArgumentException $e) {
-            throw new PluginComposerJsonInvalidException($pluginPath . '/composer.json', [$e->getMessage()]);
+            throw new PluginComposerJsonInvalidException($pluginPath . '/composer.json', [$e->getMessage()], $e);
         }
     }
 }

--- a/src/Core/Framework/Plugin/Exception/CanNotDeletePluginManagedByComposerException.php
+++ b/src/Core/Framework/Plugin/Exception/CanNotDeletePluginManagedByComposerException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class CanNotDeletePluginManagedByComposerException extends ShopwareHttpException
 {
-    public function __construct(string $reason)
+    public function __construct(string $reason, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Can not delete plugin. Please contact your system administrator. Error: {{ reason }}',
-            ['reason' => $reason]
+            ['reason' => $reason],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/DecorationPatternException.php
+++ b/src/Core/Framework/Plugin/Exception/DecorationPatternException.php
@@ -12,12 +12,12 @@ class DecorationPatternException extends ShopwareHttpException
      */
     protected $class;
 
-    public function __construct(string $class)
+    public function __construct(string $class, ?\Throwable $previous = null)
     {
         parent::__construct(sprintf(
             'The getDecorated() function of core class %s cannot be used. This class is the base class.',
             $class
-        ));
+        ), [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Plugin/Exception/KernelPluginLoaderException.php
+++ b/src/Core/Framework/Plugin/Exception/KernelPluginLoaderException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class KernelPluginLoaderException extends ShopwareHttpException
 {
-    public function __construct(string $plugin, string $reason)
+    public function __construct(string $plugin, string $reason, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Failed to load plugin "{{ plugin }}". Reason: {{ reason }}',
-            ['plugin' => $plugin, 'reason' => $reason]
+            ['plugin' => $plugin, 'reason' => $reason],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/NoPluginFoundInZipException.php
+++ b/src/Core/Framework/Plugin/Exception/NoPluginFoundInZipException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class NoPluginFoundInZipException extends ShopwareHttpException
 {
-    public function __construct(string $archive)
+    public function __construct(string $archive, ?\Throwable $previous = null)
     {
         parent::__construct(
             'No plugin was found in the zip archive: {{ archive }}',
-            ['archive' => $archive]
+            ['archive' => $archive],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginBaseClassNotFoundException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginBaseClassNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PluginBaseClassNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $baseClass)
+    public function __construct(string $baseClass, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The class "{{ baseClass }}" is not found. Probably an class loader error. Check your plugin composer.json',
-            ['baseClass' => $baseClass]
+            ['baseClass' => $baseClass],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginCannotBeDeletedException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginCannotBeDeletedException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class PluginCannotBeDeletedException extends ShopwareHttpException
 {
-    public function __construct(string $reason)
+    public function __construct(string $reason, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Cannot delete plugin. Error: {{ error }}',
-            ['error' => $reason]
+            ['error' => $reason],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginChangelogInvalidException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginChangelogInvalidException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class PluginChangelogInvalidException extends ShopwareHttpException
 {
-    public function __construct(string $changelogPath)
+    public function __construct(string $changelogPath, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The changelog of "{{ changelogPath }}" is invalid.',
-            ['changelogPath' => $changelogPath]
+            ['changelogPath' => $changelogPath],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginComposerJsonInvalidException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginComposerJsonInvalidException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PluginComposerJsonInvalidException extends ShopwareHttpException
 {
-    public function __construct(string $composerJsonPath, array $errors)
+    public function __construct(string $composerJsonPath, array $errors, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The file "{{ composerJsonPath }}" is invalid. Errors:' . \PHP_EOL . '{{ errorsString }}',
-            ['composerJsonPath' => $composerJsonPath, 'errorsString' => implode(\PHP_EOL, $errors), 'errors' => $errors]
+            ['composerJsonPath' => $composerJsonPath, 'errorsString' => implode(\PHP_EOL, $errors), 'errors' => $errors],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginComposerRemoveException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginComposerRemoveException.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PluginComposerRemoveException extends ShopwareHttpException
 {
-    public function __construct(string $pluginName, string $pluginComposerName, string $output)
+    public function __construct(string $pluginName, string $pluginComposerName, string $output, ?\Throwable $previous = null)
     {
         parent::__construct(
             sprintf('Could not execute "composer remove" for plugin "{{ pluginName }} ({{ pluginComposerName }}). Output:%s{{ output }}', \PHP_EOL),
@@ -15,7 +15,8 @@ class PluginComposerRemoveException extends ShopwareHttpException
                 'pluginName' => $pluginName,
                 'pluginComposerName' => $pluginComposerName,
                 'output' => $output,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginComposerRequireException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginComposerRequireException.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PluginComposerRequireException extends ShopwareHttpException
 {
-    public function __construct(string $pluginName, string $pluginComposerName, string $output)
+    public function __construct(string $pluginName, string $pluginComposerName, string $output, ?\Throwable $previous = null)
     {
         parent::__construct(
             sprintf('Could not execute "composer require" for plugin "{{ pluginName }} ({{ pluginComposerName }}). Output:%s{{ output }}', \PHP_EOL),
@@ -15,7 +15,8 @@ class PluginComposerRequireException extends ShopwareHttpException
                 'pluginName' => $pluginName,
                 'pluginComposerName' => $pluginComposerName,
                 'output' => $output,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginExtractionException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginExtractionException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class PluginExtractionException extends ShopwareHttpException
 {
-    public function __construct(string $reason)
+    public function __construct(string $reason, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Plugin extraction failed. Error: {{ error }}',
-            ['error' => $reason]
+            ['error' => $reason],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginHasActiveDependantsException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginHasActiveDependantsException.php
@@ -10,7 +10,7 @@ class PluginHasActiveDependantsException extends ShopwareHttpException
     /**
      * @param PluginEntity[] $dependants
      */
-    public function __construct(string $dependency, array $dependants)
+    public function __construct(string $dependency, array $dependants, ?\Throwable $previous = null)
     {
         $dependantNameList = array_map(static function ($plugin) {
             return sprintf('"%s"', $plugin->getName());
@@ -22,7 +22,8 @@ class PluginHasActiveDependantsException extends ShopwareHttpException
                 'dependency' => $dependency,
                 'dependants' => $dependants,
                 'dependantNames' => implode(', ', $dependantNameList),
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginNotAZipFileException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginNotAZipFileException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class PluginNotAZipFileException extends ShopwareHttpException
 {
-    public function __construct(string $mimeType)
+    public function __construct(string $mimeType, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Given file must be a zip file. Given: {{ mimeType }}',
-            ['mimeType' => $mimeType]
+            ['mimeType' => $mimeType],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginNotActivatedException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginNotActivatedException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class PluginNotActivatedException extends ShopwareHttpException
 {
-    public function __construct(string $pluginName)
+    public function __construct(string $pluginName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Plugin "{{ plugin }}" is not activated.',
-            ['plugin' => $pluginName]
+            ['plugin' => $pluginName],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginNotFoundException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PluginNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $pluginName)
+    public function __construct(string $pluginName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Plugin by name "{{ plugin }}" not found.',
-            ['plugin' => $pluginName]
+            ['plugin' => $pluginName],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Exception/PluginNotInstalledException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginNotInstalledException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class PluginNotInstalledException extends ShopwareHttpException
 {
-    public function __construct(string $pluginName)
+    public function __construct(string $pluginName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Plugin "{{ plugin }}" is not installed.',
-            ['plugin' => $pluginName]
+            ['plugin' => $pluginName],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Requirement/Exception/ConflictingPackageException.php
+++ b/src/Core/Framework/Plugin/Requirement/Exception/ConflictingPackageException.php
@@ -6,7 +6,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ConflictingPackageException extends RequirementException
 {
-    public function __construct(string $conflictSource, string $conflictTarget, string $actualVersion)
+    public function __construct(string $conflictSource, string $conflictTarget, string $actualVersion, ?\Throwable $previous = null)
     {
         parent::__construct(
             '"{{ conflictSource }}" conflicts with plugin/package "{{ conflictTarget }} {{ version }}"',
@@ -14,7 +14,8 @@ class ConflictingPackageException extends RequirementException
                 'conflictSource' => $conflictSource,
                 'conflictTarget' => $conflictTarget,
                 'version' => $actualVersion,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Requirement/Exception/MissingRequirementException.php
+++ b/src/Core/Framework/Plugin/Requirement/Exception/MissingRequirementException.php
@@ -4,11 +4,12 @@ namespace Shopware\Core\Framework\Plugin\Requirement\Exception;
 
 class MissingRequirementException extends RequirementException
 {
-    public function __construct(string $requirement, string $requiredVersion)
+    public function __construct(string $requirement, string $requiredVersion, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Required plugin/package "{{ requirement }} {{ version }}" is missing or not installed and activated',
-            ['requirement' => $requirement, 'version' => $requiredVersion]
+            ['requirement' => $requirement, 'version' => $requiredVersion],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Requirement/Exception/RequirementStackException.php
+++ b/src/Core/Framework/Plugin/Requirement/Exception/RequirementStackException.php
@@ -22,7 +22,8 @@ class RequirementStackException extends ShopwareHttpException
                 'method' => $method,
                 'failureCount' => \count($requirements),
                 'errors' => $this->getInnerExceptionsDetails(),
-            ]
+            ],
+            \current($requirements) ?: null
         );
     }
 

--- a/src/Core/Framework/Plugin/Requirement/Exception/VersionMismatchException.php
+++ b/src/Core/Framework/Plugin/Requirement/Exception/VersionMismatchException.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Framework\Plugin\Requirement\Exception;
 
 class VersionMismatchException extends RequirementException
 {
-    public function __construct(string $requirement, string $requiredVersion, string $actualVersion)
+    public function __construct(string $requirement, string $requiredVersion, string $actualVersion, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Required plugin/package "{{ requirement }} {{ requiredVersion }}" does not match installed version {{ version }}.',
@@ -12,7 +12,8 @@ class VersionMismatchException extends RequirementException
                 'requirement' => $requirement,
                 'requiredVersion' => $requiredVersion,
                 'version' => $actualVersion,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -111,7 +111,7 @@ class AssetService
         }
 
         if ($bundle === null) {
-            throw new PluginNotFoundException($bundleName);
+            throw new PluginNotFoundException($bundleName, $e ?? null);
         }
 
         return $bundle;

--- a/src/Core/Framework/Routing/Exception/InvalidRequestParameterException.php
+++ b/src/Core/Framework/Routing/Exception/InvalidRequestParameterException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidRequestParameterException extends ShopwareHttpException
 {
-    public function __construct(string $name)
+    public function __construct(string $name, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The parameter "{{ parameter }}" is invalid.',
-            ['parameter' => $name]
+            ['parameter' => $name],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Routing/Exception/InvalidRouteScopeException.php
+++ b/src/Core/Framework/Routing/Exception/InvalidRouteScopeException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidRouteScopeException extends ShopwareHttpException
 {
-    public function __construct(string $routeName)
+    public function __construct(string $routeName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Invalid route scope for route {{ routeName }}.',
-            ['routeName' => $routeName]
+            ['routeName' => $routeName],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Routing/Exception/LanguageNotFoundException.php
+++ b/src/Core/Framework/Routing/Exception/LanguageNotFoundException.php
@@ -9,11 +9,12 @@ class LanguageNotFoundException extends ShopwareHttpException
 {
     public const LANGUAGE_NOT_FOUND_ERROR = 'FRAMEWORK__LANGUAGE_NOT_FOUND';
 
-    public function __construct($languageId)
+    public function __construct($languageId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The language "{{ languageId }}" was not found.',
-            ['languageId' => $languageId]
+            ['languageId' => $languageId],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Routing/Exception/MissingRequestParameterException.php
+++ b/src/Core/Framework/Routing/Exception/MissingRequestParameterException.php
@@ -17,12 +17,12 @@ class MissingRequestParameterException extends ShopwareHttpException
      */
     private $path;
 
-    public function __construct(string $name, string $path = '')
+    public function __construct(string $name, string $path = '', ?\Throwable $previous = null)
     {
         $this->name = $name;
         $this->path = $path;
 
-        parent::__construct('Parameter "{{ parameterName }}" is missing.', ['parameterName' => $name]);
+        parent::__construct('Parameter "{{ parameterName }}" is missing.', ['parameterName' => $name], $previous);
     }
 
     public function getName(): string

--- a/src/Core/Framework/Routing/Exception/SalesChannelNotFoundException.php
+++ b/src/Core/Framework/Routing/Exception/SalesChannelNotFoundException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SalesChannelNotFoundException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('No matching sales channel found.');
+        parent::__construct('No matching sales channel found.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Rule/Exception/InvalidConditionException.php
+++ b/src/Core/Framework/Rule/Exception/InvalidConditionException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class InvalidConditionException extends ShopwareHttpException
 {
-    public function __construct(string $conditionName)
+    public function __construct(string $conditionName, ?\Throwable $previous = null)
     {
-        parent::__construct('The condition "{{ condition }}" is invalid.', ['condition' => $conditionName]);
+        parent::__construct('The condition "{{ condition }}" is invalid.', ['condition' => $conditionName], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Rule/Exception/UnsupportedOperatorException.php
+++ b/src/Core/Framework/Rule/Exception/UnsupportedOperatorException.php
@@ -17,14 +17,15 @@ class UnsupportedOperatorException extends ShopwareHttpException
      */
     protected $class;
 
-    public function __construct(string $operator, string $class)
+    public function __construct(string $operator, string $class, ?\Throwable $previous = null)
     {
         $this->operator = $operator;
         $this->class = $class;
 
         parent::__construct(
             'Unsupported operator {{ operator }} in {{ class }}',
-            ['operator' => $operator, 'class' => $class]
+            ['operator' => $operator, 'class' => $class],
+            $previous
         );
     }
 

--- a/src/Core/Framework/ShopwareHttpException.php
+++ b/src/Core/Framework/ShopwareHttpException.php
@@ -12,12 +12,12 @@ abstract class ShopwareHttpException extends HttpException implements ShopwareEx
      */
     protected $parameters = [];
 
-    public function __construct(string $message, array $parameters = [], ?\Throwable $e = null)
+    public function __construct(string $message, array $parameters = [], ?\Throwable $previous = null)
     {
         $this->parameters = $parameters;
         $message = $this->parse($message, $parameters);
 
-        parent::__construct($this->getStatusCode(), $message, $e);
+        parent::__construct($this->getStatusCode(), $message, $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/Framework/Store/Exception/CanNotDownloadPluginManagedByComposerException.php
+++ b/src/Core/Framework/Store/Exception/CanNotDownloadPluginManagedByComposerException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class CanNotDownloadPluginManagedByComposerException extends ShopwareHttpException
 {
-    public function __construct(string $reason)
+    public function __construct(string $reason, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Can not download plugin. Please contact your system administrator. Error: {{ reason }}',
-            ['reason' => $reason]
+            ['reason' => $reason],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Store/Exception/ExtensionNotFoundException.php
+++ b/src/Core/Framework/Store/Exception/ExtensionNotFoundException.php
@@ -7,19 +7,21 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ExtensionNotFoundException extends ShopwareHttpException
 {
-    public static function fromTechnicalName(string $technicalName): self
+    public static function fromTechnicalName(string $technicalName, ?\Throwable $previous = null): self
     {
         return new self(
             'Could not find extension with technical name "{{technicalName}}".',
-            ['technicalName' => $technicalName]
+            ['technicalName' => $technicalName],
+            $previous
         );
     }
 
-    public static function fromId(string $id): self
+    public static function fromId(string $id, ?\Throwable $previous = null): self
     {
         return new self(
             'Could not find extension with id "{{id}}".',
-            ['id' => $id]
+            ['id' => $id],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Store/Exception/ExtensionRequiresNewPrivilegesException.php
+++ b/src/Core/Framework/Store/Exception/ExtensionRequiresNewPrivilegesException.php
@@ -6,14 +6,15 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class ExtensionRequiresNewPrivilegesException extends ShopwareHttpException
 {
-    public static function fromPrivilegeList(string $appName, array $privileges): self
+    public static function fromPrivilegeList(string $appName, array $privileges, ?\Throwable $previous = null): self
     {
         return new self(
             'Updating "{{app}}" requires new privileges "{{privileges}}".',
             [
                 'app' => $appName,
                 'privileges' => implode(';', $privileges),
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Store/Exception/ExtensionThemeStillInUseException.php
+++ b/src/Core/Framework/Store/Exception/ExtensionThemeStillInUseException.php
@@ -7,14 +7,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ExtensionThemeStillInUseException extends ShopwareHttpException
 {
-    public function __construct(string $id, array $parameters = [], ?\Throwable $e = null)
+    public function __construct(string $id, array $parameters = [], ?\Throwable $previous = null)
     {
         $parameters['id'] = $id;
 
         parent::__construct(
             "The extension with id \"{{id}}\"can not be removed because it's theme is still assigned to a sales channel.",
             $parameters,
-            $e
+            $previous
         );
     }
 

--- a/src/Core/Framework/Store/Exception/InvalidExtensionIdException.php
+++ b/src/Core/Framework/Store/Exception/InvalidExtensionIdException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidExtensionIdException extends ShopwareHttpException
 {
-    public function __construct(array $parameters = [], ?\Throwable $e = null)
+    public function __construct(array $parameters = [], ?\Throwable $previous = null)
     {
-        parent::__construct('The extension id must be an non empty numeric value.', $parameters, $e);
+        parent::__construct('The extension id must be an non empty numeric value.', $parameters, $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Store/Exception/InvalidExtensionRatingValueException.php
+++ b/src/Core/Framework/Store/Exception/InvalidExtensionRatingValueException.php
@@ -8,13 +8,13 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidExtensionRatingValueException extends ShopwareHttpException
 {
-    public function __construct(int $rating, array $parameters = [], ?\Throwable $e = null)
+    public function __construct(int $rating, array $parameters = [], ?\Throwable $previous = null)
     {
         $parameters['rating'] = $rating;
         $parameters['maxRating'] = ReviewStruct::MAX_RATING;
         $parameters['minRating'] = ReviewStruct::MIN_RATING;
 
-        parent::__construct('Invalid rating value {{rating}}. The value must correspond to a number in the interval from {{minRating}} to {{maxRating}}.', $parameters, $e);
+        parent::__construct('Invalid rating value {{rating}}. The value must correspond to a number in the interval from {{minRating}} to {{maxRating}}.', $parameters, $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Store/Exception/InvalidVariantIdException.php
+++ b/src/Core/Framework/Store/Exception/InvalidVariantIdException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidVariantIdException extends ShopwareHttpException
 {
-    public function __construct(array $parameters = [], ?\Throwable $e = null)
+    public function __construct(array $parameters = [], ?\Throwable $previous = null)
     {
-        parent::__construct('The variant id must be an non empty numeric value.', $parameters, $e);
+        parent::__construct('The variant id must be an non empty numeric value.', $parameters, $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Store/Exception/LicenseDomainVerificationException.php
+++ b/src/Core/Framework/Store/Exception/LicenseDomainVerificationException.php
@@ -6,11 +6,11 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class LicenseDomainVerificationException extends ShopwareHttpException
 {
-    public function __construct(string $domain, string $reason = '')
+    public function __construct(string $domain, string $reason = '', ?\Throwable $previous = null)
     {
         $reason = $reason ? (' ' . $reason) : '';
         $message = 'License host verification failed for domain "{{ domain }}.{{ reason }}"';
-        parent::__construct($message, ['domain' => $domain, 'reason' => $reason]);
+        parent::__construct($message, ['domain' => $domain, 'reason' => $reason], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Store/Exception/LicenseNotFoundException.php
+++ b/src/Core/Framework/Store/Exception/LicenseNotFoundException.php
@@ -7,11 +7,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LicenseNotFoundException extends ShopwareHttpException
 {
-    public function __construct(int $licenseId, array $parameters = [], ?\Throwable $e = null)
+    public function __construct(int $licenseId, array $parameters = [], ?\Throwable $previous = null)
     {
         $parameters['licenseId'] = $licenseId;
 
-        parent::__construct('Could not find license with id {{licenseId}}', $parameters, $e);
+        parent::__construct('Could not find license with id {{licenseId}}', $parameters, $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Store/Exception/StoreApiException.php
+++ b/src/Core/Framework/Store/Exception/StoreApiException.php
@@ -18,10 +18,10 @@ class StoreApiException extends ShopwareHttpException
      */
     protected $documentationLink;
 
-    public function __construct(ClientException $exception)
+    public function __construct(ClientException $previous)
     {
-        $data = json_decode($exception->getResponse()->getBody()->getContents(), true);
-        parent::__construct($data['description'] ?? $exception->getMessage());
+        $data = json_decode($previous->getResponse()->getBody()->getContents(), true);
+        parent::__construct($data['description'] ?? $previous->getMessage(), [], $previous);
 
         $this->title = $data['title'] ?? '';
         $this->documentationLink = $data['documentationLink'] ?? '';

--- a/src/Core/Framework/Store/Exception/StoreInvalidCredentialsException.php
+++ b/src/Core/Framework/Store/Exception/StoreInvalidCredentialsException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class StoreInvalidCredentialsException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Invalid credentials');
+        parent::__construct('Invalid credentials', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Store/Exception/StoreLicenseDomainMissingException.php
+++ b/src/Core/Framework/Store/Exception/StoreLicenseDomainMissingException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class StoreLicenseDomainMissingException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Store license domain is missing');
+        parent::__construct('Store license domain is missing', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Store/Exception/StoreNotAvailableException.php
+++ b/src/Core/Framework/Store/Exception/StoreNotAvailableException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class StoreNotAvailableException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Store is not available');
+        parent::__construct('Store is not available', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Store/Exception/StoreSignatureValidationException.php
+++ b/src/Core/Framework/Store/Exception/StoreSignatureValidationException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class StoreSignatureValidationException extends ShopwareHttpException
 {
-    public function __construct(string $reason)
+    public function __construct(string $reason, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Store signature validation failed. Error: {{ error }}',
-            ['error' => $reason]
+            ['error' => $reason],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Store/Exception/StoreTokenMissingException.php
+++ b/src/Core/Framework/Store/Exception/StoreTokenMissingException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StoreTokenMissingException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Store token is missing');
+        parent::__construct('Store token is missing', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Store/Exception/VariantTypesNotAllowedException.php
+++ b/src/Core/Framework/Store/Exception/VariantTypesNotAllowedException.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class VariantTypesNotAllowedException extends ShopwareHttpException
 {
-    public function __construct(array $typeViolations)
+    public function __construct(array $typeViolations, ?\Throwable $previous = null)
     {
         $message = 'The variant types of the following cart positions are not allowed:';
 
@@ -15,7 +15,7 @@ class VariantTypesNotAllowedException extends ShopwareHttpException
             $message .= sprintf("\nType \"%s\" for \"%s\" (ID: %d)", $typeViolation['variantType'], $typeViolation['extensionName'], $typeViolation['extensionId']);
         }
 
-        parent::__construct($message, $typeViolations);
+        parent::__construct($message, $typeViolations, $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Test/Api/EventListener/ErrorResponseFactoryTest.php
+++ b/src/Core/Framework/Test/Api/EventListener/ErrorResponseFactoryTest.php
@@ -12,9 +12,9 @@ class SimpleShopwareHttpException extends ShopwareHttpException
     public const EXCEPTION_CODE = 'FRAMEWORK__TEST_EXCEPTION';
     public const EXCEPTION_MESSAGE = 'this is param 1: {{ paramOne }} and this is param 2: {{ paramTwo }}';
 
-    public function __construct(array $params)
+    public function __construct(array $params, ?\Throwable $previous = null)
     {
-        parent::__construct(self::EXCEPTION_MESSAGE, $params);
+        parent::__construct(self::EXCEPTION_MESSAGE, $params, $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Update/Exception/UpdateApiSignatureValidationException.php
+++ b/src/Core/Framework/Update/Exception/UpdateApiSignatureValidationException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class UpdateApiSignatureValidationException extends ShopwareHttpException
 {
-    public function __construct(string $reason)
+    public function __construct(string $reason, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Update-API signature validation failed. Error: {{ error }}',
-            ['error' => $reason]
+            ['error' => $reason],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Util/XmlReader.php
+++ b/src/Core/Framework/Util/XmlReader.php
@@ -23,7 +23,7 @@ abstract class XmlReader
         try {
             $dom = XmlUtils::loadFile($xmlFile, $this->xsdFile);
         } catch (\Exception $e) {
-            throw new XmlParsingException($xmlFile, $e->getMessage());
+            throw new XmlParsingException($xmlFile, $e->getMessage(), $e);
         }
 
         return $this->parseFile($dom);

--- a/src/Core/Framework/Uuid/Exception/InvalidUuidException.php
+++ b/src/Core/Framework/Uuid/Exception/InvalidUuidException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidUuidException extends ShopwareHttpException
 {
-    public function __construct(string $uuid)
+    public function __construct(string $uuid, ?\Throwable $previous = null)
     {
-        parent::__construct('Value is not a valid UUID: {{ input }}', ['input' => $uuid]);
+        parent::__construct('Value is not a valid UUID: {{ input }}', ['input' => $uuid], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/Framework/Uuid/Exception/InvalidUuidLengthException.php
+++ b/src/Core/Framework/Uuid/Exception/InvalidUuidLengthException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidUuidLengthException extends ShopwareHttpException
 {
-    public function __construct(int $length, string $hex)
+    public function __construct(int $length, string $hex, ?\Throwable $previous = null)
     {
         parent::__construct(
             'UUID has a invalid length. 16 bytes expected, {{ length }} given. Hexadecimal reprensentation: {{ hex }}',
-            ['length' => $length, 'hex' => $hex]
+            ['length' => $length, 'hex' => $hex],
+            $previous
         );
     }
 

--- a/src/Core/Framework/Validation/Exception/ConstraintViolationException.php
+++ b/src/Core/Framework/Validation/Exception/ConstraintViolationException.php
@@ -19,14 +19,14 @@ class ConstraintViolationException extends ShopwareHttpException
      */
     private $inputData;
 
-    public function __construct(ConstraintViolationList $violations, array $inputData)
+    public function __construct(ConstraintViolationList $violations, array $inputData, ?\Throwable $previous = null)
     {
         $this->mapErrorCodes($violations);
 
         $this->violations = $violations;
         $this->inputData = $inputData;
 
-        parent::__construct('Caught {{ count }} violation errors.', ['count' => $violations->count()]);
+        parent::__construct('Caught {{ count }} violation errors.', ['count' => $violations->count()], $previous);
     }
 
     public function getRootViolations(): ConstraintViolationList

--- a/src/Core/Framework/Validation/WriteConstraintViolationException.php
+++ b/src/Core/Framework/Validation/WriteConstraintViolationException.php
@@ -24,15 +24,20 @@ class WriteConstraintViolationException extends ShopwareHttpException implements
      */
     private $statusCode;
 
-    public function __construct(ConstraintViolationList $constraintViolationList, string $path = '', int $statusCode = Response::HTTP_BAD_REQUEST)
-    {
+    public function __construct(
+        ConstraintViolationList $constraintViolationList,
+        string $path = '',
+        int $statusCode = Response::HTTP_BAD_REQUEST,
+        ?\Throwable $previous = null
+    ) {
         $this->path = $path;
         $this->constraintViolationList = $constraintViolationList;
         $this->statusCode = $statusCode;
 
         parent::__construct(
             'Caught {{ count }} constraint violation errors.',
-            ['count' => $constraintViolationList->count()]
+            ['count' => $constraintViolationList->count()],
+            $previous
         );
     }
 

--- a/src/Core/System/Country/Exception/CountryNotFoundException.php
+++ b/src/Core/System/Country/Exception/CountryNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CountryNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Country with id "{{ countryId }}" not found.',
-            ['countryId' => $id]
+            ['countryId' => $id],
+            $previous
         );
     }
 

--- a/src/Core/System/Country/Exception/CountryStateNotFoundException.php
+++ b/src/Core/System/Country/Exception/CountryStateNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CountryStateNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $id)
+    public function __construct(string $id, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Country state with id "{{ stateId }}" not found.',
-            ['stateId' => $id]
+            ['stateId' => $id],
+            $previous
         );
     }
 

--- a/src/Core/System/Language/Exception/LanguageForeignKeyDeleteException.php
+++ b/src/Core/System/Language/Exception/LanguageForeignKeyDeleteException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LanguageForeignKeyDeleteException extends ShopwareHttpException
 {
-    public function __construct(string $language, $e)
+    public function __construct(string $language, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The language "{{ language }}" cannot be deleted because foreign key constraints exist.',
             ['language' => $language],
-            $e
+            $previous
         );
     }
 

--- a/src/Core/System/NumberRange/Exception/NoConfigurationException.php
+++ b/src/Core/System/NumberRange/Exception/NoConfigurationException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class NoConfigurationException extends ShopwareHttpException
 {
-    public function __construct(string $entityName, ?string $salesChannelId = null)
+    public function __construct(string $entityName, ?string $salesChannelId = null, ?\Throwable $previous = null)
     {
         parent::__construct(
             'No number range configuration found for entity "{{ entity }}" with sales channel "{{ salesChannelId }}".',
-            ['entity' => $entityName, 'salesChannelId' => $salesChannelId]
+            ['entity' => $entityName, 'salesChannelId' => $salesChannelId],
+            $previous
         );
     }
 

--- a/src/Core/System/SalesChannel/Exception/ContextPermissionsLockedException.php
+++ b/src/Core/System/SalesChannel/Exception/ContextPermissionsLockedException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ContextPermissionsLockedException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Context permission in SalesChannel context already locked.');
+        parent::__construct('Context permission in SalesChannel context already locked.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/System/SalesChannel/Exception/ContextRulesLockedException.php
+++ b/src/Core/System/SalesChannel/Exception/ContextRulesLockedException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ContextRulesLockedException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Context rules in application context already locked.');
+        parent::__construct('Context rules in application context already locked.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Core/System/SalesChannel/Exception/LanguageOfSalesChannelDomainDeleteException.php
+++ b/src/Core/System/SalesChannel/Exception/LanguageOfSalesChannelDomainDeleteException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LanguageOfSalesChannelDomainDeleteException extends ShopwareHttpException
 {
-    public function __construct(string $language, $e)
+    public function __construct(string $language, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The language "{{ language }}" cannot be deleted because saleschannel domains with this language exist.',
             ['language' => $language],
-            $e
+            $previous
         );
     }
 

--- a/src/Core/System/SalesChannel/Exception/SalesChannelRepositoryNotFoundException.php
+++ b/src/Core/System/SalesChannel/Exception/SalesChannelRepositoryNotFoundException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class SalesChannelRepositoryNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $entity)
+    public function __construct(string $entity, ?\Throwable $previous = null)
     {
         parent::__construct(
             'SalesChannelRepository for entity "{{ entityName }}" does not exist.',
-            ['entityName' => $entity]
+            ['entityName' => $entity],
+            $previous
         );
     }
 

--- a/src/Core/System/Snippet/Exception/FilterNotFoundException.php
+++ b/src/Core/System/Snippet/Exception/FilterNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FilterNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $filterName, string $class)
+    public function __construct(string $filterName, string $class, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The filter "{{ filter }}" was not found in "{{ class }}".',
-            ['filter' => $filterName, 'class' => $class]
+            ['filter' => $filterName, 'class' => $class],
+            $previous
         );
     }
 

--- a/src/Core/System/Snippet/Exception/InvalidSnippetFileException.php
+++ b/src/Core/System/Snippet/Exception/InvalidSnippetFileException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidSnippetFileException extends ShopwareHttpException
 {
-    public function __construct(string $locale)
+    public function __construct(string $locale, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The base snippet file for locale {{ locale }} is not registered.',
-            ['locale' => $locale]
+            ['locale' => $locale],
+            $previous
         );
     }
 

--- a/src/Core/System/StateMachine/Exception/IllegalTransitionException.php
+++ b/src/Core/System/StateMachine/Exception/IllegalTransitionException.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class IllegalTransitionException extends ShopwareHttpException
 {
-    public function __construct(string $currentState, string $transition, array $possibleTransitions)
+    public function __construct(string $currentState, string $transition, array $possibleTransitions, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Illegal transition "{{ transition }}" from state "{{ currentState }}". Possible transitions are: {{ possibleTransitionsString }}',
@@ -16,7 +16,8 @@ class IllegalTransitionException extends ShopwareHttpException
                 'currentState' => $currentState,
                 'possibleTransitionsString' => implode(', ', $possibleTransitions),
                 'possibleTransitions' => $possibleTransitions,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/System/StateMachine/Exception/StateMachineInvalidEntityIdException.php
+++ b/src/Core/System/StateMachine/Exception/StateMachineInvalidEntityIdException.php
@@ -7,14 +7,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StateMachineInvalidEntityIdException extends ShopwareHttpException
 {
-    public function __construct(string $entityName, string $entityId)
+    public function __construct(string $entityName, string $entityId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Unable to read entity "{{ entityName }}" with id "{{ entityId }}".',
             [
                 'entityName' => $entityName,
                 'entityId' => $entityId,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/System/StateMachine/Exception/StateMachineInvalidStateFieldException.php
+++ b/src/Core/System/StateMachine/Exception/StateMachineInvalidStateFieldException.php
@@ -7,13 +7,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StateMachineInvalidStateFieldException extends ShopwareHttpException
 {
-    public function __construct(string $fieldName)
+    public function __construct(string $fieldName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Field "{{ fieldName }}" does not exists or isn\'t of type StateMachineStateField.',
             [
                 'fieldName' => $fieldName,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/System/StateMachine/Exception/StateMachineNotFoundException.php
+++ b/src/Core/System/StateMachine/Exception/StateMachineNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StateMachineNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $stateMachineName)
+    public function __construct(string $stateMachineName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The StateMachine named "{{ name }}" was not found.',
-            ['name' => $stateMachineName]
+            ['name' => $stateMachineName],
+            $previous
         );
     }
 

--- a/src/Core/System/StateMachine/Exception/StateMachineStateNotFoundException.php
+++ b/src/Core/System/StateMachine/Exception/StateMachineStateNotFoundException.php
@@ -7,14 +7,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StateMachineStateNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $stateMachineName, string $technicalPlaceName)
+    public function __construct(string $stateMachineName, string $technicalPlaceName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The place "{{ place }}" for state machine named "{{ stateMachine }}" was not found.',
             [
                 'place' => $technicalPlaceName,
                 'stateMachine' => $stateMachineName,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/System/StateMachine/Exception/StateMachineWithoutInitialStateException.php
+++ b/src/Core/System/StateMachine/Exception/StateMachineWithoutInitialStateException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StateMachineWithoutInitialStateException extends ShopwareHttpException
 {
-    public function __construct(string $stateMachineName)
+    public function __construct(string $stateMachineName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The StateMachine named "{{ name }}" has no initial state.',
-            ['name' => $stateMachineName]
+            ['name' => $stateMachineName],
+            $previous
         );
     }
 

--- a/src/Core/System/SystemConfig/Exception/BundleConfigNotFoundException.php
+++ b/src/Core/System/SystemConfig/Exception/BundleConfigNotFoundException.php
@@ -6,14 +6,15 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class BundleConfigNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $configPath, string $bundleName)
+    public function __construct(string $configPath, string $bundleName, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Could not find "{{ configPath }}" for bundle "{{ bundle }}".',
             [
                 'configPath' => $configPath,
                 'bundle' => $bundleName,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Core/System/SystemConfig/Exception/ConfigurationNotFoundException.php
+++ b/src/Core/System/SystemConfig/Exception/ConfigurationNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ConfigurationNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $scope)
+    public function __construct(string $scope, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Configuration for scope "{{ $scope }}" not found.',
-            ['scope' => $scope]
+            ['scope' => $scope],
+            $previous
         );
     }
 

--- a/src/Core/System/SystemConfig/Exception/InvalidDomainException.php
+++ b/src/Core/System/SystemConfig/Exception/InvalidDomainException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidDomainException extends ShopwareHttpException
 {
-    public function __construct(string $domain)
+    public function __construct(string $domain, ?\Throwable $previous = null)
     {
-        parent::__construct('Invalid domain \'{{ domain }}\'', ['domain' => $domain]);
+        parent::__construct('Invalid domain \'{{ domain }}\'', ['domain' => $domain], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/System/SystemConfig/Exception/InvalidKeyException.php
+++ b/src/Core/System/SystemConfig/Exception/InvalidKeyException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidKeyException extends ShopwareHttpException
 {
-    public function __construct(string $key)
+    public function __construct(string $key, ?\Throwable $previous = null)
     {
-        parent::__construct('Invalid key \'{{ key }}\'', ['key' => $key]);
+        parent::__construct('Invalid key \'{{ key }}\'', ['key' => $key], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/System/SystemConfig/Exception/InvalidSettingValueException.php
+++ b/src/Core/System/SystemConfig/Exception/InvalidSettingValueException.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidSettingValueException extends ShopwareHttpException
 {
-    public function __construct(string $key, ?string $neededType = null, ?string $actualType = null)
+    public function __construct(string $key, ?string $neededType = null, ?string $actualType = null, ?\Throwable $previous = null)
     {
         $message = "Invalid value for '{{ key }}'";
         if ($neededType !== null) {
@@ -21,7 +21,7 @@ class InvalidSettingValueException extends ShopwareHttpException
             'key' => $key,
             'neededType' => $neededType,
             'actualType' => $actualType,
-        ]);
+        ], $previous);
     }
 
     public function getStatusCode(): int

--- a/src/Core/System/SystemConfig/Exception/XmlElementNotFoundException.php
+++ b/src/Core/System/SystemConfig/Exception/XmlElementNotFoundException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class XmlElementNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $element)
+    public function __construct(string $element, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Unable to locate element with the name "{{ element }}".',
-            ['element' => $element]
+            ['element' => $element],
+            $previous
         );
     }
 

--- a/src/Core/System/SystemConfig/Exception/XmlParsingException.php
+++ b/src/Core/System/SystemConfig/Exception/XmlParsingException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class XmlParsingException extends ShopwareHttpException
 {
-    public function __construct(string $xmlFile, string $message)
+    public function __construct(string $xmlFile, string $message, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Unable to parse file "{{ file }}". Message: {{ message }}',
-            ['file' => $xmlFile, 'message' => $message]
+            ['file' => $xmlFile, 'message' => $message],
+            $previous
         );
     }
 

--- a/src/Core/System/Tax/Exception/TaxNotFoundException.php
+++ b/src/Core/System/Tax/Exception/TaxNotFoundException.php
@@ -7,11 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TaxNotFoundException extends ShopwareHttpException
 {
-    public function __construct(string $taxId)
+    public function __construct(string $taxId, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Tax with id "{{ id }}" not found.',
-            ['id' => $taxId]
+            ['id' => $taxId],
+            $previous
         );
     }
 

--- a/src/Elasticsearch/Exception/ElasticsearchIndexingException.php
+++ b/src/Elasticsearch/Exception/ElasticsearchIndexingException.php
@@ -8,12 +8,14 @@ class ElasticsearchIndexingException extends ShopwareHttpException
 {
     public const CODE = 'ELASTICSEARCH_INDEXING';
 
-    public function __construct(array $items)
+    public function __construct(array $items, ?\Throwable $previous = null)
     {
         $message = \PHP_EOL . implode(\PHP_EOL . '#', array_column($items, 'reason'));
 
         parent::__construct(
-            sprintf('Following errors occurred while indexing: %s', $message)
+            sprintf('Following errors occurred while indexing: %s', $message),
+            [],
+            $previous
         );
     }
 

--- a/src/Elasticsearch/Exception/NoIndexedDocumentsException.php
+++ b/src/Elasticsearch/Exception/NoIndexedDocumentsException.php
@@ -8,10 +8,12 @@ class NoIndexedDocumentsException extends ShopwareHttpException
 {
     public const CODE = 'ELASTICSEARCH_NO_INDEXED_DOCUMENTS';
 
-    public function __construct(string $entityName)
+    public function __construct(string $entityName, ?\Throwable $previous = null)
     {
         parent::__construct(
-            sprintf('No indexed documents found for entity %s', $entityName)
+            sprintf('No indexed documents found for entity %s', $entityName),
+            [],
+            $previous
         );
     }
 

--- a/src/Elasticsearch/Exception/ServerNotAvailableException.php
+++ b/src/Elasticsearch/Exception/ServerNotAvailableException.php
@@ -8,9 +8,9 @@ class ServerNotAvailableException extends ShopwareHttpException
 {
     public const CODE = 'ELASTICSEARCH_SERVER_NOT_AVAILABLE';
 
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('Elasticsearch server is not available');
+        parent::__construct('Elasticsearch server is not available', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Elasticsearch/Exception/UnsupportedElasticsearchDefinitionException.php
+++ b/src/Elasticsearch/Exception/UnsupportedElasticsearchDefinitionException.php
@@ -8,9 +8,9 @@ class UnsupportedElasticsearchDefinitionException extends ShopwareHttpException
 {
     public const CODE = 'ELASTICSEARCH_UNSUPPORTED_DEFINITION';
 
-    public function __construct(string $entity)
+    public function __construct(string $entity, ?\Throwable $previous = null)
     {
-        parent::__construct(sprintf('Entity %s is not supported for elastic search', $entity));
+        parent::__construct(sprintf('Entity %s is not supported for elastic search', $entity), [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -198,7 +198,7 @@ class RegisterController extends StorefrontController
             );
         } catch (ConstraintViolationException $formViolations) {
             if (!$request->request->has('errorRoute')) {
-                throw new MissingRequestParameterException('errorRoute');
+                throw new MissingRequestParameterException('errorRoute', '', $formViolations);
             }
 
             $params = $this->decodeParam($request, 'errorParameters');

--- a/src/Storefront/Exception/VerificationHashNotConfiguredException.php
+++ b/src/Storefront/Exception/VerificationHashNotConfiguredException.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class VerificationHashNotConfiguredException extends ShopwareHttpException
 {
-    public function __construct(?\Throwable $e = null)
+    public function __construct(?\Throwable $previous = null)
     {
         parent::__construct(
             'No verification hash configured.',
             [],
-            $e
+            $previous
         );
     }
 

--- a/src/Storefront/Framework/Captcha/Exception/CaptchaInvalidException.php
+++ b/src/Storefront/Framework/Captcha/Exception/CaptchaInvalidException.php
@@ -8,13 +8,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CaptchaInvalidException extends ShopwareHttpException
 {
-    public function __construct(AbstractCaptcha $captcha)
+    public function __construct(AbstractCaptcha $captcha, ?\Throwable $previous = null)
     {
         parent::__construct(
             'The provided value for captcha "{{ captcha }}" is not valid.',
             [
                 'captcha' => \get_class($captcha),
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Storefront/Framework/Csrf/Exception/CsrfNotEnabledException.php
+++ b/src/Storefront/Framework/Csrf/Exception/CsrfNotEnabledException.php
@@ -6,9 +6,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class CsrfNotEnabledException extends ShopwareHttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct('CSRF protection is not enabled.');
+        parent::__construct('CSRF protection is not enabled.', [], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Storefront/Framework/Csrf/Exception/CsrfWrongModeException.php
+++ b/src/Storefront/Framework/Csrf/Exception/CsrfWrongModeException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class CsrfWrongModeException extends ShopwareHttpException
 {
-    public function __construct(string $requiredMode)
+    public function __construct(string $requiredMode, ?\Throwable $previous = null)
     {
         parent::__construct(
             'CSRF has the wrong mode. Please make sure the mode is set to "{{mode}}"',
-            ['mode' => $requiredMode]
+            ['mode' => $requiredMode],
+            $previous
         );
     }
 

--- a/src/Storefront/Framework/Csrf/Exception/InvalidCsrfTokenException.php
+++ b/src/Storefront/Framework/Csrf/Exception/InvalidCsrfTokenException.php
@@ -7,8 +7,8 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class InvalidCsrfTokenException extends HttpException
 {
-    public function __construct()
+    public function __construct(?\Throwable $previous = null)
     {
-        parent::__construct(Response::HTTP_FORBIDDEN, 'The provided CSRF token is not valid');
+        parent::__construct(Response::HTTP_FORBIDDEN, 'The provided CSRF token is not valid', $previous);
     }
 }

--- a/src/Storefront/Framework/Media/Exception/FileTypeNotAllowedException.php
+++ b/src/Storefront/Framework/Media/Exception/FileTypeNotAllowedException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class FileTypeNotAllowedException extends ShopwareHttpException
 {
-    public function __construct(string $mimeType, string $uploadType)
+    public function __construct(string $mimeType, string $uploadType, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Type "{{ mimeType }}" of provided file is not allowed for {{ uploadType }}',
-            ['mimeType' => $mimeType, 'uploadType' => $uploadType]
+            ['mimeType' => $mimeType, 'uploadType' => $uploadType],
+            $previous
         );
     }
 

--- a/src/Storefront/Framework/Media/Exception/MediaValidatorMissingException.php
+++ b/src/Storefront/Framework/Media/Exception/MediaValidatorMissingException.php
@@ -7,9 +7,9 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class MediaValidatorMissingException extends ShopwareHttpException
 {
-    public function __construct(string $type)
+    public function __construct(string $type, ?\Throwable $previous = null)
     {
-        parent::__construct('No validator for {{ type }} was found.', ['type' => $type]);
+        parent::__construct('No validator for {{ type }} was found.', ['type' => $type], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Storefront/Framework/Media/StorefrontMediaUploader.php
+++ b/src/Storefront/Framework/Media/StorefrontMediaUploader.php
@@ -66,7 +66,7 @@ class StorefrontMediaUploader
                 );
             });
         } catch (MediaNotFoundException $e) {
-            throw new UploadException($e->getMessage());
+            throw new UploadException($e->getMessage(), $e);
         }
 
         return $mediaId;

--- a/src/Storefront/Framework/Routing/Exception/SalesChannelMappingException.php
+++ b/src/Storefront/Framework/Routing/Exception/SalesChannelMappingException.php
@@ -6,11 +6,12 @@ use Shopware\Core\Framework\ShopwareHttpException;
 
 class SalesChannelMappingException extends ShopwareHttpException
 {
-    public function __construct(string $url)
+    public function __construct(string $url, ?\Throwable $previous = null)
     {
         parent::__construct(
             'Unable to find a matching sales channel for the request: {{url}}". Please make sure the domain mapping is correct.',
-            ['url' => $url]
+            ['url' => $url],
+            $previous
         );
     }
 

--- a/src/Storefront/Theme/Exception/InvalidThemeBundleException.php
+++ b/src/Storefront/Theme/Exception/InvalidThemeBundleException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidThemeBundleException extends ShopwareHttpException
 {
-    public function __construct(string $themeName)
+    public function __construct(string $themeName, ?\Throwable $previous = null)
     {
-        parent::__construct('Unable to find the theme.json for "{{ themeName }}"', ['themeName' => $themeName]);
+        parent::__construct('Unable to find the theme.json for "{{ themeName }}"', ['themeName' => $themeName], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Storefront/Theme/Exception/InvalidThemeConfigException.php
+++ b/src/Storefront/Theme/Exception/InvalidThemeConfigException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidThemeConfigException extends ShopwareHttpException
 {
-    public function __construct(string $fieldName)
+    public function __construct(string $fieldName, ?\Throwable $previous = null)
     {
-        parent::__construct('Unable to find setter for config field "{{ fieldName }}"', ['fieldName' => $fieldName]);
+        parent::__construct('Unable to find setter for config field "{{ fieldName }}"', ['fieldName' => $fieldName], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Storefront/Theme/Exception/InvalidThemeException.php
+++ b/src/Storefront/Theme/Exception/InvalidThemeException.php
@@ -7,9 +7,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class InvalidThemeException extends ShopwareHttpException
 {
-    public function __construct(string $themeName)
+    public function __construct(string $themeName, ?\Throwable $previous = null)
     {
-        parent::__construct('Unable to find the theme "{{ themeName }}"', ['themeName' => $themeName]);
+        parent::__construct('Unable to find the theme "{{ themeName }}"', ['themeName' => $themeName], $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Storefront/Theme/Exception/ThemeAssignmentException.php
+++ b/src/Storefront/Theme/Exception/ThemeAssignmentException.php
@@ -13,8 +13,13 @@ class ThemeAssignmentException extends ShopwareHttpException
     /**
      * @deprecated tag:v6.5.0 parameter $stillAssignedSalesChannels will be required
      */
-    public function __construct(string $themeName, array $themeSalesChannel, array $childThemeSalesChannel, ?SalesChannelCollection $stillAssignedSalesChannels = null)
-    {
+    public function __construct(
+        string $themeName,
+        array $themeSalesChannel,
+        array $childThemeSalesChannel,
+        ?SalesChannelCollection $stillAssignedSalesChannels = null,
+        ?\Throwable $previous = null
+    ) {
         $this->stillAssignedSalesChannels = $stillAssignedSalesChannels ?? new SalesChannelCollection();
 
         $parameters = ['themeName' => $themeName];
@@ -30,7 +35,7 @@ class ThemeAssignmentException extends ShopwareHttpException
         }
         $parameters['assignments'] = $assignments;
 
-        parent::__construct($message, $parameters);
+        parent::__construct($message, $parameters, $previous);
     }
 
     public function getErrorCode(): string

--- a/src/Storefront/Theme/Exception/ThemeCompileException.php
+++ b/src/Storefront/Theme/Exception/ThemeCompileException.php
@@ -7,14 +7,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ThemeCompileException extends ShopwareHttpException
 {
-    public function __construct(string $themeName, string $message = '')
+    public function __construct(string $themeName, string $message = '', ?\Throwable $previous = null)
     {
         parent::__construct(
             'Unable to compile the theme "{{ themeName }}". {{ message }}',
             [
                 'themeName' => $themeName,
                 'message' => $message,
-            ]
+            ],
+            $previous
         );
     }
 

--- a/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
+++ b/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
@@ -147,7 +147,8 @@ class StorefrontPluginConfigurationFactory extends AbstractStorefrontPluginConfi
                 sprintf(
                     'Got exception while parsing theme config. Exception message "%s"',
                     $e->getMessage()
-                )
+                ),
+                $e
             );
         }
 

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -213,7 +213,8 @@ class ThemeCompiler implements ThemeCompilerInterface
         } catch (\Throwable $exception) {
             throw new ThemeCompileException(
                 $configuration->getTechnicalName(),
-                $exception->getMessage()
+                $exception->getMessage(),
+                $exception
             );
         }
         $autoPreFixer = new Autoprefixer($cssOutput);


### PR DESCRIPTION
### 1. Why is this change necessary?
In case you have an issue with the SCSS compiler and you run `theme:compile` you will just get the right message but not the correct stack trace as the previous exception has not been added to the `ThemeCompileException` (child of `ShopwareHttpException`). Adding this adds more value to the unrolled exception stack traces. I noticed that this is quite frequent pattern. StoreApiException e.g. often just takes the message but does not pass on the previous exception. This makes things so much harder to debug.

### 2. What does this change do, exactly?
Fills the previous exception field much more often where ever possible and opens up the exception types to allow passing this variable into it.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
