### PR TITLE
Changed `feature:dump` to use Kernel::getProjectDir()

### DIFF
--- a/changelog/_unreleased/2021-09-01-change-feature-dump-to-use-projectdir.md
+++ b/changelog/_unreleased/2021-09-01-change-feature-dump-to-use-projectdir.md
@@ -1,0 +1,8 @@
+---
+title: Changed command "feature:dump" to use Kernel::getProjectDir()
+author: mynameisbogdan
+author_email: mynameisbogdan@protonmail.com
+author_github: mynameisbogdan
+---
+# Core
+* Changed command `feature:dump` to use Kernel::getProjectDir() instead of using a relative path to Kernel::getCacheDir()

--- a/src/Core/Framework/Feature/Command/FeatureDumpCommand.php
+++ b/src/Core/Framework/Feature/Command/FeatureDumpCommand.php
@@ -13,10 +13,7 @@ class FeatureDumpCommand extends Command
 {
     protected static $defaultName = 'feature:dump';
 
-    /**
-     * @var Kernel
-     */
-    private $kernel;
+    private Kernel $kernel;
 
     public function __construct(Kernel $kernel)
     {
@@ -37,7 +34,7 @@ class FeatureDumpCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         file_put_contents(
-            $this->kernel->getCacheDir() . '/../../config_js_features.json',
+            $this->kernel->getProjectDir() . '/var/config_js_features.json',
             json_encode(Feature::getAll())
         );
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When using a overwritten `getCacheDir()` outside the usual structure, the `config_js_features.json` is relative to that path.

### 2. What does this change do, exactly?
Changes `feature:dump` to always write `config_js_features.json`  in `Kernel::getProjectDir() . '/var`

### 3. Describe each step to reproduce the issue or behaviour.
When getCacheDir is using a different path like `var/cache/{env}/{hash}` the command `feature:dump` breaks functionality since it's relative to this path and administration webpack.config.js uses `process.env.PROJECT_ROOT, 'var', 'config_js_features.json'`.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
