### PR TITLE
Extract property-whitelist into constant for easier comprehension of relation

### DIFF
--- a/changelog/_unreleased/2021-10-12-extract-property-whitelist-into-constant-for-easier-comprehension-of-code-relation.md
+++ b/changelog/_unreleased/2021-10-12-extract-property-whitelist-into-constant-for-easier-comprehension-of-code-relation.md
@@ -1,0 +1,8 @@
+---
+title: Extract property-whitelist into constant for easier comprehension of code relation
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added new constant `\Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM` and used it in `\Shopware\Core\Content\Product\Cms\ProductListingCmsElementResolver::restrictFilters` to visualize code relation

--- a/src/Core/Content/Product/Cms/ProductListingCmsElementResolver.php
+++ b/src/Core/Content/Product/Cms/ProductListingCmsElementResolver.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductListingStruct;
 use Shopware\Core\Content\Product\SalesChannel\Listing\AbstractProductListingRoute;
+use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingFeaturesSubscriber;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -124,12 +125,12 @@ class ProductListingCmsElementResolver extends AbstractCmsElementResolver
         // setup the default behavior
         $defaults = ['manufacturer-filter', 'rating-filter', 'shipping-free-filter', 'price-filter', 'property-filter'];
 
-        $request->request->set('property-whitelist', null);
+        $request->request->set(ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM, null);
 
         $config = $slot->get('config');
 
         if (isset($config['propertyWhitelist']['value']) && \count($config['propertyWhitelist']['value']) > 0) {
-            $request->request->set('property-whitelist', $config['propertyWhitelist']['value']);
+            $request->request->set(ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM, $config['propertyWhitelist']['value']);
         }
 
         if (!isset($config['filters']['value'])) {

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingFeaturesSubscriber.php
@@ -42,6 +42,8 @@ class ProductListingFeaturesSubscriber implements EventSubscriberInterface
 {
     public const DEFAULT_SEARCH_SORT = 'score';
 
+    public const PROPERTY_GROUP_IDS_REQUEST_PARAM = 'property-whitelist';
+
     /**
      * @var EntityRepositoryInterface
      */
@@ -477,7 +479,7 @@ class ProductListingFeaturesSubscriber implements EventSubscriberInterface
         if (!$request->request->get('property-filter', true)) {
             $filters->remove('properties');
 
-            if (\count($propertyWhitelist = $request->request->all('property-whitelist'))) {
+            if (\count($propertyWhitelist = $request->request->all(self::PROPERTY_GROUP_IDS_REQUEST_PARAM))) {
                 $filters->add($this->getPropertyFilter($request, $propertyWhitelist));
             }
         }

--- a/src/Core/Content/Test/Product/Cms/ProductListingCMSElementResolverTest.php
+++ b/src/Core/Content/Test/Product/Cms/ProductListingCMSElementResolverTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductListingStruct;
 use Shopware\Core\Content\Product\Cms\ProductListingCmsElementResolver;
 use Shopware\Core\Content\Product\SalesChannel\Exception\ProductSortingNotFoundException;
+use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingFeaturesSubscriber;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
 use Shopware\Core\Content\Product\SalesChannel\Sorting\ProductSortingEntity;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -263,7 +264,7 @@ class ProductListingCMSElementResolverTest extends TestCase
         $request = $resolverContext->getRequest();
 
         foreach ($expectations as $field => $expected) {
-            if ($field === 'property-whitelist') {
+            if ($field === ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM) {
                 $value = $request->request->get($field, null);
             } else {
                 $value = $request->request->get($field, true);
@@ -286,7 +287,7 @@ class ProductListingCMSElementResolverTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 [
                     'filters' => [
@@ -302,7 +303,7 @@ class ProductListingCMSElementResolverTest extends TestCase
                     'rating-filter' => false,
                     'shipping-free-filter' => false,
                     'property-filter' => false,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 [
                     'filters' => [
@@ -318,7 +319,7 @@ class ProductListingCMSElementResolverTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => false,
                     'property-filter' => false,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 [
                     'filters' => [
@@ -334,7 +335,7 @@ class ProductListingCMSElementResolverTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 [
                     'filters' => [
@@ -350,7 +351,7 @@ class ProductListingCMSElementResolverTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 [
                     'filters' => [
@@ -366,7 +367,7 @@ class ProductListingCMSElementResolverTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 [
                     'filters' => [
@@ -382,7 +383,7 @@ class ProductListingCMSElementResolverTest extends TestCase
                     'rating-filter' => false,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 [
                     'filters' => [
@@ -398,7 +399,7 @@ class ProductListingCMSElementResolverTest extends TestCase
                     'rating-filter' => false,
                     'shipping-free-filter' => false,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 [
                     'filters' => [
@@ -414,7 +415,7 @@ class ProductListingCMSElementResolverTest extends TestCase
                     'rating-filter' => false,
                     'shipping-free-filter' => false,
                     'property-filter' => false,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 [
                     'filters' => [
@@ -430,7 +431,7 @@ class ProductListingCMSElementResolverTest extends TestCase
                     'rating-filter' => false,
                     'shipping-free-filter' => false,
                     'property-filter' => false,
-                    'property-whitelist' => [$sizeId, $textileId],
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => [$sizeId, $textileId],
                 ],
                 [
                     'filters' => [

--- a/src/Core/Content/Test/Product/SalesChannel/ProductListingFeaturesSubscriberTest.php
+++ b/src/Core/Content/Test/Product/SalesChannel/ProductListingFeaturesSubscriberTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityD
 use Shopware\Core\Content\Product\Events\ProductListingCriteriaEvent;
 use Shopware\Core\Content\Product\Events\ProductSearchCriteriaEvent;
 use Shopware\Core\Content\Product\SalesChannel\Exception\ProductSortingNotFoundException;
+use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingFeaturesSubscriber;
 use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingRoute;
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Defaults;
@@ -575,7 +576,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request(),
             ],
@@ -587,7 +588,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request([], ['manufacturer-filter' => true]),
             ],
@@ -605,7 +606,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request([], ['manufacturer-filter' => false]),
             ],
@@ -617,7 +618,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request([], ['price-filter' => true]),
             ],
@@ -635,7 +636,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request([], ['price-filter' => false]),
             ],
@@ -647,7 +648,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request([], ['rating-filter' => true]),
             ],
@@ -665,7 +666,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => false,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request([], ['rating-filter' => false]),
             ],
@@ -677,7 +678,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request([], ['shipping-free-filter' => true]),
             ],
@@ -695,7 +696,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => false,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request([], ['shipping-free-filter' => false]),
             ],
@@ -707,7 +708,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => true,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request([], ['property-filter' => true]),
             ],
@@ -724,7 +725,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => false,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
                 new Request([], ['property-filter' => false]),
             ],
@@ -741,9 +742,9 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => false,
-                    'property-whitelist' => null,
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null,
                 ],
-                new Request([], ['property-filter' => false, 'property-whitelist' => null]),
+                new Request([], ['property-filter' => false, ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null]),
             ],
             [
                 [
@@ -758,9 +759,9 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => false,
-                    'property-whitelist' => [],
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => [],
                 ],
-                new Request([], ['property-filter' => false, 'property-whitelist' => []]),
+                new Request([], ['property-filter' => false, ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => []]),
             ],
             [
                 [
@@ -777,9 +778,9 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                     'rating-filter' => true,
                     'shipping-free-filter' => true,
                     'property-filter' => false,
-                    'property-whitelist' => [$id1],
+                    ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => [$id1],
                 ],
-                new Request([], ['property-filter' => false, 'property-whitelist' => [$id1]]),
+                new Request([], ['property-filter' => false, ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => [$id1]]),
             ],
         ];
     }
@@ -945,7 +946,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                         ],
                     ],
                 ]),
-                new Request([], ['property-filter' => false, 'property-whitelist' => null]),
+                new Request([], ['property-filter' => false, ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => null]),
                 [
                     'aggregation' => 'properties',
                     'instanceOf' => null,
@@ -969,7 +970,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                         ],
                     ],
                 ]),
-                new Request([], ['property-filter' => false, 'property-whitelist' => []]),
+                new Request([], ['property-filter' => false, ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => []]),
                 [
                     'aggregation' => 'properties',
                     'instanceOf' => null,
@@ -993,7 +994,7 @@ class ProductListingFeaturesSubscriberTest extends TestCase
                         ],
                     ],
                 ]),
-                new Request([], ['property-filter' => false, 'property-whitelist' => [$ids->get('textile')]]),
+                new Request([], ['property-filter' => false, ProductListingFeaturesSubscriber::PROPERTY_GROUP_IDS_REQUEST_PARAM => [$ids->get('textile')]]),
                 [
                     'aggregation' => 'properties',
                     'instanceOf' => EntityResult::class,


### PR DESCRIPTION
### 1. Why is this change necessary?
In the past it was not easy to understand what the property-whitelist does and where it comes from. Seeing the relation of the cms loader running first, changing the incoming request and the later feature subscriber using that data is not very easy to understand. This makes it easier.

### 2. What does this change do, exactly?
Introduces a constant and used it everywhere applicable.

### 3. Describe each step to reproduce the issue or behaviour.
1. Try to understand how the filter limitation in the admin works.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
