### PR TITLE
Feature/add wishlist evets

### DIFF
--- a/changelog/_unreleased/2022-02-09-add-wishlist-events.md
+++ b/changelog/_unreleased/2022-02-09-add-wishlist-events.md
@@ -1,0 +1,13 @@
+---
+title: add wishlist events
+issue:
+author: Marcin Kaczor
+author_email: marcink@codepro.space
+author_github: CodeproSpace
+---
+
+* added add product to wishlist event file `\Shopware\Core\Checkout\Customer\Event\WishlistProductAddedEvent`
+* added remove product from wishlist event file `\Shopware\Core\Checkout\Customer\Event\WishlistProductRemovedEvent`
+* added dispatch event in wishlist add product route `\Shopware\Core\Checkout\Customer\SalesChannel\AddWishlistProductRoute`
+* added dispatch event in wishlist remove product route `\Shopware\Core\Checkout\Customer\SalesChannel\RemoveWishlistProductRoute`
+

--- a/changelog/_unreleased/2022-02-09-add-wishlist-events.md
+++ b/changelog/_unreleased/2022-02-09-add-wishlist-events.md
@@ -6,6 +6,7 @@ author_email: marcink@codepro.space
 author_github: CodeproSpace
 ---
 
+# Core
 * added add product to wishlist event file `\Shopware\Core\Checkout\Customer\Event\WishlistProductAddedEvent`
 * added remove product from wishlist event file `\Shopware\Core\Checkout\Customer\Event\WishlistProductRemovedEvent`
 * added dispatch event in wishlist add product route `\Shopware\Core\Checkout\Customer\SalesChannel\AddWishlistProductRoute`

--- a/changelog/_unreleased/2022-02-09-add-wishlist-events.md
+++ b/changelog/_unreleased/2022-02-09-add-wishlist-events.md
@@ -1,6 +1,6 @@
 ---
 title: add wishlist events
-issue:
+issue: NEXT-20092
 author: Marcin Kaczor
 author_email: marcink@codepro.space
 author_github: CodeproSpace

--- a/src/Core/Checkout/Customer/Event/WishlistProductAddedEvent.php
+++ b/src/Core/Checkout/Customer/Event/WishlistProductAddedEvent.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Shopware\Core\Checkout\Customer\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+class WishlistProductAddedEvent implements ShopwareSalesChannelEvent
+{
+    /**
+     * @var string
+     */
+    protected string $wishlistId;
+
+    /**
+     * @var string
+     */
+    protected string $productId;
+
+    /**
+     * @var SalesChannelContext
+     */
+    protected SalesChannelContext $context;
+
+    /**
+     * @param string $wishlistId
+     * @param string $productId
+     * @param SalesChannelContext $context
+     */
+    public function __construct(string $wishlistId, string $productId, SalesChannelContext $context)
+    {
+        $this->wishlistId = $wishlistId;
+        $this->productId = $productId;
+        $this->context = $context;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWishlistId(): string
+    {
+        return $this->wishlistId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProductId(): string
+    {
+        return $this->productId;
+    }
+
+    /**
+     * @return Context
+     */
+    public function getContext(): Context
+    {
+        return $this->context->getContext();
+    }
+
+    /**
+     * @return SalesChannelContext
+     */
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->context;
+    }
+}

--- a/src/Core/Checkout/Customer/Event/WishlistProductAddedEvent.php
+++ b/src/Core/Checkout/Customer/Event/WishlistProductAddedEvent.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
@@ -8,26 +8,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class WishlistProductAddedEvent implements ShopwareSalesChannelEvent
 {
-    /**
-     * @var string
-     */
     protected string $wishlistId;
 
-    /**
-     * @var string
-     */
     protected string $productId;
 
-    /**
-     * @var SalesChannelContext
-     */
     protected SalesChannelContext $context;
 
-    /**
-     * @param string $wishlistId
-     * @param string $productId
-     * @param SalesChannelContext $context
-     */
     public function __construct(string $wishlistId, string $productId, SalesChannelContext $context)
     {
         $this->wishlistId = $wishlistId;
@@ -35,33 +21,21 @@ class WishlistProductAddedEvent implements ShopwareSalesChannelEvent
         $this->context = $context;
     }
 
-    /**
-     * @return string
-     */
     public function getWishlistId(): string
     {
         return $this->wishlistId;
     }
 
-    /**
-     * @return string
-     */
     public function getProductId(): string
     {
         return $this->productId;
     }
 
-    /**
-     * @return Context
-     */
     public function getContext(): Context
     {
         return $this->context->getContext();
     }
 
-    /**
-     * @return SalesChannelContext
-     */
     public function getSalesChannelContext(): SalesChannelContext
     {
         return $this->context;

--- a/src/Core/Checkout/Customer/Event/WishlistProductRemovedEvent.php
+++ b/src/Core/Checkout/Customer/Event/WishlistProductRemovedEvent.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Shopware\Core\Checkout\Customer\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+class WishlistProductRemovedEvent implements ShopwareSalesChannelEvent
+{
+    /**
+     * @var string
+     */
+    protected string $wishlistId;
+
+    /**
+     * @var string
+     */
+    protected string $productId;
+
+    /**
+     * @var SalesChannelContext
+     */
+    protected SalesChannelContext $context;
+
+    /**
+     * @param string $wishlistId
+     * @param string $productId
+     * @param SalesChannelContext $context
+     */
+    public function __construct(string $wishlistId, string $productId, SalesChannelContext $context)
+    {
+        $this->wishlistId = $wishlistId;
+        $this->productId = $productId;
+        $this->context = $context;
+    }
+
+    /**
+     * @return string
+     */
+    public function getWishlistId(): string
+    {
+        return $this->wishlistId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getProductId(): string
+    {
+        return $this->productId;
+    }
+
+    /**
+     * @return Context
+     */
+    public function getContext(): Context
+    {
+        return $this->context->getContext();
+    }
+
+    /**
+     * @return SalesChannelContext
+     */
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->context;
+    }
+}

--- a/src/Core/Checkout/Customer/Event/WishlistProductRemovedEvent.php
+++ b/src/Core/Checkout/Customer/Event/WishlistProductRemovedEvent.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Shopware\Core\Checkout\Customer\Event;
 
@@ -8,26 +8,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class WishlistProductRemovedEvent implements ShopwareSalesChannelEvent
 {
-    /**
-     * @var string
-     */
     protected string $wishlistId;
 
-    /**
-     * @var string
-     */
     protected string $productId;
 
-    /**
-     * @var SalesChannelContext
-     */
     protected SalesChannelContext $context;
 
-    /**
-     * @param string $wishlistId
-     * @param string $productId
-     * @param SalesChannelContext $context
-     */
     public function __construct(string $wishlistId, string $productId, SalesChannelContext $context)
     {
         $this->wishlistId = $wishlistId;
@@ -35,33 +21,21 @@ class WishlistProductRemovedEvent implements ShopwareSalesChannelEvent
         $this->context = $context;
     }
 
-    /**
-     * @return string
-     */
     public function getWishlistId(): string
     {
         return $this->wishlistId;
     }
 
-    /**
-     * @return string
-     */
     public function getProductId(): string
     {
         return $this->productId;
     }
 
-    /**
-     * @return Context
-     */
     public function getContext(): Context
     {
         return $this->context->getContext();
     }
 
-    /**
-     * @return SalesChannelContext
-     */
     public function getSalesChannelContext(): SalesChannelContext
     {
         return $this->context;

--- a/src/Core/Checkout/Customer/SalesChannel/AddWishlistProductRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/AddWishlistProductRoute.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Event\WishlistProductAddedEvent;
 use Shopware\Core\Checkout\Customer\Exception\CustomerWishlistNotActivatedException;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Defaults;
@@ -20,6 +21,7 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SuccessResponse;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -42,14 +44,21 @@ class AddWishlistProductRoute extends AbstractAddWishlistProductRoute
      */
     private $systemConfigService;
 
+    /**
+     * @var EventDispatcherInterface
+     */
+    private EventDispatcherInterface $eventDispatcher;
+
     public function __construct(
         EntityRepositoryInterface $wishlistRepository,
         SalesChannelRepositoryInterface $productRepository,
-        SystemConfigService $systemConfigService
+        SystemConfigService $systemConfigService,
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->wishlistRepository = $wishlistRepository;
         $this->productRepository = $productRepository;
         $this->systemConfigService = $systemConfigService;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function getDecorated(): AbstractAddWishlistProductRoute
@@ -108,6 +117,8 @@ class AddWishlistProductRoute extends AbstractAddWishlistProductRoute
                 ],
             ],
         ], $context->getContext());
+
+        $this->eventDispatcher->dispatch(new WishlistProductAddedEvent($wishlistId, $productId, $context));
 
         return new SuccessResponse();
     }

--- a/src/Core/Checkout/Customer/SalesChannel/AddWishlistProductRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/AddWishlistProductRoute.php
@@ -44,9 +44,6 @@ class AddWishlistProductRoute extends AbstractAddWishlistProductRoute
      */
     private $systemConfigService;
 
-    /**
-     * @var EventDispatcherInterface
-     */
     private EventDispatcherInterface $eventDispatcher;
 
     public function __construct(

--- a/src/Core/Checkout/Customer/SalesChannel/RemoveWishlistProductRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RemoveWishlistProductRoute.php
@@ -43,9 +43,6 @@ class RemoveWishlistProductRoute extends AbstractRemoveWishlistProductRoute
      */
     private $systemConfigService;
 
-    /**
-     * @var EventDispatcherInterface
-     */
     private EventDispatcherInterface $eventDispatcher;
 
     public function __construct(

--- a/src/Core/Checkout/Customer/SalesChannel/RemoveWishlistProductRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RemoveWishlistProductRoute.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use OpenApi\Annotations as OA;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Event\WishlistProductRemovedEvent;
 use Shopware\Core\Checkout\Customer\Exception\CustomerWishlistNotActivatedException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerWishlistNotFoundException;
 use Shopware\Core\Checkout\Customer\Exception\WishlistProductNotFoundException;
@@ -19,6 +20,7 @@ use Shopware\Core\Framework\Routing\Annotation\Since;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SuccessResponse;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -41,14 +43,21 @@ class RemoveWishlistProductRoute extends AbstractRemoveWishlistProductRoute
      */
     private $systemConfigService;
 
+    /**
+     * @var EventDispatcherInterface
+     */
+    private EventDispatcherInterface $eventDispatcher;
+
     public function __construct(
         EntityRepositoryInterface $wishlistRepository,
         EntityRepositoryInterface $productRepository,
-        SystemConfigService $systemConfigService
+        SystemConfigService $systemConfigService,
+        EventDispatcherInterface $eventDispatcher
     ) {
         $this->wishlistRepository = $wishlistRepository;
         $this->productRepository = $productRepository;
         $this->systemConfigService = $systemConfigService;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function getDecorated(): AbstractRemoveWishlistProductRoute
@@ -105,6 +114,8 @@ class RemoveWishlistProductRoute extends AbstractRemoveWishlistProductRoute
                 'id' => $wishlistProductId,
             ],
         ], $context->getContext());
+
+        $this->eventDispatcher->dispatch(new WishlistProductRemovedEvent($wishlistId, $productId, $context));
 
         return new SuccessResponse();
     }

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -281,12 +281,14 @@
             <argument type="service" id="customer_wishlist.repository"/>
             <argument type="service" id="sales_channel.product.repository"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\RemoveWishlistProductRoute" public="true">
             <argument type="service" id="customer_wishlist.repository"/>
             <argument type="service" id="customer_wishlist_product.repository"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Customer\DataAbstractionLayer\CustomerWishlistProductExceptionHandler">

--- a/src/Core/Checkout/Test/Customer/SalesChannel/AddWishlistProductRouteTest.php
+++ b/src/Core/Checkout/Test/Customer/SalesChannel/AddWishlistProductRouteTest.php
@@ -87,9 +87,11 @@ class AddWishlistProductRouteTest extends TestCase
     {
         $productData = $this->createProduct($this->context);
         $dispatcher = $this->getContainer()->get('event_dispatcher');
+        $eventWasThrown = false;
 
-        $listener = static function (WishlistProductAddedEvent $event) use ($productData): void {
+        $listener = static function (WishlistProductAddedEvent $event) use ($productData, &$eventWasThrown): void {
             static::assertSame($productData[0], $event->getProductId());
+            $eventWasThrown = true;
         };
         $dispatcher->addListener(WishlistProductAddedEvent::class, $listener);
 
@@ -101,6 +103,7 @@ class AddWishlistProductRouteTest extends TestCase
         $response = json_decode($this->browser->getResponse()->getContent(), true);
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertTrue($response['success']);
+        static::assertTrue($eventWasThrown);
 
         $dispatcher->removeListener(WishlistProductAddedEvent::class, $listener);
     }

--- a/src/Core/Checkout/Test/Customer/SalesChannel/RemoveWishlistProductRouteTest.php
+++ b/src/Core/Checkout/Test/Customer/SalesChannel/RemoveWishlistProductRouteTest.php
@@ -182,26 +182,6 @@ class RemoveWishlistProductRouteTest extends TestCase
         static::assertEquals('Wishlist product with id ' . $productId . ' not found', $errors['detail']);
     }
 
-    public function testEventDispatchWishlistRemoveAddedEvent(): void
-    {
-        $dispatcher = $this->getContainer()->get('event_dispatcher');
-        $productId = $this->createProduct($this->context);
-        $wishlistData = $this->createCustomerWishlist($this->context, $this->customerId, $productId);
-
-        $listener = static function (WishlistProductRemovedEvent $event) use ($productId, $wishlistData): void {
-            static::assertSame($productId, $event->getProductId());
-            static::assertSame($wishlistData, $event->getWishlistId());
-        };
-        $dispatcher->addListener(WishlistProductRemovedEvent::class, $listener);
-
-        $this->browser
-            ->request(
-                'DELETE',
-                '/store-api/customer/wishlist/delete/' . $productId
-            );
-        $dispatcher->removeListener(WishlistProductRemovedEvent::class, $listener);
-    }
-
     private function createProduct(Context $context): string
     {
         $productId = Uuid::randomHex();

--- a/src/Core/Checkout/Test/Customer/SalesChannel/RemoveWishlistProductRouteTest.php
+++ b/src/Core/Checkout/Test/Customer/SalesChannel/RemoveWishlistProductRouteTest.php
@@ -87,11 +87,13 @@ class RemoveWishlistProductRouteTest extends TestCase
     {
         $productId = $this->createProduct($this->context);
         $dispatcher = $this->getContainer()->get('event_dispatcher');
+        $eventWasThrown = false;
 
         $this->createCustomerWishlist($this->context, $this->customerId, $productId);
 
-        $listener = static function (WishlistProductRemovedEvent $event) use ($productId): void {
+        $listener = static function (WishlistProductRemovedEvent $event) use ($productId, &$eventWasThrown): void {
             static::assertSame($productId, $event->getProductId());
+            $eventWasThrown = true;
         };
         $dispatcher->addListener(WishlistProductRemovedEvent::class, $listener);
 
@@ -105,6 +107,7 @@ class RemoveWishlistProductRouteTest extends TestCase
 
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
         static::assertTrue($response['success']);
+        static::assertTrue($eventWasThrown);
 
         $dispatcher->removeListener(WishlistProductRemovedEvent::class, $listener);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

While working on the integration with the marketing automation system, I had to provide data on adding / removing a product from the wishlist. Agencies use such data to remind customers of these products if, for example, they are on promotion.

In order to perform the task, I had to use the data writing event (in case of adding) and the pre-validation event (in case of deletion). However, it is not optimal. The implementation of these events will allow others easier access to the collection of this data.

### 2. What does this change do, exactly?

My changes add two events for adding and removing a product from the wishlist. They are performed in the appropriate routes right after the product add / remove function.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
