### PR TITLE
Make maximum number of URLs in a sitemap file configurable

### DIFF
--- a/changelog/_unreleased/2021-10-23-make-maximum-number-of-urls-in-a-sitemap-file-configurable.md
+++ b/changelog/_unreleased/2021-10-23-make-maximum-number-of-urls-in-a-sitemap-file-configurable.md
@@ -1,0 +1,16 @@
+---
+title: Make maximum number of URLs in a sitemap file configurable
+author: Julian Krzefski
+author_email: krzefski@heptacom.de
+author_github: jkrzefski
+---
+
+# Core
+
+* Added configuration option `shopware.sitemap.max_urls`. The value defaults to `null`, resulting in a fallback to `49999` (see `\Shopware\Core\Content\Sitemap\Service\SitemapHandle::MAX_URLS`).
+
+___
+
+# Upgrade Information
+
+* You can now configure `shopware.sitemap.max_urls` to configure the maximum number of urls in a sitemap file. This can be useful if the default of `49999` leads to broken or empty sitemap files in your hosting environment.

--- a/src/Core/Content/DependencyInjection/sitemap.xml
+++ b/src/Core/Content/DependencyInjection/sitemap.xml
@@ -22,7 +22,9 @@
             <argument type="tagged" tag="shopware.sitemap.config_handler"/>
         </service>
 
-        <service id="Shopware\Core\Content\Sitemap\Service\SitemapHandleFactoryInterface" class="Shopware\Core\Content\Sitemap\Service\SitemapHandleFactory"/>
+        <service id="Shopware\Core\Content\Sitemap\Service\SitemapHandleFactoryInterface" class="Shopware\Core\Content\Sitemap\Service\SitemapHandleFactory">
+            <argument>%shopware.sitemap.max_urls%</argument>
+        </service>
 
         <service id="Shopware\Core\Content\Sitemap\SalesChannel\SitemapRoute" public="true">
             <argument type="service" id="Shopware\Core\Content\Sitemap\Service\SitemapLister"/>

--- a/src/Core/Content/Sitemap/Service/SitemapHandle.php
+++ b/src/Core/Content/Sitemap/Service/SitemapHandle.php
@@ -29,8 +29,14 @@ class SitemapHandle implements SitemapHandleInterface
 
     private ?string $domainName = null;
 
-    public function __construct(FilesystemInterface $filesystem, SalesChannelContext $context, ?string $domain = null)
-    {
+    private ?int $maxUrls;
+
+    public function __construct(
+        FilesystemInterface $filesystem,
+        SalesChannelContext $context,
+        ?string $domain = null,
+        ?int $maxUrls = null
+    ) {
         $this->setDomainName($domain);
 
         $this->filesystem = $filesystem;
@@ -44,6 +50,7 @@ class SitemapHandle implements SitemapHandleInterface
 
         $this->tmpFiles[] = $filePath;
         $this->context = $context;
+        $this->maxUrls = $maxUrls;
     }
 
     /**
@@ -55,7 +62,7 @@ class SitemapHandle implements SitemapHandleInterface
             gzwrite($this->handle, (string) $url);
             ++$this->urlCount;
 
-            if ($this->urlCount % self::MAX_URLS === 0) {
+            if ($this->urlCount % ($this->maxUrls ?? self::MAX_URLS) === 0) {
                 $this->printFooter();
                 gzclose($this->handle);
                 ++$this->index;

--- a/src/Core/Content/Sitemap/Service/SitemapHandleFactory.php
+++ b/src/Core/Content/Sitemap/Service/SitemapHandleFactory.php
@@ -7,8 +7,15 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class SitemapHandleFactory implements SitemapHandleFactoryInterface
 {
+    private ?int $maxUrls;
+
+    public function __construct(?int $maxUrls = null)
+    {
+        $this->maxUrls = $maxUrls;
+    }
+
     public function create(FilesystemInterface $filesystem, SalesChannelContext $context, ?string $domain = null): SitemapHandleInterface
     {
-        return new SitemapHandle($filesystem, $context, $domain);
+        return new SitemapHandle($filesystem, $context, $domain, $this->maxUrls);
     }
 }

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -236,6 +236,10 @@ class Configuration implements ConfigurationInterface
                     ->min(1)
                     ->defaultValue(100)
                 ->end()
+                ->integerNode('max_urls')
+                    ->min(1)
+                    ->defaultValue(null)
+                ->end()
             ->end();
 
         return $rootNode;


### PR DESCRIPTION
### 1. Why is this change necessary?

I had trouble with the default limit of `49999` and it resulted in empty `*.xml.gz` files. Lowering the limit eliminated the issues. Having this limit as a configurable option would be nice to control it easier.

### 2. What does this change do, exactly?

It adds a new config option that is a nullable integer. When the option is not explicitly set, the constant `\Shopware\Core\Content\Sitemap\Service\SitemapHandle::MAX_URLS` is used as fallback. When it is set, its value is used instead.

### 3. Describe each step to reproduce the issue or behaviour.

Unfortunately, I wasn't able to pin down the cause of my issue. So reproducing it will probably not work reliably. I ran this command: `bin/console sitemap:generate`

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
