### PR TITLE
Add configurable administration path name

### DIFF
--- a/changelog/_unreleased/2021-05-30-configurable-administration-path.md
+++ b/changelog/_unreleased/2021-05-30-configurable-administration-path.md
@@ -1,0 +1,9 @@
+---
+title: Added configurable administration path name
+author: mynameisbogdan
+author_email: mynameisbogdan@protonmail.com
+author_github: mynameisbogdan
+---
+# Administration
+* Added new env `SHOPWARE_ADMINISTRATION_PATH_NAME` and parameter `shopware_administration.path_name` to configure the route `administration.index`
+* Changed `Shopware\Administration\Framework\Routing\AdministrationRouteScope` to set `$allowedPaths` property in constructor using parameter `shopware_administration.path_name` 

--- a/src/Administration/Controller/AdministrationController.php
+++ b/src/Administration/Controller/AdministrationController.php
@@ -83,7 +83,7 @@ class AdministrationController extends AbstractController
     /**
      * @Since("6.3.3.0")
      * @RouteScope(scopes={"administration"})
-     * @Route("/admin", defaults={"auth_required"=false}, name="administration.index", methods={"GET"})
+     * @Route("/%shopware_administration.path_name%", defaults={"auth_required"=false}, name="administration.index", methods={"GET"})
      */
     public function index(Request $request, Context $context): Response
     {

--- a/src/Administration/DependencyInjection/services.xml
+++ b/src/Administration/DependencyInjection/services.xml
@@ -3,6 +3,12 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="env(SHOPWARE_ADMINISTRATION_PATH_NAME)">admin</parameter>
+        <parameter key="shopware_administration.path_name">%env(resolve:SHOPWARE_ADMINISTRATION_PATH_NAME)%</parameter>
+    </parameters>
+
     <services>
         <service id="Shopware\Administration\Controller\AdministrationController"
                  public="true">
@@ -23,6 +29,7 @@
         </service>
 
         <service id="Shopware\Administration\Framework\Routing\AdministrationRouteScope">
+            <argument>%shopware_administration.path_name%</argument>
             <tag name="shopware.route_scope"/>
         </service>
 

--- a/src/Administration/Framework/Routing/AdministrationRouteScope.php
+++ b/src/Administration/Framework/Routing/AdministrationRouteScope.php
@@ -13,7 +13,12 @@ class AdministrationRouteScope extends AbstractRouteScope implements ApiContextR
     /**
      * @var string[]
      */
-    protected $allowedPaths = ['admin', 'api'];
+    protected $allowedPaths;
+
+    public function __construct(string $administrationPathName = 'admin')
+    {
+        $this->allowedPaths = [$administrationPathName, 'api'];
+    }
 
     public function isAllowed(Request $request): bool
     {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Adding configurable administration path name in order to change `/admin` to a custom path like `/1749admin2133`.

### 2. What does this change do, exactly?
Adds env `SHOPWARE_ADMINISTRATION_PATH_NAME` and parameter `shopware_administration.path_name` which is used in route `administration.index` making possible changing `http://shopware.local/admin` to something like `http://shopware.local/1749admin2133`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
