### PR TITLE
'Added rawTotal as required param to CartPriceField' added to UPGRADE…

### DIFF
--- a/UPGRADE-6.4.md
+++ b/UPGRADE-6.4.md
@@ -907,3 +907,55 @@ Example:
 ```js
 Shopware.Service('productStreamConditionService').addToEntityAllowList('product', 'yourProperty');
 ```
+
+## Added rawTotal as required param to CartPriceField
+This value is now required when creating an order through the API. The value contains the unrounded total value.
+The "price" part of your json to create an order should include this.
+Example:
+
+Before:
+```json
+"price": {
+  "totalPrice": 119.95,
+  "calculatedTaxes": [
+    {
+      "taxRate": 21,
+      "price": 119.95,
+      "tax": 20.82
+    }
+  ],
+  "positionPrice": 119.95,
+  "taxRules": [
+    {
+      "taxRate": 21,
+      "percentage": 100
+    }
+  ],
+  "netPrice": 99.13,
+  "taxStatus": "gross"
+},
+```
+
+After:
+```json
+"price": {
+  "totalPrice": 119.95,
+  "calculatedTaxes": [
+    {
+      "taxRate": 21,
+      "price": 119.95,
+      "tax": 20.82
+    }
+  ],
+  "positionPrice": 119.95,
+  "taxRules": [
+    {
+      "taxRate": 21,
+      "percentage": 100
+    }
+  ],
+  "netPrice": 99.13,
+  "taxStatus": "gross",
+  "rawTotal": 119,95
+},
+```


### PR DESCRIPTION
### 1. Why is this change necessary?
In commit https://github.com/shopware/platform/commit/4cac5531889924f2132b94a900f1fd18eccf74ff#diff-f001621e9b9728cd1471e5c718f0b2e09a8715f551863112b79e22087d9558f2
the rawTotal param was added as a required param to CartPrice field. It should be documented that this param is now required when creating an order through the API.

### 2. What does this change do, exactly?
Document the required param rawTotal in the 6.4-changelog

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
