### PR TITLE
Fix: Made error handler in the CLI-Updater PHP8 compatible

### DIFF
--- a/changelog/_unreleased/2022-03-14-fix-cli-updater-php8-compatibility.md
+++ b/changelog/_unreleased/2022-03-14-fix-cli-updater-php8-compatibility.md
@@ -1,0 +1,8 @@
+---
+title: Fixed the Error Handler Callback of the CLI Updater to be PHP8 compatible
+author: Felix von WIRDUZEN
+author_email: felix@wirduzen.de
+author_github: wirduzen-felix
+---
+# Core
+* Removed 5th-Argument from `set_error_handler` callback in the CLI Updater to be PHP8 compatible

--- a/src/Recovery/Update/src/Console/Application.php
+++ b/src/Recovery/Update/src/Console/Application.php
@@ -83,7 +83,7 @@ class Application extends BaseApplication
 
     private function registerErrorHandler(): void
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline, array $errcontext) {
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
             // error was suppressed with the @-operator
             if (error_reporting() === 0) {
                 return false;


### PR DESCRIPTION
### 1. Why is this change necessary?
The CLI Updater (specifically `src/Recovery/Update/src/Console/Application.php`) was not PHP8 compatible, because in PHP8 the $errcontext parameter is not passed to the callback of `set_error_handler` anymore. Therefore running the CLI Updater with PHP8 would throw the following exception:
```
Fatal error: Uncaught ArgumentCountError: Too few arguments to function Shopware\Recovery\Update\Console\Application::Shopware\Recovery\Update\Console\{closure}(), 4 passed and exactly 5 expected in /home/www/server-data/stage/vendor/shopware/recovery/Update/src/Console/Application.php:86
```
See the [PHP Docs](https://www.php.net/manual/de/function.set-error-handler.php#refsect1-function.set-error-handler-parameters) for more information on this change.

### 2. What does this change do, exactly?
This change simply removes the 5th parameter from the callback, because it isn't used.

### 3. Describe each step to reproduce the issue or behaviour.
Simply run the CLI Updater with PHP8:
```bash
php public/recovery/update/index.php
```

### 4. Please link to the relevant issues (if any).
There is no issue for this Bug. There is a thread on the forms however: [https://forum.shopware.com/t/fehler-beim-upgrade-auf-6-4-1-2/88996/9](https://forum.shopware.com/t/fehler-beim-upgrade-auf-6-4-1-2/88996/9)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
