### PR TITLE
NEXT-19711 - fix not-dispatched tasks being marked with status queued

### DIFF
--- a/changelog/_unreleased/2022-01-21-scheduled-tasks-stuck-in-queued-despite-never-dispatched.md
+++ b/changelog/_unreleased/2022-01-21-scheduled-tasks-stuck-in-queued-despite-never-dispatched.md
@@ -1,0 +1,11 @@
+---
+title: Scheduled tasks stuck in queued despite never dispatched
+issue: NEXT-19711
+author: Benny Poensgen
+author_email: poensgen@vanwittlaer.de
+author_github: vanWittlaer
+---
+
+# Core
+
+* Fix logic in scheduled-task:run command in a way that only the task failed to dispatch is set to "queued" whilst all other tasks not yet dispatched will remain "scheduled".

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
@@ -39,28 +39,24 @@ class TaskScheduler
     public function queueScheduledTasks(): void
     {
         $criteria = $this->buildCriteriaForAllScheduledTask();
-        $tasks = $this->scheduledTaskRepository->search($criteria, Context::createDefaultContext())->getEntities();
+        $context = Context::createDefaultContext();
+        $tasks = $this->scheduledTaskRepository->search($criteria, $context)->getEntities();
 
         if (\count($tasks) === 0) {
             return;
         }
 
-        $updatePayload = [];
-        /** @var ScheduledTaskEntity $task */
-        foreach ($tasks as $task) {
-            $updatePayload[] = [
-                'id' => $task->getId(),
-                'status' => ScheduledTaskDefinition::STATUS_QUEUED,
-            ];
-        }
-
-        $this->scheduledTaskRepository->update($updatePayload, Context::createDefaultContext());
-
-        // Tasks **must not** be queued before their state in the database has been updated. Otherwise
+        // Tasks **must not** be queued before their state in the database has been updated. Otherwise,
         // a worker could have already fetched the task and set its state to running before it gets set to
         // queued, thus breaking the task.
         /** @var ScheduledTaskEntity $task */
         foreach ($tasks as $task) {
+            $this->scheduledTaskRepository->update([
+                [
+                    'id' => $task->getId(),
+                    'status' => ScheduledTaskDefinition::STATUS_QUEUED,
+                ],
+            ], $context);
             $this->queueTask($task);
         }
     }

--- a/src/Core/Framework/Test/ScheduledTask/Scheduler/TaskSchedulerTest.php
+++ b/src/Core/Framework/Test/ScheduledTask/Scheduler/TaskSchedulerTest.php
@@ -158,22 +158,45 @@ class TaskSchedulerTest extends TestCase
         ));
         $this->connection->exec('DELETE FROM scheduled_task');
 
-        $taskId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        // tasks will be scheduled in sort sequence of their ids
+        $taskId1 = '2206c460e1054f2290d86fb4379cc021';
+        $taskId2 = 'cc65a904c6d246479e6c4958f262a17f';
+
         $this->scheduledTaskRepo->create([
             [
-                'id' => $taskId,
-                'name' => 'test',
+                'id' => $taskId1,
+                'name' => 'test_1',
                 'scheduledTaskClass' => TestMessage::class,
                 'runInterval' => 300,
                 'status' => ScheduledTaskDefinition::STATUS_SCHEDULED,
                 'nextExecutionTime' => (new \DateTime())->modify('-1 second'),
             ],
-        ], Context::createDefaultContext());
+        ], $context);
+
+        $this->scheduledTaskRepo->create([
+            [
+                'id' => $taskId2,
+                'name' => 'test_2',
+                'scheduledTaskClass' => RequeueDeadMessagesTask::class,
+                'runInterval' => 300,
+                'status' => ScheduledTaskDefinition::STATUS_SCHEDULED,
+                'nextExecutionTime' => (new \DateTime())->modify('-1 minute'),
+            ],
+        ], $context);
 
         $this->messageBus->expects(static::never())
             ->method('dispatch');
 
-        $this->scheduler->queueScheduledTasks();
+        try {
+            $this->scheduler->queueScheduledTasks();
+        } catch (\Exception $exception) {
+            /** @var ScheduledTaskEntity $task2Entity */
+            $task2Entity = $this->scheduledTaskRepo->search(new Criteria([$taskId2]), $context)->get($taskId2);
+            static::assertEquals(ScheduledTaskDefinition::STATUS_SCHEDULED, $task2Entity->getStatus());
+            throw $exception;
+        }
     }
 
     public function testGetNextExecutionTime(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When more than one scheduled task is due to be queued, and the TaskScheduler fails for whatever reason when trying to dispatch one task, the other tasks (which have not been dispatched yet) will get stuck in the queued status. 

### 2. What does this change do, exactly?
Fix code in TaskScheduler.php in a way that a runtime exception will only affect the task currently being processed. 

### 3. Describe each step to reproduce the issue or behaviour.
* create a number of tasks to be scheduled
* invalidate the classname for one of the tasks in the scheduled_task table (it needs to be one which will be processed by the TaskScheduler as first or one of the following, but not the last task)
* console scheduled-task:run
* you will observe the runtime exception "Tried to schedule ..."
* check scheduled_task table - you will find those tasks which could not have been dispatched still in queued status

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-19711
likely related: https://issues.shopware.com/issues/NEXT-10047
possibly related: https://issues.shopware.com/issues/SESP-152

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
