### PR TITLE
BUGFIX for NEXT-15718: Use updatedAt during cart cleanup task.

### DIFF
--- a/changelog/_unreleased/2021-06-14-use-updatedat-during-cart-cleanup-task.md
+++ b/changelog/_unreleased/2021-06-14-use-updatedat-during-cart-cleanup-task.md
@@ -1,0 +1,10 @@
+---
+title: Use updatedAt during cart cleanup task.
+issue: NEXT-15718
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed cleanup cart scheduled task to take `updated_at` into account.
+* Added compound index to `cart` table for `updated_at`.

--- a/src/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandler.php
+++ b/src/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandler.php
@@ -34,7 +34,11 @@ class CleanupCartTaskHandler extends ScheduledTaskHandler
         $time->modify(sprintf('-%s day', $this->days));
 
         $this->connection->executeStatement(
-            'DELETE FROM cart WHERE created_at <= :timestamp',
+            <<<'SQL'
+                DELETE FROM cart
+                    WHERE (updated_at IS NULL AND created_at <= :timestamp)
+                        OR (updated_at IS NOT NULL AND updated_at <= :timestamp);
+            SQL,
             ['timestamp' => $time->format(Defaults::STORAGE_DATE_TIME_FORMAT)]
         );
     }

--- a/src/Core/Migration/Test/Migration1623732234AddUpdatedAtIndexToCartTest.php
+++ b/src/Core/Migration/Test/Migration1623732234AddUpdatedAtIndexToCartTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\Test;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Migration\V6_4\Migration1623732234AddUpdatedAtIndexToCart;
+
+class Migration1623732234AddUpdatedAtIndexToCartTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testMigration(): void
+    {
+        $connection = $this->getContainer()->get(Connection::class);
+
+        if ($this->hasIndex($connection)) {
+            $connection->executeStatement('ALTER TABLE `cart` DROP INDEX `idx.cart.updated_at`;');
+        }
+
+        $migration = new Migration1623732234AddUpdatedAtIndexToCart();
+        $migration->update($connection);
+
+        static::assertTrue($this->hasIndex($connection));
+    }
+
+    private function hasIndex(Connection $connection): bool
+    {
+        return (bool) $connection->executeQuery(
+            <<<'SQL'
+                SHOW INDEXES IN `cart`
+                WHERE `Key_name` = 'idx.cart.updated_at';
+            SQL
+        )->fetchOne();
+    }
+}

--- a/src/Core/Migration/V6_4/Migration1623732234AddUpdatedAtIndexToCart.php
+++ b/src/Core/Migration/V6_4/Migration1623732234AddUpdatedAtIndexToCart.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_4;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1623732234AddUpdatedAtIndexToCart extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1623732234;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('ALTER TABLE `cart` ADD INDEX `idx.cart.updated_at` (`updated_at`)');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
To fix a regression in the cart cleanup task. It does not take the updated_at value into account.

See ticket description: https://issues.shopware.com/issues/NEXT-15718

### 2. What does this change do, exactly?
Use updated_at and created_at during cleanup task.

### 3. Describe each step to reproduce the issue or behaviour.

See ticket description: https://issues.shopware.com/issues/NEXT-15718

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-15718

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
