### PR TITLE
fix character limit for description field on OrderLineItems

### DIFF
--- a/changelog/_unreleased/2021-05-11-fix-field-definition-for-order-line-items-description-field.md
+++ b/changelog/_unreleased/2021-05-11-fix-field-definition-for-order-line-items-description-field.md
@@ -1,0 +1,10 @@
+---
+title: Fixed field definition for order line items description field
+author: Peter Roj
+author_email: roj@juicy-arts.de 
+author_github: @JuicyLung91
+---
+# Core
+* Added and replaced LongTextField to OrderLineItems to match with the migration and prevent an error for line item description that is longer than 255 characters.
+    * File Changed: src/Core/Checkout/Order/Aggregate/OrderLineItem/OrderLineItemDefinition.php
+    * The field `description` is now a `LongTextField` and not a `StringField` which is limited to 255 chars

--- a/src/Core/Checkout/Order/Aggregate/OrderLineItem/OrderLineItemDefinition.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderLineItem/OrderLineItemDefinition.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ParentAssociationField;
@@ -96,7 +97,7 @@ class OrderLineItemDefinition extends EntityDefinition
 
             (new FloatField('unit_price', 'unitPrice'))->addFlags(new ApiAware(), new Computed()),
             (new FloatField('total_price', 'totalPrice'))->addFlags(new ApiAware(), new Computed()),
-            (new StringField('description', 'description'))->addFlags(new ApiAware()),
+            (new LongTextField('description', 'description'))->addFlags(new ApiAware()),
             (new StringField('type', 'type'))->addFlags(new ApiAware()),
             (new CustomFields())->addFlags(new ApiAware()),
             new ManyToOneAssociationField('order', 'order_id', OrderDefinition::class, 'id', false),


### PR DESCRIPTION
When a lineItem (i.e. a lineItem of a new type) has a description and the description is longer than 255 chars the following erro occurs:

> request.ERROR: Uncaught PHP Exception Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException: "There are 1 error(s) while writing data.  1. [/0/lineItems/1/description] Diese Zeichenkette ist zu lang. Sie sollte höchstens 255 Zeichen haben." at /Users/roj/dev/dmf/project/fruit/vendor/shopware/platform/src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php line 41 {"exception":"[object] (Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\WriteException(code: 0): There are 1 error(s) while writing data.\n\n1. [/0/lineItems/1/description] Diese Zeichenkette ist zu lang. Sie sollte höchstens 255 Zeichen haben. at /Users/roj/dev/dmf/project/fruit/vendor/shopware/platform/src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php:41)"} []

Changing the fieldType to a LongTextField fixes it. As defined here https://github.com/shopware/platform/blob/trunk/src/Core/Migration/V6_3/Migration1536233030OrderLineItem.php the description field is a medium-sized field. 