### PR TITLE
add block for additional tabs in product detail in admin

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.html.twig
@@ -245,6 +245,10 @@
                 {{ $tc('sw-product.detail.tabReviews') }}
             </sw-tabs-item>
             {% endblock %}
+
+            {% block sw_product_detail_content_tabs_additional %}
+            {% endblock %}
+
         </sw-tabs>
         {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
It's not possible to just extend the admin with a new tab.
the only option is to append the block to a previously existing tab...but they change sometimes

so a new block for new tabs inside the tabs-container would help

### 2. What does this change do, exactly?
adding a plain block inside the tabs-container to easily add new tabs independent from other tabs

