### PR TITLE
Add title-attribute to sw-cms-list-item.html.twig

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/sw-cms-list-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/sw-cms-list-item.html.twig
@@ -35,6 +35,7 @@
             v-if="page"
             class="sw-cms-list-item__title"
             @click="onElementClick"
+            title="{{ page.translated.name }}"
         >
             {{ page.translated.name }}
         </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
It happens that you have layouts with similar names. In the standard installation there are, for example, two layouts named "Default shop page layout with contact form" and "Default shop page layout with newsletter form". These layouts seem identical on first sight, because they're shortened by "...". To let the user know which layout he's about to choose, we can add a simple title-attribute which appears on hover.

### 2. What does this change do, exactly?
It adds a title-attribute to the div element that contains the name of the layout.

### 3. Describe each step to reproduce the issue or behaviour.
Go to shopping experiences and scroll down, until you see the mentioned layouts. 
![layouts-with-similar-names](https://user-images.githubusercontent.com/30236221/120036041-d2416980-bfff-11eb-8bed-d453c303ade0.PNG)

### 4. Checklist


- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
