### PR TITLE
feat: Sort todays orders in dashboard descending

### DIFF
--- a/changelog/_unreleased/2021-11-02-sort-todays-orders-in-dashboard-descending.md
+++ b/changelog/_unreleased/2021-11-02-sort-todays-orders-in-dashboard-descending.md
@@ -1,0 +1,12 @@
+---
+title: Sort todays orders in dashboard descending
+issue: 
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: @tinect
+___
+
+# Administration
+
+* Changed method `fetchTodayData` in component `sw-dashboard-index` to sort the orders descending
+

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/index.js
@@ -326,9 +326,9 @@ Component.register('sw-dashboard-index', {
             const criteria = new Criteria(1, 10);
 
             criteria.addAssociation('currency');
-            // add filter for last 30 days
+            // add filter for today
             criteria.addFilter(Criteria.range('orderDate', { gte: this.formatDate(this.today) }));
-            criteria.addSorting(Criteria.sort('orderDateTime', 'ASC'));
+            criteria.addSorting(Criteria.sort('orderDateTime', 'DESC'));
 
             return this.orderRepository.search(criteria);
         },


### PR DESCRIPTION
### 1. Why is this change necessary?
It feels wrong and is annoying to switch page to get current status on a dashboard.

### 2. What does this change do, exactly?
Changed the sorting from ASC to DESC.
Fixed comment to match filter.

### 3. Describe each step to reproduce the issue or behaviour.
Place some orders. 
Open dashboard.
See sorting of today's orders.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
