### PR TITLE
allow min length 1;

### DIFF
--- a/changelog/_unreleased/2022-03-01-allow-min-search-length-of-1.md
+++ b/changelog/_unreleased/2022-03-01-allow-min-search-length-of-1.md
@@ -1,0 +1,8 @@
+---
+title: Allow min seach length of 1 in SearchWidgetPlugin
+author: Moritz Pietzschke
+author_email: mp@mopie.de
+author_github: pietzschke
+---
+# Storefront
+* Changed `searchWidgetMinChars` to 1, so search starts with every character entered in `SearchWidgetPlugin`.

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -20,7 +20,7 @@ export default class SearchWidgetPlugin extends Plugin {
         searchWidgetCollapseClass: 'collapsed',
 
         searchWidgetDelay: 250,
-        searchWidgetMinChars: 3,
+        searchWidgetMinChars: 1,
     };
 
     init() {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Minimum length of search text can be 1: [https://issues.shopware.com/issues/NEXT-19255](https://issues.shopware.com/issues/NEXT-19255)

### 2. What does this change do, exactly?

Allow text in SearchWidget to be minimum length 1.

### 3. Describe each step to reproduce the issue or behaviour.

Configure minimum search length to 1 or 2 and try to search from SearchWidget for these products. You cannot find them, because the search only triggers after 3 characters.

### 4. Please link to the relevant issues (if any).

[https://issues.shopware.com/issues/NEXT-19255
](https://issues.shopware.com/issues/NEXT-19255
)
[https://issues.shopware.com/issues/NEXT-18824](https://issues.shopware.com/issues/NEXT-18824
)
### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
