### PR TITLE
BUGFIX | Amount constraint.

### DIFF
--- a/src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
@@ -54,7 +54,7 @@ class LineItemListPriceRule extends Rule
     public function getConstraints(): array
     {
         return [
-            'amount' => [new NotBlank(), new Type('numeric')],
+            'amount' => [new Type('numeric')],
             'operator' => [
                 new NotBlank(),
                 new Choice(


### PR DESCRIPTION

### 1. Why is this change necessary?
Amount needs to be blank / empty if OPERATOR_EMPTY is used.

### 2. What does this change do, exactly?
Fixes a bug, that rules cannot be saved if "Streichpreis ist leer" rule is used.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
