### PR TITLE
fix: Pagination for reviews of products with shopping experience layout

### DIFF
--- a/changelog/_unreleased/2022-03-14-fix-pagination-for-reviews-of-products-with-shopping-experience-layout.md
+++ b/changelog/_unreleased/2022-03-14-fix-pagination-for-reviews-of-products-with-shopping-experience-layout.md
@@ -1,0 +1,8 @@
+---
+title: Fix pagination for reviews of products with shopping experience layout
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Show pagination for reviews of products with a custom shopping experience layout for more than 10 reviews

--- a/src/Storefront/Resources/views/storefront/component/review/review.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review.html.twig
@@ -8,7 +8,7 @@
 
 		{% set currentListPage = reviews.page + 1 %}
 
-		{% set productReviewCount = reviews|length %}
+		{% set productReviewCount = reviews.totalReviews %}
 
 		{% if productReviewCount > 0 %}
             {% set productAvgRating = reviews.matrix.averageRating|round(2, 'common')  %}
@@ -210,7 +210,7 @@
                                         {% block component_review_list_paging %}
                                             {% set criteria = reviews.criteria %}
 
-                                            {% set totalPages = (reviews.total/10)|round(0,'ceil') %}
+                                            {% set totalPages = (productReviewCount/reviewsPerListPage)|round(0,'ceil') %}
 
                                             {% if totalPages > 1 %}
                                                 {% set formAjaxSubmitOptions = {
@@ -250,7 +250,8 @@
 
                                                             {% sw_include '@Storefront/storefront/component/pagination.html.twig' with {
                                                                 entities: reviews,
-                                                                criteria: criteria
+                                                                criteria: criteria,
+                                                                total: productReviewCount,
                                                             }  %}
                                                         </form>
                                                     </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
If a product has a shopping experience layout assigned the number of reviews is not determined correct in the twig templates.

### 2. What does this change do, exactly?
Variable assignment such that the values are correct.

### 3. Describe each step to reproduce the issue or behaviour.
Have a product with more than 10 reviews and assign a layout to it.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-10807 probably it is related.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
