### PR TITLE
Fix: #1988 fix clone  (hacktoberfest2021)

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -360,6 +360,13 @@ class VersionManager
         $data = $this->filterPropertiesForClone($definition, $data, $keepIds, $id, $definition, $context->getContext());
         $data['id'] = $newId;
 
+        if(isset($data['createdAt'])) {
+            $data['createdAt'] = new \DateTime();
+        }
+        if(isset($data['updatedAt'])) {
+            $data['updatedAt'] = null;
+        }
+
         $data = array_replace_recursive($data, $behavior->getOverwrites());
 
         $versionContext = $context->createWithVersionId($versionId);

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -359,7 +359,9 @@ class VersionManager
 
         $data = $this->filterPropertiesForClone($definition, $data, $keepIds, $id, $definition, $context->getContext());
         $data['id'] = $newId;
-
+        if(isset($data['createdAt'])){
+            $data['createdAt'] = new \DateTime();
+        }
         $data = array_replace_recursive($data, $behavior->getOverwrites());
 
         $versionContext = $context->createWithVersionId($versionId);

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -359,12 +359,14 @@ class VersionManager
 
         $data = $this->filterPropertiesForClone($definition, $data, $keepIds, $id, $definition, $context->getContext());
         $data['id'] = $newId;
+
         if(isset($data['createdAt'])) {
             $data['createdAt'] = new \DateTime();
         }
         if(isset($data['updatedAt'])) {
             $data['updatedAt'] = null;
         }
+
         $data = array_replace_recursive($data, $behavior->getOverwrites());
 
         $versionContext = $context->createWithVersionId($versionId);

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -359,7 +359,12 @@ class VersionManager
 
         $data = $this->filterPropertiesForClone($definition, $data, $keepIds, $id, $definition, $context->getContext());
         $data['id'] = $newId;
-
+        if(isset($data['createdAt'])) {
+            $data['createdAt'] = new \DateTime();
+        }
+        if(isset($data['updatedAt'])) {
+            $data['updatedAt'] = null;
+        }
         $data = array_replace_recursive($data, $behavior->getOverwrites());
 
         $versionContext = $context->createWithVersionId($versionId);


### PR DESCRIPTION
### 1. Why is this change necessary?
Because cloned entites, clones also the created at timestamp which is not true

### 2. What does this change do, exactly?
if you clone an entity via API, the create_at date getting overwritten, with the current date time instead of original one. so you know which clone is the new one

### 3. Describe each step to reproduce the issue or behaviour.
If you clone an entity, for example email template from administration, the created_at date getting cloned as well

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1988

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
