### PR TITLE
Fixed search not working on administration newsletter recipient module

### DIFF
--- a/changelog/_unreleased/2021-06-24-fix-search-in-newsletter-recipient-module.md
+++ b/changelog/_unreleased/2021-06-24-fix-search-in-newsletter-recipient-module.md
@@ -1,0 +1,9 @@
+---
+title: Fixed search not working on administration newsletter recipient module #1943
+issue: NEXT-13144
+author: David Lochner
+author_email: lochner@nexxo.de
+author_github: nexxome
+---
+# Administration
+* Changed method `getList` in `src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js` to add search term to criteria correctly.

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js
@@ -71,7 +71,8 @@ Component.register('sw-newsletter-recipient-list', {
 
         getList() {
             this.isLoading = true;
-            const criteria = new Criteria(this.page, this.limit, this.term);
+            const criteria = new Criteria(this.page, this.limit);
+            criteria.setTerm(this.term);
             criteria.addSorting(Criteria.sort(this.sortBy, this.sortDirection));
             criteria.addAssociation('salesChannel');
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The search isn't working on the administration newsletter recipient module

### 2. What does this change do, exactly?
This change sets the search term on the listing criteria correctly

### 3. Describe each step to reproduce the issue or behaviour.
On the administration interface go to Marketing -> Newsletter recipients and insert something into the search field

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13144

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
