### PR TITLE
fix: Set robot tag to noindex for AJAX cookie routes

### DIFF
--- a/changelog/_unreleased/2022-02-02-set-robot-tag-to-noindex-for-ajax-cookie-routes.md
+++ b/changelog/_unreleased/2022-02-02-set-robot-tag-to-noindex-for-ajax-cookie-routes.md
@@ -1,0 +1,8 @@
+---
+title: Set robot tag to noindex for AJAX cookie routes
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Set the robot header tag of the routes `/cookie/offcanvas` and `/cookie/permission` to `noindex,follow`

--- a/src/Storefront/Controller/CookieController.php
+++ b/src/Storefront/Controller/CookieController.php
@@ -51,7 +51,10 @@ class CookieController extends StorefrontController
 
         $cookieGroups = $this->filterGoogleReCaptchaCookie($context->getSalesChannelId(), $cookieGroups);
 
-        return $this->renderStorefront('@Storefront/storefront/layout/cookie/cookie-configuration.html.twig', ['cookieGroups' => $cookieGroups]);
+        $response = $this->renderStorefront('@Storefront/storefront/layout/cookie/cookie-configuration.html.twig', ['cookieGroups' => $cookieGroups]);
+        $response->headers->set('x-robots-tag', 'noindex,follow');
+
+        return $response;
     }
 
     /**
@@ -67,7 +70,10 @@ class CookieController extends StorefrontController
 
         $cookieGroups = $this->filterGoogleReCaptchaCookie($context->getSalesChannelId(), $cookieGroups);
 
-        return $this->renderStorefront('@Storefront/storefront/layout/cookie/cookie-permission.html.twig', ['cookieGroups' => $cookieGroups]);
+        $response = $this->renderStorefront('@Storefront/storefront/layout/cookie/cookie-permission.html.twig', ['cookieGroups' => $cookieGroups]);
+        $response->headers->set('x-robots-tag', 'noindex,follow');
+
+        return $response;
     }
 
     private function filterGoogleAnalyticsCookie(SalesChannelContext $context, array $cookieGroups): array


### PR DESCRIPTION
### 1. Why is this change necessary?
I think these two routes should not be indexed by search engines.

### 2. What does this change do, exactly?
Set the corresponding `x-meta-robots` header of these routes.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
