### PR TITLE
Fix error when decorating ProductPriceCalculator

### DIFF
--- a/changelog/_unreleased/2021-06-10-fix-error-when-decorating-price-calculator.md
+++ b/changelog/_unreleased/2021-06-10-fix-error-when-decorating-price-calculator.md
@@ -1,0 +1,8 @@
+---
+title: Fix error when decorating price calculator
+issue: <tbd>
+---
+# Core
+* Updated the type of the `$priceCalculator` argument in the `ProductCartProcessor` class to 
+  `AbstractProductPriceCalculator` to allow decorating the price calculator as described
+   [in the official documentation](https://developer.shopware.com/docs/guides/plugins/plugins/checkout/cart/customize-price-calculation#decorating-the-calculator)

--- a/changelog/_unreleased/2021-06-10-fix-error-when-decorating-price-calculator.md
+++ b/changelog/_unreleased/2021-06-10-fix-error-when-decorating-price-calculator.md
@@ -1,8 +1,11 @@
 ---
 title: Fix error when decorating price calculator
 issue: <tbd>
+author: René Hrdina
+author_email: rene.hrdina@styleflasher.at
+author_github: @darinda
 ---
 # Core
-* Updated the type of the `$priceCalculator` argument in the `ProductCartProcessor` class to 
+* Changed the type of the `$priceCalculator` argument in the `ProductCartProcessor` class to 
   `AbstractProductPriceCalculator` to allow decorating the price calculator as described
    [in the official documentation](https://developer.shopware.com/docs/guides/plugins/plugins/checkout/cart/customize-price-calculation#decorating-the-calculator)

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -16,7 +16,6 @@ use Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\ReferencePriceDefinition;
-use Shopware\Core\Content\Product\SalesChannel\Price\ProductPriceCalculator;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
@@ -49,7 +48,7 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
 
     private ProductFeatureBuilder $featureBuilder;
 
-    private ProductPriceCalculator $priceCalculator;
+    private AbstractProductPriceCalculator $priceCalculator;
 
     private EntityCacheKeyGenerator $generator;
 
@@ -59,7 +58,7 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
         ProductGatewayInterface $productGateway,
         QuantityPriceCalculator $calculator,
         ProductFeatureBuilder $featureBuilder,
-        ProductPriceCalculator $priceCalculator,
+        AbstractProductPriceCalculator $priceCalculator,
         EntityCacheKeyGenerator $generator,
         SalesChannelRepositoryInterface $repository
     ) {


### PR DESCRIPTION
fixes #1907

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
It fixes the bug #1907

### 2. What does this change do, exactly?
Update the type of the `$priceCalculator` in the `ProductCartProcessor` class as described in #1907

### 3. Describe each step to reproduce the issue or behaviour.
Decorate the PriceCalculator as described [in the official documentation](https://developer.shopware.com/docs/guides/plugins/plugins/checkout/cart/customize-price-calculation#decorating-the-calculator)

### 4. Please link to the relevant issues (if any).
#1907

### 5. Checklist

- [- ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [-] I have written or adjusted the documentation according to my changes
- [-] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
