### PR TITLE
fix: initialize newly created block slots

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -1,6 +1,7 @@
 import pageState from './state';
 import template from './sw-category-detail.html.twig';
 import './sw-category-detail.scss';
+import { initMissingSlots } from '../../../sw-cms/util/create-slots'
 
 const { Component, Context, Mixin } = Shopware;
 const { Criteria, ChangesetGenerator, EntityCollection } = Shopware.Data;
@@ -330,9 +331,9 @@ Component.register('sw-category-detail', {
                     return null;
                 }
 
-                if (this.category.slotConfig !== null) {
-                    cmsPage.sections.forEach((section) => {
-                        section.blocks.forEach((block) => {
+                cmsPage.sections.forEach((section) => {
+                    section.blocks.forEach((block) => {
+                        if (this.category.slotConfig !== null) {
                             block.slots.forEach((slot) => {
                                 if (this.category.slotConfig[slot.id]) {
                                     if (slot.config === null) {
@@ -341,9 +342,15 @@ Component.register('sw-category-detail', {
                                     merge(slot.config, cloneDeep(this.category.slotConfig[slot.id]));
                                 }
                             });
-                        });
+                        }
+
+                        /**
+                         * We're only getting existing slots from the server.
+                         * When a block was updated with new fields they are not included, so we need to create them.
+                         */
+                        initMissingSlots(block);
                     });
-                }
+                });
 
                 this.updateCmsPageDataMapping();
                 Shopware.State.commit('cmsPageState/setCurrentPage', cmsPage);

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -1,7 +1,7 @@
 import pageState from './state';
 import template from './sw-category-detail.html.twig';
 import './sw-category-detail.scss';
-import { initMissingSlots } from '../../../sw-cms/util/create-slots'
+import { initMissingSlots } from '../../../sw-cms/util/create-slots';
 
 const { Component, Context, Mixin } = Shopware;
 const { Criteria, ChangesetGenerator, EntityCollection } = Shopware.Data;

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
@@ -1,10 +1,10 @@
 import template from './sw-cms-sidebar.html.twig';
 import './sw-cms-sidebar.scss';
+import { createSlotFromConfig } from '../../util/create-slots';
 
 const { Component, Mixin } = Shopware;
 const { Criteria } = Shopware.Data;
 const { cloneDeep } = Shopware.Utils.object;
-const types = Shopware.Utils.types;
 
 
 Component.register('sw-cms-sidebar', {
@@ -302,21 +302,8 @@ Component.register('sw-cms-sidebar', {
 
             Object.keys(blockConfig.slots).forEach((slotName) => {
                 const slotConfig = blockConfig.slots[slotName];
-                const element = this.slotRepository.create(Shopware.Context.api);
-                element.blockId = newBlock.id;
-                element.slot = slotName;
-
-                if (typeof slotConfig === 'string') {
-                    element.type = slotConfig;
-                } else if (types.isPlainObject(slotConfig)) {
-                    element.type = slotConfig.type;
-
-                    if (slotConfig.default && types.isPlainObject(slotConfig.default)) {
-                        Object.assign(element, cloneDeep(slotConfig.default));
-                    }
-                }
-
-                newBlock.slots.add(element);
+                const slotElement = createSlotFromConfig(this.slotRepository, newBlock.id, slotName, slotConfig);
+                newBlock.slots.add(slotElement);
             });
 
             this.page.sections[section.position].blocks.splice(dropData.dropIndex, 0, newBlock);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
@@ -2,7 +2,7 @@ const { Application } = Shopware;
 const { cloneDeep, merge } = Shopware.Utils.object;
 const Criteria = Shopware.Data.Criteria;
 const { warn } = Shopware.Utils.debug;
-const types = Shopware.Utils.types;
+import { initMissingSlots } from '../util/create-slots';
 
 Application.addServiceProvider('cmsDataResolverService', () => {
     return {
@@ -92,42 +92,6 @@ function initSlotDefaultData(slot) {
     const defaultData = slotConfig.defaultData || {};
 
     slot.data = merge(cloneDeep(defaultData), slot.data || {});
-}
-
-function initMissingSlots(block) {
-    repoFactory = repoFactory || Shopware.Service('repositoryFactory');
-    cmsService = cmsService || Shopware.Service('cmsService');
-
-    const cmsBlocks = cmsService.getCmsBlockRegistry();
-    const slotRepository = repoFactory.create('cms_slot');
-
-    const blockConfig = cmsBlocks[block.type];
-    const existingSlots = new Set();
-
-    block.slots.forEach((slot) => existingSlots.add(slot.slot));
-
-    Object.keys(blockConfig.slots).forEach((slotName) => {
-        if (existingSlots.has(slotName)) {
-            return;
-        }
-
-        const slotConfig = blockConfig.slots[slotName];
-        const element = slotRepository.create(Shopware.Context.api);
-        element.blockId = block.id;
-        element.slot = slotName;
-
-        if (typeof slotConfig === 'string') {
-            element.type = slotConfig;
-        } else if (types.isPlainObject(slotConfig)) {
-            element.type = slotConfig.type;
-
-            if (slotConfig.default && types.isPlainObject(slotConfig.default)) {
-                Object.assign(element, cloneDeep(slotConfig.default));
-            }
-        }
-
-        block.slots.add(element);
-    });
 }
 
 function optimizeCriteriaObjects(slotEntityCollection) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
@@ -43,7 +43,7 @@ function resolve(page) {
              * We're only getting existing slots from the server.
              * When a block was updated with new fields they are not included, so we need to create them.
              */
-            initMissingSlots(cmsService, block, repoFactory);
+            initMissingSlots(block);
         });
     });
 
@@ -94,7 +94,10 @@ function initSlotDefaultData(slot) {
     slot.data = merge(cloneDeep(defaultData), slot.data || {});
 }
 
-function initMissingSlots(cmsService, block, repoFactory) {
+function initMissingSlots(block) {
+    repoFactory = repoFactory || Shopware.Service('repositoryFactory');
+    cmsService = cmsService || Shopware.Service('cmsService');
+
     const cmsBlocks = cmsService.getCmsBlockRegistry();
     const slotRepository = repoFactory.create('cms_slot');
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
@@ -1,8 +1,9 @@
+import { initMissingSlots } from '../util/create-slots';
+
 const { Application } = Shopware;
 const { cloneDeep, merge } = Shopware.Utils.object;
 const Criteria = Shopware.Data.Criteria;
 const { warn } = Shopware.Utils.debug;
-import { initMissingSlots } from '../util/create-slots';
 
 Application.addServiceProvider('cmsDataResolverService', () => {
     return {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/util/create-slots.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/util/create-slots.js
@@ -1,0 +1,44 @@
+const { cloneDeep } = Shopware.Utils.object;
+const types = Shopware.Utils.types;
+
+export function initMissingSlots(block) {
+    const repoFactory = Shopware.Service('repositoryFactory');
+    const cmsService = Shopware.Service('cmsService');
+
+    const cmsBlocks = cmsService.getCmsBlockRegistry();
+    const slotRepository = repoFactory.create('cms_slot');
+
+    const blockConfig = cmsBlocks[block.type];
+    const existingSlots = new Set();
+
+    block.slots.forEach((slot) => existingSlots.add(slot.slot));
+
+    Object.keys(blockConfig.slots).forEach((slotName) => {
+        if (existingSlots.has(slotName)) {
+            return;
+        }
+
+        const slotConfig = blockConfig.slots[slotName];
+        const slotElement = createSlotFromConfig(slotRepository, block.id, slotName, slotConfig);
+
+        block.slots.add(slotElement);
+    });
+}
+
+export function createSlotFromConfig(slotRepository, blockId, slotName, slotConfig) {
+    const element = slotRepository.create(Shopware.Context.api);
+    element.blockId = blockId;
+    element.slot = slotName;
+
+    if (typeof slotConfig === 'string') {
+        element.type = slotConfig;
+    } else if (types.isPlainObject(slotConfig)) {
+        element.type = slotConfig.type;
+
+        if (slotConfig.default && types.isPlainObject(slotConfig.default)) {
+            Object.assign(element, cloneDeep(slotConfig.default));
+        }
+    }
+
+    return element;
+}


### PR DESCRIPTION
Note: This is a WIP PR. I copied the following lines of code and would like to deduplicate the code by moving it somewhere else. I'm not very familiar with the Shopware code, so I would be happy if someone can tell me where the best place to put it would be. cc @OliverSkroblin @jleifeld @pantrtxp

https://github.com/shopware/platform/blob/d31eeb52fa86bb43afbc03a9a0a5cef2276fcb86/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js#L304-L319

Edit 3: I now also added this fix to `sw-category-detail`. For that I required that code again and moved it into `sw-cms/util/create-slots.js`. I'm not 100% happy with that. Do you have any better recommendations?
Edit 4: Are there any other places where this fix should be applied to? I'm not very familiar with the Shopware Administration yet. I only created this PR because with this fix I'm saving my colleague a lot of time as he doesn't have to recreate any existing blocks just to add another field.


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Example: We create a new block for the administration with `registerCmsBlock`. This block has 1 slot, let's name it `title`. Now we're using that block and save it. When we're now adding more slots to `registerCmsBlock` these fields won't be writable as the slots are not initialized. This change creates the not existing slots.

### 2. What does this change do, exactly?
We're creating a set from all slots which we got from the server. We then loop over all available slots from the blockConfig and create non-existent slots.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a new block with `registerCmsBlock`
- Add a slot `title`
```js
'title': {
    type: 'text',
    default: {
        config: {
            content: {
                source: 'static',
                value: 'My title'
            }
        }
    }
}
```
- Log into backend and create a new template with this block and save it.
- Add a new category page and assign the layout to it.
- Add another slot to the element
```js
'text': {
    type: 'text',
    default: {
        config: {
            content: {
                source: 'static',
                value: 'Lorem Ipsum'
            }
        }
    }
}
```
- Go to the new template and the category page and see that there is no input field for the `text` slot on both.

### 4. Please link to the relevant issues (if any).
https://forum.shopware.com/t/custom-cms-block-um-einen-slot-erweitern/64999

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits [Please squash merge when it's ready]
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


Edit: I'm not sure if I'm able to create a test for this change. I will create a changelog file when I got a feedback from a Shopware core maintainer about how to refactor the code to comply with the DRY pattern.

Edit 2: TODO for me: also check where a similiar fix is required (category pages)