### PR TITLE
Beautify app modal

### DIFF
--- a/changelog/_unreleased/2021-08-02-beautify-app-modal.md
+++ b/changelog/_unreleased/2021-08-02-beautify-app-modal.md
@@ -1,0 +1,8 @@
+---
+title: Prevent error in loading plugin administration files from crashing the administration.
+author: Niklas Büchner
+author_email: code@niklasbuechner.de
+author_github: niklasbuechner
+---
+# Administration
+* Beautifies the app modal by removing the iframe border and by allowing the title to be wider than 30px if there is no icon.

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/sw-app-actions.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/sw-app-actions.scss
@@ -26,7 +26,7 @@
 
         .sw-modal__title {
             display: grid;
-            grid-template-columns: 30px auto;
+            grid-template-columns: auto auto;
             align-items: center;
             justify-items: stretch;
             justify-content: stretch;
@@ -42,6 +42,7 @@
         .sw-app-action-button-iframe {
             width: 100%;
             height: 100%;
+            border: none;
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

This change enhances the design of the app modal. Firstly, it allows the title to be wider than 30px if there is no app icon. Secondly, the pr removes the border around the modal window in order to enhance the overall appearance.

Before:
<img width="1328" alt="Screenshot 2021-08-02 at 20 05 53" src="https://user-images.githubusercontent.com/31041526/127904880-460a596c-120b-4f90-b361-21d6f3585238.png">

After:
<img width="1328" alt="Screenshot 2021-08-02 at 20 02 20" src="https://user-images.githubusercontent.com/31041526/127904572-fee85479-a38a-4a71-9b58-3a5bd1c06ae2.png">


### 2. What does this change do, exactly?
- It allows the title to be wider than 30px if there is no icon. (An in case of an icon, the icon is still only 30px wide.)
- If removes the border around the iframe.


### 3. Describe each step to reproduce the issue or behaviour.
- Create an app with an action button that opens a modal.
- Open the modal.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
