### PR TITLE
Remove getThemeConfigPath from ThemeCreateCommand::getBootstrapTemplate()

### DIFF
--- a/changelog/_unreleased/2021-09-29-remove-get-theme-config-path-from-theme-create.md
+++ b/changelog/_unreleased/2021-09-29-remove-get-theme-config-path-from-theme-create.md
@@ -1,0 +1,8 @@
+---
+title: Remove unused method getThemeConfigPath from ThemeCreateCommand::getBootstrapTemplate()
+author: mynameisbogdan
+author_email: mynameisbogdan@protonmail.com
+author_github: mynameisbogdan
+---
+# Storefront
+* Changed `src/Storefront/Theme/Command/ThemeCreateCommand.php` to remove unused method `getThemeConfigPath` from bootstrap template.

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -14,14 +14,12 @@ class ThemeCreateCommand extends Command
 {
     protected static $defaultName = 'theme:create';
 
-    /**
-     * @var string
-     */
-    private $projectDir;
+    private string $projectDir;
 
     public function __construct(string $projectDir)
     {
         parent::__construct();
+
         $this->projectDir = $projectDir;
     }
 
@@ -136,10 +134,6 @@ use Shopware\Storefront\Framework\ThemeInterface;
 
 class #class# extends Plugin implements ThemeInterface
 {
-    public function getThemeConfigPath(): string
-    {
-        return 'theme.json';
-    }
 }
 EOL;
     }


### PR DESCRIPTION
Fixes #671
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Not in used anymore, and gives the impression that the path to `theme.json` it's configurable when it's not.

### 2. What does this change do, exactly?
Removes unused method from bootstrap template in `theme:create` since now it's hardcoded as `/src/Resources/theme.json`.

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
#671

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
