### PR TITLE
Allow removal of .js-search-toggle-btn without exception in storefront

### DIFF
--- a/changelog/_unreleased/2021-09-10-less-strict-requirement-of-js-search-toggle-btn-in-storefront.md
+++ b/changelog/_unreleased/2021-09-10-less-strict-requirement-of-js-search-toggle-btn-in-storefront.md
@@ -1,0 +1,8 @@
+---
+title: Allow removal of .js-search-toggle-btn without exception in storefront
+author: Joshua Behrens
+author_email: codde@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Changed `SearchWidgetPlugin` in `src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js` to allow reference to the `.js-search-toggle-btn` is missing so block `layout_header_search_toggle` in `src/Storefront/Resources/views/storefront/layout/header/header.html.twig` can be emptied

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -170,17 +170,16 @@ export default class SearchWidgetPlugin extends Plugin {
      * @private
      */
     _registerInputFocus() {
-        try {
-            this._toggleButton = DomAccess.querySelector(document, this.options.searchWidgetCollapseButtonSelector);
-        } catch (e) {
-            // something went wrong
-            throw new Error(`the search-toggle-btn doesn´t own the "${this.options.searchWidgetCollapseButtonSelector}" class. So the search-input-field wont´t have an autofocus, on Mobile.`);
+        this._toggleButton = DomAccess.querySelector(document, this.options.searchWidgetCollapseButtonSelector, false);
+        
+        if (this._toggleButton) {
+            const event = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click';
+            this._toggleButton.addEventListener(event, () => {
+                setTimeout(() => this._focusInput(), 0);
+            });
+        } else {
+            console.warn(`the search-toggle-btn doesn´t own the "${this.options.searchWidgetCollapseButtonSelector}" class or does not exist. So the search-input-field wont´t have an autofocus, on Mobile.`);
         }
-
-        const event = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click';
-        this._toggleButton.addEventListener(event, () => {
-            setTimeout(() => this._focusInput(), 0);
-        });
     }
 
     /**
@@ -188,7 +187,7 @@ export default class SearchWidgetPlugin extends Plugin {
      * @private
      */
     _focusInput() {
-        if (!this._toggleButton.classList.contains(this.options.searchWidgetCollapseClass)) {
+        if (this._toggleButton && !this._toggleButton.classList.contains(this.options.searchWidgetCollapseClass)) {
             this._toggleButton.blur(); // otherwise iOS won´t focus the field.
             this._inputField.setAttribute('tabindex', '-1');
             this._inputField.focus();


### PR DESCRIPTION
### 1. Why is this change necessary?
When you want to redesign the mobile search and change content of block `layout_header_search_toggle` in `storefront/layout/header/header.html.twig` you will receive the exception in the JS which concerns but is totally intentional. At least make it less critical.

### 2. What does this change do, exactly?
It allows the class `.js-search-toggle-btn` to not exist in the DOM without throwing an exception.

### 3. Describe each step to reproduce the issue or behaviour.
1. Extend template `Storefront/storefront/layout/header/header.html.twig`
2. Clear block `layout_header_search_toggle`

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
