### PR TITLE
NEXT-19250 fix dashboard not showing correct order sum

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/page/sw-dashboard-index/index.js
@@ -417,7 +417,7 @@ Component.register('sw-dashboard-index', {
 
             criteria.addAssociation('stateMachineState');
 
-            criteria.addFilter(Criteria.equals('transactions.stateMachineState.name', 'paid'));
+            criteria.addFilter(Criteria.equals('transactions.stateMachineState.technicalName', 'paid'));
             criteria.addFilter(Criteria.range('orderDate', { gte: this.formatDate(this.dateAgo) }));
 
             return this.orderRepository.search(criteria);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
Dashboard Statistiks never show any order sums since the association for paid is missing

### 2. What does this change do, exactly?
Use technicalName instead of name since name needs the `state_machine_translation` table, also the translated value might not actually be equal to "paid", thus we should use the technicalName field directly

### 3. Describe each step to reproduce the issue or behaviour.
Look at Dashboard for order sums in admin, it will always show 0€

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-19250

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
