### PR TITLE
Add locale to app module iframes

### DIFF
--- a/changelog/_unreleased/2021-06-30-add-locale-to-app-modules.md
+++ b/changelog/_unreleased/2021-06-30-add-locale-to-app-modules.md
@@ -1,0 +1,8 @@
+---
+title: Add locale to app modules
+author: Joshua Behrens
+author_email: behrens@heptacom.de 
+author_github: JoshuaBehrens
+---
+# Administration
+* Added current locale as query parameter in module URLs

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -27,6 +27,7 @@
             <argument>%env(APP_URL)%</argument>
             <argument type="service" id="Shopware\Core\Framework\App\ShopId\ShopIdProvider"/>
             <argument>%kernel.shopware_version%</argument>
+            <argument type="service" id="Shopware\Core\Framework\Store\Services\StoreService"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\Validation\TranslationValidator">


### PR DESCRIPTION
### 1. Why is this change necessary?
App modules are just iframes. To make the app in that iframe feels very integrated you need to know the users language. The browser has some hints but it will be weird to have German language in the iframe within a Japanese admin. So we should pass the context locale key with it so the app in the iframe has a chance to adapt.

### 2. What does this change do, exactly?
Reads the context language and passes the first matching locale code from the language chain into the URL.

### 3. Describe each step to reproduce the issue or behaviour.
1. Code an app
2. Have international clients

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
