### PR TITLE
Allow using the current database during for tests

### DIFF
--- a/changelog/_unreleased/2022-03-11-allow-using-the-current-database-during-for-tests.md
+++ b/changelog/_unreleased/2022-03-11-allow-using-the-current-database-during-for-tests.md
@@ -1,0 +1,10 @@
+---
+title: Allow using the current database during for tests
+issue: 
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Core
+* Allow setting the env variable TEST_TOKEN to "none" to avoid not append anything to the database name for development.
+---

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -116,7 +116,12 @@ class TestBootstrapper
         $dbUrlParts = parse_url($_SERVER['DATABASE_URL'] ?? '') ?: [];
 
         $testToken = getenv('TEST_TOKEN');
-        $dbUrlParts['path'] = ($dbUrlParts['path'] ?? 'root') . '_' . ($testToken ?: 'test');
+        $dbUrlParts['path'] = $dbUrlParts['path'] ?? 'root';
+
+        // allows using the same database during development, by setting TEST_TOKEN=none
+        if ($testToken !== 'none') {
+            $dbUrlParts['path'] .= '_' . ($testToken ?: 'test');
+        }
 
         $auth = isset($dbUrlParts['user']) ? ($dbUrlParts['user'] . (isset($dbUrlParts['pass']) ? (':' . $dbUrlParts['pass']) : '') . '@') : '';
 


### PR DESCRIPTION
... by setting TEST_TOKEN=none

During development it can be helpful to use the current database to run tests on.

Just a suggestion, if you agree, I would add the changelog.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

It's a dev-experience pull request. 
During development it can be helpful to test on the current database, instead of adding a TEST_TOKEN

### 2. What does this change do, exactly?

Allowing setting the TEST_TOKEN to "none", to explicitly not add it

### 3. Describe each step to reproduce the issue or behaviour.

in the .env test

* TEST_TOKEN=none
* Run tests
* The should use the current database and not try to setup a new one

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [not applicable] I have written tests and verified that they fail without my change 
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [not yet] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
