### PR TITLE
Allow null name from delivery time translation

### DIFF
--- a/changelog/_unreleased/2021-07-20-allow-null-values-in-delivery-time-name.md
+++ b/changelog/_unreleased/2021-07-20-allow-null-values-in-delivery-time-name.md
@@ -1,0 +1,8 @@
+---
+title:  Allow null name from delivery time translation
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+*  Added null modifier to return type in `getName` in `src/Core/System/DeliveryTime/DeliveryTimeEntity.php`

--- a/src/Core/System/DeliveryTime/DeliveryTimeEntity.php
+++ b/src/Core/System/DeliveryTime/DeliveryTimeEntity.php
@@ -52,7 +52,7 @@ class DeliveryTimeEntity extends Entity
      */
     protected $products;
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The definition of that field allows null value but the getter does not.

### 2. What does this change do, exactly?
Allow nullable return type for getName.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
