### PR TITLE
fix image slider config

### DIFF
--- a/changelog/_unreleased/2022-01-27-fix-image-slider-config.md
+++ b/changelog/_unreleased/2022-01-27-fix-image-slider-config.md
@@ -1,0 +1,9 @@
+---
+title: Fix image-slider config
+issue: 
+author: Pascal Josephy
+author_email: pascal.josephy@jkweb.ch
+author_github: pascaljosephy
+---
+# Administration
+* Changed method `updateMediaDataValue` of `sw-cms-el-config-image-slider`

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
@@ -134,7 +134,11 @@ Component.register('sw-cms-el-config-image-slider', {
                     });
                 });
 
-                this.$set(this.element.data, 'sliderItems', sliderItems);
+                if (!this.element.data) {
+                    this.$set(this.element, 'data', { sliderItems });
+                } else {
+                    this.$set(this.element.data, 'sliderItems', sliderItems);
+                }
             }
         },
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The config component of the `image-slider` is broken in some cases, namely if the the key `data` is not set on `this.element`.

### 2. What does this change do, exactly?

It adds the same check as in the `image-gallery` component, as done in this commit: https://github.com/shopware/platform/commit/9f56463059764dd66b06ff111ef250d38216da90#diff-3b8c60d49809fb5621c1b89916f24eb16c00760509c899e8d08a57a045fe647dR219

### 3. Describe each step to reproduce the issue or behaviour.

- Create shopping experience with image slider
- Create category and set layout to new shopping experience
- Try to add images to the config of the image slider

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
