### PR TITLE
Feature/plugin list json

### DIFF
--- a/changelog/_unreleased/2021-11-23-plugin-list-json.md
+++ b/changelog/_unreleased/2021-11-23-plugin-list-json.md
@@ -1,0 +1,14 @@
+---
+title: bin/console plugin:list machine readable
+issue: NEXT-10723
+author: Fabian Blechschmidt
+author_github: @Schrank
+---
+# Core
+* Add option `--json` to `bin/console plugin:list`
+___
+# Upgrade Information
+
+## New option for plugins
+It is now possible to retriebe the plugin information in JSON format to easier parse it,
+e.g. in deployment or other CI processes.

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -63,7 +63,7 @@ class PluginListCommand extends Command
         $plugins = $this->pluginRepo->search($criteria, $context)->getEntities();
 
         if ($input->getOption('json')) {
-            $output->write(json_encode($plugins, JSON_THROW_ON_ERROR));
+            $output->write(json_encode($plugins, \JSON_THROW_ON_ERROR));
             return self::SUCCESS;
         }
 

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -36,6 +36,7 @@ class PluginListCommand extends Command
     {
         $this
             ->setDescription('Show a list of available plugins.')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Return result as json of plugin entities')
             ->addOption('filter', 'f', InputOption::VALUE_REQUIRED, 'Filter the plugin list to a given term');
     }
 
@@ -60,6 +61,11 @@ class PluginListCommand extends Command
         }
         /** @var PluginCollection $plugins */
         $plugins = $this->pluginRepo->search($criteria, $context)->getEntities();
+
+        if ($input->getOption('json')) {
+            $output->write(json_encode($plugins, JSON_THROW_ON_ERROR));
+            return self::SUCCESS;
+        }
 
         $pluginTable = [];
         $active = $installed = $upgradeable = 0;

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -64,6 +64,7 @@ class PluginListCommand extends Command
 
         if ($input->getOption('json')) {
             $output->write(json_encode($plugins, \JSON_THROW_ON_ERROR));
+
             return self::SUCCESS;
         }
 

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -45,14 +45,11 @@ class PluginListCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new ShopwareStyle($input, $output);
-        $io->title('Shopware Plugin Service');
         $context = Context::createDefaultContext();
 
         $criteria = new Criteria();
         $filter = $input->getOption('filter');
         if ($filter) {
-            $io->comment(sprintf('Filtering for: %s', $filter));
-
             $criteria->addFilter(new MultiFilter(
                 MultiFilter::CONNECTION_OR,
                 [
@@ -66,6 +63,12 @@ class PluginListCommand extends Command
 
         $pluginTable = [];
         $active = $installed = $upgradeable = 0;
+
+        $io->title('Shopware Plugin Service');
+
+        if ($filter) {
+            $io->comment(sprintf('Filtering for: %s', $filter));
+        }
 
         foreach ($plugins as $plugin) {
             $pluginActive = $plugin->getActive();

--- a/src/Core/Framework/Test/Plugin/Command/PluginListCommandTest.php
+++ b/src/Core/Framework/Test/Plugin/Command/PluginListCommandTest.php
@@ -86,6 +86,7 @@ class PluginListCommandTest extends TestCase
             if (!(\count($filters) === 1 && $filters[0] instanceof MultiFilter)) {
                 return false;
             }
+            /** @var MultiFilter $filter */
             $filter = $filters[0];
             // must be OR
             if ($filter->getOperator() !== MultiFilter::CONNECTION_OR) {
@@ -93,6 +94,7 @@ class PluginListCommandTest extends TestCase
             }
             $fields = ['name', 'label'];
             foreach ($filter->getQueries() as $query) {
+                /** @var ContainsFilter $query */
                 if (!(
                     $query instanceof ContainsFilter
                     && $query->getValue() === $filterValue

--- a/src/Core/Framework/Test/Plugin/Command/PluginListCommandTest.php
+++ b/src/Core/Framework/Test/Plugin/Command/PluginListCommandTest.php
@@ -136,8 +136,8 @@ class PluginListCommandTest extends TestCase
         $json = json_encode([$o1, $o2], \JSON_THROW_ON_ERROR);
 
         $commandTester = $this->executeCommand($options);
-        $this->assertSame(0, $commandTester->getStatusCode());
-        $this->assertSame($json, trim($commandTester->getDisplay()));
+        static::assertSame(0, $commandTester->getStatusCode());
+        static::assertSame($json, trim($commandTester->getDisplay()));
     }
 
     private function executeCommand(array $options): CommandTester

--- a/src/Core/Framework/Test/Plugin/Command/PluginListCommandTest.php
+++ b/src/Core/Framework/Test/Plugin/Command/PluginListCommandTest.php
@@ -22,6 +22,7 @@ class PluginListCommandTest extends TestCase
      * @var MockObject|EntityRepository
      */
     private $pluginRepoMock;
+
     private PluginListCommand $command;
 
     protected function setUp(): void
@@ -35,26 +36,26 @@ class PluginListCommandTest extends TestCase
     {
         $entities = [
             $this->createMock(PluginEntity::class),
-            $this->createMock(PluginEntity::class)
+            $this->createMock(PluginEntity::class),
         ];
         $config = [
             [
-                'getActive'         => true,
-                'getInstalledAt'    => new \DateTimeImmutable('2004-01-01T00:00:00.000001Z'),
+                'getActive' => true,
+                'getInstalledAt' => new \DateTimeImmutable('2004-01-01T00:00:00.000001Z'),
                 'getUpgradeVersion' => '3.0.1',
-                'getName'           => 'Plugin List Plugin',
-                'getLabel'          => 'plp',
-                'getVersion'        => '2.5.3',
-                'getAuthor'         => 'Fabian Blechschmidt',
+                'getName' => 'Plugin List Plugin',
+                'getLabel' => 'plp',
+                'getVersion' => '2.5.3',
+                'getAuthor' => 'Fabian Blechschmidt',
             ],
             [
-                'getActive'         => false,
-                'getInstalledAt'    => new \DateTimeImmutable('2019-05-23T00:00:00.000001Z'),
+                'getActive' => false,
+                'getInstalledAt' => new \DateTimeImmutable('2019-05-23T00:00:00.000001Z'),
                 'getUpgradeVersion' => '6.0.0',
-                'getName'           => 'Shopware Next',
-                'getLabel'          => 'swn',
-                'getVersion'        => '5.5.3',
-                'getAuthor'         => 'Shopware AG',
+                'getName' => 'Shopware Next',
+                'getLabel' => 'swn',
+                'getVersion' => '5.5.3',
+                'getAuthor' => 'Shopware AG',
             ],
         ];
 
@@ -68,8 +69,8 @@ class PluginListCommandTest extends TestCase
         $this->setupEntityCollection($entities);
 
         [$statusCode, $output] = $this->executeCommand([]);
-        $this->assertSame(0, $statusCode);
-        $this->assertStringEqualsFile(
+        static::assertSame(0, $statusCode);
+        static::assertStringEqualsFile(
             __DIR__ . '/../_assertion/PluginListCommandTest::testCommand.txt',
             implode("\n", array_map('trim', explode("\n", $output))) . "\n"
         );
@@ -79,10 +80,10 @@ class PluginListCommandTest extends TestCase
     {
         $filterValue = 'shopware-is-love';
 
-        $criteria = $this->callback(function (Criteria $criteria) use ($filterValue): bool {
+        $criteria = static::callback(function (Criteria $criteria) use ($filterValue): bool {
             $filters = $criteria->getFilters();
             // must be MultiFilter
-            if (!(count($filters) === 1 && $filters[0] instanceof MultiFilter)) {
+            if (!(\count($filters) === 1 && $filters[0] instanceof MultiFilter)) {
                 return false;
             }
             $filter = $filters[0];
@@ -92,8 +93,8 @@ class PluginListCommandTest extends TestCase
             }
             $fields = ['name', 'label'];
             foreach ($filter->getQueries() as $query) {
-                if (!
-                ($query instanceof ContainsFilter
+                if (!(
+                    $query instanceof ContainsFilter
                     && $query->getValue() === $filterValue
                     // first test against name, then label
                     && $query->getField() === array_shift($fields)
@@ -102,14 +103,15 @@ class PluginListCommandTest extends TestCase
                     return false;
                 }
             }
+
             return true;
         });
 
-        $this->pluginRepoMock->method('search')->with($criteria, $this->anything());
+        $this->pluginRepoMock->method('search')->with($criteria, static::anything());
 
         [$statusCode, $output] = $this->executeCommand(['--filter' => $filterValue]);
-        $this->assertSame(0, $statusCode);
-        $this->assertStringContainsString('Filtering for: ' . $filterValue, $output);
+        static::assertSame(0, $statusCode);
+        static::assertStringContainsString('Filtering for: ' . $filterValue, $output);
     }
 
     public function testJsonOutput(): void
@@ -119,7 +121,7 @@ class PluginListCommandTest extends TestCase
 
         $entities = [
             $plugin1 = $this->createMock(PluginEntity::class),
-            $plugin2 = $this->createMock(PluginEntity::class)
+            $plugin2 = $this->createMock(PluginEntity::class),
         ];
 
         $plugin1->method('jsonSerialize')->willReturn($o1);
@@ -128,9 +130,9 @@ class PluginListCommandTest extends TestCase
         $this->setupEntityCollection($entities);
 
         $options = ['--json' => true];
-        $json = json_encode([$o1, $o2], JSON_THROW_ON_ERROR);
+        $json = json_encode([$o1, $o2], \JSON_THROW_ON_ERROR);
         $expected = [0, $json];
-        $this->assertSame($expected, $this->executeCommand($options));
+        static::assertSame($expected, $this->executeCommand($options));
     }
 
     private function executeCommand(array $options): array

--- a/src/Core/Framework/Test/Plugin/Command/PluginListCommandTest.php
+++ b/src/Core/Framework/Test/Plugin/Command/PluginListCommandTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Plugin\Command;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\Plugin\Command\PluginListCommand;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class PluginListCommandTest extends TestCase
+{
+    /**
+     * @var MockObject|EntityRepository
+     */
+    private $pluginRepoMock;
+    private PluginListCommand $command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->pluginRepoMock = $this->createMock(EntityRepository::class);
+        $this->command = new PluginListCommand($this->pluginRepoMock);
+    }
+
+    public function testCommand(): void
+    {
+        $entities = [
+            $this->createMock(PluginEntity::class),
+            $this->createMock(PluginEntity::class)
+        ];
+        $config = [
+            [
+                'getActive'         => true,
+                'getInstalledAt'    => new \DateTimeImmutable('2004-01-01T00:00:00.000001Z'),
+                'getUpgradeVersion' => '3.0.1',
+                'getName'           => 'Plugin List Plugin',
+                'getLabel'          => 'plp',
+                'getVersion'        => '2.5.3',
+                'getAuthor'         => 'Fabian Blechschmidt',
+            ],
+            [
+                'getActive'         => false,
+                'getInstalledAt'    => new \DateTimeImmutable('2019-05-23T00:00:00.000001Z'),
+                'getUpgradeVersion' => '6.0.0',
+                'getName'           => 'Shopware Next',
+                'getLabel'          => 'swn',
+                'getVersion'        => '5.5.3',
+                'getAuthor'         => 'Shopware AG',
+            ],
+        ];
+
+        foreach ($config as $number => $methods) {
+            foreach ($methods as $method => $value) {
+                $plugin = $entities[$number];
+                $plugin->method($method)->willReturn($value);
+            }
+        }
+
+        $this->setupEntityCollection($entities);
+
+        [$statusCode, $output] = $this->executeCommand([]);
+        $this->assertSame(0, $statusCode);
+        $this->assertStringEqualsFile(
+            __DIR__ . '/../_assertion/PluginListCommandTest::testCommand.txt',
+            implode("\n", array_map('trim', explode("\n", $output))) . "\n"
+        );
+    }
+
+    public function testFilter(): void
+    {
+        $filterValue = 'shopware-is-love';
+
+        $criteria = $this->callback(function (Criteria $criteria) use ($filterValue): bool {
+            $filters = $criteria->getFilters();
+            // must be MultiFilter
+            if (!(count($filters) === 1 && $filters[0] instanceof MultiFilter)) {
+                return false;
+            }
+            $filter = $filters[0];
+            // must be OR
+            if ($filter->getOperator() !== MultiFilter::CONNECTION_OR) {
+                return false;
+            }
+            $fields = ['name', 'label'];
+            foreach ($filter->getQueries() as $query) {
+                if (!
+                ($query instanceof ContainsFilter
+                    && $query->getValue() === $filterValue
+                    // first test against name, then label
+                    && $query->getField() === array_shift($fields)
+                )
+                ) {
+                    return false;
+                }
+            }
+            return true;
+        });
+
+        $this->pluginRepoMock->method('search')->with($criteria, $this->anything());
+
+        [$statusCode, $output] = $this->executeCommand(['--filter' => $filterValue]);
+        $this->assertSame(0, $statusCode);
+        $this->assertStringContainsString('Filtering for: ' . $filterValue, $output);
+    }
+
+    public function testJsonOutput(): void
+    {
+        $o1 = ['PLUGIN1'];
+        $o2 = ['PLUGIN2'];
+
+        $entities = [
+            $plugin1 = $this->createMock(PluginEntity::class),
+            $plugin2 = $this->createMock(PluginEntity::class)
+        ];
+
+        $plugin1->method('jsonSerialize')->willReturn($o1);
+        $plugin2->method('jsonSerialize')->willReturn($o2);
+
+        $this->setupEntityCollection($entities);
+
+        $options = ['--json' => true];
+        $json = json_encode([$o1, $o2], JSON_THROW_ON_ERROR);
+        $expected = [0, $json];
+        $this->assertSame($expected, $this->executeCommand($options));
+    }
+
+    private function executeCommand(array $options): array
+    {
+        $commandTester = new CommandTester($this->command);
+        $commandTester->execute($options);
+
+        return [$commandTester->getStatusCode(), trim($commandTester->getDisplay())];
+    }
+
+    private function setupEntityCollection(array $entities): void
+    {
+        $collection = $this->createMock(EntityCollection::class);
+        $collection->method('jsonSerialize')->willReturn($entities);
+        $collection->method('getIterator')->willReturn($this->arrayAsGenerator($entities));
+        $result = $this->createMock(EntitySearchResult::class);
+        $result->method('getEntities')->willReturn($collection);
+        $this->pluginRepoMock->method('search')->willReturn($result);
+    }
+
+    private function arrayAsGenerator(array $array): \Generator
+    {
+        foreach ($array as $item) {
+            yield $item;
+        }
+    }
+}

--- a/src/Core/Framework/Test/Plugin/Command/PluginListCommandTest.php
+++ b/src/Core/Framework/Test/Plugin/Command/PluginListCommandTest.php
@@ -68,11 +68,11 @@ class PluginListCommandTest extends TestCase
 
         $this->setupEntityCollection($entities);
 
-        [$statusCode, $output] = $this->executeCommand([]);
-        static::assertSame(0, $statusCode);
+        $commandTester = $this->executeCommand([]);
+        static::assertSame(0, $commandTester->getStatusCode());
         static::assertStringEqualsFile(
             __DIR__ . '/../_assertion/PluginListCommandTest::testCommand.txt',
-            implode("\n", array_map('trim', explode("\n", $output))) . "\n"
+            implode("\n", array_map('trim', explode("\n", trim($commandTester->getDisplay())))) . "\n"
         );
     }
 
@@ -111,9 +111,10 @@ class PluginListCommandTest extends TestCase
 
         $this->pluginRepoMock->method('search')->with($criteria, static::anything());
 
-        [$statusCode, $output] = $this->executeCommand(['--filter' => $filterValue]);
-        static::assertSame(0, $statusCode);
-        static::assertStringContainsString('Filtering for: ' . $filterValue, $output);
+        $commandTester = $this->executeCommand(['--filter' => $filterValue]);
+
+        static::assertSame(0, $commandTester->getStatusCode());
+        static::assertStringContainsString('Filtering for: ' . $filterValue, trim($commandTester->getDisplay()));
     }
 
     public function testJsonOutput(): void
@@ -133,16 +134,18 @@ class PluginListCommandTest extends TestCase
 
         $options = ['--json' => true];
         $json = json_encode([$o1, $o2], \JSON_THROW_ON_ERROR);
-        $expected = [0, $json];
-        static::assertSame($expected, $this->executeCommand($options));
+
+        $commandTester = $this->executeCommand($options);
+        $this->assertSame(0, $commandTester->getStatusCode());
+        $this->assertSame($json, trim($commandTester->getDisplay()));
     }
 
-    private function executeCommand(array $options): array
+    private function executeCommand(array $options): CommandTester
     {
         $commandTester = new CommandTester($this->command);
         $commandTester->execute($options);
 
-        return [$commandTester->getStatusCode(), trim($commandTester->getDisplay())];
+        return $commandTester;
     }
 
     private function setupEntityCollection(array $entities): void

--- a/src/Core/Framework/Test/Plugin/_assertion/PluginListCommandTest::testCommand.txt
+++ b/src/Core/Framework/Test/Plugin/_assertion/PluginListCommandTest::testCommand.txt
@@ -1,0 +1,11 @@
+Shopware Plugin Service
+=======================
+
+-------------------- ------- --------- ----------------- --------------------- ----------- -------- -------------
+Plugin               Label   Version   Upgrade version   Author                Installed   Active   Upgradeable
+-------------------- ------- --------- ----------------- --------------------- ----------- -------- -------------
+Plugin List Plugin   plp     2.5.3     3.0.1             Fabian Blechschmidt   Yes         Yes      Yes
+Shopware Next        swn     5.5.3     6.0.0             Shopware AG           Yes         No       Yes
+-------------------- ------- --------- ----------------- --------------------- ----------- -------- -------------
+
+0 plugins, 2 installed, 1 active , 2 upgradeable


### PR DESCRIPTION
### 1. Why is this change necessary?

We are using plugin:list in deployer recipe and currently parsing the table which is pretty awful, annoying and error prone.


### 2. What does this change do, exactly?
Add `--json` option to plugin:list which returns the while pluginCollection as json

### 3. Describe each step to reproduce the issue or behaviour.

    bin/console plugin:list --json

### 4. Please link to the relevant issues (if any).
[NEXT-10723 | bin/console plugin:list machine readable](https://issues.shopware.com/issues/NEXT-10723)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
