### PR TITLE
Use parameters to display cache information in admin.

### DIFF
--- a/changelog/_unreleased/2022-03-08-use-parameters-to-display-cache-information-in-admin.md
+++ b/changelog/_unreleased/2022-03-08-use-parameters-to-display-cache-information-in-admin.md
@@ -1,0 +1,10 @@
+---
+title: Use parameters to display cache information in admin.
+issue: https://github.com/shopware/platform/issues/2369
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed `Shopware\Core\Framework\Api\Controller\CacheController` to retrieve cache information from parameters.
+* Changed `Shopware\Core\Framework\Api\Controller\CacheController` service definition to use `'container.service_subscriber` for the container, so `\Symfony\Bundle\FrameworkBundle\Controller\AbstractController::getParameter` works.

--- a/src/Core/Framework/Api/Controller/CacheController.php
+++ b/src/Core/Framework/Api/Controller/CacheController.php
@@ -80,8 +80,8 @@ class CacheController extends AbstractController
     public function info(): JsonResponse
     {
         return new JsonResponse([
-            'environment' => getenv('APP_ENV'),
-            'httpCache' => (bool) getenv('SHOPWARE_HTTP_CACHE_ENABLED'),
+            'environment' => $this->getParameter('kernel.environment'),
+            'httpCache' => (bool) $this->getParameter('shopware.http.cache.enabled'),
             'cacheAdapter' => $this->getUsedCache($this->adapter),
         ]);
     }

--- a/src/Core/Framework/DependencyInjection/api.xml
+++ b/src/Core/Framework/DependencyInjection/api.xml
@@ -197,8 +197,10 @@
             <argument type="service" id="cache.object"/>
             <argument type="service" id="Shopware\Storefront\Framework\Cache\CacheWarmer\CacheWarmer" on-invalid="null"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry"/>
+            <tag name="container.service_subscriber" />
+            <tag name="controller.service_arguments" />
             <call method="setContainer">
-                <argument type="service" id="service_container"/>
+                <argument type="service" id="Psr\Container\ContainerInterface" />
             </call>
         </service>
 

--- a/src/Core/Framework/Test/Api/Controller/CacheControllerTest.php
+++ b/src/Core/Framework/Test/Api/Controller/CacheControllerTest.php
@@ -98,7 +98,7 @@ class CacheControllerTest extends TestCase
         $response = $this->getBrowser()->getResponse();
 
         static::assertSame(Response::HTTP_OK, $response->getStatusCode(), print_r($response->getContent(), true));
-        static::assertSame('{"environment":"test","httpCache":false,"cacheAdapter":"CacheDecorator"}', $response->getContent());
+        static::assertSame('{"environment":"test","httpCache":true,"cacheAdapter":"CacheDecorator"}', $response->getContent());
     }
 
     public function testCacheIndexEndpoint(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

To avoid the need for `putenv` in production template and to show the actually used settings instead of what might be used.

### 2. What does this change do, exactly?
Use parameters to show cache information

### 3. Describe each step to reproduce the issue or behaviour.
disable putenv in public/index.php and bin/console of the production template when loading dotenv and the shown information is wrong.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2369

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
   - Code is already tested. No need to change the test. If it still succeeds, then everything is fine, I just changed how the information is retrieved. Once `\Shopware\Core\TestBootstrapper::loadEnvFile` disables `usePutEnv` the tests will now keep workiing which would fail before.
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
