### PR TITLE
Added decode option to config set command

### DIFF
--- a/changelog/_unreleased/2021-11-29-add-type-for-system-config-set.md
+++ b/changelog/_unreleased/2021-11-29-add-type-for-system-config-set.md
@@ -1,0 +1,10 @@
+---
+title: Add decode option to system:config:set command
+issue: https://github.com/shopware/platform/issues/2207
+author: Catalin Ionut Titov
+author_email: catalin.titov@gmail.com
+author_github: Catalin-Ionut
+___
+# Core
+* Added `decode` as optional input argument to `Shopware\Core\System\SystemConfig\Command\ConfigSet`
+___

--- a/src/Core/System/SystemConfig/Command/ConfigSet.php
+++ b/src/Core/System/SystemConfig/Command/ConfigSet.php
@@ -30,17 +30,31 @@ class ConfigSet extends Command
             ->addArgument('key', InputArgument::REQUIRED)
             ->addArgument('value', InputArgument::REQUIRED)
             ->addOption('salesChannelId', 's', InputOption::VALUE_OPTIONAL)
-        ;
+            ->addOption('decode', 'd', InputOption::VALUE_NONE, 'If provided, the input value will be interpreted as JSON. Use this option to provide values as boolean, integer or float.');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->systemConfigService->set(
             $input->getArgument('key'),
-            $input->getArgument('value'),
+            $this->handleDecode($input),
             $input->getOption('salesChannelId')
         );
 
         return 0;
+    }
+
+    protected function handleDecode(InputInterface $input)
+    {
+        $value = $input->getArgument('value');
+        if ($input->getOption('decode')) {
+            $decodedValue = json_decode($value, true);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                return $decodedValue;
+            }
+        }
+
+        return $value;
     }
 }

--- a/src/Core/System/Test/SystemConfig/Command/ConfigSetCommandTest.php
+++ b/src/Core/System/Test/SystemConfig/Command/ConfigSetCommandTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Test\SystemConfig\Command;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\SystemConfig\Command\ConfigSet;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ConfigSetCommandTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private ConfigSet $configSetCommand;
+    private SystemConfigService $systemConfigService;
+
+    protected function setUp(): void
+    {
+        $this->systemConfigService = $this->createMock(SystemConfigService::class);
+        $this->configSetCommand = new ConfigSet($this->systemConfigService);
+    }
+
+    public function configValueProvider(): iterable
+    {
+        /* value, expected_value, decode */
+        yield 'String false' => ['false', 'false', false];
+        yield 'Decode string false' => ['false', false, true];
+        yield 'String int' => ['4', '4', false];
+        yield 'Decode String int' => ['5', 5, true];
+        yield 'String float' => ['2.2', '2.2', false];
+        yield 'Decode String float' => ['3.3', 3.3, true];
+        yield 'String json' => [
+            "{\"name\":\"abc\",\"place\":\"xyz\"}",
+            "{\"name\":\"abc\",\"place\":\"xyz\"}",
+            false,
+        ];
+        yield 'Decode String json' => [
+            "{\"name\":\"abc\",\"place\":\"xyz\"}",
+            ['name' => 'abc', 'place' => 'xyz'],
+            true,
+        ];
+        yield 'Decode string remains string' => ['random string', 'random string', true];
+    }
+
+    /**
+     * @dataProvider configValueProvider
+     */
+    public function testConfigSetValue(string $value, $expectedValue, bool $decode = false): void
+    {
+        $key = 'fake_config_key';
+
+        $this->systemConfigService->expects($this->once())
+            ->method('set')
+            ->with(
+                $key,
+                static::identicalTo($expectedValue),
+                TestDefaults::SALES_CHANNEL
+            );
+
+        $commandTester = new CommandTester($this->configSetCommand);
+        $command = [
+            'key' => $key,
+            'value' => $value,
+            '--salesChannelId' => TestDefaults::SALES_CHANNEL,
+        ];
+
+        if ($decode) {
+            $command['--decode'] = true;
+        }
+
+        $commandTester->execute($command);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
#2207 
### 2. What does this change do, exactly?
Added `decode` input option to the `system:config:set` command.
### 3. Describe each step to reproduce the issue or behaviour.
#2207 
### 4. Please link to the relevant issues (if any).
#2207 
### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
