### PR TITLE
Fix allow product label overwrites

### DIFF
--- a/changelog/_unreleased/2022-01-26-fix-allow-product-label-overwrites.md
+++ b/changelog/_unreleased/2022-01-26-fix-allow-product-label-overwrites.md
@@ -1,0 +1,8 @@
+---
+title: Fix allow product label overwrites
+author: Nils Evers
+author_email: evers.nils@gmail.com
+author_github: NilsEvers
+---
+# Core
+* Fixed condition in `\Shopware\Core\Content\Product\Cart\ProductCartProcessor::enrich` to allow label overwrites for products in cart 

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -284,7 +284,7 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
         $name = $product->getTranslation('name');
 
         // set the label if its empty or the context does not have the permission to overwrite it
-        if ($label !== $name || !$behavior->hasPermission(self::ALLOW_PRODUCT_LABEL_OVERWRITES)) {
+        if ($label === '' || !$behavior->hasPermission(self::ALLOW_PRODUCT_LABEL_OVERWRITES)) {
             $lineItem->setLabel($product->getTranslation('name'));
         }
 

--- a/src/Core/Content/Test/Product/Cart/ProductCartProcessorTest.php
+++ b/src/Core/Content/Test/Product/Cart/ProductCartProcessorTest.php
@@ -210,7 +210,7 @@ class ProductCartProcessorTest extends TestCase
         $service->add($cart, $product, $context);
 
         $actualProduct = $cart->get($product->getId());
-        static::assertSame($product->getLabel(), $actualProduct->getLabel());
+        static::assertSame('My special product', $actualProduct->getLabel());
     }
 
     public function testOverwriteLabelWithPermissionNoLabel(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
At the moment it is not possible to overwrite the label of a product in cart.
The test for the given feature is also broken.

### 2. What does this change do, exactly?
Fixes an illogical condition and the belonging test as well.

### 3. Describe each step to reproduce the issue or behaviour.
Via API
- Set the permissions to allow product label overwrites
- Add a product line item with a custom label to the cart
- The label will still be the translated name of the product instead of the custom label


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
