### PR TITLE
Fix task scheduler using wrong storage DateTime format when retrieving scheduled tasks.

### DIFF
--- a/changelog/_unreleased/2022-02-04-fix-task-scheduler-using-wrong-storage-datetime-format-when-retrieving-scheduled-tasks.md
+++ b/changelog/_unreleased/2022-02-04-fix-task-scheduler-using-wrong-storage-datetime-format-when-retrieving-scheduled-tasks.md
@@ -1,0 +1,9 @@
+---
+title: Fix task scheduler using wrong storage DateTime format when retrieving scheduled tasks.
+issue: NEXT-16402
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed `\Shopware\Core\Framework\MessageQueue\ScheduledTask\Scheduler\TaskScheduler` to use `\Shopware\Core\Defaults::STORAGE_DATE_TIME_FORMAT` when retrieving scheduled tasks.

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\MessageQueue\ScheduledTask\Scheduler;
 
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\MinAggregation;
@@ -109,7 +110,7 @@ class TaskScheduler
             new RangeFilter(
                 'nextExecutionTime',
                 [
-                    RangeFilter::LT => (new \DateTime())->format(\DATE_ATOM),
+                    RangeFilter::LT => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
                 ]
             ),
             new EqualsFilter('status', ScheduledTaskDefinition::STATUS_SCHEDULED)

--- a/src/Core/Framework/Test/ScheduledTask/Scheduler/TaskSchedulerTest.php
+++ b/src/Core/Framework/Test/ScheduledTask/Scheduler/TaskSchedulerTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Test\ScheduledTask\Scheduler;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -211,7 +212,10 @@ class TaskSchedulerTest extends TestCase
         $result = $this->scheduler->getNextExecutionTime();
         static::assertInstanceOf(\DateTime::class, $result);
         // when saving the Date to the DB the microseconds aren't saved, so we can't simply compare the datetime objects
-        static::assertEquals($nextExecutionTime->format(\DATE_ATOM), $result->format(\DATE_ATOM));
+        static::assertEquals(
+            $nextExecutionTime->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            $result->format(Defaults::STORAGE_DATE_TIME_FORMAT)
+        );
     }
 
     public function testGetNextExecutionTimeIgnoresNotScheduledTasks(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

To avoid issues with timezones when retrieving the next scheduled tasks.

### 2. What does this change do, exactly?

Use the correct DateTime format when retrieving scheduled tasks.

### 3. Describe each step to reproduce the issue or behaviour.

See issue: https://github.com/shopware/platform/issues/1978

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/platform/issues/1978
https://issues.shopware.com/issues/NEXT-16402

### 5. Checklist

- [X] I have written tests and verified that they fail without my change.
   - If existing tests still work as expected, then no tests should be necessary as this is not supposed to change behavior. The only way to test this would be to change the session / server timezone which I did not want to do during a test.
- [X] I have squashed any insignificant commits
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
