### PR TITLE
Add current item to inline edit assign event

### DIFF
--- a/changelog/_unreleased/2021-06-13-add-current-item-to-inline-edit-assign-event.md
+++ b/changelog/_unreleased/2021-06-13-add-current-item-to-inline-edit-assign-event.md
@@ -1,0 +1,9 @@
+---
+title: Add current item to inline-edit-assign event of Data Grid component
+issue: -
+author: Cuong Huynh
+author_email: cuongdev@hotmail.com
+author_github: @cuonghuynh
+---
+# Core
+* Changed method `onClickSaveInlineEdit` in `src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js` to assign current item to `inline-edit-assign` event, we can access the selected item before sending save request to Shopware.

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
@@ -617,7 +617,7 @@ Component.register('sw-data-grid', {
         },
 
         onClickSaveInlineEdit(item) {
-            this.$emit('inline-edit-assign');
+            this.$emit('inline-edit-assign', item);
             this.save(item);
 
             this.disableInlineEdit();


### PR DESCRIPTION
### 1. Why is this change necessary?
Sometimes we need access to the selected item on inline edit saving. For instant, trim spaces from the title before saving.

### 2. What does this change do, exactly?
Assign selected item to inline-edit-assign event.

### 3. Describe each step to reproduce the issue or behaviour.
Trigger Inline edit feature on the Data Grid or Entity Listing component.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
