### PR TITLE
Fix theme name in theme.json (if lowercase)

### DIFF
--- a/changelog/_unreleased/2022-02-18-fix-theme-name-in-theme-json-file.md
+++ b/changelog/_unreleased/2022-02-18-fix-theme-name-in-theme-json-file.md
@@ -1,0 +1,9 @@
+---
+title: Fix theme name in theme json file
+issue: 2257
+author: Mohab E.
+author_email: mohab.elsheikh@gmail.com
+author_github: mohabmes
+---
+# Storefront
+* Changed the `$themeName` in `Theme/Command/ThemeCreateCommand.php` to `$pluginName` just to match the theme directory name created (if the theme name is lowercase). 

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -101,7 +101,7 @@ class ThemeCreateCommand extends Command
 
         $themeConfig = str_replace(
             ['#name#', '#snake-case#'],
-            [$themeName, $snakeCaseName],
+            [$pluginName, $snakeCaseName],
             $this->getThemeConfigTemplate()
         );
 


### PR DESCRIPTION
It's very simple.
Fix the theme name in theme.json by using the same name of the directory created. That should fix #2257.