### PR TITLE
Bump doctrine/inflector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "composer/semver": "~3.2.4",
         "doctrine/annotations": "1.11.1",
         "doctrine/dbal": "2.12.1",
-        "doctrine/inflector": "1.3.1",
+        "doctrine/inflector": "2.0.3",
         "dompdf/dompdf": "1.0.2",
         "elasticsearch/elasticsearch": "7.11.0",
         "enqueue/dbal": "0.10.0",

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "composer/semver": "~3.2.4",
         "doctrine/annotations": "1.11.1",
         "doctrine/dbal": "2.12.1",
-        "doctrine/inflector": "2.0.3",
+        "doctrine/inflector": "1.4.4",
         "dompdf/dompdf": "1.0.2",
         "elasticsearch/elasticsearch": "7.11.0",
         "enqueue/dbal": "0.10.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -47,7 +47,7 @@
         "composer/semver": "~3.2.4",
         "doctrine/annotations": "1.11.1",
         "doctrine/dbal": "2.12.1",
-        "doctrine/inflector": "1.3.1",
+        "doctrine/inflector": "1.4.4",
         "dompdf/dompdf": "1.0.2",
         "enqueue/dbal": "0.10.0",
         "google/cloud-storage": "1.17.0",


### PR DESCRIPTION
### 1. Why is this change necessary?
So shopware dependencies can work with php 8.0

### 2. What does this change do, exactly?
Bumps doctrine/inflector to support php 8.0

### 3. Describe each step to reproduce the issue or behaviour.
When updating to shopware 6.4.0.0 composer said: 
"doctrine/inflector 1.3.1 requires php ^7.1 -> your php version (8.0.6) does not satisfy that requirement."
"shopware/core 6.4.0.0 requires doctrine/inflector 1.3.1 -> satisfiable by doctrine/inflector[1.3.1]."