### PR TITLE
Fix type hints in StateMachineTransitionEntity

### DIFF
--- a/changelog/_unreleased/2021-05-28-fix-type-hints-in-state-machine-transition-entity.md
+++ b/changelog/_unreleased/2021-05-28-fix-type-hints-in-state-machine-transition-entity.md
@@ -1,0 +1,8 @@
+---
+title: Fix type hints in StateMachineTransitionEntity
+author: Hannes Wernery
+author_email: hannes.wernery@pickware.de
+author_github: hanneswernery
+---
+# Core
+*  Fix type hints in `Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionEntity`.

--- a/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionEntity.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionEntity.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityIdTrait;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
+use Shopware\Core\System\StateMachine\StateMachineEntity;
 
 class StateMachineTransitionEntity extends Entity
 {
@@ -23,7 +24,7 @@ class StateMachineTransitionEntity extends Entity
     protected $stateMachineId;
 
     /**
-     * @var StateMachineStateEntity|null
+     * @var StateMachineEntity|null
      */
     protected $stateMachine;
 
@@ -57,12 +58,12 @@ class StateMachineTransitionEntity extends Entity
         $this->stateMachineId = $stateMachineId;
     }
 
-    public function getStateMachine(): ?StateMachineStateEntity
+    public function getStateMachine(): ?StateMachineEntity
     {
         return $this->stateMachine;
     }
 
-    public function setStateMachine(StateMachineStateEntity $stateMachine): void
+    public function setStateMachine(StateMachineEntity $stateMachine): void
     {
         $this->stateMachine = $stateMachine;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

The `StateMachineTransitionEntity` has the wrong type hints in the `getStateMachine` and `setStateMachine` function. So when using these functions the following error is thrown.
```php
TypeError: Return value of Shopware\Core\System\StateMachine\Aggregation\StateMachineTransition\StateMachineTransitionEntity::getStateMachine() must be an instance of Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity or null, instance of Shopware\Core\System\StateMachine\StateMachineEntity returned
```

### 2. What does this change do, exactly?

This PR fixes the type hints in the `StateMachineTransitionEntity`.


### 3. Describe each step to reproduce the issue or behaviour.

Fetch any `StateMachineTransitionEntity` from the repository and call `getStateMachine()`.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
