### PR TITLE
NEXT-17729 Fix twig proxy forwarding issues for building url's

### DIFF
--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -23,11 +23,12 @@
             <parameter>https</parameter>
             <parameter>forwarded</parameter>
             <parameter>host</parameter>
-            <parameter>x_forwarded_for</parameter>
-            <parameter>x_forwarded_host</parameter>
-            <parameter>x_forwarded_proto</parameter>
-            <parameter>x_forwarded_port</parameter>
-            <parameter>x_forwarded_prefix</parameter>
+            <parameter>remote_addr</parameter>
+            <parameter>http_x_forwarded_for</parameter>
+            <parameter>http_x_forwarded_host</parameter>
+            <parameter>http_x_forwarded_proto</parameter>
+            <parameter>http_x_forwarded_port</parameter>
+            <parameter>http_x_forwarded_prefix</parameter>
         </parameter>
     </parameters>
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If you are developing or deploying behind a reversed proxy with SSL offloading, twig will create http url's instead of https.

### 2. What does this change do, exactly?
It adds the REMOTE_ADDR and fixes X-Forward-* headers, so Symfony can generate secure url's.

### 3. Describe each step to reproduce the issue or behaviour.
It can be reproduced if you run Shopware behind a proxy with SSL offloading (for example nginx proxy_pass with SSL offloading).
Go to the admin panel (/admin). It will generate the wrong url's in the template:
'administration/Resources/views/administration/index.html.twig'

This will fix this behaviour, so the global twig variable `app.request` has the necessary server variables to generate secure url's.

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
