### PR TITLE
Load administration even if plugin js does not exist

### DIFF
--- a/changelog/_unreleased/2021-01-15-prevent-missing-plugin-file-from-crashing-administration.md
+++ b/changelog/_unreleased/2021-01-15-prevent-missing-plugin-file-from-crashing-administration.md
@@ -1,0 +1,8 @@
+---
+title:              Prevent error in loading plugin administration files from crashing the administration.
+issue:              
+author:             Niklas Büchner
+author_email:       niklas.buechner@pickware.de
+---
+# Administration
+* Changed the plugin loading process to gracefully handle a missing javascript file of a plugin instead of crashing.

--- a/src/Administration/Resources/app/administration/src/core/application.js
+++ b/src/Administration/Resources/app/administration/src/core/application.js
@@ -508,23 +508,20 @@ class ApplicationBootstrapper {
      * @private
      * @returns {Promise<any[][]>}
      */
-    loadPlugins() {
+    async loadPlugins() {
         const isDevelopmentMode = process.env.NODE_ENV;
 
+        let plugins;
         // only in webpack dev mode
         if (isDevelopmentMode === 'development') {
-            return fetch('./sw-plugin-dev.json')
-                .then((rawResponse) => rawResponse.json())
-                .then((plugins) => {
-                    const injectAllPlugins = Object.values(plugins).map((plugin) => this.injectPlugin(plugin));
-                    return Promise.all(injectAllPlugins);
-                });
+            const response = await fetch('./sw-plugin-dev.json');
+            plugins = await response.json();
+        } else {
+            plugins = Shopware.Context.app.config.bundles;
         }
 
-        // in production
-        const plugins = Shopware.Context.app.config.bundles;
-
         const injectAllPlugins = Object.values(plugins).map((plugin) => this.injectPlugin(plugin));
+
         return Promise.all(injectAllPlugins);
     }
 
@@ -534,7 +531,7 @@ class ApplicationBootstrapper {
      * @param {Object} plugin
      * @returns {Promise<any[]>}
      */
-    injectPlugin(plugin) {
+    async injectPlugin(plugin) {
         let allScripts = [];
         let allStyles = [];
 
@@ -552,7 +549,13 @@ class ApplicationBootstrapper {
             allStyles.push(this.injectCss(plugin.css));
         }
 
-        return Promise.all([...allScripts, ...allStyles]);
+        try {
+            return await Promise.all([...allScripts, ...allStyles]);
+        } catch (_) {
+            console.log('Error while loading plugin', plugin);
+
+            return null;
+        }
     }
 
     /**

--- a/src/Administration/Resources/app/administration/test/core/application.spec.js
+++ b/src/Administration/Resources/app/administration/test/core/application.spec.js
@@ -1,0 +1,17 @@
+const {
+    Application
+} = Shopware;
+
+describe('core/application.js', () => {
+    it('should be error tolerant if loading a plugin\'s files fails', async () => {
+        Application.injectJs = async () => {
+            throw new Error('Inject js fails');
+        };
+
+        const result = await Application.injectPlugin({
+            js: ['some.js']
+        });
+
+        expect(result).toBeNull();
+    });
+});


### PR DESCRIPTION
### 1. Why is this change necessary?
If a plugin's administration javascript file can't be loaded the whole administration fails to initialize and only shows a white page.

Currently, if a plugin's javascript file fails to load, the administration will fail to initialize since the error is not handled adequately (https://github.com/shopware/platform/blob/master/src/Administration/Resources/app/administration/src/core/application.js#L378-L383). This pr allows the loading of the plugin to fail but ensures that the administration will load.


### 2. What does this change do, exactly?
This change allows the including of administration files of plugins to fail without taking down the whole administration.

Since the build process only uses `core-js` in version 2, I refactored the method to handle the error correctly. With `core-js` >= 3 we could have used `allSettled` here so a version upgrade would be great.

### 3. Describe each step to reproduce the issue or behaviour.
1. Install a plugin with an administration javascript file.
2. Rename the javascript file so that the administration can't load it.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.