### PR TITLE
NEXT-8566 Fix mailto/fax/tel links in WYSIWYG editor

### DIFF
--- a/changelog/_unreleased/2021-07-27-add-mailto-fax-tel-links.md
+++ b/changelog/_unreleased/2021-07-27-add-mailto-fax-tel-links.md
@@ -1,0 +1,9 @@
+---
+title: Fix mailto/fax/tel links in WYSIWYG editor
+issue: NEXT-16215
+author: Rune Laenen
+author_email:  rune@laenen.me
+author_github: runelaenen
+---
+# Administration
+* Changed regex in `addProtocol` function in `src/app/component/form/sw-text-editor/sw-text-editor-toolbar/index.js`

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/index.js
@@ -390,7 +390,7 @@ Component.register('sw-text-editor-toolbar', {
         },
 
         addProtocol(link) {
-            if (/^(\w+):\/\//.test(link)) {
+            if (/(^(\w+):\/\/)|(mailto:)|(fax:)|(tel:)/.test(link)) {
                 return link;
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To fix issue https://issues.shopware.com/issues/NEXT-8566

### 2. What does this change do, exactly?
Update the REGEX to also detect 'mailto:', 'fax:' and 'tel:' links

### 3. Describe each step to reproduce the issue or behaviour.
Add a 'mailto:test@example.com' link in the wysiwyg editor. It will add http:// in front of it.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-8566

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
