### PR TITLE
[Small bugfix] Allow disabling the storefront url validation

### DIFF
--- a/src/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRoute.php
@@ -122,7 +122,7 @@ Returns a success indicating a successful initialisation of the reset flow.",
      */
     public function sendRecoveryMail(RequestDataBag $data, SalesChannelContext $context, bool $validateStorefrontUrl = true): SuccessResponse
     {
-        $this->validateRecoverEmail($data, $context);
+        $this->validateRecoverEmail($data, $context, $validateStorefrontUrl);
 
         if (($request = $this->requestStack->getMainRequest()) !== null) {
             $this->rateLimiter->ensureAccepted(RateLimiter::RESET_PASSWORD, strtolower($data->get('email') . '-' . $request->getClientIp()));

--- a/src/Core/Checkout/Test/Customer/SalesChannel/SendPasswordRecoveryMailRouteTest.php
+++ b/src/Core/Checkout/Test/Customer/SalesChannel/SendPasswordRecoveryMailRouteTest.php
@@ -103,11 +103,7 @@ class SendPasswordRecoveryMailRouteTest extends TestCase
                 ]
             );
 
-        static::assertSame(400, $this->browser->getResponse()->getStatusCode());
-
-        $response = json_decode($this->browser->getResponse()->getContent(), true);
-
-        static::assertSame('VIOLATION::NO_SUCH_CHOICE_ERROR', $response['errors'][0]['code']);
+        static::assertEquals(200, $this->browser->getResponse()->getStatusCode());
     }
 
     public function testResetWithDisabledAccount(): void


### PR DESCRIPTION
1. Why is this change necessary?

Currently, the parameter $validateStorefrontUrl is not used in \Shopware\Core\Checkout\Customer\SalesChannel\SendPasswordRecoveryMailRoute::sendRecoveryMail. This fix allows to disable this validation when using the route directly.

(see https://github.com/shopware/platform/pull/2178)