### PR TITLE
Add check/throw new error before deleting active addresses via sore-api

### DIFF
--- a/changelog/_unreleased/2021-10-18-prevent-deleting-active-addresses-via-store-api.md
+++ b/changelog/_unreleased/2021-10-18-prevent-deleting-active-addresses-via-store-api.md
@@ -1,0 +1,8 @@
+---
+title: Prevent deleting active addresses via store-api
+issue: 2117
+author: James Joffe
+author_github: drjamesj
+---
+# API
+* Changed `DELETE /store-api/account/address/{addressId}` to throw an error if attempting to delete an active address

--- a/src/Core/Checkout/Customer/Exception/CannotDeleteActiveAddressException.php
+++ b/src/Core/Checkout/Customer/Exception/CannotDeleteActiveAddressException.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class CannotDeleteActiveAddressException extends ShopwareHttpException
+{
+    public function __construct(string $id)
+    {
+        parent::__construct(
+            'Customer address with id "{{ addressId }}" is an active address and cannot be deleted.',
+            ['addressId' => $id]
+        );
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'CHECKOUT__CUSTOMER_ADDRESS_IS_ACTIVE';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+}

--- a/src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Exception\CannotDeleteActiveAddressException;
 use Shopware\Core\Checkout\Customer\Exception\CannotDeleteDefaultAddressException;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -72,6 +73,11 @@ An automatic fallback is not applied.",
     public function delete(string $addressId, SalesChannelContext $context, CustomerEntity $customer): NoContentResponse
     {
         $this->validateAddress($addressId, $context, $customer);
+
+        if($addressId === $context->getCustomer()->getActiveBillingAddress()->getId()
+            || $addressId === $context->getCustomer()->getActiveShippingAddress()->getId()) {
+            throw new CannotDeleteActiveAddressException($addressId);
+        }
 
         if ($addressId === $customer->getDefaultBillingAddressId()
             || $addressId === $customer->getDefaultShippingAddressId()) {

--- a/src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/DeleteAddressRoute.php
@@ -74,14 +74,14 @@ An automatic fallback is not applied.",
     {
         $this->validateAddress($addressId, $context, $customer);
 
-        if($addressId === $context->getCustomer()->getActiveBillingAddress()->getId()
-            || $addressId === $context->getCustomer()->getActiveShippingAddress()->getId()) {
-            throw new CannotDeleteActiveAddressException($addressId);
+        if ($addressId === $customer->getDefaultBillingAddressId()
+        || $addressId === $customer->getDefaultShippingAddressId()) {
+            throw new CannotDeleteDefaultAddressException($addressId);
         }
 
-        if ($addressId === $customer->getDefaultBillingAddressId()
-            || $addressId === $customer->getDefaultShippingAddressId()) {
-            throw new CannotDeleteDefaultAddressException($addressId);
+        if($addressId === $context->getCustomer()->getActiveBillingAddress()->getId()
+        || $addressId === $context->getCustomer()->getActiveShippingAddress()->getId()) {
+            throw new CannotDeleteActiveAddressException($addressId);
         }
 
         $this->addressRepository->delete([['id' => $addressId]], $context->getContext());

--- a/src/Core/Checkout/Test/Customer/SalesChannel/DeleteAddressRouteTest.php
+++ b/src/Core/Checkout/Test/Customer/SalesChannel/DeleteAddressRouteTest.php
@@ -51,7 +51,6 @@ class DeleteAddressRouteTest extends TestCase
             );
 
         $response = json_decode($this->browser->getResponse()->getContent(), true);
-
         $this->browser->setServerParameter('HTTP_SW_CONTEXT_TOKEN', $response['contextToken']);
     }
 
@@ -142,6 +141,63 @@ class DeleteAddressRouteTest extends TestCase
         $response = json_decode($this->browser->getResponse()->getContent(), true);
 
         static::assertSame('CHECKOUT__CUSTOMER_ADDRESS_IS_DEFAULT', $response['errors'][0]['code']);
+    }
+
+    /**
+     * @group mysample
+     */
+    public function testDeleteActiveAddress(): void
+    {
+        $data = [
+            'salutationId' => $this->getValidSalutationId(),
+            'firstName' => 'Test',
+            'lastName' => 'Test',
+            'street' => 'Test',
+            'city' => 'Test',
+            'zipcode' => 'Test',
+            'countryId' => $this->getValidCountryId(),
+        ];
+
+        $this->browser
+            ->request(
+                'POST',
+                '/store-api/account/address',
+                [],
+                [],
+                ['CONTENT_TYPE' => 'application/json'],
+                \json_encode($data)
+            );
+
+        $response = json_decode($this->browser->getResponse()->getContent(), true);
+        $addressId = $response['id'];
+
+        $contextData = [
+            'billingAddressId' => $addressId,
+            'shippingAddressId' => $addressId
+        ];
+
+        $this->browser
+        ->request(
+            'PATCH',
+            '/store-api/context',
+            [],
+            [],
+            ['CONTENT_TYPE' => 'application/json'],
+            \json_encode($contextData)
+        );
+
+        $response = json_decode($this->browser->getResponse()->getContent(), true);
+
+        $this->browser
+            ->request(
+                'DELETE',
+                '/store-api/account/address/' . $addressId
+            );
+
+        static::assertNotSame(204, $this->browser->getResponse()->getStatusCode());
+        $response = json_decode($this->browser->getResponse()->getContent(), true);
+
+        static::assertSame('CHECKOUT__CUSTOMER_ADDRESS_IS_ACTIVE', $response['errors'][0]['code']);
     }
 
     public function testDeleteNewCreatedAddressGuest(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
This PR addresses issue #2117 which identifies unexpected behaviour when deleting an active address via the store-api.

### 2. What does this change do, exactly?
Before deleting an address, in addition to checking if it is the default billing or shipping address (existing check), a further check is made to determine if it's the current active billing or shipping address based on the customer context. If so, it will throw an error.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a new billing or shipping address for a logged in custom via store-api
2. Set the address as the active address by calling `PATCH /context`
3. Next delete the address by calling `DELETE /store-api/account/address/${addressId}`
4. Log out of the user
5. Log back into the user to be greeted with below error

```
Argument 1 passed to Shopware\Core\Checkout\Customer\CustomerEntity::setActiveBillingAddress() must be an instance of Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity, null given, called in /app/platform/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php on line 478
```

### 4. Please link to the relevant issues (if any).
#2117 

### 5. Checklist
I am a first time contributor here, please let me know which (if any) of the following are required.

- [ ] I have written tests and verified that they fail without my change -- please let me know if this is required for this PR, and if so any instructions on how to do so would be appreciated
- [X] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes -- let me know if this is necessary
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
