### PR TITLE
fix(administration): improve clickability of `sw-tabs` by making bottom-border non-blocking

### DIFF
--- a/changelog/_unreleased/2020-18-10-sw-tabs-clickability.md
+++ b/changelog/_unreleased/2020-18-10-sw-tabs-clickability.md
@@ -1,0 +1,10 @@
+---
+title: Improve clickabilty of sw-tabs 
+author: Enzo Volkmann
+author_email: enzo@exportarts.io
+author_github: @evolkmann
+---
+# Administration
+* Improve the clickability of the `sw-tabs` component. When approached with the mouse from the bottom, the
+  border that is rendered by the `::before`-style prevented the tab from being clicked. The actual clickable
+  area of the tab did not match the visual appearance.

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.scss
@@ -21,6 +21,7 @@
             width: 100%;
             height: 2px;
             background-color: $color-gray-300;
+            z-index: -1;
         }
 
         .sw-tooltip--wrapper {


### PR DESCRIPTION
### 1. Why is this change necessary?


### 2. What does this change do, exactly?

Make the `sw-tabs` clickable in the whole visible area of the tab. Previously, the lower 2px were not clickable.

### 3. Describe each step to reproduce the issue or behaviour.

1. Go to a page in the administration that uses the `sw-tabs`
2. Approach the tab from the bottom, you will notice it is only clickable when you move 2px inside it

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
