### PR TITLE
fix media library performance

### DIFF
--- a/changelog/_unreleased/2022-02-22-fix-media-library-performance.md
+++ b/changelog/_unreleased/2022-02-22-fix-media-library-performance.md
@@ -1,0 +1,9 @@
+---
+title: Fix media library performance
+issue:
+author: Pascal Josephy
+author_email: pascal.josephy@jkweb.ch
+author_github: pascaljosephy
+---
+# Administration
+* Changed method `loadItems` of `sw-media-library`

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/index.js
@@ -238,7 +238,6 @@ Component.register('sw-media-library', {
                 .addAssociation('tags')
                 .addAssociation('productMedia.product')
                 .addAssociation('categories')
-                .addAssociation('productManufacturers.products')
                 .addAssociation('mailTemplateMedia.mailTemplate')
                 .addAssociation('documentBaseConfigs')
                 .addAssociation('avatarUser')


### PR DESCRIPTION
### 1. Why is this change necessary?

When opening the media library, the performance is poor because all products of manufacturers are fetched, even though they are not used. In our case, we have around 18k products and the payload to the api/search/media endpoint is 44MB in size - as a result, the UI is not usable for a few seconds.

### 2. What does this change do, exactly?

Remove the unnecessary association.

### 3. Describe each step to reproduce the issue or behaviour.

- Add 18k products
- Link them to 1 manufacturer
- Add one media item
- Add media item to manufacturer
- Open media library

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
