### PR TITLE
Fix transactions and data consistency

### DIFF
--- a/changelog/_unreleased/2021-02-18-add-retryable-transaction-to-prevent-deadlocks.md
+++ b/changelog/_unreleased/2021-02-18-add-retryable-transaction-to-prevent-deadlocks.md
@@ -1,0 +1,52 @@
+---
+title: Adds the RetryableTransaction to prevent database deadlocks
+issue:
+author: Hannes Wernery
+author_email: hannes.wernery@pickware.de
+author_github: hanneswernery
+---
+# Core
+* Added class `src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableTransaction.php` that automatically retries a
+  transaction if it failed because of a database deadlock or lock wait timeout.
+* Deprecated constructor argument usage `(Doctrine\DBAL\Driver\Statement $query)`
+  in `src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableQuery.php`. Use arguments
+  `(Doctrine\DBAL\Connection $connection, Doctrine\DBAL\Driver\Statement $query)` instead.
+* Deprecated argument usage `(\Closure $closure)` in static function `retryable` in
+  `src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableQuery.php`. Use arguments
+  `(Doctrine\DBAL\Connection $connection, \Closure $closure)` instead.
+___
+# Upgrade Information
+If multiple `RetryableQuery` are used within the same SQL transaction, and a deadlock occurs, the whole transaction is
+rolled back internally and can be retried. But if instead only the last `RetryableQuery` is retried this can cause all
+kinds of unwanted behaviour (e.g. foreign key constraints).
+
+With the changes to the `RetryableQuery`, you are now encouraged to pass a `Doctrine\DBAL\Connection` in the constructor
+and the static `retryable` function. This way, in case of a deadlock, the `RetryableQuery` can detect an ongoing
+transaction and may rethrow the error instead of retrying itself.
+
+#### Old usages (now deprecated):
+  ```php
+  $retryableQuery = new RetryableQuery($query);
+  
+  RetryableQuery::retryable(function () use ($sql): void {
+      $this->connection->executeUpdate($sql);
+  });
+  ```
+
+#### New usages:
+  ```php
+  $retryableQuery = new RetryableQuery($connection, $query);
+  
+  RetryableQuery::retryable($this->connection, function () use ($sql): void {
+      $this->connection->executeUpdate($sql);
+  });
+  ```
+
+If you are knowingly using a SQL transaction to execute multiple statements, use the newly added `RetryableTransaction`
+class. With it the whole transaction can be retried in case of a deadlock.
+#### Example usage
+  ```php
+  RetryableTransaction::retryable($this->connection, function () use ($sql): void {
+      $this->connection->executeUpdate($sql);
+  });
+  ```

--- a/changelog/_unreleased/2021-02-18-add-retryable-transaction-to-prevent-deadlocks.md
+++ b/changelog/_unreleased/2021-02-18-add-retryable-transaction-to-prevent-deadlocks.md
@@ -14,6 +14,9 @@ author_github: hanneswernery
 * Deprecated argument usage `(\Closure $closure)` in static function `retryable` in
   `src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableQuery.php`. Use arguments
   `(Doctrine\DBAL\Connection $connection, \Closure $closure)` instead.
+* Remove second argument `Command $command` from
+  `Shopware\Core\Framework\DataAbstractionLayer\Dbal\ExceptionHandlerInterface` behind feature flag
+  _FEATURE_NEXT_16640_.
 ___
 # Upgrade Information
 If multiple `RetryableQuery` are used within the same SQL transaction, and a deadlock occurs, the whole transaction is

--- a/changelog/_unreleased/2021-08-27-improved-data-consistency.md
+++ b/changelog/_unreleased/2021-08-27-improved-data-consistency.md
@@ -1,0 +1,11 @@
+---
+title: Improved data consistency
+issue: NEXT-15805
+author: Ulrich Thomas Gabor
+author_email: ulrich.thomas.gabor@odd-solutions.de
+author_github: UlrichThomasGabor
+---
+# Core
+* All calls to `beginTransaction` have been replaced with the new `RetryableTransaction` class, as it provides a cleaner interface anyway and the previous code did not execute `rollback` on exceptions.
+* `MultiInsertQueryQueue` now uses `RetryableTransaction` as well as there is no use case where it is desirable that half of the inserts is in the DB and then the execution of the script stops and the other half is left in the wide nothingness.
+* Introduced transactions at multiple code positions to improve data consistency. Also removed all attempts to be smarter than the DBMS in case of a deadlock and try non-batchy execution of queries; executing single statements not within a transaction can lead to data inconsistency; executing single statements inside of a transaction is in no case beneficial to a batch statement. Catching exceptions also breaks the transaction control flow, i.e. they are not reverted correctly.

--- a/src/Core/Checkout/Customer/DataAbstractionLayer/CustomerWishlistProductExceptionHandler.php
+++ b/src/Core/Checkout/Customer/DataAbstractionLayer/CustomerWishlistProductExceptionHandler.php
@@ -6,6 +6,7 @@ use Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlistProduct\CustomerWi
 use Shopware\Core\Checkout\Customer\Exception\DuplicateWishlistProductException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\ExceptionHandlerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 class CustomerWishlistProductExceptionHandler implements ExceptionHandlerInterface
@@ -15,17 +16,26 @@ class CustomerWishlistProductExceptionHandler implements ExceptionHandlerInterfa
         return ExceptionHandlerInterface::PRIORITY_DEFAULT;
     }
 
-    public function matchException(\Exception $e, WriteCommand $command): ?\Exception
+    /**
+     * @internal (flag:FEATURE_NEXT_16640) - second parameter WriteCommand $command will be removed
+     */
+    public function matchException(\Exception $e, ?WriteCommand $command = null): ?\Exception
     {
-        if ($e->getCode() !== 0 || $command->getDefinition()->getEntityName() !== CustomerWishlistProductDefinition::ENTITY_NAME
-        ) {
+        if ($e->getCode() !== 0) {
+            return null;
+        }
+        if (!Feature::isActive('FEATURE_NEXT_16640') && $command->getDefinition()->getEntityName() !== CustomerWishlistProductDefinition::ENTITY_NAME) {
             return null;
         }
 
         if (preg_match('/SQLSTATE\[23000\]:.*1062 Duplicate.*uniq.customer_wishlist.sales_channel_id__customer_id\'/', $e->getMessage())) {
-            $payload = $command->getPayload();
+            $productId = '';
+            if (!Feature::isActive('FEATURE_NEXT_16640')) {
+                $payload = $command->getPayload();
+                $productId = !empty($payload['product_id']) ? Uuid::fromBytesToHex($payload['product_id']) : '';
+            }
 
-            return new DuplicateWishlistProductException(!empty($payload['product_id']) ? Uuid::fromBytesToHex($payload['product_id']) : '');
+            return new DuplicateWishlistProductException($productId);
         }
 
         return null;

--- a/src/Core/Checkout/Customer/Subscriber/CustomerMetaFieldSubscriber.php
+++ b/src/Core/Checkout/Customer/Subscriber/CustomerMetaFieldSubscriber.php
@@ -126,6 +126,7 @@ class CustomerMetaFieldSubscriber implements EventSubscriberInterface
         }
 
         $update = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE `customer` SET order_count = :order_count, order_total_amount = :order_total_amount, last_order_date = :last_order_date WHERE id = :id')
         );
 

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
@@ -124,7 +124,7 @@ class PromotionExclusionUpdater
             $tags[] = Uuid::fromBytesToHex($row['id']);
         }
 
-        RetryableQuery::retryable(function () use ($affectedIds, $deleteId): void {
+        RetryableQuery::retryable($this->connection, function () use ($affectedIds, $deleteId): void {
             $sqlStatement = "
                 UPDATE promotion
                 SET promotion.exclusion_ids = JSON_REMOVE(promotion.exclusion_ids, JSON_UNQUOTE(JSON_SEARCH(promotion.exclusion_ids,'one', :value)))
@@ -148,7 +148,7 @@ class PromotionExclusionUpdater
             return;
         }
 
-        RetryableQuery::retryable(function () use ($addId, $ids): void {
+        RetryableQuery::retryable($this->connection, function () use ($addId, $ids): void {
             $this->connection->executeUpdate(
                 'UPDATE promotion
                  SET promotion.exclusion_ids = (JSON_ARRAY_APPEND(IFNULL(promotion.exclusion_ids,JSON_ARRAY()), \'$\', :value))
@@ -179,6 +179,7 @@ class PromotionExclusionUpdater
         }
 
         $query = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE promotion SET promotion.exclusion_ids=:value WHERE id=:id')
         );
 

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
@@ -62,6 +62,7 @@ SQL;
             return;
         }
         $update = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE promotion SET order_count = :count, orders_per_customer_count = :customerCount WHERE id = :id')
         );
 

--- a/src/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdater.php
+++ b/src/Core/Content/Category/DataAbstractionLayer/CategoryBreadcrumbUpdater.php
@@ -97,7 +97,7 @@ class CategoryBreadcrumbUpdater
             VALUES (:categoryId, :versionId, :languageId, :breadcrumb, DATE(NOW()))
             ON DUPLICATE KEY UPDATE `breadcrumb` = :breadcrumb
         ');
-        $update = new RetryableQuery($update);
+        $update = new RetryableQuery($this->connection, $update);
 
         foreach ($ids as $id) {
             try {

--- a/src/Core/Content/Category/DataAbstractionLayer/CategoryIndexer.php
+++ b/src/Core/Content/Category/DataAbstractionLayer/CategoryIndexer.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\Event\CategoryIndexerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IterableQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\ChildCountUpdater;
@@ -141,23 +142,21 @@ class CategoryIndexer extends EntityIndexer
 
         $context = $message->getContext();
 
-        $this->connection->beginTransaction();
+        RetryableTransaction::retryable($this->connection, function () use ($message, $ids, $context): void {
+            if ($message->allow(self::CHILD_COUNT_UPDATER)) {
+                // listen to parent id changes
+                $this->childCountUpdater->update(CategoryDefinition::ENTITY_NAME, $ids, $context);
+            }
 
-        if ($message->allow(self::CHILD_COUNT_UPDATER)) {
-            // listen to parent id changes
-            $this->childCountUpdater->update(CategoryDefinition::ENTITY_NAME, $ids, $context);
-        }
+            if ($message->allow(self::TREE_UPDATER)) {
+                $this->treeUpdater->batchUpdate($ids, CategoryDefinition::ENTITY_NAME, $context);
+            }
 
-        if ($message->allow(self::TREE_UPDATER)) {
-            $this->treeUpdater->batchUpdate($ids, CategoryDefinition::ENTITY_NAME, $context);
-        }
-
-        if ($message->allow(self::BREADCRUMB_UPDATER)) {
-            // listen to name changes
-            $this->breadcrumbUpdater->update($ids, $context);
-        }
-
-        $this->connection->commit();
+            if ($message->allow(self::BREADCRUMB_UPDATER)) {
+                // listen to name changes
+                $this->breadcrumbUpdater->update($ids, $context);
+            }
+        });
 
         $this->eventDispatcher->dispatch(new CategoryIndexerEvent($ids, $context, $message->getSkip()));
     }

--- a/src/Core/Content/Media/DataAbstractionLayer/MediaFolderConfigurationIndexer.php
+++ b/src/Core/Content/Media/DataAbstractionLayer/MediaFolderConfigurationIndexer.php
@@ -90,6 +90,7 @@ class MediaFolderConfigurationIndexer extends EntityIndexer
         $configs = $this->repository->search($criteria, $context);
 
         $update = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE media_folder_configuration SET media_thumbnail_sizes_ro = :media_thumbnail_sizes_ro WHERE id = :id')
         );
 

--- a/src/Core/Content/Media/DataAbstractionLayer/MediaFolderIndexer.php
+++ b/src/Core/Content/Media/DataAbstractionLayer/MediaFolderIndexer.php
@@ -90,6 +90,7 @@ class MediaFolderIndexer extends EntityIndexer
         }
 
         $update = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE media_folder SET media_folder_configuration_id = :configId WHERE id = :id')
         );
 

--- a/src/Core/Content/Media/DataAbstractionLayer/MediaIndexer.php
+++ b/src/Core/Content/Media/DataAbstractionLayer/MediaIndexer.php
@@ -91,6 +91,7 @@ class MediaIndexer extends EntityIndexer
         $context = $message->getContext();
 
         $query = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE `media` SET thumbnails_ro = :thumbnails_ro WHERE id = :id')
         );
 

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigExceptionHandler.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigExceptionHandler.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Product\Aggregate\ProductSearchConfig;
 use Shopware\Core\Content\Product\Exception\DuplicateProductSearchConfigLanguageException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\ExceptionHandlerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
+use Shopware\Core\Framework\Feature;
 
 class ProductSearchConfigExceptionHandler implements ExceptionHandlerInterface
 {
@@ -13,16 +14,26 @@ class ProductSearchConfigExceptionHandler implements ExceptionHandlerInterface
         return ExceptionHandlerInterface::PRIORITY_DEFAULT;
     }
 
-    public function matchException(\Exception $e, WriteCommand $command): ?\Exception
+    /**
+     * @internal (flag:FEATURE_NEXT_16640) - second parameter WriteCommand $command will be removed
+     */
+    public function matchException(\Exception $e, ?WriteCommand $command = null): ?\Exception
     {
-        if ($e->getCode() !== 0 || $command->getDefinition()->getEntityName() !== ProductSearchConfigDefinition::ENTITY_NAME) {
+        if ($e->getCode() !== 0) {
+            return null;
+        }
+        if (!Feature::isActive('FEATURE_NEXT_16640') && $command->getDefinition()->getEntityName() !== ProductSearchConfigDefinition::ENTITY_NAME) {
             return null;
         }
 
         if (preg_match('/SQLSTATE\[23000\]:.*1062 Duplicate.*uniq.product_search_config.language_id\'/', $e->getMessage())) {
-            $payload = $command->getPayload();
+            $languageId = '';
+            if (!Feature::isActive('FEATURE_NEXT_16640')) {
+                $payload = $command->getPayload();
+                $languageId = $payload['language_id'] ?? '';
+            }
 
-            return new DuplicateProductSearchConfigLanguageException($payload['language_id'] ?? '', $e);
+            return new DuplicateProductSearchConfigLanguageException($languageId, $e);
         }
 
         return null;

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
@@ -39,7 +39,7 @@ class CheapestPriceUpdater
 
         $versionId = Uuid::fromHexToBytes($context->getVersionId());
 
-        RetryableQuery::retryable(function () use ($parentIds, $versionId): void {
+        RetryableQuery::retryable($this->connection, function () use ($parentIds, $versionId): void {
             $this->connection->executeUpdate(
                 'UPDATE product SET cheapest_price = NULL, cheapest_price_accessor = NULL WHERE (id IN (:ids) OR parent_id IN (:ids)) AND version_id = :version',
                 ['ids' => Uuid::fromHexToBytesList($parentIds), 'version' => $versionId],
@@ -48,10 +48,12 @@ class CheapestPriceUpdater
         });
 
         $cheapestPrice = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE product SET cheapest_price = :price WHERE id = :id AND version_id = :version')
         );
 
         $accessorQuery = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE product SET cheapest_price_accessor = :accessor WHERE id = :id AND version_id = :version')
         );
 

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
@@ -37,10 +37,12 @@ class ProductCategoryDenormalizer
         $liveVersionId = Uuid::fromHexToBytes(Defaults::LIVE_VERSION);
 
         $update = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE product SET category_tree = :tree WHERE id = :id AND version_id = :version')
         );
 
         $delete = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('DELETE FROM `product_category_tree` WHERE `product_id` = :id AND `product_version_id` = :version')
         );
 
@@ -92,6 +94,7 @@ class ProductCategoryDenormalizer
             $queue->execute();
         } catch (DBALException $e) {
             $query = new RetryableQuery(
+                $this->connection,
                 $this->connection->prepare('
                     INSERT IGNORE INTO product_category_tree
                         (`product_id`, `product_version_id`, `category_id`, `category_version_id`)

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
@@ -3,12 +3,11 @@
 namespace Shopware\Core\Content\Product\DataAbstractionLayer;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
-use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 class ProductCategoryDenormalizer
@@ -36,16 +35,7 @@ class ProductCategoryDenormalizer
         $versionId = Uuid::fromHexToBytes($context->getVersionId());
         $liveVersionId = Uuid::fromHexToBytes(Defaults::LIVE_VERSION);
 
-        $update = new RetryableQuery(
-            $this->connection,
-            $this->connection->prepare('UPDATE product SET category_tree = :tree WHERE id = :id AND version_id = :version')
-        );
-
-        $delete = new RetryableQuery(
-            $this->connection,
-            $this->connection->prepare('DELETE FROM `product_category_tree` WHERE `product_id` = :id AND `product_version_id` = :version')
-        );
-
+        $changeSets = [];
         $inserts = [];
         foreach ($categories as $productId => $mapping) {
             $productId = Uuid::fromHexToBytes($productId);
@@ -57,11 +47,14 @@ class ProductCategoryDenormalizer
                 $json = json_encode($categoryIds);
             }
 
-            $params = ['id' => $productId, 'tree' => $json, 'version' => $versionId];
-
-            $update->execute($params);
-
-            $delete->execute(['id' => $productId, 'version' => $versionId]);
+            $changeSets[] = [
+                'type' => 'update',
+                'params' => ['id' => $productId, 'tree' => $json, 'version' => $versionId],
+            ];
+            $changeSets[] = [
+                'type' => 'delete',
+                'params' => ['id' => $productId, 'version' => $versionId],
+            ];
 
             if (empty($categoryIds)) {
                 continue;
@@ -77,7 +70,21 @@ class ProductCategoryDenormalizer
             }
         }
 
-        $this->insertTree($inserts);
+        RetryableTransaction::retryable($this->connection, function () use ($changeSets, $inserts): void {
+            $update = $this->connection->prepare('UPDATE product SET category_tree = :tree WHERE id = :id AND version_id = :version');
+            $delete = $this->connection->prepare('DELETE FROM `product_category_tree` WHERE `product_id` = :id AND `product_version_id` = :version');
+            foreach ($changeSets as $changeSet) {
+                if ($changeSet['type'] === 'update') {
+                    $update->execute($changeSet['params']);
+                } elseif ($changeSet['type'] === 'delete') {
+                    $delete->execute($changeSet['params']);
+                } else {
+                    throw new \LogicException('only "update" and "delete" are allowed as changeSet types');
+                }
+            }
+
+            $this->insertTree($inserts);
+        });
     }
 
     private function insertTree(array $inserts): void
@@ -86,27 +93,11 @@ class ProductCategoryDenormalizer
             return;
         }
 
-        try {
-            $queue = new MultiInsertQueryQueue($this->connection, 250);
-            foreach ($inserts as $insert) {
-                $queue->addInsert('product_category_tree', $insert);
-            }
-            $queue->execute();
-        } catch (DBALException $e) {
-            $query = new RetryableQuery(
-                $this->connection,
-                $this->connection->prepare('
-                    INSERT IGNORE INTO product_category_tree
-                        (`product_id`, `product_version_id`, `category_id`, `category_version_id`)
-                    VALUES
-                        (:product_id, :product_version_id, :category_id, :category_version_id)
-                ')
-            );
-
-            foreach ($inserts as $insert) {
-                $query->execute($insert);
-            }
+        $queue = new MultiInsertQueryQueue($this->connection, 250);
+        foreach ($inserts as $insert) {
+            $queue->addInsert('product_category_tree', $insert);
         }
+        $queue->execute();
     }
 
     private function fetchMapping(array $ids, Context $context): array

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductCategoryDenormalizer.php
@@ -93,7 +93,7 @@ class ProductCategoryDenormalizer
             return;
         }
 
-        $queue = new MultiInsertQueryQueue($this->connection, 250);
+        $queue = new MultiInsertQueryQueue($this->connection, 250, true);
         foreach ($inserts as $insert) {
             $queue->addInsert('product_category_tree', $insert);
         }

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductExceptionHandler.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductExceptionHandler.php
@@ -3,8 +3,10 @@
 namespace Shopware\Core\Content\Product\DataAbstractionLayer;
 
 use Shopware\Core\Content\Product\Exception\DuplicateProductNumberException;
+use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\ExceptionHandlerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
+use Shopware\Core\Framework\Feature;
 
 class ProductExceptionHandler implements ExceptionHandlerInterface
 {
@@ -13,16 +15,26 @@ class ProductExceptionHandler implements ExceptionHandlerInterface
         return ExceptionHandlerInterface::PRIORITY_DEFAULT;
     }
 
-    public function matchException(\Exception $e, WriteCommand $command): ?\Exception
+    /**
+     * @internal (flag:FEATURE_NEXT_16640) - second parameter WriteCommand $command will be removed
+     */
+    public function matchException(\Exception $e, ?WriteCommand $command = null): ?\Exception
     {
-        if ($e->getCode() !== 0 || $command->getDefinition()->getEntityName() !== 'product') {
+        if ($e->getCode() !== 0) {
+            return null;
+        }
+        if (!Feature::isActive('FEATURE_NEXT_16640') && $command->getDefinition()->getEntityName() !== ProductDefinition::ENTITY_NAME) {
             return null;
         }
 
         if (preg_match('/SQLSTATE\[23000\]:.*1062 Duplicate.*uniq.product.product_number__version_id\'/', $e->getMessage())) {
-            $payload = $command->getPayload();
+            $productNumber = '';
+            if (!Feature::isActive('FEATURE_NEXT_16640')) {
+                $payload = $command->getPayload();
+                $productNumber = $payload['product_number'] ?? '';
+            }
 
-            return new DuplicateProductNumberException($payload['product_number'] ?? '', $e);
+            return new DuplicateProductNumberException($productNumber, $e);
         }
 
         return null;

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductIndexer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductIndexer.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IterableQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\ChildCountUpdater;
@@ -155,57 +156,55 @@ class ProductIndexer extends EntityIndexer
 
         $context = $message->getContext();
 
-        $this->connection->beginTransaction();
+        RetryableTransaction::retryable($this->connection, function () use ($message, $ids, $parentIds, $childrenIds, $context): void {
+            $all = array_filter(array_unique(array_merge($ids, $parentIds, $childrenIds)));
 
-        $all = array_filter(array_unique(array_merge($ids, $parentIds, $childrenIds)));
+            if ($message->allow(self::INHERITANCE_UPDATER)) {
+                $this->inheritanceUpdater->update(ProductDefinition::ENTITY_NAME, $all, $context);
+            }
 
-        if ($message->allow(self::INHERITANCE_UPDATER)) {
-            $this->inheritanceUpdater->update(ProductDefinition::ENTITY_NAME, $all, $context);
-        }
+            if ($message->allow(self::STOCK_UPDATER)) {
+                $this->stockUpdater->update($ids, $context);
+            }
 
-        if ($message->allow(self::STOCK_UPDATER)) {
-            $this->stockUpdater->update($ids, $context);
-        }
+            if ($message->allow(self::VARIANT_LISTING_UPDATER)) {
+                $this->variantListingUpdater->update($parentIds, $context);
+            }
 
-        if ($message->allow(self::VARIANT_LISTING_UPDATER)) {
-            $this->variantListingUpdater->update($parentIds, $context);
-        }
+            if ($message->allow(self::CHILD_COUNT_UPDATER)) {
+                $this->childCountUpdater->update(ProductDefinition::ENTITY_NAME, $parentIds, $context);
+            }
 
-        if ($message->allow(self::CHILD_COUNT_UPDATER)) {
-            $this->childCountUpdater->update(ProductDefinition::ENTITY_NAME, $parentIds, $context);
-        }
+            if ($message->allow(self::MANY_TO_MANY_ID_FIELD_UPDATER)) {
+                $this->manyToManyIdFieldUpdater->update(ProductDefinition::ENTITY_NAME, $all, $context);
+            }
 
-        if ($message->allow(self::MANY_TO_MANY_ID_FIELD_UPDATER)) {
-            $this->manyToManyIdFieldUpdater->update(ProductDefinition::ENTITY_NAME, $all, $context);
-        }
+            if ($message->allow(self::CATEGORY_DENORMALIZER_UPDATER)) {
+                $this->categoryDenormalizer->update($ids, $context);
+            }
 
-        if ($message->allow(self::CATEGORY_DENORMALIZER_UPDATER)) {
-            $this->categoryDenormalizer->update($ids, $context);
-        }
+            if ($message->allow(self::CHEAPEST_PRICE_UPDATER)) {
+                $this->cheapestPriceUpdater->update($parentIds, $context);
+            }
 
-        if ($message->allow(self::CHEAPEST_PRICE_UPDATER)) {
-            $this->cheapestPriceUpdater->update($parentIds, $context);
-        }
+            if ($message->allow(self::RATING_AVERAGE_UPDATER)) {
+                $this->ratingAverageUpdater->update($parentIds, $context);
+            }
 
-        if ($message->allow(self::RATING_AVERAGE_UPDATER)) {
-            $this->ratingAverageUpdater->update($parentIds, $context);
-        }
+            if ($message->allow(self::STREAM_UPDATER)) {
+                $this->streamUpdater->updateProducts($all, $context);
+            }
 
-        if ($message->allow(self::STREAM_UPDATER)) {
-            $this->streamUpdater->updateProducts($all, $context);
-        }
+            if ($message->allow(self::SEARCH_KEYWORD_UPDATER)) {
+                $this->searchKeywordUpdater->update(array_merge($ids, $childrenIds), $context);
+            }
 
-        if ($message->allow(self::SEARCH_KEYWORD_UPDATER)) {
-            $this->searchKeywordUpdater->update(array_merge($ids, $childrenIds), $context);
-        }
-
-        $this->connection->executeStatement(
-            'UPDATE product SET updated_at = :now WHERE id IN (:ids)',
-            ['ids' => Uuid::fromHexToBytesList($all), 'now' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)],
-            ['ids' => Connection::PARAM_STR_ARRAY]
-        );
-
-        $this->connection->commit();
+            $this->connection->executeStatement(
+                'UPDATE product SET updated_at = :now WHERE id IN (:ids)',
+                ['ids' => Uuid::fromHexToBytesList($all), 'now' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT)],
+                ['ids' => Connection::PARAM_STR_ARRAY]
+            );
+        });
 
         $this->eventDispatcher->dispatch(new ProductIndexerEvent($ids, $childrenIds, $parentIds, $context, $message->getSkip()));
     }

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
@@ -109,14 +109,14 @@ class ProductStreamUpdater extends EntityIndexer
             }
         }
 
-        RetryableQuery::retryable(function () use ($binary): void {
+        RetryableQuery::retryable($this->connection, function () use ($binary): void {
             $this->connection->executeStatement(
                 'DELETE FROM product_stream_mapping WHERE product_stream_id = :id',
                 ['id' => $binary],
             );
         });
 
-        RetryableQuery::retryable(function () use ($insert): void {
+        RetryableQuery::retryable($this->connection, function () use ($insert): void {
             $insert->execute();
         });
     }
@@ -177,7 +177,7 @@ class ProductStreamUpdater extends EntityIndexer
             }
         }
 
-        RetryableQuery::retryable(function () use ($ids): void {
+        RetryableQuery::retryable($this->connection, function () use ($ids): void {
             $this->connection->executeStatement(
                 'DELETE FROM product_stream_mapping WHERE product_id IN (:ids)',
                 ['ids' => Uuid::fromHexToBytesList($ids)],
@@ -185,7 +185,7 @@ class ProductStreamUpdater extends EntityIndexer
             );
         });
 
-        RetryableQuery::retryable(function () use ($insert): void {
+        RetryableQuery::retryable($this->connection, function () use ($insert): void {
             $insert->execute();
         });
     }

--- a/src/Core/Content/Product/DataAbstractionLayer/RatingAverageUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/RatingAverageUpdater.php
@@ -27,7 +27,7 @@ class RatingAverageUpdater
 
         $versionId = Uuid::fromHexToBytes($context->getVersionId());
 
-        RetryableQuery::retryable(function () use ($ids, $versionId): void {
+        RetryableQuery::retryable($this->connection, function () use ($ids, $versionId): void {
             $this->connection->executeUpdate(
                 'UPDATE product SET rating_average = NULL WHERE (parent_id IN (:ids) OR id IN (:ids)) AND version_id = :version',
                 ['ids' => Uuid::fromHexToBytesList($ids), 'version' => $versionId],
@@ -52,6 +52,7 @@ class RatingAverageUpdater
         $averages = $query->execute()->fetchAll();
 
         $query = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE product SET rating_average = :average WHERE id = :id AND version_id = :version')
         );
 

--- a/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
@@ -169,7 +169,7 @@ class SearchKeywordUpdater
             'versionId' => Uuid::fromHexToBytes($versionId),
         ];
 
-        RetryableQuery::retryable(function () use ($params): void {
+        RetryableQuery::retryable($this->connection, function () use ($params): void {
             $this->connection->executeUpdate(
                 'DELETE FROM product_search_keyword WHERE product_id IN (:ids) AND language_id = :language AND version_id = :versionId',
                 $params,
@@ -191,6 +191,7 @@ class SearchKeywordUpdater
         } catch (\Exception $e) {
             // catch deadlock exception and retry with single insert
             $query = new RetryableQuery(
+                $this->connection,
                 $this->connection->prepare('
                     INSERT IGNORE INTO `product_search_keyword` (`id`, `version_id`, `product_version_id`, `language_id`, `product_id`, `keyword`, `ranking`, `created_at`)
                     VALUES (:id, :version_id, :product_version_id, :language_id, :product_id, :keyword, :ranking, :created_at)
@@ -217,6 +218,7 @@ class SearchKeywordUpdater
         } catch (\Exception $e) {
             // catch deadlock exception and retry with single insert
             $query = new RetryableQuery(
+                $this->connection,
                 $this->connection->prepare('INSERT IGNORE INTO `product_keyword_dictionary` (`id`, `language_id`, `keyword`) VALUES (:id, :language_id, :keyword)')
             );
 

--- a/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
@@ -180,7 +180,7 @@ class SearchKeywordUpdater
 
     private function insertKeywords(array $keywords): void
     {
-        $queue = new MultiInsertQueryQueue($this->connection, 50);
+        $queue = new MultiInsertQueryQueue($this->connection, 50, true);
         foreach ($keywords as $insert) {
             $queue->addInsert(ProductSearchKeywordDefinition::ENTITY_NAME, $insert);
         }
@@ -189,7 +189,7 @@ class SearchKeywordUpdater
 
     private function insertDictionary(array $dictionary): void
     {
-        $queue = new MultiInsertQueryQueue($this->connection, 50, false, true);
+        $queue = new MultiInsertQueryQueue($this->connection, 50, true, true);
 
         foreach ($dictionary as $insert) {
             $queue->addInsert(ProductKeywordDictionaryDefinition::ENTITY_NAME, $insert);

--- a/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
@@ -184,24 +184,7 @@ class SearchKeywordUpdater
         foreach ($keywords as $insert) {
             $queue->addInsert(ProductSearchKeywordDefinition::ENTITY_NAME, $insert);
         }
-
-        // try batch insert
-        try {
-            $queue->execute();
-        } catch (\Exception $e) {
-            // catch deadlock exception and retry with single insert
-            $query = new RetryableQuery(
-                $this->connection,
-                $this->connection->prepare('
-                    INSERT IGNORE INTO `product_search_keyword` (`id`, `version_id`, `product_version_id`, `language_id`, `product_id`, `keyword`, `ranking`, `created_at`)
-                    VALUES (:id, :version_id, :product_version_id, :language_id, :product_id, :keyword, :ranking, :created_at)
-                ')
-            );
-
-            foreach ($keywords as $keyword) {
-                $query->execute($keyword);
-            }
-        }
+        $queue->execute();
     }
 
     private function insertDictionary(array $dictionary): void
@@ -211,21 +194,7 @@ class SearchKeywordUpdater
         foreach ($dictionary as $insert) {
             $queue->addInsert(ProductKeywordDictionaryDefinition::ENTITY_NAME, $insert);
         }
-
-        // try batch insert
-        try {
-            $queue->execute();
-        } catch (\Exception $e) {
-            // catch deadlock exception and retry with single insert
-            $query = new RetryableQuery(
-                $this->connection,
-                $this->connection->prepare('INSERT IGNORE INTO `product_keyword_dictionary` (`id`, `language_id`, `keyword`) VALUES (:id, :language_id, :keyword)')
-            );
-
-            foreach ($dictionary as $insert) {
-                $query->execute($insert);
-            }
-        }
+        $queue->execute();
     }
 
     private function buildCriteria(array $accessors, Criteria $criteria, Context $context): void

--- a/src/Core/Content/Product/DataAbstractionLayer/StockUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/StockUpdater.php
@@ -262,6 +262,7 @@ GROUP BY product_id;
         $fallback = array_diff($ids, $fallback);
 
         $update = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE product SET available_stock = stock - :open_quantity, sales = :sales_quantity, updated_at = :now WHERE id = :id')
         );
 
@@ -309,7 +310,7 @@ GROUP BY product_id;
             AND product.version_id = :version
         ';
 
-        RetryableQuery::retryable(function () use ($sql, $context, $bytes): void {
+        RetryableQuery::retryable($this->connection, function () use ($sql, $context, $bytes): void {
             $this->connection->executeUpdate(
                 $sql,
                 ['ids' => $bytes, 'version' => Uuid::fromHexToBytes($context->getVersionId())],
@@ -331,6 +332,7 @@ GROUP BY product_id;
     private function updateStock(array $products, int $multiplier): void
     {
         $query = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE product SET stock = stock + :quantity WHERE id = :id AND version_id = :version')
         );
 

--- a/src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
@@ -34,14 +34,17 @@ class VariantListingUpdater
         $listingConfiguration = $this->getListingConfiguration($ids, $context);
 
         $displayParent = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE product SET display_group = MD5(HEX(product.id)) WHERE product.id = :id AND product.version_id = :versionId')
         );
 
         $hideParent = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE product SET display_group = NULL WHERE product.id = :id AND product.version_id = :versionId')
         );
 
         $singleVariant = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE product SET display_group = MD5(HEX(product.parent_id)) WHERE product.parent_id = :id AND product.version_id = :versionId')
         );
 
@@ -97,7 +100,7 @@ class VariantListingUpdater
                 )
             ) WHERE parent_id = :parentId AND version_id = :versionId';
 
-            RetryableQuery::retryable(function () use ($sql, $params): void {
+            RetryableQuery::retryable($this->connection, function () use ($sql, $params): void {
                 $this->connection->executeUpdate($sql, $params);
             });
         }

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingExceptionHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingExceptionHandler.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Product\SalesChannel\Sorting;
 use Shopware\Core\Content\Product\Exception\DuplicateProductSortingKeyException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\ExceptionHandlerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
+use Shopware\Core\Framework\Feature;
 
 class ProductSortingExceptionHandler implements ExceptionHandlerInterface
 {
@@ -13,16 +14,26 @@ class ProductSortingExceptionHandler implements ExceptionHandlerInterface
         return ExceptionHandlerInterface::PRIORITY_DEFAULT;
     }
 
-    public function matchException(\Exception $e, WriteCommand $command): ?\Exception
+    /**
+     * @internal (flag:FEATURE_NEXT_16640) - second parameter WriteCommand $command will be removed
+     */
+    public function matchException(\Exception $e, ?WriteCommand $command = null): ?\Exception
     {
-        if ($e->getCode() !== 0 || $command->getDefinition()->getEntityName() !== ProductSortingDefinition::ENTITY_NAME) {
+        if ($e->getCode() !== 0) {
+            return null;
+        }
+        if (!Feature::isActive('FEATURE_NEXT_16640') && $command->getDefinition()->getEntityName() !== ProductSortingDefinition::ENTITY_NAME) {
             return null;
         }
 
         if (preg_match('/SQLSTATE\[23000\]:.*1062 Duplicate.*uniq.product_sorting.url_key\'/', $e->getMessage())) {
-            $payload = $command->getPayload();
+            $key = '';
+            if (!Feature::isActive('FEATURE_NEXT_16640')) {
+                $payload = $command->getPayload();
+                $key = $payload['url_key'] ?? '';
+            }
 
-            return new DuplicateProductSortingKeyException($payload['url_key'] ?? '', $e);
+            return new DuplicateProductSortingKeyException($key, $e);
         }
 
         return null;

--- a/src/Core/Content/ProductExport/DataAbstractionLayer/ProductExportExceptionHandler.php
+++ b/src/Core/Content/ProductExport/DataAbstractionLayer/ProductExportExceptionHandler.php
@@ -3,21 +3,33 @@
 namespace Shopware\Core\Content\ProductExport\DataAbstractionLayer;
 
 use Shopware\Core\Content\ProductExport\Exception\DuplicateFileNameException;
+use Shopware\Core\Content\ProductExport\ProductExportDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\ExceptionHandlerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
+use Shopware\Core\Framework\Feature;
 
 class ProductExportExceptionHandler implements ExceptionHandlerInterface
 {
-    public function matchException(\Exception $e, WriteCommand $command): ?\Exception
+    /**
+     * @internal (flag:FEATURE_NEXT_16640) - second parameter WriteCommand $command will be removed
+     */
+    public function matchException(\Exception $e, ?WriteCommand $command = null): ?\Exception
     {
-        if ($e->getCode() !== 0 || $command->getDefinition()->getEntityName() !== 'product_export') {
+        if ($e->getCode() !== 0) {
+            return null;
+        }
+        if (!Feature::isActive('FEATURE_NEXT_16640') && $command->getDefinition()->getEntityName() !== ProductExportDefinition::ENTITY_NAME) {
             return null;
         }
 
         if (preg_match('/SQLSTATE\[23000\]:.*1062 Duplicate.*file_name\'/', $e->getMessage())) {
-            $payload = $command->getPayload();
+            $fileName = '';
+            if (!Feature::isActive('FEATURE_NEXT_16640')) {
+                $payload = $command->getPayload();
+                $fileName = $payload['file_name'] ?? '';
+            }
 
-            return new DuplicateFileNameException($payload['file_name'] ?? '', $e);
+            return new DuplicateFileNameException($fileName, $e);
         }
 
         return null;

--- a/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexer.php
+++ b/src/Core/Content/ProductStream/DataAbstractionLayer/ProductStreamIndexer.php
@@ -107,6 +107,7 @@ class ProductStreamIndexer extends EntityIndexer
         $filters = FetchModeHelper::group($filters);
 
         $update = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE product_stream SET api_filter = :serialized, invalid = :invalid WHERE id = :id')
         );
 

--- a/src/Core/Content/Rule/DataAbstractionLayer/RuleIndexer.php
+++ b/src/Core/Content/Rule/DataAbstractionLayer/RuleIndexer.php
@@ -75,6 +75,7 @@ class RuleIndexer extends EntityIndexer implements EventSubscriberInterface
     {
         // Delete the payload and invalid flag of all rules
         $update = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE `rule` SET `payload` = null, `invalid` = 0')
         );
         $update->execute();

--- a/src/Core/Content/Rule/DataAbstractionLayer/RulePayloadUpdater.php
+++ b/src/Core/Content/Rule/DataAbstractionLayer/RulePayloadUpdater.php
@@ -34,6 +34,7 @@ class RulePayloadUpdater
         $rules = FetchModeHelper::group($conditions);
 
         $update = new RetryableQuery(
+            $this->connection,
             $this->connection->prepare('UPDATE `rule` SET payload = :payload, invalid = :invalid WHERE id = :id')
         );
 

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -113,7 +113,7 @@ class SeoUrlPersister
         try {
             $this->obsoleteIds($obsoleted, $dateTime, $salesChannelId);
 
-            RetryableQuery::retryable(function () use ($insertQuery): void {
+            RetryableQuery::retryable($this->connection, function () use ($insertQuery): void {
                 $insertQuery->execute();
             });
 
@@ -237,7 +237,7 @@ class SeoUrlPersister
             $query->setParameter('salesChannelId', Uuid::fromHexToBytes($salesChannelId));
         }
 
-        RetryableQuery::retryable(function () use ($query): void {
+        RetryableQuery::retryable($this->connection, function () use ($query): void {
             $query->execute();
         });
     }

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -209,7 +209,7 @@ class SeoUrlPersister
             $query->setParameter('salesChannelId', Uuid::fromHexToBytes($salesChannelId));
         }
 
-        RetryableQuery::retryable(function () use ($query): void {
+        RetryableQuery::retryable($this->connection, function () use ($query): void {
             $query->execute();
         });
     }

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -231,8 +231,6 @@ class SeoUrlPersister
             $query->setParameter('salesChannelId', Uuid::fromHexToBytes($salesChannelId));
         }
 
-        RetryableQuery::retryable($this->connection, function () use ($query): void {
-            $query->execute();
-        });
+        $query->execute();
     }
 }

--- a/src/Core/Content/Seo/SeoUrlPersister.php
+++ b/src/Core/Content/Seo/SeoUrlPersister.php
@@ -7,7 +7,7 @@ use Shopware\Core\Content\Seo\Event\SeoUrlUpdateEvent;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
-use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -108,29 +108,23 @@ class SeoUrlPersister
             $insertQuery->addInsert($this->seoUrlRepository->getDefinition()->getEntityName(), $insert);
         }
 
-        $this->connection->beginTransaction();
-
-        try {
+        RetryableTransaction::retryable($this->connection, function () use (
+            $obsoleted,
+            $dateTime,
+            $insertQuery,
+            $foreignKeys,
+            $updatedFks,
+            $salesChannelId
+        ): void {
             $this->obsoleteIds($obsoleted, $dateTime, $salesChannelId);
-
-            RetryableQuery::retryable($this->connection, function () use ($insertQuery): void {
-                $insertQuery->execute();
-            });
+            $insertQuery->execute();
 
             $deletedIds = array_diff($foreignKeys, $updatedFks);
             $notDeletedIds = array_unique(array_intersect($foreignKeys, $updatedFks));
 
             $this->markAsDeleted(true, $deletedIds, $dateTime, $salesChannelId);
             $this->markAsDeleted(false, $notDeletedIds, $dateTime, $salesChannelId);
-
-            if (!$this->connection->isRollbackOnly()) {
-                $this->connection->commit();
-            } else {
-                $this->connection->rollBack();
-            }
-        } catch (\Throwable $e) {
-            $this->connection->rollBack();
-        }
+        });
 
         $this->eventDispatcher->dispatch(new SeoUrlUpdateEvent($updates));
     }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
@@ -270,7 +270,6 @@ class EntityWriteGateway implements EntityWriteGatewayInterface
             throw $e;
         }
 
-
         // throws exception on violation and then aborts/rollbacks this transaction
         $event = new PostWriteValidationEvent($context, $commands);
         $this->eventDispatcher->dispatch($event);

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/ExceptionHandlerInterface.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/ExceptionHandlerInterface.php
@@ -14,5 +14,8 @@ interface ExceptionHandlerInterface
 
     public function getPriority(): int;
 
-    public function matchException(\Exception $e, WriteCommand $command): ?\Exception;
+    /**
+     * @internal (flag:FEATURE_NEXT_16640) - second parameter WriteCommand $command will be removed
+     */
+    public function matchException(\Exception $e, ?WriteCommand $command = null): ?\Exception;
 }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/ExceptionHandlerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/ExceptionHandlerRegistry.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer\Dbal;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
+use Shopware\Core\Framework\Feature;
 
 class ExceptionHandlerRegistry
 {
@@ -23,11 +24,18 @@ class ExceptionHandlerRegistry
         $this->exceptionHandlers[$exceptionHandler->getPriority()][] = $exceptionHandler;
     }
 
-    public function matchException(\Exception $e, WriteCommand $command): ?\Exception
+    /**
+     * @internal (flag:FEATURE_NEXT_16640) - second parameter WriteCommand $command will be removed
+     */
+    public function matchException(\Exception $e, ?WriteCommand $command = null): ?\Exception
     {
         foreach ($this->getExceptionHandlers() as $priorityExceptionHandlers) {
             foreach ($priorityExceptionHandlers as $exceptionHandler) {
-                $innerException = $exceptionHandler->matchException($e, $command);
+                if (!Feature::isActive('FEATURE_NEXT_16640')) {
+                    $innerException = $exceptionHandler->matchException($e, $command);
+                } else {
+                    $innerException = $exceptionHandler->matchException($e);
+                }
                 if ($innerException instanceof \Exception) {
                     return $innerException;
                 }

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
@@ -81,7 +81,7 @@ class MultiInsertQueryQueue
         $grouped = $this->prepare();
 
         foreach ($grouped as $query) {
-            RetryableQuery::retryable(function () use ($query): void {
+            RetryableQuery::retryable($this->connection, function () use ($query): void {
                 $this->connection->executeStatement($query);
             });
         }

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
@@ -79,12 +79,11 @@ class MultiInsertQueryQueue
         }
 
         $grouped = $this->prepare();
-
-        foreach ($grouped as $query) {
-            RetryableQuery::retryable($this->connection, function () use ($query): void {
+        RetryableTransaction::retryable($this->connection, function () use ($grouped): void {
+            foreach ($grouped as $query) {
                 $this->connection->executeStatement($query);
-            });
-        }
+            }
+        });
         unset($grouped);
 
         $this->inserts = [];

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableQuery.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableQuery.php
@@ -2,31 +2,73 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Doctrine;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Statement;
 use Doctrine\DBAL\Exception\RetryableException;
 
 class RetryableQuery
 {
     /**
+     * @var Connection|null
+     */
+    private $connection;
+
+    /**
      * @var Statement
      */
     private $query;
 
-    public function __construct(Statement $query)
+    /**
+     * @param Connection $param1
+     * @param Statement  $param2
+     */
+    public function __construct($param1, $param2 = null)
     {
-        $this->query = $query;
+        if ($param1 instanceof Statement && $param2 === null) {
+            @trigger_error(
+                'Use constructor arguments (Doctrine\DBAL\Connection $connection, Doctrine\DBAL\Driver\Statement $query) instead.',
+                \E_USER_DEPRECATED
+            );
+            $this->query = $param1;
+        } elseif ($param1 instanceof Connection && $param2 instanceof Statement) {
+            $this->connection = $param1;
+            $this->query = $param2;
+        } else {
+            throw new \InvalidArgumentException(
+                'Constructor arguments must be of type (Doctrine\DBAL\Connection $connection, Doctrine\DBAL\Driver\Statement $query).'
+            );
+        }
     }
 
     public function execute(?array $params = null): bool
     {
-        return self::retry(function () use ($params) {
+        return self::retry($this->connection, function () use ($params) {
             return $this->query->execute($params);
         }, 1);
     }
 
-    public static function retryable(\Closure $closure)
+    /**
+     * @param Connection $param1
+     * @param \Closure   $param2
+     */
+    public static function retryable($param1, $param2 = null)
     {
-        return self::retry($closure, 0);
+        if ($param1 instanceof \Closure && $param2 === null) {
+            @trigger_error(
+                'Use arguments (Doctrine\DBAL\Connection $connection, \Closure $closure) instead.',
+                \E_USER_DEPRECATED
+            );
+
+            return self::retry(null, $param1, 0);
+        }
+
+        if ($param1 instanceof Connection && $param2 instanceof \Closure) {
+            return self::retry($param1, $param2, 0);
+        }
+
+        throw new \InvalidArgumentException(
+            'Arguments must be of type (Doctrine\DBAL\Connection $connection, \Closure $closure).'
+        );
     }
 
     public function getQuery(): Statement
@@ -34,13 +76,20 @@ class RetryableQuery
         return $this->query;
     }
 
-    private static function retry(\Closure $closure, int $counter)
+    private static function retry(?Connection $connection, \Closure $closure, int $counter)
     {
         ++$counter;
 
         try {
             return $closure();
         } catch (RetryableException $e) {
+            if ($connection && $connection->getTransactionNestingLevel() > 0) {
+                // If this closure was executed inside a transaction, do not retry. Remember that the whole (outermost)
+                // transaction was already rolled back by the database when any RetryableException is thrown. Rethrow
+                // the exception here so only the outermost transaction is retried which in turn includes this closure.
+                throw $e;
+            }
+
             if ($counter > 10) {
                 throw $e;
             }
@@ -48,7 +97,7 @@ class RetryableQuery
             // randomize sleep to prevent same execution delay for multiple statements
             usleep(random_int(10, 20));
 
-            return self::retry($closure, $counter);
+            return self::retry($connection, $closure, $counter);
         }
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableTransaction.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableTransaction.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Doctrine;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\RetryableException;
+
+class RetryableTransaction
+{
+    /**
+     * Executes the given closure inside a DBAL transaction. In case of a deadlock (RetryableException) the transaction
+     * is rolled back and the closure will be retried. Because it may run multiple times the closure should not cause
+     * any side effects outside of its own scope.
+     */
+    public static function retryable(Connection $connection, \Closure $closure): void
+    {
+        self::retry($connection, $closure, 0);
+    }
+
+    private static function retry(Connection $connection, \Closure $closure, int $counter): void
+    {
+        ++$counter;
+
+        try {
+            $connection->transactional($closure);
+        } catch (RetryableException $retryableException) {
+            if ($connection->getTransactionNestingLevel() > 0) {
+                // If this RetryableTransaction was executed inside another transaction, do not retry this nested
+                // transaction. Remember that the whole (outermost) transaction was already rolled back by the database
+                // when any RetryableException is thrown.
+                // Rethrow the exception here so only the outermost transaction is retried which in turn includes this
+                // nested transaction.
+                throw $retryableException;
+            }
+
+            if ($counter > 10) {
+                throw $retryableException;
+            }
+
+            // Randomize sleep to prevent same execution delay for multiple statements
+            usleep(random_int(10, 20));
+
+            self::retry($connection, $closure, $counter);
+        }
+    }
+}

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/ChildCountUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/ChildCountUpdater.php
@@ -3,12 +3,10 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer\Indexing;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Exception\DeadlockException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
-use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
-use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableTransaction;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -32,13 +30,9 @@ class ChildCountUpdater
             return;
         }
 
-        try {
-            // try update all ids with a single sql statement, this works only if no other process writes this table
+        RetryableTransaction::retryable($this->connection, function () use ($definition, $parentIds, $context): void {
             $this->trySingleUpdate($definition, $parentIds, $context);
-        } catch (DeadlockException $e) {
-            // deadlock will appear when another process tries to write the same records
-            $this->doMultiUpdate($definition, $parentIds, $context);
-        }
+        });
     }
 
     private function trySingleUpdate(EntityDefinition $definition, array $parentIds, Context $context): void
@@ -75,52 +69,5 @@ class ChildCountUpdater
         }
 
         $this->connection->executeUpdate($sql, $params, ['ids' => Connection::PARAM_STR_ARRAY]);
-    }
-
-    private function doMultiUpdate(EntityDefinition $definition, array $parentIds, Context $context): void
-    {
-        $entityName = $definition->getEntityName();
-
-        $query = $this->connection->createQueryBuilder();
-        $query->select([
-            'LOWER(HEX(parent_id)) as id',
-            'COUNT(id) as total',
-        ]);
-        $query->from(EntityDefinitionQueryHelper::escape($entityName), 'parent');
-        $query->where('parent.parent_id IN (:ids)');
-        $query->andWhere('parent.parent_id IS NOT NULL');
-        $query->setParameter('ids', Uuid::fromHexToBytesList($parentIds), Connection::PARAM_STR_ARRAY);
-
-        if ($definition->isVersionAware()) {
-            $query->andWhere('parent.version_id = :versionId');
-            $query->setParameter('versionId', Uuid::fromHexToBytes($context->getVersionId()));
-        }
-
-        $query->groupBy('parent.parent_id');
-        $totals = $query->execute()->fetchAll();
-
-        $sql = sprintf('UPDATE %s SET child_count = :count WHERE id = :id', EntityDefinitionQueryHelper::escape($entityName));
-        $params = [];
-        if ($definition->isVersionAware()) {
-            $sql = sprintf('UPDATE %s SET child_count = :count WHERE id = :id AND version_id = :versionId', EntityDefinitionQueryHelper::escape($entityName));
-            $params = ['versionId' => Uuid::fromHexToBytes($context->getVersionId())];
-        }
-
-        $update = new RetryableQuery($this->connection, $this->connection->prepare($sql));
-
-        $totals = FetchModeHelper::keyPair($totals);
-
-        foreach ($totals as $id => $total) {
-            $update->execute(array_merge($params, ['id' => Uuid::fromHexToBytes($id), 'count' => (int) $total]));
-        }
-
-        $parentIds = array_flip($parentIds);
-        $without = array_diff_key($parentIds, $totals);
-
-        $without = array_keys($without);
-
-        foreach ($without as $id) {
-            $update->execute(array_merge($params, ['id' => Uuid::fromHexToBytes($id), 'count' => 0]));
-        }
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/ChildCountUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/ChildCountUpdater.php
@@ -106,7 +106,7 @@ class ChildCountUpdater
             $params = ['versionId' => Uuid::fromHexToBytes($context->getVersionId())];
         }
 
-        $update = new RetryableQuery($this->connection->prepare($sql));
+        $update = new RetryableQuery($this->connection, $this->connection->prepare($sql));
 
         $totals = FetchModeHelper::keyPair($totals);
 

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/InheritanceUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/InheritanceUpdater.php
@@ -114,7 +114,7 @@ class InheritanceUpdater
                 $sql
             );
 
-            RetryableQuery::retryable(function () use ($params, $sql): void {
+            RetryableQuery::retryable($this->connection, function () use ($params, $sql): void {
                 $this->connection->executeUpdate(
                     $sql,
                     $params,
@@ -163,7 +163,7 @@ class InheritanceUpdater
                 $sql
             );
 
-            RetryableQuery::retryable(function () use ($sql, $params): void {
+            RetryableQuery::retryable($this->connection, function () use ($sql, $params): void {
                 $this->connection->executeUpdate(
                     $sql,
                     $params,
@@ -190,7 +190,7 @@ class InheritanceUpdater
                 $sql
             );
 
-            RetryableQuery::retryable(function () use ($sql, $params): void {
+            RetryableQuery::retryable($this->connection, function () use ($sql, $params): void {
                 $this->connection->executeUpdate(
                     $sql,
                     $params,

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/ManyToManyIdFieldUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/ManyToManyIdFieldUpdater.php
@@ -129,7 +129,7 @@ SQL;
                 $resetTemplate
             );
 
-            RetryableQuery::retryable(function () use ($resetSql, $parameters): void {
+            RetryableQuery::retryable($this->connection, function () use ($resetSql, $parameters): void {
                 $this->connection->executeUpdate(
                     $resetSql,
                     $parameters,
@@ -137,7 +137,7 @@ SQL;
                 );
             });
 
-            RetryableQuery::retryable(function () use ($sql, $parameters): void {
+            RetryableQuery::retryable($this->connection, function () use ($sql, $parameters): void {
                 $this->connection->executeUpdate(
                     $sql,
                     $parameters,

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
@@ -141,7 +141,7 @@ class TreeUpdater
         $query->setParameter('id', $entity['id']);
         $this->makeQueryVersionAware($definition, Uuid::fromHexToBytes($context->getVersionId()), $query);
 
-        RetryableQuery::retryable(function () use ($query): void {
+        RetryableQuery::retryable($this->connection, function () use ($query): void {
             $query->execute();
         });
 

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -329,6 +329,11 @@ shopware:
               major: true
               description: "Refactor `sw-simple-search-field` component to a transparent wrapper component"
               # issue: NEXT-16271
+            - name: FEATURE_NEXT_16640
+              default: false
+              major: true
+              description: "Change ExceptionHandlerInterface by removing Command $command argument"
+              # issue: NEXT-16640
 
 
     logger:

--- a/src/Core/System/Country/CountryTaxFreeDeprecationUpdater.php
+++ b/src/Core/System/Country/CountryTaxFreeDeprecationUpdater.php
@@ -84,7 +84,7 @@ class CountryTaxFreeDeprecationUpdater implements EventSubscriberInterface
                     WHERE id = :countryId;';
         }
 
-        $update = new RetryableQuery($this->connection->prepare($query));
+        $update = new RetryableQuery($this->connection, $this->connection->prepare($query));
 
         foreach ($countries as $country) {
             if ($taxFreeType === CountryDefinition::TYPE_CUSTOMER_TAX_FREE) {
@@ -128,7 +128,7 @@ class CountryTaxFreeDeprecationUpdater implements EventSubscriberInterface
             $query = 'UPDATE `country` SET `company_tax_free` = :isTaxFree WHERE id = :countryId;';
         }
 
-        $update = new RetryableQuery($this->connection->prepare($query));
+        $update = new RetryableQuery($this->connection, $this->connection->prepare($query));
 
         foreach ($countries as $country) {
             if ($taxFreeType === CountryDefinition::TYPE_CUSTOMER_TAX_FREE) {

--- a/src/Core/System/Language/LanguageExceptionHandler.php
+++ b/src/Core/System/Language/LanguageExceptionHandler.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\System\Language;
 
-use Shopware\Core\Content\Product\SalesChannel\Sorting\ProductSortingDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\ExceptionHandlerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;

--- a/src/Core/System/Language/LanguageExceptionHandler.php
+++ b/src/Core/System/Language/LanguageExceptionHandler.php
@@ -2,9 +2,11 @@
 
 namespace Shopware\Core\System\Language;
 
+use Shopware\Core\Content\Product\SalesChannel\Sorting\ProductSortingDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\ExceptionHandlerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\Exception\LanguageForeignKeyDeleteException;
 
@@ -15,20 +17,28 @@ class LanguageExceptionHandler implements ExceptionHandlerInterface
         return ExceptionHandlerInterface::PRIORITY_LATE;
     }
 
-    public function matchException(\Exception $e, WriteCommand $command): ?\Exception
+    /**
+     * @internal (flag:FEATURE_NEXT_16640) - second parameter WriteCommand $command will be removed
+     */
+    public function matchException(\Exception $e, ?WriteCommand $command = null): ?\Exception
     {
         if ($e->getCode() !== 0) {
             return null;
         }
+        if (!Feature::isActive('FEATURE_NEXT_16640')
+            && $command instanceof DeleteCommand
+            && $command->getDefinition()->getEntityName() !== LanguageDefinition::ENTITY_NAME) {
+            return null;
+        }
 
-        if (
-            $command instanceof DeleteCommand
-            && $command->getDefinition()->getEntityName() === 'language'
-            && preg_match('/SQLSTATE\[23000\]:.*(1217|1216).*a foreign key constraint/', $e->getMessage())
-        ) {
-            $primaryKey = $command->getPrimaryKey();
+        if (preg_match('/SQLSTATE\[23000\]:.*(1217|1216).*a foreign key constraint/', $e->getMessage())) {
+            $formattedKey = '';
+            if (!Feature::isActive('FEATURE_NEXT_16640')) {
+                $primaryKey = $command->getPrimaryKey();
+                $formattedKey = isset($primaryKey['id']) ? Uuid::fromBytesToHex($primaryKey['id']) : '';
+            }
 
-            return new LanguageForeignKeyDeleteException(isset($primaryKey['id']) ? Uuid::fromBytesToHex($primaryKey['id']) : '', $e);
+            return new LanguageForeignKeyDeleteException($formattedKey, $e);
         }
 
         return null;


### PR DESCRIPTION
@OliverSkroblin As discussed. #1668 should be merged first. After that I can rebase my branch to the then-current trunk.

### 1. Why is this change necessary?
This PR fixes various transaction issues and improves data consistency.

### 2. What does this change do, exactly?
* All calls to `beginTransaction` have been replaced with the new `RetryableTransaction` class, as it provides a cleaner interface anyway and the previous code did not execute `rollback` on exceptions.
* `MultiInsertQueryQueue` now uses `RetryableTransaction` as well as there is no use case where it is desirable that half of the inserts is in the DB and then the execution of the script stops and the other half is left in the wide nothingness.
* Introduced transactions at multiple code positions to improve data consistency. Also removed all attempts to be smarter than the DBMS in case of a deadlock and try non-batchy execution of queries; executing single statements not within a transaction can lead to data inconsistency; executing single statements inside of a transaction is in no case beneficial to a batch statement. Catching exceptions also breaks the transaction control flow, i.e. they are not reverted correctly.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
This fixes all issues I mentioned in the pull request #1668.
This also fixes https://issues.shopware.com/issues/NEXT-15805.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.

### 6. To-Do-List

- [x] If you have code-style enforcers, you might want to make sure that nobody introduces new `beginTransaction`, `commit` or `rollback` calls. All transactions should be implemented using `RetryableTransaction`.
- [x] I've encountered some other occurrences of `catch (\Exception)` or `catch (\Throwable)`. This is code-smell, i.e. one likely never wants to catch ALL exceptions. You might want to review (i.e. remove) these.
- [ ] The last commit ("Make batch behave like previous non-batch") makes the code behave like previously, but I don't think it is a good idea to ignore all errors. The best way would be to fix the code such that the `IGNORE`s are not necessary anymore. The second-best solution is to change `RetryableTransaction` to pass an argument to the transactional closure (I guess this has to be done via [`Closure::bind`](https://www.php.net/manual/en/closure.bind.php) to not interfere with Doctrine), passing in its retry `$counter` so the closure can determine if this is the first execution or a following one. In the following cases, it could perform an `INSERT IGNORE` instead.
- [ ] Call `$connection->setNestTransactionsWithSavepoints(true)` globally.