### PR TITLE
Fix template inheritance in `renderView`

### DIFF
--- a/changelog/_unreleased/2021-08-18-fix-template-inheritance-renderView.md
+++ b/changelog/_unreleased/2021-08-18-fix-template-inheritance-renderView.md
@@ -1,0 +1,9 @@
+---
+title: Fix template inheritance in `renderView`
+issue:
+author: Pascal Josephy
+author_email: pascal.josephy@jkweb.ch
+author_github: pascaljosephy
+---
+# Storefront
+*  Changed method `src/Storefront/Controller/StorefrontController:renderView`

--- a/changelog/_unreleased/2021-08-18-fix-template-inheritance-renderView.md
+++ b/changelog/_unreleased/2021-08-18-fix-template-inheritance-renderView.md
@@ -6,4 +6,4 @@ author_email: pascal.josephy@jkweb.ch
 author_github: pascaljosephy
 ---
 # Storefront
-*  Changed method `src/Storefront/Controller/StorefrontController:renderView`
+* Changed method `Shopware\Storefront\Controller\StorefrontController:renderView` to respect the template inheritance 

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -190,6 +190,8 @@ abstract class StorefrontController extends AbstractController
     protected function renderView(string $view, array $parameters = []): string
     {
         if (isset($this->twig)) {
+            $view = $this->get(TemplateFinder::class)->find($view, false, null);
+
             return $this->twig->render($view, $parameters);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The method `renderView` of the `StorefrontController` directly used the Twig instance to render the desired view. This was done without resolving the view and like that enabling other plugins to overwrite the rendered views.

### 2. What does this change do, exactly?

It resolves the `$view` using the `TemplateFinder` service.

### 3. Describe each step to reproduce the issue or behaviour.

- Setup a new plugin that has an endpoint that uses `renderView` to render any view
- Setup another plugin that tries to overwrite the view

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
