### PR TITLE
NTR: Admin sort payments alphabetically in sales channels

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -133,7 +133,9 @@ Component.register('sw-sales-channel-detail-base', {
         paymentMethodCriteria() {
             const criteria = new Criteria();
 
-            criteria.addSorting(Criteria.sort('position', 'ASC'));
+            // sort by name, because that is easier for
+            // maintenance in the administration
+            criteria.addSorting(Criteria.sort('name', 'ASC'));
 
             return criteria;
         },


### PR DESCRIPTION
This is a proposal

### 1. Why is this change necessary?

If a merchant has lots of payment methods and plugins its somehow annoying when working with these in the administration. I think it might be a better idea to sort by name instead of position.


### 2. What does this change do, exactly?

switching from sortBy "position" to "name" ASC


### 3. Describe each step to reproduce the issue or behaviour.

install multiple payment methods (long list) and open the sales channel in the administration.
open the payment methods dropdown

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
<img width="1070" alt="Screen Shot 2022-02-23 at 10 43 47" src="https://user-images.githubusercontent.com/5579326/155295460-b895ec34-8ed5-4a5f-b802-afff30357d6f.png">

