### PR TITLE
[BUGFIX] Throw exception for requests in broken test environment

### DIFF
--- a/changelog/_unreleased/2021-11-21-throw-exception-for-requests-in-broken-test-environment.md
+++ b/changelog/_unreleased/2021-11-21-throw-exception-for-requests-in-broken-test-environment.md
@@ -1,0 +1,9 @@
+---
+title: Throw exception for requests in broken test environment
+issue: NEXT-18917
+author: Andreas Fernandez
+author_email: a.fernandez@scripting-base.de
+author_github: andreasfernandez
+---
+# Core
+* Changed `Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour` to throw an exception if the request in `assignSalesChannelContext()` is erroneous

--- a/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
@@ -286,6 +286,9 @@ trait SalesChannelApiTestBehaviour
         $browser->request('GET', '/store-api/context');
         $response = $browser->getResponse();
         $content = json_decode($response->getContent(), true);
+        if (isset($content['errors'])) {
+            throw new \RuntimeException($content['errors'][0]['detail']);
+        }
         $browser->setServerParameter('HTTP_SW_CONTEXT_TOKEN', $content['token']);
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
In case the testing environment is broken (e.g. missing JWT secrets, invalid .env.test file), the request done in `Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour::assignSalesChannelContext()` returns an error, but the code expects a `token`, leading to following issue:
```
ErrorException: Notice: Undefined index: token

vendor/shopware/core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php:289
```

This hides the real issue and makes debugging hard.

### 2. What does this change do, exactly?
The response is now checked for an `error` item. If such an item exists, an exception is thrown containing the message of the very first error.

### 3. Describe each step to reproduce the issue or behaviour.
After upgrading Shopware from 6.3 to 6.4, I missed `MAILER_DSN` in my .env.test file. The following shortened code revealed the issue:
```php
class RegisterRouteDecoratorTest extends TestCase
{
    use IntegrationTestBehaviour;
    use SalesChannelApiTestBehaviour;
    use CountryAddToSalesChannelTestBehaviour;

    protected function setUp(): void
    {
        $this->ids = new TestDataCollection(Context::createDefaultContext());
        $this->browser = $this->createCustomSalesChannelBrowser([
            'id' => $this->ids->create('sales-channel'),
        ]);
    }

    public function testRegistrationOfUser(): void
    {
        $this->browser->request(
            'POST',
            '/store-api/account/register',
            [],
            [],
            ['CONTENT_TYPE' => 'application/json'],
            json_encode($this->getRegistrationData(), JSON_THROW_ON_ERROR)
        );
        $response = json_decode($this->browser->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
    }
}
```

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.