### PR TITLE
Use question helper for passwords in commands

### DIFF
--- a/changelog/_unreleased/2021-09-04-use-question-helper-for-passwords-in-commands.md
+++ b/changelog/_unreleased/2021-09-04-use-question-helper-for-passwords-in-commands.md
@@ -1,0 +1,11 @@
+---
+title: Use question helper for passwords in commands
+issue: NEXT-17106
+author: mynameisbogdan
+author_email: mynameisbogdan@protonmail.com
+author_github: mynameisbogdan
+---
+# Core
+* Changed command `store:login` to ask for password if none is supplied by option.
+* Changed command `user:create` to add validation in question for empty passwords to fix max attempts functionality.
+* Changed command `user:change-password` to add validation in question for empty passwords to fix max attempts functionality.

--- a/src/Core/Framework/Test/Store/Command/StoreLoginCommandTest.php
+++ b/src/Core/Framework/Test/Store/Command/StoreLoginCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Store\Command;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Shopware\Core\Framework\Store\Command\StoreLoginCommand;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class StoreLoginCommandTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testEmptyPasswordOption(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(StoreLoginCommand::class));
+
+        static::expectException(RuntimeException::class);
+        static::expectExceptionMessage('The password cannot be empty');
+
+        $commandTester->setInputs(['', '', '']);
+        $commandTester->execute([
+            '--shopwareId' => 'no-reply@shopware.de',
+            '--user' => 'missing_user',
+        ]);
+    }
+
+    public function testValidPasswordOptionInvalidUserOption(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(StoreLoginCommand::class));
+
+        static::expectException(RuntimeException::class);
+        static::expectExceptionMessage('User not found');
+
+        $commandTester->setInputs(['non-empty-password']);
+        $commandTester->execute([
+            '--shopwareId' => 'no-reply@shopware.de',
+            '--user' => 'missing_user',
+        ]);
+    }
+}

--- a/src/Core/System/Test/User/Command/UserCreateCommandTest.php
+++ b/src/Core/System/Test/User/Command/UserCreateCommandTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Test\User\Command;
+
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\User\Command\UserCreateCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class UserCreateCommandTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private const TEST_USERNAME = 'shopware';
+
+    public function testEmptyPasswordOption(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(UserCreateCommand::class));
+
+        static::expectException(RuntimeException::class);
+        static::expectExceptionMessage('The password cannot be empty');
+
+        $commandTester->setInputs(['', '', '']);
+
+        $commandTester->execute([
+            'username' => self::TEST_USERNAME,
+        ]);
+    }
+}

--- a/src/Core/System/User/Command/UserCreateCommand.php
+++ b/src/Core/System/User/Command/UserCreateCommand.php
@@ -15,14 +15,12 @@ class UserCreateCommand extends Command
 {
     protected static $defaultName = 'user:create';
 
-    /**
-     * @var UserProvisioner
-     */
-    private $userProvisioner;
+    private UserProvisioner $userProvisioner;
 
     public function __construct(UserProvisioner $userProvisioner)
     {
         parent::__construct();
+
         $this->userProvisioner = $userProvisioner;
     }
 
@@ -51,8 +49,15 @@ class UserCreateCommand extends Command
         $username = $input->getArgument('username');
         $password = $input->getOption('password');
 
-        if (empty($password)) {
-            $passwordQuestion = new Question('Password for the user');
+        if (!$password) {
+            $passwordQuestion = new Question('Enter password for user');
+            $passwordQuestion->setValidator(static function ($value): string {
+                if ($value === null || trim($value) === '') {
+                    throw new \RuntimeException('The password cannot be empty');
+                }
+
+                return $value;
+            });
             $passwordQuestion->setHidden(true);
             $passwordQuestion->setMaxAttempts(3);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To fix max attempts functionality in `user:create` and `user:change-password`, and to ask interactively for a password `store:login`. 

### 2. What does this change do, exactly?
Adds a password question to `store:login`, and password validation to `user:create` and `user:change-password` in order to fix max attempts functionality 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
