### PR TITLE
dispatch merged event only if a merge actually has been done

### DIFF
--- a/changelog/_unreleased/2021-06-19-suppress-confusing-cart-merge-flash-message-after-login-when-not-appropriate.md
+++ b/changelog/_unreleased/2021-06-19-suppress-confusing-cart-merge-flash-message-after-login-when-not-appropriate.md
@@ -5,4 +5,4 @@ author: Axel Guckelsberger
 author_email: axel.guckelsberger@guite.de
 ---
 # Core
-* Inside `Shopware\Core\System\SalesChannel\Context\SalesChannelContextRestorer#mergeCart` there is now a check if the amount of customer cart items was greater than zero before the guest's cart is merged into it. Only if the customer's cart was already not empty before, a `CartMergedEvent` is dispatched. Hence `Shopware\Storefront\Event\CartMergedSubscriber` will not be called otherwise, so it will not produce a confusing flash message anymore.
+* Changed trigger logic for `CartMergedEvent`. The `CartMergedEvent` event is now only thrown if a merge of a previous shopping cart has really taken place.

--- a/changelog/_unreleased/2021-06-19-suppress-confusing-cart-merge-flash-message-after-login-when-not-appropriate.md
+++ b/changelog/_unreleased/2021-06-19-suppress-confusing-cart-merge-flash-message-after-login-when-not-appropriate.md
@@ -1,0 +1,8 @@
+---
+title: Suppress confusing cart merge flash message after login when not appropriate
+issue: -
+author: Axel Guckelsberger
+author_email: axel.guckelsberger@guite.de
+---
+# Core
+* Inside `Shopware\Core\System\SalesChannel\Context\SalesChannelContextRestorer#mergeCart` there is now a check if the amount of customer cart items was greater than zero before the guest's cart is merged into it. Only if the customer's cart was already not empty before, a `CartMergedEvent` is dispatched which causes that `Shopware\Storefront\Event\CartMergedSubscriber` will not cause a confusing flash message being shown anymore.

--- a/changelog/_unreleased/2021-06-19-suppress-confusing-cart-merge-flash-message-after-login-when-not-appropriate.md
+++ b/changelog/_unreleased/2021-06-19-suppress-confusing-cart-merge-flash-message-after-login-when-not-appropriate.md
@@ -5,4 +5,4 @@ author: Axel Guckelsberger
 author_email: axel.guckelsberger@guite.de
 ---
 # Core
-* Inside `Shopware\Core\System\SalesChannel\Context\SalesChannelContextRestorer#mergeCart` there is now a check if the amount of customer cart items was greater than zero before the guest's cart is merged into it. Only if the customer's cart was already not empty before, a `CartMergedEvent` is dispatched which causes that `Shopware\Storefront\Event\CartMergedSubscriber` will not cause a confusing flash message being shown anymore.
+* Inside `Shopware\Core\System\SalesChannel\Context\SalesChannelContextRestorer#mergeCart` there is now a check if the amount of customer cart items was greater than zero before the guest's cart is merged into it. Only if the customer's cart was already not empty before, a `CartMergedEvent` is dispatched. Hence `Shopware\Storefront\Event\CartMergedSubscriber` will not be called otherwise, so it will not produce a confusing flash message anymore.

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextRestorer.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextRestorer.php
@@ -96,13 +96,17 @@ class SalesChannelContextRestorer
 
     private function mergeCart(Cart $customerCart, Cart $guestCart, SalesChannelContext $customerContext): Cart
     {
+        $customerCartAlreadyContainedItems = $customerCart->getLineItems()->count() > 0;
+
         $mergeableLineItems = $guestCart->getLineItems()->filter(function (LineItem $item) use ($customerCart) {
             return ($item->getQuantity() > 0 && $item->isStackable()) || !$customerCart->has($item->getId());
         });
 
         $mergedCart = $this->cartService->add($customerCart, $mergeableLineItems->getElements(), $customerContext);
 
-        $this->eventDispatcher->dispatch(new CartMergedEvent($mergedCart, $customerContext));
+        if ($customerCartAlreadyContainedItems) {
+            $this->eventDispatcher->dispatch(new CartMergedEvent($mergedCart, $customerContext));
+        }
 
         return $mergedCart;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Every time a guest has put some product into the cart and logs in later he receives the flash message "checkout.cart-merged-hint" caused by `Shopware\Storefront\Event\CartMergedSubscriber`, saying that the cart might potentially also contain products from earlier sessions.
While the whole merge process in `Shopware\Core\System\SalesChannel\Context\SalesChannelContextRestorer#mergeCart` is only processed if `$guestCart->getLineItems()->count() > 0` it does not consider the amount of line items in `$customerCart`.

Here is the whole relevant logic:

```php
        $guestCart = $this->cartService->getCart($currentContext->getToken(), $currentContext);
        $customerCart = $this->cartService->getCart($customerContext->getToken(), $customerContext);

        if ($guestCart->getLineItems()->count() > 0) {
            $restoredCart = $this->mergeCart($customerCart, $guestCart, $customerContext);
        } else {
            $restoredCart = $this->cartService->recalculate($customerCart, $customerContext);
        }
```

### 2. What does this change do, exactly?
Since I didn't want to change the behavior itself including the risk to break things - as I only wanted to suppress the confusing message if it is not appropriate, I decided to check the amount of line items in `$customerCart` before the guest cart's items are merged into it.
After the merge is done the `CartMergedEvent` is now only dispatched if customer's cart already contained some products before the guest cart has been merged.

### 3. Describe each step to reproduce the issue or behaviour.
1. Log in with your account.
2. Ensure your customer's cart does _not_ contain any products.
3. Log out.
4. Put some products into your guest's cart.
5. Log in again
6. See the confusing flash message about earlier products.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
