### PR TITLE
Update _image-slider.scss

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_image-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_image-slider.scss
@@ -29,7 +29,6 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
 
             .image-slider-image {
                 object-fit: cover;
-                font-family: 'object-fit: cover;'; // IE polyfill
                 height: 100%;
                 position: absolute;
                 top: 0;


### PR DESCRIPTION
Since we don't support IE, how about we remove the polyfill? 
Cheers

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
--> Nope

### 1. Why is this change necessary?
Seems redundant to have polyfill for something not supported. 

### 2. What does this change do, exactly?
Less code, less confusion. 

### 3. Describe each step to reproduce the issue or behaviour.
Not really a issue, but just wierd.

### 4. Please link to the relevant issues (if any).


### 5. Checklist


- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
