### PR TITLE
Grid columns order was not restored

### DIFF
--- a/changelog/_unreleased/2021-07-30-fix-column-order-data-grid.md
+++ b/changelog/_unreleased/2021-07-30-fix-column-order-data-grid.md
@@ -1,0 +1,9 @@
+---
+title: Grid columns order was not restored
+issue:
+author: Pascal Josephy
+author_email: pascal.josephy@jkweb.ch
+author_github: pascaljosephy
+---
+# Administration
+*  Changed `sw-data-grid/index.js` to restore order of columns in stored user settings

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/index.js
@@ -374,6 +374,7 @@ Component.register('sw-data-grid', {
                         visible: column.visible,
                         align: column.visible,
                         naturalSorting: column.naturalSorting,
+                        position: Object.keys(obj).length,
                     },
                 };
             }, {});
@@ -391,6 +392,12 @@ Component.register('sw-data-grid', {
 
                         return localValue;
                     });
+            }).sort((columnA, columnB) => {
+                const positionA = userColumnSettings[columnA.dataIndex] !== undefined ?
+                    userColumnSettings[columnA.dataIndex].position : -1;
+                const positionB = userColumnSettings[columnB.dataIndex] !== undefined ?
+                    userColumnSettings[columnB.dataIndex].position : -1;
+                return positionA - positionB;
             });
         },
 

--- a/src/Administration/Resources/app/administration/test/app/component/data-grid/sw-data-grid.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/component/data-grid/sw-data-grid.spec.js
@@ -182,8 +182,8 @@ describe('components/data-grid/sw-data-grid', () => {
 
 
         // check default columns
-        expect(wrapper.vm.currentColumns[0].visible).toBe(defaultUserConfig.value.columns[0].visible);
-        expect(wrapper.vm.currentColumns[1].visible).toBe(defaultUserConfig.value.columns[1].visible);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'name').visible).toBe(defaultUserConfig.value.columns[0].visible);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'company').visible).toBe(defaultUserConfig.value.columns[1].visible);
 
         expect(wrapper.vm.compact).toBe(defaultUserConfig.value.compact);
         expect(wrapper.vm.previews).toBe(defaultUserConfig.value.previews);
@@ -194,7 +194,7 @@ describe('components/data-grid/sw-data-grid', () => {
         const name = wrapper.find('.sw-data-grid__settings-item--0 input');
         await name.setChecked(valueChecked);
 
-        expect(wrapper.vm.currentColumns[0].visible).toBe(valueChecked);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'name').visible).toBe(valueChecked);
     });
 
     it('remove property in client', async () => {
@@ -252,8 +252,8 @@ describe('components/data-grid/sw-data-grid', () => {
 
 
         // check default columns
-        expect(wrapper.vm.currentColumns[0].visible).toBe(false);
-        expect(wrapper.vm.currentColumns[1]).toBe(undefined);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'name').visible).toBe(false);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'company')).toBe(undefined);
 
         expect(wrapper.vm.compact).toBe(true);
         expect(wrapper.vm.previews).toBe(true);
@@ -309,8 +309,8 @@ describe('components/data-grid/sw-data-grid', () => {
 
 
         // check default columns
-        expect(wrapper.vm.currentColumns[0].visible).toBe(false);
-        expect(wrapper.vm.currentColumns[1].visible).toBe(true);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'name').visible).toBe(false);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'company').visible).toBe(true);
 
         expect(wrapper.vm.compact).toBe(true);
         expect(wrapper.vm.previews).toBe(true);
@@ -370,8 +370,8 @@ describe('components/data-grid/sw-data-grid', () => {
 
 
         // check default columns
-        expect(wrapper.vm.currentColumns[0].visible).toBe(false);
-        expect(wrapper.vm.currentColumns[0].mockProperty).toBe(true);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'name').visible).toBe(false);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'name').mockProperty).toBe(true);
 
         expect(wrapper.vm.compact).toBe(true);
         expect(wrapper.vm.previews).toBe(true);
@@ -427,8 +427,8 @@ describe('components/data-grid/sw-data-grid', () => {
 
 
         // check default columns
-        expect(wrapper.vm.currentColumns[0].visible).toBe(false);
-        expect(wrapper.vm.currentColumns[0].mockProperty).toBe(undefined);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'name').visible).toBe(false);
+        expect(wrapper.vm.currentColumns.find(e => e.dataIndex === 'name').mockProperty).toBe(undefined);
 
 
         expect(wrapper.vm.compact).toBe(true);


### PR DESCRIPTION
### 1. Why is this change necessary?

Since NEXT-9589, the column visibility is stored in the database, not in the local storage. However, only the options such as visibility were restored. The order of the columns was reset.

### 2. What does this change do, exactly?

It adds the field `position` to the column object in order to apply the sorting that is stored in the database.

### 3. Describe each step to reproduce the issue or behaviour.

- Go to any data grid (e.g. order list)
- Reorder and hide some columns
- Refresh the page
- The hidden columns are still hidden, but the order is reset

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
