### PR TITLE
Fixed incorrect implementation of Content-Type check in MediaService

### DIFF
--- a/src/Core/Content/Media/MediaService.php
+++ b/src/Core/Content/Media/MediaService.php
@@ -121,7 +121,7 @@ class MediaService
         }
 
         $contentType = $request->headers->get('content_type');
-        if ($contentType === 'application/json') {
+        if (strpos( $contentType , 'application/json' ) === 0) {
             return $this->fileFetcher->fetchFileFromURL($request, $tempFile);
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
https://github.com/shopware/platform/issues/2196

### 2. What does this change do, exactly?
Changes a incorrect Content-Type check fron $contentType === 'application/json' to strpos( $contentType , 'application/json' ) === 0

### 3. Describe each step to reproduce the issue or behaviour.
https://github.com/shopware/platform/issues/2196

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2196

### 5. Checklist

- [x ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [-] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [-] I have written or adjusted the documentation according to my changes
- [-] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
