### PR TITLE
fix es indexing behaviour with variants

### DIFF
--- a/changelog/_unreleased/2021-07-16-fix-es-indexing.md
+++ b/changelog/_unreleased/2021-07-16-fix-es-indexing.md
@@ -1,0 +1,18 @@
+---
+title: Fix ES indexing behaviour with variants
+issue: 
+author: Pascal Josephy
+author_email: pascal.josephy@jkweb.ch
+author_github: pascaljosephy
+---
+# Core
+*  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:buildCoalesce`
+*  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:getTranslationQuery`
+*  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:getTranslationQuery`
+*  Changed method `src/Elasticsearch/Test/Product/ElasticsearchProductTest:providerCheapestPriceFilter`
+*  Changed method `src/Elasticsearch/Test/Product/ElasticsearchProductTest:providerCheapestPriceSorting`
+*  Changed method `src/Elasticsearch/Test/Product/ElasticsearchProductTest:testLanguageFieldsWorkSimilarToDAL`
+*  Changed method `src/Elasticsearch/Test/Product/ElasticsearchProductTest:createData`
+*  Added method `src/Elasticsearch/Test/Product/ElasticsearchProductTest:testLanguageFallback`
+   
+

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -24,6 +24,7 @@ use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Shopware\Elasticsearch\Framework\AbstractElasticsearchDefinition;
 use Shopware\Elasticsearch\Framework\Indexing\EntityMapper;
+use Shopware\Elasticsearch\Product\CustomFieldUpdater;
 
 class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
 {
@@ -261,8 +262,8 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
 
         $coalesce = 'COALESCE(';
 
-        foreach (['product_translation_main', 'product_translation_parent'] as $join) {
-            foreach ($fields as $field) {
+        foreach ($fields as $field) {
+            foreach (['product_translation_main', 'product_translation_parent'] as $join) {
                 $coalesce .= sprintf('%s.`%s`', $join, $field) . ',';
             }
         }
@@ -272,53 +273,51 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
 
     private function getTranslationQuery(Context $context): QueryBuilder
     {
-        $table = $this->definition->getEntityName() . '_translation';
-
         $query = new QueryBuilder($this->connection);
 
-        $select = '`#alias#`.name  as `#alias#.name`, `#alias#`.description  as `#alias#.description`, `#alias#`.custom_fields  as `#alias#.custom_fields`';
+        $productAlias = 'p';
+        $query->from('product ', $productAlias);
+        $parentIdSelector = 'SELECT DISTINCT `p`.parent_id FROM `product` p WHERE p.id IN(:ids)';
+        $query->select(EntityDefinitionQueryHelper::escape($productAlias) . '.id AS product_id');
+        $query->where(EntityDefinitionQueryHelper::escape($productAlias) . '.id IN (:ids) OR ' .
+            EntityDefinitionQueryHelper::escape($productAlias) . '.id IN(' . $parentIdSelector . ')');
 
-        // first language has to be the from part, in this case we have to use the system language to enforce we have a record
         $chain = $context->getLanguageIdChain();
 
-        $first = array_shift($chain);
         $firstAlias = 'product_translation.translation';
 
-        $foreignKey = EntityDefinitionQueryHelper::escape($firstAlias) . '.' . $this->definition->getEntityName() . '_id';
-
-        // used as join condition
-        $query->addSelect($foreignKey);
-
-        // set first language as from part
-        $query->addSelect(str_replace('#alias#', $firstAlias, $select));
-        $query->from(EntityDefinitionQueryHelper::escape($table), EntityDefinitionQueryHelper::escape($firstAlias));
-        $query->where(EntityDefinitionQueryHelper::escape($firstAlias) . '.language_id = :languageId');
-        $query->andWhere(EntityDefinitionQueryHelper::escape($firstAlias) . '.product_id IN(:ids)');
-        $query->andWhere(EntityDefinitionQueryHelper::escape($firstAlias) . '.product_version_id = :liveVersionId');
-        $query->setParameter('languageId', Uuid::fromHexToBytes($first));
-
         foreach ($chain as $i => $language) {
-            ++$i;
+            $languageQuery = new QueryBuilder($this->connection);
 
-            $condition = '#firstAlias#.#column# = #alias#.#column# AND #alias#.language_id = :languageId' . $i;
+            $alias = 'pt';
+            $outerAlias = 'product_translation.translation.fallback_' . $i;
+            $languageParam = ':languageId' . $i;
+            if ($i == 0) {
+                $outerAlias = $firstAlias;
+                $languageParam = ':languageId';
+            }
 
-            $alias = 'product_translation.translation.fallback_' . $i;
+            $languageQuery->from('product_translation ' . EntityDefinitionQueryHelper::escape($alias));
+            $languageQuery->andWhere(EntityDefinitionQueryHelper::escape($alias) . '.language_id = ' . $languageParam);
+            $languageQuery->addSelect(EntityDefinitionQueryHelper::escape($alias) . '.product_id');
+            $languageQuery->addSelect(EntityDefinitionQueryHelper::escape($alias) . '.name');
+            $languageQuery->addSelect(EntityDefinitionQueryHelper::escape($alias) . '.description');
+            $languageQuery->addSelect(EntityDefinitionQueryHelper::escape($alias) . '.custom_fields');
 
-            $variables = [
-                '#column#' => EntityDefinitionQueryHelper::escape($this->definition->getEntityName() . '_id'),
-                '#alias#' => EntityDefinitionQueryHelper::escape($alias),
-                '#firstAlias#' => EntityDefinitionQueryHelper::escape($firstAlias),
-            ];
-
-            $query->leftJoin(
-                EntityDefinitionQueryHelper::escape($firstAlias),
-                EntityDefinitionQueryHelper::escape($table),
-                EntityDefinitionQueryHelper::escape($alias),
-                str_replace(array_keys($variables), array_values($variables), $condition)
+            $query->addSelect(
+                EntityDefinitionQueryHelper::escape($outerAlias) . '.name AS ' . EntityDefinitionQueryHelper::escape($outerAlias . '.name'),
+                EntityDefinitionQueryHelper::escape($outerAlias) . '.description AS ' . EntityDefinitionQueryHelper::escape($outerAlias . '.description'),
+                EntityDefinitionQueryHelper::escape($outerAlias) . '.custom_fields AS ' . EntityDefinitionQueryHelper::escape($outerAlias . '.custom_fields'),
             );
 
-            $query->addSelect(str_replace('#alias#', $alias, $select));
-            $query->setParameter('languageId' . $i, Uuid::fromHexToBytes($language));
+            $query->leftJoin(
+                $productAlias,
+                '(' . $languageQuery->getSQL() . ')',
+                EntityDefinitionQueryHelper::escape($outerAlias),
+                EntityDefinitionQueryHelper::escape($productAlias) . '.id = ' .
+                EntityDefinitionQueryHelper::escape($outerAlias) . '.product_id'
+            );
+            $query->setParameter($languageParam, Uuid::fromHexToBytes($language));
         }
 
         return $query;

--- a/src/Elasticsearch/Test/Product/ElasticsearchProductTest.php
+++ b/src/Elasticsearch/Test/Product/ElasticsearchProductTest.php
@@ -1913,7 +1913,7 @@ class ElasticsearchProductTest extends TestCase
         yield 'Test 70€ filter without rule' => ['from' => 70, 'to' => 71, 'expected' => ['p.1', 'v.4.2']];
         yield 'Test 79€ filter without rule' => ['from' => 79, 'to' => 80, 'expected' => ['v.2.1', 'v.2.2']];
         yield 'Test 90€ filter without rule' => ['from' => 90, 'to' => 91, 'expected' => ['v.3.1']];
-        yield 'Test 60€ filter without rule' => ['from' => 60, 'to' => 61, 'expected' => ['v.4.1']];
+        yield 'Test 60€ filter without rule' => ['from' => 60, 'to' => 61, 'expected' => ['v.dal-2.1', 'v.dal-2.2', 'v.4.1']];
         yield 'Test 110€ filter without rule' => ['from' => 110, 'to' => 111, 'expected' => ['p.5']];
         yield 'Test 120€ filter without rule' => ['from' => 120, 'to' => 121, 'expected' => ['v.6.1', 'v.6.2']];
         yield 'Test 130€ filter without rule' => ['from' => 130, 'to' => 131, 'expected' => ['v.7.1', 'v.7.2']];
@@ -1925,7 +1925,7 @@ class ElasticsearchProductTest extends TestCase
         yield 'Test 70€ filter with rule-a' => ['rules' => ['rule-a'], 'from' => 70, 'to' => 71, 'expected' => ['p.1', 'v.4.2']];
         yield 'Test 79€ filter with rule-a' => ['rules' => ['rule-a'], 'from' => 79, 'to' => 80, 'expected' => ['v.2.1', 'v.2.2']];
         yield 'Test 90€ filter with rule-a' => ['rules' => ['rule-a'], 'from' => 90, 'to' => 91, 'expected' => ['v.3.1']];
-        yield 'Test 60€ filter with rule-a' => ['rules' => ['rule-a'], 'from' => 60, 'to' => 61, 'expected' => ['v.4.1']];
+        yield 'Test 60€ filter with rule-a' => ['rules' => ['rule-a'], 'from' => 60, 'to' => 61, 'expected' => ['v.dal-2.1', 'v.dal-2.2', 'v.4.1']];
         yield 'Test 130€ filter with rule-a' => ['rules' => ['rule-a'], 'from' => 130, 'to' => 131, 'expected' => ['v.6.1']];
         yield 'Test 140€ filter with rule-a' => ['rules' => ['rule-a'], 'from' => 140, 'to' => 141, 'expected' => ['v.6.2', 'v.7.2']];
         yield 'Test 150€ filter/10 with rule-a' => ['rules' => ['rule-a'], 'from' => 150, 'to' => 151, 'expected' => ['v.7.1', 'v.10.2']];
@@ -1936,7 +1936,7 @@ class ElasticsearchProductTest extends TestCase
         yield 'Test 70€ filter with rule b+a' => ['rules' => ['rule-b', 'rule-a'], 'from' => 70, 'to' => 71, 'expected' => ['p.1', 'v.4.2']];
         yield 'Test 79€ filter with rule b+a' => ['rules' => ['rule-b', 'rule-a'], 'from' => 79, 'to' => 80, 'expected' => ['v.2.1', 'v.2.2']];
         yield 'Test 90€ filter with rule b+a' => ['rules' => ['rule-b', 'rule-a'], 'from' => 90, 'to' => 91, 'expected' => ['v.3.1']];
-        yield 'Test 60€ filter with rule b+a' => ['rules' => ['rule-b', 'rule-a'], 'from' => 60, 'to' => 61, 'expected' => ['v.4.1']];
+        yield 'Test 60€ filter with rule b+a' => ['rules' => ['rule-b', 'rule-a'], 'from' => 60, 'to' => 61, 'expected' => ['v.dal-2.1', 'v.dal-2.2', 'v.4.1']];
         yield 'Test 130€ filter with rule b+a' => ['rules' => ['rule-b', 'rule-a'], 'from' => 130, 'to' => 131, 'expected' => ['v.6.1']];
         yield 'Test 140€ filter with rule b+a' => ['rules' => ['rule-b', 'rule-a'], 'from' => 140, 'to' => 141, 'expected' => ['v.6.2', 'v.7.2']];
         yield 'Test 150€ filter with rule b+a' => ['rules' => ['rule-b', 'rule-a'], 'from' => 150, 'to' => 151, 'expected' => ['v.7.1', 'v.10.2']];
@@ -1976,27 +1976,27 @@ class ElasticsearchProductTest extends TestCase
     public function providerCheapestPriceSorting()
     {
         yield 'Test sorting without rules' => [
-            'ids' => ['v.4.1', 'p.1', 'v.4.2', 'v.2.2', 'v.2.1', 'v.3.1', 'v.3.2', 'p.5', 'v.6.1', 'v.6.2', 'v.7.1', 'v.7.2', 'v.8.1', 'v.8.2', 'v.10.2', 'v.9.1', 'v.10.1', 'v.9.2', 'v.11.1', 'v.11.2', 'v.12.1', 'v.12.2', 'v.13.1', 'v.13.2'],
+            'ids' => ['v.4.1', 'v.dal-2.1', 'v.dal-2.2', 'p.1', 'v.4.2', 'v.2.2', 'v.2.1', 'v.3.1', 'v.3.2', 'p.5', 'v.6.1', 'v.6.2', 'v.7.1', 'v.7.2', 'v.8.1', 'v.8.2', 'v.10.2', 'v.9.1', 'v.10.1', 'v.9.2', 'v.11.1', 'v.11.2', 'v.12.1', 'v.12.2', 'v.13.1', 'v.13.2'],
             'rules' => [],
         ];
 
         yield 'Test sorting with rule a' => [
-            'ids' => ['v.4.1', 'p.1', 'v.4.2', 'v.2.2', 'v.2.1', 'v.3.1', 'v.3.2', 'p.5', 'v.6.1', 'v.6.2', 'v.7.2', 'v.10.2', 'v.7.1', 'v.10.1', 'v.8.1', 'v.9.1', 'v.9.2', 'v.8.2', 'v.11.1', 'v.11.2', 'v.12.2', 'v.12.1', 'v.13.2', 'v.13.1'],
+            'ids' => ['v.4.1', 'v.dal-2.1', 'v.dal-2.2', 'p.1', 'v.4.2', 'v.2.2', 'v.2.1', 'v.3.1', 'v.3.2', 'p.5', 'v.6.1', 'v.6.2', 'v.7.2', 'v.10.2', 'v.7.1', 'v.10.1', 'v.8.1', 'v.9.1', 'v.9.2', 'v.8.2', 'v.11.1', 'v.11.2', 'v.12.2', 'v.12.1', 'v.13.2', 'v.13.1'],
             'rules' => ['rule-a'],
         ];
 
         yield 'Test sorting with rule b' => [
-            'ids' => ['v.4.1', 'p.1', 'v.4.2', 'v.2.2', 'v.2.1', 'v.3.1', 'v.3.2', 'p.5', 'v.6.1', 'v.6.2', 'v.7.1', 'v.7.2', 'v.8.1', 'v.8.2', 'v.10.2', 'v.9.1', 'v.10.1', 'v.9.2', 'v.12.1', 'v.11.1', 'v.11.2', 'v.12.2', 'v.13.1', 'v.13.2'],
+            'ids' => ['v.4.1', 'v.dal-2.1', 'v.dal-2.2', 'p.1', 'v.4.2', 'v.2.2', 'v.2.1', 'v.3.1', 'v.3.2', 'p.5', 'v.6.1', 'v.6.2', 'v.7.1', 'v.7.2', 'v.8.1', 'v.8.2', 'v.10.2', 'v.9.1', 'v.10.1', 'v.9.2', 'v.12.1', 'v.11.1', 'v.11.2', 'v.12.2', 'v.13.1', 'v.13.2'],
             'rules' => ['rule-b'],
         ];
 
         yield 'Test sorting with rule a+b' => [
-            'ids' => ['v.4.1', 'p.1', 'v.4.2', 'v.2.2', 'v.2.1', 'v.3.1', 'v.3.2', 'p.5', 'v.6.1', 'v.6.2', 'v.7.2', 'v.10.2', 'v.7.1', 'v.10.1', 'v.8.1', 'v.9.1', 'v.9.2', 'v.8.2', 'v.11.1', 'v.11.2', 'v.12.2', 'v.12.1', 'v.13.2', 'v.13.1'],
+            'ids' => ['v.4.1', 'v.dal-2.1', 'v.dal-2.2', 'p.1', 'v.4.2', 'v.2.2', 'v.2.1', 'v.3.1', 'v.3.2', 'p.5', 'v.6.1', 'v.6.2', 'v.7.2', 'v.10.2', 'v.7.1', 'v.10.1', 'v.8.1', 'v.9.1', 'v.9.2', 'v.8.2', 'v.11.1', 'v.11.2', 'v.12.2', 'v.12.1', 'v.13.2', 'v.13.1'],
             'rules' => ['rule-a', 'rule-b'],
         ];
 
         yield 'Test sorting with rule b+a' => [
-            'ids' => ['v.4.1', 'p.1', 'v.4.2', 'v.2.2', 'v.2.1', 'v.3.1', 'v.3.2', 'p.5', 'v.6.1', 'v.6.2', 'v.7.2', 'v.10.2', 'v.7.1', 'v.10.1', 'v.8.1', 'v.9.1', 'v.9.2', 'v.8.2', 'v.12.1', 'v.11.1', 'v.11.2', 'v.12.2', 'v.13.1', 'v.13.2'],
+            'ids' => ['v.4.1', 'v.dal-2.1', 'v.dal-2.2', 'p.1', 'v.4.2', 'v.2.2', 'v.2.1', 'v.3.1', 'v.3.2', 'p.5', 'v.6.1', 'v.6.2', 'v.7.2', 'v.10.2', 'v.7.1', 'v.10.1', 'v.8.1', 'v.9.1', 'v.9.2', 'v.8.2', 'v.12.1', 'v.11.1', 'v.11.2', 'v.12.2', 'v.13.1', 'v.13.2'],
             'rules' => ['rule-b', 'rule-a'],
         ];
     }
@@ -2086,6 +2086,48 @@ class ElasticsearchProductTest extends TestCase
         static::assertSame((string) $p->getTranslation('name'), $product['name']);
         static::assertSame((string) $p->getTranslation('description'), $product['description']);
         static::assertSame($p->getTranslation('customFields'), $product['customFields']);
+
+        // Fetch: Second language variant fallback to parent
+        $languageContext = new Context(new SystemSource(), [], Defaults::CURRENCY, [$ids->get('language-2'), $ids->get('language-1')]);
+        $languageContext->addExtensions($context->getExtensions());
+        $languageContext->setConsiderInheritance(true);
+        $products = $this->definition->fetch([$ids->getBytes('v.dal-2.1')], $languageContext);
+
+        $product = $products[$ids->get('v.dal-2.1')];
+
+        $p = $this->getContainer()->get('product.repository')->search(new Criteria([$ids->get('v.dal-2.1')]), $languageContext)->first();
+
+        static::assertSame((string) $p->getTranslation('name'), $product['name']);
+        static::assertSame((string) $p->getTranslation('description'), $product['description']);
+        static::assertSame($p->getTranslation('customFields'), $product['customFields']);
+
+        // Fetch: Fallback through parent to variant in other language
+        $languageContext = new Context(new SystemSource(), [], Defaults::CURRENCY, [$ids->get('language-3'), $ids->get('language-2')]);
+        $languageContext->addExtensions($context->getExtensions());
+        $languageContext->setConsiderInheritance(true);
+        $products = $this->definition->fetch([$ids->getBytes('v.dal-2.2')], $languageContext);
+
+        $product = $products[$ids->get('v.dal-2.2')];
+
+        $p = $this->getContainer()->get('product.repository')->search(new Criteria([$ids->get('v.dal-2.2')]), $languageContext)->first();
+
+        static::assertSame((string) $p->getTranslation('name'), $product['name']);
+        static::assertSame((string) $p->getTranslation('description'), $product['description']);
+        static::assertSame($p->getTranslation('customFields'), $product['customFields']);
+
+        // Fetch: Fallback to parent on null-entry
+        $languageContext = new Context(new SystemSource(), [], Defaults::CURRENCY, [$ids->get('language-1')]);
+        $languageContext->addExtensions($context->getExtensions());
+        $languageContext->setConsiderInheritance(true);
+        $products = $this->definition->fetch([$ids->getBytes('v.dal-2.2')], $languageContext);
+
+        $product = $products[$ids->get('v.dal-2.2')];
+
+        $p = $this->getContainer()->get('product.repository')->search(new Criteria([$ids->get('v.dal-2.2')]), $languageContext)->first();
+
+        static::assertSame((string) $p->getTranslation('name'), $product['name']);
+        static::assertSame((string) $p->getTranslation('description'), $product['description']);
+        static::assertSame($p->getTranslation('customFields'), $product['customFields']);
     }
 
     /**
@@ -2114,6 +2156,15 @@ class ElasticsearchProductTest extends TestCase
         static::assertSame(1.3, $product['width']);
         static::assertSame(2, $product['stock']);
         static::assertSame(0, $product['sales']);
+    }
+
+    /**
+     * @depends testIndexing
+     */
+    private function testLanguageFallback(IdsCollection $ids)
+    {
+        $products = $this->definition->fetch([$ids->getBytes('')], $this->createIndexingContext());
+
     }
 
     /**
@@ -2353,6 +2404,8 @@ class ElasticsearchProductTest extends TestCase
         $this->ids->set('language-1', $secondLanguage);
         $thirdLanguage = $this->createLanguage($secondLanguage);
         $this->ids->set('language-2', $thirdLanguage);
+        $fourthLanguage = $this->createLanguage();
+        $this->ids->set('language-3', $fourthLanguage);
 
         $this->getContainer()->get(Connection::class)->executeStatement('DELETE FROM custom_field');
 
@@ -2882,6 +2935,42 @@ class ElasticsearchProductTest extends TestCase
                 ->add('width', 1.3)
                 ->translation($secondLanguage, 'name', 'Second')
                 ->translation($thirdLanguage, 'name', 'Third')
+                ->build(),
+
+            (new ProductBuilder($this->ids, 'dal-2'))
+                ->name('Default')
+                ->category('pants')
+                ->customField('testField', 'Silk')
+                ->visibility(Defaults::SALES_CHANNEL)
+                ->tax('t1')
+                ->manufacturer('m1')
+                ->price(60)
+                ->releaseDate('2019-01-01 10:11:00')
+                ->purchasePrice(0)
+                ->stock(2)
+                ->category('c1')
+                ->category('c2')
+                ->property('red', 'color')
+                ->property('xl', 'size')
+                ->add('weight', 12.3)
+                ->add('height', 9.3)
+                ->add('width', 1.3)
+                ->translation($secondLanguage, 'name', 'Second')
+                ->translation($thirdLanguage, 'name', 'Third')
+                ->variant(
+                    (new ProductBuilder($this->ids, 'v.dal-2.1'))
+                        ->translation($secondLanguage, 'name', 'Variant 1 Second')
+                        ->translation($secondLanguage, 'description', 'Variant 1 Second Desc')
+                        ->build()
+                )
+                ->variant(
+                    (new ProductBuilder($this->ids, 'v.dal-2.2'))
+                        ->translation($secondLanguage, 'name', null)
+                        ->translation($secondLanguage, 'description', 'Variant 2 Second Desc')
+                        ->translation($thirdLanguage, 'name', 'Variant 2 Third')
+                        ->translation($thirdLanguage, 'description', 'Variant 2 Third Desc')
+                        ->build()
+                )
                 ->build(),
         ];
 


### PR DESCRIPTION
### 1. Why is this change necessary?

We found two issues that were introduced in the new ES indexing behaviour in 6.4:

- The translation resolution of the Elasticsearch Product Definition (EPD) did not work the same as in the DAL when it comes to variants: The behavior of the DAL first tries to find a translation for the current language on the variant, then on the variants parent. If it does not find those it tries the fallback language on the variant and then the fallback language on the parent.
The current behavior of the EPD first tries the whole language chain on the variant, then the whole language chain on the parent instead of alternating as DAL does.
- In addition, no fallbacks could be found for variants where there was no product_translation entry for the first language in the chain.

Note that in the documentation (https://developer.shopware.com/docs/guides/plugins/plugins/framework/data-handling/field-inheritance#translations) there is an alternative behaviour described than currently implemented in the DAL. For this PR we assumed the current implementation of the DAL to be correct.

### 2. What does this change do, exactly?

It rewrites the translation resolution query to work the same as DAL. Also, it adds test cases to test the desired behaviour.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a product variant without product translation for a language and with that language as first language in the chain.
2. Create a product variant with name and/or description linked to the parent product with an existing translation in a fallback language and index it.

For issue 1: The indexed product will have no translation.
For issue 2: The indexed product will have the fallback translation of the variant instead of the parent translation in the same language.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
