### PR TITLE
feat(storefront): add `--sales-channel` option to `theme:change` command

### DIFF
--- a/changelog/_unreleased/2021-08-27-add-sales-channel-option-for-theme-change.md
+++ b/changelog/_unreleased/2021-08-27-add-sales-channel-option-for-theme-change.md
@@ -1,0 +1,8 @@
+---
+title: Added `--sales-channel` option for the `theme:change` command
+author: Enzo Volkmann
+author_email: enzo@exportarts.io
+author_github: @evolkmann
+---
+# Storefront
+* Added `--sales-channel` option for the `theme:change` command

--- a/src/Storefront/Theme/Command/ThemeChangeCommand.php
+++ b/src/Storefront/Theme/Command/ThemeChangeCommand.php
@@ -78,7 +78,8 @@ class ThemeChangeCommand extends Command
     protected function configure(): void
     {
         $this->addArgument('theme-name', InputArgument::OPTIONAL, 'Theme name');
-        $this->addOption('all', null, InputOption::VALUE_NONE, 'Set theme for all sales channel');
+        $this->addOption('sales-channel', 's', InputOption::VALUE_REQUIRED, 'Sales Channel ID. Can not be used together with --all.');
+        $this->addOption('all', null, InputOption::VALUE_NONE, 'Set theme for all sales channel Can not be used together with -s');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -88,15 +89,30 @@ class ThemeChangeCommand extends Command
 
         /** @var SalesChannelCollection $salesChannels */
         $salesChannels = $this->salesChannelRepository->search(new Criteria(), $this->context)->getEntities();
+        $salesChannelOption = $input->getOption('sales-channel');
+
+        if ($salesChannelOption && $input->getOption('all')) {
+            $this->io->error('You can use either --sales-channel or --all, not both at the same time.');
+            return self::FAILURE;
+        }
 
         if (!$input->getOption('all')) {
-            $question = new ChoiceQuestion('Please select a sales channel:', $this->getSalesChannelChoices($salesChannels));
-            $answer = $helper->ask($input, $output, $question);
-            $parsedSalesChannel = $this->parseSalesChannelAnswer($answer, $salesChannels);
-            if ($parsedSalesChannel === null) {
-                return self::FAILURE;
+            if ($salesChannelOption) {
+                $selectedSalesChannel = $salesChannels->get($salesChannelOption);
+                if ($selectedSalesChannel === null) {
+                    $this->io->error('Could not find sales channel with ID ' . $salesChannelOption);
+                    return self::FAILURE;
+                }
+                $salesChannels = new SalesChannelCollection([$selectedSalesChannel]);
+            } else {
+                $question = new ChoiceQuestion('Please select a sales channel:', $this->getSalesChannelChoices($salesChannels));
+                $answer = $helper->ask($input, $output, $question);
+                $parsedSalesChannel = $this->parseSalesChannelAnswer($answer, $salesChannels);
+                if ($parsedSalesChannel === null) {
+                    return self::FAILURE;
+                }
+                $salesChannels = new SalesChannelCollection([$parsedSalesChannel]);
             }
-            $salesChannels = new SalesChannelCollection([$parsedSalesChannel]);
         }
 
         if (!$input->getArgument('theme-name')) {

--- a/src/Storefront/Theme/Command/ThemeChangeCommand.php
+++ b/src/Storefront/Theme/Command/ThemeChangeCommand.php
@@ -93,6 +93,7 @@ class ThemeChangeCommand extends Command
 
         if ($salesChannelOption && $input->getOption('all')) {
             $this->io->error('You can use either --sales-channel or --all, not both at the same time.');
+
             return self::FAILURE;
         }
 
@@ -101,6 +102,7 @@ class ThemeChangeCommand extends Command
                 $selectedSalesChannel = $salesChannels->get($salesChannelOption);
                 if ($selectedSalesChannel === null) {
                     $this->io->error('Could not find sales channel with ID ' . $salesChannelOption);
+
                     return self::FAILURE;
                 }
                 $salesChannels = new SalesChannelCollection([$selectedSalesChannel]);


### PR DESCRIPTION
> Hi everyone, this is my first contribution to the project itself and to be honest I did not yet find out how to properly build and test locally. Therefore I did not test this with a database connection and I am not sure if the format of the passed ID will cause any problems, but I assume that the `SalesChannelCollection->get()` method takes care of this.
>
> Please let me know if this PR is acceptable in this state :)

### 1. Why is this change necessary?

Changing the theme for only one sales channel is only possible in the interactive mode of the command. From now on, when `--no-interaction` is used, the sales channel can also be provided.

### 2. What does this change do, exactly?

- Add `--sales-channel` option to the `theme:change` command
- Usage of `--sales-channel` and `--all` is prevented
- If not provided, the regular interactive mode is used

### 3. Describe each step to reproduce the issue or behaviour.

- Use the `theme:change` command with the new option

### 4. Please link to the relevant issues (if any).

n/a

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
