### PR TITLE
Handle malformed options in the `switch` method of `ProductController`

### DIFF
--- a/changelog/_unreleased/2021-09-09-handle-malformed-options.md
+++ b/changelog/_unreleased/2021-09-09-handle-malformed-options.md
@@ -1,0 +1,7 @@
+---
+title: Handle malformed options in the `switch` method of `ProductController`
+author: Paweł Słowik
+author_email: pawel.slowik@zoho.com
+---
+# Storefront
+*  Changed the `switch` method in `src/Storefront/Controller/ProductController.php` to handle malformed options

--- a/src/Storefront/Controller/ProductController.php
+++ b/src/Storefront/Controller/ProductController.php
@@ -109,7 +109,12 @@ class ProductController extends StorefrontController
         $switchedOption = $request->query->has('switched') ? (string) $request->query->get('switched') : null;
 
         $options = (string) $request->query->get('options');
-        $newOptions = $options !== '' ? json_decode($options, true) : [];
+
+        try {
+            $newOptions = json_decode($options, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $jsonException) {
+            $newOptions = [];
+        }
 
         try {
             $redirect = $this->combinationFinder->find($productId, $switchedOption, $newOptions, $salesChannelContext);

--- a/src/Storefront/Test/Controller/ProductControllerTest.php
+++ b/src/Storefront/Test/Controller/ProductControllerTest.php
@@ -71,6 +71,22 @@ class ProductControllerTest extends TestCase
         static::assertStringContainsString($productId, $content['url']);
     }
 
+    public function testSwitchDoesNotCrashOnMalformedOptions(): void
+    {
+        $productId = $this->createProduct();
+
+        $response = $this->request(
+            'GET',
+            '/detail/' . $productId . '/switch',
+            $this->tokenize('frontend.detail.switch', [
+                'productId' => $productId,
+                'options' => 'notJson',
+            ])
+        );
+
+        static::assertSame(200, $response->getStatusCode());
+    }
+
     private function createProduct(array $config = []): string
     {
         $id = Uuid::randomHex();


### PR DESCRIPTION
### 1. Why is this change necessary?
So that the app does not crash on a malformed value for the `options` request parameter.

### 2. What does this change do, exactly?
Handles a malformed `options` parameter by ignoring it.

### 3. Describe each step to reproduce the issue or behaviour.
As described in https://github.com/shopware/platform/issues/1631

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1631

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
