### PR TITLE
Ensure that administration loads JavaScript in the same order every time

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/application.ts
+++ b/src/Administration/Resources/app/administration/src/core/application.ts
@@ -603,7 +603,10 @@ class ApplicationBootstrapper {
             // create script tag with src
             const script = document.createElement('script');
             script.src = scriptSrc;
-            script.async = true;
+            script.defer = true;
+            // dynamically inserted scripts are async by default, have to explicitly state otherwise:
+            script.async = false;
+
 
             // resolve when script was loaded succcessfully
             script.onload = ():void => {


### PR DESCRIPTION
I'm not sure whether a PR is the right format for this but here we go. I tried asking about this a few weeks ago on the Slack channel but didn't really get any answers or feedback so I'm putting it here.

### 1. Why is this change necessary?

Suppose you have two plugins which both override the same Component in the administration. For example, the shipping method page `sw-settings-shipping-detail` which is a rather large Vue Component for a rather barebones part of Shopware = often times shipping related plugins will have no choice but to modify it. They'll add some fields to the page and likely override some functions and call `$super` on the parent functions. 

The issue is that when multiple plugins start overriding the same parts, inheritance starts causing issues and suddenly we end up in a situation where certain parts of some overrides are never called. Part of what makes it frustrating is that  the issue isn't always with the same override, because the administration loads in the plugin JS bundles asynchronously and thus Plugin A might load before Plugin B sometimes, and sometimes Plugin B will load first. This will affect which overrides get called and which do not.
(Part of what makes it annoying is also just limitations in the override system for components AFAIK, but that's a different problem for another day).

Right now there's not really a solution to this problem that I know of, except trying to avoid Component function overrides as much as possible, which your support suggested when I asked them. However, sometimes this still ends up happening on functions like `onSave` where plugins want to ensure their part of the dataset on the page is saved correctly.

In Magento, for example, this sort of thing also happened all the time with system rewrites. In those situations, there were at least solutions, although they were not pretty. One solution was to make Plugin B's Override extend plugin A's, and ensure that A loaded before B. This requires knowing that the load order is fixed, however.

In Shopware 6, the load order is random. This is because the system injects every plugin's bundle as an async script, which mean they load asynchronously and execute their setup in random order. But we could easily make it a fixed load order by simply using deferred loading instead, which still loads bundles simultaneously, but then executes the scripts in the order they were defined.

This is not really a complete fix to the problem. Shopware doesn't have any way of stating which order you'd like plugins to load in, so the order is fixed, but not necessarily very controllable. This would be a nice first step, however, that would easily allow us to do _something_ in these situations.

If you have any further comments or suggestions to how we can solve these problems please let me know, as we have a few shops with this exact sort of issue.

### 2. What does this change do, exactly?

This PR would ensure that plugins load their administration JavaScript in the same order every time, by setting `defer` instead of `async` on the plugin scripts. Thus, we can still have all plugins downloading their code at the same time, but the execution of them (and thus the order in which they inject themselves into the system) is in a set order on every load.
This would enable solving issues where two plugins override the same backend JS component.

### 3. Describe each step to reproduce the issue or behaviour.

Create two plugins, A and B, each with a simple administration bundle. Logging to console in each `main.js` is enough.
Refresh the page a bunch of times and look at the console. Sometimes you'll see A before B, and sometimes you'll see B before A.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

I'll do a changelist entry, etc. if you want to implement this.

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
