### PR TITLE
NEXT-17273 - Make rule sorting deterministic to ensure all rules are loaded

### DIFF
--- a/changelog/_unreleased/2021-09-13-fix-nondeterministic-rule-loading.md
+++ b/changelog/_unreleased/2021-09-13-fix-nondeterministic-rule-loading.md
@@ -1,0 +1,10 @@
+---
+title: Fix-cache-keys-for-associations
+issue: NEXT-16716
+author: Jonas Søndergaard
+author_email: jonas@wexo.dk 
+author_github: @josniii
+---
+# Core
+* All rules are now properly loaded from the database when more than 500 rules exist.
+___

--- a/src/Core/Checkout/Cart/RuleLoader.php
+++ b/src/Core/Checkout/Cart/RuleLoader.php
@@ -35,6 +35,7 @@ class RuleLoader extends AbstractRuleLoader
     {
         $criteria = new Criteria();
         $criteria->addSorting(new FieldSorting('priority', FieldSorting::DESCENDING));
+        $criteria->addSorting(new FieldSorting('id'));
         $criteria->setLimit(500);
         $criteria->setTitle('cart-rule-loader::load-rules');
 


### PR DESCRIPTION
### 1. Why is this change necessary?

On shops with more than 500 rules in the database, the system can start skipping the loading of rules due to a combination of two things:

1) Rule loading is batched using the RepositoryIterator. The size of the batches is 500 rules.

2) Rule loading is sorted by priority, which is nondeterministic due to many rules having the same priority (usually 0, the default value).

These two factors combined mean that some rules may be skipped entirely from being loaded, because the database loads other rules with the same priority in several batches, as the sorting inside these groups of rules with the same priority is nondeterministic.

### 2. What does this change do, exactly?

Adds a secondary sorting on rule IDs when loading all rules. This ensures the order is consistent across batches.

### 3. Describe each step to reproduce the issue or behaviour.

1) Have more than 500 rules in the database, preferably all with the same priority (increases the chances of missed rules). 500 is needed as it is the batch size, so fewer could potentially do it if you reduced the batch size temporarily.

2) Check the output of \Shopware\Core\Checkout\Cart\RuleLoader::load.

Expected result: All valid rules are loaded into the RuleCollection output by the RuleLoader class.

Actual result: Some valid rules will be missing (or they won't, since the issue is nondeterminism - you could be lucky).

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-17273

### 5. Checklist

- [x] I have written tests and verified that they fail without my change - since the issue is nondeterministic and database related, I have not written any tests.
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
