### PR TITLE
feat: Add Sitemap open tag filter event

### DIFF
--- a/changelog/_unreleased/2021-12-01-add-filter-event-to-modify-the-sitemap-header.md
+++ b/changelog/_unreleased/2021-12-01-add-filter-event-to-modify-the-sitemap-header.md
@@ -1,0 +1,8 @@
+---
+title: Add filter event to modify the sitemap header
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Add `Shopware\Core\Content\Sitemap\Event\SitemapFilterOpenTagEvent` to modify the open tag of the generated sitemap

--- a/src/Core/Content/DependencyInjection/sitemap.xml
+++ b/src/Core/Content/DependencyInjection/sitemap.xml
@@ -22,7 +22,9 @@
             <argument type="tagged" tag="shopware.sitemap.config_handler"/>
         </service>
 
-        <service id="Shopware\Core\Content\Sitemap\Service\SitemapHandleFactoryInterface" class="Shopware\Core\Content\Sitemap\Service\SitemapHandleFactory"/>
+        <service id="Shopware\Core\Content\Sitemap\Service\SitemapHandleFactoryInterface" class="Shopware\Core\Content\Sitemap\Service\SitemapHandleFactory">
+            <argument type="service" id="event_dispatcher"/>
+        </service>
 
         <service id="Shopware\Core\Content\Sitemap\SalesChannel\SitemapRoute" public="true">
             <argument type="service" id="Shopware\Core\Content\Sitemap\Service\SitemapLister"/>

--- a/src/Core/Content/Sitemap/Event/SitemapFilterOpenTagEvent.php
+++ b/src/Core/Content/Sitemap/Event/SitemapFilterOpenTagEvent.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Sitemap\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SitemapFilterOpenTagEvent extends Event implements ShopwareEvent
+{
+    private SalesChannelContext $salesChannelContext;
+
+    private string $openTag = '<?xml version="1.0" encoding="UTF-8"?><urlset %urlsetNamespaces%>';
+
+    /**
+     * @var array<string, string>
+     */
+    private array $urlsetNamespaces = [
+        'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9',
+    ];
+
+    public function __construct(SalesChannelContext $salesChannelContext)
+    {
+        $this->salesChannelContext = $salesChannelContext;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getOpenTag(): string
+    {
+        return $this->openTag;
+    }
+
+    public function getFullOpenTag(): string
+    {
+        $namespaces = '';
+        foreach ($this->urlsetNamespaces as $name => $namespace) {
+            $namespaces .= sprintf(' %s="%s"', $name, $namespace);
+        }
+
+        return strtr($this->openTag, [
+            '%urlsetNamespaces%' => trim($namespaces),
+        ]);
+    }
+
+    public function setOpenTag(string $openTag): void
+    {
+        $this->openTag = $openTag;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getUrlsetNamespaces(): array
+    {
+        return $this->urlsetNamespaces;
+    }
+
+    /**
+     * @param array<string, string> $urlsetNamespaces
+     */
+    public function setUrlsetNamespaces(array $urlsetNamespaces): void
+    {
+        $this->urlsetNamespaces = $urlsetNamespaces;
+    }
+
+    public function addUrlsetNamespace(string $name, string $namespace): void
+    {
+        $this->urlsetNamespaces[$name] = $namespace;
+    }
+}

--- a/src/Core/Content/Sitemap/Service/SitemapHandleFactory.php
+++ b/src/Core/Content/Sitemap/Service/SitemapHandleFactory.php
@@ -4,11 +4,19 @@ namespace Shopware\Core\Content\Sitemap\Service;
 
 use League\Flysystem\FilesystemInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class SitemapHandleFactory implements SitemapHandleFactoryInterface
 {
+    private EventDispatcherInterface $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
     public function create(FilesystemInterface $filesystem, SalesChannelContext $context, ?string $domain = null): SitemapHandleInterface
     {
-        return new SitemapHandle($filesystem, $context, $domain);
+        return new SitemapHandle($filesystem, $context, $this->eventDispatcher, $domain);
     }
 }

--- a/src/Core/Content/Test/Sitemap/Service/SitemapHandleTest.php
+++ b/src/Core/Content/Test/Sitemap/Service/SitemapHandleTest.php
@@ -7,11 +7,14 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Sitemap\Service\SitemapHandle;
 use Shopware\Core\Content\Sitemap\Struct\Url;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class SitemapHandleTest extends TestCase
 {
+    use KernelTestBehaviour;
+
     /**
      * @var SitemapHandle
      */
@@ -29,7 +32,11 @@ class SitemapHandleTest extends TestCase
         $fileSystem = $this->createMock(Filesystem::class);
         $fileSystem->expects(static::never())->method('write');
 
-        $this->handle = new SitemapHandle($fileSystem, $this->getContext());
+        $this->handle = new SitemapHandle(
+            $fileSystem,
+            $this->getContext(),
+            $this->getContainer()->get('event_dispatcher')
+        );
 
         $this->handle->write([
             $url,
@@ -49,7 +56,11 @@ class SitemapHandleTest extends TestCase
         $fileSystem->expects(static::once())->method('write');
         $fileSystem->method('listContents')->willReturn([]);
 
-        $this->handle = new SitemapHandle($fileSystem, $this->getContext());
+        $this->handle = new SitemapHandle(
+            $fileSystem,
+            $this->getContext(),
+            $this->getContainer()->get('event_dispatcher')
+        );
 
         $this->handle->write([$url]);
         $this->handle->finish();
@@ -74,7 +85,11 @@ class SitemapHandleTest extends TestCase
         $fileSystem->expects(static::atLeast(3))->method('write');
         $fileSystem->method('listContents')->willReturn([]);
 
-        $this->handle = new SitemapHandle($fileSystem, $this->getContext());
+        $this->handle = new SitemapHandle(
+            $fileSystem,
+            $this->getContext(),
+            $this->getContainer()->get('event_dispatcher')
+        );
 
         $this->handle->write($list);
         $this->handle->finish();


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to modify the sitemap open tag. The only thing (and for which I need this change) is to add some XML namespaces, so I added some explicit functionality to ease working with the namespaces, see for example: https://www.google.com/schemas/sitemap-video/1.1/sitemap-video.xsd

### 2. What does this change do, exactly?
Add an event to modify the XML open tag.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
