### PR TITLE
feat: Return productId in switch variant

### DIFF
--- a/changelog/_unreleased/2021-10-06-feat-return-productid-in-switch-variant.md
+++ b/changelog/_unreleased/2021-10-06-feat-return-productid-in-switch-variant.md
@@ -1,0 +1,8 @@
+---
+title: Return productId in switch variant
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# API
+* Return in the response of the `frontend.detail.switch` route additionally the `productId` in order to be able to retrieve the `productId` for a specific option combination

--- a/src/Storefront/Controller/ProductController.php
+++ b/src/Storefront/Controller/ProductController.php
@@ -136,7 +136,10 @@ class ProductController extends StorefrontController
             $salesChannelContext
         );
 
-        $response = new JsonResponse(['url' => $url]);
+        $response = new JsonResponse([
+            'url' => $url,
+            'productId' => $productId,
+        ]);
         $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '1');
 
         return $response;

--- a/src/Storefront/Test/Controller/ProductControllerTest.php
+++ b/src/Storefront/Test/Controller/ProductControllerTest.php
@@ -69,6 +69,7 @@ class ProductControllerTest extends TestCase
 
         static::assertSame(200, $response->getStatusCode());
         static::assertInstanceOf(JsonResponse::class, $response);
+        static::assertEquals($productId, $content['productId']);
         static::assertStringContainsString($productId, $content['url']);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Otherwise I have not found a way to retrieve the productId for a specific combination of options using the API.

### 2. What does this change do, exactly?
Returns the productId in the JSON response of the `frontend.detail.switch` route.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
