### PR TITLE
NEXT-20238 - Decode URL-encoded values from database URL in maintenance commands

### DIFF
--- a/changelog/_unreleased/2022-02-22-database-url-decode.md
+++ b/changelog/_unreleased/2022-02-22-database-url-decode.md
@@ -1,0 +1,9 @@
+---
+title: Decode URL-encoded values from database URL in maintenance commands
+issue: NEXT-20238
+author: Martin Helmich
+author_email: m.helmich@mittwald.de
+author_github: martin-helmich
+---
+# Core
+* Decode URL-encoded values from database URL in maintenance commands

--- a/src/Core/Maintenance/System/Struct/DatabaseConnectionInformation.php
+++ b/src/Core/Maintenance/System/Struct/DatabaseConnectionInformation.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Maintenance\System\Struct;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Maintenance\System\Exception\DatabaseSetupException;
+use function is_string;
 
 class DatabaseConnectionInformation extends Struct
 {
@@ -36,6 +37,14 @@ class DatabaseConnectionInformation extends Struct
         $params = parse_url($dsn);
         if ($params === false) {
             throw new DatabaseSetupException('Environment variable \'DATABASE_URL\' does not contain a valid dsn.');
+        }
+
+        foreach ($params as $param => $value) {
+            if (!is_string($value)) {
+                continue;
+            }
+
+            $params[$param] = rawurldecode($value);
         }
 
         $path = $params['path'] ?? '/';

--- a/src/Core/Maintenance/Test/System/Struct/DatabaseConnectionInformationTest.php
+++ b/src/Core/Maintenance/Test/System/Struct/DatabaseConnectionInformationTest.php
@@ -7,6 +7,17 @@ use Shopware\Core\Maintenance\System\Struct\DatabaseConnectionInformation;
 
 class DatabaseConnectionInformationTest extends TestCase
 {
+    /**
+     * @backupGlobals enabled
+     */
+    public function testItDecodesSpecialCharsInDbPasswordsFromEnv(): void
+    {
+        $_ENV['DATABASE_URL'] = 'mysql://user:ultra%3Fsecure%23@mysql:3306/test_db';
+        $dbConnectionInformation = DatabaseConnectionInformation::fromEnv();
+
+        static::assertEquals('ultra?secure#', $dbConnectionInformation->getPassword());
+    }
+
     public function testItEncodesSpecialCharsInDbPasswords(): void
     {
         $dbConnectionInformation = (new DatabaseConnectionInformation())->assign([


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

This change fixes the bug reported in [NEXT-20238](https://issues.shopware.com/issues/NEXT-20238). See there for a detailed description and analysis.

### 2. What does this change do, exactly?

Run `rawurldecode` on any database parameters extracted by running `parse_url` on the `DATABASE_URL` environment variable. This allows the `DATABASE_URL` env var to contain url-encoded special characters (most likely, in the password) and maintenance commands to still work.

### 3. Describe each step to reproduce the issue or behaviour.

See [NEXT-20238](https://issues.shopware.com/issues/NEXT-20238).

### 4. Please link to the relevant issues (if any).

See [NEXT-20238](https://issues.shopware.com/issues/NEXT-20238)

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] ~~I have written or adjusted the documentation according to my changes~~ (N/A)
- [x] ~~This change has comments for package types, values, functions, and non-obvious lines of code~~ (N/A)
- [x] I have read the contribution requirements and fulfil them.
