### PR TITLE
Added empty template block for unknown delivery information

### DIFF
--- a/changelog/_unreleased/2021-09-10-added-unknown-delivery-information-block.md
+++ b/changelog/_unreleased/2021-09-10-added-unknown-delivery-information-block.md
@@ -1,0 +1,9 @@
+---
+title: Added unknown delivery template block
+author: Ulrich Thomas Gabor
+author_email: ulrich.thomas.gabor@odd-solutions.de
+author_github: UlrichThomasGabor
+---
+# Core
+* Added empty template block `component_delivery_information_unknown` to `component_delivery_information.html.twig` such that it can be extended.
+

--- a/src/Storefront/Resources/views/storefront/component/delivery-information.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/delivery-information.html.twig
@@ -63,6 +63,8 @@
                     })|sw_sanitize }}
                 </p>
             {% endblock %}
+        {% else %}
+            {% block component_delivery_information_unknown %}{% endblock %}
         {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Some customers want delivery information displayed in every case. Currently, this is only possible by overriding the template block containing the template logic. This change makes it possible to add information without modifying the template logic.


### 2. What does this change do, exactly?
Adds an empty extensible block to the template.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
