### PR TITLE
Fix promotion criteria

### DIFF
--- a/changelog/_unreleased/2021-09-17-fix-promotion-saleschannel-criteria.md
+++ b/changelog/_unreleased/2021-09-17-fix-promotion-saleschannel-criteria.md
@@ -1,0 +1,9 @@
+---
+title: Enable up to 100 Saleschannels as condition for promotions
+issue: NEXT-13724
+author: Alexander Kreissl
+author_email: alexander.kreissl@moonshiner.at
+author_github: mEverGard
+---
+# Administration
+-   Updated the Criteria to support up to 100 saleschannels as conditions for promotions

--- a/changelog/_unreleased/2021-09-17-fix-promotion-saleschannel-criteria.md
+++ b/changelog/_unreleased/2021-09-17-fix-promotion-saleschannel-criteria.md
@@ -1,9 +1,9 @@
 ---
-title: Enable up to 100 Saleschannels as condition for promotions
+title: Enable up to 500 Saleschannels as condition for promotions
 issue: NEXT-13724
 author: Alexander Kreissl
 author_email: alexander.kreissl@moonshiner.at
 author_github: mEverGard
 ---
 # Administration
--   Updated the Criteria to support up to 100 saleschannels as conditions for promotions
+-   Updated the Criteria to support up to 500 saleschannels as conditions for promotions

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-sales-channel-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-sales-channel-select/index.js
@@ -72,7 +72,7 @@ Component.register('sw-promotion-v2-sales-channel-select', {
     methods: {
         createdComponent() {
             this.salesChannelRepository
-                .search(new Criteria(1, 100))
+                .search(new Criteria(1, 500))
                 .then(searchresult => {
                     this.salesChannels = searchresult;
                 });

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-sales-channel-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-sales-channel-select/index.js
@@ -71,9 +71,11 @@ Component.register('sw-promotion-v2-sales-channel-select', {
 
     methods: {
         createdComponent() {
-            this.salesChannelRepository.search(new Criteria()).then((searchresult) => {
-                this.salesChannels = searchresult;
-            });
+            this.salesChannelRepository
+                .search(new Criteria(1, 100))
+                .then(searchresult => {
+                    this.salesChannels = searchresult;
+                });
         },
 
         getChangeset(salesChannelsIds) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently there are only 25 saleschannel available for promotions (not enough for our case), by updating the criteria it is not possible to view up to 100 saleschannels.

### 2. What does this change do, exactly?
Updates the criteria and ups from the default criteria limit (25) to 500.

### 3. Describe each step to reproduce the issue or behaviour.
* have more than 26+ saleschannels
* Go to promotions -> conditions -> pre-conditions -> saleschannels
* You will only find 25 saleschannels.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13724 - we created this ticket and this fix fixes the issue

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
