### PR TITLE
Also check mixed case SQL keywords in master slave check

### DIFF
--- a/changelog/_unreleased/2021-07-20-improved-debug-sql-checks-to-understand-mixed-cased-sqls.md
+++ b/changelog/_unreleased/2021-07-20-improved-debug-sql-checks-to-understand-mixed-cased-sqls.md
@@ -1,0 +1,8 @@
+---
+title: Check mixed case SQL keywords in master slave check
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+*  Added case insensitivity flag to regex in `\Shopware\Core\Profiling\Doctrine\DebugStack` to check for non-uppercased SQL statements

--- a/src/Core/Profiling/Doctrine/DebugStack.php
+++ b/src/Core/Profiling/Doctrine/DebugStack.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Logging\DebugStack as DoctrineDebugStack;
  */
 class DebugStack extends DoctrineDebugStack
 {
-    public static string $writeSqlRegex = '/^\s*(UPDATE|ALTER|BACKUP|CREATE|DELETE|DROP|EXEC|INSERT|TRUNCATE)/';
+    public static string $writeSqlRegex = '/^\s*(UPDATE|ALTER|BACKUP|CREATE|DELETE|DROP|EXEC|INSERT|TRUNCATE)/i';
 
     public function startQuery($sql, ?array $params = null, ?array $types = null): void
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
When you write your SQL with lower case or run your migrations in a non-dev environment, you won't run into this exception.

### 2. What does this change do, exactly?
It allows lower-cased SQL queries getting profiling tested(?).

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a dev environment
2. Write SQL update statement non SCREAMING CASE in a migration
3. Get no exception although "doing it wrong"

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
