### PR TITLE
[ISSUE/1227] parentTheme config field inheritance, add changelog

### DIFF
--- a/changelog/_unreleased/2021-07-07-allow-config-field-inheritance-from-parent-theme.md
+++ b/changelog/_unreleased/2021-07-07-allow-config-field-inheritance-from-parent-theme.md
@@ -1,0 +1,24 @@
+---
+title: Allow config field inheritance from parent theme
+issue: NEXT-6402
+author: Björn Meyer
+author_email: bjoern.meyer@flagbit.de 
+author_github: bjoern-flagbit
+---
+# Core
+*  Changed to allow config field inheritance from parent theme in the function `getThemeConfiguration` of `src/Storefront/Theme/ThemeService.php`
+___
+# API
+*  
+___
+# Administration
+*  
+___
+# Storefront
+*  
+___
+# Upgrade Information
+## Topic 1
+### Topic 1a
+### Topic 1b
+## Topic 2

--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -7,7 +7,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Storefront\Theme\Event\ThemeAssignedEvent;
 use Shopware\Storefront\Theme\Event\ThemeConfigChangedEvent;
 use Shopware\Storefront\Theme\Event\ThemeConfigResetEvent;
@@ -158,7 +157,7 @@ class ThemeService
         $childThemeConfig = $this->mergeStaticConfig($childTheme);
 
         $parentThemeId = $childTheme->getParentThemeId();
-        if (null !== $parentThemeId) {
+        if ($parentThemeId !== null) {
             /** @var ThemeEntity $parentTheme */
             $parentThemeSearchResult = $this->getThemeById($parentThemeId, $context);
             $parentTheme = $parentThemeSearchResult->first();
@@ -178,7 +177,7 @@ class ThemeService
             $configFields[$name] = $themeConfigFieldFactory->create($name, $item);
         }
 
-        $configFields = json_decode((string)json_encode($configFields), true);
+        $configFields = json_decode((string) json_encode($configFields), true);
 
         $labels = array_replace_recursive($baseTheme->getLabels() ?? [], $childTheme->getLabels() ?? []);
         if ($translate && !empty($labels)) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
It is useless to copy the same config fields accross themes. 
Why can I set a parentThemeId when it is not using the inheritance (confusing).

### 2. What does this change do, exactly?
It allows to inherit the config fields from a parent theme

### 3. Describe each step to reproduce the issue or behaviour.
Create two themes, add one theme as parentTheme via API, try to build the childTheme after that (there will be also a core bug)
Create some config fields ... there is no inheritance from parent to child.

### 4. Please link to the relevant issues (if any).
See https://github.com/shopware/platform/issues/1227 and https://github.com/shopware/platform/issues/507

### 5. Checklist

- [X] I have run the core tests without any error
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
