### PR TITLE
removed doubled css class (hacktoberfest)

### DIFF
--- a/changelog/_unreleased/2021-10-16-remove-double-class.md
+++ b/changelog/_unreleased/2021-10-16-remove-double-class.md
@@ -1,0 +1,12 @@
+---
+title: Remove double class
+issue: 795
+author: Vitalij Mik
+author_email: cccpmik@gmail.com
+author_github: BlackScorp
+---
+
+# Storefront
+* Removed CSS class "product-detail-buy" from src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig because it is already defined in src/Storefront/Resources/views/storefront/page/product-detail/index.html.twig
+___
+# Upgrade Information

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
@@ -1,5 +1,5 @@
 {% block page_product_detail_buy_inner %}
-    <div class="product-detail-buy js-magnifier-zoom-image-container">
+    <div class="js-magnifier-zoom-image-container">
         {% block page_product_detail_rich_snippets %}
             {% block page_product_detail_rich_snippets_brand %}
                 {% if page.product.manufacturer %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
because the css class was used twiced

### 2. What does this change do, exactly?
removed a css class from storefront 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/795

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
