### PR TITLE
[NEXT-19365] Added WebP support for saving thumbnails in ThumbnailService.php

### DIFF
--- a/changelog/_unreleased/2021-12-15-add-webp-support-for-thumbnail-service.md
+++ b/changelog/_unreleased/2021-12-15-add-webp-support-for-thumbnail-service.md
@@ -1,0 +1,9 @@
+---
+title: Add WebP support for ThumbnailService
+issue: <TODO>
+author: Simon Nitzsche
+author_email: simon.nitzsche@esera.de
+author_github: SimonNitzsche
+___
+# Core
+* Changed `writeThumbnail` method on `Shopware\Core\Content\Media\Thumbnail\ThumbnailService` to allow saving thumbnails as webp.

--- a/changelog/_unreleased/2021-12-15-add-webp-support-for-thumbnail-service.md
+++ b/changelog/_unreleased/2021-12-15-add-webp-support-for-thumbnail-service.md
@@ -1,6 +1,6 @@
 ---
 title: Add WebP support for ThumbnailService
-issue: <TODO>
+issue: NEXT-19365
 author: Simon Nitzsche
 author_email: simon.nitzsche@esera.de
 author_github: SimonNitzsche

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -464,7 +464,12 @@ class ThumbnailService
 
                 break;
             case 'image/webp':
-                imagewebp($thumbnail, null, $quality);
+                if (function_exists('imagewebp')) {
+                    imagewebp($thumbnail, null, $quality);
+                }
+                else {
+                    throw new ThumbnailCouldNotBeSavedException($url);
+                }
                 
                 break;
         }

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -464,12 +464,11 @@ class ThumbnailService
 
                 break;
             case 'image/webp':
-                if (function_exists('imagewebp')) {
-                    imagewebp($thumbnail, null, $quality);
-                }
-                else {
+                if (!function_exists('imagewebp')) {
                     throw new ThumbnailCouldNotBeSavedException($url);
                 }
+
+               imagewebp($thumbnail, null, $quality);
                 
                 break;
         }

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -463,6 +463,10 @@ class ThumbnailService
                 imagejpeg($thumbnail, null, $quality);
 
                 break;
+            case 'image/webp'
+                imagewebp($thumbnail, null, $quality);
+                
+                break;
         }
         $imageFile = ob_get_contents();
         ob_end_clean();

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -463,7 +463,7 @@ class ThumbnailService
                 imagejpeg($thumbnail, null, $quality);
 
                 break;
-            case 'image/webp'
+            case 'image/webp':
                 imagewebp($thumbnail, null, $quality);
                 
                 break;

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -464,12 +464,12 @@ class ThumbnailService
 
                 break;
             case 'image/webp':
-                if (!function_exists('imagewebp')) {
+                if (!\function_exists('imagewebp')) {
                     throw new ThumbnailCouldNotBeSavedException($url);
                 }
 
                imagewebp($thumbnail, null, $quality);
-                
+
                 break;
         }
         $imageFile = ob_get_contents();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When uploading an webp image to Shopware 6 the thumbnails are created as an empty file due to the ThumbnailService missing the case for webp.

### 2. What does this change do, exactly?
Instead of writing the thumbnails as empty files to the disk it will actually write their content.

### 3. Describe each step to reproduce the issue or behaviour.
1. Assign an .webp image to a category.
 2. The thumbnails cannot be displayed in the Storefront due to it being empty files.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
