### PR TITLE
Bugfix for Affiliate Marketing in Registration

### DIFF
--- a/changelog/_unreleased/2021-11-18-bugfix-for-affiliate-marketing-in-registration.md
+++ b/changelog/_unreleased/2021-11-18-bugfix-for-affiliate-marketing-in-registration.md
@@ -1,0 +1,8 @@
+---
+title: Bugfix for Affiliate Marketing in Registration
+author: Novusvetus / Marcel Rudolf 
+author_github: Novusvetus
+---
+# Storefront
+*  Changed `src/Storefront/Controller/RegisterController.php`, that only one of the affiliate code and the campaign code is necessary for the  data to be saved during registration.
+___

--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -331,11 +331,12 @@ class RegisterController extends StorefrontController
     {
         $affiliateCode = $session->get(AffiliateTrackingListener::AFFILIATE_CODE_KEY);
         $campaignCode = $session->get(AffiliateTrackingListener::CAMPAIGN_CODE_KEY);
-        if ($affiliateCode !== null && $campaignCode !== null) {
-            $data->add([
-                AffiliateTrackingListener::AFFILIATE_CODE_KEY => $affiliateCode,
-                AffiliateTrackingListener::CAMPAIGN_CODE_KEY => $campaignCode,
-            ]);
+        if ($affiliateCode) {
+            $data->set(AffiliateTrackingListener::AFFILIATE_CODE_KEY, $affiliateCode);
+        }
+
+        if ($campaignCode) {
+            $data->set(AffiliateTrackingListener::CAMPAIGN_CODE_KEY, $campaignCode);
         }
 
         return $data;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Contrary to what is described in the documentation (https://docs.shopware.com/en/shopware-6-en/tutorials-and-faq/affiliateprogram), you have to specify both marketing codes in order for them to be saved during registration.

### 2. What does this change do, exactly?
It ensures that even one specified parameter is stored.

### 3. Describe each step to reproduce the issue or behaviour.
Add only affiliateCode or campaignCode parameter to teh URL and register an account.
You can't see the parameter at the customer.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
