### PR TITLE
fix: Do not use ID filter if empty id array is passed

### DIFF
--- a/changelog/_unreleased/2021-05-27-do-not-use-id-filter-if-empty-id-array-is-passed.md
+++ b/changelog/_unreleased/2021-05-27-do-not-use-id-filter-if-empty-id-array-is-passed.md
@@ -1,0 +1,8 @@
+---
+title: Do not use ID filter if empty id array is passed
+author: Max
+author_email: max@swk-web.com
+author_github: aragon999
+---
+# Core
+* Do not use ID filter if empty id array is passed in `Criteria`

--- a/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
@@ -151,7 +151,7 @@ class RequestCriteriaBuilder
     {
         $searchException = new SearchRequestException();
 
-        if (isset($payload['ids'])) {
+        if (isset($payload['ids']) && !empty($payload['ids'])) {
             if (\is_string($payload['ids'])) {
                 $ids = array_filter(explode('|', $payload['ids']));
             } else {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently you can create a `Criteria` with an empty array (for the IDs). With that, the specified limit is reset and all entities are loaded.

### 2. What does this change do, exactly?
Check that payload IDs are not empty before resetting the limit.

### 3. Describe each step to reproduce the issue or behaviour.
Create a `Criteria` with an emtpy array.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
