### PR TITLE
Update privacy-notice.html.twig - privacyUrl and tosUr not translating correctly because of missing parameters

### DIFF
--- a/changelog/_unreleased/2021-10-14-add-missing-params-privacyUrl-and-tosUrl-for-privacy-links.md
+++ b/changelog/_unreleased/2021-10-14-add-missing-params-privacyUrl-and-tosUrl-for-privacy-links.md
@@ -1,0 +1,5 @@
+title:              Add missing params privacyUrl and tosUrl for privacy links
+issue:              -
+author:             Marco Zuggal
+author_email:       marco@freshsoft.eu
+author_github:      @postcat

--- a/changelog/_unreleased/2021-10-14-add-missing-params-privacyUrl-and-tosUrl-for-privacy-links.md
+++ b/changelog/_unreleased/2021-10-14-add-missing-params-privacyUrl-and-tosUrl-for-privacy-links.md
@@ -2,4 +2,4 @@ title:              Add missing params privacyUrl and tosUrl for privacy links
 issue:              -
 author:             Marco Zuggal
 author_email:       marco@freshsoft.eu
-author_github:      @postcat
+author_github:      @postcatz

--- a/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
@@ -20,9 +20,10 @@
                     {% block component_privacy_dpi_label %}
                         <label class="custom-control-label no-validation"
                                for="acceptedDataProtection">
-                            {{ "general.privacyNotice"|trans({
-                                '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') })
-                            })|raw }}
+                            {{ "general.privacyNotice"
+                            |trans({'%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
+                            |trans({'%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage')})})
+                            |raw }}
 
                             {{ "general.required"|trans|sw_sanitize }}
                         </label>
@@ -32,10 +33,10 @@
                 <div class="data-protection-information">
                     {% block component_privacy_label %}
                         <label>
-                            {{ "general.privacyNotice"|trans({
-                                '%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') }),
-                                '%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage') })
-                            })|raw }}
+                            {{ "general.privacyNotice"
+                            |trans({'%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage')})})
+                            |trans({'%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage')})})
+                            |raw }}
                         </label>
                     {% endblock %}
                 </div>


### PR DESCRIPTION

add missing parameters



### 1. Why is this change necessary?

%privacyURL% and %tosUrl% won't get translated


### 2. What does this change do, exactly?

add the missing %tosUrl% parameter


### 3. Describe each step to reproduce the issue or behaviour.

default behavior -> privacy links on register page show up as:

privacy - "https://domain.tld/%privacyURL%"
terms - "https://domain.tld/%tosUrl%"


### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-17960
same issue in another place

### 5. Checklist

- [ x] I have written tests and verified that they fail without my change
- [ x] I have squashed any insignificant commits
- [ -] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ -] I have written or adjusted the documentation according to my changes
- [ x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x] I have read the contribution requirements and fulfil them.
