### PR TITLE
Make `NumberRangeValueGeneratorInterface` service public in container

### DIFF
--- a/changelog/_unreleased/2021-09-21-make-number-range-value-generator-service-public-in-container.md
+++ b/changelog/_unreleased/2021-09-21-make-number-range-value-generator-service-public-in-container.md
@@ -1,0 +1,8 @@
+---
+title: Make service `NumberRangeValueGeneratorInterface` public in container
+author: Manuel Kress
+author_email: 6232639+windaishi@users.noreply.github.com
+author_github: windaishi
+---
+# Core
+* Made service `NumberRangeValueGeneratorInterface` public in container.

--- a/src/Core/System/DependencyInjection/number_range.xml
+++ b/src/Core/System/DependencyInjection/number_range.xml
@@ -38,7 +38,8 @@
         </service>
 
         <service class="Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGenerator"
-                 id="Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface">
+                 id="Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface"
+                 public="true">
             <argument type="service" id="Shopware\Core\System\NumberRange\ValueGenerator\Pattern\ValueGeneratorPatternRegistry" />
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface" />
             <argument type="service" id="event_dispatcher"/>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
If you want to generate a new number range value during the installation of the plugin you need to use the `NumberRangeValueGeneratorInterface` service. But the service is not public and when trying to retrieve the service from the container you end up with the following error:
```
  The "Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGenera  
  torInterface" service or alias has been removed or inlined when the contain  
  er was compiled. You should either make it public, or stop using the contai  
  ner directly and use dependency injection instead.  
```

### 2. What does this change do, exactly?
It makes the service public so it can be retrieved directly via `Container::get()` 

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
N/A


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
