### PR TITLE
[NEXT-19859] Add rel="noopener noreferrer" to flyout navigation

### DIFF
--- a/changelog/_unreleased/2022-01-25-add-rel-noopener-noreferrer-to-flyout-naviagtion.md
+++ b/changelog/_unreleased/2022-01-25-add-rel-noopener-noreferrer-to-flyout-naviagtion.md
@@ -1,6 +1,6 @@
 ---
 title: Add rel="noopener noreferrer" to flyout navigation
-issue: <TODO>
+issue: NEXT-19859
 author: Simon Nitzsche
 author_email: simon.nitzsche@esera.de
 author_github: @SimonNitzsche

--- a/changelog/_unreleased/2022-01-25-add-rel-noopener-noreferrer-to-flyout-naviagtion.md
+++ b/changelog/_unreleased/2022-01-25-add-rel-noopener-noreferrer-to-flyout-naviagtion.md
@@ -1,0 +1,9 @@
+---
+title: Add rel="noopener noreferrer" to flyout navigation
+issue: <TODO>
+author: Simon Nitzsche
+author_email: simon.nitzsche@esera.de
+author_github: @SimonNitzsche
+---
+# Storefront
+* Added rel="noopener noreferrer" to flyout navigation if the link is external

--- a/src/Storefront/Resources/views/storefront/layout/navigation/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/categories.html.twig
@@ -30,7 +30,9 @@
                             <a class="nav-item nav-link navigation-flyout-link is-level-{{ level }}{% if id == activeId or id in activePath %} active{% endif %}"
                                href="{{ link }}"
                                itemprop="url"
-                               {% if category_linknewtab(treeItem.category) %}target="_blank"{% endif %}
+                               {% if category_linknewtab(treeItem.category) %}target="_blank"
+                                   {% if treeItem.category.linkType == "external" %}rel="noopener noreferrer"{% endif %}
+                               {% endif %}
                                title="{{ name }}">
                                 <span itemprop="name">{{ name }}</span>
                             </a>

--- a/src/Storefront/Resources/views/storefront/layout/navigation/flyout.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/flyout.html.twig
@@ -11,8 +11,7 @@
                                 <a class="nav-link"
                                    href="{{ seoUrl('frontend.navigation.page', { navigationId: category.id }) }}"
                                    itemprop="url"
-                                   title="{{ name }}"
-                                   {% if category.linkType == "external" %} rel="noopener noreferrer"{% endif %}>
+                                   title="{{ name }}">
                                     {% block layout_navigation_flyout_bar_category_link_text %}
                                         {{ "general.toCategory"|trans|sw_sanitize }} {{ name }}
                                         {% sw_icon 'arrow-right' style {
@@ -64,9 +63,10 @@
                         {% block layout_navigation_flyout_teaser_image %}
                             <a class="navigation-flyout-teaser-image-container"
                                href="{{ category_url(category) }}"
-                               {% if category_linknewtab(category) %}target="_blank"{% endif %}
-                               title="{{ name }}"
-                               {% if category.linkType == "external" %} rel="noopener noreferrer"{% endif %}>
+                               {% if category_linknewtab(category) %}target="_blank"
+                                   {% if category.linkType == "external" %}rel="noopener noreferrer"{% endif %}
+                               {% endif %}
+                               title="{{ name }}">
                                 {% sw_thumbnails 'navigation-flyout-teaser-image-thumbnails' with {
                                     media: category.media,
                                     sizes: {

--- a/src/Storefront/Resources/views/storefront/layout/navigation/flyout.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/flyout.html.twig
@@ -11,7 +11,8 @@
                                 <a class="nav-link"
                                    href="{{ seoUrl('frontend.navigation.page', { navigationId: category.id }) }}"
                                    itemprop="url"
-                                   title="{{ name }}">
+                                   title="{{ name }}"
+                                   {% if category.linkType == "external" %} rel="noopener noreferrer"{% endif %}>
                                     {% block layout_navigation_flyout_bar_category_link_text %}
                                         {{ "general.toCategory"|trans|sw_sanitize }} {{ name }}
                                         {% sw_icon 'arrow-right' style {
@@ -64,7 +65,8 @@
                             <a class="navigation-flyout-teaser-image-container"
                                href="{{ category_url(category) }}"
                                {% if category_linknewtab(category) %}target="_blank"{% endif %}
-                               title="{{ name }}">
+                               title="{{ name }}"
+                               {% if category.linkType == "external" %} rel="noopener noreferrer"{% endif %}>
                                 {% sw_thumbnails 'navigation-flyout-teaser-image-thumbnails' with {
                                     media: category.media,
                                     sizes: {


### PR DESCRIPTION
### 1. Why is this change necessary?
Lighthouse report:
```
Links to cross-origin destinations are unsafe
Add `rel="noopener"` or `rel="noreferrer"` to any external links to improve performance and prevent security vulnerabilities. 
```
[Learn more](https://web.dev/external-anchors-use-rel-noopener/?utm_source=lighthouse&utm_medium=devtools)

### 2. What does this change do, exactly?
It will add `rel="noopener noreferrer` to the anchors in the flyout navigation to ensure best practices.

### 3. Describe each step to reproduce the issue or behaviour.
- Add a category that will be displayed in the flyout menu as an external link
- Run Lighthouse with `Best Practices` checked

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
