### PR TITLE
feat: Reformat output of system:config:get

### DIFF
--- a/changelog/_unreleased/2021-03-30-add-better-output-format-to-system-config-get.md
+++ b/changelog/_unreleased/2021-03-30-add-better-output-format-to-system-config-get.md
@@ -1,0 +1,8 @@
+---
+title: Better output format for system-config-get
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Add formatting options to `system:config:get`

--- a/src/Core/System/SystemConfig/Command/ConfigGet.php
+++ b/src/Core/System/SystemConfig/Command/ConfigGet.php
@@ -11,6 +11,20 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ConfigGet extends Command
 {
+    private const FORMAT_DEFAULT = 'default';
+    private const FORMAT_SCALAR = 'scalar';
+    private const FORMAT_JSON = 'json';
+    private const FORMAT_JSON_PRETTY = 'json-pretty';
+    private const FORMAT_LEGACY = 'legacy';
+
+    private const ALLOWED_FORMATS = [
+        self::FORMAT_DEFAULT,
+        self::FORMAT_SCALAR,
+        self::FORMAT_JSON,
+        self::FORMAT_JSON_PRETTY,
+        self::FORMAT_LEGACY,
+    ];
+
     protected static $defaultName = 'system:config:get';
 
     /**
@@ -29,22 +43,98 @@ class ConfigGet extends Command
         $this
             ->addArgument('key', InputArgument::REQUIRED)
             ->addOption('salesChannelId', 's', InputOption::VALUE_OPTIONAL)
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Supported formats: ' . implode(', ', self::ALLOWED_FORMATS), self::FORMAT_LEGACY)
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $format = $input->getOption('format');
+        if (!\in_array($format, self::ALLOWED_FORMATS, true)) {
+            throw new \RuntimeException("{$format} is not a valid choice as output format");
+        }
+
+        $configKey = $input->getArgument('key');
         $value = $this->systemConfigService->get(
-            $input->getArgument('key'),
+            $configKey,
             $input->getOption('salesChannelId')
         );
 
-        if (\is_array($value)) {
-            $output->writeln($value);
-        } else {
-            $output->writeln((string) $value);
+        if ($format === self::FORMAT_LEGACY) {
+            $this->writeConfigLegacy($output, $value);
+
+            return self::SUCCESS;
         }
 
-        return 0;
+        if ($format === self::FORMAT_SCALAR) {
+            if (\is_array($value)) {
+                throw new \RuntimeException('Value is an array, please specify the config key to point to a scalar, when using the scalar format.');
+            }
+
+            $this->writeConfigScalar($output, $this->getScalarValue($value));
+
+            return self::SUCCESS;
+        }
+
+        if (!\is_array($value)) {
+            $value = [$configKey => $value];
+        }
+
+        if (\in_array($format, [self::FORMAT_JSON, self::FORMAT_JSON_PRETTY], true)) {
+            $flags = 0;
+            if ($format === self::FORMAT_JSON_PRETTY) {
+                $flags |= \JSON_PRETTY_PRINT;
+            }
+
+            $this->writeConfigJson($output, $value, $flags);
+        } elseif ($format === 'default') {
+            $this->writeConfigDefault($output, $value);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function writeConfigScalar(OutputInterface $output, string $config): void
+    {
+        $output->writeln($config);
+    }
+
+    private function writeConfigLegacy(OutputInterface $output, $config): void
+    {
+        if (\is_array($config)) {
+            ksort($config);
+
+            $output->writeln($config);
+        } else {
+            $output->writeln((string) $config);
+        }
+    }
+
+    private function writeConfigJson(OutputInterface $output, array $config, int $flags): void
+    {
+        $output->writeln((string) \json_encode($config, $flags));
+    }
+
+    private function writeConfigDefault(OutputInterface $output, array $config, int $level = 1): void
+    {
+        ksort($config);
+
+        foreach ($config as $key => $entry) {
+            if (\is_array($entry)) {
+                $output->writeln($key);
+                $this->writeConfigDefault($output, $entry, $level + 1);
+            } else {
+                $output->writeln(\str_repeat(' ', $level * 2) . "{$key} => {$this->getScalarValue($entry)}");
+            }
+        }
+    }
+
+    private function getScalarValue($value): string
+    {
+        if (\is_bool($value)) {
+            $value = $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
     }
 }

--- a/src/Core/System/Test/SystemConfig/Command/ConfigGetCommandTest.php
+++ b/src/Core/System/Test/SystemConfig/Command/ConfigGetCommandTest.php
@@ -1,0 +1,118 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Test\SystemConfig\Command;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\SystemConfig\Command\ConfigGet;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ConfigGetCommandTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private ConfigGet $configGetCommand;
+
+    protected function setUp(): void
+    {
+        $this->configGetCommand = $this->getConfigGetCommand();
+    }
+
+    /**
+     * @dataProvider configFormatJsonProvider
+     */
+    public function testConfigGetJson(string $key, string $format, string $output): void
+    {
+        $commandOutput = $this->executeCommand($key, $format);
+        static::assertJsonStringEqualsJsonString($commandOutput, $output);
+    }
+
+    public function configFormatJsonProvider(): iterable
+    {
+        // config key, format, output
+        yield 'test scalar value' => ['foo.bar.testBoolTrue', 'json', '{"foo.bar.testBoolTrue":true}'];
+        yield 'test array' => ['foo.bar', 'json', '{"testBoolFalse":false,"testInt":123,"testBoolTrue":true,"testString":"test"}'];
+        yield 'test array and json-pretty format' => ['foo.bar', 'json-pretty', '{"testBoolFalse":false,"testInt":123,"testBoolTrue":true,"testString":"test"}'];
+    }
+
+    /**
+     * @dataProvider configFormatScalarProvider
+     */
+    public function testConfigGetScalar(string $key, string $output): void
+    {
+        $commandOutput = $this->executeCommand($key, 'scalar');
+        static::assertEquals($commandOutput, $output);
+    }
+
+    public function configFormatScalarProvider(): iterable
+    {
+        // config key, output
+        yield 'test string' => ['foo.bar.testString', 'test'];
+        yield 'test true' => ['foo.bar.testBoolTrue', 'true'];
+        yield 'test false' => ['foo.bar.testBoolFalse', 'false'];
+        yield 'test int' => ['foo.bar.testInt', '123'];
+    }
+
+    /**
+     * @dataProvider configFormatDefaultProvider
+     */
+    public function testConfigGetDefault(string $key, string $output): void
+    {
+        $commandOutput = $this->executeCommand($key);
+        static::assertEquals($commandOutput, $output);
+    }
+
+    public function configFormatDefaultProvider(): iterable
+    {
+        // config key, output
+        yield 'test 1D array' => ['foo.bar', "testBoolFalse => false\n  testBoolTrue => true\n  testInt => 123\n  testString => test"];
+        yield 'test 1D array nested' => ['foo', "bar\n    testBoolFalse => false\n    testBoolTrue => true\n    testInt => 123\n    testString => test"];
+        yield 'test single value true' => ['foo.bar.testBoolTrue', 'foo.bar.testBoolTrue => true'];
+        yield 'test single value int' => ['foo.bar.testInt', 'foo.bar.testInt => 123'];
+    }
+
+    /**
+     * @dataProvider configFormatLegacyProvider
+     */
+    public function testConfigGetLegacy(string $key, string $output): void
+    {
+        $commandOutput = $this->executeCommand($key, 'legacy');
+        static::assertEquals(addslashes($commandOutput), addslashes($output));
+    }
+
+    public function configFormatLegacyProvider(): iterable
+    {
+        // config key, output
+        yield 'test 1d array value' => ['foo.bar', "1\n123\ntest"];
+        yield 'test true' => ['foo.bar.testBoolTrue', '1'];
+        yield 'test false' => ['foo.bar.testBoolFalse', ''];
+        yield 'test int' => ['foo.bar.testInt', '123'];
+    }
+
+    private function executeCommand(string $key, string $format = 'default'): string
+    {
+        $commandTester = new CommandTester($this->configGetCommand);
+
+        $commandTester->execute([
+            'key' => $key,
+            '--salesChannelId' => TestDefaults::SALES_CHANNEL,
+            '--format' => $format,
+        ]);
+
+        return trim($commandTester->getDisplay());
+    }
+
+    private function getConfigGetCommand(): ConfigGet
+    {
+        $systemConfigService = $this->getContainer()->get(SystemConfigService::class);
+
+        $systemConfigService->set('foo.bar.testString', 'test', TestDefaults::SALES_CHANNEL);
+        $systemConfigService->set('foo.bar.testInt', 123, TestDefaults::SALES_CHANNEL);
+        $systemConfigService->set('foo.bar.testBoolTrue', true, TestDefaults::SALES_CHANNEL);
+        $systemConfigService->set('foo.bar.testBoolFalse', false, TestDefaults::SALES_CHANNEL);
+
+        return new ConfigGet($systemConfigService);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Returning back to the issue addressed in the PR: https://github.com/shopware/platform/pull/1756 i.e. give better readability of the console command to retrieve the Shopware configuration.
Now with some more time, it should be implemented in a backward compatible way and also including some more formats.

### 2. What does this change do, exactly?
Add the `--format` Parameter to the command `system:config:get`.

### 3. Describe each step to reproduce the issue or behaviour.
Run `php bin/console system:config:get core.newsletter`.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
