### PR TITLE
fix(administration): add `stateFieldName` argument to `StateMachineApiService` methods

### DIFF
--- a/changelog/_unreleased/2021-09-15-state-machine-api-service-state-field-name.md
+++ b/changelog/_unreleased/2021-09-15-state-machine-api-service-state-field-name.md
@@ -1,0 +1,9 @@
+---
+title: Added `stateFieldName` argument to `StateMachineApiService` methods
+author: Enzo Volkmann
+author_email: enzo@exportarts.io
+author_github: @evolkmann
+---
+# Administration
+* Added `stateFieldName` argument to `StateMachineApiService` methods. The new argument is optional
+  and is recognized by the [`StateMachineActionController`](../../src/Core/System/StateMachine/Api/StateMachineActionController.php).

--- a/src/Administration/Resources/app/administration/src/core/service/api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api.service.js
@@ -93,6 +93,23 @@ class ApiService {
     }
 
     /**
+     * @param {object} paramDictionary key-value pairs
+     * @returns {string} a string like `?key=value&key2=value2`
+     */
+    static makeQueryParams(paramDictionary = {}) {
+        const params = Object
+            .keys(paramDictionary)
+            .filter(key => typeof paramDictionary[key] === 'string')
+            .map(key => `${key}=${paramDictionary[key]}`);
+
+        if (!params.length) {
+            return '';
+        }
+
+        return `?${params.join('&')}`;
+    }
+
+    /**
      * Getter & setter for the API end point
      * @type {String}
      */

--- a/src/Administration/Resources/app/administration/src/core/service/api/state-machine.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/state-machine.api.service.js
@@ -12,14 +12,15 @@ class StateMachineApiService extends ApiService {
     }
 
     /**
-     * @param {string} stateFieldName Specify a different field name to be considered by
-     *   the StateMachineActionController.
+     * @param {string} stateFieldName (optional) Specify a different property of the base entity
+     *   that holds the state id (e.g. `stateId`)
      */
-    getState(entity, entityId, stateFieldName, additionalParams = {}, additionalHeaders = {}) {
-        let route = `_action/state-machine/${entity}/${entityId}/state`;
-        if (stateFieldName) {
-            route += `?stateFieldName=${stateFieldName}`;
-        }
+    getState(entity, entityId, stateFieldName, additionalParams = {}, additionalHeaders = {}, additionalQueryParams = {}) {
+        const query = ApiService.makeQueryParams({
+            stateFieldName,
+            ...additionalQueryParams
+        });
+        const route = `_action/state-machine/${entity}/${entityId}/state${query}`;
 
         const headers = this.getBasicHeaders(additionalHeaders);
 
@@ -31,14 +32,15 @@ class StateMachineApiService extends ApiService {
     }
 
     /**
-     * @param {string} stateFieldName Specify a different field name to be considered by
-     *   the StateMachineActionController.
+     * @param {string} stateFieldName (optional) Specify a different property of the base entity
+     *   that holds the state id (e.g. `stateId`)
      */
-    transitionState(entity, entityId, actionName, stateFieldName, additionalParams = {}, additionalHeaders = {}) {
-        let route = `_action/state-machine/${entity}/${entityId}/state/${actionName}`;
-        if (stateFieldName) {
-            route += `?stateFieldName=${stateFieldName}`;
-        }
+    transitionState(entity, entityId, actionName, stateFieldName, additionalParams = {}, additionalHeaders = {}, additionalQueryParams = {}) {
+        const query = ApiService.makeQueryParams({
+            stateFieldName,
+            ...additionalQueryParams
+        });
+        const route = `_action/state-machine/${entity}/${entityId}/state/${actionName}${query}`;
 
         const headers = this.getBasicHeaders(additionalHeaders);
 

--- a/src/Administration/Resources/app/administration/src/core/service/api/state-machine.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/state-machine.api.service.js
@@ -11,8 +11,15 @@ class StateMachineApiService extends ApiService {
         this.name = 'stateMachineService';
     }
 
-    getState(entity, entityId, additionalParams = {}, additionalHeaders = {}) {
-        const route = `_action/state-machine/${entity}/${entityId}/state`;
+    /**
+     * @param {string} stateFieldName Specify a different field name to be considered by
+     *   the StateMachineActionController.
+     */
+    getState(entity, entityId, stateFieldName, additionalParams = {}, additionalHeaders = {}) {
+        let route = `_action/state-machine/${entity}/${entityId}/state`;
+        if (stateFieldName) {
+            route += `?stateFieldName=${stateFieldName}`;
+        }
 
         const headers = this.getBasicHeaders(additionalHeaders);
 
@@ -23,8 +30,15 @@ class StateMachineApiService extends ApiService {
             });
     }
 
-    transitionState(entity, entityId, actionName, additionalParams = {}, additionalHeaders = {}) {
-        const route = `_action/state-machine/${entity}/${entityId}/state/${actionName}`;
+    /**
+     * @param {string} stateFieldName Specify a different field name to be considered by
+     *   the StateMachineActionController.
+     */
+    transitionState(entity, entityId, actionName, stateFieldName, additionalParams = {}, additionalHeaders = {}) {
+        let route = `_action/state-machine/${entity}/${entityId}/state/${actionName}`;
+        if (stateFieldName) {
+            route += `?stateFieldName=${stateFieldName}`;
+        }
 
         const headers = this.getBasicHeaders(additionalHeaders);
 

--- a/src/Administration/Resources/app/administration/test/app/service/api.service.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/service/api.service.spec.js
@@ -1,0 +1,23 @@
+import ApiService from 'src/app/service/api.service';
+
+describe('src/app/service/api.service.js', () => {
+    describe('makeQueryParams', () => {
+        it('should handle empty dictionary', () => {
+            expect(ApiService.makeQueryParams()).toEqual('');
+            expect(ApiService.makeQueryParams({})).toEqual('');
+        });
+
+        it('should handle one param', () => {
+            expect(ApiService.makeQueryParams({
+                key: 'value'
+            })).toEqual('?key=value');
+        });
+
+        it('should handle multiple params', () => {
+            expect(ApiService.makeQueryParams({
+                key: 'value',
+                key2: 'value2'
+            })).toEqual('?key=value&key2=value2');
+        });
+    });
+});


### PR DESCRIPTION
The new argument `stateFieldName` is optional. I did not add a default value in the js-functions, because this is done in the [`StateMachineActionController`](https://github.com/shopware/platform/blob/trunk/src/Core/System/StateMachine/Api/StateMachineActionController.php).

The two functions are not called with `additionalParams` or `additionalHeaders` as far as I can tell, so there is no breaking change regarding callers of the functions.

I also added `additionalQueryParams` in the same manner as `additionalParams` and `additionalHeaders`.

### 1. Why is this change necessary?

The php code already supports the query parameter, but the js functions had no way of setting it.

### 2. What does this change do, exactly?

- Adds an optional argument `stateFieldName` to the functions in the `StateMachineApiService`
- Adds optional `additionalQueryParams` argument to the functions in the `StateMachineApiService`

### 3. Describe each step to reproduce the issue or behaviour.

n/a

### 4. Please link to the relevant issues (if any).

n/a

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
