### PR TITLE
Added new event to validate entity payload before write

### DIFF
--- a/changelog/_unreleased/2021-07-29-entity-before-write-event.md
+++ b/changelog/_unreleased/2021-07-29-entity-before-write-event.md
@@ -1,0 +1,11 @@
+---
+title: Added new event to validate entity payload before write
+issue: 1983
+author: Philipp Georg
+author_email: info@moorleiche.com
+author_github: moorl
+---
+# Core
+* new class `\Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWritePayloadEvent`
+* `\Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter` added `EventDispatcher` service
+* `\Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter::write` added `EntityWritePayloadEvent`

--- a/src/Core/Framework/DataAbstractionLayer/Event/EntityWritePayloadEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/EntityWritePayloadEvent.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\Event\GenericEvent;
+use Shopware\Core\Framework\Event\NestedEvent;
+
+class EntityWritePayloadEvent extends NestedEvent implements GenericEvent
+{
+    protected array $payload;
+
+    protected Context $context;
+
+    protected EntityDefinition $definition;
+
+    protected string $name;
+
+    public function __construct(EntityDefinition $definition, array $payload, Context $context)
+    {
+        $this->payload = $payload;
+        $this->context = $context;
+        $this->definition = $definition;
+
+        $this->name = $this->definition->getEntityName() . '.write.payload';
+    }
+
+    /**
+     * @param array $payload
+     */
+    public function setPayload(array $payload): void
+    {
+        $this->payload = $payload;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @return EntityDefinition
+     */
+    public function getDefinition(): EntityDefinition
+    {
+        return $this->definition;
+    }
+
+    /**
+     * @return Context
+     */
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
+++ b/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
@@ -125,6 +125,7 @@
             <argument type="service" id="Shopware\Core\System\Language\LanguageLoader"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteResultFactory"/>
+            <argument type="service" id="Symfony\Component\EventDispatcher\EventDispatcherInterface"/>
         </service>
 
         <service id="Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteResultFactory">


### PR DESCRIPTION
### 1. Why is this change necessary?

This change serves plugin developers the possibility to pre-validate entity payloads before they are written to the database. For example if I have mandatories to the entity data.

**Note:** I will also put a new event to pre-validate entities before deletion in the next pull request.

### 2. What does this change do, exactly?

* new event class `\Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWritePayloadEvent`
* `\Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter` added `EventDispatcher` as service
* `\Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter::sync` added `EntityWritePayloadEvent`
* `\Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter::write` added `EntityWritePayloadEvent`

Example Subscriber:

```php
    public function onEntityWritePayload(EntityWritePayloadEvent $event) {
        foreach (MyMarketplace::MARKETPLACE_MANDATORIES as $table) {
            if ($event->getDefinition()->getEntityName() === $table) {
                dump($event->getPayload());exit; // Simple dump() to test
            }
        }
    }
```

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/platform/issues/1983#issuecomment-888021277

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
