### PR TITLE
SEO tools (and google?) don't like spaces in title

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/meta.html.twig
@@ -98,11 +98,11 @@
         {% endblock %}
 
         {% block layout_head_title %}
-            <title itemprop="name">
-                {% block layout_head_title_inner %}{% apply spaceless %}
+            <title itemprop="name">{% apply spaceless %}
+                {% block layout_head_title_inner %}
                     {{ metaTitle }}
-                {% endapply %}{% endblock %}
-            </title>
+                {% endblock %}
+            {% endapply %}</title>
         {% endblock %}
 
         {% block layout_head_stylesheet %}


### PR DESCRIPTION
### 1. Why is this change necessary?
SEO tools and google don't like spaces in <title> tag.

### 2. What does this change do, exactly?
Make sure that before and after the title no superflous spaces exist

### 3. Describe each step to reproduce the issue or behaviour.
Have a look on https://demoshops.splendid-internet.de/shopware/demoshop-shopware6-daily/Aerodynamic-Aluminum-Hercules-Jerky/c2fc78a37f3f4fc88503e7e3803ac31a

The title looks like this:
```
<title itemprop="name">
                    Aerodynamic Aluminum Hercules Jerky | c2fc78a37f3f4fc88503e7e3803ac31a            </title>
```

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
