### PR TITLE
Return the return-value of the transactional closure

### DIFF
--- a/changelog/2021-12-18-add-return-to-retryable.md
+++ b/changelog/2021-12-18-add-return-to-retryable.md
@@ -1,0 +1,11 @@
+---
+title: RetryableTransactions returns return value of closure
+issue: 
+flag:
+author: Ulrich Thomas Gabor
+author_email: ulrich.thomas.gabor@odd-solutions.de
+author_github: @UlrichThomasGabor
+---
+# Core
+* `RetryableTransaction::retryable` now returns the return value of the passed in closure mirroring the behavior of Doctrine.
+

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableTransaction.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableTransaction.php
@@ -12,17 +12,17 @@ class RetryableTransaction
      * is rolled back and the closure will be retried. Because it may run multiple times the closure should not cause
      * any side effects outside of its own scope.
      */
-    public static function retryable(Connection $connection, \Closure $closure): void
+    public static function retryable(Connection $connection, \Closure $closure)
     {
-        self::retry($connection, $closure, 0);
+        return self::retry($connection, $closure, 0);
     }
 
-    private static function retry(Connection $connection, \Closure $closure, int $counter): void
+    private static function retry(Connection $connection, \Closure $closure, int $counter)
     {
         ++$counter;
 
         try {
-            $connection->transactional($closure);
+            return $connection->transactional($closure);
         } catch (RetryableException $retryableException) {
             if ($connection->getTransactionNestingLevel() > 0) {
                 // If this RetryableTransaction was executed inside another transaction, do not retry this nested
@@ -40,7 +40,7 @@ class RetryableTransaction
             // Randomize sleep to prevent same execution delay for multiple statements
             usleep(random_int(10, 20));
 
-            self::retry($connection, $closure, $counter);
+            return self::retry($connection, $closure, $counter);
         }
     }
 }


### PR DESCRIPTION
The Doctrine `transactional` method is actually returning:
https://github.com/doctrine/dbal/blob/decf34ad95334180dec6497f47b1557de02ea9b0/src/Connection.php#L1217

I do not see why this should not be passed along.