### PR TITLE
Add translated error message for duplicate item error

### DIFF
--- a/src/Storefront/Controller/WishlistController.php
+++ b/src/Storefront/Controller/WishlistController.php
@@ -215,7 +215,7 @@ class WishlistController extends StorefrontController
 
             $this->addFlash(self::SUCCESS, $this->trans('wishlist.itemAddedSuccess'));
         } catch (DuplicateWishlistProductException $exception) {
-            $this->addFlash(self::WARNING, $exception->getMessage());
+            $this->addFlash(self::WARNING, $this->trans('wishlist.duplicateItemError'));
         } catch (\Throwable $exception) {
             $this->addFlash(self::DANGER, $this->trans('error.message-default'));
         }

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -548,6 +548,7 @@
     "headline": "Ihr Merkzettel",
     "itemDeleteSuccess": "Sie haben das Produkt erfolgreich von Ihrem Merkzettel entfernt.",
     "itemAddedSuccess": "Sie haben das Produkt erfolgreich zu Ihrem Merkzettel hinzugefügt.",
+    "duplicateItemError": "Dieses Produkt befindet sich bereits auf Ihrem Merkzettel.",
     "currentlyNotAvailable": "Derzeit nicht verfügbar",
     "manufacturerDisplayName": "Hersteller",
     "deliveryTimeAvailable": "Sofort verfügbar, Lieferzeit %name%",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -548,6 +548,7 @@
     "headline": "Your wishlist",
     "itemDeleteSuccess": "You have successfully removed the product from your wishlist.",
     "itemAddedSuccess": "You have successfully added the product to your wishlist.",
+    "duplicateItemError": "Product already added to wishlist.",
     "currentlyNotAvailable": "Currently not available",
     "manufacturerDisplayName": "Manufacturer",
     "deliveryTimeAvailable": "Available, delivery time %name%",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -548,7 +548,7 @@
     "headline": "Your wishlist",
     "itemDeleteSuccess": "You have successfully removed the product from your wishlist.",
     "itemAddedSuccess": "You have successfully added the product to your wishlist.",
-    "duplicateItemError": "Product already added to wishlist.",
+    "duplicateItemError": "Product has already been added to your wishlist.",
     "currentlyNotAvailable": "Currently not available",
     "manufacturerDisplayName": "Manufacturer",
     "deliveryTimeAvailable": "Available, delivery time %name%",

--- a/src/Storefront/Test/Controller/WishlistControllerTest.php
+++ b/src/Storefront/Test/Controller/WishlistControllerTest.php
@@ -226,7 +226,7 @@ class WishlistControllerTest extends TestCase
         $browser->request('GET', $_SERVER['APP_URL'] . '/wishlist/add-after-login/' . $productId);
 
         static::assertNotEmpty($warningFlash = $flashBag->get('warning'));
-        static::assertEquals('Product already added in wishlist', $warningFlash[0]);
+        static::assertEquals('Product already added to wishlist.', $warningFlash[0]);
     }
 
     private function createCustomer(): CustomerEntity

--- a/src/Storefront/Test/Controller/WishlistControllerTest.php
+++ b/src/Storefront/Test/Controller/WishlistControllerTest.php
@@ -226,7 +226,7 @@ class WishlistControllerTest extends TestCase
         $browser->request('GET', $_SERVER['APP_URL'] . '/wishlist/add-after-login/' . $productId);
 
         static::assertNotEmpty($warningFlash = $flashBag->get('warning'));
-        static::assertEquals('Product already added to wishlist.', $warningFlash[0]);
+        static::assertEquals('Product has already been added to your wishlist.', $warningFlash[0]);
     }
 
     private function createCustomer(): CustomerEntity


### PR DESCRIPTION
### 1. Why is this change necessary?
Show an translated error message when a product is already on user's wishlist.

### 2. What does this change do, exactly?
This change adds translation.

### 3. Describe each step to reproduce the issue or behaviour.
1. Login
2. Add a product to your wishlist
3. Logout
4. Add the same product again
5. When redirected to the login page, log in with the same user
6. See the untranslated error message as a flash message
