### PR TITLE
Improve exact total count

### DIFF
--- a/changelog/_unreleased/2021-05-21-improve-exact-total-count-in-dal.md
+++ b/changelog/_unreleased/2021-05-21-improve-exact-total-count-in-dal.md
@@ -1,0 +1,9 @@
+---
+title: Improve the performance of calculating the exact total count of a query
+author: Maximilian Ruesch
+author_email: maximilian.ruesch@pickware.de
+---
+# Core
+* Uses separate `COUNT()` query to calculate the exact `total` of an entity search instead of using
+  `SQL_CALC_FOUND_ROWS` and an additional `FOUND_ROWS()` query. This improves performance of calculating the total of
+  large query results.


### PR DESCRIPTION
### 1. Why is this change necessary?

As discussed with @OliverSkroblin in Slack: When searching for entities and using `TOTAL_COUNT_MODE_EXACT`, the `EntitySearcher` uses `SQL_CALC_FOUND_ROWS` which is very slow for large results.
Using a separate `COUNT()` query is at least an order of magnitude faster.

### 2. What does this change do, exactly?

Uses separate `COUNT()` query to calculate the exact `total` of an entity search instead of using `SQL_CALC_FOUND_ROWS` and an additional `FOUND_ROWS()` query.

### 3. Describe each step to reproduce the issue or behaviour.

Open any view that has more than 100.000 elements and compare the time to see the view (without caching) to a normal view with ~1.000 Elements

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
