### PR TITLE
Use non-prod check instead of dev check

### DIFF
--- a/changelog/_unreleased/2021-07-20-change-sql-logger-environment-check-from-dev-only-to-non-prod.md
+++ b/changelog/_unreleased/2021-07-20-change-sql-logger-environment-check-from-dev-only-to-non-prod.md
@@ -1,0 +1,9 @@
+---
+title: Change SQL logger environment check from dev-only to non-prod
+issue: NEXT-16479 
+author: Joshua Behrens
+author_email: behrens@heptacom.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed condition for SQL logger activation from dev-only to non-prod 

--- a/src/Core/HttpKernel.php
+++ b/src/Core/HttpKernel.php
@@ -200,7 +200,7 @@ class HttpKernel
 
         $connection = self::getConnection();
 
-        if ($this->environment === 'dev') {
+        if ($this->environment !== 'prod') {
             $connection->getConfiguration()->setSQLLogger(new DebugStack());
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The profiling testings(?) is only done on dev environment. It does not trigger on test environments. AFAIK it is more common to check for non-prod instead for a specific environment.

### 2. What does this change do, exactly?
Change `=== 'dev'` to `!== 'prod'`.

### 3. Describe each step to reproduce the issue or behaviour.
1. Run a test
2. Be in env test
3. Expect exception to happen
4. None

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
