### PR TITLE
fix: Pagination of reviews for variant products

### DIFF
--- a/changelog/_unreleased/2022-03-14-fix-pagination-of-reviews-for-variant-products.md
+++ b/changelog/_unreleased/2022-03-14-fix-pagination-of-reviews-for-variant-products.md
@@ -1,0 +1,8 @@
+---
+title: Fix pagination of reviews for variant products
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Fix pagination of reviews for variant products, for products without CMS layouts by considering the `parentId` in the form URL

--- a/src/Storefront/Resources/views/storefront/page/product-detail/review/review.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/review/review.html.twig
@@ -218,7 +218,7 @@
                                                 {% block page_product_detail_review_list_paging_form %}
                                                     <div class="product-detail-review-pagination">
                                                         <form class="product-detail-review-pagination-form"
-                                                              action="{{ path('frontend.product.reviews', { productId: reviews.productId }) }}"
+                                                              action="{{ path('frontend.product.reviews', { productId: reviews.productId, parentId: reviews.parentId }) }}"
                                                               method="post"
                                                               data-form-ajax-submit="true"
                                                               data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently for variant products it is not possible to paginate through the reviews, since the `parentId` is not considered.

### 2. What does this change do, exactly?
Add the `parentId`.

### 3. Describe each step to reproduce the issue or behaviour.
Create a product with more than 10 reviews and try to navigate to the second page of the reviews.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
