### PR TITLE
Add sw-text-editor-toolbar-button blocks

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/sw-text-editor-toolbar-button.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/sw-text-editor-toolbar-button.html.twig
@@ -95,24 +95,33 @@
         class="sw-text-editor-toolbar-button__children sw-text-editor-toolbar-button__link-menu"
     >
         {% block sw_text_editor_toolbar_button_link_menu_content %}
+        {% block sw_text_editor_toolbar_button_link_menu_content_title %}
         <p class="sw-text-editor-toolbar-button__link-menu-text">
             {{ $tc('sw-text-editor-toolbar.link.linkTo') }}
         </p>
+        {% endblock %}
+        {% block sw_text_editor_toolbar_button_link_menu_content_link %}
         <sw-field
             v-model="buttonConfig.value"
             type="text"
             :placeholder="$tc('sw-text-editor-toolbar.link.placeholder')"
         />
+        {% endblock %}
+        {% block sw_text_editor_toolbar_button_link_menu_content_new_tab %}
         <sw-field
             v-model="buttonConfig.newTab"
             type="switch"
             :label="$tc('sw-text-editor-toolbar.link.openInNewTab')"
         />
+        {% endblock %}
+        {% block sw_text_editor_toolbar_button_link_menu_content_display_as_button %}
         <sw-field
             v-model="buttonConfig.displayAsButton"
             type="switch"
             :label="$tc('sw-text-editor-toolbar.link.displayAsButton')"
         />
+        {% endblock %}
+        {% block sw_text_editor_toolbar_button_link_menu_content_button_variant %}
         <sw-field
             v-if="buttonConfig.displayAsButton"
             v-model="buttonConfig.buttonVariant"
@@ -120,6 +129,7 @@
             type="select"
             :label="$tc('sw-text-editor-toolbar.link.buttonVariant')"
         />
+        {% endblock %}
         <div class="sw-text-editor-toolbar-button__link-menu-buttons">
             {% block sw_text_editor_toolbar_button_link_menu_buttons %}
             <sw-button


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Adds {% block %} tags around every component of the 'Link' dropdown in the wysiwyg editor.

### 2. What does this change do, exactly?
Functionally, this adds nothing. But it allows plugins to hook into the dropdown better.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
