### PR TITLE
Removing duplicate DOM IDs from pagination

### DIFF
--- a/changelog/_unreleased/2022-02-16-remove-duplicate-pagination-ids.md
+++ b/changelog/_unreleased/2022-02-16-remove-duplicate-pagination-ids.md
@@ -1,0 +1,8 @@
+---
+title: Removing duplicate DOM IDs from pagination
+author: SkaveRat
+author_email: github@skaverat.net
+author_github: SkaveRat
+---
+# Storefront
+* Changed pagination snippet to use a suffix when generation DOM IDs, to prevent generation of duplicate IDs

--- a/src/Storefront/Resources/views/storefront/component/pagination.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/pagination.html.twig
@@ -2,6 +2,11 @@
     {% set currentPage = ((criteria.offset + 1) / criteria.limit )|round(0, 'ceil') %}
     {% set totalPages = (entities.total / criteria.limit)|round(0, 'ceil') %}
 
+    {% set paginationSuffix = '' %}
+    {% if paginationLocation %}
+        {% set paginationSuffix = '-' ~ paginationLocation %}
+    {% endif %}
+
     {% if totalPages > 1 %}
         <nav aria-label="pagination" class="pagination-nav">
             {% block component_pagination %}
@@ -12,14 +17,14 @@
                             <input type="radio"
                                    {% if currentPage == 1 %}disabled="disabled"{% endif %}
                                    name="p"
-                                   id="p-first"
+                                   id="p-first{{ paginationSuffix }}"
                                    value="1"
                                    class="d-none"
                                    title="pagination">
                         {% endblock %}
 
                         {% block component_pagination_first_label %}
-                            <label class="page-link" for="p-first">
+                            <label class="page-link" for="p-first{{ paginationSuffix }}">
                                 {% block component_pagination_first_link %}
                                     {% sw_icon 'arrow-medium-double-left' style { 'size': 'fluid', 'pack': 'solid'} %}
                                 {% endblock %}
@@ -34,14 +39,14 @@
                             <input type="radio"
                                    {% if currentPage == 1 %}disabled="disabled"{% endif %}
                                    name="p"
-                                   id="p-prev"
+                                   id="p-prev{{ paginationSuffix }}"
                                    value="{{ currentPage - 1 }}"
                                    class="d-none"
                                    title="pagination">
                         {% endblock %}
 
                         {% block component_pagination_prev_label %}
-                            <label class="page-link" for="p-prev">
+                            <label class="page-link" for="p-prev{{ paginationSuffix }}">
                                 {% block component_pagination_prev_link %}
                                     {% block component_pagination_prev_icon %}
                                         {% sw_icon 'arrow-medium-left' style {'size': 'fluid', 'pack': 'solid'} %}
@@ -76,7 +81,7 @@
                                 {% block component_pagination_item_input %}
                                     <input type="radio"
                                            name="p"
-                                           id="p{{ page }}"
+                                           id="p{{ page }}{{ paginationSuffix }}"
                                            value="{{ page }}"
                                            class="d-none"
                                            title="pagination"
@@ -85,7 +90,7 @@
 
                                 {% block component_pagination_item_label %}
                                     <label class="page-link"
-                                           for="p{{ page }}">
+                                           for="p{{ page }}{{ paginationSuffix }}">
                                         {% block component_pagination_item_link %}
                                             {% block component_pagination_item_text %}
                                                 {{ page }}
@@ -105,14 +110,14 @@
                             <input type="radio"
                                    {% if currentPage == totalPages %}disabled="disabled"{% endif %}
                                    name="p"
-                                   id="p-next"
+                                   id="p-next{{ paginationSuffix }}"
                                    value="{{ currentPage + 1 }}"
                                    class="d-none"
                                    title="pagination">
                         {% endblock %}
 
                         {% block component_pagination_next_label %}
-                            <label class="page-link" for="p-next">
+                            <label class="page-link" for="p-next{{ paginationSuffix }}">
                                 {% block component_pagination_next_link %}
                                     {% block component_pagination_next_icon %}
                                         {% sw_icon 'arrow-medium-right' style { 'size': 'fluid', 'pack': 'solid'} %}
@@ -129,14 +134,14 @@
                             <input type="radio"
                                    {% if currentPage == totalPages %}disabled="disabled"{% endif %}
                                    name="p"
-                                   id="p-last"
+                                   id="p-last{{ paginationSuffix }}"
                                    value="{{ totalPages }}"
                                    class="d-none"
                                    title="pagination">
                         {% endblock %}
 
                         {% block component_pagination_last_label %}
-                            <label class="page-link" for="p-last">
+                            <label class="page-link" for="p-last{{ paginationSuffix }}">
                                 {% block component_pagination_last_link %}
                                     {% block component_pagination_last_icon %}
                                         {% sw_icon 'arrow-medium-double-right' style {

--- a/src/Storefront/Resources/views/storefront/component/pagination.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/pagination.html.twig
@@ -3,7 +3,7 @@
     {% set totalPages = (entities.total / criteria.limit)|round(0, 'ceil') %}
 
     {% set paginationSuffix = '' %}
-    {% if paginationLocation %}
+    {% if feature('v6_5_0_0') and paginationLocation %}
         {% set paginationSuffix = '-' ~ paginationLocation %}
     {% endif %}
 

--- a/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
@@ -83,7 +83,8 @@
                     {% block element_product_listing_pagination_nav_bottom %}
                         {% sw_include '@Storefront/storefront/component/pagination.html.twig' with {
                             entities: searchResult,
-                            criteria: searchResult.criteria
+                            criteria: searchResult.criteria,
+                            'paginationLocation': 'bottom',
                         } %}
                     {% endblock %}
                 {% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Duplicate DOM IDs can cause unwanted behaviour in JS. Additionally this might cause accessability problems. Google Pagespeed saw this as an accessability problem.

### 2. What does this change do, exactly?
It adds a suffix to the IDs of the bottom pagination bar. The top bar remains unchanced, to avoid problems with potential frontend tests or JS that use the IDs.

Called the variable/parameter "location", so multiple paginations can be added if needed by a theme. E.g. a top, middle and bottom one. Calling it "suffix" in the parameters already, could lead to confusion.

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change **Not sure if it's needed for this change. Please let me know if it's needed.**
- [X] I have squashed any insignificant commits
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes **Let me know if it's needed for this change**
- [ ] I have written or adjusted the documentation according to my changes **Let me know if it's needed for this change**
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
