### PR TITLE
Fix JS Slider crash

### DIFF
--- a/changelog/_unreleased/2021-09-07-fix-js-crash-on-unknown-viewport.md
+++ b/changelog/_unreleased/2021-09-07-fix-js-crash-on-unknown-viewport.md
@@ -1,0 +1,9 @@
+---
+title: Fix js crash on unknown viewport
+issue: /
+author: Rune Laenen
+author_email: rune.laenen@intracto.com 
+author_github: runelaenen
+---
+# Storefront
+*  Update `slider-settings.helper.js` to early return the settings if no valid viewport was found. This can happen very early after the pageload.

--- a/src/Storefront/Resources/app/storefront/src/plugin/slider/helper/slider-settings.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/slider/helper/slider-settings.helper.js
@@ -18,6 +18,10 @@ export default class SliderSettingsHelper {
         const viewportWidth = window.breakpoints[viewport.toLowerCase()];
         const selectedViewportSettings = responsiveSettings[viewportWidth];
 
+        if (!selectedViewportSettings) {
+            return settings;
+        }
+
         return deepmerge(settings, selectedViewportSettings);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The viewport helper returns 'none' if no viewport can be detected yet (which can happen early after the pageload). The slider assumed a valid viewport was always returned, and crashed if this was not the case.

### 2. What does this change do, exactly?
Adds a check, if the returned viewport (or in our case 'none') is not found in the viewportsettings, return the default settings instead of trying to deepmerge them with `undefined`.

### 3. Describe each step to reproduce the issue or behaviour.
- Load a CMS page with a product slider.
- Crash & burn

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
