### PR TITLE
fix operator precedence

### DIFF
--- a/changelog/_unreleased/2021-07-02-fix-operator-precedence.md
+++ b/changelog/_unreleased/2021-07-02-fix-operator-precedence.md
@@ -1,0 +1,10 @@
+---
+title: Fix operator precedence
+issue: 
+flag: 
+author: Pascal Josephy
+author_email: pascal.josephy@jkweb.ch
+author_github: pascaljosephy
+---
+# Elasticsearch
+*  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:fetchProducts` to consider correct operator precedence

--- a/changelog/_unreleased/2021-07-02-fix-operator-precedence.md
+++ b/changelog/_unreleased/2021-07-02-fix-operator-precedence.md
@@ -8,3 +8,4 @@ author_github: pascaljosephy
 ---
 # Elasticsearch
 *  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:fetchProducts` to consider correct operator precedence
+___

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -430,7 +430,7 @@ FROM product p
         :productTranslationQuery:
     ) product_translation_parent ON (product_translation_parent.product_id = p.parent_id)
 
-WHERE p.id IN (:ids) AND p.version_id = :liveVersionId AND p.child_count = 0 OR p.parent_id IS NOT NULL
+WHERE p.id IN (:ids) AND p.version_id = :liveVersionId AND (p.child_count = 0 OR p.parent_id IS NOT NULL)
 
 GROUP BY p.id
 SQL;


### PR DESCRIPTION
### 1. Why is this change necessary?

The method fetchProducts didn't only return the requested products but all product variants in the database. This caused to multiple problems, e.g. very slow indexing.

### 2. What does this change do, exactly?

It fixes the operator precedence, as AND binds stronger than OR, brackets are needed.

### 3. Describe each step to reproduce the issue or behaviour.

Start indexing (e.g. with bin/console es:index). Drastic speed improvement with for example 20k product variants.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
