### PR TITLE
NEXT-11357 Added lazy loading to thumbnails 

### DIFF
--- a/changelog/_unreleased/2021-04-24-added-lazy-load-to-thumbnails.md
+++ b/changelog/_unreleased/2021-04-24-added-lazy-load-to-thumbnails.md
@@ -1,0 +1,9 @@
+---
+title: Added lazy load to thumbnails
+issue: NEXT-11357
+author: Christopher Dosin
+author_email: christopher@shapeandshift.dev
+author_github: @christopherdosin
+---
+# Storefront
+* Added `loading="lazy"` to the img tag within the `thumbnail.html.twig` utility file.

--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -55,7 +55,7 @@
         {% for key, value in breakpoint|reverse %}{% if maxWidth %}(max-width: {{ maxWidth }}px) and {% endif %}(min-width: {{ value }}px) {{ sizes[key] }}{% set maxWidth = value-1 %}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
     {% endapply %}{% endset %}
 {% endif %}
-<img {% if load %}src="{{ media|sw_encode_media_url }}" {% else %}data-src="{{ media|sw_encode_media_url }}" {% endif %}
+<img loading="lazy" {% if load %}src="{{ media|sw_encode_media_url }}" {% else %}data-src="{{ media|sw_encode_media_url }}" {% endif %}
     {% if media.thumbnails|length > 0 %}
         {% if load %}srcset="{{ srcsetValue }}" {% else %}data-srcset="{{ srcsetValue }}" {% endif %}
         {% if sizes['default'] %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Since 2019 support for Lazy Loading is supported natively by Chrome, Firefox, Opera and Edge.
This can lead to a massive reduction in transferring file size and due to this also loading time.

More about lazy load:
https://developer.mozilla.org/en-US/docs/Web/Performance/Lazy_loading

CanIUse: https://caniuse.com/loading-lazy-attr

### 2. What does this change do, exactly?
We're adding here the `loading="lazy"` attribute to the `img` tag within the `sw_thumbnails` utility,
which is also used for the product images.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-11357

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

