### PR TITLE
fix: removed registration of `touchstart` in `scroll-up.plugin.js`

### DIFF
--- a/changelog/_unreleased/2021-09-28-change-scroll-up-button-to-be-called-just-on-click.md
+++ b/changelog/_unreleased/2021-09-28-change-scroll-up-button-to-be-called-just-on-click.md
@@ -1,0 +1,9 @@
+---
+title: Change Scroll-Up-Button to be called just on click
+issue: NEXT-15245
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: @tinect
+---
+# Storefront
+* Removed registration of `touchstart` in `scroll-up.plugin.js` to prevent force scrolling up when user wanted to scroll

--- a/src/Storefront/Resources/app/storefront/src/plugin/scroll-up/scroll-up.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/scroll-up/scroll-up.plugin.js
@@ -39,12 +39,10 @@ export default class ScrollUpPlugin extends Plugin {
      * @private
      */
     _registerEvents() {
-        const submitEvent = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click';
-
         if (this._button) {
             this._toggleVisibility();
 
-            this._button.addEventListener(submitEvent, () => {
+            this._button.addEventListener('click', () => {
                 this._scrollToTop();
 
                 this.$emitter.publish('onClickButton');


### PR DESCRIPTION
### 1. Why is this change necessary?
It's very annoying when you accidentally hit the scroll-up-button while you are planing to scroll down.

### 2. What does this change do, exactly?
Remove the touchstart registration

### 3. Describe each step to reproduce the issue or behaviour.
Scroll a bit down, to have the scroll-up-button be show.
Now you want to scroll more down, but your finger accidentally hit and drag on the scroll-up-button.
Booooooom, you're now at the top of the page.

> Really annoying, isn't it?!
_tinect, aka member of the `Fat finger`-community_

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-15245

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
