### PR TITLE
Added option to skip JWT keys generation to system:install command.

### DIFF
--- a/changelog/_unreleased/2022-02-28-added-option-to-skip-jwt-keys-generation-to-system-install-command.md
+++ b/changelog/_unreleased/2022-02-28-added-option-to-skip-jwt-keys-generation-to-system-install-command.md
@@ -1,0 +1,9 @@
+---
+title: Added option to skip JWT keys generation to system:install command.
+issue: https://github.com/shopware/platform/issues/2358
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed `Shopware\Core\Maintenance\System\Command\SystemInstallCommand` to add the option `skip-jwt-keys-generation` that ensures that no JWT keys are generated, if it is executed.

--- a/src/Core/Maintenance/System/Command/SystemInstallCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemInstallCommand.php
@@ -40,6 +40,7 @@ class SystemInstallCommand extends Command
             ->addOption('shop-email', null, InputOption::VALUE_REQUIRED, 'Shop email address')
             ->addOption('shop-locale', null, InputOption::VALUE_REQUIRED, 'Default language locale of the shop')
             ->addOption('shop-currency', null, InputOption::VALUE_REQUIRED, 'Iso code for the default currency of the shop')
+            ->addOption('skip-jwt-keys-generation', null, InputOption::VALUE_NONE, 'Skips generation of jwt private and public key')
         ;
     }
 
@@ -61,10 +62,6 @@ class SystemInstallCommand extends Command
         $this->initializeDatabase($output, $input);
 
         $commands = [
-            [
-                'command' => 'system:generate-jwt',
-                'allowedToFail' => true,
-            ],
             [
                 'command' => 'database:migrate',
                 'identifier' => 'core',
@@ -94,6 +91,16 @@ class SystemInstallCommand extends Command
                 'command' => 'plugin:refresh',
             ],
         ];
+
+        if (!$input->getOption('skip-jwt-keys-generation')) {
+            array_unshift(
+                $commands,
+                [
+                    'command' => 'system:generate-jwt',
+                    'allowedToFail' => true,
+                ]
+            );
+        }
 
         /** @var Application $application */
         $application = $this->getApplication();


### PR DESCRIPTION
### 1. Why is this change necessary?
To skip JWT keys generation upon calling the system:install command, see https://github.com/shopware/platform/issues/2358


### 2. What does this change do, exactly?
Added an option to skip the JWT keys generation.

### 3. Describe each step to reproduce the issue or behaviour.
Calling `bin/console system:install` does always generate JWT keys.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2358

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
   - There are no tests for the SystemInstallCommand, so I didn't added any additional test because first the whole command should be tested. 
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
