### PR TITLE
Services test config

### DIFF
--- a/changelog/_unreleased/2022-01-17-plugin-container-configuration-for-test-environment.md
+++ b/changelog/_unreleased/2022-01-17-plugin-container-configuration-for-test-environment.md
@@ -1,0 +1,10 @@
+---
+title: plugin-container-configuration-for-test-environment
+issue: -
+author: scriptibus
+author_email: mail@lucasnothnagel.de
+author_github: mail@lucasnothnagel.de
+---
+# Core
+* In Shopware bundles it is now possible to configure the container via a `Resource/config/services_test.{xml|yml}` 
+file which is only loaded for the test environment

--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -164,5 +164,11 @@ abstract class Bundle extends SymfonyBundle
         foreach (glob($this->getPath() . '/Resources/config/services.*') as $path) {
             $delegatingLoader->load($path);
         }
+
+        if ($container->getParameter('kernel.environment') === 'test') {
+            foreach (glob($this->getPath() . '/Resources/config/services_test.*') as $path) {
+                $delegatingLoader->load($path);
+            }
+        }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
* Writing functional tests for a plugin can require mocking services in the container. Those services should only be loaded in the test environment.
* Symfony devs may be used to creating a `services_test.{xml|yml}` for such purposes.

### 2. What does this change do, exactly?
It adds the possibility to add an additional service config file named `services_test.{xml|yml}` which is only loaded for the test environment.

### 3. Describe each step to reproduce the issue or behaviour.
* Create an Interface, e.g. `FileDeleterInterface`
* Create a real implementation `PhpUnlinkFileDeleter` which actually deletes the given file
* Create a mock implementation `MockFileDeleter` in your testing namespace, only checking if the file could be deleted but not deleting it
* In the `services.xml`alias the interface with the actual implementation
* In the `services_test.xml` alias the interface with the mock implementation

Now you can run your tests without deleting any files in the process.

### 4. Please link to the relevant issues (if any).
* none

### 5. Checklist

- [x] I have written tests and verified that they fail without my change (nothing to do here?!)
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### Notes
* I'm not sure about backwards compatibility. But I can't imagine a case where this breaks existing code.
* I didn't add tests because I could not find any tests for the Bundle.php at all.