### PR TITLE
Fix floating number equality comparison in DeliveryCalculator

### DIFF
--- a/changelog/_unreleased/2021-09-10-fix-floating-number-equality-comparison-in-delivery-calculator.md
+++ b/changelog/_unreleased/2021-09-10-fix-floating-number-equality-comparison-in-delivery-calculator.md
@@ -1,0 +1,8 @@
+---
+title: Fix floating number equality comparison in DeliveryCalculator
+author: David Lochner
+author_email: lochner@nexxo.de
+author_github: nexxome
+---
+# Core
+* Changed method `Shopware\Core\Checkout\Cart\Delivery\DeliveryCalculator::matches()` to ensure that the equality of floating numbers is checked correctly.

--- a/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
@@ -20,6 +20,7 @@ use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
+use Shopware\Core\Framework\Util\FloatComparator;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class DeliveryCalculator
@@ -174,7 +175,7 @@ class DeliveryCalculator
         }
 
         // $end (optional) exclusive
-        return ($value >= $start) && (!$end || $value <= $end);
+        return (!$start || FloatComparator::greaterThanOrEquals($value, $start)) && (!$end || FloatComparator::lessThanOrEquals($value, $end));
     }
 
     private function calculateShippingCosts(ShippingMethodEntity $shippingMethod, PriceCollection $priceCollection, LineItemCollection $calculatedLineItems, SalesChannelContext $context): CalculatedPrice


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
We had a case where a customer couldn't select a shipping method, because no existing price rule matched for his cart.
The shipping method has two price rules:

1. 0 € - 59,99 €
2. 60 € - ∞

![screen3](https://user-images.githubusercontent.com/2526962/132809069-91e68308-2684-416d-be19-0ded7698ae56.png)


The total cart amount was exactly 60,00 €, but the price rule didn't match in the DeliveryCalculator because floating numbers have limited precision in equality comparison (https://www.php.net/manual/en/language.types.float.php).

![screen1](https://user-images.githubusercontent.com/2526962/132809129-b0bf0e0e-b9a4-47e9-98b3-13176d2f1691.png)

![screen2](https://user-images.githubusercontent.com/2526962/132809145-eb89e4a5-8fd1-42bb-a06d-5da4529cee8f.png)


### 2. What does this change do, exactly?
This change adds a floating number equality check in `Shopware\Core\Checkout\Cart\Delivery\DeliveryCalculator::matches()`

### 3. Describe each step to reproduce the issue or behaviour.
It is not easy to create a shipping rule and cart to reproduce this issue, but I've added a test where the calculate method in DeliveryCalculator fails without the fix.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
