### PR TITLE
Make StateMachineEntity name nullable (hacktoberfest)

### DIFF
--- a/changelog/_unreleased/2021-10-16-make-statemachineentity-name-nullable.md
+++ b/changelog/_unreleased/2021-10-16-make-statemachineentity-name-nullable.md
@@ -1,0 +1,10 @@
+---
+title: Make StateMachineEntity name nullable
+issue: 1690
+author: Vitalij Mik
+author_email: cccpmik@gmail.com
+author_github: BlackScorp
+---
+
+# Core
+* changed typehints for method setName and getName, made them nullable in src/Core/System/StateMachine/StateMachineEntity.php

--- a/src/Core/System/StateMachine/StateMachineEntity.php
+++ b/src/Core/System/StateMachine/StateMachineEntity.php
@@ -21,7 +21,7 @@ class StateMachineEntity extends Entity
     protected $technicalName;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $name;
 
@@ -70,12 +70,12 @@ class StateMachineEntity extends Entity
         $this->technicalName = $technicalName;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function setName(string $name): void
+    public function setName(?string $name): void
     {
         $this->name = $name;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
StateMaschineEntity name is used in several templates, if the name is not set, there are errors

### 2. What does this change do, exactly?
Allow name to be nullable since the name is a translated field

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/1690

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
