### PR TITLE
Attach product reviews of all variants when using CMS element

### DIFF
--- a/changelog/_unreleased/2021-12-10-load-product-reviews-of-all-variants-when-using-cms-element.md
+++ b/changelog/_unreleased/2021-12-10-load-product-reviews-of-all-variants-when-using-cms-element.md
@@ -1,0 +1,9 @@
+---
+title: Load product reviews of all variants when using CMS element
+author: Vincent Neubauer
+author_email: v.neubauer@vonmaehlen.com
+author_github: dallyger
+---
+# Storefront
+* Update `Shopware\Core\Content\Product\Cms\ProductDescriptionReviewsCmsElementResolverController` to use
+  `$product->getParentId()` if available when loading reviews.

--- a/src/Core/Content/Product/Cms/ProductDescriptionReviewsCmsElementResolver.php
+++ b/src/Core/Content/Product/Cms/ProductDescriptionReviewsCmsElementResolver.php
@@ -75,17 +75,17 @@ class ProductDescriptionReviewsCmsElementResolver extends AbstractProductDetailC
 
     private function loadProductReviews(SalesChannelProductEntity $product, Request $request, SalesChannelContext $context): ProductReviewResult
     {
+        $productId = $product->getParentId() ?? $product->getId();
         $reviewCriteria = $this->createReviewCriteria($request, $context);
         $reviews = $this->productReviewRoute
-            ->load($product->getId(), $request, $context, $reviewCriteria)
+            ->load($productId, $request, $context, $reviewCriteria)
             ->getResult();
 
         $matrix = $this->getReviewRatingMatrix($reviews);
 
         $reviewResult = ProductReviewResult::createFrom($reviews);
         $reviewResult->setMatrix($matrix);
-        $reviewResult->setProductId($product->getId());
-        $reviewResult->setCustomerReview($this->getCustomerReview($product->getId(), $context));
+        $reviewResult->setCustomerReview($this->getCustomerReview($productId, $context));
         $reviewResult->setTotalReviews($matrix->getTotalReviewCount());
         $reviewResult->setProductId($product->getId());
         $reviewResult->setParentId($product->getParentId() ?? $product->getId());


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Currently, the CMS Element responsible for inserting the description/reviews tab behaves differently from product pages without an assigned layout. This is confusing and results in unforeseen bugs when switching to a CMS based layout.

### 2. What does this change do, exactly?
This adjusts the CMS element to behave like the fallback product page layout by using the product's parent ID too (if available) when loading reviews.

### 3. Describe each step to reproduce the issue or behaviour.
* Create a fresh Shopware instance
* Add reviews to a variant product
* Switch to another variant
* Enable a custom CMS layout for product pages
* Check reviews tab

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
