### PR TITLE
Introduce core.cart.paymentFinalizeTransactionTime configuration to allow admin user change the duration of payment finalization

### DIFF
--- a/changelog/_unreleased/2021-10-12-introduce-core.cart.paymentfinalizetransactiontime-configuration-to-allow-admin-user-change-the-duration-of-payment-finalization.md
+++ b/changelog/_unreleased/2021-10-12-introduce-core.cart.paymentfinalizetransactiontime-configuration-to-allow-admin-user-change-the-duration-of-payment-finalization.md
@@ -1,0 +1,9 @@
+---
+title: Introduce core.cart.paymentFinalizeTransactionTime configuration to allow admin user change the duration of payment finalization
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+
+# Core
+* Added configuration `core.cart.paymentFinalizeTransactionTime` to allow configuration based token lifetime generated in `\Shopware\Core\Checkout\Payment\Cart\PaymentTransactionChainProcessor::process` which defaults to 30 minutes

--- a/src/Core/System/Resources/config/cart.xml
+++ b/src/Core/System/Resources/config/cart.xml
@@ -23,6 +23,12 @@
             <label lang="de-DE">Stornierungen erlauben</label>
         </input-field>
 
+        <input-field type="int">
+            <name>paymentFinalizeTransactionTime</name>
+            <defaultValue>30</defaultValue>
+            <label>Time in minutes for a customer to finalize a transaction</label>
+            <label lang="de-DE">Zeit in Minuten, die ein Kunde Zeit hat eine Transaktion abzuschließen</label>
+        </input-field>
     </card>
 
     <card>


### PR DESCRIPTION
### 1. Why is this change necessary?
When you send a mail that the customer should finally finalize their transaction the mail might be read too late or it might be even sent to late. You want to increase the 30m limit. Maybe you deal with high frequently changing currencies and want to limit transaction times even below 30m. You want to decrease the 30m limit. Nothing you were able to do in the past. Now you can.

### 2. What does this change do, exactly?
Add an admin configuration that the shop owner can easily edit. Changes a ctor call to include that configuration.

### 3. Describe each step to reproduce the issue or behaviour.
1. Send an email the customer should pay in an hourly scheduled task
2. Customer can't finalize transaction anymore when email is read as link is outdated quickly
3. Lost conversion

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
