### PR TITLE
Added translations for showing more or less information of a lineItem…

### DIFF
--- a/changelog/_unreleased/2021-11-26-added-translations-line-item-show-more-less.md
+++ b/changelog/_unreleased/2021-11-26-added-translations-line-item-show-more-less.md
@@ -1,0 +1,13 @@
+---
+title: Added translations for showing more or less information of a lineItem children
+issue:
+flag:
+author: Dominik Mank
+author_email: github@mank.dev
+author_github: @dominikmank
+---
+# Storefront
+* Added snippets `checkout.lineItemShowMore` and `checkout.lineItemShowLess` in 
+  * `src/Storefront/Resources/views/storefront/page/checkout/checkout-aside-item-children.html.twig`, 
+  * `src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item-children.html.twig`, 
+  * `src/Storefront/Resources/views/storefront/page/checkout/checkout-item-children.html.twig`

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -330,6 +330,8 @@
     "summaryHeader": "Zusammenfassung",
     "lineItemContainerHeadline": "Enthält",
     "lineItemContainerChangeLink": "ändern",
+    "lineItemShowMore": "mehr",
+    "lineItemShowLess": "weniger",
     "cartEmpty": "Ihr Warenkorb ist leer.",
     "cartHeaderInfo": "Produkt",
     "cartHeaderQuantity": "Anzahl",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -330,6 +330,8 @@
     "summaryHeader": "Summary",
     "lineItemContainerHeadline": "Contains",
     "lineItemContainerChangeLink": "change",
+    "lineItemShowMore": "more",
+    "lineItemShowLess": "less",
     "cartEmpty": "Your shopping cart is empty.",
     "cartHeaderInfo": "Product",
     "cartHeaderQuantity": "Quantity",

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item-children.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-item-children.html.twig
@@ -75,8 +75,8 @@
                                                     <div class="swag-fade-container swag-fade-container-shrinked">
                                                         {{ nestedLineItem.label }}
                                                     </div>
-                                                    <a href="#" class="swag-fading-link-more swag-fade-link-hidden">more</a>
-                                                    <a href="#" class="swag-fading-link-less swag-fade-link-hidden">less</a>
+                                                    <a href="#" class="swag-fading-link-more swag-fade-link-hidden">{{ 'checkout.lineItemShowMore'|trans|sw_sanitize }}</a>
+                                                    <a href="#" class="swag-fading-link-less swag-fade-link-hidden">{{ 'checkout.lineItemShowLess'|trans|sw_sanitize }}</a>
                                                 </div>
                                             {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/page/checkout/checkout-aside-item-children.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/checkout-aside-item-children.html.twig
@@ -75,8 +75,8 @@
                                                     <div class="swag-fade-container swag-fade-container-shrinked">
                                                         {{ nestedLineItem.label }}
                                                     </div>
-                                                    <a href="#" class="swag-fading-link-more swag-fade-link-hidden">more</a>
-                                                    <a href="#" class="swag-fading-link-less swag-fade-link-hidden">less</a>
+                                                    <a href="#" class="swag-fading-link-more swag-fade-link-hidden">{{ 'checkout.lineItemShowMore'|trans|sw_sanitize }}</a>
+                                                    <a href="#" class="swag-fading-link-less swag-fade-link-hidden">{{ 'checkout.lineItemShowLess'|trans|sw_sanitize }}</a>
                                                 </div>
                                             {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/page/checkout/checkout-item-children.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/checkout-item-children.html.twig
@@ -75,8 +75,8 @@
                                                     <div class="swag-fade-container swag-fade-container-shrinked">
                                                         {{ nestedLineItem.label }}
                                                     </div>
-                                                    <a href="#" class="swag-fading-link-more swag-fade-link-hidden">more</a>
-                                                    <a href="#" class="swag-fading-link-less swag-fade-link-hidden">less</a>
+                                                    <a href="#" class="swag-fading-link-more swag-fade-link-hidden">{{ 'checkout.lineItemShowMore'|trans|sw_sanitize }}</a>
+                                                    <a href="#" class="swag-fading-link-less swag-fade-link-hidden">{{ 'checkout.lineItemShowLess'|trans|sw_sanitize }}</a>
                                                 </div>
                                             {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
There was no translation for showing "more" or "less" information in line item childrens. So in a german shop there will be english words 

### 2. What does this change do, exactly?
Use translations

### 3. Describe each step to reproduce the issue or behaviour.
- Create product with children with a much to long meaningful title
- look that there will be "more" to see in offcanvas and checkout

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
