### PR TITLE
Switch storefront plugin data-attribute selectors to match their -option naming

### DIFF
--- a/changelog/_unreleased/2022-01-19-switch-storefront-plugin-data-attribute-selectors-to-match-their--option-naming.md
+++ b/changelog/_unreleased/2022-01-19-switch-storefront-plugin-data-attribute-selectors-to-match-their--option-naming.md
@@ -1,0 +1,51 @@
+---
+title: Switch storefront plugin data-attribute selectors to match their -option naming
+issue: NEXT-19709
+flag: NEXT_19709
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Deprecated storefront javascript plugin selector from `data-search-form` to `data-search-widget` behind feature flag NEXT_19709 and removed with update to 6.5.0 to improve developer experience for using storefront javascript plugin configurations
+* Deprecated storefront javascript plugin selector from `data-offcanvas-cart` to `data-off-canvas-cart` behind feature flag NEXT_19709 and removed with update to 6.5.0 to improve developer experience for using storefront javascript plugin configurations
+* Deprecated storefront javascript plugin selector from `data-collapse-footer` to `data-collapse-footer-columns` behind feature flag NEXT_19709 and removed with update to 6.5.0 to improve developer experience for using storefront javascript plugin configurations
+* Deprecated storefront javascript plugin selector from `data-offcanvas-menu` to `data-off-canvas-menu` behind feature flag NEXT_19709 and removed with update to 6.5.0 to improve developer experience for using storefront javascript plugin configurations
+* Deprecated storefront javascript plugin selector from `data-offcanvas-account-menu` to `data-account-menu` behind feature flag NEXT_19709 and removed with update to 6.5.0 to improve developer experience for using storefront javascript plugin configurations
+* Deprecated storefront javascript plugin selector from `data-offcanvas-tabs` to `data-off-canvas-tabs` behind feature flag NEXT_19709 and removed with update to 6.5.0 to improve developer experience for using storefront javascript plugin configurations
+* Deprecated storefront javascript plugin selector from `data-offcanvas-filter` to `data-off-canvas-filter` behind feature flag NEXT_19709 and removed with update to 6.5.0 to improve developer experience for using storefront javascript plugin configurations
+___
+# Upgrade Information
+
+When you use one of the following attributes in CSS selectors, Javascript DOM elements selectors or HTML you have to switch them and/or respect the feature flag:
+
+For Javascript:
+```javascript
+import Feature from 'src/helper/feature.helper';
+if (Feature.isActive('NEXT_19709')) {
+    /* do something with new selector */
+} else {
+    /* do something with old selector */
+}
+```
+
+For twig templates:
+```twig
+{% if feature('NEXT_19709') %}
+    {# do something with new selector #}
+{% else %}
+    {# do something with old selector #}
+{% endif %}
+```
+
+-------------
+| old | new |
+| :-- | :-- |
+| data-search-form | data-search-widget |
+| data-offcanvas-cart | data-off-canvas-cart |
+| data-collapse-footer | data-collapse-footer-columns |
+| data-offcanvas-menu | data-off-canvas-menu |
+| data-offcanvas-account-menu | data-account-menu |
+| data-offcanvas-tabs | data-off-canvas-tabs |
+| data-offcanvas-filter | data-off-canvas-filter |
+-------------

--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -112,17 +112,44 @@ PluginManager.register('DateFormat', DateFormat, '[data-date-format]');
 PluginManager.register('CookiePermission', CookiePermissionPlugin, '[data-cookie-permission]');
 PluginManager.register('CookieConfiguration', CookieConfigurationPlugin, '[data-cookie-permission]');
 PluginManager.register('ScrollUp', ScrollUpPlugin, '[data-scroll-up]');
-PluginManager.register('SearchWidget', SearchWidgetPlugin, '[data-search-form]');
+
+/** @deprecated tag:v6.5.0 Registering plugin on selector "data-search-form" is deprecated. Use "data-search-widget" instead */
+if (Feature.isActive('NEXT_19709')) {
+    PluginManager.register('SearchWidget', SearchWidgetPlugin, '[data-search-widget]');
+} else {
+    PluginManager.register('SearchWidget', SearchWidgetPlugin, '[data-search-form]');
+}
+
 PluginManager.register('CartWidget', CartWidgetPlugin, '[data-cart-widget]');
 
 PluginManager.register('AccountGuestAbortButton', AccountGuestAbortButtonPlugin, '[data-account-guest-abort-button]')
 
-PluginManager.register('OffCanvasCart', OffCanvasCartPlugin, '[data-offcanvas-cart]');
+/** @deprecated tag:v6.5.0 Registering plugin on selector "data-offcanvas-cart" is deprecated. Use "data-off-canvas-cart" instead */
+if (Feature.isActive('NEXT_19709')) {
+    PluginManager.register('OffCanvasCart', OffCanvasCartPlugin, '[data-off-canvas-cart]');
+} else {
+    PluginManager.register('OffCanvasCart', OffCanvasCartPlugin, '[data-offcanvas-cart]');
+}
+
 PluginManager.register('AddToCart', AddToCartPlugin, '[data-add-to-cart]');
-PluginManager.register('CollapseFooterColumns', CollapseFooterColumnsPlugin, '[data-collapse-footer]');
+
+/** @deprecated tag:v6.5.0 Registering plugin on selector "data-collapse-footer" is deprecated. Use "data-collapse-footer-columns" instead */
+if (Feature.isActive('NEXT_19709')) {
+    PluginManager.register('CollapseFooterColumns', CollapseFooterColumnsPlugin, '[data-collapse-footer-columns]');
+} else {
+    PluginManager.register('CollapseFooterColumns', CollapseFooterColumnsPlugin, '[data-collapse-footer]');
+}
+
 PluginManager.register('CollapseCheckoutConfirmMethods', CollapseCheckoutConfirmMethodsPlugin, '[data-collapse-checkout-confirm-methods]');
 PluginManager.register('FlyoutMenu', FlyoutMenuPlugin, '[data-flyout-menu]');
-PluginManager.register('OffcanvasMenu', OffcanvasMenuPlugin, '[data-offcanvas-menu]');
+
+/** @deprecated tag:v6.5.0 Registering plugin on selector "data-offcanvas-menu" is deprecated. Use "data-off-canvas-menu" instead */
+if (Feature.isActive('NEXT_19709')) {
+    PluginManager.register('OffCanvasMenu', OffcanvasMenuPlugin, '[data-off-canvas-menu]');
+} else {
+    PluginManager.register('OffcanvasMenu', OffcanvasMenuPlugin, '[data-offcanvas-menu]');
+}
+
 PluginManager.register('FormValidation', FormValidationPlugin, '[data-form-validation]');
 PluginManager.register('FormScrollToInvalidField', FromScrollToInvalidFieldPlugin, 'form');
 PluginManager.register('FormSubmitLoader', FormSubmitLoaderPlugin, '[data-form-submit-loader]');
@@ -131,8 +158,21 @@ PluginManager.register('FormAutoSubmit', FormAutoSubmitPlugin, '[data-form-auto-
 PluginManager.register('FormAjaxSubmit', FormAjaxSubmitPlugin, '[data-form-ajax-submit]');
 PluginManager.register('FormAddHistory', FormAddHistoryPlugin, '[data-form-add-history]');
 PluginManager.register('FormPreserver', FormPreserverPlugin, '[data-form-preserver]');
-PluginManager.register('AccountMenu', AccountMenuPlugin, '[data-offcanvas-account-menu]');
-PluginManager.register('OffCanvasTabs', OffCanvasTabsPlugin, '[data-offcanvas-tabs]');
+
+/** @deprecated tag:v6.5.0 Registering plugin on selector "data-offcanvas-account-menu" is deprecated. Use "data-account-menu" instead */
+if (Feature.isActive('NEXT_19709')) {
+    PluginManager.register('AccountMenu', AccountMenuPlugin, '[data-account-menu]');
+} else {
+    PluginManager.register('AccountMenu', AccountMenuPlugin, '[data-offcanvas-account-menu]');
+}
+
+/** @deprecated tag:v6.5.0 Registering plugin on selector "data-offcanvas-tabs" is deprecated. Use "data-off-canvas-tabs" instead */
+if (Feature.isActive('NEXT_19709')) {
+    PluginManager.register('OffCanvasTabs', OffCanvasTabsPlugin, '[data-off-canvas-tabs]');
+} else {
+    PluginManager.register('OffCanvasTabs', OffCanvasTabsPlugin, '[data-offcanvas-tabs]');
+}
+
 PluginManager.register('BaseSlider', BaseSliderPlugin, '[data-base-slider]');
 PluginManager.register('GallerySlider', GallerySliderPlugin, '[data-gallery-slider]');
 PluginManager.register('ProductSlider', ProductSliderPlugin, '[data-product-slider]');
@@ -146,7 +186,14 @@ PluginManager.register('AddressEditor', AddressEditorPlugin, '[data-address-edit
 PluginManager.register('SetBrowserClass', SetBrowserClassPlugin, 'html');
 PluginManager.register('RatingSystem', RatingSystemPlugin, '[data-rating-system]');
 PluginManager.register('Listing', ListingPlugin, '[data-listing]');
-PluginManager.register('OffCanvasFilter', OffCanvasFilterPlugin, '[data-offcanvas-filter]');
+
+/** @deprecated tag:v6.5.0 Registering plugin on selector "data-offcanvas-filter" is deprecated. Use "data-off-canvas-filter" instead */
+if (Feature.isActive('NEXT_19709')) {
+    PluginManager.register('OffCanvasFilter', OffCanvasFilterPlugin, '[data-off-canvas-filter]');
+} else {
+    PluginManager.register('OffCanvasFilter', OffCanvasFilterPlugin, '[data-offcanvas-filter]');
+}
+
 PluginManager.register('FilterBoolean', FilterBooleanPlugin, '[data-filter-boolean]');
 PluginManager.register('FilterRange', FilterRangePlugin, '[data-filter-range]');
 PluginManager.register('FilterMultiSelect', FilterMultiSelectPlugin, '[data-filter-multi-select]');

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
@@ -140,13 +140,19 @@
                                     points: product.ratingAverage,
                                     style: 'text-primary'
                                 } %}
-                                <a data-toggle="tab"
-                                   class="product-detail-reviews-link"
-                                   data-offcanvas-tabs="true"
-                                   data-remote-click="true"
-                                   data-remote-click-options='{{ remoteClickOptions|json_encode }}'
-                                   href="{{ reviewTabHref }}"
-                                   aria-controls="review-tab-pane">
+                                <a
+                                    data-toggle="tab"
+                                    class="product-detail-reviews-link"
+                                    {% if feature('NEXT_19709') %}
+                                        data-off-canvas-tabs="true"
+                                    {% else %}
+                                        data-offcanvas-tabs="true"
+                                    {% endif %}
+                                    data-remote-click="true"
+                                    data-remote-click-options='{{ remoteClickOptions|json_encode }}'
+                                    href="{{ reviewTabHref }}"
+                                    aria-controls="review-tab-pane"
+                                >
                                     {{ totalReviews }}
                                     {{ "detail.reviewLinkText"|trans({'%count%': totalReviews})|sw_sanitize }}
                                 </a>

--- a/src/Storefront/Resources/views/storefront/element/cms-element-product-description-reviews.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-product-description-reviews.html.twig
@@ -25,7 +25,11 @@
                                             <a class="nav-link {% if (ratingSuccess != 1) and (ratingSuccess != -1) %}active{% endif %} product-detail-tab-navigation-link"
                                                id="{{ descriptionTabId }}"
                                                data-toggle="tab"
-                                               data-offcanvas-tabs="true"
+                                                {% if feature('NEXT_19709') %}
+                                                    data-off-canvas-tabs="true"
+                                                {% else %}
+                                                    data-offcanvas-tabs="true"
+                                                {% endif %}
                                                href="{{ descriptionTabHref }}"
                                                role="tab"
                                                aria-controls="{{ descriptionTabContent }}"
@@ -57,7 +61,11 @@
                                                 <a class="nav-link {% if (ratingSuccess == 1) or (ratingSuccess == -1) %}active{% endif %} product-detail-tab-navigation-link review-tab"
                                                    id="{{ reviewTabId }}"
                                                    data-toggle="tab"
-                                                   data-offcanvas-tabs="true"
+                                                    {% if feature('NEXT_19709') %}
+                                                        data-off-canvas-tabs="true"
+                                                    {% else %}
+                                                        data-offcanvas-tabs="true"
+                                                    {% endif %}
                                                    href="{{ reviewTabHref }}"
                                                    role="tab"
                                                    aria-controls="{{ reviewTabContent }}"

--- a/src/Storefront/Resources/views/storefront/element/cms-element-sidebar-filter.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-sidebar-filter.html.twig
@@ -10,12 +10,18 @@
     {% if listing.aggregations.elements|length > 0 %}
         <div class="cms-element-sidebar-filter">
             {% block element_product_listing_filter_button %}
-                <button class="btn header-actions-btn filter-panel-wrapper-toggle"
-                        type="button"
+                <button
+                    class="btn header-actions-btn filter-panel-wrapper-toggle"
+                    type="button"
+                    {% if feature('NEXT_19709') %}
+                        data-off-canvas-filter="true"
+                    {% else %}
                         data-offcanvas-filter="true"
-                        aria-haspopup="true"
-                        aria-expanded="false"
-                        aria-label="{{ "general.menuLink"|trans }}">
+                    {% endif %}
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    aria-label="{{ "general.menuLink"|trans }}"
+                >
                     {% block element_product_listing_filter_button_icon %}
                         {% sw_icon 'sliders-horizontal' %}
                     {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -2,9 +2,15 @@
     <div class="container">
 
         {% block layout_footer_navigation %}
-            <div id="footerColumns"
-                 class="row footer-columns"
-                 data-collapse-footer="true">
+            <div
+                id="footerColumns"
+                class="row footer-columns"
+                {% if feature('NEXT_19709') %}
+                    data-collapse-footer-columns="true"
+                {% else %}
+                    data-collapse-footer="true"
+                {% endif %}
+            >
                 {% block layout_footer_navigation_hotline %}
                     <div class="col-md-4 footer-column js-footer-column">
                         {% block layout_footer_navigation_hotline_headline %}

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/account-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/account-widget.html.twig
@@ -4,7 +4,11 @@
             <button class="btn account-menu-btn header-actions-btn"
                     type="button"
                     id="accountWidget"
+                {% if feature('NEXT_19709') %}
+                    data-account-menu="true"
+                {% else %}
                     data-offcanvas-account-menu="true"
+                {% endif %}
                     data-toggle="dropdown"
                     aria-haspopup="true"
                     aria-expanded="false"

--- a/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
@@ -18,10 +18,16 @@
                             {% block layout_header_navigation_toggle_tablet %}
                                 <div class="nav-main-toggle">
                                     {% block layout_header_navigation_toggle_tablet_button %}
-                                        <button class="btn nav-main-toggle-btn header-actions-btn"
-                                                type="button"
+                                        <button
+                                            class="btn nav-main-toggle-btn header-actions-btn"
+                                            type="button"
+                                            {% if feature('NEXT_19709') %}
+                                                data-off-canvas-menu="true"
+                                            {% else %}
                                                 data-offcanvas-menu="true"
-                                                aria-label="{{ "general.menuLink"|trans|striptags }}">
+                                            {% endif %}
+                                            aria-label="{{ "general.menuLink"|trans|striptags }}"
+                                        >
                                             {% block layout_header_navigation_toggle_tablet_button_icon %}
                                                 {% sw_icon 'stack' %}
                                             {% endblock %}
@@ -44,10 +50,16 @@
                             <div class="col d-sm-none">
                                 <div class="menu-button">
                                     {% block layout_header_navigation_toggle_button %}
-                                        <button class="btn nav-main-toggle-btn header-actions-btn"
-                                                type="button"
+                                        <button
+                                            class="btn nav-main-toggle-btn header-actions-btn"
+                                            type="button"
+                                            {% if feature('NEXT_19709') %}
+                                                data-off-canvas-menu="true"
+                                            {% else %}
                                                 data-offcanvas-menu="true"
-                                                aria-label="{{ "general.menuLink"|trans|striptags }}">
+                                            {% endif %}
+                                            aria-label="{{ "general.menuLink"|trans|striptags }}"
+                                        >
                                             {% block layout_header_navigation_toggle_button_icon %}
                                                 {% sw_icon 'stack' %}
                                             {% endblock %}
@@ -98,8 +110,14 @@
 
                         {% block layout_header_actions_cart %}
                             <div class="col-auto">
-                                <div class="header-cart"
-                                     data-offcanvas-cart="true">
+                                <div
+                                    class="header-cart"
+                                    {% if feature('NEXT_19709') %}
+                                        data-off-canvas-cart="true"
+                                    {% else %}
+                                        data-offcanvas-cart="true"
+                                    {% endif %}
+                                >
                                     <a class="btn header-cart-btn header-actions-btn"
                                        href="{{ path('frontend.checkout.cart.page') }}"
                                        data-cart-widget="true"

--- a/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
@@ -4,7 +4,11 @@
         <div class="header-search">
             <form action="{{ path('frontend.search.page') }}"
                   method="get"
-                  data-search-form="true"
+                {% if feature('NEXT_19709') %}
+                    data-search-widget="true"
+                {% else %}
+                    data-search-form="true"
+                {% endif %}
                   data-url="{{ path('frontend.search.suggest') }}?search="
                   class="header-search-form">
                 {% block layout_header_search_input_group %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
@@ -138,13 +138,19 @@
                                     points: page.product.ratingAverage,
                                     style: 'text-primary'
                                 } %}
-                                <a data-toggle="tab"
-                                   class="product-detail-reviews-link"
-                                   data-offcanvas-tabs="true"
-                                   data-remote-click="true"
-                                   data-remote-click-options='{{ remoteClickOptions|json_encode }}'
-                                   href="#review-tab-pane"
-                                   aria-controls="review-tab-pane">
+                                <a
+                                    data-toggle="tab"
+                                    class="product-detail-reviews-link"
+                                    {% if feature('NEXT_19709') %}
+                                        data-off-canvas-tabs="true"
+                                    {% else %}
+                                        data-offcanvas-tabs="true"
+                                    {% endif %}
+                                    data-remote-click="true"
+                                    data-remote-click-options='{{ remoteClickOptions|json_encode }}'
+                                    href="#review-tab-pane"
+                                    aria-controls="review-tab-pane"
+                                >
                                     {{ page.reviews.totalReviews }}
                                     {{ "detail.reviewLinkText"|trans({'%count%': page.reviews.totalReviews})|sw_sanitize }}
                                 </a>

--- a/src/Storefront/Resources/views/storefront/page/product-detail/tabs.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/tabs.html.twig
@@ -8,14 +8,20 @@
                         role="tablist">
                         {% block page_product_detail_tabs_navigation_description %}
                             <li class="nav-item">
-                                <a class="nav-link {% if (ratingSuccess != 1) and (ratingSuccess != -1) %}active{% endif %} product-detail-tab-navigation-link"
-                                   id="description-tab"
-                                   data-toggle="tab"
-                                   data-offcanvas-tabs="true"
-                                   href="#description-tab-pane"
-                                   role="tab"
-                                   aria-controls="description-tab-pane"
-                                   aria-selected="true">
+                                <a
+                                    class="nav-link {% if (ratingSuccess != 1) and (ratingSuccess != -1) %}active{% endif %} product-detail-tab-navigation-link"
+                                    id="description-tab"
+                                    data-toggle="tab"
+                                    {% if feature('NEXT_19709') %}
+                                        data-off-canvas-tabs="true"
+                                    {% else %}
+                                        data-offcanvas-tabs="true"
+                                    {% endif %}
+                                    href="#description-tab-pane"
+                                    role="tab"
+                                    aria-controls="description-tab-pane"
+                                    aria-selected="true"
+                                >
                                     <span>{{ "detail.tabsDescription"|trans|sw_sanitize }}</span>
                                     <span class="product-detail-tab-navigation-icon">
                                         {% sw_icon 'arrow-medium-right' style {'pack':'solid'} %}
@@ -39,14 +45,20 @@
                         {% block page_product_detail_tabs_navigation_review %}
                             {% if config('core.listing.showReview') %}
                                 <li class="nav-item">
-                                    <a class="nav-link {% if (ratingSuccess == 1) or (ratingSuccess == -1) %}active{% endif %} product-detail-tab-navigation-link"
-                                       id="review-tab"
-                                       data-toggle="tab"
-                                       data-offcanvas-tabs="true"
-                                       href="#review-tab-pane"
-                                       role="tab"
-                                       aria-controls="review-tab-pane"
-                                       aria-selected="true">
+                                    <a
+                                        class="nav-link {% if (ratingSuccess == 1) or (ratingSuccess == -1) %}active{% endif %} product-detail-tab-navigation-link"
+                                        id="review-tab"
+                                        data-toggle="tab"
+                                        {% if feature('NEXT_19709') %}
+                                            data-off-canvas-tabs="true"
+                                        {% else %}
+                                            data-offcanvas-tabs="true"
+                                        {% endif %}
+                                        href="#review-tab-pane"
+                                        role="tab"
+                                        aria-controls="review-tab-pane"
+                                        aria-selected="true"
+                                    >
                                         {{ "detail.tabsReview"|trans|sw_sanitize }}
                                         <span class="product-detail-tab-navigation-icon">
                                             {% sw_icon 'arrow-medium-right' style {'pack':'solid'} %}


### PR DESCRIPTION
### 1. Why is this change necessary?

It improves DX by fixing breaks in patterns. Pattern can be noticed [here](https://developer.shopware.com/docs/guides/plugins/plugins/storefront/add-custom-javascript#modify-existing-options).

### 2. What does this change do, exactly?

It duplicates plugin registrations on slightly different selectors to match the data attribute in the selector to the option field. There are also deprecation hints that are most likely never seen by a frontend dev and might need to be placed somewhere else.

### 3. Describe each step to reproduce the issue or behaviour.

1. Make an offcanvas tab from scratch
2. Want to move offcanvas to bottom instead to flyin from the right
3. See option in `OffCanvasTabs` storefront plugin
4. Go from `<div data-offcanvas-tabs="true"></div>` to `<div  data-offcanvas-tabs="true" data-offcanvas-tabs-options="{{ { offcanvasPostion: 'bottom' }|json_encode|escape('html_attr') }}">`
5. Why is this not changing the offcanvas?
6. Change class manually from `is-right` to `is-bottom`. Works
7. Debug why class is not changed: `right` is passed to the class
8. Verify correct json encoding of attribute value
9. Debug into plugin init
10. PLUGIN INIT LOOKS FOR `data-off-canvas-tabs-options` INSTEAD OF MY `data-offcanvas-tabs-options` BECAUSE THE REGISTRATION SELECTOR DOES NOT MATCH THE PLUGIN NAME WHICH IS USED IN KEBAB CASE TO LOOK UP THE OPTIONS DATA ATTRIBUTE NAME ( ╯°□°)╯ ┻━━┻ 

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Todo

1. Calm down ┬─┬ノ( º _ ºノ)  ☑️
2. Add changelog ☑️
3. Discuss how to prevent this in the future