### PR TITLE
perf: check selector for better dom-selector in plugin registration

### DIFF
--- a/changelog/_unreleased/2021-11-12-check-selector-for-better-dom-selector-in-plugin-registration.md
+++ b/changelog/_unreleased/2021-11-12-check-selector-for-better-dom-selector-in-plugin-registration.md
@@ -1,0 +1,11 @@
+---
+title: Check selector for better dom-selector in plugin registration
+issue: 
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+# Storefront
+* Added private method `_queryElements` to `plugin.manager` to determ the best dom-selector based on common characters `a-zA-Z1-9_-`
+* Changed private method `_initializePlugin` to use private method `queryElements` when selector is a string
+


### PR DESCRIPTION
### 1. Why is this change necessary?
The current JS-plugin-registration in storefront uses querySelectorAll which is the slowest in any case.

With this change, we could promote add and using id- or classes-selectors for better performance.

Additional note: In our project we are using related elements directly in plugin-registration instead of string, but this doesn't work for re-initializing plugin, if complete element has been replaced by ajax.

### 2. What does this change do, exactly?
Added checks for the selector given as string and decide a better selector.
Due to performance and common usages, I'm just considering `\w-` (= `a-zA-Z1-9_-`) for regex. Others like umlauts and other special chars will fail over to the querySelectorAll.

### 3. Describe each step to reproduce the issue or behaviour.
Regex-test for id: https://regex101.com/r/ydYKjX/4

It's hard to describe... let pictures show it:

> Please note: these tests with firefox (chrome is similar) are based on a shop, not just a small dom-collection.

Selector by data-attribute (sure, a LITTLE bit slower):
![image](https://user-images.githubusercontent.com/135993/141480260-2e4e2bb8-286e-43ac-9390-399ce57f36d8.png)

Selector by ID (existing element):
![image](https://user-images.githubusercontent.com/135993/141480474-78c0e493-231e-4813-9c28-38232f3355fc.png)

selector by class (existing element):
![image](https://user-images.githubusercontent.com/135993/141485793-b22f6a20-8e2e-4e26-b117-28bb155ae066.png)


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
