### PR TITLE
Add umask support for HTMLPurifier cache files

### DIFF
--- a/changelog/_unreleased/2021-07-26-html-purifier-respect-umask.md
+++ b/changelog/_unreleased/2021-07-26-html-purifier-respect-umask.md
@@ -1,0 +1,7 @@
+---
+title: Html Purifier respect umask
+author_email: ingowalther@iwebspace.net
+author_github: ingowalther
+---
+# Storefront
+* Add `$config->set('Cache.SerializerPermissions', 0775 & ~umask());` to  `src/Core/Framework/Util/HtmlSanitizer.php`

--- a/changelog/_unreleased/2021-07-26-html-purifier-respect-umask.md
+++ b/changelog/_unreleased/2021-07-26-html-purifier-respect-umask.md
@@ -1,7 +1,8 @@
 ---
 title: Html Purifier respect umask
+author: Ingo Walther
 author_email: ingowalther@iwebspace.net
 author_github: ingowalther
 ---
 # Storefront
-* Add `$config->set('Cache.SerializerPermissions', 0775 & ~umask());` to  `src/Core/Framework/Util/HtmlSanitizer.php`
+* Added `$config->set('Cache.SerializerPermissions', 0775 & ~umask());` to  `src/Core/Framework/Util/HtmlSanitizer.php` (Mode 0775: Owner can read, write and execute, Group can read, write and execute, Everyone who is not in the group, and not the owner, can read and execute)

--- a/src/Core/Framework/Util/HtmlSanitizer.php
+++ b/src/Core/Framework/Util/HtmlSanitizer.php
@@ -70,6 +70,8 @@ class HtmlSanitizer
             $config->set('Cache.DefinitionImpl', null);
         }
 
+        $config->set('Cache.SerializerPermissions', 0775 & ~umask());
+
         return $config;
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
HTMLPurifier does not respect umask. The permission for the files (not directories) will be set to "0644".

### 2. What does this change do, exactly?
Add support for umask.

### 3. Describe each step to reproduce the issue or behaviour.
Request a page in the store front.
Check the permissions in the cache/HTML and cache/URL folders.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1975

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
