### PR TITLE
Don't watch vendor admin js as it can be uglified

### DIFF
--- a/changelog/_unreleased/2021-08-01-dont-watch-vendor-admin-js-as-it-can-be-uglified.md
+++ b/changelog/_unreleased/2021-08-01-dont-watch-vendor-admin-js-as-it-can-be-uglified.md
@@ -1,0 +1,9 @@
+---
+title: Don't watch vendor admin js as it can be uglified
+issue: 
+author: Tommy Quissens
+author_email: tommy.quissens@gmail.com
+author_github: Tommy Quissens
+---
+# Administration
+* The admin watcher breaks when there are linting errors in the vendor directory. This change excludes the admin js from the linting check

--- a/src/Administration/Resources/app/administration/webpack.config.js
+++ b/src/Administration/Resources/app/administration/webpack.config.js
@@ -211,7 +211,7 @@ const webpackConfig = {
                     include: [
                         path.resolve(__dirname, 'src'),
                         path.resolve(__dirname, 'test'),
-                        ...pluginEntries.map(plugin => fs.realpathSync(plugin.filePath))
+                        ...pluginEntries.filter(plugin => !plugin.basePath.includes('vendor')).map(plugin => fs.realpathSync(plugin.filePath))
                     ],
                     options: {
                         configFile: path.join(__dirname, '.eslintrc.js'),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The admin watcher breaks when there are linting errors in the vendor directory.

### 2. What does this change do, exactly?
Filters admin js entrypoints which are located in the vendor directory.

### 3. Describe each step to reproduce the issue or behaviour.
Start the admin watcher with lint errors in the vendor map

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
