### PR TITLE
NEXT-13575 unhex languageId for comparison with parent languageId

### DIFF
--- a/changelog/_unreleased/2021-05-29-fix-language-inheritance-for-seo-urls.md
+++ b/changelog/_unreleased/2021-05-29-fix-language-inheritance-for-seo-urls.md
@@ -1,0 +1,8 @@
+---
+title: fix-language-inheritance-for-seo-urls
+issue: NEXT-13575
+author: Digital Loop
+author_email: shopware@digital-loop.com 
+---
+# Core
+*  Changed method `getParentLanguageId` in `src/Core/Content/Seo/SeoUrlUpdater.php` to fix language inheritance for seo urls.

--- a/src/Core/Content/Seo/SeoUrlUpdater.php
+++ b/src/Core/Content/Seo/SeoUrlUpdater.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
 
 /**
@@ -193,7 +194,7 @@ class SeoUrlUpdater
     {
         // TODO: optimize to one query
         $result = $this->connection
-            ->executeQuery('SELECT LOWER(HEX(parent_id)) FROM language WHERE id = :id', ['id' => $languageId])
+            ->executeQuery('SELECT LOWER(HEX(parent_id)) FROM language WHERE id = :id', ['id' => Uuid::fromHexToBytes($languageId)])
             ->fetchColumn();
 
         return $result ? (string) $result : null;

--- a/src/Core/Content/Test/Seo/SeoUrlUpdaterTest.php
+++ b/src/Core/Content/Test/Seo/SeoUrlUpdaterTest.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Test\Seo;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\Framework\Test\TestDataCollection;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\LandingPageSeoUrlRoute;
+
+class SeoUrlUpdaterTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use SalesChannelApiTestBehaviour;
+
+    // Language codes
+    private const DEFAULT = 'en-GB';
+    private const PARENT = 'de-DE';
+    private const CHILD = 'de-TEST';
+
+    /**
+     * @var TestDataCollection
+     */
+    private $ids;
+
+    /**
+     * @var array
+     */
+    private $salesChannel;
+
+    /**
+     * Checks whether the seo url updater is using the correct language for translations.
+     *
+     * @dataProvider seoLanguageDataProvider
+     */
+    public function testSeoLanguageInheritance(array $translations, string $pathInfo): void
+    {
+        // Create landing page (triggers seo url updater)
+        $this->getContainer()->get('landing_page.repository')->upsert([
+            [
+                'id' => $id = UUID::randomHex(),
+                'translations' => array_map(function (string $translation): array {
+                    return [
+                        'name' => $translation,
+                        'url' => $translation,
+                        'languageId' => $this->ids->get($translation)
+                    ];
+                }, $translations),
+                'salesChannels' => [['id' => $this->salesChannel['id']]]
+            ]
+        ], $this->ids->getContext());
+
+        // Search for created seo url
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('foreignKey', $id));
+        $criteria->addFilter(new EqualsFilter('routeName', LandingPageSeoUrlRoute::ROUTE_NAME));
+        $criteria->addFilter(new EqualsFilter('salesChannelId', $this->salesChannel['id']));
+        $seoUrl = $this->getContainer()->get('seo_url.repository')->search(
+            $criteria,
+            $this->ids->getContext()
+        )->first();
+
+        // Check if seo url was created
+        static::assertNotNull($seoUrl);
+
+        // Check if seo path matches the expected path
+        static::assertStringStartsWith($pathInfo, $seoUrl->getSeoPathInfo());
+    }
+
+    public function seoLanguageDataProvider(): array
+    {
+        return [
+            [
+                // All translations available > expected to use child translation
+                'translations' => [self::DEFAULT, self::PARENT, self::CHILD],
+                'pathInfo' => self::CHILD
+            ],
+            [
+                // Parent translation missing > expected to use child translation
+                'translations' => [self::DEFAULT, self::CHILD],
+                'pathInfo' => self::CHILD
+            ],
+            [
+                // Child translation missing > expected to use parent translation
+                'translations' => [self::DEFAULT, self::PARENT],
+                'pathInfo' => self::PARENT
+            ],
+            [
+                // Parent and child translations missing > expected to use default translation
+                'translations' => [self::DEFAULT],
+                'pathInfo' => self::DEFAULT
+            ],
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->ids = new TestDataCollection();
+
+        // Get language ids
+        $this->ids->set(self::DEFAULT, Defaults::LANGUAGE_SYSTEM);
+        $this->ids->set(self::PARENT, $this->getDeDeLanguageId());
+        $this->ids->create(self::CHILD);
+
+        // Create storefront saleschannel for child language
+        $this->salesChannel = $this->createSalesChannel([
+            // Create child language
+            'language' => [
+                'id' => $this->ids->get(self::CHILD),
+                'name' => self::CHILD,
+                'parentId' => $this->ids->get(self::PARENT),
+                // Create locale for child language
+                'locale' => [
+                    'id' => $this->ids->create('childLocale'),
+                    'code' => self::CHILD,
+                    'translations' => [
+                        [
+                            'languageId' => $this->ids->get(self::DEFAULT),
+                            'name' => self::CHILD,
+                            'territory' => self::CHILD
+                        ]
+                    ]
+                ],
+                'translationCodeId' => $this->ids->get('childLocale')
+            ],
+            'languages' => [['id' => $this->ids->get(self::CHILD)]],
+            // Add domain for child language
+            'domains' => [
+                [
+                    'languageId' => $this->ids->get(self::CHILD),
+                    'currencyId' => Defaults::CURRENCY,
+                    'snippetSetId' => $this->getSnippetSetIdForLocale(self::PARENT),
+                    'url' => 'http://localhost',
+                ]
+            ]
+        ]);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently language inheritance does not work correctly for seo urls.

### 2. What does this change do, exactly?
This change fixes a sql query that compares uuid as binary with uuid as string.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a fresh demo shop
- Select **English** as the default language
- Add Austrian-German (de-AT) as a sublanguage to German
- Create a saleschannel domain for the austrian language
- Index seo urls
- The austrian shop will create seo urls using english product and landing page names even if a translation in de-DE is available.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13575

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
