### PR TITLE
NEXT-17739 Catch GCP NotFoundException when copying assets

### DIFF
--- a/changelog/_unreleased/2021-10-06-catch-google-cloud-notfound-exception-on-writing-assets.md
+++ b/changelog/_unreleased/2021-10-06-catch-google-cloud-notfound-exception-on-writing-assets.md
@@ -1,0 +1,9 @@
+---
+title: Catch NotFoundException when copying assets to GCP bucket
+issue: NEXT-17739
+author: Stefan van Essen
+author_email: git@stefan-van-essen.nl
+author_github: eXistenZNL
+---
+# Core
+* Added a try/catch block to `Shopware\Core\Framework\Plugin\Util\AssetService::copyAssetsFromBundle()` to prevent an uncaught exception from bubbling up

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Plugin\Util;
 
+use Google\Cloud\Core\Exception\NotFoundException;
 use League\Flysystem\FilesystemInterface;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotFoundException;
@@ -49,7 +50,12 @@ class AssetService
         }
 
         $targetDirectory = $this->getTargetDirectory($bundle);
-        $this->filesystem->deleteDir($targetDirectory);
+
+        try {
+            $this->filesystem->deleteDir($targetDirectory);
+        } catch (NotFoundException $e) {
+            // The Gcloud client throws an exception if the file doesn't exist, ignore this.
+        }
 
         $this->copy($originDir, $targetDirectory);
 

--- a/src/Core/Framework/Test/Plugin/Util/AssetServiceTest.php
+++ b/src/Core/Framework/Test/Plugin/Util/AssetServiceTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Plugin\Util;
+
+use Google\Cloud\Core\Exception\NotFoundException;
+use League\Flysystem\FilesystemInterface;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
+use Shopware\Core\Framework\Plugin\KernelPluginCollection;
+use Shopware\Core\Framework\Plugin\Util\AssetService;
+use Shopware\Core\Framework\Test\Plugin\Util\_fixture\Plugin\TestPlugin;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class AssetServiceTest extends TestCase
+{
+    public function testHandlesGoogleCloudNotFoundExceptionOnCopyAssetsFromBundle(): void
+    {
+        $filesystem = $this->createMock(FilesystemInterface::class);
+        $kernel = $this->createMock(KernelInterface::class);
+        $cacheInvalidator = $this->createMock(CacheInvalidator::class);
+        $testPlugin = new TestPlugin(true, dirname(__FILE__) . '/_fixture');
+
+        $kernel->method('getBundle')->willReturn($testPlugin);
+
+        // The Google Cloud adapter of Flysystem will throw an error when a file does not exist.
+        $filesystem->method('deleteDir')
+            ->willThrowException(new NotFoundException('Google Cloud Bucket directory not found.'));
+
+        $this->expectNotToPerformAssertions();
+
+        (new AssetService(
+            $filesystem,
+            $kernel,
+            new KernelPluginCollection([
+                'test' => $testPlugin
+            ]),
+            $cacheInvalidator,
+            '.'
+        ))->copyAssetsFromBundle('test');
+    }
+}

--- a/src/Core/Framework/Test/Plugin/Util/_fixture/Plugin/TestPlugin.php
+++ b/src/Core/Framework/Test/Plugin/Util/_fixture/Plugin/TestPlugin.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Plugin\Util\_fixture\Plugin;
+
+use Shopware\Core\Framework\Plugin;
+
+class TestPlugin extends Plugin
+{
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Having this fix makes is possible to install Shopware in an environment that uses a Google Cloud Platform bucket as the public filesystem.

### 2. What does this change do, exactly?

It catches the thrown `Google\Cloud\Core\Exception\NotFoundException` upon copying the assets for bundles to Google Cloud. The reason this exception is thrown is that the export action always removes any pre-existing assets and copies a fresh set of bundle assets in place. However if the directory does not exist yet on Google Cloud bucket, the exception is thrown by the Google Cloud PHP library that is used by the `superbalist/flysystem-google-cloud-storage` package.

### 3. Describe each step to reproduce the issue or behaviour.

1. Configure Shopware6 to use a public filesystem of type `google-storage`.
1. Do a complete Shopware6 installation from scratch by running `bin/console system:install`.
1. See that the installer breaks when copying the assets because of the exception thrown.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-17739

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
