### PR TITLE
fix: Change the selector for the product id and name for the detail page tracking

### DIFF
--- a/changelog/_unreleased/2021-12-05-fix-determination-of-product-id-and-name-of-ga-plugin.md
+++ b/changelog/_unreleased/2021-12-05-fix-determination-of-product-id-and-name-of-ga-plugin.md
@@ -1,0 +1,10 @@
+---
+title: Fix determination of product id and name of GA plugin
+issue: NEXT-17278
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed the selector of the Google Analytics `ViewItemEvent` (`app/storefront/src/plugin/google-analytics/events/view-item.event.js`), for the product id to `[itemtype="https://schema.org/Product"] meta[itemprop="productID"]` and for the product name to `[itemtype="https://schema.org/Product"] [itemprop="name"]` to also work for soldout products
+* Removed `findProductId` of the Google Analytics `ViewItemEvent`, use the value of `[itemtype="https://schema.org/Product"] meta[itemprop="productID"]` if needed

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item.event.js
@@ -12,12 +12,38 @@ export default class ViewItemEvent extends AnalyticsEvent
             return;
         }
 
-        const form = DomAccessHelper.querySelector(document, '#productDetailPageBuyProductForm');
-        const productId = this.findProductId(DomAccessHelper.querySelectorAll(form, 'input'));
-        const productName = DomAccessHelper.querySelector(form, 'input[name=product-name]').value;
+        const productItemElement = DomAccessHelper.querySelector(
+            document,
+            '[itemtype="https://schema.org/Product"]',
+            false
+        );
+        if (!productItemElement) {
+            console.warn('[Google Analytics Plugin] Product itemtype ([itemtype="https://schema.org/Product"]) could not be found in document.');
 
-        if (!productId) {
-            console.warn('[Google Analytics Plugin] Product ID could not be found.');
+            return;
+        }
+
+        const productIdElement = DomAccessHelper.querySelector(
+            productItemElement,
+            'meta[itemprop="productID"]',
+            false
+        );
+        const productNameElement = DomAccessHelper.querySelector(
+            productItemElement,
+            '[itemprop="name"]',
+            false
+        );
+        if (!productIdElement || !productNameElement) {
+            console.warn('[Google Analytics Plugin] Product ID (meta[itemprop="productID"]) or product name ([itemprop="name"]) could not be found within product scope.');
+
+            return;
+        }
+
+        const productId = productIdElement.content;
+        const productName = productNameElement.textContent.trim();
+        if (!productId || !productName) {
+            console.warn('[Google Analytics Plugin] Product ID or product name is empty, do not track page view.');
+
             return;
         }
 
@@ -27,21 +53,5 @@ export default class ViewItemEvent extends AnalyticsEvent
                 'name': productName,
             }],
         });
-    }
-
-    /**
-     * @param { NodeList } inputs
-     * @return ?string
-     */
-    findProductId(inputs) {
-        let productId = null;
-
-        inputs.forEach(item => {
-            if (DomAccessHelper.getAttribute(item, 'name').endsWith('[id]')) {
-                productId = item.value;
-            }
-        });
-
-        return productId;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently for soldout products the corresponding buy form is removed. Thus the determination of the product id and name does not work anymore for such items.

### 2. What does this change do, exactly?
Adapt the selectors from where the values are determined, to be the content of the rich snippets.

### 3. Describe each step to reproduce the issue or behaviour.
Set a product to stock `0` and activate the clearance sale, and check the tracking on the product detail page.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-17278

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
