### PR TITLE
Add fields to `ElasticsearchProductDefinition`

### DIFF
--- a/changelog/_unreleased/2021-08-24-add-fields-to-es-product-definition.md
+++ b/changelog/_unreleased/2021-08-24-add-fields-to-es-product-definition.md
@@ -1,0 +1,11 @@
+---
+title: Add fields to `ElasticsearchProductDefinition`
+issue: 
+author: Pascal Josephy
+author_email: pascal.josephy@jkweb.ch
+author_github: pascaljosephy
+---
+# Core
+*  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:getMapping`
+*  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:fetch`
+*  Changed method `src/Elasticsearch/Product/ElasticsearchProductDefinition:fetchProducts`

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -400,7 +400,6 @@ SELECT
     LOWER(HEX(p.id)) AS id,
     IFNULL(p.active, pp.active) AS active,
     p.available AS available,
-    IFNULL(p.is_closeout, pp.is_closeout) AS isCloseout,
     :nameTranslated: AS name,
     :descriptionTranslated: AS description,
     :customFieldsTranslated: AS customFields,

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -68,6 +68,8 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 'id' => EntityMapper::KEYWORD_FIELD,
                 'parentId' => EntityMapper::KEYWORD_FIELD,
                 'active' => EntityMapper::BOOLEAN_FIELD,
+                'available' => EntityMapper::BOOLEAN_FIELD,
+                'isCloseout' => EntityMapper::BOOLEAN_FIELD,
                 'categoriesRo' => [
                     'type' => 'nested',
                     'properties' => [
@@ -208,6 +210,8 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 'name' => $this->stripText($item['name'] ?? ''),
                 'ratingAverage' => (float) $item['ratingAverage'],
                 'active' => (bool) $item['active'],
+                'available' => (bool) $item['available'],
+                'isCloseout' => (bool) $item['isCloseout'],
                 'shippingFree' => (bool) $item['shippingFree'],
                 'customFields' => $this->formatCustomFields($item['customFields'] ? json_decode($item['customFields'], true) : []),
                 'visibilities' => $visibilities,
@@ -395,6 +399,8 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
 SELECT
     LOWER(HEX(p.id)) AS id,
     IFNULL(p.active, pp.active) AS active,
+    p.available AS available,
+    IFNULL(p.is_closeout, pp.is_closeout) AS isCloseout,
     :nameTranslated: AS name,
     :descriptionTranslated: AS description,
     :customFieldsTranslated: AS customFields,


### PR DESCRIPTION
### 1. Why is this change necessary?

The `ProductCloseoutFilter` uses the fields `isCloseout` and `available`, both of which were not present in the product document mapping of Elasticsearch.

### 2. What does this change do, exactly?

It adds the two missing fields to the mapping and populates their values.

### 3. Describe each step to reproduce the issue or behaviour.

- Add products with isCloseout=1 and stock=0 (available=0)
- Activate ES
- Activate the `core.listing.hideCloseoutProductsWhenOutOfStock` setting
- There you go

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
