### PR TITLE
 Increase cookie lifetime

### DIFF
--- a/src/Recovery/Install/src/app.php
+++ b/src/Recovery/Install/src/app.php
@@ -35,7 +35,7 @@ function getApplication(KernelInterface $kernel): App
 
         if (!headers_sent()) {
             if (session_status() !== \PHP_SESSION_ACTIVE) {
-                session_set_cookie_params(600, $sessionPath);
+                session_set_cookie_params(1800, $sessionPath);
             }
 
             @session_start();


### PR DESCRIPTION
The installation can take more than 10 minutes, therefore a longer lifetime would be good.

### 1. Why is this change necessary?
When the installation takes more than 10 Minutes, especially during database tasks, the installation throws an error.

### 2. What does this change do, exactly?
Increase cookie lifetime from 600 to 1800.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
