### PR TITLE
Removed version check when reading plugin composer.json to avoid warn…

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,22 +8,22 @@ Add notes on your change right now in the documentation files in /src/Docs/Resou
 -->
 
 ### 1. Why is this change necessary?
-Avoid composer warnings regarding version field when executing CLI command plugin:refresh
+
 
 ### 2. What does this change do, exactly?
-It disables the version check in the config validator, which only produces this warning.
+
 
 ### 3. Describe each step to reproduce the issue or behaviour.
-bin/console plugin:refresh
+
 
 ### 4. Please link to the relevant issues (if any).
-https://issues.shopware.com/issues/NEXT-17345
+
 
 ### 5. Checklist
 
 - [ ] I have written tests and verified that they fail without my change
 - [ ] I have squashed any insignificant commits
-- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
+- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
 - [ ] I have written or adjusted the documentation according to my changes
 - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
-- [X] I have read the contribution requirements and fulfil them.
+- [ ] I have read the contribution requirements and fulfil them.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,22 +8,22 @@ Add notes on your change right now in the documentation files in /src/Docs/Resou
 -->
 
 ### 1. Why is this change necessary?
-
+Avoid composer warnings regarding version field when executing CLI command plugin:refresh
 
 ### 2. What does this change do, exactly?
-
+It disables the version check in the config validator, which only produces this warning.
 
 ### 3. Describe each step to reproduce the issue or behaviour.
-
+bin/console plugin:refresh
 
 ### 4. Please link to the relevant issues (if any).
-
+https://issues.shopware.com/issues/NEXT-17345
 
 ### 5. Checklist
 
 - [ ] I have written tests and verified that they fail without my change
 - [ ] I have squashed any insignificant commits
-- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
+- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
 - [ ] I have written or adjusted the documentation according to my changes
 - [ ] This change has comments for package types, values, functions, and non-obvious lines of code
-- [ ] I have read the contribution requirements and fulfil them.
+- [X] I have read the contribution requirements and fulfil them.

--- a/changelog/_unreleased/2021-09-19-remove-composer-version-warning-in-plugin-refresh-command.md
+++ b/changelog/_unreleased/2021-09-19-remove-composer-version-warning-in-plugin-refresh-command.md
@@ -1,0 +1,9 @@
+---
+title: 2021-09-19-Remove-Composer-Version-Warning-In-Plugin-Refresh-Command
+issue: NEXT-17345
+author: Edip Aydin
+author_email: ea@networker.de 
+author_github: Edip Aydin
+---
+# Core
+* Removed version check when reading plugin composer.json to avoid warnings for all plugins

--- a/src/Core/Framework/Plugin/Composer/PackageProvider.php
+++ b/src/Core/Framework/Plugin/Composer/PackageProvider.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Plugin\Composer;
 
 use Composer\IO\IOInterface;
 use Composer\Package\CompletePackageInterface;
+use Composer\Package\Loader\ValidatingArrayLoader;
 use Composer\Util\ConfigValidator;
 use Shopware\Core\Framework\Plugin\Exception\PluginComposerJsonInvalidException;
 
@@ -17,7 +18,7 @@ class PackageProvider
         $composerJsonPath = $pluginPath . '/composer.json';
         $validator = new ConfigValidator($composerIO);
 
-        [$errors, $publishErrors, $warnings] = $validator->validate($composerJsonPath);
+        [$errors, $publishErrors, $warnings] = $validator->validate($composerJsonPath, ValidatingArrayLoader::CHECK_ALL, 0);
         $errors = array_merge($errors, $publishErrors);
         if (\count($errors) !== 0) {
             throw new PluginComposerJsonInvalidException($composerJsonPath, $errors);


### PR DESCRIPTION
### 1. Why is this change necessary?
Avoid composer warnings regarding version field when executing CLI command plugin:refresh

### 2. What does this change do, exactly?
It disables the version check in the config validator, which only produces this warning.

### 3. Describe each step to reproduce the issue or behaviour.
bin/console plugin:refresh

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-17345

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
