### PR TITLE
fix: tree item width in flow builder

### DIFF
--- a/changelog/_unreleased/2022-02-14-fix-tree-item-width-in-flow-builder.md
+++ b/changelog/_unreleased/2022-02-14-fix-tree-item-width-in-flow-builder.md
@@ -1,0 +1,10 @@
+---
+title: Fix tree item width in flow builder issue: NA author: Huzaifa Mustafa author_email: hello@huzaifamustafa.com
+author_github: @zaifastafa
+---
+
+# Storefront
+
+* Changed `width` of `.sw-tree-item`
+  in `src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss` to `max-content` to
+  adjust the width automatically when we go deeper into the tree node.

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
@@ -42,7 +42,7 @@
         }
 
         .sw-tree-item {
-            min-width: 100%;
+            min-width: max-content;
         }
 
         .sw-tree-item__children {


### PR DESCRIPTION
### 1. Why is this change necessary?
When we go to the flow builder, if there are deeper nodes in the tree, the text gets truncated. 
![image](https://user-images.githubusercontent.com/24492269/153801512-68fbe8c7-fb1e-463a-9be8-88bbe1673612.png)


### 2. What does this change do, exactly?
It fixes the width so it shows the text properly for all tree levels. 
![image](https://user-images.githubusercontent.com/24492269/153801848-8d6ca6b4-cca3-41b1-8c15-10027dd3e143.png)


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have read the contribution requirements and fulfil them.
