### PR TITLE
fix links to legal pages on registration form

### DIFF
--- a/changelog/_unreleased/2021-11-03-fix-links-to-legal-pages-on-registration-form.md
+++ b/changelog/_unreleased/2021-11-03-fix-links-to-legal-pages-on-registration-form.md
@@ -1,0 +1,9 @@
+---
+title: Fix links to legal pages on registration form
+issue: ~
+author: Axel Guckelsberger
+author: Axel Guckelsberger
+author_email: axel.guckelsberger@guite.de
+---
+# Storefront
+* Corrected translation arguments for `general.privacyNotice` key in `src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig`.

--- a/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
@@ -20,8 +20,11 @@
                     {% block component_privacy_dpi_label %}
                         <label class="custom-control-label no-validation"
                                for="acceptedDataProtection">
+                            {# @deprecated tag:v6.5.0 - Translation parameter %url% will be removed, use %privacyUrl% and %tosUrl% instead #}
                             {{ "general.privacyNotice"|trans({
-                                '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') })
+                                '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage'),
+                                '%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') }),
+                                '%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage') })
                             })|raw }}
 
                             {{ "general.required"|trans|sw_sanitize }}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Links to terms of services and privacy policy are broken if the checkbox to confirm them is enabled.

### 2. What does this change do, exactly?
Use the correct arguments for the `general.privacyNotice` translation key, like they are used also without the checkbox.

### 3. Describe each step to reproduce the issue or behaviour.
1. Go to registration settings at `/admin#/sw/settings/login/registration/index`
2. Enable the checkbox to confirm privacy policy during registration.
3. Open `/account/login` on your storefront page.
4. Click on "privacy policy" or "terms of service".
5. Note the modal show a 404 page instead of the expected page.

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
