### PR TITLE
Allow custom fields to be sent on address upsert

### DIFF
--- a/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
@@ -145,6 +145,7 @@ class UpsertAddressRoute extends AbstractUpsertAddressRoute
             'phoneNumber' => $data->get('phoneNumber'),
             'additionalAddressLine1' => $data->get('additionalAddressLine1'),
             'additionalAddressLine2' => $data->get('additionalAddressLine2'),
+            'customFields' => $data->get('customFields')->all(),
         ];
 
         $mappingEvent = new DataMappingEvent($data, $addressData, $context->getContext());


### PR DESCRIPTION
### 1. Why is this change necessary?
Custom fields on address aren't saved if they are sent through the api. This PR is just an example of how I updated the code on my staging environment to make it work. I can't seem to get the project up and running on my local device (M1 chip issues with docker) So I didn't know how to write the tests. If this is the way to go, maybe you guys could implement it :) 

### 2. What does this change do, exactly?
This change adds the customfield data to AddressUpsert

### 3. Describe each step to reproduce the issue or behaviour.
Add custom field to Address, send with api and it won't save

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
