### PR TITLE
Fix breadcrumb structured data

### DIFF
--- a/changelog/_unreleased/2021-08-03-fix-breadcrumb-structured-data.md
+++ b/changelog/_unreleased/2021-08-03-fix-breadcrumb-structured-data.md
@@ -1,0 +1,9 @@
+---
+title: Fix breadcrumb structured data
+issue:
+author: Pascal Josephy
+author_email: pascal.josephy@jkweb.ch
+author_github: pascaljosephy
+---
+# Storefront
+*  Fixed structured data in `Shopware\Storefront\Resources\views\storefront\layout\breadcrumb.html.twig`

--- a/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
@@ -27,7 +27,7 @@
                                     itemscope
                                     itemtype="https://schema.org/ListItem">
                                     {% if breadcrumbCategory.type == 'folder' %}
-                                        <div>{{ name }}</div>
+                                        <div itemprop="name">{{ name }}</div>
                                     {% else %}
                                         <a href="{{ category_url(breadcrumbCategory) }}"
                                            class="breadcrumb-link {% if key is same as(categoryId) %} is-active{% endif %}"
@@ -38,8 +38,8 @@
                                                   href="{{ category_url(breadcrumbCategory) }}"/>
                                             <span class="breadcrumb-title" itemprop="name">{{ name }}</span>
                                         </a>
-                                        <meta itemprop="position" content="{{ breadcrumbCategory.id }}"/>
                                     {% endif %}
+                                    <meta itemprop="position" content="{{ loop.index }}"/>
                                 </li>
                             {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The structured data for the breadcrumb list was wrong:

- The position was no integer
- The position for `folder` types was missing
- The name for `folder` types was missing

Remark: Still for `folder` types the `item` field is missing (see https://developers.google.com/search/docs/data-types/breadcrumb#breadcrumb-list for details), but as the category shouldn't have a link we ignore this for now.

### 2. What does this change do, exactly?

It changes the twig template.

### 3. Describe each step to reproduce the issue or behaviour.

- Setup shop
- Setup one root category as `folder`
- Run https://search.google.com/test/rich-results on any product in that root category

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
