### PR TITLE
NEXT-14809 Gallery image aspect ratio zoom config (tall images fix) and magnifier over gallery config

### DIFF
--- a/changelog/_unreleased/2021-10-12-gallery-tall-images-issue-aspect-ratio-zoom-config-and-magnifier-over-gallery-config.md
+++ b/changelog/_unreleased/2021-10-12-gallery-tall-images-issue-aspect-ratio-zoom-config-and-magnifier-over-gallery-config.md
@@ -1,0 +1,16 @@
+---
+title: Gallery image aspect ratio zoom config (tall images fix) and magnifier over gallery config
+issue: NEXT-14809
+author: Robert Rypula
+author_email: r.rypula@webweit.de
+---
+# Administration
+* Added two parameters `magnifierOverGallery` and `keepAspectRatioOnZoom` to `administration/src/module/sw-cms/elements/image-gallery/index.js`.
+* Added default value preset to initConfig method at `administration/src/module/sw-cms/elements/image-gallery/config/index.js`.
+* Added block with new checkboxes at `administration\src\module\sw-cms\elements\image-gallery\config\sw-cms-el-config-image-gallery.html.twig`.
+* Added new snippets related to checkboxes to `administration\src\module\sw-cms\snippet\*.json`
+# Storefront
+* Added new parameter `keepAspectRatioOnZoom` to the plugin `storefront\src\plugin\magnifier\magnifier.plugin.js`
+* Changed methods `_setZoomImageSize(...)`, `calculateZoomImageBackgroundPosition(...)` and `_getOverlaySize(....)` to include new `keepAspectRatioOnZoom` parameter at `storefront\src\plugin\magnifier\magnifier.plugin.js`
+* Changed styles - due to bug the overlay was hidden even the magnifier area was not the gallery at `storefront\src\scss\component\_cms-element.scss`
+* Added logic that consumes parameters from the administration and passes them to the magnifier plugin at `storefront\element\cms-element-image-gallery.html.twig`

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/index.js
@@ -138,6 +138,8 @@ Component.register('sw-cms-el-config-image-gallery', {
             this.element.config.navigationDots.value = 'inside';
             this.element.config.zoom.value = true;
             this.element.config.fullScreen.value = true;
+            this.element.config.keepAspectRatioOnZoom.value = true;
+            this.element.config.magnifierOverGallery.value = false;
             this.element.config.displayMode.value = 'contain';
             this.element.config.minHeight.value = '430px';
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
@@ -261,6 +261,27 @@
                         {% endblock %}
                     </div>
                     {% endblock %}
+
+                    {% block sw_cms_element_image_gallery_config_settings_aspect_ratio_magnifier_over_gallery_toggles %}
+                    <div class="sw-cms-el-config-image-gallery__setting-option">
+
+                        {% block sw_cms_element_image_gallery_config_settings_toggle_keep_aspect_ratio_on_zoom %}
+                        <sw-switch-field
+                            v-model="element.config.keepAspectRatioOnZoom.value"
+                            bordered
+                            :label="$tc('sw-cms.elements.imageGallery.config.label.keepAspectRatioOnZoom')"
+                        />
+                        {% endblock %}
+
+                        {% block sw_cms_element_image_gallery_config_settings_toggle_magnifier_over_gallery %}
+                        <sw-switch-field
+                            v-model="element.config.magnifierOverGallery.value"
+                            bordered
+                            :label="$tc('sw-cms.elements.imageGallery.config.label.magnifierOverGallery')"
+                        />
+                        {% endblock %}
+                    </div>
+                    {% endblock %}
                 </div>
             </sw-container>
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/index.js
@@ -51,6 +51,14 @@ Shopware.Service('cmsService').registerCmsElement({
             source: 'static',
             value: false,
         },
+        keepAspectRatioOnZoom: {
+            source: 'static',
+            value: true,
+        },
+        magnifierOverGallery: {
+            source: 'static',
+            value: false,
+        },
     },
     enrich: function enrich(elem, data) {
         if (Object.keys(data).length < 1) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -212,7 +212,9 @@
             "navigationPreviewPositionLeft": "Links",
             "navigationPreviewPositionUnderneath": "Darunter",
             "zoom": "Zoom",
-            "fullscreen": "Vollbild-Galerie"
+            "fullscreen": "Vollbild-Galerie",
+            "keepAspectRatioOnZoom": "Seitenverhältnis beim Zoomen beibehalten",
+            "magnifierOverGallery": "Lupe über Galerie"
           }
         }
       },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -212,7 +212,9 @@
             "navigationPreviewPositionLeft": "Left",
             "navigationPreviewPositionUnderneath": "Underneath",
             "zoom": "Zoom",
-            "fullscreen": "Fullscreen gallery"
+            "fullscreen": "Fullscreen gallery",
+            "keepAspectRatioOnZoom": "Keep aspect ratio on zoom",
+            "magnifierOverGallery": "Magnifier over gallery"
           }
         }
       },

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
@@ -203,9 +203,11 @@ General styling for cms elements
 }
 
 .cms-element-image-gallery {
-    // hides magnifier overlay because zoom container is displayed over gallery
-    .magnifier-overlay {
-        display: none;
+    .js-magnifier-zoom-image-container {
+        // hides magnifier overlay because zoom container is displayed over gallery
+        .magnifier-overlay {
+            display: none;
+        }
     }
 }
 

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -10,7 +10,8 @@
 
         {% set zoom = sliderConfig.zoom.value %}
         {% set gutter = sliderConfig.gutter.value %}
-        {% set magnifierOverGallery = true %}
+        {% set keepAspectRatioOnZoom = sliderConfig.keepAspectRatioOnZoom.value %}
+        {% set magnifierOverGallery = sliderConfig.magnifierOverGallery.value %}
         {% set zoomModal = sliderConfig.fullScreen.value %}
         {% set minHeight = sliderConfig.minHeight.value %}
         {% set displayMode = sliderConfig.displayMode.value %}
@@ -38,6 +39,12 @@
         {% set magnifierOptions = magnifierOptions|merge({
             'magnifierOverGallery': true,
             'cursorType': 'crosshair'
+        }) %}
+    {% endif %}
+
+    {% if keepAspectRatioOnZoom is defined and keepAspectRatioOnZoom is not null %}
+        {% set magnifierOptions = magnifierOptions|merge({
+            'keepAspectRatioOnZoom': keepAspectRatioOnZoom
         }) %}
     {% endif %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
On tall images it's impossible to zoom the bottom edge of the image (this happens also on very long images). Also when you change layout of the product the magnifier over gallery is forced due to hardcoded value in the Shopware Core Code.

![image](https://user-images.githubusercontent.com/6407731/136921512-c3e8aa23-bccd-4746-9fe7-6ef0483d617f.png)


### 2. What does this change do, exactly?
Adds two options to the Gallery config modal in the admin that allows you to change the default Shopware behavior:

- **Keep aspect ratio on zoom** (default checked to keep default shopware functionality)
- **Magnifier over gallery** (default unchecked to keep default shopware functionality)

![image](https://user-images.githubusercontent.com/6407731/136921920-ee0ede3c-bbae-410b-894c-af1b43de4cf3.png)

This PR keeps default shopware functionality

![default-behaviour-on-tall-images](https://user-images.githubusercontent.com/6407731/136921838-1f172689-acfd-4a25-b6d3-b7661cf11a05.gif)

When **Keep aspect ratio on zoom** is disabled then the zoom overlay becomes square and user is able to reach the bottom edge of the image

![square-zoom-on-tall-images](https://user-images.githubusercontent.com/6407731/136921701-187bb7e3-a182-423d-9313-082499f11691.gif)

In addition user can decide what to do with the **magnifier over gallery option**. Currenty in Shopware there is a bug that forces magnifier over gallery option as soon as user changes default product layout to the custom one. This PR adds checkbox to control that option.
![image](https://user-images.githubusercontent.com/6407731/136924333-a70cf7b6-52f7-4469-b815-43d56e7c4873.png)

![magnifier-over-gallery-enabled](https://user-images.githubusercontent.com/6407731/136921722-37aa198b-7e63-45b4-a259-b447b3d320a9.gif)

### 3. Describe each step to reproduce the issue or behavior.

**Case 1**
- Create a product and add very tall image
- Go to the product page
- Put mouse over gallery image and check zoom on the right

**Current behavior**: It's impossible to zoom the bottom edge
**Expected behavior**: User should be able to zoom even the bottom part. Since the right area is rather square the zoom overlay should be also square. The behavior should be configured in the admin.

**Case 2**
- Create a new product layout and assign it to the product
- Go to the product page
- Put mouse over gallery and check what happens

**Current behavior**: Zoom is shown over the gallery but in the default shopware product template it was over buy area (right side)
**Expected behavior**: User should be able to change that behavior in the admin - currently it's hardcoded in the shopware code

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-14809

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
