### PR TITLE
feat: add alt and title of media onto thumbnails

### DIFF
--- a/changelog/_unreleased/2021-11-02-add-alt--and-title-tags-to-thumbnails.md
+++ b/changelog/_unreleased/2021-11-02-add-alt--and-title-tags-to-thumbnails.md
@@ -1,0 +1,9 @@
+---
+title: Add Alt- and Title-Attributes from media to thumbnails
+issue: 
+author: Sebastian König
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+# Storefront
+* Added alt and title attributes from media to thumbnails if there is non set explicitly

--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -15,6 +15,18 @@
     {% set autoColumnSizes = true %}
 {% endif %}
 
+{% if attributes is not defined %}
+    {% set attributes = {} %}
+{% endif %}
+
+{% if attributes.alt is not defined and media.translated.alt is defined %}
+    {% set attributes = attributes|merge({'alt': media.translated.alt}) %}
+{% endif %}
+
+{% if attributes.title is not defined and media.translated.title is defined %}
+    {% set attributes = attributes|merge({'title': media.translated.title}) %}
+{% endif %}
+
 {# uses cms block column count and all available thumbnails to determine the correct image size for the current viewport #}
 {% if media.thumbnails|length > 0 %}
     {% if autoColumnSizes and columns and sizes is not defined %}


### PR DESCRIPTION
### 1. Why is this change necessary?
There is no alt or title tag on thumbnails when not explitly set in template.

### 2. What does this change do, exactly?
Add alt and title of media onto thumbnails if there is non set explicitly

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).
Idea coming from #2151

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
