### PR TITLE
Changed version constraint for aws/aws-sdk-php dependency to ^3.198.5

### DIFF
--- a/changelog/_unreleased/2021-12-07-changed-version-constraint-aws-sdk-dependency.md
+++ b/changelog/_unreleased/2021-12-07-changed-version-constraint-aws-sdk-dependency.md
@@ -1,0 +1,9 @@
+---
+title: Changed version constraint for aws/aws-sdk-php dependency.
+issue: NEXT-19198
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed version constraint for aws/aws-sdk-php dependency.

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "ext-xml": "*",
         "ext-zip": "*",
         "ext-zlib": "*",
-        "aws/aws-sdk-php": "~3.198.5",
+        "aws/aws-sdk-php": "^3.198.5",
         "cocur/slugify": "4.0.0",
         "composer-runtime-api": "^2.0",
         "composer/composer": "^2.1.9",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -48,7 +48,7 @@
         "ext-zip": "*",
         "ext-zlib": "*",
         "ext-sodium": "*",
-        "aws/aws-sdk-php": "~3.198.5",
+        "aws/aws-sdk-php": "^3.198.5",
         "cocur/slugify": "4.0.0",
         "composer-runtime-api": "^2.0",
         "composer/composer": "^2.1.9",


### PR DESCRIPTION
### 1. Why is this change necessary?
To allow newer versions of aws/aws-sdk-php to be installed with allows the installation of `guzzlehttp/psr7`.

### 2. What does this change do, exactly?
Allow updated dependencies.

### 3. Describe each step to reproduce the issue or behaviour.
See: https://github.com/shopware/platform/issues/2220

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2220
https://issues.shopware.com/issues/NEXT-19198

### 5. Checklist

- [X] I have written tests and verified that they fail without my change --> There is actually nothing to test as I just changed a dependency. The existing tests, however should still work correctly but from what I can see the pipelines are not working correctly in general currently.
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes --> Nothing to document.
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
