### PR TITLE
Hide cheapest variant price in ajax loading

### DIFF
--- a/changelog/_unreleased/2021-08-20-hide-cheapest-price-in-product-listing-ajax-loading.md
+++ b/changelog/_unreleased/2021-08-20-hide-cheapest-price-in-product-listing-ajax-loading.md
@@ -1,0 +1,8 @@
+---
+title: Hide cheapest price in product listing ajax loading
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Added CSS selector `.product-cheapest-price-price` for the animation overlay during a product loading in `src/Storefront/Resources/app/storefront/src/scss/component/_loader.scss` to hide still visible data in the product boxes that are used as placeholders

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_loader.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_loader.scss
@@ -75,6 +75,7 @@ Skeleton screen for reloading product-listing with subtle shimmer effect
     .product-variant-characteristics,
     .product-description,
     .product-price-unit,
+    .product-cheapest-price-price,
     .product-price {
         border-radius: $border-radius;
         color: transparent;


### PR DESCRIPTION
### 1. Why is this change necessary?
When you async load your products in a listing all facts of the previous result are hidden. All but the cheapest variant price.

Before:
![pr-cheapest-price-animation-before](https://user-images.githubusercontent.com/1133593/130239720-2bcd511a-f34e-4a7a-8703-d9504afc9542.gif)

After:
![pr-cheapest-price-animation-after](https://user-images.githubusercontent.com/1133593/130239734-f4a8cca6-1b09-4808-8051-906319e52dda.gif)

### 2. What does this change do, exactly?
Add a selector to an animation rule to the fact is hidden as well.

### 3. Describe each step to reproduce the issue or behaviour.
1. Generate demo data
2. See listing

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
