### PR TITLE
Improve error on executeQuery write operations

### DIFF
--- a/changelog/_unreleased/2021-06-26-improve-error-message-for-executequery-on-write-operations.md
+++ b/changelog/_unreleased/2021-06-26-improve-error-message-for-executequery-on-write-operations.md
@@ -1,0 +1,10 @@
+---
+title: Improve error message for write operations with executeQuery
+issue: NEXT-15902
+author: Fabian Blechschmidt
+author_email: blechschmidt@fabian-blechschmidt.de
+author_github: Schrank
+---
+# Core
+* Improve error message for write operations with executeQuery
+* Fix test

--- a/src/Core/Profiling/Doctrine/DebugStack.php
+++ b/src/Core/Profiling/Doctrine/DebugStack.php
@@ -56,7 +56,7 @@ class DebugStack extends DoctrineDebugStack
 
         if ($matches) {
             throw new \RuntimeException(
-                sprintf('Write operations are not supported when using executeQuery. Query: %s', $query)
+                sprintf('Write operations are not supported when using executeQuery (use executeStatement instead). Query: %s', $query)
             );
         }
     }

--- a/src/Core/Profiling/Test/DebugStackTest.php
+++ b/src/Core/Profiling/Test/DebugStackTest.php
@@ -14,7 +14,7 @@ class DebugStackTest extends TestCase
     {
         $connection = $this->getContainer()->get(Connection::class);
 
-        static::expectExceptionMessage('Write operations are not supported when using executeQuery.');
+        static::expectExceptionMessage('Write operations are not supported when using executeQuery (use executeStatement instead).');
         $connection->executeQuery('CREATE TABLE `test` (
             `id` BINARY(16) NOT NULL PRIMARY KEY
         )');


### PR DESCRIPTION
FIXES NEXT-15902

Improve error message for write operations with executeQuery

### 1. Why is this change necessary?
I can create a migration with bin/console and my IDE gives me an autocompletion on query for executeQuery, but it doesn't work - now I know immediatly what I did wrong AND how to proceed!

### 2. What does this change do, exactly?
Improve an error message so the dev know, what the next step/change is.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
