### PR TITLE
Fixes issue 2029 - Fix placeholderVisible state depending on isEmpty on mode switch

### DIFF
--- a/changelog/_unreleased/2021-09-03-fix-state-text-editor-code-editor-switch.md
+++ b/changelog/_unreleased/2021-09-03-fix-state-text-editor-code-editor-switch.md
@@ -1,0 +1,12 @@
+---
+title:              Fix placeholderVisible state depending on isEmpty on mode switch
+issue:              2029
+author:             Wolfgang Kreminger
+author_email:       r4pt0s@protonmail.com
+author_github:      @r4pt0s
+---
+
+# Administration
+
+-   Changed `onContentChange` method in `platform/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/index.js` to fix state update of placeHolderVisible
+-   Changed `emitHtmlContent` method in `platform/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/index.js` to fix state update of placeHolderVisible on switching from code to text editor mode

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/index.js
@@ -804,6 +804,7 @@ Component.register('sw-text-editor', {
 
         onContentChange() {
             this.isEmpty = this.emptyCheck(this.getContentValue());
+            this.placeholderVisible = this.isEmpty;
 
             this.setWordCount();
         },
@@ -823,6 +824,9 @@ Component.register('sw-text-editor', {
         emitHtmlContent(value) {
             this.content = value;
             this.$emit('input', value);
+
+            this.isEmpty = value === '';
+            this.placeholderVisible = this.isEmpty;
         },
 
         getContentValue() {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To provide a meaningful user experience with expected behaviour for merchants.

### 2. What does this change do, exactly?
It updates the placeholderVisible state properly depending on mode switch (code editor mode => text editor mode)

### 3. Describe each step to reproduce the issue or behaviour.
See issue nr [#2029](https://github.com/shopware/platform/issues/2029)

### 4. Please link to the relevant issues (if any).
[#2029](https://github.com/shopware/platform/issues/2029)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ X] I have squashed any insignificant commits
- [X ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ X] I have read the contribution requirements and fulfil them.
