### PR TITLE
Don't limit the number of loaded state transitions

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-card/index.js
@@ -239,7 +239,7 @@ Component.register('sw-order-state-history-card', {
         },
 
         stateMachineStateCriteria() {
-            const criteria = new Criteria();
+            const criteria = new Criteria(1, null);
             criteria.addSorting({ field: 'name', order: 'ASC' });
             criteria.addAssociation('stateMachine');
             criteria.addFilter(


### PR DESCRIPTION
### 1. Why is this change necessary?

The states loaded via the getAllStates() method are used to determine the available state transitions that an order can go through. By not explicitly setting the limit of the criteria object to NULL, the criteria receives the default LIMIT value of 25. Thus, only the first 25 state transitions are loaded from the database.


### 2. What does this change do, exactly?

This change set's the `limit` property of the criteria object to NULL, allowing all state transitions to be loaded.

### 3. Describe each step to reproduce the issue or behaviour.
Once you have more than 25 state transitions in your database, this becomes a problem.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
