### PR TITLE
fix: select current date if the day of birth empty

### DIFF
--- a/changelog/_unreleased/2021-08-05-wrong-birthday-selected-if-empty.md
+++ b/changelog/_unreleased/2021-08-05-wrong-birthday-selected-if-empty.md
@@ -1,0 +1,8 @@
+---
+title: Wrong birthday selected if empty
+author: Stephan Franck
+author_email: stephan@vierpunkt.de
+author_github: @stephan4p
+---
+# Storefront
+* Changed twig template `src/Storefront/Resources/views/storefront/page/account/profile/personal.html.twig` to not preselect current day when no birthdate is provided

--- a/src/Storefront/Resources/views/storefront/page/account/profile/personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/profile/personal.html.twig
@@ -5,9 +5,14 @@
 {% block component_address_personal_fields_birthday_selects %}
     {% block page_account_profile_personal_fields_birthday_selects %}
         <div class="form-row">
-            {% set birthday = data.birthday|date('d') %}
-            {% set birthmonth = data.birthday|date('m') %}
-            {% set birthyear = data.birthday|date('Y') %}
+            {% set birthday = false %}
+            {% set birthmonth = false %}
+            {% set birthyear = false %}
+            {% if data.birthday %}
+                {% set birthday = data.birthday|date('d') %}
+                {% set birthmonth = data.birthday|date('m') %}
+                {% set birthyear = data.birthday|date('Y') %}
+            {% endif %}
 
             {% block page_account_profile_personal_fields_birthday_select_day %}
                 <div class="form-group col-4 col-md-2">


### PR DESCRIPTION
### 1. Why is this change necessary?
If we leave the day of birth empty during registration he select the current date as day of birth in the account profile

### 2. What does this change do, exactly?
Query whether birthday is filled. Only then the variables for the select are generated.

### 3. Describe each step to reproduce the issue or behaviour.
- Register an user account and leave the birthday blank
- Look at account Profile and the the current day selected

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
