### PR TITLE
Prevent context changes spill outside of the sync service usage

### DIFF
--- a/changelog/_unreleased/2021-09-08-prevent-context-changes-affect-outside-of-sync-service-usage.md
+++ b/changelog/_unreleased/2021-09-08-prevent-context-changes-affect-outside-of-sync-service-usage.md
@@ -1,0 +1,8 @@
+---
+title: Prevent context changes affect outside of the sync service usage
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed `SyncService::sync` to clone the context before using it so internally used extensions are not affecting later usage of the same context object

--- a/src/Core/Framework/Api/Sync/SyncService.php
+++ b/src/Core/Framework/Api/Sync/SyncService.php
@@ -51,6 +51,8 @@ class SyncService implements SyncServiceInterface
      */
     public function sync(array $operations, Context $context, SyncBehavior $behavior): SyncResult
     {
+        $context = clone $context;
+
         if (\count($behavior->getSkipIndexers())) {
             $context->addExtension(EntityIndexerRegistry::EXTENSION_INDEXER_SKIP, new ArrayEntity($behavior->getSkipIndexers()));
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
When you take a context of an event and use that for your sync service call it will modify the context. Other event subscribers will now also have a changed context. It is taught to just pass on your context but not as a clone.

This also means all those who are fiddling with the context are not getting things back out of it anymore. So it is breaking from my POV.

### 2. What does this change do, exactly?
Clones a context object before its properties get written.

### 3. Describe each step to reproduce the issue or behaviour.
1. Subscribe to an event
2. Use SyncApi to write multiple stuff but without indexing as your custom stuff does not need indexing with the context of the event
3. Follow ups are also now writing without indexing as well

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
