### PR TITLE
Replace Twig LineItem types with constants

### DIFF
--- a/changelog/_unreleased/2021-10-02-replace-twig-line-item-types-with-constants.md
+++ b/changelog/_unreleased/2021-10-02-replace-twig-line-item-types-with-constants.md
@@ -1,0 +1,8 @@
+---
+title: Replace Twig LineItem types with constants
+author: Ioannis Pourliotis
+author_email: dev@pourliotis.de
+author_github: @PheysX
+---
+# Storefront
+* Replaced Twig LineItem types in `src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item.html.twig`, `src/Storefront/Resources/views/storefront/page/account/order-history/order-detail-list-item.html.twig`, `src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig`, `src/Storefront/Resources/views/storefront/page/checkout/checkout-aside-item.html.twig` and `src/Storefront/Resources/views/storefront/page/checkout/checkout-item.html.twig` with the equivalent constants located in `src/Core/Checkout/Cart/LineItem/LineItem.php`.

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item.html.twig
@@ -65,7 +65,7 @@
                             <div class="cart-item-details-container">
                                 {% block component_offcanvas_product_label %}
                                     <div class="cart-item-details">
-                                        {% if type == 'product' %}
+                                        {% if type == constant('Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItem::PRODUCT_LINE_ITEM_TYPE') %}
                                             <a href="{{ seoUrl('frontend.detail.page', {'productId': referencedId}) }}"
                                                class="cart-item-label"
                                                title="{{ label }}">
@@ -93,7 +93,7 @@
                                 {% endblock %}
 
                                 {% block component_offcanvas_product_details_features %}
-                                    {% if lineItem.type == 'product' and lineItem.payload.features is not null %}
+                                    {% if lineItem.type == constant('Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItem::PRODUCT_LINE_ITEM_TYPE') and lineItem.payload.features is not null %}
                                         {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
                                             'features': lineItem.payload.features
                                         } %}

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail-list-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail-list-item.html.twig
@@ -181,7 +181,7 @@
 
                             {% block page_account_order_item_detail_price_value %}
                                 <span class="order-item-value order-item-price-value">
-                                    {% if lineItem.type == 'promotion' %}
+                                    {% if lineItem.type == constant('Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItem::PROMOTION_LINE_ITEM_TYPE') %}
                                         /
                                     {% else %}
                                         {{ lineItem.unitPrice|currency(order.currency.isoCode) }}{{ "general.star"|trans|sw_sanitize }}

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig
@@ -118,7 +118,7 @@
                                                     {% block page_account_order_item_context_menu_reorder_form_line_items_input %}
                                                         {% for lineItem in order.lineItems %}
                                                             {% block page_account_order_item_context_menu_reorder_form_line_item_input %}
-                                                                {% if lineItem.type == 'product' %}
+                                                                {% if lineItem.type == constant('Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItem::PRODUCT_LINE_ITEM_TYPE') %}
                                                                     <input type="hidden"
                                                                            name="lineItems[{{ lineItem.identifier }}][id]"
                                                                            value="{{ lineItem.identifier }}">

--- a/src/Storefront/Resources/views/storefront/page/checkout/checkout-aside-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/checkout-aside-item.html.twig
@@ -74,7 +74,7 @@
                     {% endblock %}
 
                     {% block page_checkout_aside_item_info_features %}
-                        {% if lineItem.type == 'product' and lineItem.payload.features is not null %}
+                        {% if lineItem.type == constant('Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItem::PRODUCT_LINE_ITEM_TYPE') and lineItem.payload.features is not null %}
                             {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
                                 'features': lineItem.payload.features
                             } %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/checkout-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/checkout-item.html.twig
@@ -96,7 +96,7 @@
                                             <div class="cart-item-details-container">
 
                                                 {% block page_checkout_item_info_label %}
-                                                    {% if lineItem.type == 'product' %}
+                                                    {% if lineItem.type == constant('Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItem::PRODUCT_LINE_ITEM_TYPE') %}
                                                         <a href="{{ seoUrl('frontend.detail.page', {'productId': lineItem.referencedId}) }}"
                                                            class="cart-item-label"
                                                            title="{{ lineItem.label }}"
@@ -131,7 +131,7 @@
                                                 {% endblock %}
 
                                                 {% block page_checkout_item_info_features %}
-                                                    {% if lineItem.type == 'product' and lineItem.payload.features is not null %}
+                                                    {% if lineItem.type == constant('Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItem::PRODUCT_LINE_ITEM_TYPE') and lineItem.payload.features is not null %}
                                                         {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
                                                             'features': lineItem.payload.features
                                                         } %}
@@ -158,7 +158,7 @@
                                                 {% endblock %}
 
                                                 {% block page_checkout_item_wishlist %}
-                                                    {% if config('core.cart.wishlistEnabled') and lineItem.type == 'product' %}
+                                                    {% if config('core.cart.wishlistEnabled') and lineItem.type == constant('Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItem::PRODUCT_LINE_ITEM_TYPE') %}
                                                         {% sw_include '@Storefront/storefront/component/product/card/wishlist.html.twig' with {
                                                             showText: true,
                                                             size: 'sm',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Replace LineItem type strings with constants to avoid possible future breaks.

### 2. What does this change do, exactly?
Replaced Twig LineItem type strings in
* `src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item.html.twig`
* `src/Storefront/Resources/views/storefront/page/account/order-history/order-detail-list-item.html.twig`
* `src/Storefront/Resources/views/storefront/page/account/order-history/order-item.html.twig`
* `src/Storefront/Resources/views/storefront/page/checkout/checkout-aside-item.html.twig`
* `src/Storefront/Resources/views/storefront/page/checkout/checkout-item.html.twig` 

with the equivalent constants located in `src/Core/Checkout/Cart/LineItem/LineItem.php`.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
