### PR TITLE
Update OrderStateChangeEventListener.php

### DIFF
--- a/src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
+++ b/src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
@@ -75,7 +75,7 @@ class OrderStateChangeEventListener implements EventSubscriberInterface
         $this->businessEventCollector = $businessEventCollector;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             'state_machine.order.state_changed' => 'onOrderStateChange',


### PR DESCRIPTION
Return type is missing.

Method with always return array type. Just define return type as array in the method.