### PR TITLE
add order critieria event and test

### DIFF
--- a/changelog/_unreleased/2022-02-12-add-finish-page-criteria-event.md
+++ b/changelog/_unreleased/2022-02-12-add-finish-page-criteria-event.md
@@ -1,0 +1,13 @@
+---
+title: Add finish page criteria event
+issue: 
+author: Marcin Kaczor
+author_email: marcink@codepro.space
+author_github: CodeproSpace
+---
+
+# Core
+* added order criteria event on finish page: `\Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPageOrderCriteriaEvent`
+* added dispatch order criteria event in file: `\Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPageLoader`
+* added test in file: `\Shopware\Storefront\Test\Page\Checkout\FinishPageTest`
+

--- a/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoader.php
+++ b/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoader.php
@@ -115,6 +115,10 @@ class CheckoutFinishPageLoader
 
         $criteria->getAssociation('transactions')->addSorting(new FieldSorting('createdAt'));
 
+        $this->eventDispatcher->dispatch(
+            new CheckoutFinishPageOrderCriteriaEvent($criteria, $salesChannelContext)
+        );
+
         try {
             $searchResult = $this->orderRoute
                 ->load(new Request(), $salesChannelContext, $criteria)

--- a/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageOrderCriteriaEvent.php
+++ b/src/Storefront/Page/Checkout/Finish/CheckoutFinishPageOrderCriteriaEvent.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Checkout\Finish;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+class CheckoutFinishPageOrderCriteriaEvent implements ShopwareSalesChannelEvent
+{
+    protected Criteria $criteria;
+
+    protected SalesChannelContext $context;
+
+    public function __construct(Criteria $criteria, SalesChannelContext $context)
+    {
+        $this->context = $context;
+        $this->criteria = $criteria;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->context;
+    }
+}

--- a/src/Storefront/Test/Page/Checkout/FinishPageTest.php
+++ b/src/Storefront/Test/Page/Checkout/FinishPageTest.php
@@ -4,10 +4,12 @@ namespace Shopware\Storefront\Test\Page\Checkout;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Exception\OrderNotFoundException;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPage;
 use Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPageLoadedEvent;
 use Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPageLoader;
+use Shopware\Storefront\Page\Checkout\Finish\CheckoutFinishPageOrderCriteriaEvent;
 use Shopware\Storefront\Test\Page\StorefrontPageTestBehaviour;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -39,6 +41,15 @@ class FinishPageTest extends TestCase
         $context = $this->createSalesChannelContextWithLoggedInCustomerAndWithNavigation();
         $orderId = $this->placeRandomOrder($context);
         $request = new Request([], [], ['orderId' => $orderId]);
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+        $eventWasThrown = false;
+        $criteria = new Criteria([$orderId]);
+
+        $listener = static function (CheckoutFinishPageOrderCriteriaEvent $event) use ($criteria, &$eventWasThrown): void {
+            static::assertSame($criteria->getIds(), $event->getCriteria()->getIds());
+            $eventWasThrown = true;
+        };
+        $dispatcher->addListener(CheckoutFinishPageOrderCriteriaEvent::class, $listener);
 
         /** @var CheckoutFinishPageLoadedEvent $event */
         $event = null;
@@ -49,6 +60,9 @@ class FinishPageTest extends TestCase
         static::assertInstanceOf(CheckoutFinishPage::class, $page);
         static::assertSame(13.04, $page->getOrder()->getPrice()->getNetPrice());
         self::assertPageEvent(CheckoutFinishPageLoadedEvent::class, $event, $context, $request, $page);
+        static::assertTrue($eventWasThrown);
+
+        $dispatcher->removeListener(CheckoutFinishPageOrderCriteriaEvent::class, $listener);
     }
 
     /**

--- a/src/Storefront/Test/Page/Checkout/FinishPageTest.php
+++ b/src/Storefront/Test/Page/Checkout/FinishPageTest.php
@@ -45,11 +45,14 @@ class FinishPageTest extends TestCase
         $eventWasThrown = false;
         $criteria = new Criteria([$orderId]);
 
-        $listener = static function (CheckoutFinishPageOrderCriteriaEvent $event) use ($criteria, &$eventWasThrown): void {
-            static::assertSame($criteria->getIds(), $event->getCriteria()->getIds());
-            $eventWasThrown = true;
-        };
-        $dispatcher->addListener(CheckoutFinishPageOrderCriteriaEvent::class, $listener);
+        $this->addEventListener(
+            $dispatcher,
+            CheckoutFinishPageOrderCriteriaEvent::class,
+            static function ($event) use ($criteria, &$eventWasThrown): void {
+                static::assertSame($criteria->getIds(), $event->getCriteria()->getIds());
+                $eventWasThrown = true;
+            }
+        );
 
         /** @var CheckoutFinishPageLoadedEvent $event */
         $event = null;
@@ -61,8 +64,6 @@ class FinishPageTest extends TestCase
         static::assertSame(13.04, $page->getOrder()->getPrice()->getNetPrice());
         self::assertPageEvent(CheckoutFinishPageLoadedEvent::class, $event, $context, $request, $page);
         static::assertTrue($eventWasThrown);
-
-        $dispatcher->removeListener(CheckoutFinishPageOrderCriteriaEvent::class, $listener);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

When writing plugins for Shopware, whenever I wanted to display some additional information on the thank you page, I had to create a new database request. Most often I needed to add product data. Thanks to the application of event criteria, which is used in many similar situations in Shopware, we can extend associations. 

### 2. What does this change do, exactly?

My code adding an event that allows you to extend the criteria when retrieving order data on the thank you page.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
