### PR TITLE
Order placed criteria event added

### DIFF
--- a/changelog/_unreleased/2021-08-08-order-placed-criteria-event.md
+++ b/changelog/_unreleased/2021-08-08-order-placed-criteria-event.md
@@ -1,0 +1,9 @@
+---
+title: Order Placed Criteria Event
+issue: NEXT-16526
+author: Konstantin Kiritsenko
+author_email: k@componentk.com
+author_github: @augsteyer
+---
+# Core
+* Added criteria event dispatch after order is placed

--- a/src/Core/Checkout/Cart/Event/CheckoutOrderPlacedCriteriaEvent.php
+++ b/src/Core/Checkout/Cart/Event/CheckoutOrderPlacedCriteriaEvent.php
@@ -11,6 +11,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 class CheckoutOrderPlacedCriteriaEvent extends Event implements ShopwareSalesChannelEvent
 {
     protected SalesChannelContext $context;
+
     protected Criteria $criteria;
 
     public function __construct(Criteria $criteria, SalesChannelContext $context)

--- a/src/Core/Checkout/Cart/Event/CheckoutOrderPlacedCriteriaEvent.php
+++ b/src/Core/Checkout/Cart/Event/CheckoutOrderPlacedCriteriaEvent.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CheckoutOrderPlacedCriteriaEvent extends Event implements ShopwareSalesChannelEvent
+{
+    protected SalesChannelContext $context;
+    protected Criteria $criteria;
+
+    public function __construct(Criteria $criteria, SalesChannelContext $context)
+    {
+        $this->context = $context;
+        $this->criteria = $criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->context;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+}

--- a/src/Core/Checkout/Cart/SalesChannel/CartOrderRoute.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartOrderRoute.php
@@ -6,6 +6,7 @@ use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartCalculator;
 use Shopware\Core\Checkout\Cart\CartPersisterInterface;
+use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedCriteriaEvent;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
 use Shopware\Core\Checkout\Cart\Order\OrderPersisterInterface;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -128,6 +129,7 @@ class CartOrderRoute extends AbstractCartOrderRoute
             ->addAssociation('currency')
             ->addAssociation('addresses.country');
 
+        $this->eventDispatcher->dispatch(new CheckoutOrderPlacedCriteriaEvent($criteria, $context));
         /** @var OrderEntity|null $orderEntity */
         $orderEntity = $this->orderRepository->search($criteria, $context->getContext())->first();
 

--- a/src/Core/Checkout/Test/Cart/SalesChannel/CartOrderRouteTest.php
+++ b/src/Core/Checkout/Test/Cart/SalesChannel/CartOrderRouteTest.php
@@ -434,7 +434,6 @@ class CartOrderRouteTest extends TestCase
     {
         $this->createCustomerAndLogin();
 
-        /** @var $event CheckoutOrderPlacedCriteriaEvent|null */
         $event = null;
         $this->catchEvent(CheckoutOrderPlacedCriteriaEvent::class, $event);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Shopware generally fires Criteria events on API endpoints/controllers whenever it is loading repository objects. This allows to intercept these criteria search calls, and add custom associations. We can intercept the order object loading in many requests for Admin & Storefront already. But not after the order is created. Currently the mail template is hooking up to the OrderPlaced event, but we have no way of intercepting this order loading to add associations to pass to email templates.

TLDR: Makes it easier to add email template variables via custom associations.

### 2. What does this change do, exactly?
Adds an event after the order is created and before it is loaded & "placed". 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
