### PR TITLE
added exception for api request...

### DIFF
--- a/public/.htaccess.dist
+++ b/public/.htaccess.dist
@@ -83,4 +83,10 @@ DirectoryIndex index.php
   </IfModule>
 </IfModule>
 
+# Uncomment if you use folder protection via .htaccess/.htpasswd in accordance to documentation
+# <RequireAny>
+#    Require expr %{THE_REQUEST} =~ m#.*?\s+\/api.*?#
+#    Require valid-user
+# </RequireAny>
+
 # END Shopware


### PR DESCRIPTION
... in case of folder protection via .htaccess/.htpasswd is in use in accordance to https://docs.shopware.com/en/shopware-6-en/first-steps/installing-shopware-6?category=shopware-6-en/getting-started#htaccess-adjustments. This might be much more simple to fix by somebody who didn't read the documentation before installation. Additionally, I will add an issue claiming for better error message in blank admin that appears if one didn't uncomment these lines after folder protection.

### 1. Why is this change necessary?

If using folder protection after installation of the shop, the admin panel is not reachable any more and comes up with a blank page instead. As a next step I would check .htaccess to find out what happened. If I stumble upon this entry, it is easier for me to uncomment it instead of reading through the documentation.

### 2. What does this change do, exactly?

* Added exception for api request in case of folder protection via .htaccess/.htpasswd is in use in accordance to https://docs.shopware.com/en/shopware-6-en/first-steps/installing-shopware-6?category=shopware-6-en/getting-started#htaccess-adjustments.
* Should work in both, Apache v2.2 as well as Apache v2.4
* As code is commented, I cannot see any interference to plugins and/or apps.

### 3. Describe each step to reproduce the issue or behaviour.

Install the shop and use folder protection via .htaccess/.htpasswd afterwards

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-4664 and a couple of other duplicates and not resolved issues

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.