### PR TITLE
NEXT-18953 Always remove required property

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -817,7 +817,7 @@ Component.register('sw-category-detail', {
                             if (configField.entity) {
                                 delete configField.entity;
                             }
-                            if (configField.required) {
+                            if (configField.hasOwnProperty('required')) {
                                 delete configField.required;
                             }
                             if (configField.type) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
@@ -236,7 +236,7 @@ Component.register('sw-cms-sidebar', {
                     if (configField.entity) {
                         delete configField.entity;
                     }
-                    if (configField.required) {
+                    if (configField.hasOwnProperty('required')) {
                         delete configField.required;
                     }
                 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -772,7 +772,7 @@ Component.register('sw-cms-detail', {
                             if (configField.entity) {
                                 delete configField.entity;
                             }
-                            if (configField.required) {
+                            if (configField.hasOwnProperty('required')) {
                                 delete configField.required;
                             }
                         });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -1033,7 +1033,7 @@ Component.register('sw-product-detail', {
                             if (configField.entity) {
                                 delete configField.entity;
                             }
-                            if (configField.required) {
+                            if (configField.hasOwnProperty('required')) {
                                 delete configField.required;
                             }
                             if (configField.type) {


### PR DESCRIPTION
### 1. Why is this change necessary?
For example you have a custom slot, with media required false, the required property is not removed before saving to the API and will fail to save.
That's because `required: false`, will evaluate to false, it should always remove it, because its not allowed in the API.

`
slots: {
        image: {
            type: 'image',
            default: {
                config: {
                    displayMode: { source: 'static', value: 'standard' },
                    media: {
                        required: false,
                    },
                },
                data: {
                    media: {
                        url: '/administration/static/img/cms/preview_mountain_large.jpg',
                    },
                },
            },
        },
    },
`

### 2. What does this change do, exactly?
It always removes the required property before doing a save action.

### 3. Describe each step to reproduce the issue or behaviour.
Create a custom CmsBlock with for example an image that is not required.
Try to save it, you will get a 400, that the required property is not allowed in the data.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-18953

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
