### PR TITLE
fix es criteria parser

### DIFF
--- a/changelog/_unreleased/2021-07-25-fix-es-criteria-parser.md
+++ b/changelog/_unreleased/2021-07-25-fix-es-criteria-parser.md
@@ -1,10 +1,10 @@
 ---
-flag:
+title: Fix Elasticsearch CriteriaParser
 author: Pascal Josephy
 author_email: pascal.josephy@jkweb.ch
 author_github: pascaljosephy
 ---
-# Elasticsearch
+# Core
 *  Added method `src/Elasticsearch/Product/ElasticsearchProductDefinition:fetchPropertyGroups`
 *  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:fetch`
 *  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:getMapping`

--- a/changelog/_unreleased/2021-07-25-fix-es-criteria-parser.md
+++ b/changelog/_unreleased/2021-07-25-fix-es-criteria-parser.md
@@ -1,0 +1,12 @@
+---
+flag:
+author: Pascal Josephy
+author_email: pascal.josephy@jkweb.ch
+author_github: pascaljosephy
+---
+# Elasticsearch
+*  Added method `src/Elasticsearch/Product/ElasticsearchProductDefinition:fetchPropertyGroups`
+*  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:fetch`
+*  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:getMapping`
+*  Changed method `src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser:parseAggregation` to not handle nesting for FilterAggregation
+*  Changed method `src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser:parseFilterAggregation` to handle nested queries and aggregations

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -135,7 +135,7 @@ class CriteriaParser
 
         $esAggregation = $this->createAggregation($aggregation, $fieldName, $definition, $context);
 
-        if (!$path) {
+        if (!$path || $aggregation instanceof FilterAggregation) {
             return $esAggregation;
         }
 
@@ -182,9 +182,6 @@ class CriteriaParser
         $query = new BoolQuery();
         foreach ($aggregation->getFilter() as $filter) {
             $parsed = $this->parseFilter($filter, $definition, $definition->getEntityName(), $context);
-            if ($parsed instanceof NestedQuery) {
-                $parsed = $parsed->getQuery();
-            }
             $query->add($parsed);
         }
 
@@ -197,7 +194,7 @@ class CriteriaParser
         }
 
         $filter->addAggregation(
-            $this->parseNestedAggregation($nested, $definition, $context)
+            $this->parseAggregation($nested, $definition, $context)
         );
 
         return $filter;


### PR DESCRIPTION
### 1. Why is this change necessary?

There were a few issues in the `CriteriaParser` that builds Elasticsearch DSL queries from `Criteria` objects. Specifically, this PR fixes at least two issues:

* https://issues.shopware.com/issues/NEXT-16385
* https://issues.shopware.com/issues/NEXT-15038

### 2. What does this change do, exactly?

To fix https://issues.shopware.com/issues/NEXT-15038:

There was a general issue in how aggregations were translated to Elasticsearch DSL aggregations. If the field of an aggregation was a nested field, the whole aggregation was wrapped in a nested block, for example like this: 


```
          "options-filtered": {
            "nested": {
                "path": "options"
            },
            "aggregations": {
                "options-filtered": {
                    "filter": {
                        "terms": {
                            "manufacturerId": [
                                "4f81ed4a0f3e4e99a57778aeab40d622"
                            ]
                        }
                    },
                    "aggregations": {
                        "options": {
                            "terms": {
                                "field": "options.id",
                                "size": 10000
                            }
                        }
                    }
                }
            }
        }
```

However, as the filter can be on a property in a completely different path, this can not be generally done with filter aggregations. Therefore, we changed the implementation of `parseAggregation` to make an exception for `FilterAggregation` and instead consider the nesting in the method `parseFilterAggregation` directly. Using this change, the above DAL query translates now correctly to:

```
          "options-filtered": {
            "filter": {
                "terms": {
                    "manufacturerId": [
                        "4f81ed4a0f3e4e99a57778aeab40d622"
                    ]
                }
            },
            "aggregations": {
                "options": {
                    "nested": {
                        "path": "options"
                    },
                    "aggregations": {
                        "options": {
                            "terms": {
                                "field": "options.id",
                                "size": 10000
                            }
                        }
                    }
                }
            }
        }
```

To fix https://issues.shopware.com/issues/NEXT-16385:

The property whitelist is implemented in the `ProductListingFeaturesSubscriber` (https://github.com/shopware/platform/blob/trunk/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php#L505) and uses the aggregation `product.properties.groupId`. We therefore extend the product definition for Elasticsearch to also store the groupId of properties and options. 

Furthermore, there was another error parsing the `FilterAggregation` in the DAL. If the filter query used a nested property, the resulting Elasticsearch DSL looked like this:

```
        "properties-filter": {
            "nested": {
                "path": "properties"
            },
            "aggregations": {
                "properties-filter": {
                    "filter": {
                        "terms": {
                            "properties.groupId": [
                                "a7b61971d67a474eb2bc281f9e4d5ee2"
                            ]
                        }
                    },
                    "aggregations": {
                        "properties": {
                            "terms": {
                                "field": "properties.id",
                                "size": 10000
                            }
                        }
                    }
                }
            }
        },
```

The filter query contains a nested property, which for some reason is removed from the Elasticsearch DSL in the method `parseFilterAggregation` (https://github.com/shopware/platform/blob/6366e824106d4a5ec080a3ca7a1119b0beaa8cc7/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php#L185). As nested queries are now handled directly inside the aggregation of the `FilterAggregation`, the nested query should be used directly. This leads to the correct DSL:

```
        "properties-filter": {
            "filter": {
                "nested": {
                    "path": "properties",
                    "query": {
                        "terms": {
                            "properties.groupId": [
                                "a7b61971d67a474eb2bc281f9e4d5ee2"
                            ]
                        }
                    }
                }
            },
            "aggregations": {
                "properties": {
                    "nested": {
                        "path": "properties"
                    },
                    "aggregations": {
                        "properties": {
                            "terms": {
                                "field": "properties.id",
                                "size": 10000
                            }
                        }
                    }
                }
            }
        },
```

General remark: We just fixed the two linked issues - it might be that there are other / new issues with these fixes. It would be an idea to add some formal tests to the criteria parser to ensure it's correctness also for future scenarios.

### 3. Describe each step to reproduce the issue or behaviour.

See the related issues for steps to reproduce.

### 4. Please link to the relevant issues (if any).

* https://issues.shopware.com/issues/NEXT-16385
* https://issues.shopware.com/issues/NEXT-15038

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
