### PR TITLE
Fix active ShippingMethod in Offcanvas-Cart

### DIFF
--- a/changelog/_unreleased/2022-02-03-fix-offcanvas-cart-active-shipping-method.md
+++ b/changelog/_unreleased/2022-02-03-fix-offcanvas-cart-active-shipping-method.md
@@ -1,0 +1,8 @@
+---
+title: Fix active ShippingMethod in Offcanvas-Cart
+issue: -
+author: David Fecke
+author_github: @leptoquark1
+---
+# Storefront
+* Added `activeShipping` variable in `Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig` to restore its scope as needed in block `component_offcanvas_summary_content_shipping`.

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
@@ -17,9 +17,7 @@
         </dl>
 
         {% if page.cart.deliveries is defined %}
-
             {% for activeShipping in page.cart.deliveries.elements %}
-
                 {% block component_offcanvas_summary_content_info %}
                     <div class="row offcanvas-shipping-info">
                         <span class="col-7 shipping-label shipping-cost">
@@ -36,9 +34,11 @@
                         </span>
                     </div>
                 {% endblock %}
-        {% endfor %}
+            {% endfor %}
 
-        {% block component_offcanvas_summary_content_shipping %}
+            {% set activeShipping = page.cart.deliveries.elements | first %}
+
+            {% block component_offcanvas_summary_content_shipping %}
                 {% if page.shippingMethods|length %}
                     <div class="offcanvas-shipping-preference mb-2 mt-2 offcanvas-shipping-preference--hidden">
                         <form


### PR DESCRIPTION
### 1. Why is this change necessary?

The changes in `storefront/component/checkout/offcanvas-cart-summary.html.twig` introduced by [NEXT-16805 - Show shipping costs discount in offcanvas cart](https://github.com/shopware/platform/commit/781ce2d71ac585a28beaa17467bb60bbe8603028) did brake the scope of the variable `activeShipping` as needed in block `component_offcanvas_summary_content_shipping` to pre-select the correct option in the shipping-method select.

Code affected by this bug:
[storefront/component/checkout/offcanvas-cart-summary.html.twig#L19-L74](https://github.com/shopware/platform/blob/781ce2d71ac585a28beaa17467bb60bbe8603028/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig#L19-L74)

(Unset variable `activeShipping` used to select the active shipping method option in line 63)


### 2. What does this change do, exactly?

- Without this change it may brake any Plugins depending on `activeShipping` variable available in the scope of the block `component_offcanvas_summary_content_shipping`.
- The only reason the actual active shipping method is currently selected may be
  - that every Evergreen Browser does fallback to select the first not disabled option available in a select.
  - However, since the `\Shopware\Core\Checkout\Shipping\SalesChannel\ShippingMethodRoute::load` does reorder the shipping methods _(prioritizing the active from context by calling `sortShippingMethodsByPreference`)_ it accidentally keeps the Browser from fallback selecting the wrong shipping method.


### 3. Describe each step to reproduce the issue or behaviour.

See in Offcanvas Cart that no ShippingMethod option have the desired attribute `selected="selected"`


### 4. Please link to the relevant issues (if any).

-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
