### PR TITLE
Allow timeZone to update for yourself

### DIFF
--- a/src/Core/Framework/Api/Controller/UserController.php
+++ b/src/Core/Framework/Api/Controller/UserController.php
@@ -110,7 +110,7 @@ class UserController extends AbstractController
             throw new ExpectedUserHttpException();
         }
 
-        $allowedChanges = ['firstName', 'lastName', 'username', 'localeId', 'email', 'avatarMedia', 'avatarId', 'password'];
+        $allowedChanges = ['firstName', 'lastName', 'username', 'localeId', 'email', 'avatarMedia', 'avatarId', 'password', 'timeZone'];
 
         if (!empty(array_diff(array_keys($request->request->all()), $allowedChanges))) {
             throw new MissingPrivilegeException(['user:update']);


### PR DESCRIPTION
### 1. Why is this change necessary?

When you use the API route to update yourself you can't update the timezone.

### 2. What does this change do, exactly?

It allows you to change the timezone of yourself.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use admin without user:editor ACL that triggers the use of the 6.3 introduced API routes to update yourself instead of using the generic entity API for user
2. Go into change yourself area in admin
3. Change timezone in UI
4. Get rejected by API

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Questions

So why is this a draft? I want to update my timezone just because I can. As I for-whatever-reason don't have `user:editor` I use the old API call introduced in 6.3 behind the scenes. Now I receive an answer that says I am missing ACL `user:update`. Uhm, ok. I check my ACL and I got user:update. Now the debugging starts and I find out that my request parameters are not in an allowlist. And I get an ACL violation message. What kind of message do I have to use instead? I can't let this stay an ACL violation message, because it is not controlled by ACL at all.

My ACL: `Shopware.Service().get('acl').privileges.filter(i => i.indexOf('user') !== -1)`

```json
[
  "acl_user_role:create",
  "acl_user_role:delete",
  "acl_user_role:read",
  "acl_user_role:update",
  "user.update_profile",
  "user:create",
  "user:delete",
  "user:read",
  "user:update",
  "user_access_key:create",
  "user_access_key:delete",
  "user_access_key:read",
  "user_access_key:update",
  "user_change_me",
  "user_config:create",
  "user_config:read",
  "user_config:update",
  "users_and_permissions.creator",
  "users_and_permissions.deleter",
  "users_and_permissions.editor",
  "users_and_permissions.viewer"
]
```
