### PR TITLE
NEXT-16508 - Fixed entity exists and not validators work correctly with composite constraints.

### DIFF
--- a/changelog/_unreleased/2021-08-04-fixed-entity-exists-validators-work-with-composite-constraint.md
+++ b/changelog/_unreleased/2021-08-04-fixed-entity-exists-validators-work-with-composite-constraint.md
@@ -1,0 +1,11 @@
+---
+title: Fixed entity exists and not validators work correctly with composite constraints.
+issue: NEXT-16508
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed `EntityExistsValidator` and `EntityNotExistsValidator` to work in combination with composite constraints like Symfony's `All` constraint by cloning the criteria object.
+* Changed `EntityNotExistsValidator` to only be valid, if the expected entity does not exist.
+* Changed `EntityExistsValidator` and `EntityNotExistsValidator` to only include one entity in the result as that is enough to determine exists for non `id` property searches.

--- a/src/Core/Framework/DataAbstractionLayer/Validation/EntityExistsValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Validation/EntityExistsValidator.php
@@ -39,12 +39,16 @@ class EntityExistsValidator extends ConstraintValidator
 
         $definition = $this->definitionRegistry->getByEntityName($constraint->getEntity());
 
-        $criteria = $constraint->getCriteria();
+        $criteria = clone $constraint->getCriteria();
         $criteria->addFilter(new EqualsFilter($constraint->getPrimaryProperty(), $value));
+
+        // Only one entity is enough to determine existence.
+        // As the property can be set in the constraint, the search above does not necessarily return just one entity.
+        $criteria->setLimit(1);
 
         $result = $this->entitySearcher->search($definition, $criteria, $constraint->getContext());
 
-        if ($result->getTotal()) {
+        if ($result->getTotal() > 0) {
             return;
         }
 

--- a/src/Core/Framework/Test/DataAbstractionLayer/Validation/EntityExistsValidatorTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Validation/EntityExistsValidatorTest.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Validation;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
+use Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
+use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Locale\LocaleDefinition;
+use Symfony\Component\Validator\Constraints\All;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorBuilder;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class EntityExistsValidatorTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testCriteriaObjectIsNotModified(): void
+    {
+        $validator = $this->getValidator();
+
+        $criteria = new Criteria();
+        $criteria->setLimit(50);
+
+        $context = Context::createDefaultContext();
+
+        $constraint = new EntityExists(
+            ['context' => $context, 'entity' => LocaleDefinition::ENTITY_NAME, 'criteria' => $criteria]
+        );
+
+        $validator->validate(Uuid::randomHex(), [$constraint]);
+
+        static::assertCount(0, $criteria->getFilters());
+        static::assertSame(50, $criteria->getLimit());
+    }
+
+    public function testValidatorWorks(): void
+    {
+        $repository = $this->createRepository(LocaleDefinition::class);
+
+        $context = Context::createDefaultContext();
+        $id1 = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+
+        $repository->create(
+            [
+                ['id' => $id1, 'name' => 'Test 1', 'territory' => 'test', 'code' => 'test' . $id1],
+                ['id' => $id2, 'name' => 'Test 2', 'territory' => 'test', 'code' => 'test' . $id2],
+            ],
+            $context
+        );
+
+        $validator = $this->getValidator();
+        $constraint = new EntityExists(
+            ['context' => $context, 'entity' => LocaleDefinition::ENTITY_NAME]
+        );
+
+        $violations = $validator->validate($id1, $constraint);
+        // Entity exists and therefore there are no violations.
+        static::assertCount(0, $violations);
+
+        $violations = $validator->validate($id2, $constraint);
+        // Entity exists and therefore there are no violations.
+        static::assertCount(0, $violations);
+
+        $violations = $validator->validate(Uuid::randomHex(), $constraint);
+        // Entity does not exist and therefore there is one violation.
+        static::assertCount(1, $violations);
+    }
+
+    public function testValidatorWorksWithCompositeConstraint(): void
+    {
+        $repository = $this->createRepository(LocaleDefinition::class);
+
+        $context = Context::createDefaultContext();
+        $id1 = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+
+        $repository->create(
+            [
+                ['id' => $id1, 'name' => 'Test 1', 'territory' => 'test', 'code' => 'test' . $id1],
+                ['id' => $id2, 'name' => 'Test 2', 'territory' => 'test', 'code' => 'test' . $id2],
+            ],
+            $context
+        );
+
+        $validator = $this->getValidator();
+
+        $constraint = new All(
+            [
+                'constraints' => [
+                    new EntityExists(
+                        ['context' => $context, 'entity' => LocaleDefinition::ENTITY_NAME]
+                    ),
+                ],
+            ]
+        );
+
+        $violations = $validator->validate([$id1, $id2], [$constraint]);
+
+        // No violations as both entities exist.
+        static::assertCount(0, $violations);
+
+        $violations = $validator->validate([$id1, Uuid::randomHex(), $id2], [$constraint]);
+
+        // One violation as one does not exist.
+        static::assertCount(1, $violations);
+    }
+
+    protected function createRepository(string $definition): EntityRepository
+    {
+        return new EntityRepository(
+            $this->getContainer()->get($definition),
+            $this->getContainer()->get(EntityReaderInterface::class),
+            $this->getContainer()->get(VersionManager::class),
+            $this->getContainer()->get(EntitySearcherInterface::class),
+            $this->getContainer()->get(EntityAggregatorInterface::class),
+            $this->getContainer()->get(EventDispatcherInterface::class),
+            $this->getContainer()->get(EntityLoadedEventFactory::class)
+        );
+    }
+
+    protected function getValidator(): ValidatorInterface
+    {
+        return $this->getValidatorBuilder()->getValidator();
+    }
+
+    protected function getValidatorBuilder(): ValidatorBuilder
+    {
+        return $this->getContainer()->get('validator.builder');
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Validation/EntityNotExistsValidatorTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Validation/EntityNotExistsValidatorTest.php
@@ -1,0 +1,141 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Validation;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
+use Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityNotExists;
+use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Locale\LocaleDefinition;
+use Symfony\Component\Validator\Constraints\All;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Component\Validator\ValidatorBuilder;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class EntityNotExistsValidatorTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testCriteriaObjectIsNotModified(): void
+    {
+        $criteria = new Criteria();
+        $criteria->setLimit(50);
+
+        $context = Context::createDefaultContext();
+        $constraint = new EntityNotExists(
+            ['context' => $context, 'entity' => LocaleDefinition::ENTITY_NAME, 'criteria' => $criteria]
+        );
+
+        $validator = $this->getValidator();
+
+        $validator->validate(Uuid::randomHex(), $constraint);
+
+        static::assertCount(0, $criteria->getFilters());
+        static::assertSame(50, $criteria->getLimit());
+    }
+
+    public function testValidatorWorks(): void
+    {
+        $repository = $this->createRepository(LocaleDefinition::class);
+
+        $context = Context::createDefaultContext();
+        $id1 = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+
+        $repository->create(
+            [
+                ['id' => $id1, 'name' => 'Test 1', 'territory' => 'test', 'code' => 'test' . $id1],
+                ['id' => $id2, 'name' => 'Test 2', 'territory' => 'test', 'code' => 'test' . $id2],
+            ],
+            $context
+        );
+
+        $validator = $this->getValidator();
+
+        $constraint = new EntityNotExists(
+            ['context' => $context, 'entity' => LocaleDefinition::ENTITY_NAME]
+        );
+
+        $violations = $validator->validate($id1, $constraint);
+        // Entity exists and therefore there is one violation.
+        static::assertCount(1, $violations);
+
+        $violations = $validator->validate($id2, $constraint);
+        // Entity exists and therefore there is one violation.
+        static::assertCount(1, $violations);
+
+        $violations = $validator->validate(Uuid::randomHex(), $constraint);
+        // Entity does not exist and therefore there are no violations.
+        static::assertCount(0, $violations);
+    }
+
+    public function testValidatorWorksWithCompositeConstraint(): void
+    {
+        $repository = $this->createRepository(LocaleDefinition::class);
+
+        $context = Context::createDefaultContext();
+        $id1 = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+
+        $repository->create(
+            [
+                ['id' => $id1, 'name' => 'Test 1', 'territory' => 'test', 'code' => 'test' . $id1],
+                ['id' => $id2, 'name' => 'Test 2', 'territory' => 'test', 'code' => 'test' . $id2],
+            ],
+            $context
+        );
+
+        $validator = $this->getValidator();
+
+        $constraint = new All(
+            [
+                'constraints' => [
+                    new EntityNotExists(
+                        ['context' => $context, 'entity' => LocaleDefinition::ENTITY_NAME]
+                    ),
+                ],
+            ]
+        );
+
+        $violations = $validator->validate([Uuid::randomHex(), Uuid::randomHex()], $constraint);
+
+        // No violations as both entities do not exist.
+        static::assertCount(0, $violations);
+
+        $violations = $validator->validate([Uuid::randomHex(), $id1, Uuid::randomHex(), $id2], $constraint);
+
+        // Two violations as two entities exist.
+        static::assertCount(2, $violations);
+    }
+
+    protected function createRepository(string $definition): EntityRepository
+    {
+        return new EntityRepository(
+            $this->getContainer()->get($definition),
+            $this->getContainer()->get(EntityReaderInterface::class),
+            $this->getContainer()->get(VersionManager::class),
+            $this->getContainer()->get(EntitySearcherInterface::class),
+            $this->getContainer()->get(EntityAggregatorInterface::class),
+            $this->getContainer()->get(EventDispatcherInterface::class),
+            $this->getContainer()->get(EntityLoadedEventFactory::class)
+        );
+    }
+
+    protected function getValidator(): ValidatorInterface
+    {
+        return $this->getValidatorBuilder()->getValidator();
+    }
+
+    protected function getValidatorBuilder(): ValidatorBuilder
+    {
+        return $this->getContainer()->get('validator.builder');
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

To allow entity exists and not exists validators to be used in combination with composite constraints like Symfony's `All` constraint. 

For more information, see: https://issues.shopware.com/issues/NEXT-16508


### 2. What does this change do, exactly?
Fixes https://issues.shopware.com/issues/NEXT-16508

### 3. Describe each step to reproduce the issue or behaviour.
See https://issues.shopware.com/issues/NEXT-16508

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-16508

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
