### PR TITLE
Make sure access key generation for user uses right access point

### DIFF
--- a/changelog/_unreleased/2021-08-06-wrong-admin-api-access-key.md
+++ b/changelog/_unreleased/2021-08-06-wrong-admin-api-access-key.md
@@ -1,0 +1,6 @@
+---
+title: Make sure access key generation for user uses right access point
+---
+# Administration
+* Generate access key prefixed with `SWUA` for admin users
+

--- a/changelog/_unreleased/2021-08-06-wrong-admin-api-access-key.md
+++ b/changelog/_unreleased/2021-08-06-wrong-admin-api-access-key.md
@@ -1,5 +1,8 @@
 ---
 title: Make sure access key generation for user uses right access point
+author: Jisse Reitsma
+author_email: jisse@yireo.com
+author_github: jissereitsma
 ---
 # Administration
 * Generate access key prefixed with `SWUA` for admin users

--- a/src/Administration/Resources/app/administration/src/core/service/api/integration.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/integration.api.service.js
@@ -18,12 +18,13 @@ class IntegrationApiService extends ApiService {
      * @param {Object} [additionalHeaders = {}]
      * @returns {Promise<T>}
      */
-    generateKey(additionalParams = {}, additionalHeaders = {}) {
+    generateKey(additionalParams = {}, additionalHeaders = {}, user = false) {
         const params = additionalParams;
         const headers = this.getBasicHeaders(additionalHeaders);
+        const endpoint = user ? '/_action/access-key/user' : '/_action/access-key/intergration';
 
         return this.httpClient
-            .get('/_action/access-key/intergration', {
+            .get(endpoint, {
                 params,
                 headers,
             })

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/index.js
@@ -257,7 +257,7 @@ Component.register('sw-users-permissions-user-detail', {
 
             this.isModalLoading = true;
             newKey.quantityStart = 1;
-            this.integrationService.generateKey().then((response) => {
+            this.integrationService.generateKey({}, {}, true).then((response) => {
                 newKey.accessKey = response.accessKey;
                 newKey.secretAccessKey = response.secretAccessKey;
                 this.currentIntegration = newKey;


### PR DESCRIPTION
### 1. Why is this change necessary?
In the Administration, you can generate an Access Key for an user via the window **Settings > System > Users & Permissions** under the tab **Integrations** of a specific user. When generating this Access Key, it starts with `SWIA` instead of `SWUA`, marking it as an Access Key for an integration, instead of an Access Key for an user. Because of this, the credentials will never work: A POST request to `api/oauth/token` will always return an error `The user credentials were incorrect`.

### 2. What does this change do, exactly?
To fix this, the Access Key needs to be prefixed with `SWUA`, which can be done by using the endpoint `_action/access-key/user` instead of `_action/access-key/intergration`. This PR makes that fix possible for the `sw-users-permissions-user-detail` component while the functionality of the original integration page (under **Settings > System > Integrations**) is left untouched.

We found out about this during a Shopware 6 training together with @riconeitzel, Rick Schippers, Bjorn Meyer and others.

### 3. Describe each step to reproduce the issue or behaviour.
Without the fix, the Access Key generated for a specific user starts with `SWIA` and it does not work wen dealing with an API client like Postman. With this fix, it starts with `SWUA`.

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
