### PR TITLE
Remove is-loading from gallery-slider on mobile

### DIFF
--- a/changelog/_unreleased/2021-06-014-gallery-slider-mobile-is-loading.md
+++ b/changelog/_unreleased/2021-06-014-gallery-slider-mobile-is-loading.md
@@ -1,0 +1,9 @@
+---
+title: Remove is-loading from gallery-slider on mobile
+issue: NEXT-11516
+author: Sebastian Diez
+author_email: s.diez@seidemann-web.com
+author_github: @s-diez
+---
+# Storefront
+* Remove "is-loading" css-class after loading gallery-slider on mobile.

--- a/src/Storefront/Resources/app/storefront/src/plugin/slider/gallery-slider.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/slider/gallery-slider.plugin.js
@@ -205,7 +205,7 @@ export default class GallerySliderPlugin extends BaseSliderPlugin {
       const navContainer = this.el.querySelector(this.options.thumbnailsSelector);
       const controlsContainer = this.el.querySelector(this.options.controlsSelector);
 
-      const hasThumbnails = (!!navContainer);
+      const hasThumbnails = !!navContainer && this._thumbnailSliderSettings.enabled;
 
       if (container) {
           const onInit = () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

On mobile resolutions the gallery slider is never marked as loaded. The css-class `is-loading` remains. This can lead to white space after the gallery or a gallery which ist partly hidden.

### 2. What does this change do, exactly?

Fixes the check if the thumbnail slider or the main slider marks the gallery as loaded.

### 3. Describe each step to reproduce the issue or behaviour.

- Open a shop detail page for a product with more then one image
- Resize the browser to a mobile resolution for example 400px
- Reload the page
- Inspect the product image slider (`.product-detail-media .gallery-slider-row`)
- See the css-class ìs-loading` still remaining

### 4. Please link to the relevant issues (if any).

- https://issues.shopware.com/issues/NEXT-11516
- https://issues.shopware.com/issues/NEXT-14224

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
