### PR TITLE
NEXT-15178: send emails to customer and configured recipients

### DIFF
--- a/src/Core/Content/MailTemplate/Subscriber/MailSendSubscriber.php
+++ b/src/Core/Content/MailTemplate/Subscriber/MailSendSubscriber.php
@@ -111,9 +111,6 @@ class MailSendSubscriber implements EventSubscriberInterface
         $data = new DataBag();
 
         $recipients = $mailEvent->getMailStruct()->getRecipients();
-        if (isset($config['recipients']) && !empty($config['recipients'])) {
-            $recipients = $config['recipients'];
-        }
 
         $data->set('recipients', $recipients);
         $data->set('senderName', $mailTemplate->getTranslation('senderName'));
@@ -147,6 +144,15 @@ class MailSendSubscriber implements EventSubscriberInterface
                 $event->getContext(),
                 $this->getTemplateData($mailEvent)
             );
+
+            if (isset($config['recipients']) && !empty($config['recipients'])) {
+                $data->set('recipients', $config['recipients']);
+                $this->emailService->send(
+                    $data->all(),
+                    $event->getContext(),
+                    $this->getTemplateData($mailEvent)
+                );
+            }
 
             $writes = array_map(static function ($id) {
                 return ['id' => $id, 'sent' => true];


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

The provided fix for issue NEXT-15178 has a bug. Commit e3cf77e results in sending the E-Mail only to the configured recipients but not to the customer. 

### 2. What does this change do, exactly?

It removes the code which overrides the recipient array and instead adds a second mail with newly set recipient.

### 3. Describe each step to reproduce the issue or behaviour.

* Set custom order mail recipients in business events
* Place an order
* The customer does not get an order confirmation e-mail but only the custom recipients if set.

### 4. Please link to the relevant issues (if any).

NEXT-15178

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
  * The test was already added within commit e3cf77e
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
  * Please let me know if this is really wanted for such a small patch?
- [ ] I have written or adjusted the documentation according to my changes
  * not needed
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
  * not needed
- [x] I have read the contribution requirements and fulfil them.
