### PR TITLE
fix: consider Advanded Prices for OpenGraph price

### DIFF
--- a/changelog/_unreleased/2022-01-31-consider-advanced-prices-in-openGraph-price.md
+++ b/changelog/_unreleased/2022-01-31-consider-advanced-prices-in-openGraph-price.md
@@ -1,0 +1,10 @@
+---
+title: Consider Advanded Prices for OpenGraph price
+issue: 
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+# Storefront
+* Consider Advanced prices for meta tag `product:price:amount`
+

--- a/src/Storefront/Resources/views/storefront/page/product-detail/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/meta.html.twig
@@ -19,8 +19,13 @@
         <meta property="product:brand"
               content="{{ page.product.manufacturer.translated.name }}"/>
     {% endif %}
+
+    {% set metaPrice = page.product.calculatedPrice %}
+    {% if page.product.calculatedPrices.count > 0 %}
+        {% set metaPrice = page.product.calculatedPrices.last %}
+    {% endif %}
     <meta property="product:price:amount"
-          content="{{ page.product.calculatedPrice.unitPrice|round(context.currency.itemRounding.decimals) }}"/>
+          content="{{ metaPrice.unitPrice|round(context.currency.itemRounding.decimals) }}"/>
     <meta property="product:price:currency"
           content="{{ context.currency.isoCode }}"/>
     <meta property="product:product_link"


### PR DESCRIPTION
### 1. Why is this change necessary?
When you have advanced prices managing all prices (especially for language-shop and so on), this should be considered in the OpenGraph-Price, too.

### 2. What does this change do, exactly?
Use last item of calculatedPrices if set.

### 3. Describe each step to reproduce the issue or behaviour.
set price to 999 Euro
add always valid advanced price with 1 Euro
see 999 is in product:price:amount

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
