### PR TITLE
fix: EntitySearchResult page for zero offset

### DIFF
--- a/changelog/_unreleased/2022-01-28-fix-entity-search-result-page-for-zero-offset.md
+++ b/changelog/_unreleased/2022-01-28-fix-entity-search-result-page-for-zero-offset.md
@@ -1,0 +1,8 @@
+---
+title: Fix EntitySearchResult page for zero offset
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Return correct page in EntitySearchResult if the offset was set to zero

--- a/src/Core/Content/Test/Product/SalesChannel/Detail/_fixtures/recursion_encoding_with_layout_result.json
+++ b/src/Core/Content/Test/Product/SalesChannel/Detail/_fixtures/recursion_encoding_with_layout_result.json
@@ -822,7 +822,7 @@
                           "apiAlias": "ratingMatrix_aggregation"
                         }
                       },
-                      "page": 0,
+                      "page": 1,
                       "limit": 10,
                       "elements": [
                         {

--- a/src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
@@ -65,7 +65,7 @@ class EntitySearchResult extends EntityCollection
         $this->criteria = $criteria;
         $this->context = $context;
         $this->limit = $criteria->getLimit();
-        $this->page = !$criteria->getLimit() ? 1 : (int) ceil(($criteria->getOffset() ?? 0 + 1) / $criteria->getLimit());
+        $this->page = !$criteria->getLimit() ? 1 : (int) ceil((($criteria->getOffset() ?? 0) + 1) / $criteria->getLimit());
 
         parent::__construct($entities);
         $this->entity = $entity;

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/EntitySearchResultTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/EntitySearchResultTest.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Search;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Struct\ArrayEntity;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class EntitySearchResultTest extends TestCase
+{
+    /**
+     * @dataProvider resultPageCriteriaDataProvider
+     */
+    public function testResultPage(Criteria $criteria, int $page): void
+    {
+        $entity = new ArrayEntity(['id' => Uuid::randomHex()]);
+        $entityCollection = new EntityCollection([$entity]);
+        $result = new EntitySearchResult(
+            ArrayEntity::class,
+            100,
+            $entityCollection,
+            null,
+            $criteria,
+            Context::createDefaultContext()
+        );
+
+        static::assertSame($page, $result->getPage());
+    }
+
+    public function resultPageCriteriaDataProvider(): \Generator
+    {
+        yield [(new Criteria())->setLimit(5)->setOffset(0), 1];
+        yield [(new Criteria())->setLimit(5)->setOffset(1), 1];
+        yield [(new Criteria())->setLimit(5)->setOffset(9), 2];
+        yield [(new Criteria())->setLimit(5)->setOffset(10), 3];
+        yield [(new Criteria())->setLimit(5)->setOffset(11), 3];
+        yield [(new Criteria())->setLimit(10)->setOffset(25), 3];
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/EntitySearcherTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/EntitySearcherTest.php
@@ -90,6 +90,7 @@ class EntitySearcherTest extends TestCase
 
         static::assertSame(2, $result->getTotal());
         static::assertCount(2, $result->getEntities());
+        static::assertSame(1, $result->getPage());
     }
 
     public function testSortingAndTotalCountWithManyAssociation(): void
@@ -197,10 +198,12 @@ class EntitySearcherTest extends TestCase
         $criteria->addSorting(new FieldSorting('product.options.id'));
 
         $criteria->setLimit(25);
+        $criteria->setOffset(0);
         $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT);
 
         $result = $this->productRepository->search($criteria, $context);
 
+        static::assertSame(1, $result->getPage());
         static::assertSame(6, $result->getTotal());
         static::assertCount(6, $result->getEntities());
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
There is currently a bug, that the page is 0, although the first page should be 1. Probably only a bracket is missing.
Thanks to @313 for finding this bug.

### 2. What does this change do, exactly?
Fix the operator precedence, such that the page is correct if the offset is 0.

### 3. Describe each step to reproduce the issue or behaviour.
In Shopware there is no place to reproduce this issue since the page is always recomputed, e.g. https://github.com/shopware/platform/blob/d6c853ca3b6b167d61d70e6329f4fcface5c5245/src/Storefront/Resources/views/storefront/component/pagination.html.twig#L2

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
