### PR TITLE
added logging to swallowed exceptions

### DIFF
--- a/changelog/_unreleased/2022-02-07-added-logging-to-swallowed-exceptions.md
+++ b/changelog/_unreleased/2022-02-07-added-logging-to-swallowed-exceptions.md
@@ -1,0 +1,9 @@
+---
+title: added logging to swallowed exceptions
+issue: 
+author: Dominik Mank
+author_email: github@mank.dev
+author_github: dominikmank
+---
+
+* added logging to `\Shopware\Storefront\Controller\AccountProfileController` when an exception is catched. 

--- a/src/Storefront/Controller/AccountProfileController.php
+++ b/src/Storefront/Controller/AccountProfileController.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Storefront\Controller;
 
+use Psr\Log\LoggerInterface;
 use Shopware\Core\Checkout\Cart\Exception\CustomerNotLoggedInException;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractChangeCustomerProfileRoute;
@@ -43,13 +44,16 @@ class AccountProfileController extends StorefrontController
 
     private AbstractDeleteCustomerRoute $deleteCustomerRoute;
 
+    private LoggerInterface $logger;
+
     public function __construct(
         AccountOverviewPageLoader $overviewPageLoader,
         AccountProfilePageLoader $profilePageLoader,
         AbstractChangeCustomerProfileRoute $changeCustomerProfileRoute,
         AbstractChangePasswordRoute $changePasswordRoute,
         AbstractChangeEmailRoute $changeEmailRoute,
-        AbstractDeleteCustomerRoute $deleteCustomerRoute
+        AbstractDeleteCustomerRoute $deleteCustomerRoute,
+        LoggerInterface $logger
     ) {
         $this->overviewPageLoader = $overviewPageLoader;
         $this->profilePageLoader = $profilePageLoader;
@@ -57,6 +61,7 @@ class AccountProfileController extends StorefrontController
         $this->changePasswordRoute = $changePasswordRoute;
         $this->changeEmailRoute = $changeEmailRoute;
         $this->deleteCustomerRoute = $deleteCustomerRoute;
+        $this->logger = $logger;
     }
 
     /**
@@ -119,6 +124,7 @@ class AccountProfileController extends StorefrontController
         } catch (ConstraintViolationException $formViolations) {
             return $this->forwardToRoute('frontend.account.profile.page', ['formViolations' => $formViolations]);
         } catch (\Exception $exception) {
+            $this->logger->error($exception->getMessage(), ['e' => $exception]);
             $this->addFlash(self::DANGER, $this->trans('error.message-default'));
         }
 
@@ -143,6 +149,7 @@ class AccountProfileController extends StorefrontController
 
             return $this->forwardToRoute('frontend.account.profile.page', ['formViolations' => $formViolations, 'emailFormViolation' => true]);
         } catch (\Exception $exception) {
+            $this->logger->error($exception->getMessage(), ['e' => $exception]);
             $this->addFlash(self::DANGER, $this->trans('error.message-default'));
         }
 
@@ -184,6 +191,7 @@ class AccountProfileController extends StorefrontController
             $this->deleteCustomerRoute->delete($context, $customer);
             $this->addFlash(self::SUCCESS, $this->trans('account.profileDeleteSuccessAlert'));
         } catch (\Exception $exception) {
+            $this->logger->error($exception->getMessage(), ['e' => $exception]);
             $this->addFlash(self::DANGER, $this->trans('error.message-default'));
         }
 

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -53,6 +53,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ChangePasswordRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ChangeEmailRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\DeleteCustomerRoute"/>
+            <argument type="service" id="logger"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>


### PR DESCRIPTION
### 1. Why is this change necessary?
because catching exception and swallowing them without any notice to the application is bad.

Tbh it would be better to remove the catching \Exception block, but it would be a bc (i think) and i don't know if it was done intentionally. 

### 2. What does this change do, exactly?
added logging, so that the original exception is visible in the log, so that an administrator can see what happened.

### 3. Describe each step to reproduce the issue or behaviour.
-


### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
