### PR TITLE
BUGFIX for NEXT-15702 - Save carts with persistent data but no line items.

### DIFF
--- a/changelog/_unreleased/2021-06-14-save-carts-with-persistent-data-but-no-line-items.md
+++ b/changelog/_unreleased/2021-06-14-save-carts-with-persistent-data-but-no-line-items.md
@@ -1,0 +1,11 @@
+---
+title: Save carts with persistent data but no line items.
+issue: NEXT-15702
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed method `save` in `Shopware\Core\Checkout\Cart\CartPersister` to dispatch an event before the cart is saved. This event determines, if the cart has to be saved.
+* Added new event `Shopware\Core\Checkout\Cart\Event\BeforeCartSavedEvent` to be fired before the cart is saved. This event determines, if a cart has to be saved. Furthermore, it allows modifications to the cart just before it is saved, e.g. remove unnecessary extensions.
+* Added event subscribers for the new event to ensure the cart is saved, if it has line items, a customer comment, affiliation code, campaign code or manual shipping charges. 

--- a/src/Core/Checkout/Cart/CartPersister.php
+++ b/src/Core/Checkout/Cart/CartPersister.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Cart;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
+use Shopware\Core\Checkout\Cart\Event\BeforeCartSavedEvent;
 use Shopware\Core\Checkout\Cart\Event\CartSavedEvent;
 use Shopware\Core\Checkout\Cart\Exception\CartDeserializeFailedException;
 use Shopware\Core\Checkout\Cart\Exception\CartTokenNotFoundException;
@@ -60,18 +61,21 @@ class CartPersister implements CartPersisterInterface
      */
     public function save(Cart $cart, SalesChannelContext $context): void
     {
+        $event = new BeforeCartSavedEvent($context, $cart);
+        $this->eventDispatcher->dispatch($event);
+
+        if (!$event->savesCart()) {
+            $this->delete($cart->getToken(), $context);
+
+            return;
+        }
+
         $sql = <<<'SQL'
             INSERT INTO `cart` (`token`, `name`, `currency_id`, `shipping_method_id`, `payment_method_id`, `country_id`, `sales_channel_id`, `customer_id`, `price`, `line_item_count`, `cart`, `rule_ids`, `created_at`)
             VALUES (:token, :name, :currency_id, :shipping_method_id, :payment_method_id, :country_id, :sales_channel_id, :customer_id, :price, :line_item_count, :cart, :rule_ids, :now)
             ON DUPLICATE KEY UPDATE `name` = :name,`currency_id` = :currency_id, `shipping_method_id` = :shipping_method_id, `payment_method_id` = :payment_method_id, `country_id` = :country_id, `sales_channel_id` = :sales_channel_id, `customer_id` = :customer_id,`price` = :price, `line_item_count` = :line_item_count, `cart` = :cart, `rule_ids` = :rule_ids, `updated_at` = :now
             ;
         SQL;
-        //prevent empty carts
-        if ($cart->getLineItems()->count() <= 0) {
-            $this->delete($cart->getToken(), $context);
-
-            return;
-        }
 
         $customerId = $context->getCustomer() ? Uuid::fromHexToBytes($context->getCustomer()->getId()) : null;
 

--- a/src/Core/Checkout/Cart/Delivery/Subscriber/ManualShippingCostsBeforeCartSavedSubscriber.php
+++ b/src/Core/Checkout/Cart/Delivery/Subscriber/ManualShippingCostsBeforeCartSavedSubscriber.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Delivery\Subscriber;
+
+use Shopware\Core\Checkout\Cart\Delivery\DeliveryProcessor;
+use Shopware\Core\Checkout\Cart\Event\BeforeCartSavedEvent;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ManualShippingCostsBeforeCartSavedSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            BeforeCartSavedEvent::class => 'needsSaving',
+        ];
+    }
+
+    public function needsSaving(BeforeCartSavedEvent $event): void
+    {
+        $extension = $event->getCart()->getExtension(DeliveryProcessor::MANUAL_SHIPPING_COSTS);
+        if (!$extension instanceof CalculatedPrice) {
+            return;
+        }
+
+        $event->needsSaving();
+    }
+}

--- a/src/Core/Checkout/Cart/Event/BeforeCartSavedEvent.php
+++ b/src/Core/Checkout/Cart/Event/BeforeCartSavedEvent.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Event;
+
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BeforeCartSavedEvent extends Event implements ShopwareSalesChannelEvent
+{
+    /**
+     * @var SalesChannelContext
+     */
+    protected $context;
+
+    /**
+     * @var Cart
+     */
+    protected $cart;
+
+    /**
+     * @var bool
+     */
+    protected $save = false;
+
+    public function __construct(SalesChannelContext $context, Cart $cart)
+    {
+        $this->context = $context;
+        $this->cart = $cart;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->context;
+    }
+
+    public function getCart(): Cart
+    {
+        return $this->cart;
+    }
+
+    public function savesCart(): bool
+    {
+        return $this->save;
+    }
+
+    public function needsSaving(): void
+    {
+        $this->save = true;
+
+        $this->stopPropagation();
+    }
+}

--- a/src/Core/Checkout/Cart/Subscriber/BeforeCartSaved/AffiliateCodeBeforeCartSavedSubscriber.php
+++ b/src/Core/Checkout/Cart/Subscriber/BeforeCartSaved/AffiliateCodeBeforeCartSavedSubscriber.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Subscriber\BeforeCartSaved;
+
+use Shopware\Core\Checkout\Cart\Event\BeforeCartSavedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class AffiliateCodeBeforeCartSavedSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            BeforeCartSavedEvent::class => 'needsSaving',
+        ];
+    }
+
+    public function needsSaving(BeforeCartSavedEvent $event): void
+    {
+        if ($event->getCart()->getAffiliateCode() === null) {
+            return;
+        }
+
+        $event->needsSaving();
+    }
+}

--- a/src/Core/Checkout/Cart/Subscriber/BeforeCartSaved/CampaignCodeBeforeCartSavedSubscriber.php
+++ b/src/Core/Checkout/Cart/Subscriber/BeforeCartSaved/CampaignCodeBeforeCartSavedSubscriber.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Subscriber\BeforeCartSaved;
+
+use Shopware\Core\Checkout\Cart\Event\BeforeCartSavedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CampaignCodeBeforeCartSavedSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            BeforeCartSavedEvent::class => 'needsSaving',
+        ];
+    }
+
+    public function needsSaving(BeforeCartSavedEvent $event): void
+    {
+        if ($event->getCart()->getCampaignCode() === null) {
+            return;
+        }
+
+        $event->needsSaving();
+    }
+}

--- a/src/Core/Checkout/Cart/Subscriber/BeforeCartSaved/CustomerCommentBeforeCartSavedSubscriber.php
+++ b/src/Core/Checkout/Cart/Subscriber/BeforeCartSaved/CustomerCommentBeforeCartSavedSubscriber.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Subscriber\BeforeCartSaved;
+
+use Shopware\Core\Checkout\Cart\Event\BeforeCartSavedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CustomerCommentBeforeCartSavedSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            BeforeCartSavedEvent::class => 'needsSaving',
+        ];
+    }
+
+    public function needsSaving(BeforeCartSavedEvent $event): void
+    {
+        if ($event->getCart()->getCustomerComment() === null) {
+            return;
+        }
+
+        $event->needsSaving();
+    }
+}

--- a/src/Core/Checkout/Cart/Subscriber/BeforeCartSaved/LineItemsBeforeCartSavedSubscriber.php
+++ b/src/Core/Checkout/Cart/Subscriber/BeforeCartSaved/LineItemsBeforeCartSavedSubscriber.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Subscriber\BeforeCartSaved;
+
+use Shopware\Core\Checkout\Cart\Event\BeforeCartSavedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class LineItemsBeforeCartSavedSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            BeforeCartSavedEvent::class => 'needsSaving',
+        ];
+    }
+
+    public function needsSaving(BeforeCartSavedEvent $event): void
+    {
+        if ($event->getCart()->getLineItems()->count() <= 0) {
+            return;
+        }
+
+        $event->needsSaving();
+    }
+}

--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -104,6 +104,19 @@
             <argument type="service" id="event_dispatcher"/>
         </service>
 
+        <service id="Shopware\Core\Checkout\Cart\Subscriber\BeforeCartSaved\AffiliateCodeBeforeCartSavedSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+        <service id="Shopware\Core\Checkout\Cart\Subscriber\BeforeCartSaved\CampaignCodeBeforeCartSavedSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+        <service id="Shopware\Core\Checkout\Cart\Subscriber\BeforeCartSaved\CustomerCommentBeforeCartSavedSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+        <service id="Shopware\Core\Checkout\Cart\Subscriber\BeforeCartSaved\LineItemsBeforeCartSavedSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
         <service id="Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator">
             <argument type="service" id="Shopware\Core\Checkout\Cart\Price\GrossPriceCalculator"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Price\NetPriceCalculator"/>
@@ -143,6 +156,10 @@
             <argument type="service" id="Shopware\Core\Checkout\Cart\Price\QuantityPriceCalculator"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Tax\PercentageTaxRuleBuilder"/>
             <argument type="service" id="Shopware\Core\Checkout\Cart\Tax\TaxDetector"/>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Cart\Delivery\Subscriber\ManualShippingCostsBeforeCartSavedSubscriber">
+            <tag name="kernel.event_subscriber"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Cart\PriceActionController" public="true">

--- a/src/Core/Framework/Test/Api/Controller/SalesChannelProxyControllerTest.php
+++ b/src/Core/Framework/Test/Api/Controller/SalesChannelProxyControllerTest.php
@@ -541,13 +541,14 @@ class SalesChannelProxyControllerTest extends TestCase
 
         $cart = $this->getStoreApiCart($browser, Defaults::SALES_CHANNEL, $salesChannelContext->getToken());
 
-        //shipping costs is now based on shipping method, there is one tax rate (shipping costs by manual value in cart is removed)
+        //after re-adding a line item, there is one tax rate and the manual shipping costs are restored.
         $shippingCosts = $cart['deliveries'][0]['shippingCosts'];
+
         static::assertArrayHasKey('unitPrice', $shippingCosts);
-        static::assertEquals(0, $shippingCosts['unitPrice']);
+        static::assertEquals(20, $shippingCosts['unitPrice']);
 
         static::assertArrayHasKey('totalPrice', $shippingCosts);
-        static::assertEquals(0, $shippingCosts['totalPrice']);
+        static::assertEquals(20, $shippingCosts['totalPrice']);
 
         static::assertCount(1, $shippingCosts['calculatedTaxes']);
         static::assertEquals(19, $shippingCosts['calculatedTaxes'][0]['taxRate']);


### PR DESCRIPTION
### 1. Why is this change necessary?
See ticket description. Before reviewing check first comment https://github.com/shopware/platform/pull/1909#issuecomment-859768382 below because if that makes more sense I will adjust the PR accordingly amd that comment here: https://github.com/shopware/platform/pull/1909/files#r650256732

### 2. What does this change do, exactly?
Ensures that carts are saved and not deleted in case they have extensions but are otherwise empty (no line items).

### 3. Describe each step to reproduce the issue or behaviour.

See ticket description.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-15702

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
