### PR TITLE
🐛  Assign result of addToResponse(...)

### DIFF
--- a/src/Recovery/Install/src/app.php
+++ b/src/Recovery/Install/src/app.php
@@ -155,7 +155,7 @@ function getApplication(KernelInterface $kernel): App
         $container->offsetSet('install.language', $selectedLanguage);
 
         $cookie = new SetCookie('installed-locale', $localeForLanguage($selectedLanguage), time() + 7200, '/');
-        $cookie->addToResponse($response);
+        $response = $cookie->addToResponse($response);
 
         $viewAttributes = [];
 


### PR DESCRIPTION
### 1. Why is this change necessary?

`addToResponse(...)` calls `ResponseInterface->withAddedHeader`

Most (if not all) PSR-7 methods are immutable. 

We need to assign the result of `addToResponse(...)`

This will never have worked before?

### 2. What does this change do, exactly?

Attach the `installed-locale` cookie to the response

### 3. Describe each step to reproduce the issue or behaviour.



### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
