### PR TITLE
fix: abort request in SearchWidgetPlugin before loading indicator is created

### DIFF
--- a/changelog/_unreleased/2021-10-11-fix-loading-indicator-in-search-suggest.md
+++ b/changelog/_unreleased/2021-10-11-fix-loading-indicator-in-search-suggest.md
@@ -1,0 +1,12 @@
+---
+title: Fix loading indicator in search suggest
+issue:
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: @tinect
+---
+# Storefront
+* Changed private method `_suggest` in `SearchWidgetPlugin` to abort client request before the loading indicator is created. This fixes the loading indicator to be removed when the search term has been changed.
+___
+# Upgrade Information
+

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -106,6 +106,7 @@ export default class SearchWidgetPlugin extends Plugin {
      */
     _suggest(value) {
         const url = this._url + encodeURIComponent(value);
+        this._client.abort();
 
         // init loading indicator
         const indicator = new ButtonLoadingIndicator(this._submitButton);
@@ -113,7 +114,6 @@ export default class SearchWidgetPlugin extends Plugin {
 
         this.$emitter.publish('beforeSearch');
 
-        this._client.abort();
         this._client.get(url, (response) => {
             // remove existing search results popover first
             this._clearSuggestResults();
@@ -176,7 +176,7 @@ export default class SearchWidgetPlugin extends Plugin {
             console.warn(`Called selector '${this.options.searchWidgetCollapseButtonSelector}' for the search toggle button not found. Autofocus has been disabled on mobile.`);
             return
         }
-        
+
         const event = (DeviceDetection.isTouchDevice()) ? 'touchstart' : 'click';
         this._toggleButton.addEventListener(event, () => {
             setTimeout(() => this._focusInput(), 0);


### PR DESCRIPTION
### 1. Why is this change necessary?
When customer uses the searchWidget and changes the term when the request has been sent, the request gets aborted, but also the loading indicator. The loading indicator doesn't get recreated with the request from the changed term because the abort is called to late.

### 2. What does this change do, exactly?
From the abort before the creation of loadingindi

### 3. Describe each step to reproduce the issue or behaviour.
- have an uncached or slow shop (or add a sleep(3) in suggest-controller)
- visit storefront
- open devtools
- type a searchterm into the search field
- see devtools starting a refresh
- see loading indicator next to the search field
- edit the searchterm
- see previous request got cancelled, see new request running
- see **NO** more loading indicator next to the search field - but request is running :-)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
