### PR TITLE
only one sitemap entry for variants with canonical

### DIFF
--- a/changelog/_unreleased/2021-06-01-no-none-canonical-variant-sitemap-url.md
+++ b/changelog/_unreleased/2021-06-01-no-none-canonical-variant-sitemap-url.md
@@ -1,0 +1,11 @@
+---
+title: No none canonical URL in sitemap for variants
+issue:
+author: Sebastian Diez
+author_email: s.diez@seidemann-web.com
+author_github: @s-diez
+---
+# Core
+* Added test for generation of product variant urls for ProductUrlProvider
+* Added test for generation of product variant urls with canonical variant for ProductUrlProvider
+* Only generate one sitemap entry for the canonical product for variants with a canonical product in ProductUrlProvider

--- a/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
@@ -128,6 +128,7 @@ class ProductUrlProvider extends AbstractUrlProvider
         $query->andWhere('`product`.available = 1');
         $query->andWhere('IFNULL(`product`.active, parent.active) = 1');
         $query->andWhere('(`product`.child_count = 0 OR `product`.parent_id IS NOT NULL)');
+        $query->andWhere('(`product`.parent_id IS NULL OR parent.canonical_product_id IS NULL OR parent.canonical_product_id = `product`.id)');
         $query->andWhere('visibilities.product_version_id = :versionId');
         $query->andWhere('visibilities.sales_channel_id = :salesChannelId');
 


### PR DESCRIPTION
### 1. Why is this change necessary?

According to the [Guidelines from Google ](https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls?hl=en#sitemap-method) only the canonical URL should be included in the sitemap. But for product variants with a canonical product an entry for all variants is generated.


### 2. What does this change do, exactly?

Adds more tests for the generation of sitemap entries for variants and filters the products to generate sitemap entries to not include variants which have a canonical product.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a product with variants
2. Assign a variant as canonical product to the parent
3. Create the sitemap through console oder admin
4. Open the generated sitemap
5. Find entries for all variants of the new product instead of just the canonical product

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-14579 lists this issue as one of the problems, but maybe a new issue for this single Problem would be better. Therefore I have not mentioned an Issue in the changelog yet.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
