### PR TITLE
NEXT-7754 - Fix thumbnail generation when physical file is missing

### DIFF
--- a/changelog/_unreleased/2021-05-21-fix-thumbnail-generation-when-physical-file-missing.md
+++ b/changelog/_unreleased/2021-05-21-fix-thumbnail-generation-when-physical-file-missing.md
@@ -1,0 +1,10 @@
+---
+title: Fix Thumbnail generation when physical file is missing
+issue: NEXT-7754
+author: David Fecke
+author_github: @leptoquark1
+---
+# Core
+* Fix `updateThumbnails` function in `src/Core/Content/Media/Thumbnail/ThumbnailService.php` so that the physical presence of the thumbnail file is respected
+* Added new parameter `$strict` to method `Shopware\Core\Content\Media\Thumbnail\ThumbnailService::updateThumbnails`
+* Added option `--strict` to command `media:generate-thumbnails`. Supplying it, a physical file check for existing thumbnails is performed.

--- a/changelog/_unreleased/2021-11-20-refactor-thumbnails-handler-distinguish-between-message-types.md
+++ b/changelog/_unreleased/2021-11-20-refactor-thumbnails-handler-distinguish-between-message-types.md
@@ -1,0 +1,13 @@
+---
+title: Refactor GenerateThumbnailsHandler to distinguish between message types
+author: David Fecke
+author_github: @leptoquark1
+---
+# Core
+* Fix different behaviour or results expected when `media:generate-thumbnails` command is executed with or without the `async` flag.
+* The `GenerateThumbnailsHandler` now distinguish which method is executed in the`ThumbnailService` based on the message type.
+* Added two methods `isStrict` and `setIsStrict` and it's corresponding property `isStrict` to class `UpdateThumbnailsMessage`
+* The `GenerateThumbnailsHandler` will now proceed with `ThumbnailService::generate` when handling `GenerateThumbnailsMessage`
+* The `GenerateThumbnailsHandler` will proceed with `ThumbnailService::updateThumbnails` when handling `UpdateThumbnailsMessage`
+* When processed by MessageBus the optional strict flag for thumbnail generation (as introduced in _NEXT-7754_) will be passed,
+  to the respective `ThumbnailService::updateThumbnails` method as expected. So it may considered in following generation process.

--- a/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
+++ b/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
@@ -266,6 +266,7 @@ class GenerateThumbnailsCommand extends Command
         $this->io->comment('Generating batch jobs...');
         while (($result = $mediaIterator->fetch()) !== null) {
             $msg = new UpdateThumbnailsMessage();
+            $msg->setIsStrict($this->isStrict);
             $msg->setMediaIds($result->getEntities()->getIds());
             $msg->withContext($context);
 

--- a/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
+++ b/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
@@ -64,6 +64,11 @@ class GenerateThumbnailsCommand extends Command
      */
     private $isAsync;
 
+    /**
+     * @var bool
+     */
+    private $isStrict;
+
     public function __construct(
         ThumbnailService $thumbnailService,
         EntityRepositoryInterface $mediaRepository,
@@ -104,6 +109,12 @@ class GenerateThumbnailsCommand extends Command
                 InputOption::VALUE_NONE,
                 'Queue up batch jobs instead of generating thumbnails directly'
             )
+            ->addOption(
+                'strict',
+                's',
+                InputOption::VALUE_NONE,
+                'Additionally checks that physical files for existing thumbnails are present'
+            )
         ;
     }
 
@@ -133,6 +144,7 @@ class GenerateThumbnailsCommand extends Command
         $this->folderFilter = $this->getFolderFilterFromInput($input, $context);
         $this->batchSize = $this->getBatchSizeFromInput($input);
         $this->isAsync = $input->getOption('async');
+        $this->isStrict = $input->getOption('strict');
     }
 
     private function getBatchSizeFromInput(InputInterface $input): int
@@ -181,7 +193,7 @@ class GenerateThumbnailsCommand extends Command
             /** @var MediaEntity $media */
             foreach ($result->getEntities() as $media) {
                 try {
-                    if ($this->thumbnailService->updateThumbnails($media, $context) > 0) {
+                    if ($this->thumbnailService->updateThumbnails($media, $context, $this->isStrict) > 0) {
                         ++$generated;
                     } else {
                         ++$skipped;

--- a/src/Core/Content/Media/Message/GenerateThumbnailsHandler.php
+++ b/src/Core/Content/Media/Message/GenerateThumbnailsHandler.php
@@ -35,7 +35,13 @@ class GenerateThumbnailsHandler extends AbstractMessageHandler
         /** @var MediaCollection $entities */
         $entities = $this->mediaRepository->search($criteria, $context)->getEntities();
 
-        $this->thumbnailService->generate($entities, $context);
+        if ($msg instanceof UpdateThumbnailsMessage) {
+            foreach ($entities as $media) {
+                $this->thumbnailService->updateThumbnails($media, $context, $msg->isStrict());
+            }
+        } else {
+            $this->thumbnailService->generate($entities, $context);
+        }
     }
 
     public static function getHandledMessages(): iterable

--- a/src/Core/Content/Media/Message/UpdateThumbnailsMessage.php
+++ b/src/Core/Content/Media/Message/UpdateThumbnailsMessage.php
@@ -4,4 +4,15 @@ namespace Shopware\Core\Content\Media\Message;
 
 class UpdateThumbnailsMessage extends GenerateThumbnailsMessage
 {
+    private bool $isStrict = false;
+
+    public function isStrict(): bool
+    {
+        return $this->isStrict;
+    }
+
+    public function setIsStrict(bool $isStrict): void
+    {
+        $this->isStrict = $isStrict;
+    }
 }

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -156,8 +156,10 @@ class ThumbnailService
     /**
      * @throws FileTypeNotSupportedException
      * @throws ThumbnailCouldNotBeSavedException
+     *
+     * @deprecated tag:v6.5.0 - Parameter $strict will be mandatory in future implementation
      */
-    public function updateThumbnails(MediaEntity $media, Context $context): int
+    public function updateThumbnails(MediaEntity $media, Context $context /* , bool $strict = false */): int
     {
         if (!$this->mediaCanHaveThumbnails($media, $context)) {
             $this->deleteAssociatedThumbnails($media, $context);
@@ -175,6 +177,8 @@ class ThumbnailService
             return 0;
         }
 
+        $strict = \func_get_args()[2] ?? false;
+
         $tobBeCreatedSizes = new MediaThumbnailSizeCollection($config->getMediaThumbnailSizes()->getElements());
         $toBeDeletedThumbnails = new MediaThumbnailCollection($media->getThumbnails()->getElements());
 
@@ -182,6 +186,7 @@ class ThumbnailService
             foreach ($toBeDeletedThumbnails as $thumbnail) {
                 if ($thumbnail->getWidth() === $thumbnailSize->getWidth()
                     && $thumbnail->getHeight() === $thumbnailSize->getHeight()
+                    && ($strict === false || $this->getFileSystem($media)->has($this->urlGenerator->getRelativeThumbnailUrl($media, $thumbnail)))
                 ) {
                     $toBeDeletedThumbnails->remove($thumbnail->getId());
                     $tobBeCreatedSizes->remove($thumbnailSize->getId());

--- a/src/Core/Content/Test/Media/Commands/GenerateThumbnailsCommandTest.php
+++ b/src/Core/Content/Test/Media/Commands/GenerateThumbnailsCommandTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity;
 use Shopware\Core\Content\Media\Commands\GenerateThumbnailsCommand;
 use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Content\Media\Message\UpdateThumbnailsMessage;
 use Shopware\Core\Content\Media\Pathname\UrlGeneratorInterface;
 use Shopware\Core\Content\Media\Thumbnail\ThumbnailService;
 use Shopware\Core\Content\Test\Media\MediaFixtures;
@@ -18,6 +19,8 @@ use Shopware\Core\Framework\Test\TestCaseBase\CommandTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 class GenerateThumbnailsCommandTest extends TestCase
 {
@@ -263,6 +266,51 @@ class GenerateThumbnailsCommandTest extends TestCase
         );
 
         $this->runCommand($command, $input, $output);
+    }
+
+    public function testItDispatchesUpdateThumbnailsMessageWithCorrectStrictProperty(): void
+    {
+        $this->createValidMediaFiles();
+        $newMedia = $this->getNewMediaEntities();
+
+        $output = new BufferedOutput();
+
+        $affectedMediaIds = array_merge(array_combine($this->initialMediaIds, $this->initialMediaIds), $newMedia->getIds());
+
+        $expectedMessageStrict = new UpdateThumbnailsMessage();
+        $expectedMessageStrict->withContext($this->context);
+        $expectedMessageStrict->setIsStrict(true);
+        $expectedMessageStrict->setMediaIds($affectedMediaIds);
+
+        $expectedMessageNonStrict = new UpdateThumbnailsMessage();
+        $expectedMessageNonStrict->withContext($this->context);
+        $expectedMessageNonStrict->setIsStrict(false);
+        $expectedMessageNonStrict->setMediaIds($affectedMediaIds);
+
+        $messageBusMock = $this->getMockBuilder(MessageBusInterface::class)
+            ->disableOriginalConstructor()->getMock();
+        $messageBusMock->expects(static::exactly(4))->method('dispatch')
+            ->withConsecutive(
+                [$expectedMessageStrict, static::anything()],
+                [$expectedMessageNonStrict, static::anything()],
+                [$expectedMessageNonStrict, static::anything()],
+                [$expectedMessageStrict, static::anything()],
+            )
+            ->willReturnCallback(function ($m, $s) {
+                return Envelope::wrap($m, $s);
+            });
+
+        $command = new GenerateThumbnailsCommand(
+            $this->getContainer()->get(ThumbnailService::class),
+            $this->mediaRepository,
+            $this->mediaFolderRepository,
+            $messageBusMock,
+        );
+
+        $this->runCommand($command, new StringInput('--strict --async'), $output);
+        $this->runCommand($command, new StringInput('--async'), $output);
+        $this->runCommand($command, new StringInput('--async'), $output);
+        $this->runCommand($command, new StringInput('--strict --async'), $output);
     }
 
     protected function assertThumbnailExists(MediaEntity $media, MediaThumbnailEntity $thumbnail): void


### PR DESCRIPTION
### 1. Why is this change necessary?

Regeneration of thumbnails requires a check of the physical file to ensure that the thumbnail was actually generated and not just having a virtual representation in the database.

The circumstances why this situation might occur are not relevant.

However, possible causes could be:

 - Third-party actions such as file monitoring processes and automated clean-up operations
 - Unintentional deletion by humans
 - Previously unknown Bugs in Code that can cause such a condition
 - ...

### 2. What does this change do, exactly?

Adds a physical file check when updating thumbnails.


### 3. Describe each step to reproduce the issue or behaviour.

- Make sure you have generated thumbnails.
- Delete the Thumbnail folder or only a specific file from the sub-folders
- Execute `bin/console media:generate-thumbnails`
- Check that every thumbnail generation was skipped

### 4. Please link to the relevant issues (if any).

- [NEXT-7754](https://issues.shopware.com/issues/NEXT-7754)
- [artikelbild-thumbnails-verschwinden-sind-kaputt-404-wieso](https://forum.shopware.com/t/artikelbild-thumbnails-verschwinden-sind-kaputt-404-wieso/69272)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

Reopens #1879 @J-Rahe 