### PR TITLE
fix: storefront-presentation modal loads forever if shop has more than 100 option groups

### DIFF
--- a/changelog/_unreleased/2022-02-07-fix-storefront-presentation-group-loading.md
+++ b/changelog/_unreleased/2022-02-07-fix-storefront-presentation-group-loading.md
@@ -1,0 +1,8 @@
+---
+title: Add locking during version merge
+author: Felix von WIRDUZEN
+author_email: felix@wirduzen.de
+author_github: wirduzen-felix
+---
+# Administration
+    * Changed method `loadGroups()` in `module/sw-product/view/sw-product-detail-variants/index.js` to load all option groups, even if there are more than 100.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
@@ -136,11 +136,24 @@ Component.register('sw-product-detail-variants', {
                     const groupCriteria = new Criteria();
                     groupCriteria
                         .setLimit(100)
-                        .setPage(1);
+                        .setPage(1)
+                        .setTotalCountMode(1);
 
                     this.groupRepository.search(groupCriteria).then((searchResult) => {
-                        this.groups = searchResult;
-                        resolve();
+                        if(searchResult.total > 100){
+                            const groupCriteriaTotal = new Criteria();
+                            groupCriteriaTotal
+                                .setLimit(searchResult.total)
+                                .setPage(1)
+                                .setTotalCountMode(0);
+                            this.groupRepository.search(groupCriteriaTotal).then((searchResultTotal) => {
+                                this.groups = searchResultTotal;
+                                resolve();
+                            });
+                        }else{
+                            this.groups = searchResult;
+                            resolve();
+                        }
                     });
                 });
             });


### PR DESCRIPTION

### 1. Why is this change necessary?
If a shop has more than 100 option groups the Storefront Presentation modal would load forever. This makes it impossible to change the order of the variants and so on.

### 2. What does this change do, exactly?
It first tries to load the first 100 option groups, than looks at the total count. If the total count is greater than 100, it will load the remaining groups. There's probably a better way to solve this, but I'm currently not aware of any way to disable the limit entirely.

### 3. Describe each step to reproduce the issue or behaviour.
Just create more than 100 option groups.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
