### PR TITLE
fix: show shortName of currency instead of id in priceCurrency itemprop

### DIFF
--- a/changelog/_unreleased/2021-06-14-fix-price-currency-itemprop.md
+++ b/changelog/_unreleased/2021-06-14-fix-price-currency-itemprop.md
@@ -1,0 +1,10 @@
+---
+title: Changed currencyId to CurrencyShortName
+issue: 
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: @tinect
+---
+# Storefront
+* Changed content of priceCurrency to currencies shortName in block `buy_widget_price_block_table_body_cell_quantity` of file `component/buy-widget/buy-widget-price.html.twig`
+* Changed content of priceCurrency to currencies shortName in block `page_product_detail_price_block_table_body_cell_quantity` of file `page/product-detail/buy-widget-price.html.twig`

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
@@ -35,7 +35,7 @@
 
                                             {% block buy_widget_price_block_table_body_cell_quantity %}
                                                 <th scope="row" class="product-block-prices-cell product-block-prices-cell-thin">
-                                                    <meta itemprop="priceCurrency" content="{{ page.header.activeCurrency.id }}" />
+                                                    <meta itemprop="priceCurrency" content="{{ page.header.activeCurrency.translated.shortName }}" />
                                                     <meta itemprop="price" content="{{ price.unitPrice }}" />
                                                     <link itemprop="availability" href="https://schema.org/InStock" />
 

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-price.html.twig
@@ -35,7 +35,7 @@
 
                                                 {% block page_product_detail_price_block_table_body_cell_quantity %}
                                                     <th scope="row" class="product-block-prices-cell product-block-prices-cell-thin">
-                                                        <meta itemprop="priceCurrency" content="{{ page.header.activeCurrency.id }}" />
+                                                        <meta itemprop="priceCurrency" content="{{ page.header.activeCurrency.translated.shortName }}" />
                                                         <meta itemprop="price" content="{{ price.unitPrice }}" />
                                                         <link itemprop="availability" href="https://schema.org/InStock" />
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The itemprob "priceCurrency" contains the id instead of the shortName.

### 2. What does this change do, exactly?
Show shortName

### 3. Describe each step to reproduce the issue or behaviour.
Check priceCurrency in html source of detailpage.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
