### PR TITLE
Form preserver iterates through wrong elements

### DIFF
--- a/changelog/_unreleased/2021-12-10-form-preserver-iterates-through-wrong-elements.md
+++ b/changelog/_unreleased/2021-12-10-form-preserver-iterates-through-wrong-elements.md
@@ -1,0 +1,8 @@
+---
+title: Form preserver iterates through wrong elements
+author: Wanne Van Camp
+author_email: wanne.vancamp@meteor.be
+author_github: @wannevancamp
+---
+# Storefront
+* Changed formelement selector `this.el.children` to `this.el.elements` in `Resources/app/storefront/src/plugin/forms/form-preserver.plugin.js` to select the correct input fields.

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-preserver.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-preserver.plugin.js
@@ -59,7 +59,7 @@ export default class FormPreserverPlugin extends Plugin {
      * @private
      */
     _prepareElements() {
-        let formElements = this.el.children;
+        let formElements = this.el.elements;
         const outSideFormElements = DomAccess.querySelectorAll(document, `:not(form) > [form="${this.el.id}"]`, this.options.strictMode);
 
         formElements = Array.from(formElements);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
See ticket  #2227


### 2. What does this change do, exactly?
See ticket #2227 and title


### 3. Describe each step to reproduce the issue or behaviour.
See ticket  #2227

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
