### PR TITLE
NEXT-20222 Fix 'Plugin ACL' bug

### DIFF
--- a/changelog/_unreleased/2022-02-21-fix-plugin-acl-bug.md
+++ b/changelog/_unreleased/2022-02-21-fix-plugin-acl-bug.md
@@ -1,0 +1,9 @@
+---
+title: Fix 'Plugin ACL' bug
+issue: NEXT-20222
+author: Rune Laenen
+author_email: rune@laenen.me
+author_github: runelaenen
+---
+# Core
+* Added `array_values` in `\Shopware\Core\Framework\Plugin\Subscriber\PluginAclPrivilegesSubscriber::onAclRoleLoaded`.

--- a/src/Core/Framework/Plugin/Subscriber/PluginAclPrivilegesSubscriber.php
+++ b/src/Core/Framework/Plugin/Subscriber/PluginAclPrivilegesSubscriber.php
@@ -46,7 +46,7 @@ class PluginAclPrivilegesSubscriber implements EventSubscriberInterface
         foreach ($additionalRolePrivileges as $additionalRole => $additionalPrivileges) {
             foreach ($aclRoles as $aclRole) {
                 if ($additionalRole === AclRoleDefinition::ALL_ROLE_KEY || \in_array($additionalRole, $aclRole->getPrivileges(), true)) {
-                    $newPrivileges = array_unique(array_merge($aclRole->getPrivileges(), $additionalPrivileges));
+                    $newPrivileges = array_values(array_unique(array_merge($aclRole->getPrivileges(), $additionalPrivileges)));
                     $aclRole->setPrivileges($newPrivileges);
                 }
             }

--- a/src/Core/Framework/Test/Plugin/PluginAclTest.php
+++ b/src/Core/Framework/Test/Plugin/PluginAclTest.php
@@ -104,6 +104,26 @@ class PluginAclTest extends TestCase
         static::assertSame(['product.viewer', 'product:read', 'swag_demo_data:read'], $enrichedAclRole->getPrivileges());
     }
 
+    public function testAclPluginSubscriberAssociativeArray(): void
+    {
+        $this->activatePlugin(self::PLUGIN_ACL_PRODUCT_VIEWER);
+
+        $aclRoles = [$this->getAclRoleMock('pluginAclTestProductViewer', ['product.viewer', 'product:read'])];
+
+        $event = new EntityLoadedEvent(
+            $this->createMock(AclRoleDefinition::class),
+            $aclRoles,
+            Context::createDefaultContext()
+        );
+
+        $this->pluginAclSubscriber->onAclRoleLoaded($event);
+
+        /** @var AclRoleEntity $enrichedAclRole */
+        $enrichedAclRole = $event->getEntities()[0];
+
+        static::assertSame($enrichedAclRole->getPrivileges(), array_values($enrichedAclRole->getPrivileges()));
+    }
+
     public function testAclPluginOpenToAllDeactivated(): void
     {
         $this->deactivatePlugin(self::PLUGIN_ACL_OPEN_TO_ALL);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/contribution/contribution-guideline?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
The subscriber can add additional fields using array_merge. This changes the array from an indexed array (with sequencial numeric keys) to an associative array (with any key, in this case numeric but with missing numbers) This is not a problem in PHP, as PHP will loop over any array just fine, but when converted to JSON, an indexed array will become a Javascript Array, while an associative array becomes an Object in Javascript. 
This all makes the admin throw error because it tries to `.reduce()` the object on login - making logging in impossible. 

### 2. What does this change do, exactly?
Add array_values to recalculate the keys, and make sure it's an indexed array.

### 3. Describe each step to reproduce the issue or behaviour.
Add a role and assign it to a user, try logging in with the user. I haven't been able to narrow it down to a certain configuration, so you might have to try some times to get a bugged configuration.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-20222

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
