### PR TITLE
Fix 'Malformed UTF-8 characters, possibly incorrectly encoded' Error

### DIFF
--- a/changelog/_unreleased/2022-01-28-fix-malformed-utf8-characters-error-sync-api.md
+++ b/changelog/_unreleased/2022-01-28-fix-malformed-utf8-characters-error-sync-api.md
@@ -1,0 +1,8 @@
+---
+title:              Fix 'Malformed UTF-8 characters, possibly incorrectly encoded' Error
+issue:              
+author:             Alessandro Aussems
+author_email:       me@alessandroaussems.be                
+---
+# Core
+* Add `createResponse` in `src/Core/Framework/Api/Controller/SyncController.php` that adds the **JSON_INVALID_UTF8_SUBSTITUTE** encoding option to the response

--- a/src/Core/Framework/Api/Controller/SyncController.php
+++ b/src/Core/Framework/Api/Controller/SyncController.php
@@ -156,13 +156,22 @@ a list of identifiers can be provided.",
         });
 
         if (Feature::isActive('FEATURE_NEXT_15815')) {
-            return new JsonResponse($result, Response::HTTP_OK);
+            return $this->createResponse($result, Response::HTTP_OK);
         }
 
         if ($behavior->failOnError() && !$result->isSuccess()) {
-            return new JsonResponse($result, Response::HTTP_BAD_REQUEST);
+            return $this->createResponse($result, Response::HTTP_BAD_REQUEST);
         }
 
-        return new JsonResponse($result, Response::HTTP_OK);
+        return $this->createResponse($result, Response::HTTP_OK);
+    }
+
+    private function createResponse(SyncResult $result, int $statusCode = 200): JsonResponse
+    {
+        $response = new JsonResponse(null, $statusCode);
+        $response->setEncodingOptions(JSON_INVALID_UTF8_SUBSTITUTE);
+        $response->setData($result);
+
+        return $response;
     }
 }

--- a/src/Core/Framework/Api/Controller/SyncController.php
+++ b/src/Core/Framework/Api/Controller/SyncController.php
@@ -169,7 +169,7 @@ a list of identifiers can be provided.",
     private function createResponse(SyncResult $result, int $statusCode = 200): JsonResponse
     {
         $response = new JsonResponse(null, $statusCode);
-        $response->setEncodingOptions(JSON_INVALID_UTF8_SUBSTITUTE);
+        $response->setEncodingOptions(\JSON_INVALID_UTF8_SUBSTITUTE);
         $response->setData($result);
 
         return $response;


### PR DESCRIPTION
Fix 'Malformed UTF-8 characters, possibly incorrectly encoded' Error On Sync Api

### 1. Why is this change necessary?
Currently when the error message on the Sync Api contains a UUID the error message "Malformed UTF-8 characters, possibly incorrectly encoded" is shown. Which is not very helpfull


### 2. What does this change do, exactly?
Adds the "JSON_INVALID_UTF8_SUBSTITUTE" option to the Sync API Json Response


### 3. Describe each step to reproduce the issue or behaviour.
For ex: upsert a product, try to link an non existing media entity to it. "Malformed UTF-8 characters, possibly incorrectly encoded" error will be shown.


### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
