### PR TITLE
fix(snippets): add space before order number

### DIFF
--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -376,7 +376,7 @@
     "finishUpdateHeader": "Vielen Dank für die Aktualisierung Ihrer Bestellung!",
     "finishPaymentHeader": "Die Zahlungsart Ihrer Bestellung wurde zu \"%paymentName%\" geändert!",
     "finishInfoHeader": "Informationen",
-    "finishInfoOrdernumber": "Ihre Bestellnummer:",
+    "finishInfoOrdernumber": "Ihre Bestellnummer: ",
     "finishInfoConfirmationMail": "Bestellbestätigungs-E-Mail wurde verschickt.",
     "finishButtonBackToShop": "Zurück zum Shop",
     "finishChangePayment":  "Zahlungsart ändern",


### PR DESCRIPTION
See the english version for a comparison: https://github.com/shopware/platform/blob/trunk/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json#L379

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?

Space is missing before the order number in the default german snippets.


- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
