### PR TITLE
Option to skip CSS compilation within the "bin/console theme:compile" command

### DIFF
--- a/src/Storefront/Theme/Command/ThemeCompileCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCompileCommand.php
@@ -43,7 +43,8 @@ class ThemeCompileCommand extends Command
     public function configure(): void
     {
         $this
-            ->addOption('keep-assets', 'k', InputOption::VALUE_NONE, 'Keep current assets, do not delete them');
+            ->addOption('keep-assets', 'k', InputOption::VALUE_NONE, 'Keep current assets, do not delete them')
+            ->addOption('skip-css', null, InputOption::VALUE_NONE, 'Skip CSS compilation');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -60,7 +61,8 @@ class ThemeCompileCommand extends Command
             if (!$themes || !$theme = $themes->first()) {
                 continue;
             }
-            $this->themeService->compileTheme($salesChannel->getId(), $theme->getId(), $context, null, !$input->getOption('keep-assets'));
+
+            $this->themeService->compileTheme($salesChannel->getId(), $theme->getId(), $context, null, !$input->getOption('keep-assets'), (bool)$input->getOption('skip-css'));
         }
 
         $this->io->note(sprintf('Took %f seconds', microtime(true) - $start));

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -194,7 +194,7 @@ class ThemeCompiler implements ThemeCompilerInterface
                 if (mb_strpos($originalPath, $resolve) === 0) {
                     $dirname = $resolvePath . \dirname(mb_substr($originalPath, mb_strlen($resolve)));
                     $filename = basename($originalPath);
-                    $extension = pathinfo($filename, PATHINFO_EXTENSION) === '' ? '.scss' : '';
+                    $extension = pathinfo($filename, \PATHINFO_EXTENSION) === '' ? '.scss' : '';
                     $path = $dirname . \DIRECTORY_SEPARATOR . $filename . $extension;
                     if (file_exists($path)) {
                         return $path;

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -278,7 +278,7 @@ class ThemeCompiler implements ThemeCompilerInterface
 
                 $variables[$key] = '\'' . $data['value'] . '\'';
             } elseif ($data['type'] === 'switch' || $data['type'] === 'checkbox') {
-                $variables[$key] = (int)($data['value']);
+                $variables[$key] = (int) ($data['value']);
             } else {
                 $variables[$key] = $data['value'];
             }
@@ -315,7 +315,7 @@ class ThemeCompiler implements ThemeCompilerInterface
 
         $dump = str_replace(
             ['#class#', '#variables#'],
-            [self::class, implode(PHP_EOL, $this->formatVariables($themeVariablesEvent->getVariables()))],
+            [self::class, implode(\PHP_EOL, $this->formatVariables($themeVariablesEvent->getVariables()))],
             $this->getVariableDumpTemplate()
         );
 

--- a/src/Storefront/Theme/ThemeCompilerInterface.php
+++ b/src/Storefront/Theme/ThemeCompilerInterface.php
@@ -7,5 +7,5 @@ use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConf
 
 interface ThemeCompilerInterface
 {
-    public function compileTheme(string $salesChannelId, string $themeId, StorefrontPluginConfiguration $themeConfig, StorefrontPluginConfigurationCollection $configurationCollection, bool $withAssets = true): void;
+    public function compileTheme(string $salesChannelId, string $themeId, StorefrontPluginConfiguration $themeConfig, StorefrontPluginConfigurationCollection $configurationCollection, bool $withAssets = true, bool $skipCss = false): void;
 }

--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -60,7 +60,8 @@ class ThemeService
         string $themeId,
         Context $context,
         ?StorefrontPluginConfigurationCollection $configurationCollection = null,
-        bool $withAssets = true
+        bool $withAssets = true,
+        bool $skipCss = false
     ): void {
         $themePluginConfiguration = $this->getPluginConfiguration($themeId, $context);
 
@@ -69,7 +70,8 @@ class ThemeService
             $themeId,
             $themePluginConfiguration,
             $configurationCollection ?? $this->pluginRegistry->getConfigurations(),
-            $withAssets
+            $withAssets,
+            $skipCss
         );
     }
 


### PR DESCRIPTION
This PR adds a CLI option `--skip-css` to the command `bin/console theme:compile` to allow to skip CSS compilation. When developing JavaScript in the Production Template, a recompile of the JavaScript is needed (which usually takes less than 0.1 seconds). However, the CSS compilation adds another ~3.6 seconds on top of this, which is totally not needed. This option makes that development faster. Theoretically, more flags could be added (like skipping the JavaScript compilation, skipping assets) - let's debate that later.

### 1. Why is this change necessary?
When dealing with JavaScript-only compilation, this PR kind of speeds up things 35x.

### 2. What does this change do, exactly?
This PR implements a new CLI option to the command `theme:compile`.

### 3. Describe each step to reproduce the issue or behaviour.
Once the PR is applied, run the command `bin/console theme:compile -k`. Note the time it takes to complete. Next, run `bin/console theme:compile -k --skip-css`. Note the time it takes to complete.

### 4. Please link to the relevant issues (if any).
Not relevant.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X ] I have read the contribution requirements and fulfil them.
