### PR TITLE
Removes getParentDefinitionClass from NumberRangeTypeDefinition

### DIFF
--- a/changelog/_unreleased/2021-06-17-fix-number-range-type-definition.md
+++ b/changelog/_unreleased/2021-06-17-fix-number-range-type-definition.md
@@ -1,0 +1,8 @@
+---
+title: Fix definition for NumberRangeType
+author: Nils Evers
+author_email: evers.nils@gmail.com
+author_github: NilsEvers
+---
+# Core
+* Removed getParentDefinitionClass from NumberRangeTypeDefinition

--- a/src/Core/System/NumberRange/Aggregate/NumberRangeType/NumberRangeTypeDefinition.php
+++ b/src/Core/System/NumberRange/Aggregate/NumberRangeType/NumberRangeTypeDefinition.php
@@ -43,11 +43,6 @@ class NumberRangeTypeDefinition extends EntityDefinition
         return '6.0.0.0';
     }
 
-    protected function getParentDefinitionClass(): string
-    {
-        return NumberRangeDefinition::class;
-    }
-
     protected function defineFields(): FieldCollection
     {
         return new FieldCollection([


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The table number_range_type has no foreign key relation to number_range, so the NumberRangeTypeDefinition should not include the method getParentDefinitionClass. 

### 2. What does this change do, exactly?
Remove the method getParentDefinitionClass from the NumberRangeTypeDefinition.

### 3. Describe each step to reproduce the issue or behaviour.
Using the repository to insert or update NumberRangeTypes will fail.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
