### PR TITLE
NEXT-19250 add MailAware FlowBuilder can use OrderPaymentMethodChange…

### DIFF
--- a/src/Core/Checkout/Order/Event/OrderPaymentMethodChangedEvent.php
+++ b/src/Core/Checkout/Order/Event/OrderPaymentMethodChangedEvent.php
@@ -14,11 +14,12 @@ use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
 use Shopware\Core\Framework\Event\MailActionInterface;
+use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Event\SalesChannelAware;
 use Symfony\Contracts\EventDispatcher\Event;
 
-class OrderPaymentMethodChangedEvent extends Event implements MailActionInterface, SalesChannelAware, OrderAware, CustomerAware
+class OrderPaymentMethodChangedEvent extends Event implements MailActionInterface, SalesChannelAware, OrderAware, CustomerAware, MailAware
 {
     public const EVENT_NAME = 'checkout.order.payment_method.changed';
 


### PR DESCRIPTION
…dEvent to send mail

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
FlowBuilder can only send mails if the triggering Event is instance of MailAware

### 2. What does this change do, exactly?
add MailAware to Shopware\Core\Checkout\Order\Event\OrderPaymentMethodChangedEvent

### 3. Describe each step to reproduce the issue or behaviour.
Create Flowbuilder Flow where changing the payment method of an order should send an email to the customer

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-19500

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.
