### PR TITLE
Make submit button look ups non-failing to match follow up code

### DIFF
--- a/changelog/_unreleased/2021-12-16-allow-form-submit-buttons-outside-the-form.md
+++ b/changelog/_unreleased/2021-12-16-allow-form-submit-buttons-outside-the-form.md
@@ -1,0 +1,9 @@
+---
+title: Allow form submit buttons outside the form
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+
+# Storefront
+* Changed submit button lookup in `FormSubmitLoaderPlugin` to allow moving submit buttons out of the form container that works with form-attribute reference

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-submit-loader.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-submit-loader.plugin.js
@@ -40,7 +40,7 @@ export default class FormSubmitLoaderPlugin extends Plugin {
      * @private
      */
     _getSubmitButton() {
-        this._submitButton = DomAccess.querySelector(this._form, 'button[type=submit]');
+        this._submitButton = DomAccess.querySelector(this._form, 'button[type=submit]', false);
 
         if (!this._submitButton) {
             return this._getSubmitButtonWithId();
@@ -60,7 +60,7 @@ export default class FormSubmitLoaderPlugin extends Plugin {
         const id = this._form.id;
         if (!id) return false;
 
-        this._submitButton = DomAccess.querySelector(this._form, `button[type=submit][form=${id}]`);
+        this._submitButton = DomAccess.querySelector(document.body, `button[type=submit][form=${id}]`, false);
 
         return this._submitButton;
     }

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader-outer-form-submit-button.plugin.template.html
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader-outer-form-submit-button.plugin.template.html
@@ -1,0 +1,5 @@
+<div>
+    <button type="submit" id="formBtn" form="test">Not part of the form but still the right submit button</button>
+
+    <form id="test" data-form-submit-loader="true"></form>
+</div>

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader.plugin.test.js
@@ -5,6 +5,7 @@
 /* eslint-disable */
 import Storage from 'src/helper/storage/storage.helper';
 import template from './form-submit-loader.plugin.template.html';
+import outerFormTemplate from './form-submit-loader-outer-form-submit-button.plugin.template.html';
 import FormSubmitLoader from "../../../src/plugin/forms/form-submit-loader.plugin";
 
 describe('Form submit loader tests', () => {
@@ -13,6 +14,55 @@ describe('Form submit loader tests', () => {
 
     beforeEach(() => {
         document.body.innerHTML = template;
+
+        window.PluginManager = {
+            getPluginInstancesFromElement: () => {
+                return new Map();
+            },
+            getPlugin: () => {
+                return {
+                    get: () => []
+                };
+            }
+        };
+
+        Storage.clear();
+        form = document.querySelector('#test');
+        formSubmitLoaderPlugin = new FormSubmitLoader(form, null, 'FormSubmitLoader');
+    });
+
+    afterEach(() => {
+        formSubmitLoaderPlugin = undefined;
+    });
+
+    test('form submit loader plugin exists', () => {
+        expect(typeof formSubmitLoaderPlugin).toBe('object');
+    });
+
+    test('form is the sames as passed from', () => {
+        expect(formSubmitLoaderPlugin._form).toBe(form);
+    });
+
+    test('find correct submit button', () => {
+        const submitButton = document.querySelector('#formBtn');
+        expect(formSubmitLoaderPlugin._submitButton).toBe(submitButton);
+    });
+
+    test('submit button is disabled on submit', () => {
+        let event = new Event('submit');
+        formSubmitLoaderPlugin._onFormSubmit(event);
+
+        const submitButton = document.querySelector('#formBtn');
+        expect(submitButton.disabled).toBe(true);
+    });
+});
+
+describe('Form submit loader tests when submit button is out of form', () => {
+    let formSubmitLoaderPlugin = undefined;
+    let form = undefined;
+
+    beforeEach(() => {
+        document.body.innerHTML = outerFormTemplate;
 
         window.PluginManager = {
             getPluginInstancesFromElement: () => {


### PR DESCRIPTION
### 1. Why is this change necessary?
Imagine you want to place a submit button out of a form container. The form uses the FormSubmitLoader. It can look up buttons by form attribute but 
1. it searches the form container for it :(
2. it fails when the first submit button (that inside the form container) hasn't been found as the search step throws an exception when it was not succesful

### 2. What does this change do, exactly?
Add a parameter to the button look ups to allow soft failure as the rest of the code suggests to happen. Allow submit button search by form id on the complete document.

### 3. Describe each step to reproduce the issue or behaviour.
Move the orderConfirm submit button on checkout somewhere else on the page. It will technically work but the js won't like it

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
