### PR TITLE
Add support for big xml product exports.

### DIFF
--- a/src/Core/Content/ProductExport/Validator/XmlValidator.php
+++ b/src/Core/Content/ProductExport/Validator/XmlValidator.php
@@ -22,7 +22,7 @@ class XmlValidator implements ValidatorInterface
             $backup = false;
         }
 
-        if (!simplexml_load_string($productExportContent)) {
+        if (!simplexml_load_string($productExportContent, 'SimpleXMLElement', LIBXML_COMPACT | LIBXML_PARSEHUGE)) {
             $errors->add(new XmlValidationError($productExportEntity->getId(), libxml_get_errors()));
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
We need that change for a big Shopware installation, that has many products. If these parameters are not added, big xml files cannot be generated.

### 2. What does this change do, exactly?
Allow support for big xml validation. 
See more information here: https://www.php.net/manual/de/libxml.constants.php

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
