### PR TITLE
Throw an Exception on weird Criteria. Fixes NEXT-19034

### DIFF
--- a/changelog/_unreleased/2021-11-26-hardened-criteria-evaluation.md
+++ b/changelog/_unreleased/2021-11-26-hardened-criteria-evaluation.md
@@ -1,0 +1,11 @@
+---
+title: Made the evaluation of Criteria object more robust.
+issue: NEXT-19034
+flag:
+author: Ulrich Thomas Gabor
+author_email: ulrich.thomas.gabor@odd-solutions.de
+author_github: @UlrichThomasGabor
+---
+# Core
+* Made the evaluation of Criteria object more robust, i.e. a warning is printed to the logger when a non-existing associations is encountered.
+

--- a/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
+++ b/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
@@ -98,6 +98,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\CriteriaQueryBuilder"/>
+            <argument type="service" id="logger"/>
         </service>
 
         <service class="Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityAggregator" id="Shopware\Core\Framework\DataAbstractionLayer\Search\EntityAggregatorInterface">


### PR DESCRIPTION
### 1. Why is this change necessary?
The lax evaluation of passed-in Criteria hides bugs.

### 2. What does this change do, exactly?
It throws an Exception, when Criteria could not be resolved.

### 3. Describe each step to reproduce the issue or behaviour.
See https://issues.shopware.com/issues/NEXT-19034

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
