### PR TITLE
Add object check before field access to ensure sw-entity-multi-id-select updating correctly

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-id-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-id-select/index.js
@@ -104,7 +104,7 @@ Component.register('sw-entity-multi-id-select', {
                 this.collection = collection;
             }
 
-            if (this.ids.length <= 0) {
+            if (!this.ids || this.ids.length <= 0) {
                 this.collection = collection;
                 return Promise.resolve(this.collection);
             }


### PR DESCRIPTION
### 1. Why is this change necessary?

When you use custom fields you can end up in thinking you see the right selection but don't see the effects they have because a field did not update properly.

### 2. What does this change do, exactly?

The current code tries to access length of something that can be null. The prop definition assumes to fall back to [] but this seems not to check within methods triggered from watch? maybe? I just added a null check so we are good without failure.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have a custom field onto products that is an entity id selection of media
2. Set the custom field value to `null` via API for language A
3. Set the custom field value to a selection in the admin for language B
4. Open product in language B
5. See filled entity selection
6. Switch language to language A
7. Still see the filled entity selection
8. Re-open product in language A
9. See empty entity selection
10. 🤨 

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Hotfix

```javascript
const { Component } = Shopware;

Component.override('sw-entity-multi-id-select', {
    methods: {
        createdComponent() {
            this.ids = this.ids || [];

            return this.$super('createdComponent');
        }
    }
});
```
