### PR TITLE
Use app label not technical name in app modal

### DIFF
--- a/changelog/_unreleased/2020-08-02-show-label-in-app-modal.md
+++ b/changelog/_unreleased/2020-08-02-show-label-in-app-modal.md
@@ -1,0 +1,8 @@
+---
+title: Show app label in app modal instead of technical name
+author: Niklas Büchner
+author_email: code@niklasbuechner.de
+author_github: niklasbuechner
+---
+# Administration
+* Shows the app label in the app modal of a action button instead of the app's technical name.

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/index.js
@@ -1,7 +1,7 @@
 import template from './sw-app-actions.html.twig';
 import './sw-app-actions.scss';
 
-const { Component, Mixin } = Shopware;
+const { Component, Context, Mixin, State } = Shopware;
 const { Criteria } = Shopware.Data;
 
 const actionTypeConstants = Object.freeze({
@@ -81,6 +81,17 @@ Component.register('sw-app-actions', {
             criteria.addFilter(Criteria.equals('userId', this.currentUser?.id));
 
             return criteria;
+        },
+
+        appLabel() {
+            if (!this.action) {
+                return '';
+            }
+
+            const currentLocale = State.get('session').currentLocale;
+            const fallbackLocale = Context.app.fallbackLocale;
+
+            return this.action.appLabel[currentLocale] || this.action.appLabel[fallbackLocale] || '';
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/sw-app-actions.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/sw-app-actions.html.twig
@@ -42,7 +42,7 @@
                     class="sw-app-action-button__icon"
                     :src="`data:image/png;base64, ${action.icon}`"
                 >
-                <span>{{ action.app }}</span>
+                <span>{{ appLabel }}</span>
             </div>
             {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently the app modal shows the app's technical name as title. That should be the app's label.

### 2. What does this change do, exactly?

If makes the modal show the correct title.

### 3. Describe each step to reproduce the issue or behaviour.

- Create an app which opens a modal.
- Look at the title.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
