### PR TITLE
Add total amount to newsletter recipients list page headline

### DIFF
--- a/changelog/_unreleased/2021-10-02-add-total-amount-to-newsletter-recipients-list-page-headline.md
+++ b/changelog/_unreleased/2021-10-02-add-total-amount-to-newsletter-recipients-list-page-headline.md
@@ -1,0 +1,8 @@
+---
+title: Add total amount to newsletter recipients list page headline
+author: Ioannis Pourliotis
+author_email: dev@pourliotis.de
+author_github: @PheysX
+---
+# Administration
+Added the total amount of newsletter recipients to the `smart-bar-header` slot headline in `src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.html.twig`.

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.html.twig
@@ -23,6 +23,15 @@
             />
             {{ $tc('sw-newsletter-recipient.list.textHeadline') }}
             {% endblock %}
+
+            {% block sw_newsletter_recipient_list_smart_bar_header_amount %}
+            <span
+                v-if="!isLoading"
+                class="sw-page__smart-bar-amount"
+            >
+                ({{ total }})
+            </span>
+            {% endblock %}
         </h2>
         {% endblock %}
     </template>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The user expects to see the total amount in the header like in every other list module. The user experience should be the same.


### 2. What does this change do, exactly?
Added the total amount of newsletter recipients to the `smart-bar-header` slot headline in `src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-list/sw-newsletter-recipient-list.html.twig`.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
