### PR TITLE
SalesChannel analytics code cannot be deleted in administration after it is set once

### DIFF
--- a/changelog/_unreleased/2021-10-06-handle-removing-google-tracking-id-in-saleschannel-analytics-tab.md
+++ b/changelog/_unreleased/2021-10-06-handle-removing-google-tracking-id-in-saleschannel-analytics-tab.md
@@ -1,0 +1,9 @@
+---
+title: Removing a set Google tracking-ID in SalesChannel analytics tab
+author: Ioannis Pourliotis
+author_email: dev@pourliotis.de
+author_github: @PheysX
+---
+# Administration
+* Handle deleting of the Google tracking-ID in the analytics tab. Changed the `onSave` method in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js`.
+* Changed `Shopware.Context.api` to the shorter version `Context.api` in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js`.

--- a/changelog/_unreleased/2021-10-06-handle-removing-google-tracking-id-in-saleschannel-analytics-tab.md
+++ b/changelog/_unreleased/2021-10-06-handle-removing-google-tracking-id-in-saleschannel-analytics-tab.md
@@ -7,3 +7,4 @@ author_github: @PheysX
 # Administration
 * Changed `onSave` method to handle Google tracking-ID deletion in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js`.
 * Changed `Shopware.Context.api` to the shorter version `Context.api` in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js`.
+* Changed jest test `src/Administration/Resources/app/administration/test/module/sw-sales-channel/page/sw-sales-channel-detail.spec.js` to test analytics association.

--- a/changelog/_unreleased/2021-10-06-handle-removing-google-tracking-id-in-saleschannel-analytics-tab.md
+++ b/changelog/_unreleased/2021-10-06-handle-removing-google-tracking-id-in-saleschannel-analytics-tab.md
@@ -5,5 +5,5 @@ author_email: dev@pourliotis.de
 author_github: @PheysX
 ---
 # Administration
-* Handle deleting of the Google tracking-ID in the analytics tab. Changed the `onSave` method in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js`.
+* Changed `onSave` method to handle Google tracking-ID deletion in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js`.
 * Changed `Shopware.Context.api` to the shorter version `Context.api` in `src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js`.

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -296,15 +296,15 @@ Component.register('sw-sales-channel-detail', {
 
             const analyticsId = this.salesChannel.analyticsId;
             if (analyticsId && !this.salesChannel?.analytics?.trackingId) {
-                this.salesChannel.analyticsId = null
-                delete this.salesChannel.analytics
+                this.salesChannel.analyticsId = null;
+                delete this.salesChannel.analytics;
             }
 
             try {
-                await this.salesChannelRepository.save(this.salesChannel, Context.api)
+                await this.salesChannelRepository.save(this.salesChannel, Context.api);
 
                 if (analyticsId && !this.salesChannel?.analytics?.trackingId) {
-                    await this.salesChannelAnalyticsRepository.delete(analyticsId, Context.api)
+                    await this.salesChannelAnalyticsRepository.delete(analyticsId, Context.api);
                 }
 
                 this.isLoading = false;

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/page/sw-sales-channel-detail/index.js
@@ -294,11 +294,7 @@ Component.register('sw-sales-channel-detail', {
                 this.salesChannel.productExports.add(this.productExport);
             }
 
-            const analyticsId = this.salesChannel.analyticsId;
-            if (analyticsId && !this.salesChannel?.analytics?.trackingId) {
-                this.salesChannel.analyticsId = null;
-                delete this.salesChannel.analytics;
-            }
+            const analyticsId = this.updateAnalytics();
 
             try {
                 await this.salesChannelRepository.save(this.salesChannel, Context.api);
@@ -321,6 +317,16 @@ Component.register('sw-sales-channel-detail', {
                     }),
                 });
             }
+        },
+
+        updateAnalytics() {
+            const analyticsId = this.salesChannel.analyticsId;
+            if (analyticsId && !this.salesChannel?.analytics?.trackingId) {
+                this.salesChannel.analyticsId = null;
+                delete this.salesChannel.analytics;
+            }
+
+            return analyticsId;
         },
 
         abortOnLanguageChange() {

--- a/src/Administration/Resources/app/administration/test/module/sw-sales-channel/page/sw-sales-channel-detail.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-sales-channel/page/sw-sales-channel-detail.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
+import { createLocalVue, shallowMount } from '@vue/test-utils';
 import 'src/module/sw-sales-channel/page/sw-sales-channel-detail';
 
 function createWrapper(privileges = []) {
@@ -35,11 +35,19 @@ function createWrapper(privileges = []) {
                 create: () => ({
                     create: () => ({}),
                     get: () => Promise.resolve({
+                        id: '1a2b3c4d',
+                        analyticsId: '1a2b3c',
+                        analytics: {
+                            id: '1a2b3c',
+                            trackingId: 'tracking-id'
+                        },
                         productExports: {
                             first: () => ({})
                         }
                     }),
-                    search: () => Promise.resolve([])
+                    search: () => Promise.resolve([]),
+                    delete: () => Promise.resolve(),
+                    save: () => Promise.resolve()
                 })
             },
             exportTemplateService: {
@@ -88,6 +96,44 @@ describe('src/module/sw-sales-channel/page/sw-sales-channel-detail', () => {
         const saveButton = wrapper.find('.sw-sales-channel-detail__save-action');
 
         expect(saveButton.attributes().disabled).toBeFalsy();
+        wrapper.destroy();
+    });
+
+    it('should remove analytics association on save when analyticsId is empty', async () => {
+        const wrapper = createWrapper([
+            'sales_channel.editor'
+        ]);
+
+        await wrapper.setData({
+            isLoading: false
+        });
+
+        wrapper.vm.salesChannel.analytics.trackingId = null;
+
+        const analyticsId = wrapper.vm.updateAnalytics();
+
+        expect(typeof analyticsId).toBe('string');
+        expect(wrapper.vm.salesChannel.analyticsId).toBeNull();
+        expect(wrapper.vm.salesChannel.analytics).toBeUndefined();
+
+        wrapper.destroy();
+    });
+
+    it('should not remove analytics association on save when analyticsId is not empty', async () => {
+        const wrapper = createWrapper([
+            'sales_channel.editor'
+        ]);
+
+        await wrapper.setData({
+            isLoading: false
+        });
+
+        const analyticsId = wrapper.vm.updateAnalytics();
+
+        expect(typeof analyticsId).toBe('string');
+        expect(wrapper.vm.salesChannel.analyticsId).toEqual('1a2b3c');
+        expect(wrapper.vm.salesChannel.analytics.id).toEqual(wrapper.vm.salesChannel.analyticsId);
+
         wrapper.destroy();
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
You can't remove the google anayltics id in the saleschannel settings in administration because the sales_channel_analytics table doesn't allow a null value for the column `tracking_id`.

### 2. What does this change do, exactly?
When the trackingId is not set, it will delete the analytics table entry and removes the analyticsId FK in saleschannel.

### 3. Describe each step to reproduce the issue or behaviour.
Add new saleschannel
Add an anayltics code in analytics tab
save
Remove it and save

The request won't be successful


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
