### PR TITLE
Add BuildValidationEvent to NewsletterSubscribeRoute

### DIFF
--- a/changelog/_unreleased/2021-11-16-add-new-buildvalidationevent-to-newslettersubscriberoute.md
+++ b/changelog/_unreleased/2021-11-16-add-new-buildvalidationevent-to-newslettersubscriberoute.md
@@ -1,0 +1,9 @@
+---
+title: Add new BuildValidationEvent to NewsletterSubscribeRoute
+issue: 
+author: Philipp von Wedel
+author_email: philipp@plugware.io
+author_github: @plugware
+---
+# Core
+* Changed `Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute::getOptInValidator` to add new `Shopware\Core\Framework\Validation\BuildValidationEvent`.

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
@@ -18,6 +18,8 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Framework\Validation\BuildValidationEvent;
+use Shopware\Core\Framework\Validation\DataBag\DataBag;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidator;
@@ -273,6 +275,9 @@ The subscription is only successful, if the /newsletter/confirm route is called 
             $definition
                 ->add('storefrontUrl', new NotBlank(), new Choice(array_values($this->getDomainUrls($context))));
         }
+
+        $validationEvent = new BuildValidationEvent($definition, new DataBag(), $context->getContext());
+        $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         return $definition;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Add possibility to extend validator definition at newsletter subscription.

### 2. What does this change do, exactly?
Add `Shopware\Core\Framework\Validation\BuildValidationEvent` to `Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute::getOptInValidator`

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
