### PR TITLE
Use shopware headless

### DIFF
--- a/src/Core/Checkout/Customer/Event/AddressListingCriteriaEvent.php
+++ b/src/Core/Checkout/Customer/Event/AddressListingCriteriaEvent.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Storefront\Page\Address\Listing;
+namespace Shopware\Core\Checkout\Customer\Event;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -8,9 +8,6 @@ use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
-/**
- * @deprecated tag:v6.5.0 - Use @see \Shopware\Core\Checkout\Customer\Event\AddressListingCriteriaEvent instead
- */
 class AddressListingCriteriaEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {
     /**

--- a/src/Core/Checkout/Customer/SalesChannel/ListAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ListAddressRoute.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Event\AddressListingCriteriaEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -13,7 +14,7 @@ use Shopware\Core\Framework\Routing\Annotation\LoginRequired;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Storefront\Page\Address\Listing\AddressListingCriteriaEvent;
+use Shopware\Storefront\Page\Address\Listing\AddressListingCriteriaEvent as StorefrontAddressListingCriteriaEvent;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -68,9 +69,8 @@ class ListAddressRoute extends AbstractListAddressRoute
             ->addAssociation('country')
             ->addFilter(new EqualsFilter('customer_address.customerId', $customer->getId()));
 
-        $this->eventDispatcher->dispatch(
-            new AddressListingCriteriaEvent($criteria, $context)
-        );
+        $this->eventDispatcher->dispatch(new StorefrontAddressListingCriteriaEvent($criteria, $context));
+        $this->eventDispatcher->dispatch(new AddressListingCriteriaEvent($criteria, $context));
 
         return new ListAddressRouteResponse($this->addressRepository->search($criteria, $context->getContext()));
     }

--- a/src/Core/Content/ProductExport/Event/ProductExportContentTypeEvent.php
+++ b/src/Core/Content/ProductExport/Event/ProductExportContentTypeEvent.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\ProductExport\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ProductExportContentTypeEvent extends Event
+{
+    /**
+     * @var string
+     */
+    private $fileFormat;
+
+    /**
+     * @var string
+     */
+    private $contentType;
+
+    public function __construct(string $fileFormat, string $contentType)
+    {
+        $this->fileFormat = $fileFormat;
+        $this->contentType = $contentType;
+    }
+
+    public function getFileFormat(): string
+    {
+        return $this->fileFormat;
+    }
+
+    public function getContentType(): string
+    {
+        return $this->contentType;
+    }
+
+    public function setContentType(string $contentType): void
+    {
+        $this->contentType = $contentType;
+    }
+}

--- a/src/Core/Content/ProductExport/SalesChannel/ExportController.php
+++ b/src/Core/Content/ProductExport/SalesChannel/ExportController.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\ProductExport\SalesChannel;
 use League\Flysystem\FilesystemInterface;
 use Monolog\Logger;
 use OpenApi\Annotations as OA;
+use Shopware\Core\Content\ProductExport\Event\ProductExportContentTypeEvent;
 use Shopware\Core\Content\ProductExport\Event\ProductExportLoggingEvent;
 use Shopware\Core\Content\ProductExport\Exception\ExportNotFoundException;
 use Shopware\Core\Content\ProductExport\Exception\ExportNotGeneratedException;
@@ -19,7 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
-use Shopware\Storefront\Event\ProductExportContentTypeEvent;
+use Shopware\Storefront\Event\ProductExportContentTypeEvent as StorefrontProductExportContentTypeEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -150,7 +151,10 @@ class ExportController
                 break;
         }
 
-        $event = new ProductExportContentTypeEvent($fileFormat, $contentType);
+        $event = new StorefrontProductExportContentTypeEvent($fileFormat, $contentType);
+        $this->eventDispatcher->dispatch($event);
+
+        $event = new ProductExportContentTypeEvent($fileFormat, $event->getContentType());
         $this->eventDispatcher->dispatch($event);
 
         return $event->getContentType();

--- a/src/Core/DevOps/System/Command/SystemInstallCommand.php
+++ b/src/Core/DevOps/System/Command/SystemInstallCommand.php
@@ -10,6 +10,9 @@ use Doctrine\DBAL\FetchMode;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Kernel;
+use Shopware\Storefront\Theme\Command\ThemeChangeCommand;
+use Shopware\Storefront\Theme\Command\ThemeCompileCommand;
+use Shopware\Storefront\Theme\Command\ThemeRefreshCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -147,14 +150,24 @@ class SystemInstallCommand extends Command
             [
                 'command' => 'dal:refresh:index',
             ],
-            [
-                'command' => 'theme:refresh',
-            ],
-            [
-                'command' => 'theme:compile',
-                'allowedToFail' => true,
-            ],
         ];
+
+        if (\class_exists(ThemeRefreshCommand::class)) {
+            $commands[] = [
+                [
+                    'command' => 'theme:refresh',
+                ],
+            ];
+        }
+
+        if (\class_exists(ThemeCompileCommand::class)) {
+            $commands[] = [
+                [
+                    'command' => 'theme:compile',
+                    'allowedToFail' => true,
+                ],
+            ];
+        }
 
         if ($input->getOption('basic-setup')) {
             $commands[] = [
@@ -170,7 +183,7 @@ class SystemInstallCommand extends Command
                 '--url' => (string) EnvironmentHelper::getVariable('APP_URL', 'http://localhost'),
             ];
 
-            if (!$input->getOption('no-assign-theme')) {
+            if (\class_exists(ThemeChangeCommand::class) && !$input->getOption('no-assign-theme')) {
                 $commands[] = [
                     'command' => 'theme:change',
                     'allowedToFail' => true,

--- a/src/Core/Framework/Api/Controller/AclController.php
+++ b/src/Core/Framework/Api/Controller/AclController.php
@@ -10,7 +10,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\Routing\Annotation\Acl;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;
-use Shopware\Storefront\Framework\Cache\Annotation\HttpCache;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -41,7 +40,6 @@ class AclController extends AbstractController
 
     /**
      * @Since("6.3.3.0")
-     * @HttpCache()
      * @Route("/api/_action/acl/privileges", name="api.acl.privileges.get", methods={"GET"}, defaults={"auth_required"=true})
      * @Acl({"api_acl_privileges_get"})
      */

--- a/src/Core/Framework/DependencyInjection/api.xml
+++ b/src/Core/Framework/DependencyInjection/api.xml
@@ -198,13 +198,6 @@
             </call>
         </service>
 
-        <service id="Shopware\Core\Framework\Api\Controller\CaptchaController" public="true">
-            <argument type="tagged" tag="shopware.storefront.captcha"/>
-            <call method="setContainer">
-                <argument type="service" id="service_container"/>
-            </call>
-        </service>
-
         <!-- API OAuth Repositories -->
         <service id="Shopware\Core\Framework\Api\OAuth\AccessTokenRepository"/>
         <service id="Shopware\Core\Framework\Api\OAuth\ClientRepository">

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -350,7 +350,7 @@
         <service id="Shopware\Core\Framework\App\AppUrlChangeResolver\UninstallAppsStrategy">
             <argument type="service" id="app.repository"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
-            <argument type="service" id="Shopware\Storefront\Theme\ThemeAppLifecycleHandler"/>
+            <argument type="service" id="Shopware\Core\Framework\App\AppStateService"/>
 
             <tag name="shopware.app_url_changed_resolver"/>
         </service>

--- a/src/Core/Framework/DependencyInjection/store.xml
+++ b/src/Core/Framework/DependencyInjection/store.xml
@@ -123,7 +123,7 @@
 
         <service id="Shopware\Core\Framework\Store\Services\ExtensionLoader">
             <argument type="service" id="language.repository"/>
-            <argument type="service" id="theme.repository"/>
+            <argument type="service" id="theme.repository" on-invalid="null"/>
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppLoader"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\Service\ConfigurationService"/>
             <argument type="service" id="Shopware\Core\Framework\Store\Services\StoreService"/>
@@ -159,7 +159,7 @@
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\AppLifecycle"/>
             <argument type="service" id="app.repository"/>
             <argument type="service" id="sales_channel.repository"/>
-            <argument type="service" id="theme.repository"/>
+            <argument type="service" id="theme.repository" on-invalid="null"/>
             <argument type="service" id="Shopware\Core\Framework\App\AppStateService"/>
             <tag name="shopware.feature" flag="FEATURE_NEXT_12608"/>
         </service>

--- a/src/Core/Framework/Store/Helper/PermissionCategorization.php
+++ b/src/Core/Framework/Store/Helper/PermissionCategorization.php
@@ -148,10 +148,6 @@ use Shopware\Core\System\Unit\UnitDefinition;
 use Shopware\Core\System\User\Aggregate\UserAccessKey\UserAccessKeyDefinition;
 use Shopware\Core\System\User\Aggregate\UserRecovery\UserRecoveryDefinition;
 use Shopware\Core\System\User\UserDefinition;
-use Shopware\Storefront\Theme\Aggregate\ThemeMediaDefinition;
-use Shopware\Storefront\Theme\Aggregate\ThemeSalesChannelDefinition;
-use Shopware\Storefront\Theme\Aggregate\ThemeTranslationDefinition;
-use Shopware\Storefront\Theme\ThemeDefinition;
 
 /**
  * @internal
@@ -181,6 +177,14 @@ class PermissionCategorization
     private const CATEGORY_SOCIAL_SHOPPING = 'social_shopping';
     private const CATEGORY_TAG = 'tag';
     private const CATEGORY_THEME = 'theme';
+    /** @see \Shopware\Storefront\Theme\ThemeDefinition::ENTITY_NAME */
+    private const THEME_ENTITY_NAME = 'theme';
+    /** @see \Shopware\Storefront\Theme\Aggregate\ThemeTranslationDefinition::ENTITY_NAME  */
+    private const THEME_TRANSLATION_ENTITY_NAME = 'theme_translation';
+    /** @see \Shopware\Storefront\Theme\Aggregate\ThemeMediaDefinition::ENTITY_NAME */
+    private const THEME_MEDIA_ENTITY_NAME = 'theme_media';
+    /** @see \Shopware\Storefront\Theme\Aggregate\ThemeSalesChannelDefinition::ENTITY_NAME  */
+    private const THEME_SALES_CHANNEL_ENTITY_NAME = 'theme_sales_channel';
 
     private const PERMISSION_CATEGORIES = [
         self::CATEGORY_ADMIN_USER => [
@@ -379,10 +383,10 @@ class PermissionCategorization
             TagDefinition::ENTITY_NAME,
         ],
         self::CATEGORY_THEME => [
-            ThemeDefinition::ENTITY_NAME,
-            ThemeTranslationDefinition::ENTITY_NAME,
-            ThemeMediaDefinition::ENTITY_NAME,
-            ThemeSalesChannelDefinition::ENTITY_NAME,
+            self::THEME_ENTITY_NAME,
+            self::THEME_TRANSLATION_ENTITY_NAME,
+            self::THEME_MEDIA_ENTITY_NAME,
+            self::THEME_SALES_CHANNEL_ENTITY_NAME,
         ],
     ];
 

--- a/src/Core/Framework/Store/Services/ExtensionLoader.php
+++ b/src/Core/Framework/Store/Services/ExtensionLoader.php
@@ -35,7 +35,7 @@ class ExtensionLoader
 {
     private const DEFAULT_LOCALE = 'en_GB';
 
-    private EntityRepositoryInterface $themeRepository;
+    private ?EntityRepositoryInterface $themeRepository;
 
     /**
      * @var array<string>|null
@@ -52,7 +52,7 @@ class ExtensionLoader
 
     public function __construct(
         EntityRepositoryInterface $languageRepository,
-        EntityRepositoryInterface $themeRepository,
+        ?EntityRepositoryInterface $themeRepository,
         AbstractAppLoader $appLoader,
         ConfigurationService $configurationService,
         StoreService $storeService
@@ -204,7 +204,7 @@ class ExtensionLoader
      */
     private function getInstalledThemeNames(Context $context): array
     {
-        if ($this->installedThemeNames === null) {
+        if ($this->installedThemeNames === null && $this->themeRepository instanceof EntityRepositoryInterface) {
             $themeNameAggregationName = 'theme_names';
             $criteria = new Criteria();
             $criteria->addAggregation(new TermsAggregation($themeNameAggregationName, 'technicalName'));

--- a/src/Core/Framework/Store/Services/StoreAppLifecycleService.php
+++ b/src/Core/Framework/Store/Services/StoreAppLifecycleService.php
@@ -42,10 +42,7 @@ class StoreAppLifecycleService extends AbstractStoreAppLifecycleService
      */
     private $salesChannelRepository;
 
-    /**
-     * @var EntityRepositoryInterface
-     */
-    private $themeRepository;
+    private ?EntityRepositoryInterface $themeRepository;
 
     /**
      * @var AppStateService
@@ -63,7 +60,7 @@ class StoreAppLifecycleService extends AbstractStoreAppLifecycleService
         AbstractAppLifecycle $appLifecycle,
         EntityRepositoryInterface $appRepository,
         EntityRepositoryInterface $salesChannelRepository,
-        EntityRepositoryInterface $themeRepository,
+        ?EntityRepositoryInterface $themeRepository,
         AppStateService $appStateService
     ) {
         $this->storeClient = $storeClient;
@@ -191,6 +188,10 @@ class StoreAppLifecycleService extends AbstractStoreAppLifecycleService
 
     private function getThemeIdByTechnicalName(string $technicalName, Context $context): ?string
     {
+        if (!$this->themeRepository instanceof EntityRepositoryInterface) {
+            return null;
+        }
+
         return $this->themeRepository->searchIds(
             (new Criteria())->addFilter(new EqualsFilter('technicalName', $technicalName)),
             $context

--- a/src/Core/HttpKernel.php
+++ b/src/Core/HttpKernel.php
@@ -171,7 +171,7 @@ class HttpKernel
         // check for http caching
         $enabled = $container->hasParameter('shopware.http.cache.enabled')
             && $container->getParameter('shopware.http.cache.enabled');
-        if ($enabled) {
+        if ($enabled && $container->has(CacheStore::class)) {
             $kernel = new HttpCache($kernel, $container->get(CacheStore::class), null, ['debug' => $this->debug]);
         }
 

--- a/src/Core/Migration/Test/Migration1612184092AddUrlLandingPageTest.php
+++ b/src/Core/Migration/Test/Migration1612184092AddUrlLandingPageTest.php
@@ -8,11 +8,20 @@ use Shopware\Core\Content\LandingPage\Aggregate\LandingPageTranslation\LandingPa
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Migration\Migration1612184092AddUrlLandingPage;
-use Shopware\Storefront\Framework\Seo\SeoUrlRoute\LandingPageSeoUrlRoute;
 
 class Migration1612184092AddUrlLandingPageTest extends TestCase
 {
     use KernelTestBehaviour;
+
+    /**
+     * @see \Shopware\Storefront\Framework\Seo\SeoUrlRoute\LandingPageSeoUrlRoute::ROUTE_NAME
+     */
+    private const ROUTE_NAME = 'frontend.landing.page';
+
+    /**
+     * @see \Shopware\Storefront\Framework\Seo\SeoUrlRoute\LandingPageSeoUrlRoute::DEFAULT_TEMPLATE
+     */
+    private const DEFAULT_TEMPLATE = '{{ landingPage.translated.url }}';
 
     /**
      * @var Connection
@@ -41,7 +50,7 @@ class Migration1612184092AddUrlLandingPageTest extends TestCase
             'SELECT id
             FROM `seo_url_template`
             WHERE `seo_url_template`.`route_name` = :routeName',
-            ['routeName' => LandingPageSeoUrlRoute::ROUTE_NAME]
+            ['routeName' => self::ROUTE_NAME]
         );
 
         static::assertNotEmpty($seoUrlTemplate);
@@ -62,9 +71,9 @@ class Migration1612184092AddUrlLandingPageTest extends TestCase
         $this->connection->delete(
             'seo_url_template',
             [
-                'route_name' => LandingPageSeoUrlRoute::ROUTE_NAME,
+                'route_name' => self::ROUTE_NAME,
                 'entity_name' => LandingPageDefinition::ENTITY_NAME,
-                'template' => LandingPageSeoUrlRoute::DEFAULT_TEMPLATE,
+                'template' => self::DEFAULT_TEMPLATE,
             ]
         );
     }

--- a/src/Core/Migration/Test/Migration1624262862UpdateDefaultValueOnCaptchaV2Test.php
+++ b/src/Core/Migration/Test/Migration1624262862UpdateDefaultValueOnCaptchaV2Test.php
@@ -9,7 +9,6 @@ use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Migration\V6_4\Migration1624262862UpdateDefaultValueOnCaptchaV2;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Shopware\Storefront\Framework\Captcha\BasicCaptcha;
 
 class Migration1624262862UpdateDefaultValueOnCaptchaV2Test extends TestCase
 {
@@ -17,6 +16,11 @@ class Migration1624262862UpdateDefaultValueOnCaptchaV2Test extends TestCase
     use DatabaseTransactionBehaviour;
 
     private const CONFIG_KEY = 'core.basicInformation.activeCaptchasV2';
+
+    /**
+     * @see \Shopware\Storefront\Framework\Captcha\BasicCaptcha::CAPTCHA_NAME
+     */
+    private const CAPTCHA_NAME = 'basicCaptcha';
 
     private Connection $connection;
 
@@ -53,7 +57,7 @@ class Migration1624262862UpdateDefaultValueOnCaptchaV2Test extends TestCase
     {
         $systemConfig = $this->getContainer()->get(SystemConfigService::class);
 
-        $systemConfig->set('core.basicInformation.activeCaptchas', [BasicCaptcha::CAPTCHA_NAME]);
+        $systemConfig->set('core.basicInformation.activeCaptchas', [self::CAPTCHA_NAME]);
         $connection = $this->getContainer()->get(Connection::class);
 
         $connection->update('system_config', [
@@ -73,6 +77,6 @@ class Migration1624262862UpdateDefaultValueOnCaptchaV2Test extends TestCase
         ]);
         $activeCaptchasV2 = json_decode($activeCaptchasV2, true);
 
-        static::assertTrue($activeCaptchasV2['_value'][BasicCaptcha::CAPTCHA_NAME]['isActive']);
+        static::assertTrue($activeCaptchasV2['_value'][self::CAPTCHA_NAME]['isActive']);
     }
 }

--- a/src/Core/Migration/V6_4/Migration1612184092AddUrlLandingPage.php
+++ b/src/Core/Migration/V6_4/Migration1612184092AddUrlLandingPage.php
@@ -3,11 +3,7 @@
 namespace Shopware\Core\Migration\V6_4;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Content\LandingPage\LandingPageDefinition;
-use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Migration\MigrationStep;
-use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Storefront\Framework\Seo\SeoUrlRoute\LandingPageSeoUrlRoute;
 
 class Migration1612184092AddUrlLandingPage extends MigrationStep
 {
@@ -22,23 +18,6 @@ class Migration1612184092AddUrlLandingPage extends MigrationStep
             ALTER TABLE `landing_page_translation`
             ADD COLUMN `url` varchar(255) NULL AFTER `name`
         ');
-
-        $seoUrlTemplate = $connection->fetchAll(
-            'SELECT id
-            FROM `seo_url_template`
-            WHERE `seo_url_template`.`route_name` = :routeName',
-            ['routeName' => LandingPageSeoUrlRoute::ROUTE_NAME]
-        );
-
-        if (empty($seoUrlTemplate)) {
-            $connection->insert('seo_url_template', [
-                'id' => Uuid::randomBytes(),
-                'route_name' => LandingPageSeoUrlRoute::ROUTE_NAME,
-                'entity_name' => LandingPageDefinition::ENTITY_NAME,
-                'template' => LandingPageSeoUrlRoute::DEFAULT_TEMPLATE,
-                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
-            ]);
-        }
     }
 
     public function updateDestructive(Connection $connection): void

--- a/src/Storefront/Controller/Api/CaptchaController.php
+++ b/src/Storefront/Controller/Api/CaptchaController.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Core\Framework\Api\Controller;
+namespace Shopware\Storefront\Controller\Api;
 
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -7,6 +7,13 @@
     <services>
         <defaults public="true" />
 
+        <service id="Shopware\Storefront\Controller\Api\CaptchaController" public="true">
+            <argument type="tagged" tag="shopware.storefront.captcha"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+
         <service id="Shopware\Storefront\Controller\AccountOrderController">
             <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountOrderPageLoader"/>
             <argument type="service" id="Shopware\Storefront\Page\Account\Order\AccountEditOrderPageLoader"/>

--- a/src/Storefront/Event/ProductExportTypeEvent.php
+++ b/src/Storefront/Event/ProductExportTypeEvent.php
@@ -4,6 +4,9 @@ namespace Shopware\Storefront\Event;
 
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @deprecated tag:v6.5.0 - Use @see \Shopware\Core\Content\ProductExport\Event\ProductExportContentTypeEvent instead
+ */
 class ProductExportContentTypeEvent extends Event
 {
     /**

--- a/src/Storefront/Migration/V6_4/Migration1612184092AddUrlLandingPage.php
+++ b/src/Storefront/Migration/V6_4/Migration1612184092AddUrlLandingPage.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Migration\V6_4;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Storefront\Framework\Seo\SeoUrlRoute\LandingPageSeoUrlRoute;
+
+class Migration1612184092AddUrlLandingPage extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1612184092;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $seoUrlTemplate = $connection->fetchAll(
+            'SELECT id
+            FROM `seo_url_template`
+            WHERE `seo_url_template`.`route_name` = :routeName',
+            ['routeName' => LandingPageSeoUrlRoute::ROUTE_NAME]
+        );
+
+        if (empty($seoUrlTemplate)) {
+            $connection->insert('seo_url_template', [
+                'id' => Uuid::randomBytes(),
+                'route_name' => LandingPageSeoUrlRoute::ROUTE_NAME,
+                'entity_name' => LandingPageDefinition::ENTITY_NAME,
+                'template' => LandingPageSeoUrlRoute::DEFAULT_TEMPLATE,
+                'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]);
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Following the guide in [shopware/production](https://github.com/shopware/production/#managing-dependencies) to build a headless shopware you will only require `shopware/core`. When you do that you fail at some steps and this PR shall fix them all so we are not

![grafik](https://user-images.githubusercontent.com/1133593/125407040-c8aa7000-e3b9-11eb-8e98-0fec5771d5da.png)


### 2. What does this change do, exactly?
* Fix building the symfony container by reducing the usage of storefront classes from core code
* Move classes from storefront to core when they also fit there
* Resolve constants and refer to their original source to break dependency
* Add class_exists check
* Ignore most of these on tests as those are run first in [shopware/development](https://github.com/shopware/development) where all comes together (I'll hate myself for this when I want to run these tests from `vendor/shopware/core` in the future 😅) 
* Make symfony dependencies null on failure and allow null services in classes

### 3. Describe each step to reproduce the issue or behaviour.
* Follow [shopware/production](https://github.com/shopware/production/#managing-dependencies) to get headless start
* Run `bin/console system:install` and fail at building container
* Fix
* Run `bin/console system:install` and fail at running storefront commands
* Fix
* List routes and fail at unknown `HttpCache` attribute
* Fix

### 4. Checklist

I skipped most of the checks from this list to show where this will go to and what I am might missing from the target picture. When this is ready I am happy to follow the missing changelog and the code migration guide that allows a less breaking code migration.

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
