### PR TITLE
NEXT-16526 fixes nullable return type in OAuth/ScopeRepo

### DIFF
--- a/changelog/_unreleased/2021-08-05-fixes-nullable-return-type-hint-in-oauth-scoperepo.md
+++ b/changelog/_unreleased/2021-08-05-fixes-nullable-return-type-hint-in-oauth-scoperepo.md
@@ -1,0 +1,9 @@
+---
+title: Fixes nullable return type for OAuth/ScopeRepository
+issue: NEXT-16526
+author: Rico Neitzel
+author_email: rico@run-as-root.sh
+author_github: @riconeitzel
+---
+# Core
+* Changed `Core\Framework\Api\OAuth\ScopeRepository`::`getScopeEntityByIdentifier()` to support a null return value

--- a/src/Core/Framework/Api/OAuth/ScopeRepository.php
+++ b/src/Core/Framework/Api/OAuth/ScopeRepository.php
@@ -40,7 +40,7 @@ class ScopeRepository implements ScopeRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getScopeEntityByIdentifier($identifier): ScopeEntityInterface
+    public function getScopeEntityByIdentifier($identifier): ?ScopeEntityInterface
     {
         return $this->scopes[$identifier] ?? null;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Code Smell - function can return null but return type was not nullable

### 2. What does this change do, exactly?

nullables the return type

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.