### PR TITLE
perf: check selector for better dom-selector in plugin registration

### DIFF
--- a/changelog/_unreleased/2021-11-12-check-selector-for-better-dom-selector-in-plugin-registration.md
+++ b/changelog/_unreleased/2021-11-12-check-selector-for-better-dom-selector-in-plugin-registration.md
@@ -1,0 +1,11 @@
+---
+title: Check selector for better dom-selector in plugin registration
+issue: 
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+# Storefront
+* Added private method `_queryElements` to `plugin.manager` to determ the best dom-selector based on common characters `a-zA-Z1-9_-`
+* Added handling of HTMLCollection to `iterator.helper`
+

--- a/src/Storefront/Resources/app/storefront/src/helper/iterator.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/helper/iterator.helper.js
@@ -35,6 +35,10 @@ export default class Iterator {
             return source.forEach(callback);
         }
 
+        if (source instanceof HTMLCollection) {
+            return Array.from(source).forEach(callback);
+        }
+
         if (source instanceof Object) {
             return Object.keys(source).forEach(key => {
                 callback(source[key], key)

--- a/src/Storefront/Resources/app/storefront/src/plugin-system/plugin.manager.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin-system/plugin.manager.js
@@ -266,7 +266,7 @@ class PluginManagerSingleton {
         }
 
         if (typeof selector === 'string') {
-            selector = document.querySelectorAll(selector);
+            selector = PluginManagerSingleton._queryElements(selector);
         }
 
         return Iterator.iterate(selector, el => {
@@ -275,9 +275,51 @@ class PluginManagerSingleton {
     }
 
     /**
+     * Determs the way to query the elements.
+     *
+     * [data-*] => querySelectorAll
+     * #fooBar => getElementById
+     * #foo_bar => getElementById
+     * #foo-bar => getElementById
+     * #foo .bar => querySelectorAll
+     * .fooBar => getElementsByClassName
+     * .FOO => getElementsByClassName
+     * .foo_bar => getElementsByClassName
+     * .foo-bar => getElementsByClassName
+     * .foo .bar => querySelectorAll
+     *
+     * FOO => getElementsByTagName
+     * FOO .bar => querySelectorAll
+     *
+     * For performance reason used regex based on common characters `a-zA-Z1-9_-`
+     * instead of the entire compatible characters
+     *
+     * @param {string} selector
+     *
+     * @return {NodeList|HTMLCollection|Array}
+     */
+    static _queryElements(selector) {
+        if (selector.startsWith('.')) {
+            const regexEl = /^\.([\w-]+)$/.exec(selector);
+            if (regexEl) {
+                return document.getElementsByClassName(regexEl[1]);
+            }
+        } else if (selector.startsWith('#')) {
+            const regexEl = /^#([\w-]+)$/.exec(selector);
+            if (regexEl) {
+                return [document.getElementById(regexEl[1])];
+            }
+        } else if (/^([\w-]+)$/.exec(selector)) {
+            return document.getElementsByTagName(selector);
+        }
+
+        return document.querySelectorAll(selector);
+    }
+
+    /**
      * Executes a vanilla plugin class on the passed element.
      *
-     * @param {String|NodeList|HTMLElement} el
+     * @param {Node|HTMLElement} el
      * @param {Plugin} pluginClass
      * @param {Object} options
      * @param {string} pluginName

--- a/src/Storefront/Resources/app/storefront/test/helper/iterator.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/iterator.helper.test.js
@@ -73,6 +73,25 @@ describe('iterator.helper.js', () => {
 
     });
 
+    test('it iterates HTML collections', () => {
+        document.body.innerHTML = '<ul><li>first</li><li>second</li><li>third</li></ul>';
+        const nodeList = document.getElementsByTagName('li');
+        expect(nodeList.length).toBe(3);
+
+        const callback = jest.fn();
+        Iterator.iterate(nodeList, callback);
+
+        expect(callback).toBeCalledTimes(3);
+
+        const arrayNodeList = Array.from(nodeList);
+        expect(nodeList.length).toBe(arrayNodeList.length);
+
+        expect(callback).nthCalledWith(1, arrayNodeList[0], 0, arrayNodeList);
+        expect(callback).nthCalledWith(2, arrayNodeList[1], 1, arrayNodeList);
+        expect(callback).nthCalledWith(3, arrayNodeList[2], 2, arrayNodeList);
+
+    });
+
     test('it throws for primitives', () => {
         expect(() => { return Iterator.iterate('iterate over string') }).toThrowError();
         expect(() => { return Iterator.iterate(new String('iterate over string')) }).toThrowError();

--- a/src/Storefront/Resources/app/storefront/test/plugin-system/plugin.manager.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin-system/plugin.manager.test.js
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+import PluginManager from 'src/plugin-system/plugin.manager';
+import Plugin from 'src/plugin-system/plugin.class';
+import Iterator from "../../src/helper/iterator.helper";
+
+class FooPlugin extends Plugin {
+    init() {}
+}
+
+beforeEach(() => {
+    document.body.innerHTML = '<div data-plugin="true" class="test-class"></div><div id="test-id"></div>';
+});
+
+describe('Plugin manager', () => {
+    it('should initialize plugin with class selector', () => {
+        PluginManager.register('FooPlugin', FooPlugin, '.test-class');
+
+        PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPlugin').length).toBe(1);
+        expect(PluginManager.getPluginInstances('FooPlugin')[0]._initialized).toBe(true);
+
+        PluginManager.deregister('FooPlugin', '.test-class');
+    });
+
+    it('should initialize plugin with id selector', () => {
+        PluginManager.register('FooPluginID', FooPlugin, '#test-id');
+
+        PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPluginID').length).toBe(1);
+        expect(PluginManager.getPluginInstances('FooPluginID')[0]._initialized).toBe(true);
+
+        PluginManager.deregister('FooPluginID', '#test-id');
+    });
+
+    it('should initialize plugin with tag selector', () => {
+        PluginManager.register('FooPluginTag', FooPlugin, 'div');
+
+        PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPluginTag').length).toBe(2);
+
+        Iterator.iterate(PluginManager.getPluginInstances('FooPluginTag'), (instance) => {
+            expect(instance._initialized).toBe(true);
+        });
+
+        PluginManager.deregister('FooPluginTag', 'div');
+    });
+
+    it('should initialize plugin with data-attribute selector', () => {
+        PluginManager.register('FooPluginDataAttr', FooPlugin, '[data-plugin]');
+
+        PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPluginDataAttr').length).toBe(1);
+
+        expect(PluginManager.getPluginInstances('FooPluginDataAttr')[0]._initialized).toBe(true);
+
+        PluginManager.deregister('FooPluginDataAttr', '[data-plugin]');
+    });
+
+    it('should initialize plugin with mixed selector (class and data-attribute)', () => {
+        const selector = '.test-class[data-plugin]';
+        PluginManager.register('FooPluginClassDataAttr', FooPlugin, selector);
+
+        PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPluginClassDataAttr').length).toBe(1);
+
+        expect(PluginManager.getPluginInstances('FooPluginClassDataAttr')[0]._initialized).toBe(true);
+
+        PluginManager.deregister('FooPluginClassDataAttr', selector);
+    });
+});


### PR DESCRIPTION
### 1. Why is this change necessary?
[previous PR](https://github.com/shopware/platform/pull/2182)

The current JS-plugin-registration in storefront uses querySelectorAll which is the slowest in any case.

With this change, we could promote add and using id- or classes-selectors for better performance.

Additional note: In our project we are using related elements directly in plugin-registration instead of string, but this doesn't work for re-initializing plugin, if complete element has been replaced by ajax.

### 2. What does this change do, exactly?
Added checks for the selector given as string and decide a better selector.
Due to performance and common usages, I'm just considering `\w-` (= `a-zA-Z1-9_-`) for regex. Others like umlauts and other special chars will fail over to the querySelectorAll.

### 3. Describe each step to reproduce the issue or behaviour.
Regex-test for id: https://regex101.com/r/ydYKjX/4

It's hard to describe... let pictures show it:

> Please note: these tests with firefox (chrome is similar) are based on a shop, not just a small dom-collection.

Selector by data-attribute (sure, a LITTLE bit slower):
![image](https://user-images.githubusercontent.com/135993/141480260-2e4e2bb8-286e-43ac-9390-399ce57f36d8.png)

Selector by ID (existing element):
![image](https://user-images.githubusercontent.com/135993/141480474-78c0e493-231e-4813-9c28-38232f3355fc.png)

selector by class (existing element):
![image](https://user-images.githubusercontent.com/135993/141485793-b22f6a20-8e2e-4e26-b117-28bb155ae066.png)


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
