### PR TITLE
NEXT-17713 Fix views path bug

### DIFF
--- a/changelog/_unreleased/2021-10-05-use-view-from-event.md
+++ b/changelog/_unreleased/2021-10-05-use-view-from-event.md
@@ -1,0 +1,8 @@
+---
+title: Use view from event
+author: Rune Laenen
+author_email: rune@laenen.me
+author_github: runelaenen
+---
+# Storefront
+* Changed `\Shopware\Storefront\Controller\StorefrontController::renderStorefront` to use the view from the event instead of the original view path.

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -54,7 +54,7 @@ abstract class StorefrontController extends AbstractController
         }
         $this->get('event_dispatcher')->dispatch($event);
 
-        $response = $this->render($view, $event->getParameters(), new StorefrontResponse());
+        $response = $this->render($event->getView(), $event->getParameters(), new StorefrontResponse());
 
         if (!$response instanceof StorefrontResponse) {
             throw new \RuntimeException('Symfony render implementation changed. Providing a response is no longer supported');

--- a/src/Storefront/Test/Controller/StorefrontControllerTest.php
+++ b/src/Storefront/Test/Controller/StorefrontControllerTest.php
@@ -82,6 +82,23 @@ class StorefrontControllerTest extends TestCase
         static::assertEquals('inherited', $rendered);
     }
 
+    public function testStorefrontPluginTemplatePaths(): void
+    {
+        $twig = $this->createFinder([
+            new BundleFixture('TestPlugin1', __DIR__ . '/fixtures/Plugins/TestPlugin1/'),
+            new BundleFixture('Storefront', __DIR__ . '/fixtures/Storefront/'),
+        ]);
+
+        $controller = new TestController();
+        $controller->setTwig($twig);
+        $controller->setContainer($this->getContainer());
+        $controller->setTemplateFinder($twig->getExtension(InheritanceExtension::class)->getFinder());
+
+        $rendered = $controller->testRenderViewInheritance('@Storefront/storefront/page/plugin/index.html.twig');
+
+        static::assertEquals('plugin', $rendered);
+    }
+
     public function cartProvider(): \Generator
     {
         yield 'cart with salutation errors' => [

--- a/src/Storefront/Test/Controller/fixtures/Plugins/TestPlugin1/Resources/views/storefront/page/plugin/index.html.twig
+++ b/src/Storefront/Test/Controller/fixtures/Plugins/TestPlugin1/Resources/views/storefront/page/plugin/index.html.twig
@@ -1,0 +1,2 @@
+{% sw_extends '@Storefront/storefront/base.html.twig' %}
+{% block base_head %}plugin{% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The change from FEATURE_NEXT_17275 breaks plugin views in controllers. The old path (with '@Storefront') is still used instead of the correct updated '@PluginName' path.

### 2. What does this change do, exactly?
Use the view from the event. (= the updated '@PluginName' path)

### 3. Describe each step to reproduce the issue or behaviour.

> Add view in plugin.
> Create controller in plugin.
> renderStorefront('@Storefront/storefront/foo/bar/path.html.twig')

**Expected result:**
Not an error, but the template rendered.

**Actual result:**
Error that '@Storefront/storefront/foo/bar/path.html.twig' not found.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-17713

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
