### PR TITLE
Makes filter-panel.html.twig extensible

### DIFF
--- a/changelog/_unreleased/2021-12-18-added-block-to-filter-panel.html.twig-extensible.md to make filter list extensible
+++ b/changelog/_unreleased/2021-12-18-added-block-to-filter-panel.html.twig-extensible.md to make filter list extensible
@@ -1,0 +1,13 @@
+---
+title: Added block to `filter-panel.html.twig` to make it possible to easily/robustly add filters to the storefront
+issue:
+flag:
+author: Sven Lauer
+author_email: sven@sven-lauer.net
+author_github: svlauer
+---
+
+# Storefront
+*  Added a new block `component_filter_panel_items` to `@Storefront/storefront/component/lists/filter-panel.html.twig` which wraps *only* the filters provided by core. In contrast to the existing blocks, this block can be overwritten-with-`parent()` to add additional filters.
+___
+

--- a/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
@@ -14,78 +14,80 @@
         <div class="filter-panel{% if sidebar %} is--sidebar{% endif %}">
             {% block component_filter_panel_items_container %}
                 <div class="filter-panel-items-container">
+                    {% block component_filter_panel_items %}
 
-                    {% block component_filter_panel_item_manufacturer %}
-                        {# @var manufacturers \Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult #}
-                        {% set manufacturers = listing.aggregations.get('manufacturer') %}
-                        {% if not manufacturers.entities is empty %}
-                            {% set manufacturersSorted = manufacturers.entities|sort((a, b) => a.translated.name|lower <=> b.translated.name|lower) %}
+                        {% block component_filter_panel_item_manufacturer %}
+                            {# @var manufacturers \Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult #}
+                            {% set manufacturers = listing.aggregations.get('manufacturer') %}
+                            {% if not manufacturers.entities is empty %}
+                                {% set manufacturersSorted = manufacturers.entities|sort((a, b) => a.translated.name|lower <=> b.translated.name|lower) %}
 
-                            {% sw_include '@Storefront/storefront/component/listing/filter/filter-multi-select.html.twig' with {
-                                elements: manufacturersSorted,
-                                sidebar: sidebar,
-                                name: 'manufacturer',
-                                displayName: 'listing.filterManufacturerDisplayName'|trans|sw_sanitize
-                            } %}
-                        {% endif %}
-                    {% endblock %}
-
-                    {% block component_filter_panel_item_properties %}
-                        {# @var properties \Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult #}
-                        {% set properties = listing.aggregations.get('properties') %}
-
-                        {% if not properties.entities is empty %}
-                            {% for property in properties.entities %}
-                                {% sw_include '@Storefront/storefront/component/listing/filter/filter-property-select.html.twig' with {
-                                    elements: property.options,
+                                {% sw_include '@Storefront/storefront/component/listing/filter/filter-multi-select.html.twig' with {
+                                    elements: manufacturersSorted,
                                     sidebar: sidebar,
-                                    name: 'properties',
-                                    displayName: property.translated.name,
-                                    displayType: property.displayType,
-                                    pluginSelector: 'filter-property-select',
-                                    propertyName: property.translated.name
+                                    name: 'manufacturer',
+                                    displayName: 'listing.filterManufacturerDisplayName'|trans|sw_sanitize
                                 } %}
-                            {% endfor %}
-                        {% endif %}
-                    {% endblock %}
+                            {% endif %}
+                        {% endblock %}
 
-                    {% block component_filter_panel_item_price %}
-                        {% set price = listing.aggregations.get('price') %}
+                        {% block component_filter_panel_item_properties %}
+                            {# @var properties \Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult #}
+                            {% set properties = listing.aggregations.get('properties') %}
 
-                        {% if price.min >= 0 and price.max >= 0 %}
-                            {% sw_include '@Storefront/storefront/component/listing/filter/filter-range.html.twig' with {
-                                price: price,
-                                sidebar: sidebar,
-                                name: 'price',
-                                minKey: 'min-price',
-                                maxKey: 'max-price',
-                                displayName: 'listing.filterPriceDisplayName'|trans|sw_sanitize,
-                            } %}
-                        {% endif %}
-                    {% endblock %}
+                            {% if not properties.entities is empty %}
+                                {% for property in properties.entities %}
+                                    {% sw_include '@Storefront/storefront/component/listing/filter/filter-property-select.html.twig' with {
+                                        elements: property.options,
+                                        sidebar: sidebar,
+                                        name: 'properties',
+                                        displayName: property.translated.name,
+                                        displayType: property.displayType,
+                                        pluginSelector: 'filter-property-select',
+                                        propertyName: property.translated.name
+                                    } %}
+                                {% endfor %}
+                            {% endif %}
+                        {% endblock %}
 
-                    {% block component_filter_panel_item_rating_select %}
-                        {% set rating = listing.aggregations.get('rating') %}
+                        {% block component_filter_panel_item_price %}
+                            {% set price = listing.aggregations.get('price') %}
 
-                        {% if rating.max > 0 %}
-                            {% sw_include '@Storefront/storefront/component/listing/filter/filter-rating-select.html.twig' with {
-                                sidebar: sidebar,
-                                name: 'rating',
-                                pluginSelector: 'filter-rating-select',
-                                displayName: 'listing.filterRatingDisplayName'|trans|sw_sanitize
-                            } %}
-                        {% endif %}
-                    {% endblock %}
+                            {% if price.min >= 0 and price.max >= 0 %}
+                                {% sw_include '@Storefront/storefront/component/listing/filter/filter-range.html.twig' with {
+                                    price: price,
+                                    sidebar: sidebar,
+                                    name: 'price',
+                                    minKey: 'min-price',
+                                    maxKey: 'max-price',
+                                    displayName: 'listing.filterPriceDisplayName'|trans|sw_sanitize,
+                                } %}
+                            {% endif %}
+                        {% endblock %}
 
-                    {% block component_filter_panel_item_shipping_free %}
-                        {% set shippingFree = listing.aggregations.get('shipping-free') %}
+                        {% block component_filter_panel_item_rating_select %}
+                            {% set rating = listing.aggregations.get('rating') %}
 
-                        {% if shippingFree.max > 0 %}
-                            {% sw_include '@Storefront/storefront/component/listing/filter/filter-boolean.html.twig' with {
-                                name: 'shipping-free',
-                                displayName: 'listing.filterFreeShippingDisplayName'|trans|sw_sanitize
-                            } %}
-                        {% endif %}
+                            {% if rating.max > 0 %}
+                                {% sw_include '@Storefront/storefront/component/listing/filter/filter-rating-select.html.twig' with {
+                                    sidebar: sidebar,
+                                    name: 'rating',
+                                    pluginSelector: 'filter-rating-select',
+                                    displayName: 'listing.filterRatingDisplayName'|trans|sw_sanitize
+                                } %}
+                            {% endif %}
+                        {% endblock %}
+
+                        {% block component_filter_panel_item_shipping_free %}
+                            {% set shippingFree = listing.aggregations.get('shipping-free') %}
+
+                            {% if shippingFree.max > 0 %}
+                                {% sw_include '@Storefront/storefront/component/listing/filter/filter-boolean.html.twig' with {
+                                    name: 'shipping-free',
+                                    displayName: 'listing.filterFreeShippingDisplayName'|trans|sw_sanitize
+                                } %}
+                            {% endif %}
+                        {% endblock %}
                     {% endblock %}
                 </div>
             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently, there is no good way to add additional filters to the storefront in a plugin. The reason is that in `@Storefront/storefront/component/lists/filter-panel.html.twig`, the innermost block wrapping the filters provided by shopware core also wraps the container div.

This means that in order to add an additional filter, a plugin author has to either (i) overwrite that block and re-define all filters (since a `parent()` call would not allow the author to put anything **in** the container div) or (ii) overwrite one of the blocks for the provided filters to append their own (this is what is recommended in [the documentation](https://developer.shopware.com/docs/guides/plugins/plugins/storefront/add-listing-filters#add-your-filter-to-the-storefront-ui).
Both approaches are rather fragile and can easily wreak havoc if the core template is changed.

### 2. What does this change do, exactly?

This change simply adds a new block `component_filter_panel_items` to the template, which only wraps the provided filter blocks. With this, adding an additional filter is as simple as `sw_extends`ing the template, overriding the new block and `parent()`ing in the provided filters.

### 3. Describe each step to reproduce the issue or behaviour.

N/A

### 4. Please link to the relevant issues (if any).

#2246

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
