### PR TITLE
NEXT-19084 - Allow min search index length of 1

### DIFF
--- a/changelog/_unreleased/2021-12-12-allow-setting-min-search-length-to-1.md
+++ b/changelog/_unreleased/2021-12-12-allow-setting-min-search-length-to-1.md
@@ -1,0 +1,9 @@
+---
+title: Allow min_search_length to be set to 1
+issue: NEXT-19084
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Administration
+* Changed `min_search_length` to allow an input of 1.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/index.js
@@ -25,7 +25,7 @@ Shopware.Component.register('sw-settings-search-search-behaviour', {
 
     data: () => {
         return {
-            min: 2,
+            min: 1,
             max: 20,
         };
     },

--- a/src/Administration/Resources/app/administration/test/module/sw-settings-search/component/sw-settings-search-search-behaviour.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-settings-search/component/sw-settings-search-search-behaviour.spec.js
@@ -123,8 +123,8 @@ describe('module/sw-settings-search/component/sw-settings-search-search-behaviou
         expect(wrapper.vm.searchBehaviourConfigs.minSearchLength).toBe(20);
 
         // take the min value if the current value smaller than the min value.
-        await minSearchLengthElement.setValue(1);
+        await minSearchLengthElement.setValue(0);
         await minSearchLengthElement.trigger('change');
-        expect(wrapper.vm.searchBehaviourConfigs.minSearchLength).toBe(2);
+        expect(wrapper.vm.searchBehaviourConfigs.minSearchLength).toBe(1);
     });
 });


### PR DESCRIPTION
It is technically no problem to have a index length of 1, also this is
not prohibited in the backend code.

This PR allows such settings also in the admin panel.


### 1. Why is this change necessary?

This is crucial for shops with products such as "100 A" and "100 B".

### 2. What does this change do, exactly?

Search indexing length of 1 is allowed in the admin

### 3. Describe each step to reproduce the issue or behaviour.

1. Set mimum search length of 1 in /admin#/sw/settings/search/index/general
2. The setting resets to 2

On a higher level, searches for "100 A" in a shop with products "100 A" and "100 B" often show "100 B" first

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-19084

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [-] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
