### PR TITLE
Add possibility to add data resolvers without injecting new services

### DIFF
--- a/changelog/_unreleased/2021-09-27-add-method-to-cms-slot-data-resolver.md
+++ b/changelog/_unreleased/2021-09-27-add-method-to-cms-slot-data-resolver.md
@@ -1,0 +1,12 @@
+---
+title: Add possibility to add data resolvers without injecting new services
+issue: NEXT-???
+author: tyurderi (Net Inventors)
+author_email: info@netinventors.de
+---
+
+# Core
+
+* Added method `addResolver` to `\Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver`
+* Added new constructor parameter `EventDispatcherInterface $eventDispatcher` to `\Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver`
+* Added new event `\Shopware\Core\Content\Cms\Events\CmsSlotDataResolverEvent` that is being thrown in `\Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver::resolve`

--- a/src/Core/Content/Cms/Events/CmsSlotDataResolverEvent.php
+++ b/src/Core/Content/Cms/Events/CmsSlotDataResolverEvent.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cms\Events;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\NestedEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver;
+
+class CmsSlotDataResolverEvent extends NestedEvent implements ShopwareSalesChannelEvent
+{
+    private CmsSlotsDataResolver $resolver;
+
+    private SalesChannelContext  $salesChannelContext;
+
+    public function __construct(CmsSlotsDataResolver $resolver, SalesChannelContext $salesChannelContext)
+    {
+        $this->resolver            = $resolver;
+        $this->salesChannelContext = $salesChannelContext;
+    }
+
+    public function getResolver(): CmsSlotsDataResolver
+    {
+        return $this->resolver;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+}

--- a/src/Core/Content/DependencyInjection/cms.xml
+++ b/src/Core/Content/DependencyInjection/cms.xml
@@ -39,6 +39,7 @@
                 <argument type="service" key="product" id="sales_channel.product.repository" />
             </argument>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\Content\Cms\DataResolver\Element\TextCmsElementResolver">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Yet the CmsSlotsDataResolver service is restricted to register resolvers using dependency injection. This is not useful when resolvers need to be registered dynamically from e.g. database or cache.

### 2. What does this change do, exactly?
As described in the changelog, it simply creates a new method `addResolver` in the `CmsSlotsDataResolver` class that can be used to register a new resolver on the fly.

It also created a new event `CmsSlotDataResolverEvent` that is dispatched in the `resolve` method of `CmsSlotsDataResolver` to give plugins the possibility to register their resolves then.

### 3. Describe each step to reproduce the issue or behaviour.
I don't think there is anything to reproduce because this is not a bug fix.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
