### PR TITLE
allow html in mail template subject and content plain (hacktoberfest)

### DIFF
--- a/changelog/_unreleased/2021-10-16-allow-html-in-mail-subject-and-content.md
+++ b/changelog/_unreleased/2021-10-16-allow-html-in-mail-subject-and-content.md
@@ -1,0 +1,10 @@
+---
+title: Allow HTML in Mail subject and content
+issue: 2111
+author: Vitalij Mik
+author_email: cccpmik@gmail.com
+author_github: BlackScorp
+---
+
+# Core
+* added new AllowHtml(true) flags to the fields subject and content plain in src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
@@ -46,9 +46,9 @@ class MailTemplateTranslationDefinition extends EntityTranslationDefinition
         return new FieldCollection([
             (new StringField('sender_name', 'senderName'))->addFlags(new ApiAware()),
             (new LongTextField('description', 'description'))->addFlags(new ApiAware()),
-            (new StringField('subject', 'subject'))->addFlags(new Required()),
+            (new StringField('subject', 'subject'))->addFlags(new Required(), new AllowHtml(false)),
             (new LongTextField('content_html', 'contentHtml'))->addFlags(new Required(), new AllowHtml(false)),
-            (new LongTextField('content_plain', 'contentPlain'))->addFlags(new Required()),
+            (new LongTextField('content_plain', 'contentPlain'))->addFlags(new Required(), new AllowHtml(false)),
             (new CustomFields())->addFlags(new ApiAware()),
         ]);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
strip_tags removed spaceship operator from mail subject and mail content plain

### 2. What does this change do, exactly?
allow html for mail subject and content plain so the spacesship operator will not be removed

### 3. Describe each step to reproduce the issue or behaviour.
see https://github.com/shopware/platform/issues/2111

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2111

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
