### PR TITLE
fix: Improve Google Analytics tracking of order

### DIFF
--- a/changelog/_unreleased/2021-12-02-track-orders-on-finish-page-using-the-order-number-as-transaction-id.md
+++ b/changelog/_unreleased/2021-12-02-track-orders-on-finish-page-using-the-order-number-as-transaction-id.md
@@ -1,0 +1,10 @@
+---
+title: Track orders on finish page using the order number as transaction id
+issue: NEXT-12660
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed the Google Analytics order tracking to only track the order on the finish page instead when submitting the confirm form, such that the orders are only tracked once they are really submitted
+* Changed the transaction ID of the tracked order to be the order number instead of a random ID preventing tracking of the same order multiple times

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
@@ -5,36 +5,25 @@ import LineItemHelper from 'src/plugin/google-analytics/line-item.helper';
 export default class PurchaseEvent extends AnalyticsEvent
 {
     supports(controllerName, actionName) {
-        return controllerName === 'checkout' && actionName === 'confirmpage' && window.trackOrders;
+        return controllerName === 'checkout' && actionName === 'finishpage' && window.trackOrders;
     }
 
     execute() {
-        const tosInput = DomAccessHelper.querySelector(document, '#tos');
-
-        DomAccessHelper.querySelector(document, '#confirmFormSubmit').addEventListener('click', this._onConfirm.bind(this, tosInput));
-    }
-
-    _onConfirm(tosInput) {
         if (!this.active) {
             return;
         }
 
-        if (!tosInput.checked) {
+        const orderNumberElement = DomAccessHelper.querySelector(document, '.hidden-ordernumber-information');
+        const orderNumber = DomAccessHelper.getDataAttribute(orderNumberElement, 'order-number');
+        if (!orderNumber) {
+            console.warn('Cannot determine order number - Skip tracking of the order');
+
             return;
         }
 
         gtag('event', 'purchase', { ...{
-            'transaction_id': this.generateUuid(),
+            'transaction_id': orderNumber,
             'items':  LineItemHelper.getLineItems(),
         }, ...LineItemHelper.getAdditionalProperties() });
-    }
-
-    generateUuid() {
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(replace) {
-            const random = Math.random() * 16 | 0;
-            const value = replace === 'x' ? random : (random & 0x3 | 0x8);
-
-            return value.toString(16);
-        });
     }
 }

--- a/src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/finish/index.html.twig
@@ -7,7 +7,6 @@
 {% block base_navigation %}{% endblock %}
 
 {% block page_checkout_main_content %}
-
     {% block base_flashbags_checkout %}
         <div class="flashbags">
             {% for type, messages in app.flashes %}
@@ -37,6 +36,21 @@
                     {% endblock %}
                 </div>
             </div>
+        {% endblock %}
+    {% endblock %}
+
+    {% block page_checkout_finish_hidden_information %}
+        {% block page_checkout_finish_hidden_information_order_number %}
+            <span class="d-none hidden-ordernumber-information"
+                  data-order-number="{{ page.order.orderNumber }}">
+            </span>
+        {% endblock %}
+
+        {% block page_checkout_finish_hidden_information_line_items %}
+            {% sw_include '@Storefront/storefront/component/checkout/hidden-line-items-information.html.twig' with {
+                cart: page.order,
+                lineItems: page.order.lineItems,
+            } %}
         {% endblock %}
     {% endblock %}
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently there are two problems with tracking orders using Google Analytics:
1. If there is an order using e.g. PayPal the order might be tracked, although it has never been completed (if the customer cancels the payment).
2. If the customer than uses the "Submit order" button several times the same order is tracked multiple times with different transaction ids.

### 2. What does this change do, exactly?
This PR changes the order tracking to happen on the finish page, which solves the first problem. Through this change we also have a unique identifier of the order, namely the order number, which is than used as `transaction_id` instead of a random generated ID which solves the second problem.

### 3. Describe each step to reproduce the issue or behaviour.
Try tracking orders using Google Analytics 

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-12660
https://forum.shopware.com/t/google-analytics-bestellungen-tracken/67142/32

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
