### PR TITLE
[Newsletter] Support newsletter resubscription after unsubscribing using DOI

### DIFF
--- a/changelog/_unreleased/2021-06-15-allow-newsletter-resubscribe.md
+++ b/changelog/_unreleased/2021-06-15-allow-newsletter-resubscribe.md
@@ -1,0 +1,8 @@
+---
+title: Allow newsletter resubscribe after opt-out
+author: Jannik Zschiesche
+author_email: j.zschiesche@21torr.com
+author_github: @apfelbox
+---
+# Core
+* Changed newsletter unsubscription to properly reset the double opt-in confirmation date. This fixes resubscription after unsubscribing.

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRoute.php
@@ -20,7 +20,6 @@ use Shopware\Core\System\SalesChannel\NoContentResponse;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Validator\Constraints\EqualTo;
-use Symfony\Component\Validator\Constraints\IsNull;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -134,7 +133,6 @@ class NewsletterConfirmRoute extends AbstractNewsletterConfirmRoute
     {
         $definition = new DataValidationDefinition('newsletter_recipient.opt_in_before');
         $definition->add('id', new NotBlank())
-            ->add('confirmedAt', new IsNull())
             ->add('status', new EqualTo(['value' => NewsletterSubscribeRoute::STATUS_NOT_SET]))
             ->add('em', new EqualTo(['value' => $emHash]));
 

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
@@ -186,7 +186,10 @@ The subscription is only successful, if the /newsletter/confirm route is called 
         if (isset($recipientId)) {
             /** @var NewsletterRecipientEntity $recipient */
             $recipient = $this->newsletterRecipientRepository->search(new Criteria([$recipientId]), $context->getContext())->first();
-            if ($recipient->getConfirmedAt()) {
+
+            // If the user was previously subscribed but has unsubscribed now, the `getConfirmedAt()`
+            // will still be set. So we need to check for the status as well.
+            if ($recipient->getStatus() !== self::STATUS_OPT_OUT && $recipient->getConfirmedAt()) {
                 return new NoContentResponse();
             }
         }

--- a/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
@@ -61,7 +61,7 @@ trait SalesChannelApiTestBehaviour
     public function getSalesChannelApiSalesChannelId(): string
     {
         if (!$this->salesChannelIds) {
-            throw new \LogicException('The sales channel id con only be requested after calling `createSalesChannelApiClient`.');
+            throw new \LogicException('The sales channel id can only be requested after calling `createSalesChannelApiClient`.');
         }
 
         return end($this->salesChannelIds);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Right now, when using DOI for newsletter subscriptions, the user can't resubscribe.


### 2. What does this change do, exactly?
When DOI is confirmed, internally the `confirmedAt` field is set. 
Now when subscribing a user, if the user already exists and has a `confirmedAt` set, then the request is aborted.

That is however incorrect in the current implementation: because we never reset the `confirmedAt` when unsubscribing the user, an unsubscribed user will also early exit here and can't resubscribe.

### 3. Describe each step to reproduce the issue or behaviour.
See the test case:

1. subscribe
2. confirm DOI
3. unsubscribe
4. try to resubscribe


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

---

A different solution would be to reset the `confirmedAt` field when unsubscribing, however this field might be relevant if looking up old users ("when did I approve the confirmation? Oh, at 5th of May, ok")

A second solution might be to add a task that continuously removes opt-out newsletter subscriptions, but that might be unwanted for certain installations.
