### PR TITLE
Add missing crsf data attribute to delete product from wishlist.

### DIFF
--- a/changelog/_unreleased/2021-08-26-add-missing-csrf-attribute-when-ajax.md
+++ b/changelog/_unreleased/2021-08-26-add-missing-csrf-attribute-when-ajax.md
@@ -1,0 +1,10 @@
+---
+title: Add missing `data-form-csrf-handler="true"` to delete product from wishlist
+issue:
+flag:
+author: Adam Sprada
+author_email: adam@sprada.pl
+author_github: asprada
+___
+# Storefront
+* Added missing data attribute `data-form-csrf-handler="true"` in the `src/Storefront/Resources/views/storefront/component/product/card/box-wishlist.html.twig` to be able to delete product from wishlist when csrf mode is set to ajax.

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-wishlist.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-wishlist.html.twig
@@ -17,7 +17,8 @@
 
                     <form action="{{ path('frontend.wishlist.product.delete', {'id': id}) }}"
                           method="post"
-                          class="product-wishlist-form">
+                          class="product-wishlist-form"
+                          data-form-csrf-handler="true">
 
                         {% block component_product_box_wishlist_remove_csrf %}
                             {{ sw_csrf('frontend.wishlist.product.delete') }}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When we change the `csrf` method to `ajax` then `src/Storefront/Resources/views/storefront/component/product/card/box-wishlist.html.twig` is missing the `data-form-csrf-handler="true"` data attribute to initialise the JS plugin to fetch a valid token on submit. Removing product from the wishlist is then impossible due to `InvalidCsrfTokenException`.

### 2. What does this change do, exactly?
It adds the `data-form-csrf-handler="true"` data attribute to the form responsible for delete product from the wishlist.

### 3. Describe each step to reproduce the issue or behaviour.
1. Change the `csrf` method to `ajax` in e.g. `config/packages/storefront.yaml`.
2. Activate wishlist functionality in the admin panel.
3. Login in to the customer account.
4. Add product to the wishlist (e.g. from the category page).
5. Go to the `/wishlist` page.
6. Try to remove product from the wishlist.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
