### PR TITLE
Fix load more than 100 property groups and friends

### DIFF
--- a/changelog/_unreleased/2020-09-06-add-repository-iterator-in-administration-to-improve-loading-entities.md
+++ b/changelog/_unreleased/2020-09-06-add-repository-iterator-in-administration-to-improve-loading-entities.md
@@ -1,0 +1,91 @@
+---
+title: Add repository iterator in administration to improve loading entities
+issue: NEXT-10262
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added new method `iterateIds` in `src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php` to allow easier iterating over `fetchIds`
+* Added new method `iterate` in `src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php` to allow easier iterating over `fetch`
+___
+# Administration
+* Added `RepositoryIterator` to `Shopware.Data` that replicates PHP `Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator`
+* Added `TotalCountMode` to `Shopware.Data`
+* Changes loading entities to use request iteration in method `showSearch` in `src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/index.js`
+* Changes loading entities to use request iteration in method `loadGroups` in `src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/index.js`
+* Changes loading entities to use request iteration in method `loadOptions` in `src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/index.js`
+* Changes loading entities to use request iteration in method `groupProperties` in `src/Administration/Resources/app/administration/src/app/component/base/sw-property-assignment/index.js`
+* Changes loading entities to use request iteration in method `getTreeItems` in `src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js`
+* Changes loading entities to use request iteration in method `searchCategories` in `src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js`
+* Changes loading entities to use request iteration in method `getSubFolders` in `src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-content/index.js`
+* Changes loading entities to use request iteration in method `createdComponent` in `src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-settings/index.js`
+* Changes loading entities to use request iteration in method `getSubFolders` in `src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/index.js`
+* Changes loading entities to use request iteration in method `createdComponent` in `src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-config/index.js`
+* Changes loading entities to use request iteration in method `checkForUpdates` in `src/Administration/Resources/app/administration/src/core/service/customer-group-registration-listener.service.js`
+* Changes loading entities to use request iteration in method `loadRootCategories` in `src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/index.js`
+* Changes loading entities to use request iteration in method `loadCustomFieldSet` in `src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js`
+* Changes loading entities to use request iteration in method `createdComponent` in `src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js`
+* Changes loading entities to use request iteration in method `onChangeLanguage` in `src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js`
+* Changes loading entities to use request iteration in method `createdComponent` in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js`
+* Changes loading entities to use request iteration in method `refreshList` in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js`
+* Changes loading entities to use request iteration in method `createdComponent` in `src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-mapping/index.js`
+* Changes loading entities to use request iteration in method `getCustomFieldSets` in `src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js`
+* Changes loading entities to use request iteration in method `createdComponent` in `src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js`
+* Changes loading entities to use request iteration in method `loadFilters` in `src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/index.js`
+* Changes loading entities to use request iteration in method `getProductCustomFields` in `src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/index.js`
+* Changes loading entities to use request iteration in method `getChildrenIds` in `src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js`
+* Changes loading entities to use request iteration in method `getProductStreamFilter` in `src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js`
+* Changes loading entities to use request iteration in method `loadCurrencies` in `src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/index.js`
+* Changes loading entities to use request iteration in method `loadCurrencies` in `src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js`
+* Changes loading entities to use request iteration in method `loadTaxes` in `src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js`
+* Changes loading entities to use request iteration in method `getList` in `src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js`
+* Changes loading entities to use request iteration in method `mountedComponent` in `src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js`
+* Changes loading entities to use request iteration in method `loadAssignedProducts` in `src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js`
+* Changes loading entities to use request iteration in method `loadGroups` in `src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js`
+* Changes loading entities to use request iteration in method `loadLanguages` in `src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/index.js`
+* Changes loading entities to use request iteration in method `loadExclusions` in `src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-basic-form/index.js`
+* Changes loading entities to use request iteration in method `loadSetGroups` in `src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-cart-condition-form/index.js`
+* Changes loading entities to use request iteration in method `createdComponent` in `src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-discount-component/index.js`
+* Changes loading entities to use request iteration in method `createdComponent` in `src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-sales-channel-select/index.js`
+* Changes loading entities to use request iteration in method `reloadCustomers` in `src/Administration/Resources/app/administration/src/module/sw-promotion/service/persona-customer-grid.service.js`
+* Changes loading entities to use request iteration in method `loadEntityData` in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js`
+* Changes loading entities to use request iteration in method `createdComponent` in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js`
+* Changes loading entities to use request iteration in method `loadCustomFieldSets` in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js`
+* Changes loading entities to use request iteration in method `loadStorefrontDomains` in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js`
+* Changes loading entities to use request iteration in method `loadSeoUrls` in `src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js`
+* Changes loading entities to use request iteration in method `loadAvailableSalesChannel` in `src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js`
+* Changes loading entities to use request iteration in method `_fetchEntities` in `src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/service/feature-grid-translation.service.js`
+* Changes loading entities to use request iteration in method `loadConditions` in `src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/index.js`
+* Changes loading entities to use request iteration in method `initSalesChannelCollection` in `src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js`
+* Changes loading entities to use request iteration in method `loadCurrencies` in `src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/index.js`
+* Changes counting entities to use count request in method `checkIfPropertiesExists` in `src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-properties/index.js`
+* Changes counting entities to use count request in method `createdComponent` in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal/index.js`
+* Changes counting entities to use count request in method `onChangeFileNameDebounce` in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js`
+* Changes counting entities to use count request in method `isCustomFieldNameUnique` in `src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/index.js`
+* Changes counting entities to use count request in method `onSave` in `src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-create/index.js`
+* Changes counting entities to use count request in method `onChangeDebounce` in `src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/index.js`
+___
+# Upgrade Information
+
+## Administration entity list loading
+
+When you load entities in the administration via a repository from the repositoryFactory service you will send a single request you will get a page of entities:
+```javascript
+repositoryFactory.create('product')
+    .search(new Shopware.Data.Criteria())
+    .then(products => {
+        console.log(products);
+    });
+```
+
+Now you can use the repository built-in repository iterator factory methods to get all pages of the entity without changing lots of your code:
+```javascript
+repositoryFactory.create('product')
+    .iterate()
+    .then(products => {
+        console.log(products);
+    });
+```
+
+`iterate` can still receive a criteria which is useful to determine the page size and filters as well as a context object as parameters.

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-property-assignment/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-property-assignment/index.js
@@ -124,8 +124,8 @@ Component.register('sw-property-assignment', {
             );
 
             // Fetch groups with options
-            this.groupRepository.search(groupSearchCriteria, Shopware.Context.api).then((res) => {
-                this.groups = res;
+            this.groupRepository.iterate(groupSearchCriteria).then((groups) => {
+                this.groups = groups;
             });
 
             return true;

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-property-search/index.js
@@ -1,9 +1,8 @@
 import template from './sw-property-search.html.twig';
 import './sw-property-search.scss';
 
-const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
-const utils = Shopware.Utils;
+const { Component, Data, Utils } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-property-search', {
     template,
@@ -182,7 +181,7 @@ Component.register('sw-property-search', {
             this.showTree();
         },
 
-        onSearchOptions: utils.debounce(function debouncedSearch(input) {
+        onSearchOptions: Utils.debounce(function debouncedSearch(input) {
             const validInput = input || '';
 
             this.optionPage = 1;
@@ -218,7 +217,7 @@ Component.register('sw-property-search', {
             this.displaySearch = true;
             this.displayTree = false;
 
-            this.propertyGroupOptionRepository.search(this.propertyGroupOptionCriteria, Shopware.Context.api)
+            this.propertyGroupOptionRepository.iterate(Criteria.fromCriteria(this.propertyGroupOptionCriteria))
                 .then((groupOptions) => {
                     this.groupOptions = groupOptions;
                     this.optionTotal = groupOptions.total;
@@ -238,7 +237,7 @@ Component.register('sw-property-search', {
         },
 
         loadGroups() {
-            this.propertyGroupRepository.search(this.propertyGroupCriteria, Shopware.Context.api).then((groups) => {
+            this.propertyGroupRepository.iterate(Criteria.fromCriteria(this.propertyGroupCriteria)).then((groups) => {
                 this.groups = groups;
                 this.groupTotal = groups.total;
                 this.addOptionCount();
@@ -251,7 +250,7 @@ Component.register('sw-property-search', {
             criteria.setTotalCountMode(1);
             criteria.addAssociation('group');
 
-            this.propertyGroupOptionRepository.search(criteria, Shopware.Context.api)
+            this.propertyGroupOptionRepository.iterate(criteria)
                 .then((groupOptions) => {
                     this.groupOptions = this.sortOptions(groupOptions);
                     this.optionTotal = groupOptions.total;

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
@@ -186,7 +186,7 @@ Component.register('sw-category-tree-field', {
             criteria.addFilter(Criteria.equals('parentId', parentId));
 
             // search for categories
-            return this.globalCategoryRepository.search(criteria, Shopware.Context.api).then((searchResult) => {
+            return this.globalCategoryRepository.iterate(criteria).then((searchResult) => {
                 // when requesting root categories, replace the data
                 if (parentId === null) {
                     this.categories = searchResult;
@@ -249,8 +249,7 @@ Component.register('sw-category-tree-field', {
             categorySearchCriteria.addFilter(Criteria.equals('type', 'page'));
             categorySearchCriteria.setTerm(term);
 
-            // search for categories
-            return this.globalCategoryRepository.search(categorySearchCriteria, Shopware.Context.api);
+            return this.globalCategoryRepository.iterate(categorySearchCriteria);
         },
 
         isSearchItemChecked(itemId) {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-content/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-folder-content/index.js
@@ -1,8 +1,8 @@
 import template from './sw-media-folder-content.html.twig';
 import './sw-media-folder-content.scss';
 
-const { Component, Context } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Context, Data } = Shopware;
+const { Criteria } = Data;
 
 Component.register('sw-media-folder-content', {
     template,
@@ -62,7 +62,7 @@ Component.register('sw-media-folder-content', {
                 .addAssociation('children')
                 .addSorting(Criteria.sort('name', 'asc'));
 
-            const searchResult = await this.mediaFolderRepository.search(criteria, Context.api);
+            const searchResult = await this.mediaFolderRepository.iterate(criteria);
             this.subFolders = searchResult.filter(this.filterItems);
         },
 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-settings/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-modal-folder-settings/index.js
@@ -1,8 +1,8 @@
 import template from './sw-media-modal-folder-settings.html.twig';
 import './sw-media-modal-folder-settings.scss';
 
-const { Component, Mixin, Context } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Data, Mixin, Context } = Shopware;
+const { Criteria } = Data;
 
 /**
  * @private
@@ -90,9 +90,7 @@ Component.register('sw-media-modal-folder-settings', {
                 this.configuration.mediaThumbnailSizes.entity,
                 this.configuration.mediaThumbnailSizes.source,
             );
-
-            this.configuration.mediaThumbnailSizes = await this.mediaFolderConfigurationThumbnailSizeRepository
-                .search(new Criteria(), Context.api);
+            this.configuration.mediaThumbnailSizes = await this.mediaFolderConfigurationThumbnailSizeRepository.iterateAsync();
 
             if (this.folder.parentId !== null) {
                 this.parent = await this.mediaFolderRepository.get(this.folder.parentId, Context.api);

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-sidebar-media-item/index.js
@@ -129,7 +129,7 @@ Component.register('sw-sidebar-media-item', {
             const criteria = new Criteria(1, 50);
             criteria.addFilter(Criteria.equals('parentId', this.mediaFolderId));
 
-            const folder = await this.mediaFolderRepository.search(criteria, Context.api);
+            const folder = await this.mediaFolderRepository.iterate(criteria);
             this.subFolders = folder;
             return folder;
         },

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-config/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-sales-channel-config/index.js
@@ -75,7 +75,7 @@ Component.register('sw-sales-channel-config', {
     methods: {
         createdComponent() {
             if (!this.salesChannel.length) {
-                this.salesChannelRepository.search(this.criteria, Shopware.Context.api).then(res => {
+                this.salesChannelRepository.iterate(Criteria.fromCriteria(this.criteria)).then(res => {
                     res.add({
                         id: null,
                         translated: {

--- a/src/Administration/Resources/app/administration/src/core/data/index.js
+++ b/src/Administration/Resources/app/administration/src/core/data/index.js
@@ -9,6 +9,7 @@ import EntityDefinition from './entity-definition.data';
 import EntityFactory from './entity-factory.data';
 import EntityHydrator from './entity-hydrator.data';
 import Repository from './repository.data';
+import RepositoryIterator from './repository-iterator.data';
 import ErrorResolver from './error-resolver.data';
 import ErrorStore from './error-store.data';
 import FilterFactory from './filter-factory.data';
@@ -22,6 +23,7 @@ export default {
     EntityFactory,
     EntityHydrator,
     Repository,
+    RepositoryIterator,
     ErrorResolver,
     ErrorStore,
     FilterFactory,

--- a/src/Administration/Resources/app/administration/src/core/data/index.js
+++ b/src/Administration/Resources/app/administration/src/core/data/index.js
@@ -1,5 +1,8 @@
 import ChangesetGenerator from './changeset-generator.data';
+// eslint-disable-next-line import/no-duplicates
 import Criteria from './criteria.data';
+// eslint-disable-next-line import/no-duplicates
+import TotalCountMode from './criteria.data';
 import Entity from './entity.data';
 import EntityCollection from './entity-collection.data';
 import EntityDefinition from './entity-definition.data';
@@ -22,4 +25,5 @@ export default {
     ErrorResolver,
     ErrorStore,
     FilterFactory,
+    TotalCountMode,
 };

--- a/src/Administration/Resources/app/administration/src/core/data/repository-iterator.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data/repository-iterator.data.js
@@ -1,5 +1,19 @@
 import Criteria from './criteria.data';
 
+/**
+ * Callback for iterating entities
+ *
+ * @callback iterateEntitiesCallback
+ * @param {Object} entities
+ */
+
+/**
+ * Callback for iterating entities
+ *
+ * @callback iterateIdsCallback
+ * @param {Array<String>} ids
+ */
+
 export default class RepositoryIterator {
     /**
      * @param {Repository} repository
@@ -41,6 +55,45 @@ export default class RepositoryIterator {
     }
 
     /**
+     * @param {iterateIdsCallback} callback
+     * @returns {Promise<Array<String>>}
+     */
+    iterateIds(callback = null) {
+        const fetch = (result) => {
+            return this.fetch().then(response => {
+                if (response === null) {
+                    return Promise.resolve(result);
+                }
+
+                result.push(...response);
+
+                if (callback !== null) {
+                    callback(response);
+                }
+
+                return fetch(result);
+            });
+        };
+
+        return fetch([]);
+    }
+
+    async * iterateIdsAsync() {
+        const fetchIds = async () => this.fetchIds();
+
+        do {
+            // eslint-disable-next-line no-await-in-loop
+            const ids = await fetchIds();
+
+            if (ids === null) {
+                break;
+            }
+
+            yield* ids;
+        } while (true);
+    }
+
+    /**
      * @return {Promise<Object>}
      */
     fetch() {
@@ -49,5 +102,46 @@ export default class RepositoryIterator {
         this.criteria.setPage(this.criteria.page + 1);
         return this.repository.search(criteria, this.context)
             .then(entities => (entities.length > 0 ? entities : null));
+    }
+
+    /**
+     * @param {iterateEntitiesCallback} callback
+     * @returns {Promise<Array<Object>>}
+     */
+    iterate(callback = null) {
+        const fetch = (result) => {
+            return this.fetch().then(response => {
+                if (response === null) {
+                    return Promise.resolve(result);
+                }
+
+                result.push(...response);
+                result.criteria = response.criteria;
+                result.total = response.total;
+
+                if (callback !== null) {
+                    callback(response);
+                }
+
+                return fetch(result);
+            });
+        };
+
+        return fetch([]);
+    }
+
+    async * iterateAsync() {
+        const fetch = async () => this.fetch();
+
+        do {
+            // eslint-disable-next-line no-await-in-loop
+            const items = await fetch();
+
+            if (items === null) {
+                break;
+            }
+
+            yield* items.data;
+        } while (true);
     }
 }

--- a/src/Administration/Resources/app/administration/src/core/data/repository-iterator.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data/repository-iterator.data.js
@@ -1,0 +1,53 @@
+import Criteria from './criteria.data';
+
+export default class RepositoryIterator {
+    /**
+     * @param {Repository} repository
+     * @param {Context} context
+     * @param {Criteria} criteria
+     */
+    constructor(repository, criteria = null, context = null) {
+        this.repository = repository;
+        this.criteria = criteria || new Criteria();
+        this.context = context || Shopware.Context.api;
+
+        if (this.criteria.limit === null || this.criteria.limit < 1) {
+            this.criteria.setLimit(25);
+        }
+    }
+
+    /**
+     * @return {Promise<number>}
+     */
+    getTotal() {
+        const criteria = Criteria.fromCriteria(this.criteria)
+            .setPage(1)
+            .setLimit(1)
+            .setTotalCountMode(Criteria.TOTAL_COUNT_MODE_EXACT);
+
+        return this.repository.searchIds(criteria, this.context)
+            .then(response => response.total);
+    }
+
+    /**
+     * @return {Promise<Array<string>>}
+     */
+    fetchIds() {
+        const criteria = Criteria.fromCriteria(this.criteria);
+        criteria.setTotalCountMode(Criteria.TOTAL_COUNT_MODE_NONE);
+        this.criteria.setPage(this.criteria.page + 1);
+        return this.repository.searchIds(criteria, this.context)
+            .then(response => (response.data.length > 0 ? response.data : null));
+    }
+
+    /**
+     * @return {Promise<Object>}
+     */
+    fetch() {
+        const criteria = Criteria.fromCriteria(this.criteria);
+        criteria.setTotalCountMode(Criteria.TOTAL_COUNT_MODE_NONE);
+        this.criteria.setPage(this.criteria.page + 1);
+        return this.repository.search(criteria, this.context)
+            .then(entities => (entities.length > 0 ? entities : null));
+    }
+}

--- a/src/Administration/Resources/app/administration/src/core/data/repository.data.js
+++ b/src/Administration/Resources/app/administration/src/core/data/repository.data.js
@@ -1,4 +1,5 @@
 import Criteria from './criteria.data';
+import RepositoryIterator from './repository-iterator.data';
 
 export default class Repository {
     /**
@@ -412,35 +413,43 @@ export default class Repository {
     }
 
     /**
-     * Allows to iterate all ids of the provided criteria.
+     * Iterates over a paginated search request for the repository entity.
      * @param {Criteria} criteria
-     * @param {function} callback
-     * @param context
+     * @param {Object} context
      * @returns {Promise}
      */
-    iterateIds(criteria, callback, context = Shopware.Context.api) {
-        if (criteria.limit == null) {
-            criteria.setLimit(50);
-        }
-        criteria.setTotalCountMode(1);
+    iterate(criteria, context = Shopware.Context.api) {
+        return new RepositoryIterator(this, criteria, context).iterate(null);
+    }
 
-        return this.searchIds(criteria, context).then((response) => {
-            const ids = response.data;
+    /**
+     * Iterates over a paginated search request for the repository entity.
+     * @param {Criteria} criteria
+     * @param {Object} context
+     * @returns {Promise}
+     */
+    async iterateAsync(criteria, context = Shopware.Context.api) {
+        return new RepositoryIterator(this, criteria, context).iterateAsync();
+    }
 
-            if (ids.length <= 0) {
-                return Promise.resolve();
-            }
+    /**
+     * Iterates over a paginated search request for the repository entity ids.
+     * @param {Criteria} criteria
+     * @param {Object} context
+     * @returns {Promise}
+     */
+    iterateIds(criteria, context = Shopware.Context.api) {
+        return new RepositoryIterator(this, criteria, context).iterateIds(null);
+    }
 
-            return callback(ids).then(() => {
-                if (ids.length < criteria.limit) {
-                    return Promise.resolve();
-                }
-
-                criteria.setPage(criteria.page + 1);
-
-                return this.iterateIds(criteria, callback);
-            });
-        });
+    /**
+     * Iterates over a paginated search request for the repository entity ids.
+     * @param {Criteria} criteria
+     * @param {Object} context
+     * @returns {Promise}
+     */
+    async iterateIdsAsync(criteria, context = Shopware.Context.api) {
+        return new RepositoryIterator(this, criteria, context).iterateIdsAsync();
     }
 
     /**

--- a/src/Administration/Resources/app/administration/src/core/service/customer-group-registration-listener.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/customer-group-registration-listener.service.js
@@ -27,7 +27,7 @@ export default function addCustomerGroupRegistrationListener(loginService) {
         criteria.addAssociation('requestedGroup');
         criteria.addFilter(Criteria.not('AND', [Criteria.equals('requestedGroupId', null)]));
 
-        const customers = await customerRepository.search(criteria, Shopware.Context.api);
+        const customers = await customerRepository.iterateAsync(criteria);
 
         customers.forEach(createNotification);
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-tree/index.js
@@ -440,8 +440,9 @@ Component.register('sw-category-tree', {
         loadRootCategories() {
             const criteria = Criteria.fromCriteria(this.criteria)
                 .addFilter(Criteria.equals('parentId', null));
+            criteria.limit = 500;
 
-            return this.categoryRepository.search(criteria).then((result) => {
+            return this.categoryRepository.iterate(criteria).then((result) => {
                 this.addCategories(result);
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -509,7 +509,7 @@ Component.register('sw-category-detail', {
         loadCustomFieldSet() {
             this.isCustomFieldLoading = true;
 
-            return this.customFieldSetRepository.search(this.customFieldSetCriteria)
+            return this.customFieldSetRepository.iterate(Criteria.fromCriteria(this.customFieldSetCriteria))
                 .then((customFieldSet) => {
                     return this.$store.commit('swCategoryDetail/setCustomFieldSets', customFieldSet);
                 }).finally(() => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -299,7 +299,7 @@ Component.register('sw-cms-detail', {
                     Criteria.equals('typeId', defaultStorefrontId),
                 );
 
-                this.salesChannelRepository.search(criteria).then((response) => {
+                this.salesChannelRepository.iterate(criteria).then((response) => {
                     this.salesChannels = response;
 
                     if (this.salesChannels.length > 0) {
@@ -467,7 +467,7 @@ Component.register('sw-cms-detail', {
         onChangeLanguage() {
             this.isLoading = true;
 
-            return this.salesChannelRepository.search(new Criteria()).then((response) => {
+            return this.salesChannelRepository.iterate().then((response) => {
                 this.salesChannels = response;
                 const isSystemDefaultLanguage = Shopware.State.getters['context/isSystemDefaultLanguage'];
                 this.$store.commit('cmsPageState/setIsSystemDefaultLanguage', isSystemDefaultLanguage);

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js
@@ -120,11 +120,11 @@ Component.register('sw-customer-detail-addresses', {
             customFieldSetCriteria.addFilter(Criteria.equals('relations.entityName', 'customer_address'))
                 .addAssociation('customFields');
 
-            this.customFieldSetRepository.search(customFieldSetCriteria).then((customFieldSets) => {
+            this.customFieldSetRepository.iterate(customFieldSetCriteria).then((customFieldSets) => {
                 this.customerAddressCustomFieldSets = customFieldSets;
+            }).finally(() => {
+                this.isLoading = false;
             });
-
-            this.isLoading = false;
         },
 
         getAddressColumns() {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
@@ -91,7 +91,7 @@ Component.register('sw-customer-detail-order', {
             criteria.addAssociation('stateMachineState')
                 .addAssociation('currency');
 
-            this.orderRepository.search(criteria).then((orders) => {
+            this.orderRepository.iterate(criteria).then((orders) => {
                 this.orders = orders;
                 this.isLoading = false;
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-mapping/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-mapping/index.js
@@ -145,12 +145,12 @@ Shopware.Component.register('sw-import-export-edit-profile-modal-mapping', {
         createdComponent() {
             this.toggleAddMappingActionState(this.profile.sourceEntity);
 
-            this.languageRepository.search(this.languageCriteria).then(languages => {
+            this.languageRepository.iterate(Criteria.fromCriteria(this.languageCriteria)).then(languages => {
                 this.languages = languages;
                 this.languages.push({ locale: { code: 'DEFAULT' } });
             });
 
-            this.currencyRepository.search(this.currencyCriteria).then(currencies => {
+            this.currencyRepository.iterate(Criteria.fromCriteria(this.currencyCriteria)).then(currencies => {
                 this.currencies = currencies;
                 this.currencies.push({ isoCode: 'DEFAULT' });
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
@@ -79,7 +79,7 @@ Component.register('sw-media-quickinfo', {
                 .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true))
                 .setLimit(100);
 
-            const searchResult = await this.customFieldSetRepository.search(criteria);
+            const searchResult = await this.customFieldSetRepository.iterateAsync(criteria);
             this.customFieldSets = searchResult.filter(set => set.customFields.length > 0);
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/index.js
@@ -59,11 +59,11 @@ Component.register('sw-newsletter-recipient-list', {
             this.tagCollection = new EntityCollection('/tag', 'tag', Shopware.Context.api, new Criteria());
 
             const criteria = new Criteria(1, 100);
-            this.repositoryFactory.create('language').search(criteria, Shopware.Context.api).then((items) => {
+            this.repositoryFactory.create('language').iterate(criteria).then((items) => {
                 this.languageFilters = items;
             });
 
-            this.salesChannelRepository.search(new Criteria(1, 100)).then((salesChannels) => {
+            this.salesChannelRepository.iterate(new Criteria(1, 100)).then((salesChannels) => {
                 this.salesChannelFilters = salesChannels;
             });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/index.js
@@ -184,7 +184,7 @@ Component.register('sw-product-stream-detail', {
                 const filterCriteria = new Criteria();
                 filterCriteria.addFilter(Criteria.equals('productStreamId', this.productStreamId));
 
-                return this.productStreamFiltersRepository.search(filterCriteria, Context.api).then((productFilter) => {
+                this.productStreamFiltersRepository.iterate(filterCriteria).then((productFilter) => {
                     return this.loadFilters(productFilter);
                 });
             }
@@ -301,7 +301,7 @@ Component.register('sw-product-stream-detail', {
                 .addAssociation('customFields')
                 .addAssociation('relations');
 
-            return this.customFieldSetRepository.search(customFieldsCriteria, Context.api).then((customFieldSets) => {
+            this.customFieldSetRepository.iterate(customFieldsCriteria).then((customFieldSets) => {
                 customFieldSets.forEach((customFieldSet) => {
                     const customFields = customFieldSet.customFields
                         .reduce((acc, customField) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js
@@ -92,11 +92,7 @@ Component.register('sw-product-clone-modal', {
                 Criteria.equals('parentId', this.product.id),
             );
 
-            return this.repository
-                .searchIds(criteria)
-                .then((response) => {
-                    return response.data;
-                });
+            return this.repository.iterateIds(criteria);
         },
 
         duplicateVariant(duplicate, ids, callback) {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js
@@ -200,7 +200,7 @@ Component.register('sw-product-cross-selling-form', {
             if (this.productStreamFilterRepository === null) {
                 return [];
             }
-            return this.productStreamFilterRepository.search(this.productStreamFilterCriteria)
+            return this.productStreamFilterRepository.iterate(Criteria.fromCriteria(this.productStreamFilterCriteria))
                 .then((productStreamFilter) => {
                     this.productStreamFilter = productStreamFilter;
                 });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/index.js
@@ -97,11 +97,9 @@ Component.register('sw-product-variants-configurator-prices', {
         },
 
         loadCurrencies() {
-            this.currencyRepository
-                .search(new Criteria())
-                .then((searchResult) => {
-                    this.currencies = searchResult;
-                });
+            this.currencyRepository.iterate().then((searchResult) => {
+                this.currencies = searchResult;
+            });
         },
 
         getOptionsForGroup() {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
@@ -1,8 +1,8 @@
 import template from './sw-product-variants-overview.html.twig';
 import './sw-products-variants-overview.scss';
 
-const { Component, Mixin, Context } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Component, Data, Mixin, Context } = Shopware;
+const { Criteria, TotalCountMode } = Data;
 const { mapState, mapGetters } = Shopware.Component.getComponentHelper();
 
 Component.register('sw-product-variants-overview', {
@@ -146,7 +146,7 @@ Component.register('sw-product-variants-overview', {
                 const searchCriteria = new Criteria();
 
                 // Criteria for Search
-                searchCriteria.setTotalCountMode(1);
+                searchCriteria.setTotalCountMode(TotalCountMode.EXACT_TOTAL_COUNT);
                 searchCriteria
                     .setPage(this.page)
                     .setLimit(this.limit)

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -599,7 +599,7 @@ Component.register('sw-product-detail', {
         loadCurrencies() {
             Shopware.State.commit('swProductDetail/setLoading', ['currencies', true]);
 
-            return this.currencyRepository.search(new Criteria(1, 500)).then((res) => {
+            return this.currencyRepository.iterate(new Criteria(1, 500)).then((res) => {
                 Shopware.State.commit('swProductDetail/setCurrencies', res);
             }).then(() => {
                 Shopware.State.commit('swProductDetail/setLoading', ['currencies', false]);
@@ -609,7 +609,7 @@ Component.register('sw-product-detail', {
         loadTaxes() {
             Shopware.State.commit('swProductDetail/setLoading', ['taxes', true]);
 
-            return this.taxRepository.search(this.taxCriteria).then((res) => {
+            return this.taxRepository.iterate(Criteria.fromCriteria(this.taxCriteria)).then((res) => {
                 Shopware.State.commit('swProductDetail/setTaxes', res);
             }).then(() => {
                 Shopware.State.commit('swProductDetail/setLoading', ['taxes', false]);

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
@@ -230,7 +230,7 @@ Component.register('sw-product-list', {
             try {
                 const result = await Promise.all([
                     this.productRepository.search(criteria),
-                    this.currencyRepository.search(this.currencyCriteria),
+                    this.currencyRepository.iterate(Criteria.fromCriteria(this.currencyCriteria)),
                 ]);
 
                 const products = result[0];

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-base/index.js
@@ -1,10 +1,10 @@
-import { Criteria, TotalCountMode } from 'src/core/data/criteria.data';
 import template from './sw-product-detail-base.html.twig';
 import './sw-product-detail-base.scss';
 
-const { Component, Context, Utils, Mixin } = Shopware;
+const { Component, Context, Data, Utils, Mixin } = Shopware;
 const { mapState, mapGetters } = Component.getComponentHelper();
 const { isEmpty } = Utils.types;
+const { Criteria, TotalCountMode } = Data;
 
 Component.register('sw-product-detail-base', {
     template,

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-base/index.js
@@ -1,4 +1,4 @@
-import Criteria from 'src/core/data/criteria.data';
+import { Criteria, TotalCountMode } from 'src/core/data/criteria.data';
 import template from './sw-product-detail-base.html.twig';
 import './sw-product-detail-base.scss';
 
@@ -357,7 +357,7 @@ Component.register('sw-product-detail-base', {
             criteria.addFilter(Criteria.equals('productId', this.product.id));
             criteria.setPage(this.page);
             criteria.setLimit(this.limit);
-            criteria.setTotalCountMode(1);
+            criteria.setTotalCountMode(TotalCountMode.EXACT_TOTAL_COUNT);
 
             // load all our individual codes of our promotion
             // into our local promotion object.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
@@ -206,7 +206,7 @@ Component.register('sw-product-detail-context-prices', {
             );
 
             Shopware.State.commit('swProductDetail/setLoading', ['rules', true]);
-            this.ruleRepository.search(ruleCriteria).then((res) => {
+            this.ruleRepository.iterate(ruleCriteria).then((res) => {
                 this.rules = res;
                 this.totalRules = res.total;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
@@ -74,7 +74,7 @@ Component.register('sw-product-detail-cross-selling', {
                 .addSorting(Criteria.sort('position', 'ASC'))
                 .addAssociation('product');
 
-            repository.search(
+            repository.iterate(
                 criteria,
                 { ...Shopware.Context.api, inheritance: true },
             ).then((assignedProducts) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-properties/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-properties/index.js
@@ -2,7 +2,7 @@ import template from './sw-product-detail-properties.html.twig';
 import './sw-product-detail-properties.scss';
 
 const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { RepositoryIterator } = Shopware.Data;
 const { mapState, mapGetters } = Shopware.Component.getComponentHelper();
 
 // @deprecated tag:v6.5.0 - Will be removed and has been replaced by sw-product-properties
@@ -65,8 +65,9 @@ Component.register('sw-product-detail-properties', {
         },
 
         checkIfPropertiesExists() {
-            this.propertyRepository.search(new Criteria(1, 1)).then((res) => {
-                this.propertiesAvailable = res.total > 0;
+            const iterator = new RepositoryIterator(this.propertyRepository);
+            iterator.getTotal().then(total => {
+                this.propertiesAvailable = total > 0;
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
@@ -118,7 +118,7 @@ Component.register('sw-product-detail-variants', {
                         .setLimit(100)
                         .setPage(1);
 
-                    this.groupRepository.search(groupCriteria).then((searchResult) => {
+                    return this.groupRepository.iterate(groupCriteria).then((searchResult) => {
                         this.groups = searchResult;
                         resolve();
                     });

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/index.js
@@ -200,7 +200,7 @@ Component.register('sw-profile-index', {
             languageCriteria.addFilter(Criteria.equalsAny('locale.code', registeredLocales));
             languageCriteria.limit = 500;
 
-            return this.languageRepository.search(languageCriteria).then((result) => {
+            return this.languageRepository.iterate(languageCriteria).then((result) => {
                 this.languages = [];
                 const localeIds = [];
                 let fallbackId = '';

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-basic-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-basic-form/index.js
@@ -63,7 +63,7 @@ Component.register('sw-promotion-basic-form', {
             const promotionRepository = this.repositoryFactory.create('promotion');
             const criteria = (new Criteria()).addFilter(Criteria.equalsAny('id', this.promotion.exclusionIds));
 
-            promotionRepository.search(criteria).then((excluded) => {
+            promotionRepository.iterate(criteria).then((excluded) => {
                 this.excludedPromotions = excluded;
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-cart-condition-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-cart-condition-form/index.js
@@ -114,7 +114,7 @@ Component.register('sw-promotion-cart-condition-form', {
                 Criteria.equals('promotionId', this.promotion.id),
             );
 
-            this.repositoryGroups.search(criteria).then((groups) => {
+            this.repositoryGroups.iterate(criteria).then((groups) => {
                 this.promotion.setgroups = groups;
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-discount-component/index.js
@@ -312,7 +312,7 @@ Component.register('sw-promotion-discount-component', {
             this.syncService = Shopware.Service('syncService');
             this.httpClient = this.syncService.httpClient;
 
-            this.currencyRepository.search(new Criteria()).then((response) => {
+            this.currencyRepository.iterate().then((response) => {
                 this.currencies = response;
                 this.defaultCurrency = this.currencies.find(currency => currency.isSystemDefault);
                 this.currencySymbol = this.defaultCurrency.symbol;

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-individualcodes/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-individualcodes/index.js
@@ -5,9 +5,9 @@ import template from './sw-promotion-individualcodes.html.twig';
 import './sw-promotion-individualcodes.scss';
 
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
-const { Component, Mixin } = Shopware;
+const { Component, Data, Mixin } = Shopware;
 const { string } = Shopware.Utils;
-const Criteria = Shopware.Data.Criteria;
+const { Criteria, TotalCountMode } = Data;
 
 /**
  * @deprecated tag:v6.5.0 - will be removed, use `sw-promotion-v2` instead
@@ -330,7 +330,7 @@ Component.register('sw-promotion-individualcodes', {
             criteria.addFilter(Criteria.equals('promotionId', this.promotion.id));
             criteria.setPage(this.gridCurrentPageNr);
             criteria.setLimit(this.gridPageLimit);
-            criteria.setTotalCountMode(1);
+            criteria.setTotalCountMode(TotalCountMode.EXACT_TOTAL_COUNT);
 
             // load all our individual codes of our promotion
             // into our local promotion object.

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-sales-channel-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/component/sw-promotion-sales-channel-select/index.js
@@ -1,7 +1,6 @@
 import template from './sw-promotion-sales-channel-select.html.twig';
 
 const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
 
 /**
  * @deprecated tag:v6.5.0 - will be removed, use `sw-promotion-v2` instead
@@ -78,7 +77,7 @@ Component.register('sw-promotion-sales-channel-select', {
 
     methods: {
         createdComponent() {
-            this.salesChannelRepository.search(new Criteria()).then((searchresult) => {
+            this.salesChannelRepository.iterate().then((searchresult) => {
                 this.salesChannels = searchresult;
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/service/individual-code-generator.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/service/individual-code-generator.service.js
@@ -1,6 +1,7 @@
 import EventEmitter from 'events';
 import CodeGenerator from './code-generator.service';
-import { Criteria, TotalCountMode } from '../../../core/data/criteria.data';
+
+const { Criteria, TotalCountMode } = Shopware.Data;
 
 /**
  * @deprecated tag:v6.5.0 - will be removed, use `sw-promotion-v2` instead

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/service/individual-code-generator.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/service/individual-code-generator.service.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'events';
 import CodeGenerator from './code-generator.service';
-import Criteria from '../../../core/data/criteria.data';
+import { Criteria, TotalCountMode } from '../../../core/data/criteria.data';
 
 /**
  * @deprecated tag:v6.5.0 - will be removed, use `sw-promotion-v2` instead
@@ -191,7 +191,7 @@ export default class IndividualCodeGenerator extends EventEmitter {
         const criteria = new Criteria();
         criteria.setLimit(1);
         criteria.addFilter(Criteria.equals('promotionId', this.promotionId));
-        criteria.setTotalCountMode(1);
+        criteria.setTotalCountMode(TotalCountMode.EXACT_TOTAL_COUNT);
 
         let count = 0;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion/service/persona-customer-grid.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion/service/persona-customer-grid.service.js
@@ -1,5 +1,3 @@
-const { Criteria } = Shopware.Data;
-
 /**
  * @deprecated tag:v6.5.0 - will be removed, use `sw-promotion-v2` instead
  */
@@ -32,11 +30,9 @@ export default class PersonaCustomerGridService {
     }
 
     async reloadCustomers() {
-        const criteria = new Criteria();
-
         // search all customer persona entries and load them
         // into our customer list which will be shown using our vue grid.
-        await this.repoPromotionCustomers.search(criteria, this.context).then((customers) => {
+        await this.repoPromotionCustomers.iterateAsync(null, this.context).then((customers) => {
             this.dataSource = customers;
         });
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/structure/sw-sales-channel-menu/index.js
@@ -101,7 +101,7 @@ Component.register('sw-sales-channel-menu', {
         },
 
         loadEntityData() {
-            this.salesChannelRepository.search(this.salesChannelCriteria).then((response) => {
+            this.salesChannelRepository.iterate(Criteria.fromCriteria(this.salesChannelCriteria)).then((response) => {
                 this.salesChannels = response;
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal-grid/index.js
@@ -50,7 +50,7 @@ Component.register('sw-sales-channel-modal-grid', {
         createdComponent() {
             this.isLoading = true;
             const context = { ...Shopware.Context.api, languageId: Shopware.State.get('session').languageId };
-            this.salesChannelTypeRepository.search(new Criteria(1, 500), context).then((response) => {
+            this.salesChannelTypeRepository.iterate(new Criteria(1, 500), context).then((response) => {
                 this.total = response.total;
                 this.salesChannelTypes = response;
                 this.isLoading = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-modal/index.js
@@ -2,7 +2,7 @@ import template from './sw-sales-channel-modal.html.twig';
 import './sw-sales-channel-modal.scss';
 
 const { Component, Defaults } = Shopware;
-const { Criteria } = Shopware.Data;
+const { RepositoryIterator } = Shopware.Data;
 
 Component.register('sw-sales-channel-modal', {
     template,
@@ -52,11 +52,9 @@ Component.register('sw-sales-channel-modal', {
     methods: {
         createdComponent() {
             this.productStreamsLoading = true;
-            this.productStreamRepository.search(new Criteria(1, 1)).then((result) => {
-                if (result.total > 0) {
-                    this.productStreamsExist = true;
-                }
-                this.productStreamsLoading = false;
+            const iterator = new RepositoryIterator(this.productStreamRepository);
+            iterator.getTotal().then(total => {
+                this.productStreamsExist = total > 0;
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -254,7 +254,7 @@ Component.register('sw-sales-channel-detail', {
                 .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true));
 
             this.customFieldRepository
-                .search(criteria, Context.api)
+                .iterate(criteria)
                 .then((searchResult) => {
                     this.customFieldSets = searchResult;
                 });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -2,7 +2,7 @@ import template from './sw-sales-channel-detail-base.html.twig';
 import './sw-sales-channel-detail-base.scss';
 
 const { Component, Mixin, Context, Defaults } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Criteria, RepositoryIterator } = Shopware.Data;
 const domUtils = Shopware.Utils.dom;
 const ShopwareError = Shopware.Classes.ShopwareError;
 const utils = Shopware.Utils;
@@ -501,7 +501,8 @@ Component.register('sw-sales-channel-detail-base', {
                 ),
             );
 
-            this.productExportRepository.search(criteria).then(({ total }) => {
+            const iterator = new RepositoryIterator(this.productExportRepository, criteria);
+            iterator.getTotal().then(total => {
                 this.invalidFileName = total > 0;
                 this.isFileNameChecking = false;
             }).catch(() => {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -466,7 +466,7 @@ Component.register('sw-sales-channel-detail-base', {
 
             criteria.addFilter(Criteria.equals('salesChannelId', storefrontSalesChannelId));
 
-            this.globalDomainRepository.search(criteria)
+            this.globalDomainRepository.iterate(criteria)
                 .then((searchResult) => {
                     this.storefrontDomains = searchResult;
                 });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-list/index.js
@@ -1,7 +1,7 @@
 import template from './sw-custom-field-list.html.twig';
 import './sw-custom-field-list.scss';
 
-const { Criteria } = Shopware.Data;
+const { Criteria, RepositoryIterator } = Shopware.Data;
 const { Component, Mixin, Feature } = Shopware;
 const types = Shopware.Utils.types;
 
@@ -174,8 +174,9 @@ Component.register('sw-custom-field-list', {
             // Search the server for the customField name
             const criteria = new Criteria();
             criteria.addFilter(Criteria.equals('name', customField.name));
-            return this.globalCustomFieldRepository.search(criteria).then((res) => {
-                return res.length === 0;
+            const iterator = new RepositoryIterator(this.globalCustomFieldRepository, criteria);
+            return iterator.getTotal().then(total => {
+                return total === 0;
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-create/index.js
@@ -1,7 +1,7 @@
 import template from './sw-settings-custom-field-set-create.html.twig';
 
 const { Component } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Criteria, RepositoryIterator } = Shopware.Data;
 const utils = Shopware.Utils;
 
 Component.extend('sw-settings-custom-field-set-create', 'sw-settings-custom-field-set-detail', {
@@ -31,8 +31,9 @@ Component.extend('sw-settings-custom-field-set-create', 'sw-settings-custom-fiel
             const criteria = new Criteria();
             criteria.addFilter(Criteria.equals('name', this.set.name));
 
-            return this.customFieldSetRepository.search(criteria).then((res) => {
-                if (res.length === 0) {
+            const iterator = new RepositoryIterator(this.customFieldSetRepository, criteria);
+            return iterator.getTotal().then(total => {
+                if (total === 0) {
                     this.$super('onSave');
 
                     return;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/index.js
@@ -177,7 +177,7 @@ Component.register('sw-settings-customer-group-detail', {
             criteria.addGroupField('seoPathInfo');
             criteria.addGroupField('salesChannelId');
 
-            this.seoUrls = await this.seoUrlRepository.search(criteria);
+            this.seoUrls = await this.seoUrlRepository.iterateAsync(criteria);
         },
 
         loadCustomFieldSets() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
@@ -409,7 +409,7 @@ Component.register('sw-settings-document-detail', {
         },
 
         async loadAvailableSalesChannel() {
-            this.salesChannels = await this.salesChannelRepository.search(new Criteria(1, 500));
+            this.salesChannels = await this.salesChannelRepository.iterateAsync();
         },
 
         showOption(item) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/service/feature-grid-translation.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/service/feature-grid-translation.service.js
@@ -57,7 +57,7 @@ export default class FeatureGridTranslationService {
             identifier,
         ));
 
-        return repo.search(criteria, Shopware.Context.api).then((items) => {
+        return repo.iterate(criteria).then((items) => {
             this.entities[type] = items;
         });
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/page/sw-settings-rule-detail/index.js
@@ -146,7 +146,7 @@ Component.register('sw-settings-rule-detail', {
             const context = { ...Context.api, inheritance: true };
 
             if (conditions === null) {
-                return this.conditionRepository.search(new Criteria(), context).then((searchResult) => {
+                return this.conditionRepository.iterate(new Criteria(), context).then((searchResult) => {
                     return this.loadConditions(searchResult);
                 });
             }
@@ -165,7 +165,7 @@ Component.register('sw-settings-rule-detail', {
                 criteria.addAssociation('options.group');
             }
 
-            return this.conditionRepository.search(criteria, conditions.context).then((searchResult) => {
+            return this.conditionRepository.iterate(criteria, conditions.context).then((searchResult) => {
                 conditions.push(...searchResult);
                 conditions.criteria = searchResult.criteria;
                 conditions.total = searchResult.total;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/index.js
@@ -1,7 +1,7 @@
 import template from './sw-settings-salutation-detail.html.twig';
 
 const { Component, Mixin } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Criteria, RepositoryIterator } = Shopware.Data;
 const ShopwareError = Shopware.Classes.ShopwareError;
 const { mapPropertyErrors } = Shopware.Component.getComponentHelper();
 const utils = Shopware.Utils;
@@ -213,7 +213,8 @@ Component.register('sw-settings-salutation-detail', {
                 ),
             );
 
-            this.salutationRepository.search(criteria).then(({ total }) => {
+            const iterator = new RepositoryIterator(this.salutationRepository, criteria);
+            iterator.getTotal().then(total => {
                 this.invalidKey = total > 0;
                 this.isKeyChecking = false;
             }).catch(() => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url/index.js
@@ -146,7 +146,7 @@ Component.register('sw-seo-url', {
             salesChannelCriteria.setIds([]);
             salesChannelCriteria.addAssociation('type');
 
-            this.salesChannelRepository.search(salesChannelCriteria).then((salesChannelCollection) => {
+            this.salesChannelRepository.iterate(salesChannelCriteria).then((salesChannelCollection) => {
                 Shopware.State.commit('swSeoUrl/setSalesChannelCollection', salesChannelCollection);
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/index.js
@@ -192,7 +192,7 @@ Component.register('sw-settings-shipping-detail', {
 
         loadCurrencies() {
             this.currenciesLoading = true;
-            this.currencyRepository.search(new Criteria(1, 500), Context.api).then((currencyResponse) => {
+            this.currencyRepository.iterate(new Criteria(1, 500)).then((currencyResponse) => {
                 Shopware.State.commit('swShippingDetail/setCurrencies', this.sortCurrencies(currencyResponse));
                 this.currenciesLoading = false;
             });

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -65,6 +65,13 @@ class RepositoryIterator
         return null;
     }
 
+    public function iterateIds(): \Generator
+    {
+        while (($ids = $this->fetchIds()) !== null) {
+            yield from $ids;
+        }
+    }
+
     public function fetch(): ?EntitySearchResult
     {
         $this->criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_NONE);
@@ -79,5 +86,12 @@ class RepositoryIterator
         }
 
         return $result;
+    }
+
+    public function iterate(): \Generator
+    {
+        while (($result = $this->fetch()) !== null) {
+            yield from $result->getEntities()->getIterator();
+        }
     }
 }

--- a/src/Docs/Resources/current/20-developer-guide/100-administration/60-fetching-and-handling-data.md
+++ b/src/Docs/Resources/current/20-developer-guide/100-administration/60-fetching-and-handling-data.md
@@ -26,6 +26,9 @@ The data handling was created with **predictability** as its main design goal. I
 `Criteria`
  : Contains all information for a search request (filter, sorting, pagination, ...)
 
+`RepositoryIterator`
+ : A utility class to support paginated access on repository searches
+
 ## Get access to a repository
 
 To create a repository it is required to inject the RepositoryFactory:
@@ -127,6 +130,27 @@ Component.register('sw-show-case-list', {
             .get(entityId, Shopware.Context.api)
             .then((entity) => {
                 this.entity = entity;
+            });
+    }
+});
+```
+
+## How to fetch all entities
+
+The result size of a repository search is limited with a pagination by default. To iterate over all entities for a given query the RepositoryIterator powered methods iterate and iterateAsync are your choices:
+  
+```js
+Component.register('sw-show-case-list', {
+    inject: ['repositoryFactory'],
+    
+    created() {
+        // create a repository for the `product` entity
+        this.repository = this.repositoryFactory.create('product');
+        
+        this.repository
+            .iterate()
+            .then((result) => {
+                this.result = result;
             });
     }
 });
@@ -463,3 +487,11 @@ Component.register('sw-show-case-list', {
     }
 });
 ```
+
+## Possible pitfalls
+
+Although javascript Criteria class resembles the same class in php there are small differences.
+The javascript class works with pages instead to the limit-offset known from database operations.
+As the pagination should be used using the API it is preset to the first page and 25 results per page.
+Using the Criteria class in php has no limits by default.
+This can result in different expectations regarding their usage although the similar appearance.


### PR DESCRIPTION
### 0. Sequel (not SQL)

This is a follow up to https://github.com/shopware/platform/pull/1508 of a follow up from https://github.com/shopware/platform/pull/1310 so @htkassner can pick it up more easily .

It differs in order of arguments so we always have criteria followed by an optional context and it is a rebase.

It now overrides iterateIds by @OliverSkroblin in the admin js repository class is overriden to contain my implementation from the previous PR.

It still does not fix self-paginating components like `sw-cms-el-config-product-listing`.

The changelog only mentions on issue as I don't know all of them.

### 1. Why is this change necessary?

There are lots of occassions where a complete list of objects is required but not requested properly. Most of these places are visible when you see a criteria limit of 100 or 500. These are tries to load all the data but this is not all the data. This might be the case because although it is tried to have php and admin-js behave identically regarding DAL operations it is not as the criteria in admin-js works with limited pages that have a preset of 1, 25 and the php criteria works with limit offset and has a preset of null, null. Those who work with the admin-js criteria and are familiar with it from php get fooled.

### 2. What does this change do, exactly?

Add the php-known RepositoryIterator and some constants from the criteria. Use the repository iterator at a lot of places that behave better now.
### 3. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-10262
https://issues.shopware.com/issues/NEXT-10349

And probably some more

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
