### PR TITLE
refactor: Allow multiple buttons in the form submit loading indicator

### DIFF
--- a/changelog/_unreleased/2022-02-02-allow-multiple-buttons-in-the-form-loading-indicator.md
+++ b/changelog/_unreleased/2022-02-02-allow-multiple-buttons-in-the-form-loading-indicator.md
@@ -1,0 +1,8 @@
+---
+title: Allow multiple buttons in the form loading indicator
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Refactor the `FormSubmitLoaderPlugin` to allow more than one button, which should be marked as loading

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader-multiple-submit-buttons.plugin.template.html
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader-multiple-submit-buttons.plugin.template.html
@@ -1,0 +1,9 @@
+<div>
+    <button type="submit" id="formBtn1" class="valid-form-button" form="test">Not part of the form but still the right submit button</button>
+    <button type="submit" id="formBtn2" class="valid-form-button" form="test">Not part of the form but still the right submit button</button>
+
+    <form id="test" data-form-submit-loader="true">
+        <button type="submit" id="formBtn2" class="valid-form-button">Button part of the form</button>
+        <button type="submit" id="formBtn2" class="valid-form-button">Button part of the form</button>
+    </form>
+</div>

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-submit-loader.plugin.test.js
@@ -6,6 +6,7 @@
 import Storage from 'src/helper/storage/storage.helper';
 import template from './form-submit-loader.plugin.template.html';
 import outerFormTemplate from './form-submit-loader-outer-form-submit-button.plugin.template.html';
+import multipleButtonFormTemplate from './form-submit-loader-multiple-submit-buttons.plugin.template.html';
 import editedSelectorTemplate from './form-submit-loader-edited-form-selector.plugin.template.html';
 import FormSubmitLoader from "../../../src/plugin/forms/form-submit-loader.plugin";
 
@@ -56,7 +57,8 @@ describe('Form submit loader tests', () => {
 
     test('find correct submit button', () => {
         const submitButton = document.querySelector('#formBtn');
-        expect(formSubmitLoaderPlugin._submitButton).toBe(submitButton);
+        expect(formSubmitLoaderPlugin._submitButtons.length).toBe(1);
+        expect(formSubmitLoaderPlugin._submitButtons).toContain(submitButton);
     });
 
     test('submit button is disabled on submit', () => {
@@ -95,7 +97,8 @@ describe('Form submit loader tests when submit button is out of form', () => {
 
     test('find correct submit button', () => {
         const submitButton = document.querySelector('#formBtn');
-        expect(formSubmitLoaderPlugin._submitButton).toBe(submitButton);
+        expect(formSubmitLoaderPlugin._submitButtons.length).toBe(1);
+        expect(formSubmitLoaderPlugin._submitButtons).toContain(submitButton);
     });
 
     test('submit button is disabled on submit', () => {
@@ -104,6 +107,48 @@ describe('Form submit loader tests when submit button is out of form', () => {
 
         const submitButton = document.querySelector('#formBtn');
         expect(submitButton.disabled).toBe(true);
+    });
+});
+
+describe('Form submit loader tests with multiple buttons inside and outside the form', () => {
+    let formSubmitLoaderPlugin;
+    let form;
+
+    beforeEach(() => {
+        document.body.innerHTML = multipleButtonFormTemplate;
+
+        const setUp = setUpFormLoader('#test');
+
+        form = setUp.form;
+        formSubmitLoaderPlugin = setUp.plugin;
+    });
+
+    afterEach(() => {
+        formSubmitLoaderPlugin = undefined;
+    });
+
+    test('form submit loader plugin exists', () => {
+        expect(typeof formSubmitLoaderPlugin).toBe('object');
+    });
+
+    test('form is the same as passed form', () => {
+        expect(formSubmitLoaderPlugin._form).toBe(form);
+    });
+
+    test('find correct submit buttons', () => {
+        const submitButtons = Array.from(document.querySelectorAll('.valid-form-button'));
+        expect(formSubmitLoaderPlugin._submitButtons.length).toBe(4);
+        expect(formSubmitLoaderPlugin._submitButtons).toEqual(expect.arrayContaining(submitButtons));
+    });
+
+    test('submit button is disabled on submit', () => {
+        let event = new Event('submit');
+        formSubmitLoaderPlugin._onFormSubmit(event);
+
+        const submitButtons = document.querySelectorAll('.valid-form-button');
+        submitButtons.forEach((button) => {
+            expect(button.disabled).toBe(true);
+        })
     });
 });
 
@@ -116,7 +161,8 @@ describe('form submit loader loads button if selector is edited', () => {
         const { plugin } = setUpFormLoader('#test-with-button');
 
         expect(plugin.options.formWrapperSelector).toBe('.form-container-one');
-        expect(plugin._submitButton.id).toBe('inside-form-one');
+        expect(plugin._submitButtons.length).toBe(1);
+        expect(plugin._submitButtons[0].id).toBe('inside-form-one');
     });
 
     test('it loads button inside the container', () => {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to use the `FormSubmitLoaderPlugin` for more than one button, or in other words only one button is set to the loading state after submitting the form.

### 2. What does this change do, exactly?
Refactor the code to allow more than one button which should be set to the loading state.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
