### PR TITLE
NEXT-19865 - Use new twig template name for each unique template to remove statefulness

### DIFF
--- a/changelog/_unreleased/2022-01-22-fix-statefulness-issues-of-twig-environment-in-seo-url-generator.md
+++ b/changelog/_unreleased/2022-01-22-fix-statefulness-issues-of-twig-environment-in-seo-url-generator.md
@@ -1,0 +1,12 @@
+---
+title: Fix issues by statefulness twig environment in SeoUrlGenerator
+issue: NEXT-19865
+author: JoshuaBehrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed usage of broken twig templates in `Shopware\Core\Content\Seo\SeoUrlGenerator` to bullet-proof it against invalid configured SEO URL templates
+* Changed used execution time when using `Shopware\Core\Content\Seo\SeoUrlGenerator` with a broken SEO URL template as a broken twig will not be used anymore to try to generate URLs
+* Changed internal template name for template from string `Shopware\Core\Content\Seo\SeoUrlGenerator` to ensure Twig caching can rely on template name
+* Added logging to twig usage errors in `Shopware\Core\Content\Seo\SeoUrlGenerator`

--- a/src/Core/Content/Seo/SeoUrlGenerator.php
+++ b/src/Core/Content/Seo/SeoUrlGenerator.php
@@ -2,9 +2,11 @@
 
 namespace Shopware\Core\Content\Seo;
 
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\LandingPage\LandingPageCollection;
 use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Seo\Exception\InvalidTemplateException;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlMapping;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
@@ -25,8 +27,10 @@ use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment;
+use Twig\Error\Error;
 use Twig\Error\SyntaxError;
 use Twig\Loader\ArrayLoader;
+use Twig\Loader\ChainLoader;
 
 #[Package('buyers-experience')]
 class SeoUrlGenerator
@@ -43,7 +47,8 @@ class SeoUrlGenerator
         private readonly RouterInterface $router,
         private readonly RequestStack $requestStack,
         private readonly Environment $twig,
-        TwigVariableParserFactory $parserFactory
+        TwigVariableParserFactory $parserFactory,
+        private readonly LoggerInterface $logger,
     ) {
         $this->twigVariableParser = $parserFactory->getParser($twig);
     }
@@ -62,18 +67,18 @@ class SeoUrlGenerator
 
         $repository = $this->definitionRegistry->getRepository($config->getDefinition()->getEntityName());
 
-        $associations = $this->getAssociations($template, $repository->getDefinition());
-        $criteria->addAssociations($associations);
+        if ($this->setTwigTemplate($config, $template)) {
+            $associations = $this->getAssociations($template, $repository->getDefinition());
+            $criteria->addAssociations($associations);
 
-        $criteria->setLimit(50);
+            $criteria->setLimit(50);
 
-        /** @var RepositoryIterator<LandingPageCollection|CategoryCollection|ProductCollection> $iterator */
-        $iterator = $context->enableInheritance(static fn (Context $context): RepositoryIterator => new RepositoryIterator($repository, $context, $criteria));
+            /** @var RepositoryIterator<LandingPageCollection|CategoryCollection|ProductCollection> $iterator */
+            $iterator = $context->enableInheritance(static fn (Context $context): RepositoryIterator => new RepositoryIterator($repository, $context, $criteria));
 
-        $this->setTwigTemplate($config, $template);
-
-        while ($entities = $iterator->fetch()) {
-            yield from $this->generateUrls($route, $config, $salesChannel, $entities);
+            while ($entities = $iterator->fetch()) {
+                yield from $this->generateUrls($route, $config, $salesChannel, $entities, $this->getTemplateName($template));
+            }
         }
     }
 
@@ -82,8 +87,13 @@ class SeoUrlGenerator
      *
      * @return iterable<SeoUrlEntity>
      */
-    private function generateUrls(SeoUrlRouteInterface $seoUrlRoute, SeoUrlRouteConfig $config, SalesChannelEntity $salesChannel, EntityCollection $entities): iterable
-    {
+    private function generateUrls(
+        SeoUrlRouteInterface $seoUrlRoute,
+        SeoUrlRouteConfig $config,
+        SalesChannelEntity $salesChannel,
+        EntityCollection $entities,
+        string $templateName
+    ): iterable {
         $request = $this->requestStack->getMainRequest();
 
         $basePath = $request ? $request->getBasePath() : '';
@@ -107,7 +117,7 @@ class SeoUrlGenerator
 
             $copy->setPathInfo($pathInfo);
 
-            $seoPathInfo = $this->getSeoPathInfo($mapping, $config);
+            $seoPathInfo = $this->getSeoPathInfo($mapping, $config, $templateName);
 
             if ($seoPathInfo === null || $seoPathInfo === '') {
                 continue;
@@ -120,11 +130,19 @@ class SeoUrlGenerator
         }
     }
 
-    private function getSeoPathInfo(SeoUrlMapping $mapping, SeoUrlRouteConfig $config): ?string
+    private function getSeoPathInfo(SeoUrlMapping $mapping, SeoUrlRouteConfig $config, string $templateName): ?string
     {
         try {
-            return trim($this->twig->render('template', $mapping->getSeoPathInfoContext()));
-        } catch (\Throwable $error) {
+            return trim($this->twig->render($templateName, $mapping->getSeoPathInfoContext()));
+        } catch (Error $error) {
+            $this->logger->critical('Error received on rendering SEO URL template', [
+                'exception' => $error,
+                'mapping_entity_type' => \get_class($mapping->getEntity()),
+                'mapping_error' => $mapping->getError(),
+                'mapping_info_path' => $mapping->getInfoPathContext(),
+                'mapping' => $mapping,
+            ]);
+
             if (!$config->getSkipInvalid()) {
                 throw SeoException::invalidTemplate('Error: ' . $error->getMessage());
             }
@@ -133,18 +151,37 @@ class SeoUrlGenerator
         }
     }
 
-    private function setTwigTemplate(SeoUrlRouteConfig $config, string $template): void
+    private function setTwigTemplate(SeoUrlRouteConfig $config, string $template): bool
     {
+        $templateName = $this->getTemplateName($template);
         $template = '{% autoescape \'' . self::ESCAPE_SLUGIFY . "' %}$template{% endautoescape %}";
-        $this->twig->setLoader(new ArrayLoader(['template' => $template]));
+        $this->twig->setLoader(new ChainLoader([
+            new ArrayLoader([$templateName => $template]),
+            $this->twig->getLoader(),
+        ]));
 
         try {
-            $this->twig->loadTemplate($this->twig->getTemplateClass('template'), 'template');
+            $this->twig->loadTemplate($this->twig->getTemplateClass($templateName), $templateName);
         } catch (SyntaxError $syntaxError) {
+            $this->logger->critical('Error initializing SEO URL template', [
+                'exception' => $syntaxError,
+                'template' => $template,
+                'template_name' => $templateName,
+            ]);
+
             if (!$config->getSkipInvalid()) {
                 throw SeoException::invalidTemplate('Syntax error: ' . $syntaxError->getMessage());
             }
+
+            return false;
         }
+
+        return true;
+    }
+
+    private function getTemplateName(string $template): string
+    {
+        return 'seo_url_template_' . \md5($template);
     }
 
     private function removePrefix(string $subject, string $prefix): string

--- a/src/Core/Framework/DependencyInjection/seo.xml
+++ b/src/Core/Framework/DependencyInjection/seo.xml
@@ -31,6 +31,7 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="shopware.seo_url.twig"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory"/>
+            <argument type="service" id="logger"/>
         </service>
 
         <service id="Shopware\Core\Content\Seo\SeoUrlPersister">


### PR DESCRIPTION
### 1. Why is this change necessary?
When you have a broken SEO URL template it can silently break follow up usages.

### 2. What does this change do, exactly?
1. Add a logger so you can at least have a chance of spotting the error in the log files
2. Make a new instance of twig each time you want to generate URLs as you can't clone a twig environment safely
3. Do not try to generate URLs with a broken twig (reduces wall time and makes it faster to spot issues)
4. Remove a stateful service by having a twig environment for each generator

### 3. Describe each step to reproduce the issue or behaviour.
1. Have a broken twig template as SEO URL template
2. Run `dal:refresh:index` to re-index category URLs
3. Bake a cake on the computer in the meantime
4. Have no new URLs
5. Admin says green tick behind pattern
6. Check log files. Nothing there
7. Debug a lot
8. Find twig trying to render a category URL with a template of the categories but the compiled twig class for rendering product URLs?!?!?
9. Find muted exceptions
10. Curl up and crying oneself to sleep

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Extras

Big thanks is going to @remco-verton for his twig debugging and detect the cache poisoning from using the same name. This knowledge made this pull request non-breaking!