### PR TITLE
NEXT-18824 - Add configurable minimal search length for suggestions

### DIFF
--- a/changelog/_unreleased/2022-03-02-add-configurable-minimal-search-length-for-suggestions.md
+++ b/changelog/_unreleased/2022-03-02-add-configurable-minimal-search-length-for-suggestions.md
@@ -1,0 +1,10 @@
+---
+title: Added configurable minimal search length for product suggestions
+issue: NEXT-18824
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@iodigital.com
+author_github: @MelvinAchterhuis
+---
+# Storefront
+* Added `productSearchConfig` association to `src/Storefront/Pagelet/Header/HeaderPageletLoader.php`.
+* Added `data-search-widget-options` to `src/Storefront/Resources/views/storefront/layout/header/search.html.twig`

--- a/src/Storefront/Pagelet/Header/HeaderPageletLoader.php
+++ b/src/Storefront/Pagelet/Header/HeaderPageletLoader.php
@@ -114,6 +114,7 @@ class HeaderPageletLoader implements HeaderPageletLoaderInterface
         );
 
         $criteria->addSorting(new FieldSorting('name', FieldSorting::ASCENDING));
+        $criteria->addAssociation('productSearchConfig');
         $apiRequest = new Request();
 
         $event = new LanguageRouteRequestEvent($request, $apiRequest, $context, $criteria);

--- a/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
@@ -2,9 +2,13 @@
     <div class="collapse"
          id="searchCollapse">
         <div class="header-search">
+            {% set searchWidgetOptions = {
+                searchWidgetMinChars: page.header.activeLanguage.productSearchConfig.minSearchLength ?: 3
+            } %}
             <form action="{{ path('frontend.search.page') }}"
                   method="get"
                   data-search-form="true"
+                  data-search-widget-options='{{ searchWidgetOptions|json_encode }}'
                   data-url="{{ path('frontend.search.suggest') }}?search="
                   class="header-search-form">
                 {% block layout_header_search_input_group %}


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently the merchant can set a minimal search length in Settings -> Search. However this doesn't reflect the search suggestions on the storefront. That value is currently hardcoded at 3 characters. 

### 2. What does this change do, exactly?

Adds `productSearchConfig` association to the language in `HeaderPagelet` so we can use it in the Twig and JS. 

### 3. Describe each step to reproduce the issue or behaviour.

Set minimal search length to 1 or 2 in Settings -> Search and start searching on storefront. Suggestions will appear after third character is filled in. 

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-18824

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
