### PR TITLE
PromotionNotEligibleError for irrelevant promotions

### DIFF
--- a/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionDeliveryCalculator.php
@@ -69,7 +69,7 @@ class PromotionDeliveryCalculator
         // reduce discount lineItems if fixed price discounts are in collection
         $checkedDiscountLineItems = $this->reduceDiscountLineItemsIfFixedPresent($discountLineItems);
 
-        $exclusions = $this->buildExclusions($checkedDiscountLineItems);
+        $exclusions = $this->buildExclusions($checkedDiscountLineItems, $toCalculate, $context);
 
         foreach ($checkedDiscountLineItems as $discountItem) {
             if ($notDiscountedDeliveriesValue <= 0.0) {
@@ -123,7 +123,7 @@ class PromotionDeliveryCalculator
      * that are excluded somehow.
      * The validation which one to take will be done later.
      */
-    private function buildExclusions(LineItemCollection $discountLineItems): array
+    private function buildExclusions(LineItemCollection $discountLineItems, Cart $calculated, SalesChannelContext $context): array
     {
         // array that holds all excluded promotion ids.
         // if a promotion has exclusions they are added on the stack
@@ -149,7 +149,9 @@ class PromotionDeliveryCalculator
 
             // add all exclusions to the stack
             foreach ($discountItem->getPayloadValue('exclusions') as $id) {
-                $exclusions[$id] = true;
+                if ($this->isRequirementValid($discountItem, $calculated, $context)) {
+                    $exclusions[$id] = true;
+                }
             }
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Under some circumstances it is possible that you get a PromotionNotEligibleError in the cart even if there is no other promotion relevant for you.

### 2. What does this change do, exactly?
With this change a promotion's rules are checked before the exclusion list is computed.

### 3. Describe each step to reproduce the issue or behaviour.
Create two promotions:

The first promotion has to reduce your basket amount. Add a rule builder **cart** rule that you do **NOT** fulfill (e.g. 10000€ basket value). **Disallow the combination with other promotions**.

The second promotion must reduce your **shipping costs**.  Add "Always Valid" as the cart rule. Combination with other promotions is allowed.

When you add an article (price below 10000€) to your cart and navigate to the cart overview, you'll see a PromotionNotEligibleError for the first promotion, although this promotion is not relevant for you. 

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
