### PR TITLE
NEXT-16716 - Add associations to cache key for criteria to ensure associations are loaded as expected

### DIFF
--- a/changelog/_unreleased/2021-08-16-fix-cache-keys-for-associations.md
+++ b/changelog/_unreleased/2021-08-16-fix-cache-keys-for-associations.md
@@ -1,0 +1,10 @@
+---
+title: Fix-cache-keys-for-associations
+issue: NEXT-16716
+author: Jonas Søndergaard
+author_email: jonas@wexo.dk 
+author_github: @josniii
+---
+# Core
+* Added Associations to Criteria cache keys, to ensure correct associations are loaded along with entites.
+___

--- a/src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
@@ -49,6 +49,7 @@ class EntityCacheKeyGenerator
             $criteria->getTotalCountMode(),
             $criteria->getGroupFields(),
             $criteria->getAggregations(),
+            $criteria->getAssociations(),
         ]));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, associations are not included when generating Criteria cache keys, causing issues where data that should be loaded might not be (and data that shouldn't be loaded could be)

### 2. What does this change do, exactly?
This PR simply adds associations to the cache key. This will result in fewer cache hits, but they would have been wrong hits anyways.

### 3. Describe each step to reproduce the issue or behaviour.
See https://github.com/shopware/platform/issues/2020
With this change added, the example works as expected. Second result correctly misses the cache from the first, and loads the required associations.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2020
https://issues.shopware.com/issues/NEXT-16716

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
(No unit tests are added as I couldn't find any other tests written for this area to begin with, but I have tested with the testcase mentioned in the issue)
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
