### PR TITLE
Fix/2319 - Changed system config memoization to use separate service.

### DIFF
--- a/changelog/_unreleased/2022-02-21-changed-move-system-config-memoization-to-use-separate-service.md
+++ b/changelog/_unreleased/2022-02-21-changed-move-system-config-memoization-to-use-separate-service.md
@@ -1,0 +1,11 @@
+---
+title: Changed system config memoization to use separate service.
+issue: https://github.com/shopware/platform/issues/2319
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed `Shopware\Core\System\SystemConfig\SystemConfigService` to not memoize the system configuration.
+* Added `Shopware\Core\System\SystemConfig\Store\MemoizedSystemConfigStore` to memoize the system configuration and clear it upon changes.
+* Added `Shopware\Core\System\SystemConfig\MemoizedSystemConfigLoader` to memoize the system configuration in `Shopware\Core\System\SystemConfig\Store\MemoizedSystemConfigStore`.

--- a/src/Core/Framework/Test/TestCaseBase/SystemConfigTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SystemConfigTestBehaviour.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Framework\Test\TestCaseBase;
 
-use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Core\System\SystemConfig\Store\MemoizedSystemConfigStore;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait SystemConfigTestBehaviour
@@ -15,14 +15,9 @@ trait SystemConfigTestBehaviour
      */
     public function resetInternalSystemConfigCache(): void
     {
-        $systemConfigService = $this->getContainer()->get(SystemConfigService::class);
-
-        // reset internal system config cache
-        $reflection = new \ReflectionClass($systemConfigService);
-
-        $property = $reflection->getProperty('configs');
-        $property->setAccessible(true);
-        $property->setValue($systemConfigService, []);
+        /** @var MemoizedSystemConfigStore $store */
+        $store = $this->getContainer()->get(MemoizedSystemConfigStore::class);
+        $store->reset();
     }
 
     abstract protected function getContainer(): ContainerInterface;

--- a/src/Core/System/DependencyInjection/configuration.xml
+++ b/src/Core/System/DependencyInjection/configuration.xml
@@ -39,6 +39,11 @@
             <argument type="service" id="event_dispatcher"/>
         </service>
 
+        <service id="Shopware\Core\System\SystemConfig\Store\MemoizedSystemConfigStore">
+            <tag name="kernel.event_subscriber"/>
+            <tag name="kernel.reset" method="reset"/>
+        </service>
+
         <service id="Shopware\Core\System\SystemConfig\SystemConfigLoader">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Symfony\Component\HttpKernel\KernelInterface"/>
@@ -48,6 +53,11 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\CachedSystemConfigLoader.inner"/>
             <argument type="service" id="cache.object"/>
             <argument type="service" id="logger"/>
+        </service>
+
+        <service id="Shopware\Core\System\SystemConfig\MemoizedSystemConfigLoader" decorates="Shopware\Core\System\SystemConfig\SystemConfigLoader" decoration-priority="-2000">
+            <argument type="service" id="Shopware\Core\System\SystemConfig\MemoizedSystemConfigLoader.inner"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\Store\MemoizedSystemConfigStore"/>
         </service>
 
         <service id="Shopware\Core\System\SystemConfig\Facade\SystemConfigFacadeHookFactory" public="true">

--- a/src/Core/System/SystemConfig/MemoizedSystemConfigLoader.php
+++ b/src/Core/System/SystemConfig/MemoizedSystemConfigLoader.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SystemConfig;
+
+use Shopware\Core\System\SystemConfig\Store\MemoizedSystemConfigStore;
+
+class MemoizedSystemConfigLoader extends AbstractSystemConfigLoader
+{
+    private AbstractSystemConfigLoader $decorated;
+
+    private MemoizedSystemConfigStore $memoizedSystemConfigStore;
+
+    public function __construct(
+        AbstractSystemConfigLoader $decorated,
+        MemoizedSystemConfigStore $memoizedSystemConfigStore
+    ) {
+        $this->decorated = $decorated;
+        $this->memoizedSystemConfigStore = $memoizedSystemConfigStore;
+    }
+
+    public function getDecorated(): AbstractSystemConfigLoader
+    {
+        return $this->decorated;
+    }
+
+    public function load(?string $salesChannelId): array
+    {
+        $config = $this->memoizedSystemConfigStore->getConfig($salesChannelId);
+
+        if ($config !== null) {
+            return $config;
+        }
+
+        $config = $this->getDecorated()->load($salesChannelId);
+        $this->memoizedSystemConfigStore->setConfig($salesChannelId, $config);
+
+        return $config;
+    }
+}

--- a/src/Core/System/SystemConfig/Store/MemoizedSystemConfigStore.php
+++ b/src/Core/System/SystemConfig/Store/MemoizedSystemConfigStore.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SystemConfig\Store;
+
+use Shopware\Core\System\SystemConfig\Event\SystemConfigChangedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\Service\ResetInterface;
+
+/**
+ * @internal
+ */
+final class MemoizedSystemConfigStore implements EventSubscriberInterface, ResetInterface
+{
+    /**
+     * @var array[]
+     */
+    private array $configs = [];
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SystemConfigChangedEvent::class => [
+                ['onValueChanged', 1500],
+            ],
+        ];
+    }
+
+    public function onValueChanged(SystemConfigChangedEvent $event): void
+    {
+        $this->removeConfig($event->getSalesChannelId());
+    }
+
+    public function setConfig(?string $salesChannelId, array $config): void
+    {
+        $this->configs[$this->getKey($salesChannelId)] = $config;
+    }
+
+    public function getConfig(?string $salesChannelId): ?array
+    {
+        return $this->configs[$this->getKey($salesChannelId)] ?? null;
+    }
+
+    public function removeConfig(?string $salesChannelId): void
+    {
+        if ($salesChannelId === null) {
+            $this->reset();
+
+            return;
+        }
+
+        unset($this->configs[$this->getKey($salesChannelId)]);
+    }
+
+    public function reset(): void
+    {
+        $this->configs = [];
+    }
+
+    private function getKey(?string $salesChannelId): string
+    {
+        return $salesChannelId ?? '_global_';
+    }
+}

--- a/src/Core/System/SystemConfig/SystemConfigService.php
+++ b/src/Core/System/SystemConfig/SystemConfigService.php
@@ -30,11 +30,6 @@ class SystemConfigService
 
     private EntityRepositoryInterface $systemConfigRepository;
 
-    /**
-     * @var array[]
-     */
-    private array $configs = [];
-
     private ConfigReader $configReader;
 
     private array $keys = ['all' => true];
@@ -73,7 +68,7 @@ class SystemConfigService
             $this->traces[$trace][self::buildName($key)] = true;
         }
 
-        $config = $this->load($salesChannelId);
+        $config = $this->loader->load($salesChannelId);
 
         $parts = explode('.', $key);
 
@@ -138,7 +133,7 @@ class SystemConfigService
      */
     public function all(?string $salesChannelId = null): array
     {
-        return $this->load($salesChannelId);
+        return $this->loader->load($salesChannelId);
     }
 
     /**
@@ -215,9 +210,6 @@ class SystemConfigService
      */
     public function set(string $key, $value, ?string $salesChannelId = null): void
     {
-        // reset internal cache
-        $this->configs = [];
-
         $key = trim($key);
         $this->validate($key, $salesChannelId);
 
@@ -344,19 +336,6 @@ class SystemConfigService
         unset($this->traces[$key]);
 
         return $trace;
-    }
-
-    private function load(?string $salesChannelId): array
-    {
-        $key = $salesChannelId ?? 'global';
-
-        if (isset($this->configs[$key])) {
-            return $this->configs[$key];
-        }
-
-        $this->configs[$key] = $this->loader->load($salesChannelId);
-
-        return $this->configs[$key];
     }
 
     /**

--- a/src/Core/System/Test/SystemConfig/MemoizedSystemConfigLoaderTest.php
+++ b/src/Core/System/Test/SystemConfig/MemoizedSystemConfigLoaderTest.php
@@ -1,0 +1,383 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Test\SystemConfig;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SystemConfig\AbstractSystemConfigLoader;
+use Shopware\Core\System\SystemConfig\CachedSystemConfigLoader;
+use Shopware\Core\System\SystemConfig\Event\SystemConfigChangedEvent;
+use Shopware\Core\System\SystemConfig\MemoizedSystemConfigLoader;
+use Shopware\Core\System\SystemConfig\Store\MemoizedSystemConfigStore;
+use Shopware\Core\System\SystemConfig\SystemConfigLoader;
+use Shopware\Core\System\Test\SystemConfig\_fixtures\MemoizedSystemConfigLoaderTest\DecoratedMemoizedResetTestSystemConfigLoader;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class MemoizedSystemConfigLoaderTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testMemoizationWithSalesChannelIdWorks(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::once())
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        // Ensure a second call does not call the load method and returns the same result.
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationWithoutSalesChannelIdWorks(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::once())
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(null);
+        static::assertSame($expectedConfig, $config);
+
+        // Ensure a second call does not call the load method and returns the same result.
+        $config = $service->load(null);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationResetsForSalesChannelId(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        // Reset config without sales channel ID.
+        $configStore->removeConfig(TestDefaults::SALES_CHANNEL);
+
+        // The load method is now called a second time as memoization has been reset for the sales channel.
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationResetsWithoutSalesChannelId(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(null);
+        static::assertSame($expectedConfig, $config);
+
+        // Reset config without sales channel ID.
+        $configStore->removeConfig(null);
+
+        // The load method is now called a second time as the global memoization has been reset.
+        $config = $service->load(null);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationResetWithoutSalesChannelIdForAllSalesChannels(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        // AS the global config is reset, all sales channels are reset and load is called a second time.
+        $configStore->removeConfig(null);
+
+        // The load method is now called a second time as the memoization has been reset for all sales channels.
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationDoesNotResetOnResetForDifferentSalesChannelId(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(1))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        // Reset the config for a different sales channel ID.
+        $configStore->removeConfig(Uuid::randomHex());
+
+        // The load method is not called again as the config was reset for a different sales channel ID.
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testUsingDifferentSalesChannelIdsCallsLoad(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        // Ensure that using a different sales channel ID calls the load method again.
+        $config = $service->load(Uuid::randomHex());
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testUsingGlobalAndSalesChannelIdLoadCallsLoad(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(null);
+        static::assertSame($expectedConfig, $config);
+
+        // Ensure that using a sales channel ID calls the load method again.
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationResetsOnValueChangeEventForSalesChannelId(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = $this->getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher->addSubscriber($configStore);
+
+        // Dispatching the event resets the memoization and ensures load is called a second time.
+        $dispatcher->dispatch(new SystemConfigChangedEvent('abc.config.foo', 'none', TestDefaults::SALES_CHANNEL));
+
+        // The load method is now called a second time as memoization has been reset for the sales channel.
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationResetsOnValueChangeEventWithoutSalesChannelId(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(null);
+        static::assertSame($expectedConfig, $config);
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = $this->getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher->addSubscriber($configStore);
+
+        // Dispatching the event resets the memoization and ensures load is called a second time.
+        $dispatcher->dispatch(new SystemConfigChangedEvent('abc.config.foo', 'none', null));
+
+        // The load method is now called a second time as the global memoization has been reset.
+        $config = $service->load(null);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationResetsOnValueChangeEventWithoutSalesChannelIdForAllSalesChannels(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = $this->getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher->addSubscriber($configStore);
+
+        // Dispatching the event resets the memoization for all sales channels and ensures load is called a second time.
+        $dispatcher->dispatch(new SystemConfigChangedEvent('abc.config.foo', 'none', null));
+
+        // The load method is now called a second time as the memoization has been reset for all sales channels.
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationDoesNotResetOnValueChangedEventForDifferentSalesChannelId(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(1))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = $this->getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher->addSubscriber($configStore);
+
+        // Dispatching the event resets the memoization for a different sales channel ID.
+        $dispatcher->dispatch(new SystemConfigChangedEvent('abc.config.foo', 'none', Uuid::randomHex()));
+
+        // The load method is not called again as the config was reset for a different sales channel ID.
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationResetsWhenCallingMethod(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        $configStore->reset();
+
+        // The load method is now called a second time as memoization has been reset.
+        $config = $service->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationResetsOnValueChangeEventWithDecoratedSystemConfigLoader(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+        $decorated = new DecoratedMemoizedResetTestSystemConfigLoader($service);
+
+        $config = $decorated->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        /** @var EventDispatcherInterface $dispatcher */
+        $dispatcher = $this->getContainer()->get(EventDispatcherInterface::class);
+        $dispatcher->addSubscriber($configStore);
+
+        // Dispatching the event resets the memoization and ensures load is called a second time.
+        $dispatcher->dispatch(new SystemConfigChangedEvent('abc.config.foo', 'none', TestDefaults::SALES_CHANNEL));
+
+        // The load method is now called a second time as memoization has been reset for the sales channel.
+        $config = $decorated->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testMemoizationResetsWhenCallingMethodWithDecoratedSystemConfigLoader(): void
+    {
+        $expectedConfig = ['abc' => ['config' => ['foo' => 'abc']]];
+
+        $mock = $this->createMock(AbstractSystemConfigLoader::class);
+        $mock->expects(static::exactly(2))
+            ->method('load')
+            ->willReturn($expectedConfig);
+
+        $configStore = new MemoizedSystemConfigStore();
+        $service = new MemoizedSystemConfigLoader($mock, $configStore);
+        $decorated = new DecoratedMemoizedResetTestSystemConfigLoader($service);
+
+        $config = $decorated->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+
+        $configStore->reset();
+
+        // The load method is now called a second time as memoization has been reset.
+        $config = $decorated->load(TestDefaults::SALES_CHANNEL);
+        static::assertSame($expectedConfig, $config);
+    }
+
+    public function testServiceDecorationChainPriority(): void
+    {
+        $service = $this->getContainer()->get(SystemConfigLoader::class);
+
+        static::assertInstanceOf(MemoizedSystemConfigLoader::class, $service);
+        static::assertInstanceOf(CachedSystemConfigLoader::class, $service->getDecorated());
+        static::assertInstanceOf(SystemConfigLoader::class, $service->getDecorated()->getDecorated());
+    }
+}

--- a/src/Core/System/Test/SystemConfig/_fixtures/MemoizedSystemConfigLoaderTest/DecoratedMemoizedResetTestSystemConfigLoader.php
+++ b/src/Core/System/Test/SystemConfig/_fixtures/MemoizedSystemConfigLoaderTest/DecoratedMemoizedResetTestSystemConfigLoader.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\Test\SystemConfig\_fixtures\MemoizedSystemConfigLoaderTest;
+
+use Shopware\Core\System\SystemConfig\AbstractSystemConfigLoader;
+
+class DecoratedMemoizedResetTestSystemConfigLoader extends AbstractSystemConfigLoader
+{
+    private AbstractSystemConfigLoader $decorated;
+
+    public function __construct(AbstractSystemConfigLoader $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    public function getDecorated(): AbstractSystemConfigLoader
+    {
+        return $this->decorated;
+    }
+
+    public function load(?string $salesChannelId): array
+    {
+        return $this->getDecorated()->load($salesChannelId);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
To give better control on changing configuration values using config loader decoration chain, e.g. modify it according to items in the cart which is not possible currently as the config value has been memoized in the system config service which cannot be modified once the cart is available. I admit it is probably an edge case but it is still helpful and a better solution then storing it directly in the system config service.

For more info see also the issue: https://github.com/shopware/platform/issues/2319

Another potential issue might be value encrypting / decryption and deciding if a value should be memoized or how it should be memoized.

### 2. What does this change do, exactly?
See changelog entry.

### 3. Describe each step to reproduce the issue or behaviour.
See issue: https://github.com/shopware/platform/issues/2319

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2319

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
