### PR TITLE
Cross-selling twig condition shifted as filter to the for loop, add twig condition to cross-selling

### DIFF
--- a/changelog/_unreleased/2021-10-8-add-cross-selling-twig-filter.md
+++ b/changelog/_unreleased/2021-10-8-add-cross-selling-twig-filter.md
@@ -1,0 +1,13 @@
+---
+title: Cross-selling twig condition shifted as filter to the for loop
+issue: NEXT-17805
+author: Sebastian Aschenbach
+author_github: @saschen
+author_email: sa@krusemedien.com
+---
+# Storefront
+* Changed if condition in file `src/Storefront/Resources/views/storefront/block/cms-block-cross-selling.html.twig` so that it is not only dependent on the first element
+* Added if condition in file `src/Storefront/Resources/views/storefront/page/product-detail/index.html.twig` so that it is only displayed when at least one cross-selling is active
+* Changed condition shifted as filter to the for loop in file `src/Storefront/Resources/views/storefront/element/cms-element-cross-selling.html.twig`
+* Changed condition shifted as filter to the for loop in file `src/Storefront/Resources/views/storefront/page/product-detail/cross-selling/tabs.html.twig`
+

--- a/src/Storefront/Resources/views/storefront/block/cms-block-cross-selling.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-cross-selling.html.twig
@@ -1,7 +1,7 @@
 {% block block_cross_selling %}
     {% set element = block.slots.getSlot('content') %}
     {% set columns = 1 %}
-    {% if element.data.crossSellings.elements[0].total > 0 %}
+    {% if element.data.crossSellings.elements|filter(item => item.total > 0)|length > 0 %}
         <div class="col-12" data-cms-element-id="{{ element.id }}">
             {% block block_cross_selling_inner %}
                 {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-cross-selling.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-cross-selling.html.twig
@@ -2,7 +2,6 @@
     {% if not sliderConfig %}
         {% set sliderConfig = element.fieldConfig.elements %}
     {% endif %}
-
     <div class="product-detail-cross-selling">
         <div class="card card-tabs" data-cross-selling="true">
             {% block cms_element_cross_selling_tabs_navigation %}
@@ -11,11 +10,10 @@
                         <ul class="nav nav-tabs product-detail-tab-navigation-list"
                             id="product-detail-cross-selling-tabs"
                             role="tablist">
-                            {% for item in element.data.crossSellings.elements %}
+                            {% for item in element.data.crossSellings.elements|filter(item => item.total > 0 and item.crossSelling.active == true) %}
                                 {% set crossSelling = item.crossSelling %}
                                 {% set products = item.products %}
                                 {% set id = crossSelling.id %}
-                                {% if crossSelling.active and products %}
                                     <li class="nav-item">
                                         <a class="nav-link product-detail-tab-navigation-link{% if loop.first %} active{% endif %}"
                                            id="cross-selling-tab-{{ id }}"
@@ -30,7 +28,6 @@
                                             </span>
                                         </a>
                                     </li>
-                                {% endif %}
                             {% endfor %}
                         </ul>
                     {% endblock %}
@@ -41,7 +38,7 @@
                 <div class="product-detail-tabs-content card-body">
                     {% block cms_element_cross_selling_tabs_content_container %}
                         <div class="tab-content">
-                            {% for item in element.data.crossSellings.elements %}
+                            {% for item in element.data.crossSellings.elements|filter(item => item.total > 0 and item.crossSelling.active == true) %}
                                 {% set crossSelling = item.crossSelling %}
                                 {% set products = item.products %}
                                 {% set id = crossSelling.id %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/cross-selling/tabs.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/cross-selling/tabs.html.twig
@@ -6,24 +6,22 @@
                     <ul class="nav nav-tabs product-detail-tab-navigation-list"
                         id="product-detail-cross-selling-tabs"
                         role="tablist">
-                        {% for item in crossSellings %}
+                        {% for item in crossSellings|filter(item => item.total > 0 and item.crossSelling.active == true)  %}
                             {% set id = item.crossSelling.id %}
-                            {% if item.crossSelling.active and item.getProducts().elements %}
-                                <li class="nav-item">
-                                    <a class="nav-link product-detail-tab-navigation-link{% if loop.first %} active{% endif %}"
-                                       id="cs-{{ id }}-tab"
-                                       data-toggle="tab"
-                                       href="#cs-{{ id }}-tab-pane"
-                                       role="tab"
-                                       aria-controls="cs-{{ id }}-tab-pane"
-                                       aria-selected="true">
-                                        {{ item.crossSelling.translated.name }}
-                                        <span class="product-detail-tab-navigation-icon">
-                                            {% sw_icon 'arrow-medium-right' style {'pack':'solid'} %}
-                                        </span>
-                                    </a>
-                                </li>
-                            {% endif %}
+                            <li class="nav-item">
+                                <a class="nav-link product-detail-tab-navigation-link{% if loop.first %} active{% endif %}"
+                                   id="cs-{{ id }}-tab"
+                                   data-toggle="tab"
+                                   href="#cs-{{ id }}-tab-pane"
+                                   role="tab"
+                                   aria-controls="cs-{{ id }}-tab-pane"
+                                   aria-selected="true">
+                                    {{ item.crossSelling.translated.name }}
+                                    <span class="product-detail-tab-navigation-icon">
+                                        {% sw_icon 'arrow-medium-right' style {'pack':'solid'} %}
+                                    </span>
+                                </a>
+                            </li>
                         {% endfor %}
                     </ul>
                 {% endblock %}
@@ -34,56 +32,54 @@
             <div class="product-detail-tabs-content card-body">
                 {% block page_product_detail_cross_selling_tabs_content_container %}
                     <div class="tab-content">
-                        {% for item in crossSellings %}
+                        {% for item in crossSellings|filter(item => item.total > 0 and item.crossSelling.active == true) %}
                             {% set id = item.crossSelling.id %}
-                            {% if item.crossSelling.active and item.getProducts().elements %}
-                                <div class="tab-pane fade show{% if loop.first %} active{% endif %}"
-                                     id="cs-{{ id }}-tab-pane"
-                                     role="tabpanel"
-                                     aria-labelledby="cs-{{ id }}-tab">
-                                        {% set config = {
-                                            'title': {
-                                                'value': item.crossSelling.name
-                                            },
-                                            'border': {
-                                                'value': false
-                                            },
-                                            'rotate': {
-                                                'value': false
-                                            },
-                                            'products': {
-                                                'value': item.getProducts()
-                                            },
-                                            'boxLayout': {
-                                                'value': 'standard'
-                                            },
-                                            'elMinWidth': {
-                                                'value': '300px'
-                                            },
-                                            'navigation': {
-                                                'value': true
-                                            },
-                                            'displayMode': {
-                                                'value': 'minimal'
-                                            },
-                                            'verticalAlign': {
-                                                'value': 'top'
-                                            },
-                                        } %}
+                            <div class="tab-pane fade show{% if loop.first %} active{% endif %}"
+                                 id="cs-{{ id }}-tab-pane"
+                                 role="tabpanel"
+                                 aria-labelledby="cs-{{ id }}-tab">
+                                {% set config = {
+                                    'title': {
+                                        'value': item.crossSelling.name
+                                    },
+                                    'border': {
+                                        'value': false
+                                    },
+                                    'rotate': {
+                                        'value': false
+                                    },
+                                    'products': {
+                                        'value': item.getProducts()
+                                    },
+                                    'boxLayout': {
+                                        'value': 'standard'
+                                    },
+                                    'elMinWidth': {
+                                        'value': '300px'
+                                    },
+                                    'navigation': {
+                                        'value': true
+                                    },
+                                    'displayMode': {
+                                        'value': 'minimal'
+                                    },
+                                    'verticalAlign': {
+                                        'value': 'top'
+                                    },
+                                } %}
 
-                                        {% sw_include "@Storefront/storefront/element/cms-element-product-slider.html.twig" with {
-                                            sliderConfig: config,
-                                            element: {
-                                                'data': {
-                                                    'products': {
-                                                        elements: item.getProducts()
-                                                    }
-                                                },
-                                                type: 'product-slider'
+                                {% sw_include "@Storefront/storefront/element/cms-element-product-slider.html.twig" with {
+                                    sliderConfig: config,
+                                    element: {
+                                        'data': {
+                                            'products': {
+                                                elements: item.getProducts()
                                             }
-                                        } %}
-                                </div>
-                            {% endif %}
+                                        },
+                                        type: 'product-slider'
+                                    }
+                                } %}
+                            </div>
                         {% endfor %}
                     </div>
                 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/index.html.twig
@@ -62,11 +62,13 @@
                 {% endblock %}
 
                 {% block page_product_detail_cross_selling %}
-                    <div class="product-detail-tabs product-detail-cross-selling">
-                        {% sw_include '@Storefront/storefront/page/product-detail/cross-selling/tabs.html.twig' with {
-                            crossSellings: page.crossSellings
-                        } %}
-                    </div>
+                    {% if page.crossSellings.elements|filter(item => item.total > 0)|length > 0 %}
+                        <div class="product-detail-tabs product-detail-cross-selling">
+                            {% sw_include '@Storefront/storefront/page/product-detail/cross-selling/tabs.html.twig' with {
+                                crossSellings: page.crossSellings
+                            } %}
+                        </div>
+                    {% endif %}
                 {% endblock %}
             {% endblock %}
         </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
When you have multiple Active Cross-selling assign to one Product, but the first one has no assigns  products, the storefront output is not correct.

Case 1: (Default product page Layout is assigned)
Nothing will displayed in the storefront.

Case 2: (no product page Layout is assigned)
Only the title from the scross-selling is on screen only wehen you click on the title the slider appears.

### 2. What does this change do, exactly?

1. Condition shifted as filter to the for loop, so that the condition "if loop.first" is always right.
2. Add/change if condition, so that cross-selling will be correct displayed


### 3. Describe each step to reproduce the issue or behaviour.
- Assign multiple cross sellings to one product.
- Assign products to the second cross selling
- dont asign any product to the first scross selling

See it in frontend

-Assign Default product page Layout to the Product

See it in frontend

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-17805

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
