### PR TITLE
Update cms-element-form-privacy.html.twig - make privacyUrl and tosUr…

### DIFF
--- a/changelog/_unreleased/2021-10-13-set-privacyUrl-and-tosUrl.md
+++ b/changelog/_unreleased/2021-10-13-set-privacyUrl-and-tosUrl.md
@@ -1,0 +1,7 @@
+---
+title:              Set privacyUrl and tosUrl correctly
+issue:              NEXT-17851
+author:             Robert Nowotny
+author_email:       rnowotny1966@gmail.com
+author_github:      @bitranox
+---

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -16,15 +16,13 @@
 
         {% block cms_form_privacy_opt_in_label %}
             <label for="{{ identifierTemplate|format(_key) }}" class=" custom-control-label">
-                {{ "general.privacyNotice"|trans({
-                    '%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') })
-                })
-                |trans({
-                    '%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage') })
-                })
+                {{ "general.privacyNotice"
+                |trans({'%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
+                {# replace '%url%' for compatibility with versions before 6.4.5.1 - should be deprecated #}
+                |trans({'%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
+                |trans({'%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage') })})
                 |raw }}
             </label>
         {% endblock %}
-
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -17,10 +17,11 @@
         {% block cms_form_privacy_opt_in_label %}
             <label for="{{ identifierTemplate|format(_key) }}" class=" custom-control-label">
                 {{ "general.privacyNotice"
-                |trans({'%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
                 {# replace '%url%' for compatibility with versions before 6.4.5.1 - should be deprecated #}
                 |trans({'%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
-                |trans({'%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage') })})
+                {# new '%privacyUrl%' and '%tosUrl%' for versions after 6.4.5.1 #}
+                |trans({'%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
+                |trans({'%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage')})})
                 |raw }}
             </label>
         {% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -17,9 +17,9 @@
         {% block cms_form_privacy_opt_in_label %}
             <label for="{{ identifierTemplate|format(_key) }}" class=" custom-control-label">
                 {{ "general.privacyNotice"
-                {# replace '%url%' for compatibility with versions before 6.4.5.1 - should be deprecated #}
+                {# replace '%url%' for compatibility before v6.4.5.1 #}
                 |trans({'%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
-                {# new '%privacyUrl%' and '%tosUrl%' for versions after 6.4.5.1 #}
+                {# new '%privacyUrl%' and '%tosUrl%' after v6.4.5.1 #}
                 |trans({'%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
                 |trans({'%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage')})})
                 |raw }}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -17,9 +17,14 @@
         {% block cms_form_privacy_opt_in_label %}
             <label for="{{ identifierTemplate|format(_key) }}" class=" custom-control-label">
                 {{ "general.privacyNotice"|trans({
-                    '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') })
-                })|raw }}
+                    '%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') })
+                })
+                |trans({
+                    '%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage') })
+                })
+                |raw }}
             </label>
         {% endblock %}
+
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -17,9 +17,9 @@
         {% block cms_form_privacy_opt_in_label %}
             <label for="{{ identifierTemplate|format(_key) }}" class=" custom-control-label">
                 {{ "general.privacyNotice"
-                {# replace %url% for backwards compatibility before v6.4.5.1 #}
+                {# replace '%url%' for versions before 6.4.5.1 #}
                 |trans({'%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
-                {# new %privacyUrl% and %tosUrl% after v6.4.5.1 #}
+                {# replace '%privacyUrl%' and '%tosUrl%' for versions after 6.4.5.1 #}
                 |trans({'%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
                 |trans({'%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage')})})
                 |raw }}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -17,9 +17,9 @@
         {% block cms_form_privacy_opt_in_label %}
             <label for="{{ identifierTemplate|format(_key) }}" class=" custom-control-label">
                 {{ "general.privacyNotice"
-                {# replace '%url%' for backwards compatibility before v6.4.5.1 #}
+                {# replace %url% for backwards compatibility before v6.4.5.1 #}
                 |trans({'%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
-                {# new '%privacyUrl%' and '%tosUrl%' after v6.4.5.1 #}
+                {# new %privacyUrl% and %tosUrl% after v6.4.5.1 #}
                 |trans({'%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
                 |trans({'%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage')})})
                 |raw }}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -14,12 +14,12 @@
                    required>
         {% endblock %}
 
+        {# replace url for versions before 6.4.5.1 #}
+        {# replace privacyUrl and tosUrl for versions after 6.4.5.1 #}
         {% block cms_form_privacy_opt_in_label %}
             <label for="{{ identifierTemplate|format(_key) }}" class=" custom-control-label">
                 {{ "general.privacyNotice"
-                {# replace '%url%' for versions before 6.4.5.1 #}
                 |trans({'%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
-                {# replace '%privacyUrl%' and '%tosUrl%' for versions after 6.4.5.1 #}
                 |trans({'%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
                 |trans({'%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage')})})
                 |raw }}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -17,7 +17,7 @@
         {% block cms_form_privacy_opt_in_label %}
             <label for="{{ identifierTemplate|format(_key) }}" class=" custom-control-label">
                 {{ "general.privacyNotice"
-                {# replace '%url%' for compatibility before v6.4.5.1 #}
+                {# replace '%url%' for backwards compatibility before v6.4.5.1 #}
                 |trans({'%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
                 {# new '%privacyUrl%' and '%tosUrl%' after v6.4.5.1 #}
                 |trans({'%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})


### PR DESCRIPTION
Shopware Issue tracker Ticket: NEXT-17851 - privacyUrl and tosUrl not working
### 1. Why is this change necessary?
privacyUrl and tosUrl not working

### 2. What does this change do, exactly?
fix the Error

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
Shopware Issue tracker Ticket: NEXT-17851
