### PR TITLE
Bugfix autowiring type+name for already defined repositories

### DIFF
--- a/changelog/_unreleased/2021-09-06-bugfix-autowiring-type-name-for-already-defined-repositories.md
+++ b/changelog/_unreleased/2021-09-06-bugfix-autowiring-type-name-for-already-defined-repositories.md
@@ -1,0 +1,8 @@
+---
+title: Bugfix autowiring type+name for already defined repositories
+author: mynameisbogdan
+author_email: mynameisbogdan@protonmail.com
+author_github: mynameisbogdan
+---
+# Core
+* Changed `Shopware\Core\Framework\DependencyInjection\CompilerPass\EntityCompilerPass` to add `registerAliasForArgument` for already defined repositories and move duplicated calls after try-catch.

--- a/src/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/EntityCompilerPass.php
@@ -58,7 +58,6 @@ class EntityCompilerPass implements CompilerPassInterface
                 $repository = $container->getDefinition($repositoryId);
                 //@deprecated tag:v6.5.0 (flag:FEATURE_NEXT_16155) - remove add method call
                 $repository->addMethodCall('setEntityLoadedEventFactory', [new Reference(EntityLoadedEventFactory::class)]);
-                $repository->setPublic(true);
             } catch (ServiceNotFoundException $exception) {
                 $repository = new Definition(
                     EntityRepository::class,
@@ -72,11 +71,11 @@ class EntityCompilerPass implements CompilerPassInterface
                         new Reference(EntityLoadedEventFactory::class),
                     ]
                 );
-                $repository->setPublic(true);
-
                 $container->setDefinition($repositoryId, $repository);
-                $container->registerAliasForArgument($repositoryId, EntityRepositoryInterface::class);
             }
+            $repository->setPublic(true);
+            $container->registerAliasForArgument($repositoryId, EntityRepositoryInterface::class);
+
             $repositoryNameMap[$entity] = $repositoryId;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Repositories already defined in services does not support autowiring type+name.

### 2. What does this change do, exactly?
Adds autowiring type+name for already defined repositories.

### 3. Describe each step to reproduce the issue or behaviour.
Use autowiring with `Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface $productRepository` in v6.4.4.0.

### 4. Please link to the relevant issues (if any).
The "regression" with `EntityRepositoryInterface $productRepository` was introduced in dc4961b33c432d97f99ca5b44dc335bd95e97032.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
