### PR TITLE
fix: compiler fails on non existing image (by checking for "is define…

### DIFF
--- a/changelog/_unreleased/2022-02-18-fix-feed-fail-on-undefined-cover-image.md
+++ b/changelog/_unreleased/2022-02-18-fix-feed-fail-on-undefined-cover-image.md
@@ -1,0 +1,9 @@
+---
+title: Google Product Feed - handle Articles without an Image 
+issue: NEXT-18930
+author: wolf128058
+author_email: jonas.hess@mailbox.org
+author_github: wolf128058
+---
+# Storefront
+* Changed: `src/Administration/Resources/app/administration/src/module/sw-sales-channel/product-export-templates/google-product-search-de/body.xml.twig` Wrapping the cover.media-call in a check for "is defined". And skipping this image  if there is no image. So the feed for Google Products does not fail completely if only one product has no cover image.

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/product-export-templates/google-product-search-de/body.xml.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/product-export-templates/google-product-search-de/body.xml.twig
@@ -5,7 +5,7 @@
     <g:google_product_category>950{# change your Google Shopping category #}</g:google_product_category>
     <g:product_type>{{ product.categories.first.getBreadCrumb|slice(1)|join(' > ')|raw|escape }}</g:product_type>
     <link>{{ seoUrl('frontend.detail.page', {'productId': product.id}) }}</link>
-    <g:image_link>{{ product.cover.media.url }}</g:image_link>
+    {% if product.cover.media is defined %}<g:image_link>{{ product.cover.media.url }}</g:image_link>{% endif %}
     <g:condition>new</g:condition>
     <g:availability>
         {%- if product.availableStock >= product.minPurchase and product.deliveryTime -%}


### PR DESCRIPTION
This change is so tiny... Either you get it or you don't get it. 

Checking product.cover.media.url  for being defined before using it is all i do.
And that saves me from defect feeds in case somebody did not give all articles a cover-image.