### PR TITLE
add min order quantity error to product cart processor

### DIFF
--- a/changelog/_unreleased/2022-01-28-add-min-order-quantity-error.md
+++ b/changelog/_unreleased/2022-01-28-add-min-order-quantity-error.md
@@ -1,0 +1,10 @@
+---
+title: Add min order quantity error
+author: Nils Evers
+author_email: evers.nils@gmail.com
+author_github: NilsEvers
+---
+# Core
+* Added `\Shopware\Core\Content\Product\Cart\MinOrderQuantityError`
+* Refactored `\Shopware\Core\Content\Product\Cart\ProductCartProcessor::validateStock` to add an error to the cart when the quantity is modified to match the products min order quantity.
+* Updated test case `\Shopware\Core\Content\Test\Product\Cart\ProductCartProcessorTest::testProcessCartShouldReturnFixedQuantity`  

--- a/src/Core/Content/Product/Cart/MinOrderQuantityError.php
+++ b/src/Core/Content/Product/Cart/MinOrderQuantityError.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Cart;
+
+use Shopware\Core\Checkout\Cart\Error\Error;
+
+class MinOrderQuantityError extends Error
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var int
+     */
+    protected $quantity;
+
+    public function __construct(string $id, string $name, int $quantity)
+    {
+        $this->id = $id;
+
+        $this->message = sprintf(
+            'Your input quantity does not meet the minimum order quantity of the %s. The quantity was changed to %s',
+            $name,
+            $quantity
+        );
+
+        parent::__construct($this->message);
+        $this->name = $name;
+        $this->quantity = $quantity;
+    }
+
+    public function getParameters(): array
+    {
+        return ['name' => $this->name, 'quantity' => $this->quantity];
+    }
+
+    public function getId(): string
+    {
+        return $this->getMessageKey() . $this->id;
+    }
+
+    public function getMessageKey(): string
+    {
+        return 'min-order-quantity';
+    }
+
+    public function getLevel(): int
+    {
+        return self::LEVEL_WARNING;
+    }
+
+    public function blockOrder(): bool
+    {
+        return true;
+    }
+}

--- a/src/Core/Content/Test/Product/Cart/ProductCartProcessorTest.php
+++ b/src/Core/Content/Test/Product/Cart/ProductCartProcessorTest.php
@@ -39,6 +39,8 @@ class ProductCartProcessorTest extends TestCase
     public const TEST_LOCALE_ID = 'cf735c44dc7b4428bb3870fe4ffea2df';
     public const CUSTOM_FIELD_ID = '24c8b3e8cacc4bf2a743b8c5a7522a33';
     public const PURCHASE_STEP_QUANTITY_ERROR_KEY = 'purchase-steps-quantity';
+    public const MIN_ORDER_QUANTITY_ERROR_KEY = 'min-order-quantity';
+    public const PRODUCT_STOCK_REACHED_ERROR_KEY = 'product-stock-reached';
 
     /**
      * @var TestDataCollection
@@ -546,7 +548,7 @@ class ProductCartProcessorTest extends TestCase
      * @dataProvider productDeliverabilityProvider
      * @group slow
      */
-    public function testProcessCartShouldReturnFixedQuantity(int $minPurchase, int $purchaseSteps, int $maxPurchase, int $quantity, int $quantityExpected, bool $isCheckMessage): void
+    public function testProcessCartShouldReturnFixedQuantity(int $minPurchase, int $purchaseSteps, int $maxPurchase, int $quantity, int $quantityExpected, ?string $errorKey): void
     {
         $additionalData = [
             'maxPurchase' => $maxPurchase,
@@ -576,27 +578,27 @@ class ProductCartProcessorTest extends TestCase
 
         $actualProduct = $cart->get($product->getId());
         static::assertEquals($quantityExpected, $actualProduct->getQuantity());
-        if ($isCheckMessage) {
-            static::assertEquals(self::PURCHASE_STEP_QUANTITY_ERROR_KEY, $service->getCart($token, $context)->getErrors()->first()->getMessageKey());
+        if ($errorKey !== null) {
+            static::assertEquals($errorKey, $service->getCart($token, $context)->getErrors()->first()->getMessageKey());
         }
     }
 
     public function productDeliverabilityProvider()
     {
         return [
-            'fixed quantity should be return 2' => [2, 2, 20, 3, 2, true],
-            'fixed quantity should be return 4' => [2, 2, 20, 5, 4, true],
-            'fixed quantity should be return 3' => [1, 2, 20, 4, 3, true],
-            'fixed quantity should be return 9' => [1, 2, 20, 10, 9, true],
-            'fixed quantity should be return 5, actual quantity is 6' => [5, 5, 20, 6, 5, true],
-            'fixed quantity should be return 5, actual quantity is 7' => [5, 5, 20, 7, 5, true],
-            'fixed quantity should be return 5, actual quantity is 8' => [5, 5, 20, 8, 5, true],
-            'fixed quantity should be return 5, actual quantity is 9' => [5, 5, 20, 9, 5, true],
-            'fixed quantity should be return equal max purchase' => [2, 2, 20, 22, 20, false],
-            'fixed quantity should be return equal min purchase' => [2, 2, 20, 1, 2, false],
-            'fixed quantity should be return 1' => [1, 3, 5, 2, 1, true],
-            'fixed quantity should be return 10 with error message' => [10, 3, 13, 11, 10, true],
-            'fixed quantity should be return 10, without error message' => [10, 2, 20, 2, 10, false],
+            'fixed quantity should be return 2' => [2, 2, 20, 3, 2, self::PURCHASE_STEP_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return 4' => [2, 2, 20, 5, 4, self::PURCHASE_STEP_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return 3' => [1, 2, 20, 4, 3, self::PURCHASE_STEP_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return 9' => [1, 2, 20, 10, 9, self::PURCHASE_STEP_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return 5, actual quantity is 6' => [5, 5, 20, 6, 5, self::PURCHASE_STEP_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return 5, actual quantity is 7' => [5, 5, 20, 7, 5, self::PURCHASE_STEP_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return 5, actual quantity is 8' => [5, 5, 20, 8, 5, self::PURCHASE_STEP_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return 5, actual quantity is 9' => [5, 5, 20, 9, 5, self::PURCHASE_STEP_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return equal max purchase' => [2, 2, 20, 22, 20, self::PRODUCT_STOCK_REACHED_ERROR_KEY],
+            'fixed quantity should be return equal min purchase' => [2, 2, 20, 1, 2, self::MIN_ORDER_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return 1' => [1, 3, 5, 2, 1, self::PURCHASE_STEP_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return 10 with purchase step error message' => [10, 3, 13, 11, 10, self::PURCHASE_STEP_QUANTITY_ERROR_KEY],
+            'fixed quantity should be return 10, with min order quantity error message' => [10, 2, 20, 2, 10, self::MIN_ORDER_QUANTITY_ERROR_KEY],
         ];
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
When adding a product to the cart, with a lower quantity than the product _min order quantity_, the line items quantity will be silently changed to the _min order quantity_, without any errors. This is especially unfavourable when working with the API, as there is no indication that the quantity was updated. 
With this change, the behaviour is the same as when the quantity is updated to match the _purchase steps_.

### 2. What does this change do, exactly?
- Adds a new Cart Error `\Shopware\Core\Content\Product\Cart\MinOrderQuantityError`
- Refactors `\Shopware\Core\Content\Product\Cart\ProductCartProcessor::validateStock` to add an error to the cart when the quantity is modified to match the products min order quantity.
- And some minor refactoring of the validateStock method

### 3. Describe each step to reproduce the issue or behaviour.
via API
- add a product line item to the cart with a quantity of 1, where the min order quantity of the product is higher
- the quantity will be updated to match the min order quantity without any errors

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
