### PR TITLE
Fix: null check entity repository

### DIFF
--- a/changelog/_unreleased/2021-09-23-fix-use-isset-for-null-check-of-typed-property.md
+++ b/changelog/_unreleased/2021-09-23-fix-use-isset-for-null-check-of-typed-property.md
@@ -1,0 +1,8 @@
+---
+title: Use isset for null check of typed property
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Fix: Use isset for null check of typed property in `Shopware\Core\Framework\DataAbstractionLayer\EntityRepository::setEntityLoadedEventFactory`

--- a/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
@@ -86,7 +86,7 @@ class EntityRepository implements EntityRepositoryInterface
      */
     public function setEntityLoadedEventFactory(EntityLoadedEventFactory $eventFactory): void
     {
-        if ($this->eventFactory !== null) {
+        if (isset($this->eventFactory)) {
             return;
         }
 

--- a/src/Core/Framework/Test/DataAbstractionLayer/EntityRepositoryTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/EntityRepositoryTest.php
@@ -55,6 +55,15 @@ class EntityRepositoryTest extends TestCase
      */
     private $connection;
 
+    public function testSetEntityLoadedEventFactory(): void
+    {
+        $repository = $this->createRepository(LocaleDefinition::class, false);
+
+        $repository->setEntityLoadedEventFactory(
+            $this->getContainer()->get(EntityLoadedEventFactory::class)
+        );
+    }
+
     public function testWrite(): void
     {
         $repository = $this->createRepository(LocaleDefinition::class);
@@ -1210,16 +1219,23 @@ class EntityRepositoryTest extends TestCase
         static::assertCount(2, $multiFilter->getQueries());
     }
 
-    protected function createRepository(string $definition): EntityRepository
-    {
-        return new EntityRepository(
+    protected function createRepository(
+        string $definition,
+        bool $loadWithEventFactory = true
+    ): EntityRepository {
+        $arguments = [
             $this->getContainer()->get($definition),
             $this->getContainer()->get(EntityReaderInterface::class),
             $this->getContainer()->get(VersionManager::class),
             $this->getContainer()->get(EntitySearcherInterface::class),
             $this->getContainer()->get(EntityAggregatorInterface::class),
             $this->getContainer()->get('event_dispatcher'),
-            $this->getContainer()->get(EntityLoadedEventFactory::class)
-        );
+        ];
+
+        if ($loadWithEventFactory) {
+            $arguments[] = $this->getContainer()->get(EntityLoadedEventFactory::class);
+        }
+
+        return new EntityRepository(...$arguments);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Otherwise if one uses a custom repository it will fail, if the `EntityLoadedEventFactory` has not been injected.

### 2. What does this change do, exactly?
Fix the null check.

### 3. Describe each step to reproduce the issue or behaviour.
Create a custom repository and do not inject the `Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory`.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
