### PR TITLE
Added option to skip assets compilation during execution of system:update:finish command.

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -24,6 +24,7 @@ return [
         'The return type of Shopware\\\\Core\\\\Framework\\\\Changelog\\\\Command\\\\Changelog(Check|Change|Create)Command#execute\(\) changed from no type to int',
         'Symfony\\\\Component\\\\HttpFoundation\\\\Response::\\$statusTexts',
         'Symfony\\\\Component\\\\HttpKernel\\\\Kernel#\\$bundles',
+        'The return type of Symfony\\\\Component\\\\Console\\\\Command\\\\Command#configure\(\) changed from no type to void', // The method has no return type by default but it most likely will add one in the future, so it should be added now. However, doing so can be considered a BC change as any extended class needs to add the return type now.
 
         // OpenAPI library update
         'The return type of Shopware\\\\Core\\\\Framework\\\\Api\\\\ApiDefinition\\\\Generator\\\\OpenApi\\\\DeactivateValidationAnalysis#validate',

--- a/changelog/_unreleased/2022-03-08-added-option-to-skip-assets-compilation-during-execution-of-system-update-finish-command.md
+++ b/changelog/_unreleased/2022-03-08-added-option-to-skip-assets-compilation-during-execution-of-system-update-finish-command.md
@@ -1,0 +1,11 @@
+---
+title: Added option to skip assets compilation during execution of system:update:finish command.
+issue: https://github.com/shopware/platform/issues/2366
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed `Shopware\Storefront\Theme\Subscriber\UpdateSubscriber` to check if the state `Shopware\Core\Framework\Plugin\PluginLifecycleService::STATE_SKIP_ASSET_BUILDING` exists.
+* Changed `Shopware\Core\Maintenance\System\Command\SystemUpdateFinishCommand` to add a new command option `--skip-asset-build`.
+* Changed `Shopware\Core\Maintenance\System\Command\SystemUpdateFinishCommand` to add the state `Shopware\Core\Framework\Plugin\PluginLifecycleService::STATE_SKIP_ASSET_BUILDING` if the `--skip-asset-build` option has been provided.

--- a/src/Core/Maintenance/System/Command/SystemUpdateFinishCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemUpdateFinishCommand.php
@@ -6,6 +6,7 @@ use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
+use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Update\Api\UpdateController;
 use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
 use Shopware\Core\Framework\Update\Event\UpdatePreFinishEvent;
@@ -14,6 +15,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -34,6 +36,17 @@ class SystemUpdateFinishCommand extends Command
     {
         parent::__construct();
         $this->container = $container;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'skip-asset-build',
+                null,
+                InputOption::VALUE_NONE,
+                'Use this option to skip asset building'
+            );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -73,6 +86,10 @@ class SystemUpdateFinishCommand extends Command
             $this->runMigrations($output);
         } finally {
             $kernel->reboot(null, $pluginLoader);
+        }
+
+        if ($input->getOption('skip-asset-build')) {
+            $context->addState(PluginLifecycleService::STATE_SKIP_ASSET_BUILDING);
         }
 
         /** @var EventDispatcherInterface $eventDispatcher */

--- a/src/Storefront/Theme/Subscriber/UpdateSubscriber.php
+++ b/src/Storefront/Theme/Subscriber/UpdateSubscriber.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Theme\Subscriber;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Storefront\Theme\ThemeCollection;
@@ -47,6 +48,10 @@ class UpdateSubscriber implements EventSubscriberInterface
     {
         $context = $event->getContext();
         $this->themeLifecycleService->refreshThemes($context);
+
+        if ($context->hasState(PluginLifecycleService::STATE_SKIP_ASSET_BUILDING)) {
+            return;
+        }
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('active', true));


### PR DESCRIPTION
### 1. Why is this change necessary?

In order to skip unnecessary theme compilation on system:update:finish e.g. auto-deployments that do this automatically afterwards.

### 2. What does this change do, exactly?

See changelog and issue.

### 3. Describe each step to reproduce the issue or behaviour.

See issue/changelog.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2366

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
   - No test exists yet for the command itself and it wouldn't be that easy to test this specific behavior. In any case first a general test needs to be created.
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
