### PR TITLE
Fix demodata generation for orders

### DIFF
--- a/changelog/_unreleased/2021-11-25-fix-order-generation-in-demodata.md
+++ b/changelog/_unreleased/2021-11-25-fix-order-generation-in-demodata.md
@@ -1,0 +1,9 @@
+---
+title: Fix order generation in demodata
+issue: NEXT-17712
+author: Maximilian Ruesch
+author_email: maximilian.ruesch@pickware.de
+author_github: maximilianruesch
+---
+# Core
+* Changed the `OrderGenerator` to set the shipping method in the `Cart` to the shipping method of the randomly selected sales channel.

--- a/src/Core/Framework/Demodata/Generator/OrderGenerator.php
+++ b/src/Core/Framework/Demodata/Generator/OrderGenerator.php
@@ -145,7 +145,12 @@ SQL;
             $new = $blueprint->getLineItems()->slice($offset, $itemCount);
 
             $cart = $this->cartService->createNew($salesChannelContext->getToken(), 'demo-data');
-            $cart->setData($blueprint->getData());
+
+            $dataCollection = $blueprint->getData();
+            $shippingMethod = $salesChannelContext->getShippingMethod();
+            $dataCollection->set(DeliveryProcessor::buildKey($shippingMethod->getId()), $shippingMethod);
+            $cart->setData($dataCollection);
+
             $cart->addLineItems($new);
             $cart->addExtension(OrderConverter::ORIGINAL_ORDER_NUMBER, new IdStruct(Uuid::randomHex()));
             $cart->setTransactions($blueprint->getTransactions());


### PR DESCRIPTION
### 1. Why is this change necessary?

This fixes a bug in the order generation which causes it to fail with the following exception message: `Shipping method with id "..." not found.`. This is due to the sales channel context for the generation being selected randomly which may contain a different shipping method than the order blueprint configured at the start of the generation.

### 2. What does this change do, exactly?

Previously, data was just copied from the order blueprint to the currently created cart. Now data is copied and the shipping method is changed to fit the one in the currently used sales channel context

### 3. Describe each step to reproduce the issue or behaviour.

Try to generate several orders with multiple sales channels and shipping methods.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-17712

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
