### PR TITLE
(NEXT-14201) Allow to manage more than 25 Sales Channels (again) from the admin UI menu

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js
@@ -29,6 +29,8 @@ Component.register('sw-sales-channel-menu', {
         salesChannelCriteria() {
             const criteria = new Criteria();
 
+            criteria.setPage(1);
+            criteria.setLimit(500);
             criteria.addSorting(Criteria.sort('sales_channel.name', 'ASC'));
             criteria.addAssociation('type');
             criteria.addAssociation('domains');


### PR DESCRIPTION
**Problem description:**

In 6.3.4.x you could manage up to 500 sales channels from the admin UI menu.

6.4+ Changed this behaviour which leads into a deprived functionality of Shopware when maintaining more than 25 sales channels.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

6.3.x allowed you to manage more than 25 sales channels in admin interface (up to 500)

### 2. What does this change do, exactly?

Revive an already working feature (administer more than 25 sales channels from the admin UI menu)

### 3. Describe each step to reproduce the issue or behaviour.

Create more than 25 sales channels in 6.3 => Result: They are shown & navigatable in the admin menu on the left.

whereas:

Create more than 25 sales channel in 6.4.3 => Result: only the first 25 are shown, thus the rest can not be navigated.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
