### PR TITLE
feat: Add event to validate the cart before creating an order

### DIFF
--- a/changelog/_unreleased/2021-11-05-add-event-to-validate-the-cart-before-creating-an-order.md
+++ b/changelog/_unreleased/2021-11-05-add-event-to-validate-the-cart-before-creating-an-order.md
@@ -1,0 +1,8 @@
+---
+title: Add event to validate the cart before creating an order
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Add event `Shopware\Core\Checkout\Order\Event\OrderCartValidationEvent` to validate the cart before creating an order

--- a/src/Core/Checkout/Order/Event/OrderCartValidationEvent.php
+++ b/src/Core/Checkout/Order/Event/OrderCartValidationEvent.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Order\Event;
+
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class OrderCartValidationEvent extends Event implements ShopwareSalesChannelEvent
+{
+    private Cart $cart;
+
+    private SalesChannelContext $context;
+
+    public function __construct(Cart $cart, SalesChannelContext $context)
+    {
+        $this->cart = $cart;
+        $this->context = $context;
+    }
+
+    public function getCart(): Cart
+    {
+        return $this->cart;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->context;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to validate the cart using an event before the order is created in the order service. Only the event `order.create` exists where it is not possible to access the cart. Due to the structure of the current code I decided to add an additional event.

### 2. What does this change do, exactly?
Add the event `Shopware\Core\Checkout\Order\Event\OrderCartValidationEvent`

### 3. Describe each step to reproduce the issue or behaviour.
No issue.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
