### PR TITLE
[NEXT-15437] Inject base translator

### DIFF
--- a/changelog/_unreleased/2021-05-25-inject-base-translator-instead-of-shopware-adapter.md
+++ b/changelog/_unreleased/2021-05-25-inject-base-translator-instead-of-shopware-adapter.md
@@ -1,0 +1,9 @@
+---
+title: Inject base translator instead of Shopware Adapter
+issue: NEXT-15437
+author: Jonas Søndergaard
+author_email: jonas@wexo.dk 
+author_github: Josniii
+---
+# Core
+*  Changed service DI definitions to use `translator` instead of `Shopware\Core\Framework\Adapter\Translation\Translator`

--- a/src/Core/Checkout/DependencyInjection/document.xml
+++ b/src/Core/Checkout/DependencyInjection/document.xml
@@ -68,7 +68,7 @@
         <service id="Shopware\Core\Checkout\Document\Twig\DocumentTemplateRenderer">
             <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TemplateFinder"/>
             <argument type="service" id="twig"/>
-            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator"/>
+            <argument type="service" id="translator"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
 

--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -87,7 +87,7 @@
             <argument type="service" id="logger"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="mail_template_type.repository"/>
-            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator"/>
+            <argument type="service" id="translator"/>
             <argument type="service" id="language.repository"/>
         </service>
 

--- a/src/Core/Content/DependencyInjection/product_export.xml
+++ b/src/Core/Content/DependencyInjection/product_export.xml
@@ -37,7 +37,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Content\ProductExport\Service\ProductExportValidator"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService"/>
-            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator"/>
+            <argument type="service" id="translator"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="string">%product_export.read_buffer_size%</argument>
@@ -69,7 +69,7 @@
             <argument type="service" id="Shopware\Core\Content\ProductExport\Service\ProductExportFileHandler"/>
             <argument type="service" id="messenger.bus.shopware"/>
             <argument type="service" id="Shopware\Core\Content\ProductExport\Service\ProductExportRenderer"/>
-            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator"/>
+            <argument type="service" id="translator"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>

--- a/src/Core/Content/DependencyInjection/product_export.xml
+++ b/src/Core/Content/DependencyInjection/product_export.xml
@@ -37,7 +37,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Content\ProductExport\Service\ProductExportValidator"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService"/>
-            <argument type="service" id="translator"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="string">%product_export.read_buffer_size%</argument>
@@ -69,7 +69,7 @@
             <argument type="service" id="Shopware\Core\Content\ProductExport\Service\ProductExportFileHandler"/>
             <argument type="service" id="messenger.bus.shopware"/>
             <argument type="service" id="Shopware\Core\Content\ProductExport\Service\ProductExportRenderer"/>
-            <argument type="service" id="translator"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextService"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -479,7 +479,7 @@ base-uri 'self';
 
         <service id="Shopware\Core\Framework\Adapter\Cache\CacheTracer">
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
-            <argument type="service" id="Shopware\Core\Framework\Adapter\Translation\Translator"/>
+            <argument type="service" id="translator"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheTagCollection"/>
         </service>
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Based on discussion [here](https://github.com/shopware/docs/pull/288) I was made aware that in reality one should probably use the base `translator` when injecting translation into one's classes. However, Shopware doesn't do this. This PR changes this.

### 2. What does this change do, exactly?
Replaces `Shopware\Core\Framework\Adapter\Translation\Translator` with `translator` whereever Shopware uses translation inside a PHP class.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-15437
See https://github.com/shopware/docs/pull/288 which adds a section on translation in PHP classes to the docs.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
