### PR TITLE
Add inline edit for position in property options

### DIFF
--- a/changelog/_unreleased/2021-09-20-add-inline-edit-position-in-property-options.md
+++ b/changelog/_unreleased/2021-09-20-add-inline-edit-position-in-property-options.md
@@ -1,0 +1,8 @@
+---
+title: Add inline edit for position in property options
+author: mynameisbogdan
+author_email: mynameisbogdan@protonmail.com
+author_github: mynameisbogdan
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js` to add inline edit for property `position`.

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/index.js
@@ -175,6 +175,7 @@ Component.register('sw-property-option-list', {
             }, {
                 property: 'position',
                 label: this.$tc('sw-property.detail.labelOptionPosition'),
+                inlineEdit: 'number',
             }];
         },
     },


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To improve UX by changing of property `position` in `list`, and not only in `detail`.

### 2. What does this change do, exactly?
**Before**
![Screenshot 2021-09-20 at 14 23 18](https://user-images.githubusercontent.com/707714/134003512-61c0cdae-57bd-4dc2-b81a-b796d10919c9.jpg)

**After**
![Screenshot 2021-09-20 at 15 37 38](https://user-images.githubusercontent.com/707714/134003552-d78fe116-f0d3-4a09-a63c-f8ea892974ae.jpg)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
