### PR TITLE
Bugfix: do not remove oldOrders, if no deeplink filter set

### DIFF
--- a/changelog/_unreleased/2021-09-27-bugfix-show-all-orders-in-storefront-history.md
+++ b/changelog/_unreleased/2021-09-27-bugfix-show-all-orders-in-storefront-history.md
@@ -1,0 +1,13 @@
+---
+title: Bugfix: show all orders in storefront history
+author: Marcel Tams
+author_email: marcel.tams@networkteam.com 
+author_github: amtee
+---
+# Core
+* In method `load` in file `src/Core/Checkout/Order/SalesChannel/OrderRoute.php`  there
+was a misleading condition. Any `$deepLinkFilter` but false led to removing `orders` with last updated 
+  or created older than 30 days the latest order.
+  
+  
+

--- a/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
@@ -114,7 +114,7 @@ class OrderRoute extends AbstractOrderRoute
         $orders = $this->orderRepository->search($criteria, $context->getContext());
 
         // remove old orders only if there is a deeplink filter
-        if ($deepLinkFilter === true) {
+        if ($deepLinkFilter !== null) {
             $orders = $this->filterOldOrders($orders);
         }
 

--- a/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
+++ b/src/Core/Checkout/Order/SalesChannel/OrderRoute.php
@@ -113,7 +113,8 @@ class OrderRoute extends AbstractOrderRoute
 
         $orders = $this->orderRepository->search($criteria, $context->getContext());
 
-        if ($deepLinkFilter !== false) {
+        // remove old orders only if there is a deeplink filter
+        if ($deepLinkFilter === true) {
             $orders = $this->filterOldOrders($orders);
         }
 


### PR DESCRIPTION
- the given condition leads to an incomplete order history, if a customer has orders 30 days older than his latest order
- fixed by setting it to an implicit true comparison

### 1. Why is this change necessary?

Update 6.4.3 to 6.4.4 changes the behaviour of the order history. `/account/data` which renders the order-history template should show every order in the account's history. But it does not, due to the implementation changes. 

### 2. What does this change do, exactly?

This change transforms the misleading condition from `!== false` to an implicit `=== true` This makes sure, that oldOrders online get removed from the query if a deeplinkCode filter has been set. 

### 3. Describe each step to reproduce the issue or behaviour.

Create orders with order dates differ by more than 30 days. The older one will be liste in 6.4.3.x and not listed in `/account/data` in 6.4.4.1

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change (not 
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
