### PR TITLE
datetime format in administration

### DIFF
--- a/changelog/_unreleased/2021-10-06-adjust-and-format-datetimes-in-administration.md
+++ b/changelog/_unreleased/2021-10-06-adjust-and-format-datetimes-in-administration.md
@@ -1,0 +1,12 @@
+---
+title: Adjust and format datetimes in administration
+author: Ioannis Pourliotis
+author_email: dev@pourliotis.de
+author_github: @PheysX
+---
+# Administration
+* Changed the `createdAt` column to `orderDateTime` in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`
+* Formatted dateTimes to show hours and minutes in:
+  * `src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig`
+  * `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`
+  * `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js`

--- a/changelog/_unreleased/2021-10-06-adjust-and-format-datetimes-in-administration.md
+++ b/changelog/_unreleased/2021-10-06-adjust-and-format-datetimes-in-administration.md
@@ -6,6 +6,8 @@ author_github: @PheysX
 ---
 # Administration
 * Changed the `createdAt` column to `orderDateTime` in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`.
+* Added the `sw-time-ago` component to `orderDateTime` column in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`.
 * Deprecated block `sw_customer_detail_order_card_grid_columns_date` in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`, will be removed in v6.5.0. Use `sw_customer_detail_order_card_grid_columns_order_date_time` instead.
 * Added dateTime format to `lastLogin` column in `src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig`.
 * Removed hours and minutes from birthday in `src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig`.
+* Added jest test `src/Administration/Resources/app/administration/test/module/sw-customer/component/sw-customer-base-info.spec.js`.

--- a/changelog/_unreleased/2021-10-06-adjust-and-format-datetimes-in-administration.md
+++ b/changelog/_unreleased/2021-10-06-adjust-and-format-datetimes-in-administration.md
@@ -1,12 +1,10 @@
 ---
-title: Adjust and format datetimes in administration
+title: Adjust and format dateTimes in administration
 author: Ioannis Pourliotis
 author_email: dev@pourliotis.de
 author_github: @PheysX
 ---
 # Administration
-* Changed the `createdAt` column to `orderDateTime` in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`
-* Formatted dateTimes to show hours and minutes in:
-  * `src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig`
-  * `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`
-  * `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js`
+* Changed the `createdAt` column to `orderDateTime` in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`.
+* Added dateTime format to `lastLogin` column in `src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig`.
+* Removed hours and minutes from birthday in `src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig`.

--- a/changelog/_unreleased/2021-10-06-adjust-and-format-datetimes-in-administration.md
+++ b/changelog/_unreleased/2021-10-06-adjust-and-format-datetimes-in-administration.md
@@ -6,5 +6,6 @@ author_github: @PheysX
 ---
 # Administration
 * Changed the `createdAt` column to `orderDateTime` in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`.
+* Deprecated block `sw_customer_detail_order_card_grid_columns_date` in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`, will be removed in v6.5.0. Use `sw_customer_detail_order_card_grid_columns_order_date_time` instead.
 * Added dateTime format to `lastLogin` column in `src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig`.
 * Removed hours and minutes from birthday in `src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig`.

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
@@ -186,7 +186,7 @@
             </dt>
             <dd>
                 <template v-if="customer.lastLogin">
-                    {{ customer.lastLogin | date({hour: '2-digit', minute: '2-digit'}) }}
+                    {{ customer.lastLogin | date }}
                 </template>
                 <template v-else>
                     {{ $tc('sw-customer.baseInfo.emptyTextLogin') }}
@@ -225,7 +225,7 @@
             {% block sw_customer_base_metadata_birthday_content %}
             <dd v-if="!customerEditMode">
                 <template v-if="customer.birthday">
-                    {{ customer.birthday | date }}
+                    {{ customer.birthday | date({ minute: undefined, hour: undefined }) }}
                 </template>
                 <template v-else>
                     {{ $tc('sw-customer.baseInfo.emptyTextBirthday') }}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
@@ -184,7 +184,7 @@
             <dt class="sw-customer-base-info__label">
                 {{ $tc('sw-customer.baseInfo.labelLastLogin') }}
             </dt>
-            <dd>
+            <dd class="sw-customer-base__label-last-login">
                 <template v-if="customer.lastLogin">
                     {{ customer.lastLogin | date }}
                 </template>
@@ -223,7 +223,10 @@
             {% endblock %}
 
             {% block sw_customer_base_metadata_birthday_content %}
-            <dd v-if="!customerEditMode">
+            <dd
+                v-if="!customerEditMode"
+                class="sw-customer-base__label-birthday"
+            >
                 <template v-if="customer.birthday">
                     {{ customer.birthday | date({ minute: undefined, hour: undefined }) }}
                 </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
@@ -185,7 +185,12 @@
                 {{ $tc('sw-customer.baseInfo.labelLastLogin') }}
             </dt>
             <dd>
-                {{ customer.lastLogin ? customer.lastLogin : $tc('sw-customer.baseInfo.emptyTextLogin') }}
+                <template v-if="customer.lastLogin">
+                    {{ customer.lastLogin | date({hour: '2-digit', minute: '2-digit'}) }}
+                </template>
+                <template v-else>
+                    {{ $tc('sw-customer.baseInfo.emptyTextLogin') }}
+                </template>
             </dd>
         </sw-description-list>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
@@ -42,7 +42,7 @@
 
                 {% block sw_customer_detail_order_card_grid_columns_order_date_time %}
                 <template #column-orderDateTime="{ item }">
-                    {{ item.orderDateTime | date({hour: '2-digit', minute: '2-digit'}) }}
+                    {{ item.orderDateTime }}
                 </template>
                 {% endblock %}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
@@ -40,6 +40,9 @@
                 </template>
                 {% endblock %}
 
+                {# @deprecated tag:v6.5.0 - block will be removed - Use block `sw_customer_detail_order_card_grid_columns_order_date_time` instead #}
+                {% block sw_customer_detail_order_card_grid_columns_date %}{% endblock %}
+
                 {% block sw_customer_detail_order_card_grid_columns_order_date_time %}
                 <template #column-orderDateTime="{ item }">
                     {{ item.orderDateTime }}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
@@ -26,25 +26,25 @@
             :is-loading="isLoading"
         >
             {% block sw_customer_detail_order_card_grid_columns %}
-            {% block sw_customer_detail_order_card_grid_columns_number %}
-            <template #column-orderNumber="{ item }">
-                <router-link :to="{ name: 'sw.order.detail', params: { id: item.id } }">
-                    {{ item.orderNumber }}
-                </router-link>
-            </template>
-            {% endblock %}
+                {% block sw_customer_detail_order_card_grid_columns_number %}
+                <template #column-orderNumber="{ item }">
+                    <router-link :to="{ name: 'sw.order.detail', params: { id: item.id } }">
+                        {{ item.orderNumber }}
+                    </router-link>
+                </template>
+                {% endblock %}
 
-            {% block sw_customer_detail_order_card_grid_columns_amount %}
-            <template #column-amountTotal="{ item }">
-                {{ item.amountTotal | currency(item.currency.shortName) }}
-            </template>
-            {% endblock %}
+                {% block sw_customer_detail_order_card_grid_columns_amount %}
+                <template #column-amountTotal="{ item }">
+                    {{ item.amountTotal | currency(item.currency.shortName) }}
+                </template>
+                {% endblock %}
 
-            {% block sw_customer_detail_order_card_grid_columns_date %}
-            <template #column-createdAt="{ item }">
-                {{ item.createdAt|date }}
-            </template>
-            {% endblock %}
+                {% block sw_customer_detail_order_card_grid_columns_order_date_time %}
+                <template #column-orderDateTime="{ item }">
+                    {{ item.orderDateTime | date({hour: '2-digit', minute: '2-digit'}) }}
+                </template>
+                {% endblock %}
             {% endblock %}
 
             {% block sw_customer_detail_order_card_grid_columns_action %}

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig
@@ -45,7 +45,7 @@
 
                 {% block sw_customer_detail_order_card_grid_columns_order_date_time %}
                 <template #column-orderDateTime="{ item }">
-                    {{ item.orderDateTime }}
+                    <sw-time-ago :date="item.orderDateTime" />
                 </template>
                 {% endblock %}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js
@@ -93,18 +93,14 @@ Component.register('sw-order-user-card', {
 
         lastChangedDate() {
             if (this.currentOrder) {
-                const options = { hour: '2-digit', minute: '2-digit' };
-
                 if (this.currentOrder.updatedAt) {
                     return format.date(
                         this.currentOrder.updatedAt,
-                        options,
                     );
                 }
 
                 return format.date(
                     this.currentOrder.orderDateTime,
-                    options,
                 );
             }
             return '';

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js
@@ -93,14 +93,18 @@ Component.register('sw-order-user-card', {
 
         lastChangedDate() {
             if (this.currentOrder) {
+                const options = { hour: '2-digit', minute: '2-digit' };
+
                 if (this.currentOrder.updatedAt) {
                     return format.date(
                         this.currentOrder.updatedAt,
+                        options,
                     );
                 }
 
                 return format.date(
                     this.currentOrder.orderDateTime,
+                    options,
                 );
             }
             return '';

--- a/src/Administration/Resources/app/administration/test/module/sw-customer/component/sw-customer-base-info.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-customer/component/sw-customer-base-info.spec.js
@@ -1,0 +1,110 @@
+import { shallowMount } from '@vue/test-utils';
+import 'src/module/sw-customer/component/sw-customer-base-info';
+
+const responses = global.repositoryFactoryMock.responses;
+
+responses.addResponse({
+    method: 'Post',
+    url: '/search/order',
+    status: 200,
+    response: {
+        data: [
+            {
+                id: '1'
+            }
+        ]
+    }
+});
+
+responses.addResponse({
+    method: 'Post',
+    url: '/search/language',
+    status: 200,
+    response: {
+        data: [
+            {
+                id: '1'
+            }
+        ]
+    }
+});
+
+function createWrapper() {
+    return shallowMount(Shopware.Component.build('sw-customer-base-info'), {
+        propsData: {
+            customer: {
+                birthday: '1992-12-22T00:00:00.000+00:00',
+                lastLogin: '2021-10-14T11:23:44.195+00:00',
+                group: {
+                    translated: {
+                        name: 'Group test'
+                    }
+                },
+                defaultPaymentMethod: {
+                    translated: {
+                        distinguishableName: 'Payment test'
+                    }
+                }
+            },
+            customerEditMode: false,
+            isLoading: false
+        },
+        stubs: {
+            'sw-container': true,
+            'sw-loader': true,
+            'sw-description-list': true,
+            'sw-entity-single-select': true,
+            'sw-checkbox-field': true,
+            'sw-help-text': true,
+            'sw-datepicker': true
+        }
+    });
+}
+
+describe('module/sw-customer/page/sw-customer-base-info', () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = createWrapper();
+    });
+
+    afterEach(() => {
+        wrapper.destroy();
+    });
+
+    it('should be a Vue.JS component', async () => {
+        expect(wrapper.vm).toBeTruthy();
+    });
+
+    it('should display the birthday', async () => {
+        expect(wrapper.find('.sw-customer-base__label-birthday').text()).toBe('22 December 1992');
+    });
+
+    it('should display the empty birthday snippet placeholder', async () => {
+        await wrapper.setProps({
+            customer: {
+                ...wrapper.props().customer,
+                birthday: null
+            }
+        });
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find('.sw-customer-base__label-birthday').text()).toBe('sw-customer.baseInfo.emptyTextBirthday');
+    });
+
+    it('should display the last login date', async () => {
+        expect(wrapper.find('.sw-customer-base__label-last-login').text()).toBe('14 October 2021, 11:23');
+    });
+
+    it('should display the last login snippet placeholder', async () => {
+        await wrapper.setProps({
+            customer: {
+                ...wrapper.props().customer,
+                lastLogin: null
+            }
+        });
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.find('.sw-customer-base__label-last-login').text()).toBe('sw-customer.baseInfo.emptyTextLogin');
+    });
+});


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
* The orderDateTime in `sw-customer-detail-order.html.twig` is not the orderDateTime and its not formatted.
* Show hours and minutes in datetimes to give the shopowner in this views more control and a more specific result.



### 2. What does this change do, exactly?
* Changed the `createdAt` column to `orderDateTime` in `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`
* Formatted dateTimes to show hours and minutes in:
  * `src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig`
  * `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/sw-customer-detail-order.html.twig`
  * `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
