### PR TITLE
fix: Product detail product:price meta tags for OpenGraph

### DIFF
--- a/changelog/_unreleased/2021-09-28-fix-product-detail-product-price-meta-tags-for-opengraph.md
+++ b/changelog/_unreleased/2021-09-28-fix-product-detail-product-price-meta-tags-for-opengraph.md
@@ -1,0 +1,8 @@
+---
+title: Fix Product detail product:price meta tags for OpenGraph
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Use `product:price:amount` and `product:price:currency` meta tags for the OpenGraph product price

--- a/src/Storefront/Resources/views/storefront/page/product-detail/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/meta.html.twig
@@ -19,8 +19,10 @@
         <meta property="product:brand"
               content="{{ page.product.manufacturer.translated.name }}"/>
     {% endif %}
-    <meta property="product:price"
-          content="{{ page.product.calculatedPrice.unitPrice|currency }}"/>
+    <meta property="product:price:amount"
+          content="{{ page.product.calculatedPrice.unitPrice|round(context.currency.itemRounding.decimals) }}"/>
+    <meta property="product:price:currency"
+          content="{{ context.currency.isoCode }}"/>
     <meta property="product:product_link"
           content="{{ seoUrl('frontend.detail.page', { productId: page.product.id }) }}"/>
 


### PR DESCRIPTION
### 1. Why is this change necessary?
According to the [OpenGraph specification](https://developers.facebook.com/docs/marketing-api/catalog/guides/microdata-tags#opengraph) there is no `product:price` meta tag, only `product:price:amount` and `product:price:currency` exist.

### 2. What does this change do, exactly?
Changes the meta tags.

### 3. Describe each step to reproduce the issue or behaviour.
Look at the meta tags of the product detail page.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
