### PR TITLE
Add new inner block to order list bulk slot

### DIFF
--- a/changelog/_unreleased/2021-10-02-add-new-inner-block-to-order-list-bulk-slot.md
+++ b/changelog/_unreleased/2021-10-02-add-new-inner-block-to-order-list-bulk-slot.md
@@ -1,0 +1,8 @@
+---
+title: Add new inner block to order list bulk slot
+author: Ioannis Pourliotis
+author_email: dev@pourliotis.de 
+author_github: @PheysX
+---
+# Administration
+Added a new inner block `sw_order_list_bulk_selected_actions_content_bulk_edit` in `src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig` to make data grid bulk slot extendable.

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -291,6 +291,7 @@
 
                 {% block sw_order_list_bulk_selected_actions_content %}
                 <template #bulk>
+                    {% block sw_order_list_bulk_selected_actions_content_bulk_edit %}
                     <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
                     <a
                         v-if="acl.can('order.editor')"
@@ -299,6 +300,7 @@
                     >
                         {{ $tc('global.sw-bulk-edit-modal.bulkEdit') }}
                     </a>
+                    {% endblock %}
                 </template>
                 {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When we want to extend the bulk action slot, we have to copy the whole content in our plugin.
So multiple plugins will remove each other.


### 2. What does this change do, exactly?
Added a new inner block `sw_order_list_bulk_selected_actions_content_bulk_edit` in `src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig` to make data grid bulk slot extendable.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
