### PR TITLE
fix: Use an empty string as fallback password to not fail in rawurlencode

### DIFF
--- a/changelog/_unreleased/2021-10-17-allow-to-use-an-empty-password-in-the-system-setup-command.md
+++ b/changelog/_unreleased/2021-10-17-allow-to-use-an-empty-password-in-the-system-setup-command.md
@@ -1,0 +1,8 @@
+---
+title: Allow to use an empty password in the `system:setup` command
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Allow to use an empty password in the `system:setup` command

--- a/src/Core/Maintenance/System/Command/SystemSetupCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemSetupCommand.php
@@ -182,7 +182,7 @@ class SystemSetupCommand extends Command
         };
 
         $dbUser = $io->ask('Database user', 'app', $emptyValidation);
-        $dbPass = $io->askHidden('Database password');
+        $dbPass = $io->askHidden('Database password') ?: '';
         $dbHost = $io->ask('Database host', 'localhost', $emptyValidation);
         $dbPort = $io->ask('Database port', '3306', $emptyValidation);
         $dbName = $io->ask('Database name', 'shopware', $emptyValidation);


### PR DESCRIPTION
### 1. Why is this change necessary?
Entering a password will result in an error: `rawurlencode expects a string, null given` 

### 2. What does this change do, exactly?
Always make sure that the password is a string.

### 3. Describe each step to reproduce the issue or behaviour.
use `system:setup` using an empty password.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
