### PR TITLE
Remove obsolete property assignment in constructor

### DIFF
--- a/src/Elasticsearch/Framework/Indexing/CreateAliasTaskHandler.php
+++ b/src/Elasticsearch/Framework/Indexing/CreateAliasTaskHandler.php
@@ -28,7 +28,6 @@ class CreateAliasTaskHandler extends ScheduledTaskHandler
         parent::__construct($scheduledTaskRepository);
         $this->client = $client;
         $this->connection = $connection;
-        $this->scheduledTaskRepository = $scheduledTaskRepository;
         $this->elasticsearchHelper = $elasticsearchHelper;
         $this->config = $config;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The change is not necessarily necessary. But the line I removed was never necessary in the first place. This property assignment is already performed by the parent class. (see https://github.com/shopware/platform/blob/v6.4.5.1/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandler.php#L20)

### 2. What does this change do, exactly?
It removes a line with an obsolete property assignment.

### 3. Describe each step to reproduce the issue or behaviour.
None.

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
