### PR TITLE
NEXT-18059 It's not possible to edit existing user without setting up a new password when browser remembers it (Chrome)

### DIFF
--- a/changelog/_unreleased/2021-10-15-impossible-to-edit-user-in-admin-without-setting-up-new-password.md
+++ b/changelog/_unreleased/2021-10-15-impossible-to-edit-user-in-admin-without-setting-up-new-password.md
@@ -1,0 +1,7 @@
+---
+title: It's not possible to edit existing user without setting up a new password when browser remembers it (Chrome)
+author: Robert Rypula
+author_email: r.rypula@webweit.de
+---
+# Administration
+* Changed autocomplete attributes from `off` to `new-password` at `administration/src/module/sw-customer/component/sw-customer-card/sw-customer-card.html.twig`.

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-card/sw-customer-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-card/sw-customer-card.html.twig
@@ -150,7 +150,7 @@
                         <sw-password-field
                             v-if="editMode"
                             v-model="customer.passwordNew"
-                            autocomplete="off"
+                            autocomplete="new-password"
                             :label="$tc('sw-profile.index.labelNewPassword')"
                             :placeholder="$tc('sw-customer.card.placeholderNewPassword')"
                         />
@@ -160,7 +160,7 @@
                         <sw-password-field
                             v-if="editMode"
                             v-model="customer.passwordConfirm"
-                            autocomplete="off"
+                            autocomplete="new-password"
                             :label="$tc('sw-profile.index.labelNewPasswordConfirm')"
                             :placeholder="$tc('sw-customer.card.placeholderNewPasswordConfirm')"
                         />


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When browser remembered password of some user (on storefront) and later that user wants to edit that account in administration area the password is already prefilled (touched). This makes impossible to edit that user without setting up a new password.

![password-issue](https://user-images.githubusercontent.com/6407731/137445558-3c555a2e-5d50-42fd-80a6-074a5dfbc416.gif)

### 2. What does this change do, exactly?
Changes both password input's autocomplete attribute that is currently set to `off` to `new-password`.

### 3. Describe each step to reproduce the issue or behavior.
1. Create a user on storefront
2. Log in to that user on storefront and remember the password in Chrome browser
3. Log in to the administration, find that customer and edit it
4. Update first name (or any other _non password_ field)
5. Click save

**Current behavior:** Error is shown that password doesn't match but user newer touched password fields
**Expected behavior:** When user doesn't touch password fields it should just save changes without password errors.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
