### PR TITLE
Fix catch when exception does not contain a response property

### DIFF
--- a/changelog/_unreleased/2021-10-12-fix-catch-on-saving-cms-details-when-exception-does-not-contain-a-response-property.md
+++ b/changelog/_unreleased/2021-10-12-fix-catch-on-saving-cms-details-when-exception-does-not-contain-a-response-property.md
@@ -1,0 +1,8 @@
+---
+title: Fix catch on saving CMS details when exception does not contain a response property
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Changed notification content access in catch to ensure notification display when exception is not a response related exception in `src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -395,7 +395,7 @@ Component.register('sw-cms-detail', {
                 this.isLoading = false;
                 this.createNotificationError({
                     title: exception.message,
-                    message: exception.response.statusText,
+                    message: exception?.response?.statusText ?? this.$t('global.default.error'),
                 });
 
                 warn(this._name, exception.message, exception.response);


### PR DESCRIPTION
### 1. Why is this change necessary?
The underlying service method should not be forced to throw an exception that is about a response. When it is not the catch fails to create a message box.

### 2. What does this change do, exactly?
Adds a check whether the exception has a response property to pull data from it.

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
