### PR TITLE
NEXT-16202: sitemap store-api route loads config saleschannel specific

### DIFF
--- a/changelog/_unreleased/2021-12-10-sitemap-store-api-route-now-uses-saleschannel-config.md
+++ b/changelog/_unreleased/2021-12-10-sitemap-store-api-route-now-uses-saleschannel-config.md
@@ -1,0 +1,9 @@
+---
+title: Sitemap store-api route now uses saleschannel config
+issue: NEXT-16202
+author: Niklas Wolf
+author_email: wolfniklas94@web.de 
+author_github: niklaswolf
+---
+# API
+*  System config loaded when using the store-api sitemap endpoint is saleschannel specific now. 

--- a/src/Core/Content/Sitemap/SalesChannel/CachedSitemapRoute.php
+++ b/src/Core/Content/Sitemap/SalesChannel/CachedSitemapRoute.php
@@ -103,7 +103,7 @@ class CachedSitemapRoute extends AbstractSitemapRoute
             return $this->getDecorated()->load($request, $context);
         }
 
-        $strategy = $this->config->getInt('core.sitemap.sitemapRefreshStrategy');
+        $strategy = $this->config->getInt('core.sitemap.sitemapRefreshStrategy', $context->getSalesChannelId());
         if ($strategy === SitemapExporterInterface::STRATEGY_LIVE) {
             $this->logger->info('cache-miss: ' . self::buildName($context->getSalesChannelId()));
 

--- a/src/Core/Content/Sitemap/SalesChannel/SitemapRoute.php
+++ b/src/Core/Content/Sitemap/SalesChannel/SitemapRoute.php
@@ -62,7 +62,7 @@ class SitemapRoute extends AbstractSitemapRoute
     {
         $sitemaps = $this->sitemapLister->getSitemaps($context);
 
-        if ($this->systemConfigService->getInt('core.sitemap.sitemapRefreshStrategy') !== SitemapExporterInterface::STRATEGY_LIVE) {
+        if ($this->systemConfigService->getInt('core.sitemap.sitemapRefreshStrategy', $context->getSalesChannelId()) !== SitemapExporterInterface::STRATEGY_LIVE) {
             return new SitemapRouteResponse(new SitemapCollection($sitemaps));
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to use different configurations for different saleschannels, because only the default config is getting loaded. 

### 2. What does this change do, exactly?
Added loading of saleschannel specific config.

### 3. Describe each step to reproduce the issue or behaviour.
- add a different sitemap configuration for different saleschannels
- make a request to the store-api sitemap route for different salechannels
- the different configuration should be used

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-16202

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
