### PR TITLE
NEXT-7754 - Fix thumbnail generation when physical file is missing

### DIFF
--- a/changelog/_unreleased/2021-05-21-fix-thumbnail-generation-when-physical-file-missing.md
+++ b/changelog/_unreleased/2021-05-21-fix-thumbnail-generation-when-physical-file-missing.md
@@ -1,0 +1,8 @@
+---
+title: Fix thumbnail generation when physical file is missing
+issue: NEXT-7754
+author: David Fecke
+author_github: @leptoquark1
+---
+# Core
+* Fix `updateThumbnails` function in `src/Core/Content/Media/Thumbnail/ThumbnailService.php` so that the physical presence of the thumbnail file is respected

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -175,11 +175,13 @@ class ThumbnailService
 
         $tobBeCreatedSizes = new MediaThumbnailSizeCollection($config->getMediaThumbnailSizes()->getElements());
         $toBeDeletedThumbnails = new MediaThumbnailCollection($media->getThumbnails()->getElements());
+        $fileSystem = $this->getFileSystem($media);
 
         foreach ($tobBeCreatedSizes as $thumbnailSize) {
             foreach ($toBeDeletedThumbnails as $thumbnail) {
                 if ($thumbnail->getWidth() === $thumbnailSize->getWidth()
                     && $thumbnail->getHeight() === $thumbnailSize->getHeight()
+                    && $fileSystem->has($this->urlGenerator->getRelativeThumbnailUrl($media, $thumbnail))
                 ) {
                     $toBeDeletedThumbnails->remove($thumbnail->getId());
                     $tobBeCreatedSizes->remove($thumbnailSize->getId());


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Regeneration of thumbnails requires a check of the physical file to ensure that the thumbnail was actually generated and not just having a virtual representation in the database.

The circumstances why this situation might occur are not relevant.

However, possible causes could be:

 - Third-party actions such as file monitoring processes and automated clean-up operations
 - Unintentional deletion by humans
 - Previously unknown Bugs in Code that can cause such a condition
 - ...

### 2. What does this change do, exactly?

Adds a physical file check when updating thumbnails.


### 3. Describe each step to reproduce the issue or behaviour.

- Make sure you have generated thumbnails.
- Delete the Thumbnail folder or only a specific file from the sub-folders
- Execute `bin/console media:generate-thumbnails`
- Check that every thumbnail generation was skipped

### 4. Please link to the relevant issues (if any).

- [NEXT-7754](https://issues.shopware.com/issues/NEXT-7754)
- [artikelbild-thumbnails-verschwinden-sind-kaputt-404-wieso](https://forum.shopware.com/t/artikelbild-thumbnails-verschwinden-sind-kaputt-404-wieso/69272)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
