### PR TITLE
Add try-catch on loading cmsElements when type is not registered

### DIFF
--- a/changelog/_unreleased/2021-09-15-catch-unknown-cms-element-types-in-cms-editor.md
+++ b/changelog/_unreleased/2021-09-15-catch-unknown-cms-element-types-in-cms-editor.md
@@ -1,0 +1,9 @@
+---
+title: Add try-catch on loading cmsElements when cms element type is not registered
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added additional try-catch in `src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js` to match the right catch in `src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js`
+* Added additional check and warning in `src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js` to expect cms elements registry might not have a slot type registered

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cmsDataResolver.service.js
@@ -18,38 +18,46 @@ const slots = {};
 
 function resolve(page) {
     const loadedData = [];
-
-    contextService = Shopware.Context.api;
-    repoFactory = Shopware.Service('repositoryFactory');
-    cmsService = Shopware.Service('cmsService');
-    cmsElements = cmsService.getCmsElementRegistry();
-
     const slotEntityList = {};
-    page.sections.forEach((section) => {
-        section.blocks.forEach((block) => {
-            block.slots.forEach((slot) => {
-                slots[slot.id] = slot;
-                initSlotConfig(slot);
-                initSlotDefaultData(slot);
 
-                const slotData = cmsElements[slot.type].collect(slot);
-                if (Object.keys(slotData).length > 0) {
-                    slotEntityList[slot.id] = slotData;
-                }
+    try {
+        contextService = Shopware.Context.api;
+        repoFactory = Shopware.Service('repositoryFactory');
+        cmsService = Shopware.Service('cmsService');
+        cmsElements = cmsService.getCmsElementRegistry();
+
+        page.sections.forEach((section) => {
+            section.blocks.forEach((block) => {
+                block.slots.forEach((slot) => {
+                    slots[slot.id] = slot;
+                    initSlotConfig(slot);
+                    initSlotDefaultData(slot);
+                    const cmsElement = cmsElements[slot.type];
+
+                    if (cmsElement) {
+                        const slotData = cmsElement.collect(slot);
+                        if (Object.keys(slotData).length > 0) {
+                            slotEntityList[slot.id] = slotData;
+                        }
+                    } else {
+                        warn(`Missing registration for slot type ${slot.type}. Slot ${slot.id} Block ${block.name} (${block.id}) Section ${section.name} (${section.id})`);
+                    }
+                });
             });
         });
-    });
 
-    const { directReads, searches } = optimizeCriteriaObjects(slotEntityList);
+        const { directReads, searches } = optimizeCriteriaObjects(slotEntityList);
 
-    loadedData.push(
-        fetchByIdentifier(directReads),
-    );
+        loadedData.push(
+            fetchByIdentifier(directReads),
+        );
 
-    loadedData.push(
-        fetchByCriteria(searches),
-    );
-
+        loadedData.push(
+            fetchByCriteria(searches),
+        );
+    } catch (e) {
+        return Promise.resolve(e);
+    }
 
     return Promise.all(loadedData).then(([readResults, searchResults]) => {
         Object.entries(slotEntityList).forEach(([slotId, slotEntityData]) => {
@@ -64,7 +72,11 @@ function resolve(page) {
                 }
             });
 
-            cmsElements[slot.type].enrich(slot, slotEntities);
+            const cmsElement = cmsElements[slot.type];
+
+            if (cmsElement) {
+                cmsElement.enrich(slot, slotEntities);
+            }
         });
 
         return true;


### PR DESCRIPTION
### 1. Why is this change necessary?
When a plugin adds a cms element, you use that cms element, and disable the plugin. Most of the plugins don't care about their usage and just gets deactivated (which is probably really good so you are not blocked disabling it, when you really need to). Now the CMS editor fails to completely load the page because you get a TypeError stating: hey you can't access collect on undefined. But this TypeError is caught and not displayed. So let's rather give it a try and load everything so we can still get a good editing experience.

### 2. What does this change do, exactly?
Adds a try-catch to pass the caught exception as resolved promise back like the `Promise.all().catch()`. Unsure why it is like it is but I follow along. I would've rather seen a `Promise.reject()` there. There is now a check whether we have received an object from the cms element registry any way and we soft fail with a warning that is hopefully more helpful than what happens now.

### 3. Describe each step to reproduce the issue or behaviour.
1. Install and activate a plugin with a CMS element
2. Use that CMS element
3. Deactivate plugin

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
