### PR TITLE
Fix JsonFieldSerializer for invalid UTF8 characters

### DIFF
--- a/changelog/_unreleased/2021-10-15-fix-json-field-serializer-invalid-characters.md
+++ b/changelog/_unreleased/2021-10-15-fix-json-field-serializer-invalid-characters.md
@@ -1,0 +1,8 @@
+---
+title: Fix JsonFieldSerializer for invalid UTF8 characters
+issue: NEXT-17698
+author: Maximilian Ruesch
+author_email: maximilian.ruesch@pickware.de
+---
+# Core
+* The JsonFieldSerializer now ignores invalid UTF8 characters and throws more precise exceptions if it fails to encode a value.

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
@@ -32,7 +32,7 @@ class JsonFieldSerializer extends AbstractFieldSerializer
     /**
      * mariadbs `JSON_VALID` function does not allow escaped unicode.
      */
-    public static function encodeJson($value, int $options = \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION): string
+    public static function encodeJson($value, int $options = \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR | \JSON_INVALID_UTF8_IGNORE): string
     {
         return json_encode($value, $options);
     }

--- a/src/Core/Framework/Test/DataAbstractionLayer/FieldSerializer/JsonFieldSerializerTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/FieldSerializer/JsonFieldSerializerTest.php
@@ -9,7 +9,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ConfigJsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\ConfigJsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
@@ -29,7 +28,7 @@ class JsonFieldSerializerTest extends TestCase
     use DataAbstractionLayerFieldTestBehaviour;
 
     /**
-     * @var ConfigJsonFieldSerializer
+     * @var JsonFieldSerializer
      */
     private $serializer;
 
@@ -166,5 +165,12 @@ class JsonFieldSerializerTest extends TestCase
         $result = $this->serializer->encode($field, $this->existence, $kvPair, $this->parameters)->current();
 
         static::assertNull($result);
+    }
+
+    public function testIgnoresInvalidUtf8Characters(): void
+    {
+        $result = $this->serializer::encodeJson("something\x82 another");
+
+        static::assertEquals('"something another"', $result);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

When you try to encode invalid UTF8 characters, currently no exception is thrown, instead the used function `json_encode` returns `false`. As this does not fit the hinted return type, a type exception is thrown which clouds the exact cause of the problem.

### 2. What does this change do, exactly?

It fixes the handling of invalid UTF8 characters and improves the exception handling of the `JsonFieldSerializer`.

### 3. Describe each step to reproduce the issue or behaviour.

Try to save a SQL Exception that contains unescaped ids in the database using the `JsonField`. 

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-17698

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
