### PR TITLE
Skip updating stock and inheritance in indexing message when already done

### DIFF
--- a/changelog/_unreleased/2021-09-22-skip-updating-stock-and-inheritance-in-indexing-message-when-already-done.md
+++ b/changelog/_unreleased/2021-09-22-skip-updating-stock-and-inheritance-in-indexing-message-when-already-done.md
@@ -1,0 +1,8 @@
+---
+title: Skip updating stock and inheritance in indexing message when already done
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed skip state of `\Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexingMessage` that is sent from `\Shopware\Core\Content\Product\DataAbstractionLayer\ProductIndexer::update` to skip stock updates and inheritance updates as this has been done right before sending message

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductIndexer.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductIndexer.php
@@ -128,7 +128,14 @@ class ProductIndexer extends EntityIndexer
 
         $this->stockUpdater->update($updates, $event->getContext());
 
-        return new ProductIndexingMessage(array_values($updates), null, $event->getContext());
+        $message = new ProductIndexingMessage(array_values($updates), null, $event->getContext());
+
+        $message->setSkip(\array_merge($message->getSkip(), [
+            self::INHERITANCE_UPDATER,
+            self::STOCK_UPDATER,
+        ]));
+
+        return $message;
     }
 
     public function getTotal(): int


### PR DESCRIPTION
### 1. Why is this change necessary?

When you update a product and it triggers indexing.

### 2. What does this change do, exactly?

It skips the stock and inheritance updates for product indexing message that are created from an entity update.

### 3. Describe each step to reproduce the issue or behaviour.

Update a product.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Appendix

When https://github.com/shopware/platform/pull/2081 is merged, I will also update this one.