### PR TITLE
Fix shipping method tracking url translation

### DIFF
--- a/changelog/_unreleased/2021-12-06-shipping-method-tracking-url-translation.md
+++ b/changelog/_unreleased/2021-12-06-shipping-method-tracking-url-translation.md
@@ -1,0 +1,12 @@
+---
+title:              Fix shipping method tracking url translation
+issue:              NEXT-19153
+flag:               
+author:             Christoph Pötz
+author_email:       christoph.poetz@acris.at
+author_github:      @acris-cp
+---
+# Storefront
+*  Changed calling of shipping method tracking url to get translated
+___
+

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
@@ -134,7 +134,7 @@
                                                             <dd class="col-6 col-md-7">
                                                                 {% for delivery in order.deliveries %}
                                                                     {% set trackingCodes = delivery.trackingCodes %}
-                                                                    {% set trackingUrl = delivery.shippingMethod.trackingUrl %}
+                                                                    {% set trackingUrl = delivery.shippingMethod.translated.trackingUrl %}
 
                                                                     {% for trackingCode in trackingCodes %}
                                                                         {% if trackingUrl %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The shipping method tracking url don't calls the translated.

### 2. What does this change do, exactly?
It fixes calling the translated value.

### 3. Describe each step to reproduce the issue or behaviour.
1. Enter a shipping method tracking url in admin in english (as default language).
2. Open german shop and the order history. No url is found - correct would be fallback on english value.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-19153

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
