### PR TITLE
chore(cleanup): Remove outdated template variables

### DIFF
--- a/changelog/_unreleased/2021-06-12-deprecate-outdated-template-variables.md
+++ b/changelog/_unreleased/2021-06-12-deprecate-outdated-template-variables.md
@@ -1,0 +1,8 @@
+---
+title: Deprecate outdated template variables
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Deprecate outdated variables purchaseUnit, listingPrice and fromPrice from the price-unit template

--- a/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
@@ -1,6 +1,9 @@
 {% block component_product_box_price_info %}
+    {% deprecated '@deprecated tag:v6.5.0 - purchaseUnit will be removed, use product.purchaseUnit if needed' %}
     {% set purchaseUnit = product.purchaseUnit %}
+    {% deprecated '@deprecated tag:v6.5.0 - listingPrice will be removed without replacement, since it was removed from the product struct' %}
     {% set listingPrice = product.calculatedListingPrice %}
+    {% deprecated '@deprecated tag:v6.5.0 - fromPrice will be removed without replacement' %}
     {% set fromPrice = listingPrice.from %}
 
     {% set cheapest = product.calculatedCheapestPrice %}


### PR DESCRIPTION
### 1. Why is this change necessary?
There were some variables forgotten to be removed from the price-unit template, which can be confusing.

### 2. What does this change do, exactly?
Remove the outdated template variables.

### 3. Describe each step to reproduce the issue or behaviour.
Not sure if one can reproduce any behaviour :-)

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
