### PR TITLE
Make ignorable-tables optional, ignore dead_message by default, use --hex-blob dump

### DIFF
--- a/changelog/_unreleased/2021-11-05-add-ignorable-tables-system-dump-option,-ignore-dead_message-by-default-and-use-hex-blob-dump.md
+++ b/changelog/_unreleased/2021-11-05-add-ignorable-tables-system-dump-option,-ignore-dead_message-by-default-and-use-hex-blob-dump.md
@@ -1,0 +1,10 @@
+---
+title: Add ignorable-tables system:dump option, ignore dead_message by default and use --hex-blob dump
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added option `ignore-tables` in `system:dump` to allow better re-usage in non e2e cases
+* Added `dead_message` table as default ignored table on dump `system:dump`
+* Added `--hex-blob` option to mysqldump to ensure correct encoding for blob values like primary keys as the command output is running through a shell pipe which can break binary content

--- a/src/Core/DevOps/System/Command/SystemDumpDatabaseCommand.php
+++ b/src/Core/DevOps/System/Command/SystemDumpDatabaseCommand.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\DevOps\System\Command;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class SystemDumpDatabaseCommand extends Command
@@ -33,13 +34,12 @@ class SystemDumpDatabaseCommand extends Command
 
         file_put_contents($path, 'SET unique_checks=0;SET foreign_key_checks=0;');
         $cmd = sprintf(
-            'mysqldump -u %s -p%s -h %s --port=%s -q --opt --no-autocommit --ignore-table %s --ignore-table %s %s >> %s',
+            'mysqldump -u %s -p%s -h %s --port=%s -q --opt --hex-blob --no-autocommit %s %s >> %s',
             escapeshellarg($params['user']),
             escapeshellarg($params['password']),
             escapeshellarg($params['host']),
             escapeshellarg((string) $params['port']),
-            escapeshellarg($dbName . '.enqueue'),
-            escapeshellarg($dbName . '.message_queue_stats'),
+            $this->getIgnoreTableStmt((array) $input->getOption('ignore-table'), $dbName),
             escapeshellarg($dbName),
             escapeshellarg($path)
         );
@@ -48,5 +48,24 @@ class SystemDumpDatabaseCommand extends Command
         system($cmd, $returnCode);
 
         return $returnCode;
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('ignore-table', 'i', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Tables to ignore on export', ['enqueue', 'message_queue_stats', 'dead_message']);
+    }
+
+    protected function getIgnoreTableStmt(array $ignorableTables, string $dbName): string
+    {
+        $ignorableTables = \array_filter($ignorableTables);
+
+        if ($ignorableTables === []) {
+            return '';
+        }
+
+        return \implode(' ', \array_map(
+            static fn (string $table): string => '--ignore-table ' . \escapeshellarg($dbName . '.' . $table),
+            $ignorableTables
+        ));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
* --hex-blob ensures that at least ids are not breaking in some shells
* when you ignore enqueue and message_queue_stats, you should ignore dead_message as well
* When the ignored tables are not configurable it is not easy to re-use. But I'd like to

### 2. What does this change do, exactly?
Add an option to the system:dump command to define the ignored tables.
Add the item dead_messages to the ignored table list.
Add --hex-blob as parameter in the mysqldump shell command.

### 3. Describe each step to reproduce the issue or behaviour.
1. Register command in production template
2. Dump setup that uses enqueue table
3. Look into dump to read old messages
4. enqueue table is missing

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
