### PR TITLE
Change bundle loading so it can load bundles before itself

### DIFF
--- a/changelog/_unreleased/2021-10-12-load-additional-bundles-in-order.md
+++ b/changelog/_unreleased/2021-10-12-load-additional-bundles-in-order.md
@@ -1,0 +1,23 @@
+---
+title: Load additional bundles in order
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed bundle loading order by the keys from `\Shopware\Core\Framework\Plugin::getAdditionalBundles` in `\Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader::getBundles` to allow bundle loading prior the plugin itself
+___
+# Upgrade Information
+When you depend on a self-shipped bundle to already been loaded before your plugin, you can now use negative keys in `getAdditionalBundles` to express a different order. Use negative keys to load them before your plugin instance:
+
+```
+class AcmePlugin extends Plugin
+{
+    public function getAdditionalBundles(AdditionalBundleParameters $parameters): array
+    {
+        return [
+            -10 => new DependencyBundle(),
+        ];
+    }
+}
+```

--- a/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
@@ -80,16 +80,13 @@ abstract class KernelPluginLoader extends Bundle
         }
 
         foreach ($this->pluginInstances->getActives() as $plugin) {
-            if (!\in_array($plugin->getName(), $loadedBundles, true)) {
-                yield $plugin;
-                $loadedBundles[] = $plugin->getName();
-            }
-
             $copy = new KernelPluginCollection($this->getPluginInstances()->all());
             $additionalBundleParameters = new AdditionalBundleParameters($this->classLoader, $copy, $kernelParameters);
             $additionalBundles = $plugin->getAdditionalBundles($additionalBundleParameters);
+            [$preLoaded, $postLoaded] = $this->splitBundlesIntoPreAndPost($additionalBundles);
 
-            foreach ($additionalBundles as $bundle) {
+            /** @var Bundle $bundle */
+            foreach ([...\array_values($preLoaded), $plugin, ...\array_values($postLoaded)] as $bundle) {
                 if (!\in_array($bundle->getName(), $loadedBundles, true)) {
                     yield $bundle;
                     $loadedBundles[] = $bundle->getName();
@@ -290,5 +287,28 @@ abstract class KernelPluginLoader extends Bundle
 
             $this->pluginInstances->add($plugin);
         }
+    }
+
+    /**
+     * @param Bundle[] $bundles
+     * @return array<Bundle[]>
+     */
+    private function splitBundlesIntoPreAndPost(array $bundles): array
+    {
+        $pre = [];
+        $post = [];
+
+        foreach ($bundles as $index => $bundle) {
+            if (\is_int($index) && $index < 0) {
+                $pre[$index] = $bundle;
+            } else {
+                $post[$index] = $bundle;
+            }
+        }
+
+        \ksort($pre);
+        \ksort($post);
+
+        return [$pre, $post];
     }
 }

--- a/src/Core/Framework/Test/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php
+++ b/src/Core/Framework/Test/Plugin/KernelPluginLoader/StaticKernelPluginLoaderTest.php
@@ -185,12 +185,12 @@ class StaticKernelPluginLoaderTest extends TestCase
 
         $bundles = iterator_to_array($loader->getBundles());
 
-        static::assertCount(3, $bundles);
-        static::assertInstanceOf('SwagTest\SwagTest', $bundles[0]);
+        static::assertCount(4, $bundles);
+        static::assertInstanceOf('SwagTest\SwagTest', $bundles[1]);
         static::assertSame($loader, $bundles[2]);
     }
 
-    public function testGetBundlesWithAdditionalBundlesThatAreDuplicates(): void
+    public function testGetBundlesWithAdditionalBundlesThatAreDuplicatesButKeepOrder(): void
     {
         $activePluginData = $this->getActivePlugin()->jsonSerialize();
         $activePluginDataWithUnneededBundles = $this->getActivePluginWithBundle()->jsonSerialize();
@@ -201,10 +201,11 @@ class StaticKernelPluginLoaderTest extends TestCase
 
         $bundles = iterator_to_array($loader->getBundles([], ['FrameworkBundle']));
 
-        static::assertCount(4, $bundles);
-        static::assertInstanceOf('SwagTest\SwagTest', $bundles[0]);
-        static::assertInstanceOf('Shopware\Core\Framework\Test\Plugin\_fixture\bundles\FooBarBundle', $bundles[1]);
-        static::assertInstanceOf('SwagTestWithBundle\SwagTestWithBundle', $bundles[2]);
+        static::assertCount(5, $bundles);
+        static::assertInstanceOf('Shopware\Core\Framework\Test\Plugin\_fixture\bundles\GizmoBundle', $bundles[0]);
+        static::assertInstanceOf('SwagTest\SwagTest', $bundles[1]);
+        static::assertInstanceOf('Shopware\Core\Framework\Test\Plugin\_fixture\bundles\FooBarBundle', $bundles[2]);
+        static::assertInstanceOf('SwagTestWithBundle\SwagTestWithBundle', $bundles[3]);
         static::assertSame($loader, $bundles[3]);
     }
 

--- a/src/Core/Framework/Test/Plugin/_fixture/bundles/GizmoBundle.php
+++ b/src/Core/Framework/Test/Plugin/_fixture/bundles/GizmoBundle.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Plugin\_fixture\bundles;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class GizmoBundle extends Bundle
+{
+    protected $name = 'GizmoBundleName';
+}

--- a/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTest/src/SwagTest.php
+++ b/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTest/src/SwagTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Plugin\Context\DeactivateContext;
 use Shopware\Core\Framework\Plugin\Context\UninstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
 use Shopware\Core\Framework\Test\Plugin\_fixture\bundles\FooBarBundle;
+use Shopware\Core\Framework\Test\Plugin\_fixture\bundles\GizmoBundle;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 class SwagTest extends Plugin
@@ -96,9 +97,11 @@ class SwagTest extends Plugin
     public function getAdditionalBundles(AdditionalBundleParameters $parameters): array
     {
         require_once __DIR__ . '/../../../bundles/FooBarBundle.php';
+        require_once __DIR__ . '/../../../bundles/GizmoBundle.php';
 
         return [
             new FooBarBundle(),
+            -10 => new GizmoBundle(),
         ];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
When you want to load an additional bundle that needs to be processed prior to your own plugin in terms of container and bundle management then you can't influence it. Now you can!

### 2. What does this change do, exactly?
It allows for negative indices to be used where 0 represents after the plugin and everything below before the plugin. So this is no BC.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add bundle which sets up stuff
2. Let your plugin depend on it
3. Break

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Hotfix

Right now you can make two plugins. One ships the dependency and is installed (time-wise) before yours, and the other is using that dependency.
