### PR TITLE
Added possibility to use transformers for environment variables used by the EnvironmentHelper utility.

### DIFF
--- a/changelog/_unreleased/2022-02-02-added-possibility-to-use-transformers-for-environment-variables.md
+++ b/changelog/_unreleased/2022-02-02-added-possibility-to-use-transformers-for-environment-variables.md
@@ -1,0 +1,9 @@
+---
+title: Added possibility to use transformers for environment variables used by the EnvironmentHelper utility.
+issue: https://issues.shopware.com/issues/NEXT-19880
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed `EnvironmentHelper` utility to allow adding and removing of transformers and use them to transform the environment variable.

--- a/src/Core/DevOps/Environment/EnvironmentHelper.php
+++ b/src/Core/DevOps/Environment/EnvironmentHelper.php
@@ -4,6 +4,8 @@ namespace Shopware\Core\DevOps\Environment;
 
 class EnvironmentHelper
 {
+    private static array $transformers = [];
+
     /**
      * Reads an env var first from $_SERVER then from $_ENV super globals
      * The caller needs to take care of casting the return value to the appropriate type
@@ -14,11 +16,51 @@ class EnvironmentHelper
      */
     public static function getVariable(string $key, $default = null)
     {
-        return $_SERVER[$key] ?? $_ENV[$key] ?? $default;
+        $value = $_SERVER[$key] ?? $_ENV[$key] ?? null;
+        $transformerData = new EnvironmentHelperTransformerData($key, $value, $default);
+
+        foreach (self::$transformers as $transformers) {
+            foreach ($transformers as $transformer) {
+                $transformer::transform($transformerData);
+            }
+        }
+
+        return $transformerData->getValue() ?? $transformerData->getDefault();
     }
 
     public static function hasVariable(string $key): bool
     {
         return \array_key_exists($key, $_SERVER) || \array_key_exists($key, $_ENV);
+    }
+
+    public static function addTransformer(string $transformerClass, int $priority = 0): void
+    {
+        if (!is_subclass_of($transformerClass, EnvironmentHelperTransformerInterface::class, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Expected class to implement "%1$s" but got "%2$s".',
+                    EnvironmentHelperTransformerInterface::class,
+                    $transformerClass
+                )
+            );
+        }
+
+        self::$transformers[$priority][$transformerClass] = $transformerClass;
+
+        krsort(self::$transformers, \SORT_NUMERIC);
+    }
+
+    public static function removeTransformer(string $transformerClass, int $priority = 0): void
+    {
+        if (!isset(self::$transformers[$priority][$transformerClass])) {
+            return;
+        }
+
+        unset(self::$transformers[$priority][$transformerClass]);
+    }
+
+    public static function removeAllTransformers(): void
+    {
+        self::$transformers = [];
     }
 }

--- a/src/Core/DevOps/Environment/EnvironmentHelperTransformerData.php
+++ b/src/Core/DevOps/Environment/EnvironmentHelperTransformerData.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\Environment;
+
+class EnvironmentHelperTransformerData
+{
+    private string $key;
+
+    /**
+     * @var bool|float|int|string|null
+     */
+    private $value;
+
+    /**
+     * @var bool|float|int|string|null
+     */
+    private $default;
+
+    public function __construct(string $key, $value, $default)
+    {
+        $this->key = $key;
+        $this->value = $value;
+        $this->default = $default;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function setValue($value): void
+    {
+        $this->value = $value;
+    }
+
+    public function getDefault()
+    {
+        return $this->default;
+    }
+
+    public function setDefault($default): void
+    {
+        $this->default = $default;
+    }
+}

--- a/src/Core/DevOps/Environment/EnvironmentHelperTransformerInterface.php
+++ b/src/Core/DevOps/Environment/EnvironmentHelperTransformerInterface.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\Environment;
+
+interface EnvironmentHelperTransformerInterface
+{
+    public static function transform(EnvironmentHelperTransformerData $data): void;
+}

--- a/src/Core/DevOps/Test/Environment/_fixtures/EnvironmentHelperTransformer.php
+++ b/src/Core/DevOps/Test/Environment/_fixtures/EnvironmentHelperTransformer.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\Test\Environment\_fixtures;
+
+use Shopware\Core\DevOps\Environment\EnvironmentHelperTransformerData;
+use Shopware\Core\DevOps\Environment\EnvironmentHelperTransformerInterface;
+
+class EnvironmentHelperTransformer implements EnvironmentHelperTransformerInterface
+{
+    public static function transform(EnvironmentHelperTransformerData $data): void
+    {
+        $data->setValue($data->getValue() !== null ? $data->getValue() . ' bar' : null);
+        $data->setDefault($data->getDefault() . ' baz');
+    }
+}

--- a/src/Core/DevOps/Test/Environment/_fixtures/EnvironmentHelperTransformer2.php
+++ b/src/Core/DevOps/Test/Environment/_fixtures/EnvironmentHelperTransformer2.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\Test\Environment\_fixtures;
+
+use Shopware\Core\DevOps\Environment\EnvironmentHelperTransformerData;
+use Shopware\Core\DevOps\Environment\EnvironmentHelperTransformerInterface;
+
+class EnvironmentHelperTransformer2 implements EnvironmentHelperTransformerInterface
+{
+    public static function transform(EnvironmentHelperTransformerData $data): void
+    {
+        $data->setValue($data->getValue() !== null ? $data->getValue() . ' baz' : null);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

See: https://github.com/shopware/platform/issues/2296


### 2. What does this change do, exactly?

See: https://github.com/shopware/platform/issues/2296

Changed `EnvironmentHelper` utility to allow adding and removing of transformers and use them to transform the environment variable.

### 3. Describe each step to reproduce the issue or behaviour.

See: https://github.com/shopware/platform/issues/2296

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/platform/issues/2296
https://issues.shopware.com/issues/NEXT-19880

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
