### PR TITLE
Why fetch every time?

### DIFF
--- a/changelog/_unreleased/2022-03-28-cart-fetch-xhr-edit.md
+++ b/changelog/_unreleased/2022-03-28-cart-fetch-xhr-edit.md
@@ -4,7 +4,7 @@ author: Mark Ringtved Nielsen
 author_email: mrn@geni.digital
 author_github: mrn-rigtved & ringtved
 ---
-# Storfront
-* Changed `cart-widget.plugin.init()` removed call `cart-widget.plugin.fetch()` so we dont fetch eveytime we init the storfront plugin.
+# Storefront
+* Changed `cart-widget.plugin.init()` removed call `cart-widget.plugin.fetch()` so we dont fetch eveytime we init the storefront plugin.
 * Changed `cart-widget.plugin.fetch()` added `if(storedContent)` to check if we have data in storage else fetch the content.
 * Changed `session storage` comments to `local storage` we use the localstorage there for the comments need to match.

--- a/changelog/_unreleased/2022-03-28-cart-fetch-xhr-edit.md
+++ b/changelog/_unreleased/2022-03-28-cart-fetch-xhr-edit.md
@@ -1,0 +1,10 @@
+---
+title: Cart context fetch change
+author: Mark Ringtved Nielsen
+author_email: mrn@geni.digital
+author_github: mrn-rigtved & ringtved
+---
+# Storfront
+* Changed `cart-widget.plugin.init()` removed call `cart-widget.plugin.fetch()` so we dont fetch eveytime we init the storfront plugin.
+* Changed `cart-widget.plugin.fetch()` added `if(storedContent)` to check if we have data in storage else fetch the content.
+* Changed `session storage` comments to `local storage` we use the localstorage there for the comments need to match.

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/cart-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/cart-widget.plugin.js
@@ -13,18 +13,19 @@ export default class CartWidgetPlugin extends Plugin {
         this._client = new HttpClient();
 
         this.insertStoredContent();
-        this.fetch();
     }
 
     /**
      * reads the persisted content
-     * from the session cache an renders it
+     * from the local cache an renders it
      * into the element
      */
     insertStoredContent() {
         const storedContent = Storage.getItem(this.options.cartWidgetStorageKey);
         if (storedContent) {
             this.el.innerHTML = storedContent;
+        } else {
+            this.fetch();
         }
 
         this.$emitter.publish('insertStoredContent');
@@ -32,7 +33,7 @@ export default class CartWidgetPlugin extends Plugin {
 
     /**
      * Fetch the current cart widget template by calling the api
-     * and persist the response to the browser's session storage
+     * and persist the response to the browser's local storage
      */
     fetch() {
         this._client.get(window.router['frontend.checkout.info'], (response) => {


### PR DESCRIPTION
### 1. Why is this change necessary?
We might have the data in local storage then there is no reason to fetch it.
If we don't have the content we can just get it.

Why have the comments say session storage when it's local storage?

### 2. What does this change do, exactly?
We only fetch if we don't have any data matching the key in local storage.
So we reduce the fetch requests.

### 3. Describe each step to reproduce the issue or behaviour.
I just made a page load on the landing page and some category pages then I saw we always call from this plugin.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
