### PR TITLE
NEXT-15200 - Allow ContextSwitchRoute to be decorated by inheriting abstract class

### DIFF
--- a/changelog/_unreleased/2021-05-07-fix-contextswitchroute-decoration-inheritance.md
+++ b/changelog/_unreleased/2021-05-07-fix-contextswitchroute-decoration-inheritance.md
@@ -1,0 +1,10 @@
+---
+title: Fix-ContextSwitchRoute-decoration-inheritance
+issue: NEXT-15200
+author: Jonas Søndergaard
+author_email: jonas@wexo.dk 
+author_github: Josniii
+---
+# Core
+*  Changed constructor of \Shopware\Core\System\SalesChannel\SalesChannel\SalesChannelContextSwitcher to use abstract class to allow decorators to inherit \Shopware\Core\System\SalesChannel\SalesChannel\AbstractContextSwitchRoute
+___

--- a/src/Core/System/SalesChannel/SalesChannel/SalesChannelContextSwitcher.php
+++ b/src/Core/System/SalesChannel/SalesChannel/SalesChannelContextSwitcher.php
@@ -12,7 +12,7 @@ class SalesChannelContextSwitcher
      */
     private $contextSwitchRoute;
 
-    public function __construct(ContextSwitchRoute $contextSwitchRoute)
+    public function __construct(AbstractContextSwitchRoute $contextSwitchRoute)
     {
         $this->contextSwitchRoute = $contextSwitchRoute;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Right now, the `ContextSwitchRoute` is unable to be decorated using the pattern described in the docs:
https://developer.shopware.com/docs/guides/plugins/plugins/plugin-fundamentals/adjusting-service#decorating-the-service
Here, the example specifies that the decorator should inherit the abstract class. This is not possible due to the `SalesChannelContextSwitcher` injecting the concrete implementation and not the abstract base class. Thus, any decorators have to inherit from this class and not the abstract class.

### 2. What does this change do, exactly?
This merge simply changes `SalesChannelContextSwitcher` to inject the abstract class instead. This shouldn't have any effect on how the base system runs as the injected class is the same, but allows decorators to inherit from the abstract class. 

### 3. Describe each step to reproduce the issue or behaviour.
Create a decorator for `ContextSwitchRoute` that extends `AbstractContextSwitchRoute` like in the docs:
```
class ContextSwitchRouteDecorator extends AbstractContextSwitchRoute
{
    /**
     * @var AbstractContextSwitchRoute
     */
    private $decoratedService;

    public function __construct(AbstractContextSwitchRoute $contextSwitchRoute) {
        $this->decoratedService = $contextSwitchRoute;
    }

    public function getDecorated(): AbstractContextSwitchRoute
    {
        return $this->decoratedService;
    }

    public function switchContext(RequestDataBag $data, SalesChannelContext $context): ContextTokenResponse
    {
        /** do something with the decorator */
        return $this->decoratedService->switchContext($data, $context);
    }
}
```
The system will fail with an error like so:

> Argument 1 passed to Shopware\Core\System\SalesChannel\SalesChannel\SalesChannelContextSwitcher::__construct() must be an instance of Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute, instance of Josniii\Test\Core\System\SalesChannel\SalesChannel\ContextSwitchRouteDecorator

### 4. Please link to the relevant issues (if any).

Issue here: https://issues.shopware.com/issues/NEXT-15200

### 5. Checklist

- [x] I have written tests and verified that they fail without my change - I don't think this change warrants extra tests. Then we might as well test everywhere a decorated service is injected.
- [o] I have squashed any insignificant commits
- [o] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes - There isn't any documentation for this.
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [o] I have read the contribution requirements and fulfil them.
