### PR TITLE
Add new event to change the criteria for products before a product export is generated

### DIFF
--- a/changelog/_unreleased/2021-06-07-add-event-to-change-product-criteria-during-product-export.md
+++ b/changelog/_unreleased/2021-06-07-add-event-to-change-product-criteria-during-product-export.md
@@ -1,0 +1,8 @@
+---
+title: Add event to change product criteria during product export
+author: Timo Helmke
+author_email: t.helmke@kellerkinder.de 
+author_github: @t2oh4e
+---
+# Core
+* Added a new event to change the criteria for products before a product export is generated

--- a/src/Core/Content/ProductExport/Event/ProductExportProductCriteriaEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportProductCriteriaEvent.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\ProductExport\Event;
+
+use Shopware\Core\Content\ProductExport\ProductExportEntity;
+use Shopware\Core\Content\ProductExport\Struct\ExportBehavior;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\NestedEvent;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+class ProductExportProductCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
+{
+    protected Criteria $criteria;
+
+    protected ProductExportEntity $productExport;
+
+    protected ExportBehavior $exportBehaviour;
+
+    protected SalesChannelContext $salesChannelContext;
+
+    public function __construct(Criteria $criteria, ProductExportEntity $productExport, ExportBehavior $exportBehavior, SalesChannelContext $salesChannelContext)
+    {
+        $this->criteria = $criteria;
+        $this->productExport = $productExport;
+        $this->exportBehaviour = $exportBehavior;
+        $this->salesChannelContext = $salesChannelContext;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+
+    public function getProductExport(): ProductExportEntity
+    {
+        return $this->productExport;
+    }
+
+    public function getExportBehaviour(): ExportBehavior
+    {
+        return $this->exportBehaviour;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+}

--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -7,6 +7,7 @@ use Monolog\Logger;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\ProductExport\Event\ProductExportChangeEncodingEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
+use Shopware\Core\Content\ProductExport\Event\ProductExportProductCriteriaEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportRenderBodyContextEvent;
 use Shopware\Core\Content\ProductExport\Exception\EmptyExportException;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
@@ -133,6 +134,8 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
         );
 
         $criteria = new Criteria();
+        $criteria->setTitle('product-export::products');
+
         $criteria
             ->addFilter(...$filters)
             ->setOffset($exportBehavior->offset())
@@ -143,6 +146,10 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             ->addAssociation('media')
             ->addAssociation('prices')
             ->addAssociation('properties.group');
+
+        $this->eventDispatcher->dispatch(
+            new ProductExportProductCriteriaEvent($criteria, $productExport, $exportBehavior, $context)
+        );
 
         $iterator = new SalesChannelRepositoryIterator($this->productRepository, $context, $criteria);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
It's currently not possible to add more data to product exports e.g. for custom associations or associations from the core other than those defined in the generator.

### 2. What does this change do, exactly?
Introduces a new event and dispatches it before a product export feed is generated

### 3. Describe each step to reproduce the issue or behaviour.
* Create a product export sales channel
* Customize the template and try to use the tags e.g.
* You can't because the association is not added to the criteria
* Be angry at @t2oh4e because he didn't add an event when creating the export generator

After this PR you can use a subscriber to add the necessary data like this:

```
class ProductCriteriaSubcriber implements EventSubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [
            ProductExportProductCriteriaEvent::class => 'onProductExportProductCriteria',
        ];
    }

    public function onProductExportProductCriteria(ProductExportProductCriteriaEvent $event): void
    {
        $event->getCriteria()->addAssociation('tags');
    }
}
```

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
