### PR TITLE
Fix loaders not being applied to non-entrypoint/symlinked module files

### DIFF
--- a/changelog/_unreleased/2021-07-27-Fix-babel-loader-and-eslint-loader-includes.md
+++ b/changelog/_unreleased/2021-07-27-Fix-babel-loader-and-eslint-loader-includes.md
@@ -1,0 +1,10 @@
+---
+title: Fix babel-loader and eslint-loader includes
+issue: NEXT-16458
+author: Carl Kittelberger
+author_email: icedream@icedream.pw 
+author_github: icedream
+---
+# Administration
+* Fix Babel not being used for JavaScript files that are installed via symbolic links (for example via Composer repositories of type `path`).
+* Fix ESLint not being used for JavaScript files that are not entrypoints or that are installed via symbolic links.

--- a/src/Administration/Resources/app/administration/webpack.config.js
+++ b/src/Administration/Resources/app/administration/webpack.config.js
@@ -216,7 +216,7 @@ const webpackConfig = {
                     include: [
                         path.resolve(__dirname, 'src'),
                         path.resolve(__dirname, 'test'),
-                        ...pluginEntries.map(plugin => plugin.filePath)
+                        ...pluginEntries.map(plugin => fs.realpathSync(plugin.path))
                     ],
                     options: {
                         configFile: path.join(__dirname, '.eslintrc.js'),
@@ -234,7 +234,7 @@ const webpackConfig = {
                 include: [
                     path.resolve(__dirname, 'src'),
                     path.resolve(__dirname, 'test'),
-                    ...pluginEntries.map(plugin => plugin.path)
+                    ...pluginEntries.map(plugin => fs.realpathSync(plugin.path))
                 ],
                 options: {
                     compact: true,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Currently, for the Administration Webpack setup, the `babel-loader` and the `eslint-loader` are only applied to Shopware JavaScript files or the plugin entrypoint JavaScript file, with the `babel-loader` also applying to other module JavaScript files whereas `eslint-loader` does not. They do not apply at all to paths for modules that have been installed as *symlinks* via Composer (this happens by default when a package is installed via a repository of type `path`).

This leads to script errors being missed, and ECMAScript features that would otherwise be transpiled by Babel not being usable in symlinked modules.

### 2. What does this change do, exactly?

It fixes up the list of `include` paths for both `babel-loader` and `eslint-loader` in the Administration Webpack configuration, so all JavaScript files of a plugin are considered for applying these loaders.

### 3. Describe each step to reproduce the issue or behaviour.

Specifically for the `babel-loader`:

1. In a symlinked plugin, create a JavaScript file with the content `console.log(window?.a);` - this should make Babel transpile this code via the [optional chaining plugin](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining) that is by default loaded in via `@babel/preset-env` as included in the Webpack configuration.
2. Use any of the build scripts and watch the Webpack output - it will fail with the error message `Module parse failed: Unexpected token` and `You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file.`.

For the `eslint-loader` you can write a JavaScript file with some lint errors, for example missing semicolons, and place it in some path inside a module that is either symlinked or not an entrypoint JavaScript path. ESLint will not detect that error. In a module that is *not* symlinked, you can move that erroneous JavaScript into the entrypoint JavaScript file and only then ESLint will throw an error.

### 4. Please link to the relevant issues (if any).

Part of this problem has been dealt with in https://github.com/shopware/platform/commit/4802b98f8d72d85c27b20b6fdfd72be2f4b23b98. It lists `NEXT-15085` as a ticket but I can't find it, and I haven't created a ticket for this yet myself. It also only fixed modules that were not symlinked and it didn't fix the include list for `eslint-loader` at all.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
