### PR TITLE
Developer experience: Add EchoSQLLogger

### DIFF
--- a/changelog/_unreleased/2021-05-22-add-sql-logger.md
+++ b/changelog/_unreleased/2021-05-22-add-sql-logger.md
@@ -1,0 +1,8 @@
+---
+title: Developer experience: Add EchoSQLLogger
+issue: 
+author: Alexander Menk
+author_github: @amenk
+---
+# Core
+* Add `\Shopware\Core\Profiling\Doctrine\EchoSQLLogger` to print queries that can be executed directly for debugging.

--- a/src/Core/Profiling/Doctrine/EchoSQLLogger.php
+++ b/src/Core/Profiling/Doctrine/EchoSQLLogger.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Profiling\Doctrine;
+
+use Doctrine\DBAL\Logging\SQLLogger;
+use Shopware\Core\Profiling\Twig\DoctrineExtension;
+
+/**
+ * Print executed SQL to the console, in such a way that they can be easily copied to other SQL tools for further
+ * debugging. This is similar to the symfony debug bar, but useful in CLI commands and tests.
+ *
+ * Usage in tests:
+ *     Kernel::getConnection()->getConfiguration()->setSQLLogger(
+ *         new \Shopware\Core\Profiling\Doctrine\EchoSQLLogger()
+ *     );
+ */
+class EchoSQLLogger implements SQLLogger
+{
+    public function startQuery($sql, ?array $params = null, ?array $types = null): void
+    {
+        $doctrineExtension = new DoctrineExtension();
+        echo $doctrineExtension->replaceQueryParameters(
+            $sql,
+            array_merge($params ?? [], $types ?? [])
+        )
+            . ';'
+            . \PHP_EOL;
+    }
+
+    public function stopQuery(): void
+    {
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

It improves developer experience by providing a way to print queries, for example in tests, for further debugging.
There is already the EchoSQLLogger from Doctrine, but it is less useful in Shopware because

1. UUIDs are printed as binary parameters, rendering them unreadable / unusable
2. Parameters are not inlined as in the debug bar, making it harder to analyse them in the SQL tool of one's choice by copy&paste.

### 2. What does this change do, exactly?

It adds a SQL Logger which is similar to what the debug bar offers.

### 3. Describe each step to reproduce the issue or behaviour.

When debugging, add

     Kernel::getConnection()->getConfiguration()->setSQLLogger(
         new \Shopware\Core\Profiling\Doctrine\EchoSQLLogger()
     );

This will print out the SQL quries

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change - not added because of trivial functionality
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes - if the MR gets accepted, I will add the procedure to shopware/docs
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
