### PR TITLE
Add memory limit to admin worker

### DIFF
--- a/changelog/_unreleased/2022-01-14-add-admin-worker-memory-limit.md
+++ b/changelog/_unreleased/2022-01-14-add-admin-worker-memory-limit.md
@@ -1,0 +1,8 @@
+---
+title: Add memory limit to admin worker
+issue: NEXT-19493
+author: Niklas Büchner
+author_email: niklas.buechner@pickware.de
+---
+# Administration
+* Added a memory limit to the admin worker.

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -181,6 +181,9 @@ class Configuration implements ConfigurationInterface
                 ->booleanNode('enable_admin_worker')
                     ->defaultValue(true)
                 ->end()
+                ->scalarNode('memory_limit')
+                    ->defaultValue('128M')
+                ->end()
             ->end();
 
         return $rootNode;

--- a/src/Core/Framework/DependencyInjection/message-queue.xml
+++ b/src/Core/Framework/DependencyInjection/message-queue.xml
@@ -103,6 +103,7 @@
             <argument type="service" id="messenger.listener.dispatch_pcntl_signal_listener"/>
             <argument type="service" id="Shopware\Core\Framework\MessageQueue\Subscriber\EarlyReturnMessagesListener"/>
             <argument type="string">%messenger.default_transport_name%</argument>
+            <argument type="string">%shopware.admin_worker.memory_limit%</argument>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Command/ScheduledTaskRunner.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Command/ScheduledTaskRunner.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\MessageQueue\ScheduledTask\Command;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\Scheduler\TaskScheduler;
+use Shopware\Core\Framework\Util\MemorySizeCalculator;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -56,7 +57,7 @@ class ScheduledTaskRunner extends Command
 
         $memoryLimit = $input->getOption('memory-limit');
         if ($memoryLimit) {
-            $memoryLimit = $this->convertToBytes($memoryLimit);
+            $memoryLimit = MemorySizeCalculator::convertToBytes($memoryLimit);
         }
 
         while (!$this->shouldStop) {
@@ -103,23 +104,5 @@ class ScheduledTaskRunner extends Command
         }
 
         return $workerStartedAt < $cacheItem->get();
-    }
-
-    private function convertToBytes(string $memoryLimit): int
-    {
-        $memoryLimit = mb_strtolower($memoryLimit);
-        $max = (int) mb_strtolower(ltrim($memoryLimit, '+'));
-
-        switch (mb_substr($memoryLimit, -1)) {
-            case 't': $max *= 1024;
-            // no break
-            case 'g': $max *= 1024;
-            // no break
-            case 'm': $max *= 1024;
-            // no break
-            case 'k': $max *= 1024;
-        }
-
-        return $max;
     }
 }

--- a/src/Core/Framework/Test/Util/MemorySizeCalculatorTest.php
+++ b/src/Core/Framework/Test/Util/MemorySizeCalculatorTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Util;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Util\MemorySizeCalculator;
+
+class MemorySizeCalculatorTest extends TestCase
+{
+    /**
+     * @dataProvider memorySizeDataProvider
+     */
+    public function testBytesConversion($limit, $bytes): void
+    {
+        static::assertEquals($bytes, MemorySizeCalculator::convertToBytes($limit));
+    }
+
+    /**
+     * We are trying to replicate the Symfony's convertToBytes method. Therefore, we will use the test cases Symfony
+     * uses.
+     *
+     * See also:
+     * https://github.com/symfony/symfony/blob/3a96e4cde6aa0c9e138bdfcce60564a2f396c070/src/Symfony/Component/HttpKernel/Tests/DataCollector/MemoryDataCollectorTest.php
+     */
+    public function memorySizeDataProvider(): array
+    {
+        return [
+            ['2k', 2048],
+            ['2 k', 2048],
+            ['8m', 8 * 1024 * 1024],
+            ['+2 k', 2048],
+            ['+2???k', 2048],
+            ['0x10', 16],
+            ['0xf', 15],
+            ['010', 8],
+            ['+0x10 k', 16 * 1024],
+            ['1g', 1024 * 1024 * 1024],
+            ['1G', 1024 * 1024 * 1024],
+            ['-1', -1],
+            ['0', 0],
+            ['2mk', 2048], // the unit must be the last char, so in this case 'k', not 'm'
+        ];
+    }
+}

--- a/src/Core/Framework/Util/MemorySizeCalculator.php
+++ b/src/Core/Framework/Util/MemorySizeCalculator.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Util;
+
+class MemorySizeCalculator
+{
+    /**
+     * This code is the same as the memory limit implementation of Symfony's consume message command. Since we want to
+     * replicate the behaviour here we will be using the same implementation.
+     *
+     * See also:
+     * https://github.com/symfony/messenger/blob/4319c25b76573cff46f112ee8cc83fffa4b97579/Command/ConsumeMessagesCommand.php#L243-L266
+     */
+    public static function convertToBytes(string $memoryLimit): int
+    {
+        $memoryLimit = strtolower($memoryLimit);
+        $max = ltrim($memoryLimit, '+');
+        if (str_starts_with($max, '0x')) {
+            $max = \intval($max, 16);
+        } elseif (str_starts_with($max, '0')) {
+            $max = \intval($max, 8);
+        } else {
+            $max = (int) $max;
+        }
+
+        switch (substr(rtrim($memoryLimit, 'b'), -1)) {
+            case 't': $max *= 1024;
+            // no break
+            case 'g': $max *= 1024;
+            // no break
+            case 'm': $max *= 1024;
+            // no break
+            case 'k': $max *= 1024;
+        }
+
+        return $max;
+    }
+}

--- a/src/Docs/Resources/current/20-developer-guide/80-core/10-message-queue.md
+++ b/src/Docs/Resources/current/20-developer-guide/80-core/10-message-queue.md
@@ -314,7 +314,7 @@ For more information on this check the [symfony docs](https://symfony.com/doc/cu
 
 The admin-worker can be configured/disabled in the general shopware.yml configuration.
 If you want to use the admin worker you have specify each transport, that previously was configured.
-The poll interval is the time in seconds that the admin-worker polls messages from the queue. After the poll-interval is over the request terminates and the administration initiates a new request.
+The poll interval is the time in seconds that the admin-worker polls messages from the queue. After the poll-interval is over or the memory limit is reached the request terminates and the administration initiates a new request.
 ```yaml
 # config/packages/shopware.yaml
 shopware:
@@ -322,4 +322,5 @@ shopware:
         enable_admin_worker: true
         poll_interval: 20
         transports: ["default"]
+        memory_limit: 128M
 ``` 


### PR DESCRIPTION
### 1. Why is this change necessary?

The admin work does not have a memory limit. This results in the worker continuing to consume messages until the time limit is reached. This can result in a message running into a memory limit and failing. Which in turn will move the message into the dead message table and the message will only be retried after 20 minutes. This is too long for time critical messages.

Here is an example of this process. When the very first `importChunk` message is processed, the memory consumption grows until the worker runs into a fatal memory error. The second message does not run into the error since it stops before too much memory is consumed. Due to the behavior explained above, it is favorable to ensure that the worker restarts instead of running into the memory limit.

![logs](https://user-images.githubusercontent.com/31041526/149802850-aaaef4ff-9b0d-4d63-80ac-8686fdf16660.png)

### 2. What does this change do, exactly?

This change adds a memory limit to the admin worker and thereby prevents the admin worker from consuming more messages if there is only little memory left. The default value ist set to 25% of the php memory system requirement.

### 3. Describe each step to reproduce the issue or behaviour.

Create a message which consumes e.g. a fourth of the memory limit and holds the memory and have the worker consume it 4 times in a single worker request.

### 4. Please link to the relevant issues (if any).
- [https://issues.shopware.com/issues/NEXT-19493](https://issues.shopware.com/issues/NEXT-19493)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
  This logic can not easily be unit tested since the used classes are instantiated within the method itself.
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
