### PR TITLE
add CustomerLoginFailureEvent

### DIFF
--- a/changelog/_unreleased/2022-02-04-customer-login-failure-event.md
+++ b/changelog/_unreleased/2022-02-04-customer-login-failure-event.md
@@ -1,0 +1,6 @@
+---
+title: Add customer login failure event
+issue: none
+---
+# Core
+* Add `\Shopware\Core\Checkout\Customer\Event\CustomerLoginFailureEvent` to allow plugins to be notified about login failure.

--- a/src/Core/Checkout/Customer/CustomerEvents.php
+++ b/src/Core/Checkout/Customer/CustomerEvents.php
@@ -80,6 +80,11 @@ class CustomerEvents
     public const CUSTOMER_LOGIN_EVENT = 'checkout.customer.login';
 
     /**
+     * @Event("Shopware\Core\Checkout\Customer\Event\CustomerLoginFailureEvent")
+     */
+    public const CUSTOMER_LOGIN_FAILURE_EVENT = 'checkout.customer.login.failure';
+
+    /**
      * @Event("Shopware\Core\Checkout\Customer\Event\CustomerLogoutEvent")
      */
     public const CUSTOMER_LOGOUT_EVENT = 'checkout.customer.logout';

--- a/src/Core/Checkout/Customer/Event/CustomerLoginFailureEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerLoginFailureEvent.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\BusinessEventInterface;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
+use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CustomerLoginFailureEvent extends Event implements BusinessEventInterface, SalesChannelAware, ShopwareSalesChannelEvent
+{
+    public const EVENT_NAME = 'checkout.customer.login.failure';
+
+    protected string $customerEmail;
+
+    protected SalesChannelContext $salesChannelContext;
+
+    protected \Throwable $failureException;
+
+    public function __construct(SalesChannelContext $salesChannelContext, string $customerEmail, \Throwable $failureException)
+    {
+        $this->customerEmail = $customerEmail;
+        $this->salesChannelContext = $salesChannelContext;
+        $this->failureException = $failureException;
+    }
+
+    public function getName(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelContext->getSalesChannel()->getId();
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add('customerEmail', new ScalarValueType(ScalarValueType::TYPE_STRING));
+    }
+
+    public function getCustomerEmail(): string
+    {
+        return $this->customerEmail;
+    }
+
+    public function getFailureException(): \Throwable
+    {
+        return $this->failureException;
+    }
+}

--- a/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
@@ -6,6 +6,7 @@ use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerBeforeLoginEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
+use Shopware\Core\Checkout\Customer\Event\CustomerLoginFailureEvent;
 use Shopware\Core\Checkout\Customer\Exception\BadCredentialsException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerAuthThrottledException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundException;
@@ -130,6 +131,8 @@ class LoginRoute extends AbstractLoginRoute
                 $context
             );
         } catch (CustomerNotFoundException | BadCredentialsException $exception) {
+            $this->eventDispatcher->dispatch(new CustomerLoginFailureEvent($context, $email, $exception));
+
             throw new UnauthorizedHttpException('json', $exception->getMessage());
         }
 


### PR DESCRIPTION
Hello, here is a new event to help plugins to handle login failure attempts.
This is my first contribution to the shopware project, sorry in advance if it is not compliant, don't hesitate to precise to me on how to improve it to be compliant


### 1. Why is this change necessary?
To allow custom plugin to be notified about login failure (ex for statistics or logs)

### 2. What does this change do, exactly?
Adding an event when customer login to a storefront with an unavailable customer account or a wrong password.
Event is throwed with the corresponding email and the exception thrown by the login route (CustomerNotFoundException or BadCredentialsException)

### 3. Describe each step to reproduce the issue or behaviour.
Add a subscriber for the event and login with wrong credentials

### 4. Please link to the relevant issues (if any).
n/a

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.



