### PR TITLE
Added events to SystemConfigService to easily allow encrypting and decrypting of stored configuration values in combination with decorating the SystemConfigLoader.

### DIFF
--- a/changelog/_unreleased/2022-02-04-added-events-to-systemconfigservice-to-easily-allow-encrypting-and-decrypting-of-stored-configuration-values.md
+++ b/changelog/_unreleased/2022-02-04-added-events-to-systemconfigservice-to-easily-allow-encrypting-and-decrypting-of-stored-configuration-values.md
@@ -1,0 +1,10 @@
+---
+title: Added events to SystemConfigService to easily allow encrypting and decrypting of stored configuration values in combination with decorating the SystemConfigLoader.
+issue: NEXT-19942
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Added `Shopware\Core\System\SystemConfig\Event\BeforeSystemConfigChangedEvent` and dispatch it before a system config value is stored.
+* Added `\Shopware\Core\System\SystemConfig\Event\SystemConfigDomainLoadedEvent` and dispatch it after the domain configuration is loaded.

--- a/src/Core/System/SystemConfig/Event/BeforeSystemConfigChangedEvent.php
+++ b/src/Core/System/SystemConfig/Event/BeforeSystemConfigChangedEvent.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SystemConfig\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BeforeSystemConfigChangedEvent extends Event
+{
+    private string $key;
+
+    private ?string $salesChannelId;
+
+    /**
+     * @var string|float|int|bool|array|null
+     */
+    private $value;
+
+    /**
+     * @param array|bool|float|int|string|null $value
+     */
+    public function __construct(string $key, $value, ?string $salesChannelId)
+    {
+        $this->key = $key;
+        $this->salesChannelId = $salesChannelId;
+        $this->value = $value;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @return array|bool|float|int|string|null
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param array|bool|float|int|string|null $value
+     */
+    public function setValue($value): void
+    {
+        $this->value = $value;
+    }
+
+    public function getSalesChannelId(): ?string
+    {
+        return $this->salesChannelId;
+    }
+}

--- a/src/Core/System/SystemConfig/Event/SystemConfigDomainLoadedEvent.php
+++ b/src/Core/System/SystemConfig/Event/SystemConfigDomainLoadedEvent.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SystemConfig\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SystemConfigDomainLoadedEvent extends Event
+{
+    private array $config;
+
+    private string $domain;
+
+    private bool $inherit;
+
+    private ?string $salesChannelId;
+
+    public function __construct(string $domain, array $config, bool $inherit, ?string $salesChannelId)
+    {
+        $this->config = $config;
+        $this->domain = $domain;
+        $this->inherit = $inherit;
+        $this->salesChannelId = $salesChannelId;
+    }
+
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
+    public function setConfig(array $config): void
+    {
+        $this->config = $config;
+    }
+
+    public function getDomain(): string
+    {
+        return $this->domain;
+    }
+
+    public function isInherit(): bool
+    {
+        return $this->inherit;
+    }
+
+    public function getSalesChannelId(): ?string
+    {
+        return $this->salesChannelId;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

It allows one to modify system config values before storing and loading them. This allows one to encrypt / decrypt configuration values.

### 2. What does this change do, exactly?

* Added `Shopware\Core\System\SystemConfig\Event\BeforeSystemConfigChangedEvent` and dispatch it before a system config value is stored.
* Added `Shopware\Core\System\SystemConfig\Event\SystemConfigLoadedEvent` and dispatch it before a system config value is loaded.

### 3. Describe each step to reproduce the issue or behaviour.

New feature. Just adds events.

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/platform/issues/2306
https://issues.shopware.com/issues/NEXT-19942

### 5. Checklist

- [X] I have written tests and verified that they fail without my change.
   - I only added events, so no tests added as other similar events in SystemConfigService do not use events either.
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
