### PR TITLE
Log elasticsearch issues in any case

### DIFF
--- a/changelog/_unreleased/2021-08-24-log-elasticsearch-issues-in-any-case.md
+++ b/changelog/_unreleased/2021-08-24-log-elasticsearch-issues-in-any-case.md
@@ -1,0 +1,10 @@
+---
+title: Log elasticsearch issues in any case
+issue: NEXT-16905
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Elasticsearch
+* Changed order of statements in `logOrThrowException` in `src/Elasticsearch/Framework/ElasticsearchHelper.php` to always log exceptions
+* Deprecated and renamed `Shopware\Elasticsearch\Framework\ElasticsearchHelper::logOrThrowException` to match new behaviour into `tryToThrow`

--- a/src/Elasticsearch/Framework/ElasticsearchHelper.php
+++ b/src/Elasticsearch/Framework/ElasticsearchHelper.php
@@ -61,8 +61,18 @@ class ElasticsearchHelper
         $this->throwException = $throwException;
     }
 
+    /**
+     * @deprecated tag:v6.5.0 - use tryToThrow instead
+     */
     public function logOrThrowException(\Throwable $exception): bool
     {
+        return $this->tryToThrow($exception);
+    }
+
+    public function tryToThrow(\Throwable $exception): bool
+    {
+        $this->logger->critical($exception->getMessage());
+
         if ($this->environment === 'test') {
             throw $exception;
         }
@@ -74,8 +84,6 @@ class ElasticsearchHelper
         if ($this->throwException) {
             throw $exception;
         }
-
-        $this->logger->critical($exception->getMessage());
 
         return false;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
When you run in prod mode and have an elastichsearch falling back to database search you don't know why because neither a log message is logged or an exception is thrown.

### 2. What does this change do, exactly?
Log in any case of an exception before environment evaluation is done.

### 3. Describe each step to reproduce the issue or behaviour.
1. Use plugins that extend elasticsearch queries
2. Have a slow page or weird behaviour when enabling elastic based search
3. No hints in the log files

### 4. Checklist
Is there a legit way how to test it when the first check literally is: am I in a test?

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
