### PR TITLE
allow to set permissions on sales channel proxy api

### DIFF
--- a/changelog/_unreleased/2022-02-01-allow-to-set-permissions-on-sales-channel-proxy-api.md
+++ b/changelog/_unreleased/2022-02-01-allow-to-set-permissions-on-sales-channel-proxy-api.md
@@ -1,0 +1,12 @@
+---
+title: Allow to set permissions on sales channel proxy api.md
+issue: NEXT-19905
+author: Nils Evers
+author_email: evers.nils@gmail.com
+author_github: NilsEvers
+---
+# Core
+* Refactored `\Shopware\Core\Framework\Api\Controller\SalesChannelProxyController::persistPermissions` to accept context permissions from request 
+___
+# Administration
+* Updated `StoreContextService.updateCustomerContext` to always send `ADMIN_ORDER_PERMISSIONS`

--- a/src/Administration/Resources/app/administration/src/core/service/api/store-context.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/store-context.api.service.js
@@ -18,6 +18,7 @@ class StoreContextService extends ApiService {
         contextToken,
         additionalParams = {},
         additionalHeaders = {},
+        permissions = ['allowProductPriceOverwrites'],
     ) {
         const route = '_proxy/switch-customer';
         const headers = {
@@ -28,7 +29,7 @@ class StoreContextService extends ApiService {
         return this.httpClient
             .patch(
                 route,
-                { customerId: customerId, salesChannelId: salesChannelId },
+                { customerId: customerId, salesChannelId: salesChannelId, permissions: permissions },
                 { additionalParams, headers },
             );
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to set any context permissions when working with the sales channel proxy api.
For example it is not possible to set `skipProductRecalculation`, `skipPromotion`, `skipProductStockValidation` and so on, which really defeats the usefulness of the proxy api.

### 2. What does this change do, exactly?
It refactors `\Shopware\Core\Framework\Api\Controller\SalesChannelProxyController::persistPermissions` to accept permissions set on the request.

This allows to pass a custom set of permissions when  calling `/api/_proxy/switch-customer`
```json
"salesChannelId":  "bbed0a0206b54ebbbcf320cd2bc293d8",
"customerId": "6c97534c2c0747f39e8751e43cb2b013",
"permissions": [
    "allowProductPriceOverwrites",
    "allowProductLabelOverwrites",
    "skipProductRecalculation",
    "skipPromotion",
]
```

If no permissions are given, the behaviour is still as before.

### 3. Describe each step to reproduce the issue or behaviour.
Via Api, try to pass custom permissions , for example to skip promotions.

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
