### PR TITLE
Support product without options

### DIFF
--- a/changelog/_unreleased/2021-05-27-product-without-options-crashes-product-detail-page.md
+++ b/changelog/_unreleased/2021-05-27-product-without-options-crashes-product-detail-page.md
@@ -1,0 +1,13 @@
+---
+title: Product without options crashes product detail page
+issue: NEXT-15468
+author: Jan-Marten de Boer
+author_email: janmarten@elgentos.nl 
+author_github: janmarten@elgentos.nl
+---
+# Core
+* Changed method
+  `\Shopware\Core\Content\Product\SalesChannel\Detail\ProductConfiguratorLoader::buildCurrentOptions`
+  by short circuiting `$product->getOptionIds()` with `?? []` to support products
+  without options. The method `$product->getOptionIds()` may return `null` which
+  is an illegal value for the foreach it is used in.

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
@@ -209,7 +209,7 @@ class ProductConfiguratorLoader
         $keyMap = $groups->getOptionIdMap();
 
         $current = [];
-        foreach ($product->getOptionIds() as $optionId) {
+        foreach ($product->getOptionIds() ?? [] as $optionId) {
             $groupId = $keyMap[$optionId] ?? null;
             if ($groupId === null) {
                 continue;

--- a/src/Core/Content/Test/Product/SalesChannel/Detail/ProductConfiguratorOrderTest.php
+++ b/src/Core/Content/Test/Product/SalesChannel/Detail/ProductConfiguratorOrderTest.php
@@ -86,6 +86,12 @@ class ProductConfiguratorOrderTest extends TestCase
         static::assertEquals(['f', 'e', 'd', 'c', 'b', 'a'], $groupNames);
     }
 
+    public function testOrderWithoutOptions(): void
+    {
+        $groupNames = $this->getOrder([], [], []);
+        static::assertEquals([], $groupNames);
+    }
+
     private static function ashuffle(array &$a)
     {
         $keys = array_keys($a);
@@ -99,13 +105,16 @@ class ProductConfiguratorOrderTest extends TestCase
         return true;
     }
 
-    private function getOrder(?array $groupPositionOrder = null, ?array $configuratorGroupConfigOrder = null): array
-    {
+    private function getOrder(
+        ?array $groupPositionOrder = null,
+        ?array $configuratorGroupConfigOrder = null,
+        ?array $groupIds = null
+    ): array {
         // create product with property groups and 1 variant and get its configurator settings
         $productId = Uuid::randomHex();
         $variantId = Uuid::randomHex();
 
-        $groupIds = [
+        $groupIds ??= [
             'a' => Uuid::randomHex(),
             'b' => Uuid::randomHex(),
             'c' => Uuid::randomHex(),


### PR DESCRIPTION
When a product has no options, the configurator loader no longer breaks.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Without this change, products that have no options break the product detail page.

- https://github.com/shopware/platform/issues/1883
- https://issues.shopware.com/issues/NEXT-15468

### 2. What does this change do, exactly?

It short circuits the result of `$product->getOptionIds()` through `?? []` so that the encompassing `foreach` has a valid iterable value to work with. If there are no options on the product, `$product->getOptionIds()` returns `null`, which is not a valid value for the `foreach`.

### 3. Describe each step to reproduce the issue or behaviour.

- Create a product without options
- Activate the product and visit its detail page on the storefront.

### 4. Please link to the relevant issues (if any).

- https://github.com/shopware/platform/issues/1883
- https://issues.shopware.com/issues/NEXT-15468

Closes #1883 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- ~I have written or adjusted the documentation according to my changes~
- ~This change has comments for package types, values, functions, and non-obvious lines of code~
- [x] I have read the contribution requirements and met them.
