### PR TITLE
allow tokenization of characters with length 1;

### DIFF
--- a/changelog/_unreleased/2022-03-09-search-tokenizer-allow-length-of-1.md
+++ b/changelog/_unreleased/2022-03-09-search-tokenizer-allow-length-of-1.md
@@ -1,0 +1,8 @@
+---
+title: Allow tokens to be minimum length of 1
+author: Moritz Pietzschke
+author_email: mp@mopie.de
+author_github: pietzschke
+---
+# Storefront
+* Changed `Tokenizer` to allow tokens to be minimum length of 1.

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Tokenizer.php
@@ -18,7 +18,7 @@ class Tokenizer implements TokenizerInterface
         foreach ($tags as $tag) {
             $tag = trim($tag);
 
-            if (empty($tag) || mb_strlen($tag) < 3) {
+            if (empty($tag)) {
                 continue;
             }
 

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/Term/TokenizerTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/Term/TokenizerTest.php
@@ -21,7 +21,7 @@ class TokenizerTest extends TestCase
         return [
             [
                 '    ',
-                []
+                [],
             ],
             [
                 'shopware AG',

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/Term/TokenizerTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/Term/TokenizerTest.php
@@ -20,8 +20,12 @@ class TokenizerTest extends TestCase
     {
         return [
             [
+                '    ',
+                []
+            ],
+            [
                 'shopware AG',
-                ['shopware'],
+                ['shopware', 'ag'],
             ],
             [
                 'Österreicher Essen',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Tokenizer only allows tokens with a minimum length of 3. The search is configurable for the search term length. 
With a setting of 1 in the search config, the tokenizer would still leave out tokens, because they need to have a minimum length of 3. 

### 2. What does this change do, exactly?
Allow tokens that have a minimum length of 1. 

### 3. Describe each step to reproduce the issue or behaviour.
Create a product with the title "AB CDE". Set the search config to allow term length of 1 or 2. 
Rebuild the search index and have a look at the index table. Only "CDE" got indexed. "AB" was filtered out by the tokenizer.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
