### PR TITLE
feat: Allow to specify the number of demodata rules

### DIFF
--- a/changelog/_unreleased/2022-03-14-allow-to-specify-the-number-of-demodata-rules.md
+++ b/changelog/_unreleased/2022-03-14-allow-to-specify-the-number-of-demodata-rules.md
@@ -1,0 +1,8 @@
+---
+title: Allow to specify the number of demodata rules
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Allow to specify the number of rules which should be generated using the in the `framework:demodata` command using `--rules` or `-R`

--- a/src/Core/Framework/Demodata/Command/DemodataCommand.php
+++ b/src/Core/Framework/Demodata/Command/DemodataCommand.php
@@ -75,6 +75,7 @@ class DemodataCommand extends Command
         $this->addOption('customer-attributes', null, InputOption::VALUE_REQUIRED, 'Customer attribute count');
         $this->addOption('media-attributes', null, InputOption::VALUE_REQUIRED, 'Media attribute count');
         $this->addOption('flows', 'fl', InputOption::VALUE_OPTIONAL, 'Flows count', '0');
+        $this->addOption('rules', 'R', InputOption::VALUE_OPTIONAL, 'Rules count', '25');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -92,7 +93,7 @@ class DemodataCommand extends Command
 
         $request = new DemodataRequest();
 
-        $request->add(RuleDefinition::class, 25);
+        $request->add(RuleDefinition::class, (int) $input->getOption('rules'));
         $request->add(MediaDefinition::class, (int) $input->getOption('media'));
         $request->add(CustomerDefinition::class, (int) $input->getOption('customers'));
         $request->add(PropertyGroupDefinition::class, (int) $input->getOption('properties'));


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to limit the number of rules which are generated, such that when one wants to generate demodata for a single entity, always 25 rules are generated.

### 2. What does this change do, exactly?
Allow to set the number of rules using the command line.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
