### PR TITLE
fix: Company tax free detection with disabled vat id check

### DIFF
--- a/changelog/_unreleased/2021-08-19-fix-company-tax-free-detection-with-disabled-vat-id-check.md
+++ b/changelog/_unreleased/2021-08-19-fix-company-tax-free-detection-with-disabled-vat-id-check.md
@@ -1,0 +1,8 @@
+---
+title: Fix company tax free detection with disabled vat id check
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Fix company tax free detection with disabled vat id check for invalid vat ids

--- a/src/Core/Checkout/Cart/Tax/TaxDetector.php
+++ b/src/Core/Checkout/Cart/Tax/TaxDetector.php
@@ -51,15 +51,17 @@ class TaxDetector
         $vatPattern = $shippingLocationCountry->getVatIdPattern();
         $vatIds = $customer->getVatIds();
 
-        if ($vatPattern === null || empty($vatIds)) {
+        if (empty($vatIds)) {
             return false;
         }
 
-        $regex = '/^' . $vatPattern . '$/i';
+        if (!empty($vatPattern) && $shippingLocationCountry->getCheckVatIdPattern()) {
+            $regex = '/^' . $vatPattern . '$/i';
 
-        foreach ($vatIds as $vatId) {
-            if (!preg_match($regex, $vatId)) {
-                return false;
+            foreach ($vatIds as $vatId) {
+                if (!preg_match($regex, $vatId)) {
+                    return false;
+                }
             }
         }
 

--- a/src/Core/Checkout/Test/Cart/CartTaxTest.php
+++ b/src/Core/Checkout/Test/Cart/CartTaxTest.php
@@ -71,7 +71,8 @@ class CartTaxTest extends TestCase
         float $countryTaxFreeFrom,
         float $countryCompanyTaxFreeFrom,
         int $quantity,
-        ?array $vatIds = null
+        ?array $vatIds = null,
+        ?bool $checkVatIdPattern = true
     ): void {
         $this->createShippingMethod();
 
@@ -100,7 +101,15 @@ class CartTaxTest extends TestCase
             'taxFreeFrom' => $currencyTaxFreeFrom,
         ]], $this->ids->context);
 
-        $this->updateCountry($countryId, $countryTaxFree, $countryTaxFreeFrom, $countryCompanyTaxFree, $countryCompanyTaxFreeFrom);
+        $this->updateCountry(
+            $countryId,
+            $countryTaxFree,
+            $countryTaxFreeFrom,
+            $countryCompanyTaxFree,
+            $countryCompanyTaxFreeFrom,
+            Defaults::CURRENCY,
+            $checkVatIdPattern
+        );
 
         $this->browser->request(
             'POST',
@@ -142,7 +151,8 @@ class CartTaxTest extends TestCase
         float $countryTaxFreeFrom,
         float $countryCompanyTaxFreeFrom,
         int $quantity,
-        ?array $vatIds = null
+        ?array $vatIds = null,
+        ?bool $checkVatIdPattern = true
     ): void {
         $currencyId = Uuid::fromBytesToHex($this->getCurrencyIdByIso('CHF'));
 
@@ -178,7 +188,9 @@ class CartTaxTest extends TestCase
             $countryTaxFree,
             $countryTaxFreeFrom,
             $countryCompanyTaxFree,
-            $countryCompanyTaxFreeFrom
+            $countryCompanyTaxFreeFrom,
+            Defaults::CURRENCY,
+            $checkVatIdPattern
         );
 
         $this->browser->request(
@@ -312,6 +324,7 @@ class CartTaxTest extends TestCase
      * float $countryCompanyTaxFreeFrom
      * int $quantity
      * ?array vatIds
+     * ?bool checkVatIdPattern
      *
      * @return array[]
      */
@@ -338,7 +351,10 @@ class CartTaxTest extends TestCase
             'case 18 tax-free' => ['tax-free', 0, false, true, 0, 1000, 2],
             'case 19 tax-free' => ['tax-free', 0, false, true, 0, 999.99, 3],
             'case 20 tax-free' => ['tax-free', 0, true, false, 1000, 0, 3],
-            'case 21 no tax-free' => ['no tax-free', 0, true, true, 1000, 100, 1, ['DE1234567890123']],
+            'case 21 no tax-free' => ['no tax-free', 0, true, true, 1000, 100, 1, ['DE1234567890123'], true],
+            'case 22 tax-free' => ['tax-free', 0, false, true, 1000, 100, 1, ['DE1234567890123'], false],
+            'case 23 tax-free' => ['tax-free', 0, false, true, 1000, 100, 1, ['DE123456789'], false],
+            'case 23 tax-free' => ['tax-free', 0, false, true, 1000, 100, 1, ['DE123456789'], true],
         ];
     }
 
@@ -429,7 +445,8 @@ class CartTaxTest extends TestCase
         float $countryTaxFreeFrom,
         bool $countryCompanyTaxFree,
         float $countryCompanyTaxFreeFrom,
-        string $currencyId = Defaults::CURRENCY
+        string $currencyId = Defaults::CURRENCY,
+        bool $checkVatIdPattern = true
     ): void {
         $this->countryRepository->update([[
             'id' => $countryId,
@@ -444,6 +461,7 @@ class CartTaxTest extends TestCase
                 'amount' => $countryCompanyTaxFreeFrom,
             ],
             'vatIdPattern' => '(DE)?[0-9]{9}',
+            'checkVatIdPattern' => $checkVatIdPattern,
         ]], $this->ids->context);
     }
 

--- a/src/Core/Checkout/Test/Cart/Tax/TaxDetectorTest.php
+++ b/src/Core/Checkout/Test/Cart/Tax/TaxDetectorTest.php
@@ -133,7 +133,52 @@ class TaxDetectorTest extends TestCase
         static::assertFalse($detector->isNetDelivery($context));
     }
 
-    public function testIsNotNetDeliveryWithCompanyFreeTaxAndVatIdPattern(): void
+    public function testIsNotNetDeliveryWithCompanyFreeTaxAndWrongVatIdPattern(): void
+    {
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $countryRepository = $this->getContainer()->get('country.repository');
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('iso', 'DE'));
+        $criteria->setLimit(1);
+
+        $deCountry = $countryRepository->search($criteria, Context::createDefaultContext())->first();
+        $data = [
+            'id' => $deCountry->getId(),
+            'customerTax' => [
+                'enabled' => false,
+                'currencyId' => Defaults::CURRENCY,
+                'amount' => 0,
+            ],
+            'companyTax' => [
+                'enabled' => true,
+                'currencyId' => Defaults::CURRENCY,
+                'amount' => 0,
+            ],
+            'vatIdPattern' => '(DE)?[0-9]{9}',
+            'checkVatIdPattern' => true,
+        ];
+
+        $countryRepository->update([$data], Context::createDefaultContext());
+        $deCountry = $countryRepository->search($criteria, Context::createDefaultContext())->first();
+
+        $customer = $this->createMock(CustomerEntity::class);
+        $customer->expects(static::once())->method('getCompany')->willReturn('ABC Company');
+        $customer->expects(static::once())->method('getVatIds')->willReturn(['VN123123']);
+
+        $context->expects(static::once())->method('getShippingLocation')->willReturn(
+            ShippingLocation::createFromCountry($deCountry)
+        );
+
+        $context->expects(static::once())->method('getCustomer')->willReturn(
+            $customer
+        );
+
+        $detector = $this->getContainer()->get(TaxDetector::class);
+        static::assertFalse($detector->isNetDelivery($context));
+    }
+
+    public function testIsNetDeliveryWithCompanyFreeTaxAndWrongVatIdButVatIdCheckDisabled(): void
     {
         $context = $this->createMock(SalesChannelContext::class);
 
@@ -175,7 +220,7 @@ class TaxDetectorTest extends TestCase
         );
 
         $detector = $this->getContainer()->get(TaxDetector::class);
-        static::assertFalse($detector->isNetDelivery($context));
+        static::assertTrue($detector->isNetDelivery($context));
     }
 
     public function testIsNotNetDelivery(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Otherwise wrong vat ids will not be accounted for a tax free order, although the vat id check is disabled in the country configuration.

### 2. What does this change do, exactly?
Fix the wrong behavior and the test.

### 3. Describe each step to reproduce the issue or behaviour.
Configure a country with either `check_vat_id_pattern` disabled or `vat_id_pattern` set to null. 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
