### PR TITLE
uuid validation just, if input is string

### DIFF
--- a/src/Core/Framework/Uuid/Uuid.php
+++ b/src/Core/Framework/Uuid/Uuid.php
@@ -98,9 +98,13 @@ class Uuid
         return self::fromBytesToHex(md5($string, true));
     }
 
-    public static function isValid(string $id): bool
+    public static function isValid($id): bool //HOTFIX tf 2021-10-18
     {
-        if (!preg_match('/' . self::VALID_PATTERN . '/', $id)) {
+        if($id && is_string($id)) {
+            if (!preg_match('/' . self::VALID_PATTERN . '/', $id)) {
+                return false;
+            }
+        } else {
             return false;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
If in the theme/theme.json config file is an integrer item like this:
`
"config": {
        "fields": {
            "low-in-stock": {
                "label": {
                    "en-GB": "Low stock value for Badge",
                    "de-DE": "Min Lager Wert für Badge"
                },
                "custom": {
                    "numberType": "int",
                    "min": 1,
                    "max": 10
                },
                "value": 3,
                "editable": true
            }
        }
    }
`
The Uuid::isVaild in DatabaseConfigLoadre.php will throw an error, when build the storefront section. Because the config array $config['fields'] contains as value the as integer.

Error output in this case:
In Uuid.php line 101:                                                                                                                                                                                                                    Argument 1 passed to Shopware\Core\Framework\Uuid\Uuid::isValid() must be of the type string, int given, called in /var/www/html/vendor/shopware/storefront/Theme/ConfigLoader/DatabaseConfigLoader.php on line 234  
                                                                                                                                                                                                                     

### 2. What does this change do, exactly?
Validation of uuids just, if input is a string. Otherwise the method returns false

### 3. Describe each step to reproduce the issue or behaviour.
Theme.json setup with config field as integer. And run 
`bin/build-storefront.sh`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
