### PR TITLE
fix: remove check of variable storageExists in CartWidgetPlugin

### DIFF
--- a/changelog/_unreleased/2021-10-12-remove-check-of-variable-storageexists-in-cartwidgetplugin.md
+++ b/changelog/_unreleased/2021-10-12-remove-check-of-variable-storageexists-in-cartwidgetplugin.md
@@ -1,0 +1,9 @@
+---
+title: Remove check of variable storageExists in CartWidgetPlugin
+issue:
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: @tinect
+___
+# Storefront
+* Changed method `insertStoredContent` of `CartWidgetPlugin` to ignore variable `_storageExists` which never exists

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/cart-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/cart-widget.plugin.js
@@ -22,11 +22,9 @@ export default class CartWidgetPlugin extends Plugin {
      * into the element
      */
     insertStoredContent() {
-        if (this._storageExists) {
-            const storedContent = Storage.getItem(this.options.cartWidgetStorageKey);
-            if (storedContent) {
-                this.el.innerHTML = storedContent;
-            }
+        const storedContent = Storage.getItem(this.options.cartWidgetStorageKey);
+        if (storedContent) {
+            this.el.innerHTML = storedContent;
         }
 
         this.$emitter.publish('insertStoredContent');


### PR DESCRIPTION
### 1. Why is this change necessary?
This variable never exists in any release:  
https://github.com/shopware/platform/commit/4c7959cfc25b14f9256086394dbccf0b48d60508#diff-66b5c7f1cb8f416c1f0d7ff7cbdcf49f3a937045779b3e63a07bba2e586dfdc5L11

### 2. What does this change do, exactly?
Changed method `insertStoredContent` of `CartWidgetPlugin` to ignore variable `_storageExists` which never exists

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
