### PR TITLE
Improvements on command descriptions

### DIFF
--- a/src/Core/Framework/App/Command/AbstractAppActivationCommand.php
+++ b/src/Core/Framework/App/Command/AbstractAppActivationCommand.php
@@ -64,7 +64,7 @@ abstract class AbstractAppActivationCommand extends Command
 
     protected function configure(): void
     {
-        $this->setDescription($this->action . ' the app in the folder with the given name')
+        $this->setDescription(ucfirst($this->action) . ' the app in the folder with the given name')
             ->addArgument(
                 'name',
                 InputArgument::REQUIRED,

--- a/src/Core/Framework/App/Command/ValidateAppCommand.php
+++ b/src/Core/Framework/App/Command/ValidateAppCommand.php
@@ -95,7 +95,7 @@ class ValidateAppCommand extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('checks manifests for errors')
+        $this->setDescription('Check manifests for errors')
             ->addArgument(
                 'name',
                 InputArgument::OPTIONAL,


### PR DESCRIPTION
Small adjustments. Making sure command descriptions have a better wording.

- First letter should be uppercase
- Correct English plural

