### PR TITLE
BUGFIX: NEXT-11506 - Update cart instead of deleting and inserting.

### DIFF
--- a/changelog/_unreleased/2021-05-05-update-cart-instead-of-deleting-and-inserting.md
+++ b/changelog/_unreleased/2021-05-05-update-cart-instead-of-deleting-and-inserting.md
@@ -1,0 +1,9 @@
+---
+title: Update cart instead of deleting and inserting.
+issue: NEXT-11506
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed method `save` in `Shopware\Core\Checkout\Cart\CartPersister` class to insert or update the cart to ensure concurrent requests will not retrieve an empty cart.

--- a/src/Core/Checkout/Test/Cart/CartPersisterTest.php
+++ b/src/Core/Checkout/Test/Cart/CartPersisterTest.php
@@ -59,7 +59,12 @@ class CartPersisterTest extends TestCase
     {
         $connection = $this->createMock(Connection::class);
         $eventDispatcher = new EventDispatcher();
-        $connection->expects(static::never())->method('insert');
+
+        // Cart should be deleted (in case it exists).
+        $connection->expects(static::once())->method('delete');
+
+        // Cart should not be inserted or updated.
+        $connection->expects(static::never())->method('executeUpdate');
 
         $persister = new CartPersister($connection, $eventDispatcher);
 
@@ -72,6 +77,11 @@ class CartPersisterTest extends TestCase
     {
         $connection = $this->createMock(Connection::class);
         $eventDispatcher = new EventDispatcher();
+
+        // Verify that cart deletion is never called.
+        $connection->expects(static::never())->method('delete');
+
+        // Check that cart insert or update is called.
         $connection->expects(static::once())->method('executeUpdate');
 
         $persister = new CartPersister($connection, $eventDispatcher);

--- a/src/Core/Migration/V6_4/Migration1620201616AddUpdatedAtToCart.php
+++ b/src/Core/Migration/V6_4/Migration1620201616AddUpdatedAtToCart.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_4;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1620201616AddUpdatedAtToCart extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1620201616;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeUpdate('ALTER TABLE `cart` ADD COLUMN `updated_at` DATETIME(3) NULL;');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
To fix NEXT-11506. This ensures that concurrent requests will not receive an empty cart and therefore remove existing carts.

### 2. What does this change do, exactly?
It does an update or insert in one state to the cart. It is not a perfect solution for concurrent requests but it will definitely ensure that the cart is not removed by a concurrent request (as it just happens to access the cart upon deletion).

### 3. Describe each step to reproduce the issue or behaviour.

- Add items to a store API cart.
- Execute multiple product list requests at the same time.
- The cart's items will be lost, if the timing is just right which makes it tricky to test but it definitely does happen.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-11506

### 5. Checklist

- [X] I have written tests and verified that they fail without my change: Adjusted existing tests to check that the cart delete is not called.
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code.
- [X] I have read the contribution requirements and fulfil them.
