### PR TITLE
fix null coalescing default for admin flag

### DIFF
--- a/src/Core/Maintenance/User/Service/UserProvisioner.php
+++ b/src/Core/Maintenance/User/Service/UserProvisioner.php
@@ -33,7 +33,7 @@ class UserProvisioner
             'password' => password_hash($password, \PASSWORD_BCRYPT),
             'locale_id' => $additionalData['localeId'] ?? $this->getLocaleOfSystemLanguage(),
             'active' => true,
-            'admin' => $additionalData['admin'] ?? true,
+            'admin' => $additionalData['admin'] ?? false,
             'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ];
 


### PR DESCRIPTION
The `bin/console user:create` command always created a new user with admin rights, even if the admin flag is not set.
This fixes the issue by setting the correct default value `false` in case the flag is not present.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The `bin/console user:create` command always created a new user with admin rights, even if the admin flag is not set.


### 2. What does this change do, exactly?
This fixes the issue by setting the correct default value `false` in case the flag is not present.


### 3. Describe each step to reproduce the issue or behaviour.
Create an new user with `bin/console user:create` without passing the admin flag and check the permissions of the resulting user.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
