### PR TITLE
Fix same ChangeSets on multiple WriteResults

### DIFF
--- a/changelog/_unreleased/2021-05-21-fix-same-changeset-in-writeresults-with-same-entity-type.md
+++ b/changelog/_unreleased/2021-05-21-fix-same-changeset-in-writeresults-with-same-entity-type.md
@@ -1,0 +1,8 @@
+---
+title: Fixes calculating an equivalent ChangeSet for multiple WriteResults
+author: Maximilian Ruesch
+author_email: maximilian.ruesch@pickware.de
+---
+# Core
+* The matching of the new `state` of the entity to the `WriteCommand` is fixed by using additional checks if relevant
+  info of the objects matches.

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
@@ -528,11 +528,9 @@ class EntityWriteGateway implements EntityWriteGatewayInterface
             // check if current loop matches the command primary key
             $primaryKey = array_intersect($command->getPrimaryKey(), $state);
 
-            if (!$primaryKey) {
-                continue;
+            if (count(array_diff_assoc($command->getPrimaryKey(), $primaryKey)) === 0) {
+                return new ChangeSet($state, $command->getPayload(), $command instanceof DeleteCommand);
             }
-
-            return new ChangeSet($state, $command->getPayload(), $command instanceof DeleteCommand);
         }
 
         return new ChangeSet([], [], $command instanceof DeleteCommand);


### PR DESCRIPTION
### 1. Why is this change necessary?

When changing multiple entities in a single request (e.g. deleting an order and its order line items), the `EntityWriteGateway` matches the changesets wrongly. Hence respective `_WRITTEN` or `_DELETED` events will carry a wrong changeset.
This can cause all kinds of unintended behavior. We had this issue when deleting an order did not cause the `reserved_stock` of a product to be recalculated correctly.

### 2. What does this change do, exactly?

Improves the matching of states and `WriteCommands` in the `EntityWriteGateway` by using more set operations.

### 3. Describe each step to reproduce the issue or behaviour.

- Create an order with multiple order line items.
- Delete the order (and therefore the order line items)
- Listen to the `OrderEvents::ORDER_LINE_ITEM_DELETED_EVENT` event. There will be an event for each of the order line item, but all changesets will refer to the same order line item.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/master/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
