### PR TITLE
Add EntityIndexingMessage::addSkip to add skipped contents more easily

### DIFF
--- a/changelog/_unreleased/2021-09-22-add-entity-indexing-message-add-skip-to-add-skipped-contents-more-easily.md
+++ b/changelog/_unreleased/2021-09-22-add-entity-indexing-message-add-skip-to-add-skipped-contents-more-easily.md
@@ -1,0 +1,8 @@
+---
+title: Add EntityIndexingMessage::addSkip to add skipped contents more easily
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added new method `addSkip` in `\Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage` to allow easier adding more skip tags

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductIndexer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductIndexer.php
@@ -130,10 +130,10 @@ class ProductIndexer extends EntityIndexer
 
         $message = new ProductIndexingMessage(array_values($updates), null, $event->getContext());
 
-        $message->setSkip(\array_merge($message->getSkip(), [
+        $message->addSkip([
             self::INHERITANCE_UPDATER,
             self::STOCK_UPDATER,
-        ]));
+        ]);
 
         return $message;
     }

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexingMessage.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexingMessage.php
@@ -25,6 +25,9 @@ class EntityIndexingMessage
      */
     private $forceQueue;
 
+    /**
+     * @var string[]
+     */
     private array $skip = [];
 
     public function __construct($data, $offset = null, ?Context $context = null, bool $forceQueue = false)
@@ -71,14 +74,28 @@ class EntityIndexingMessage
         return $this->forceQueue;
     }
 
+    /**
+     * @return string[]
+     */
     public function getSkip(): array
     {
         return $this->skip;
     }
 
+    /**
+     * @param string[] $skip
+     */
     public function setSkip(array $skip): void
     {
-        $this->skip = $skip;
+        $this->skip = \array_unique(\array_values($skip));
+    }
+
+    /**
+     * @param string[] ...$skip
+     */
+    public function addSkip(string ...$skip): void
+    {
+        $this->skip = \array_unique(\array_merge($this->skip, \array_values($skip)));
     }
 
     public function allow(string $name): bool


### PR DESCRIPTION
### 1. Why is this change necessary?

Because of https://github.com/shopware/platform/pull/2082

### 2. What does this change do, exactly?

It adds addSkip to allow easier changing changing without having to call setSkip/getSkip/array_merge yourself.

### 3. Describe each step to reproduce the issue or behaviour.

To do https://github.com/shopware/platform/pull/2082

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
