### PR TITLE
fix: No JS error when plugin is registered for non existing element

### DIFF
--- a/changelog/_unreleased/2022-02-10-no-js-error-when-plugin-is-registered-for-non-existing-element.md
+++ b/changelog/_unreleased/2022-02-10-no-js-error-when-plugin-is-registered-for-non-existing-element.md
@@ -1,0 +1,8 @@
+---
+title: No JS error when plugin is registered for non existing element
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Only call `PluginManager_initializePluginOnElement` for existing elements to avoid JavaScript errors

--- a/src/Storefront/Resources/app/storefront/src/plugin-system/plugin.manager.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin-system/plugin.manager.js
@@ -275,7 +275,7 @@ class PluginManagerSingleton {
     }
 
     /**
-     * Determs the way to query the elements.
+     * Determines the way to query the elements.
      *
      * [data-*] => querySelectorAll
      * #fooBar => getElementById
@@ -307,7 +307,9 @@ class PluginManagerSingleton {
         } else if (selector.startsWith('#')) {
             const regexEl = /^#([\w-]+)$/.exec(selector);
             if (regexEl) {
-                return [document.getElementById(regexEl[1])];
+                const el = document.getElementById(regexEl[1]);
+
+                return (el) ? [el] : [];
             }
         } else if (/^([\w-]+)$/.exec(selector)) {
             return document.getElementsByTagName(selector);

--- a/src/Storefront/Resources/app/storefront/test/plugin-system/plugin.manager.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin-system/plugin.manager.test.js
@@ -12,6 +12,51 @@ class FooPluginClass extends Plugin {
 describe('Plugin manager', () => {
     beforeEach(() => {
         document.body.innerHTML = '<div data-plugin="true" class="test-class"></div><div id="test-id"></div>';
+        jest.spyOn(console, 'error').mockImplementation();
+    });
+
+    afterEach(() => {
+        expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('should not fail for non-existing id', () => {
+        PluginManager.register('FooPlugin', FooPluginClass, '#nonExistingId');
+
+        PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPlugin').length).toBe(0);
+
+        PluginManager.deregister('FooPlugin', '#nonExistingId');
+    });
+
+    it('should not fail for non-existing HTML tag', () => {
+        PluginManager.register('FooPlugin', FooPluginClass, 'nonExistingHtmlTag');
+
+        PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPlugin').length).toBe(0);
+
+        PluginManager.deregister('FooPlugin', 'nonExistingHtmlTag');
+    });
+
+    it('should not fail for non-existing class', () => {
+        PluginManager.register('FooPlugin', FooPluginClass, '.non-existing-class');
+
+        PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPlugin').length).toBe(0);
+
+        PluginManager.deregister('FooPlugin', '.non-existing-class');
+    });
+
+    it('should not fail for non-existing selector', () => {
+        PluginManager.register('FooPlugin', FooPluginClass, '[data-non-existing-data-attribute]');
+
+        PluginManager.initializePlugins();
+
+        expect(PluginManager.getPluginInstances('FooPlugin').length).toBe(0);
+
+        PluginManager.deregister('FooPlugin', '[data-non-existing-data-attribute]');
     });
 
     it('should initialize plugin with class selector', () => {


### PR DESCRIPTION
### 1. Why is this change necessary?
Since Shopware 6.4.8.0 there is an error thrown, if one tries to register a plugin for an non-existing element:
![grafik](https://user-images.githubusercontent.com/6317761/153498906-12388934-5569-44a2-8d7b-ac47faa1d65e.png)

### 2. What does this change do, exactly?
Catch the case when the error would occur and do not trigger it. The other option would be to implement a strict mode for `_initializePluginOnElement`.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
