### PR TITLE
feat: Allow target attribute in snippets

### DIFF
--- a/changelog/_unreleased/2021-11-24-allow-target-attribute-in-snippets.md
+++ b/changelog/_unreleased/2021-11-24-allow-target-attribute-in-snippets.md
@@ -1,0 +1,8 @@
+---
+title: Allow target attribute in snippets
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Allow target attribute in snippets

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-detail/index.js
@@ -212,7 +212,7 @@ Component.register('sw-settings-snippet-detail', {
                 if (!snippet.author) {
                     snippet.author = this.currentAuthor;
                 }
-                snippet.value = Sanitizer.sanitize(snippet.value);
+                snippet.value = Sanitizer.sanitize(snippet.value, { ADD_ATTR: ['target'] });
 
                 if (!snippet.hasOwnProperty('value') || snippet.value === null) {
                     // If you clear the input-box, reset it to its origin value


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to define links which open in a new window using the snippets. If one wants to accomplish such a snippet the snippet has to be divided into several snippets, which makes it very cumbersome to work with them.

### 2. What does this change do, exactly?
Allow the target attribute for snippets.

### 3. Describe each step to reproduce the issue or behaviour.
Try to create a snippet which contains something like: `<a href="..." target="_blank" rel="noopener">Foobar</a>`. Without this PR currently the `target="_blank"` part is removed.

Note I do not explicitly check that the `rel` attribute is set, see https://web.dev/external-anchors-use-rel-noopener/ since it could also be a link linking to an internal page or so.

### 4. Please link to the relevant issues (if any).
https://forum.shopware.com/t/externer-link-im-sw6-target-geht-nicht/71332

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
