### PR TITLE
Added missing dependency "guzzlehttp/psr7" and fixed deprecation.

### DIFF
--- a/changelog/_unreleased/2021-12-10-added-missing-dependency-and-fixed-deprecation.md
+++ b/changelog/_unreleased/2021-12-10-added-missing-dependency-and-fixed-deprecation.md
@@ -1,0 +1,12 @@
+---
+title: Added missing dependency "guzzlehttp/psr7" and fixed deprecation.
+issue: NEXT-19242
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Added missing dependency `guzzlehttp/psr7`.
+# Storefront
+* Added missing dependency `guzzlehttp/psr7`.
+* Changed `ThemeLifecycleService` to use Guzzle MimeType class instead of the deprecated function.

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "ezyang/htmlpurifier": "4.13.0",
         "google/cloud-storage": "~1.25.1",
         "guzzlehttp/guzzle": "~7.2",
+        "guzzlehttp/psr7": "^1.7 || ^2.0",
         "jdorn/sql-formatter": "1.2.17",
         "lcobucci/jwt": "~4.1.5",
         "league/flysystem": "~1.1.4",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -61,6 +61,7 @@
         "ezyang/htmlpurifier": "4.13.0",
         "google/cloud-storage": "~1.25.1",
         "guzzlehttp/guzzle": "~7.2",
+        "guzzlehttp/psr7": "^1.7 || ^2.0",
         "jdorn/sql-formatter": "1.2.17",
         "lcobucci/jwt": "~4.1.5",
         "league/flysystem": "~1.1.4",

--- a/src/Storefront/Theme/ThemeLifecycleService.php
+++ b/src/Storefront/Theme/ThemeLifecycleService.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Storefront\Theme;
 
+use GuzzleHttp\Psr7\MimeType;
 use Shopware\Core\Content\Media\Exception\DuplicatedMediaFileNameException;
 use Shopware\Core\Content\Media\File\FileNameProvider;
 use Shopware\Core\Content\Media\File\FileSaver;
@@ -17,7 +18,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationCollection;
-use function GuzzleHttp\Psr7\mimetype_from_filename;
 
 class ThemeLifecycleService
 {
@@ -179,7 +179,7 @@ class ThemeLifecycleService
             'media' => ['id' => $mediaId, 'mediaFolderId' => $themeFolderId],
             'mediaFile' => new MediaFile(
                 $path,
-                mimetype_from_filename($pathinfo['basename']),
+                MimeType::fromFilename($pathinfo['basename']),
                 $pathinfo['extension'],
                 filesize($path)
             ),

--- a/src/Storefront/composer.json
+++ b/src/Storefront/composer.json
@@ -34,6 +34,7 @@
         "php": "^7.4.3 || ^8.0",
         "cocur/slugify": "4.0.0",
         "doctrine/dbal": "2.13.3",
+        "guzzlehttp/psr7": "^1.7 || ^2.0",
         "padaliyajay/php-autoprefixer": "1.3",
         "scssphp/scssphp": "1.0.7",
         "shopware/core": "*",


### PR DESCRIPTION
### 1. Why is this change necessary?
See ticket: https://github.com/shopware/platform/issues/2224
to avoid deprecations and to work with guzzelhttp/psr7 v2.x

### 2. What does this change do, exactly?
See ticket https://github.com/shopware/platform/issues/2224 and title

### 3. Describe each step to reproduce the issue or behaviour.
No steps necessary.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2224
https://issues.shopware.com/issues/NEXT-19242

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
