### PR TITLE
NoTicket: Use abstract object rather than implementation of contextSwitchRoute

### DIFF
--- a/changelog/_unreleased/2021-05-27-make-use-of-abstraction-of-the-contextswitchroute.md
+++ b/changelog/_unreleased/2021-05-27-make-use-of-abstraction-of-the-contextswitchroute.md
@@ -1,0 +1,10 @@
+---
+title: Make use of abstraction of the ContextSwitchRoute
+issue: noticket
+author: Steffen Beisenherz
+author_email: s.beisenherz@kellerkinder.de 
+author_github: Sironheart
+___
+# Storefront
+*  Changed the AccountOrderController so it now does not require the shopware implementation of the ContextSwitchRoute 
+   anymore, instead accepting any implementation of the AbstractContextSwitchRoute

--- a/src/Storefront/Controller/AccountOrderController.php
+++ b/src/Storefront/Controller/AccountOrderController.php
@@ -19,7 +19,7 @@ use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
-use Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute;
+use Shopware\Core\System\SalesChannel\SalesChannel\AbstractContextSwitchRoute;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Event\RouteRequest\CancelOrderRouteRequestEvent;
 use Shopware\Storefront\Event\RouteRequest\HandlePaymentMethodRouteRequestEvent;
@@ -43,7 +43,7 @@ class AccountOrderController extends StorefrontController
     private $orderPageLoader;
 
     /**
-     * @var ContextSwitchRoute
+     * @var AbstractContextSwitchRoute
      */
     private $contextSwitchRoute;
 
@@ -90,7 +90,7 @@ class AccountOrderController extends StorefrontController
     public function __construct(
         AccountOrderPageLoader $orderPageLoader,
         AccountEditOrderPageLoader $accountEditOrderPageLoader,
-        ContextSwitchRoute $contextSwitchRoute,
+        AbstractContextSwitchRoute $contextSwitchRoute,
         AbstractCancelOrderRoute $cancelOrderRoute,
         AbstractSetPaymentOrderRoute $setPaymentOrderRoute,
         AbstractHandlePaymentMethodRoute $handlePaymentMethodRoute,


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently you are forced to use the Shopware Implementation to extend the logic of the ContextSwitchRoute. Using a different Type Declaration prevents errors getting thrown

### 2. What does this change do, exactly?
Change the AccountOrderController to use the AbstractContextSwitchRoute, rather than the Shopware Implementation of this Abstract.

### 3. Describe each step to reproduce the issue or behaviour.
Create a new plugin, decorate the AbstractContextSwitchRoute by implementing the AbstractContextSwitchRoute. As soon as you did this errors are getting thrown.

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
