### PR TITLE
Fix/product review include variants

### DIFF
--- a/changelog/_unreleased/2022-03-14-refactor-loading-of-reviews.md
+++ b/changelog/_unreleased/2022-03-14-refactor-loading-of-reviews.md
@@ -1,0 +1,16 @@
+---
+title: Refactor loading of reviews
+issue: NEXT-00000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added core loader to loading reviews `Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader`
+* Added `Shopware\Core\Content\Product\SalesChannel\Review\Event\ProductReviewsLoadedEvent` and `Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult`
+* Changed loading of reviews in `Shopware\Core\Content\Product\Cms\ProductDescriptionReviewsCmsElementResolver` and `Shopware\Storefront\Page\Product\Review\ProductReviewLoader` using the `Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader`
+___
+# Storefront
+* Deprecated `Shopware\Storefront\Page\Product\Review\ProductReviewLoader` use `Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader` instead
+* Deprecated `Shopware\Storefront\Page\Product\Review\ProductReviewsLoadedEvent` use `Shopware\Core\Content\Product\SalesChannel\Review\Event\ProductReviewsLoadedEvent` instead
+* Deprecated `Shopware\Storefront\Page\Product\Review\ReviewLoaderResult`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4376,11 +4376,6 @@ parameters:
 			path: src/Core/Content/Product/Cms/CrossSellingCmsElementResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Cms\\\\ProductDescriptionReviewsCmsElementResolver\\:\\:getCustomerReview\\(\\) should return Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductReview\\\\ProductReviewEntity\\|null but returns Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\|null\\.$#"
-			count: 1
-			path: src/Core/Content/Product/Cms/ProductDescriptionReviewsCmsElementResolver.php
-
-		-
 			message: "#^PHPDoc tag @var with type Shopware\\\\Core\\\\Content\\\\Product\\\\ProductCollection\\|null is not subtype of native type Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection\\.$#"
 			count: 1
 			path: src/Core/Content/Product/Cms/ProductSliderCmsElementResolver.php
@@ -16324,11 +16319,6 @@ parameters:
 			message: "#^Property Shopware\\\\Storefront\\\\Page\\\\Address\\\\AddressEditorModalStruct\\:\\:\\$messages type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Storefront/Page/Address/AddressEditorModalStruct.php
-
-		-
-			message: "#^Method Shopware\\\\Storefront\\\\Page\\\\Product\\\\Review\\\\ProductReviewLoader\\:\\:getCustomerReview\\(\\) should return Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductReview\\\\ProductReviewEntity\\|null but returns Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\|null\\.$#"
-			count: 1
-			path: src/Storefront/Page/Product/Review/ProductReviewLoader.php
 
 		-
 			message: "#^Method Shopware\\\\Storefront\\\\Page\\\\Sitemap\\\\SitemapPage\\:\\:getSitemaps\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -214,7 +214,7 @@
         </service>
 
         <service id="Shopware\Core\Content\Product\Cms\ProductDescriptionReviewsCmsElementResolver">
-            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewRoute"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader"/>
             <tag name="shopware.cms.data_resolver"/>
         </service>
 
@@ -427,6 +427,11 @@
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheTracer"/>
             <argument type="service" id="event_dispatcher"/>
             <argument>%shopware.cache.invalidation.product_review_route%</argument>
+        </service>
+
+        <service id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader">
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewRoute"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\SalesChannel\Detail\ProductConfiguratorLoader">

--- a/src/Core/Content/Product/Cms/ProductDescriptionReviewsCmsElementResolver.php
+++ b/src/Core/Content/Product/Cms/ProductDescriptionReviewsCmsElementResolver.php
@@ -7,20 +7,10 @@ use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\EntityResolverContext;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductDescriptionReviewsStruct;
-use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewEntity;
-use Shopware\Core\Content\Product\SalesChannel\Review\AbstractProductReviewRoute;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult;
 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewResult;
-use Shopware\Core\Content\Product\SalesChannel\Review\RatingMatrix;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\FilterAggregation;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\TermsAggregation;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Bucket\TermsResult;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,14 +18,10 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 class ProductDescriptionReviewsCmsElementResolver extends AbstractProductDetailCmsElementResolver
 {
-    private const LIMIT = 10;
-    private const DEFAULT_PAGE = 1;
-    private const FILTER_LANGUAGE = 'filter-language';
-
     /**
      * @internal
      */
-    public function __construct(private readonly AbstractProductReviewRoute $productReviewRoute)
+    public function __construct(private readonly ProductReviewLoader $productReviewLoader)
     {
     }
 
@@ -71,111 +57,21 @@ class ProductDescriptionReviewsCmsElementResolver extends AbstractProductDetailC
         /** @var SalesChannelProductEntity|null $product */
         if ($product !== null) {
             $data->setProduct($product);
-            $data->setReviews($this->loadProductReviews($product, $request, $resolverContext->getSalesChannelContext()));
-        }
-    }
-
-    private function loadProductReviews(SalesChannelProductEntity $product, Request $request, SalesChannelContext $context): ProductReviewResult
-    {
-        $reviewCriteria = $this->createReviewCriteria($request, $context);
-        $reviews = $this->productReviewRoute
-            ->load($product->getParentId() ?? $product->getId(), $request, $context, $reviewCriteria)
-            ->getResult();
-
-        $matrix = $this->getReviewRatingMatrix($reviews);
-
-        $reviewResult = ProductReviewResult::createFrom($reviews);
-        $reviewResult->setMatrix($matrix);
-        $reviewResult->setProductId($product->getId());
-        $reviewResult->setCustomerReview($this->getCustomerReview($product->getId(), $context));
-        $reviewResult->setTotalReviews($matrix->getTotalReviewCount());
-        $reviewResult->setProductId($product->getId());
-        $reviewResult->setParentId($product->getParentId() ?? $product->getId());
-
-        return $reviewResult;
-    }
-
-    private function createReviewCriteria(Request $request, SalesChannelContext $context): Criteria
-    {
-        $limit = (int) $request->get('limit', self::LIMIT);
-        $page = (int) $request->get('p', self::DEFAULT_PAGE);
-        $offset = $limit * ($page - 1);
-
-        $criteria = new Criteria();
-        $criteria->setLimit($limit);
-        $criteria->setOffset($offset);
-
-        $sorting = new FieldSorting('createdAt', 'DESC');
-        if ($request->get('sort', 'points') === 'points') {
-            $sorting = new FieldSorting('points', 'DESC');
-        }
-
-        $criteria->addSorting($sorting);
-
-        if ($request->get('language') === self::FILTER_LANGUAGE) {
-            $criteria->addPostFilter(
-                new EqualsFilter('languageId', $context->getContext()->getLanguageId())
+            $reviews = $this->loadProductReviews(
+                $product,
+                $request,
+                $resolverContext->getSalesChannelContext()
             );
+            $data->setReviews(ProductReviewResult::createFrom($reviews));
         }
-
-        $this->handlePointsAggregation($request, $criteria);
-
-        return $criteria;
     }
 
-    private function handlePointsAggregation(Request $request, Criteria $criteria): void
+    private function loadProductReviews(SalesChannelProductEntity $product, Request $request, SalesChannelContext $context): ProductReviewLoaderResult
     {
-        $points = $request->get('points', []);
+        $reviewRequest = clone $request;
+        $reviewRequest->attributes->set('productId', $product->getId());
+        $reviewRequest->attributes->set('parentId', $product->getParentId());
 
-        if (\is_array($points) && \count($points) > 0) {
-            $pointFilter = [];
-            foreach ($points as $point) {
-                $pointFilter[] = new RangeFilter('points', [
-                    'gte' => $point - 0.5,
-                    'lt' => $point + 0.5,
-                ]);
-            }
-
-            $criteria->addPostFilter(new MultiFilter(MultiFilter::CONNECTION_OR, $pointFilter));
-        }
-
-        $criteria->addAggregation(
-            new FilterAggregation(
-                'status-filter',
-                new TermsAggregation('ratingMatrix', 'points'),
-                [new EqualsFilter('status', 1)]
-            )
-        );
-    }
-
-    private function getCustomerReview(string $productId, SalesChannelContext $context): ?ProductReviewEntity
-    {
-        $customer = $context->getCustomer();
-
-        if (!$customer) {
-            return null;
-        }
-
-        $criteria = new Criteria();
-        $criteria->setLimit(1);
-        $criteria->setOffset(0);
-        $criteria->addFilter(new EqualsFilter('customerId', $customer->getId()));
-
-        $customerReviews = $this->productReviewRoute
-            ->load($productId, new Request(), $context, $criteria)
-            ->getResult();
-
-        return $customerReviews->first();
-    }
-
-    private function getReviewRatingMatrix(EntitySearchResult $reviews): RatingMatrix
-    {
-        $aggregation = $reviews->getAggregations()->get('ratingMatrix');
-
-        if ($aggregation instanceof TermsResult) {
-            return new RatingMatrix($aggregation->getBuckets());
-        }
-
-        return new RatingMatrix([]);
+        return $this->productReviewLoader->load($reviewRequest, $context);
     }
 }

--- a/src/Core/Content/Product/ProductException.php
+++ b/src/Core/Content/Product/ProductException.php
@@ -2,8 +2,10 @@
 
 namespace Shopware\Core\Content\Product;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
 use Symfony\Component\HttpFoundation\Response;
 
 #[Package('inventory')]
@@ -13,6 +15,7 @@ class ProductException extends HttpException
     public const PRODUCT_PROXY_MANIPULATION_NOT_ALLOWED_CODE = 'PRODUCT_PROXY_MANIPULATION_NOT_ALLOWED';
     public const PRODUCT_INVALID_PRICE_DEFINITION_CODE = 'PRODUCT_INVALID_PRICE_DEFINITION';
     public const CATEGORY_NOT_FOUND = 'PRODUCT__CATEGORY_NOT_FOUND';
+    public const PRODUCT_MISSING_PRODUCT_ID_IN_REQUEST_CODE = 'PRODUCT__MISSING_PRODUCT_ID_IN_REQUEST';
 
     public static function invalidCheapestPriceFacade(string $id): self
     {
@@ -50,6 +53,20 @@ class ProductException extends HttpException
             self::CATEGORY_NOT_FOUND,
             'Category "{{ categoryId }}" not found.',
             ['categoryId' => $categoryId]
+        );
+    }
+
+    public static function missingProductId(string $path = ''): HttpException
+    {
+        if (!Feature::isActive('v6.6.0.0')) {
+            return new MissingRequestParameterException('productId', $path);
+        }
+
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::PRODUCT_MISSING_PRODUCT_ID_IN_REQUEST_CODE,
+            'Parameter "productId" is missing.',
+            ['path' => $path]
         );
     }
 }

--- a/src/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEvent.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\SalesChannel\Review\Event;
+
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\NestedEvent;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+#[Package('inventory')]
+class ProductReviewsLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
+{
+    public function __construct(
+        protected readonly ProductReviewLoaderResult $searchResult,
+        protected readonly SalesChannelContext $salesChannelContext,
+        protected readonly Request $request
+    ) {
+    }
+
+    public function getSearchResult(): ProductReviewLoaderResult
+    {
+        return $this->searchResult;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Review/ProductReviewLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Review/ProductReviewLoader.php
@@ -1,0 +1,170 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\SalesChannel\Review;
+
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewEntity;
+use Shopware\Core\Content\Product\ProductException;
+use Shopware\Core\Content\Product\SalesChannel\Review\Event\ProductReviewsLoadedEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\FilterAggregation;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\TermsAggregation;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Bucket\TermsResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+#[Package('inventory')]
+class ProductReviewLoader
+{
+    private const LIMIT = 10;
+    private const DEFAULT_PAGE = 1;
+    private const FILTER_LANGUAGE = 'filter-language';
+    private const DEFAULT_SORTING = 'createdAt';
+    private const ALLOWED_SORTINGS = ['createdAt', 'points'];
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly AbstractProductReviewRoute $route,
+        private readonly EventDispatcherInterface $eventDispatcher
+    ) {
+    }
+
+    /**
+     * Load reviews for one product. The request must contain the productId or the
+     * parentId otherwise a ProductException is thrown
+     *
+     * @throws ProductException
+     * @throws \Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException
+     */
+    public function load(Request $request, SalesChannelContext $context): ProductReviewLoaderResult
+    {
+        $productId = $request->get('parentId') ?? $request->get('productId');
+        if (!$productId) {
+            throw ProductException::missingProductId();
+        }
+
+        $criteria = $this->createCriteria($request, $context);
+        $reviews = $this->route
+            ->load($productId, $request, $context, $criteria)
+            ->getResult()
+        ;
+
+        $reviewResult = ProductReviewLoaderResult::createFrom($reviews);
+        $reviewResult->setProductId($request->get('productId'));
+        $reviewResult->setParentId($request->get('parentId'));
+
+        $aggregation = $reviews->getAggregations()->get('ratingMatrix');
+        if ($aggregation instanceof TermsResult) {
+            $matrix = $aggregation->getBuckets();
+        }
+
+        $reviewResult->setMatrix(new RatingMatrix($matrix ?? []));
+        $reviewResult->setCustomerReview($this->getCustomerReview($productId, $context));
+        $reviewResult->setTotalReviews(
+            $reviewResult->getMatrix()->getTotalReviewCount()
+        );
+
+        $this->eventDispatcher->dispatch(new ProductReviewsLoadedEvent($reviewResult, $context, $request));
+
+        return $reviewResult;
+    }
+
+    private function createCriteria(Request $request, SalesChannelContext $context): Criteria
+    {
+        $limit = (int) $request->get('limit', self::LIMIT);
+        $page = (int) $request->get('p', self::DEFAULT_PAGE);
+        $offset = $limit * ($page - 1);
+
+        $sort = (string) $request->get('sort', self::DEFAULT_SORTING);
+        if (!\in_array($sort, self::ALLOWED_SORTINGS, true)) {
+            $sort = self::DEFAULT_SORTING;
+        }
+
+        $criteria = new Criteria();
+        $criteria
+            ->setLimit($limit)
+            ->setOffset($offset)
+            ->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT)
+            ->addSorting(new FieldSorting($sort, 'DESC'))
+        ;
+
+        if ($request->get('language') === self::FILTER_LANGUAGE) {
+            $criteria->addPostFilter(
+                new EqualsFilter('languageId', $context->getContext()->getLanguageId())
+            );
+        }
+
+        $this->handlePointsAggregation($request, $criteria, $context->getCustomer());
+
+        return $criteria;
+    }
+
+    /**
+     * get review by productId and customer
+     * a customer should only create one review per product, so if there are more than one
+     * review we only take one
+     *
+     * @throws \Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException
+     */
+    private function getCustomerReview(string $productId, SalesChannelContext $context): ?ProductReviewEntity
+    {
+        $customer = $context->getCustomer();
+        if ($customer === null) {
+            return null;
+        }
+
+        $criteria = new Criteria();
+        $criteria
+            ->setLimit(1)
+            ->setOffset(0)
+            ->addFilter(new EqualsFilter('customerId', $customer->getId()))
+        ;
+
+        $customerReview = $this->route
+            ->load($productId, new Request(), $context, $criteria)
+            ->getResult()
+            ->first()
+        ;
+
+        return ($customerReview instanceof ProductReviewEntity) ? $customerReview : null;
+    }
+
+    private function handlePointsAggregation(Request $request, Criteria $criteria, ?CustomerEntity $customer): void
+    {
+        $points = $request->get('points', []);
+        if (\is_array($points) && \count($points) > 0) {
+            $pointFilter = [];
+            foreach ($points as $point) {
+                $pointFilter[] = new RangeFilter('points', [
+                    'gte' => $point - 0.5,
+                    'lt' => $point + 0.5,
+                ]);
+            }
+
+            $criteria->addPostFilter(new MultiFilter(MultiFilter::CONNECTION_OR, $pointFilter));
+        }
+
+        $reviewFilters = [new EqualsFilter('status', true)];
+        if ($customer !== null) {
+            $reviewFilters[] = new EqualsFilter('customerId', $customer->getId());
+        }
+
+        $criteria->addAggregation(
+            new FilterAggregation(
+                'customer-login-filter',
+                new TermsAggregation('ratingMatrix', 'points'),
+                [
+                    new MultiFilter(MultiFilter::CONNECTION_OR, $reviewFilters),
+                ]
+            )
+        );
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Review/ProductReviewLoaderResult.php
+++ b/src/Core/Content/Product/SalesChannel/Review/ProductReviewLoaderResult.php
@@ -1,0 +1,96 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\SalesChannel\Review;
+
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('inventory')]
+class ProductReviewLoaderResult extends EntitySearchResult
+{
+    /**
+     * @deprecated tag:v6.6.0 - Will be strictly declared as type: string
+     *
+     * @var string
+     */
+    protected $productId;
+
+    /**
+     * @deprecated tag:v6.6.0 - Will be strictly declared as type: ?string
+     *
+     * @var string|null
+     */
+    protected $parentId;
+
+    /**
+     * @deprecated tag:v6.6.0 - Will be strictly declared as type: RatingMatrix
+     *
+     * @var RatingMatrix
+     */
+    protected $matrix;
+
+    /**
+     * @deprecated tag:v6.6.0 - Will be strictly declared as type: ?ProductReviewEntity
+     *
+     * @var ProductReviewEntity|null
+     */
+    protected $customerReview;
+
+    /**
+     * @deprecated tag:v6.6.0 - Will be strictly declared as type: int
+     *
+     * @var int
+     */
+    protected $totalReviews;
+
+    public function getProductId(): string
+    {
+        return $this->productId;
+    }
+
+    public function setProductId(string $productId): void
+    {
+        $this->productId = $productId;
+    }
+
+    public function getParentId(): ?string
+    {
+        return $this->parentId;
+    }
+
+    public function setParentId(?string $parentId): void
+    {
+        $this->parentId = $parentId;
+    }
+
+    public function getMatrix(): RatingMatrix
+    {
+        return $this->matrix;
+    }
+
+    public function setMatrix(RatingMatrix $matrix): void
+    {
+        $this->matrix = $matrix;
+    }
+
+    public function getCustomerReview(): ?ProductReviewEntity
+    {
+        return $this->customerReview;
+    }
+
+    public function setCustomerReview(?ProductReviewEntity $customerReview): void
+    {
+        $this->customerReview = $customerReview;
+    }
+
+    public function getTotalReviews(): int
+    {
+        return $this->totalReviews;
+    }
+
+    public function setTotalReviews(int $totalReviews): void
+    {
+        $this->totalReviews = $totalReviews;
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Review/ProductReviewResult.php
+++ b/src/Core/Content/Product/SalesChannel/Review/ProductReviewResult.php
@@ -2,85 +2,12 @@
 
 namespace Shopware\Core\Content\Product\SalesChannel\Review;
 
-use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewEntity;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.6.0 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead
+ */
 #[Package('inventory')]
-class ProductReviewResult extends EntitySearchResult
+class ProductReviewResult extends ProductReviewLoaderResult
 {
-    /**
-     * @var string|null
-     */
-    protected $parentId;
-
-    /**
-     * @var string
-     */
-    protected $productId;
-
-    /**
-     * @var RatingMatrix
-     */
-    protected $matrix;
-
-    /**
-     * @var ProductReviewEntity|null
-     */
-    protected $customerReview;
-
-    /**
-     * @var int
-     */
-    protected $totalReviews;
-
-    public function getProductId(): string
-    {
-        return $this->productId;
-    }
-
-    public function setProductId(string $productId): void
-    {
-        $this->productId = $productId;
-    }
-
-    public function getMatrix(): RatingMatrix
-    {
-        return $this->matrix;
-    }
-
-    public function setMatrix(RatingMatrix $matrix): void
-    {
-        $this->matrix = $matrix;
-    }
-
-    public function getCustomerReview(): ?ProductReviewEntity
-    {
-        return $this->customerReview;
-    }
-
-    public function setCustomerReview(?ProductReviewEntity $customerReview): void
-    {
-        $this->customerReview = $customerReview;
-    }
-
-    public function getTotalReviews(): int
-    {
-        return $this->totalReviews;
-    }
-
-    public function setTotalReviews(int $totalReviews): void
-    {
-        $this->totalReviews = $totalReviews;
-    }
-
-    public function getParentId(): ?string
-    {
-        return $this->parentId;
-    }
-
-    public function setParentId(?string $parentId): void
-    {
-        $this->parentId = $parentId;
-    }
 }

--- a/src/Core/Content/Test/Product/Cms/Type/ProductDescriptionReviewsTypeDataResolverTest.php
+++ b/src/Core/Content/Test/Product/Cms/Type/ProductDescriptionReviewsTypeDataResolverTest.php
@@ -8,12 +8,11 @@ use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductDescriptionReviewsStruct;
 use Shopware\Core\Content\Product\Cms\ProductDescriptionReviewsCmsElementResolver;
-use Shopware\Core\Content\Product\SalesChannel\Review\AbstractProductReviewRoute;
-use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewRouteResponse;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,15 +28,20 @@ class ProductDescriptionReviewsTypeDataResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        $productReviewRouteMock = $this->createMock(AbstractProductReviewRoute::class);
-        $productReviewRouteMock->method('load')->willReturn(
-            new ProductReviewRouteResponse(
-                new EntitySearchResult('product', 0, new EntityCollection(), null, new Criteria(), Context::createDefaultContext())
+        $productReviewLoaderMock = $this->createMock(ProductReviewLoader::class);
+        $productReviewLoaderMock->method('load')->willReturn(
+            new ProductReviewLoaderResult(
+                'product',
+                0,
+                new EntityCollection(),
+                null,
+                new Criteria(),
+                Context::createDefaultContext()
             )
         );
 
         $this->productDescriptionReviewResolver = new ProductDescriptionReviewsCmsElementResolver(
-            $productReviewRouteMock
+            $productReviewLoaderMock
         );
     }
 

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -321,8 +321,7 @@
         </service>
 
         <service id="Shopware\Storefront\Page\Product\Review\ProductReviewLoader">
-            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewRoute"/>
-            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader"/>
         </service>
 
         <service id="Shopware\Storefront\Controller\CountryStateController" public="true">

--- a/src/Storefront/Page/Product/Review/ProductReviewLoader.php
+++ b/src/Storefront/Page/Product/Review/ProductReviewLoader.php
@@ -2,40 +2,26 @@
 
 namespace Shopware\Storefront\Page\Product\Review;
 
-use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewEntity;
-use Shopware\Core\Content\Product\SalesChannel\Review\AbstractProductReviewRoute;
-use Shopware\Core\Content\Product\SalesChannel\Review\RatingMatrix;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader as CoreProductReviewLoader;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\FilterAggregation;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\TermsAggregation;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Bucket\TermsResult;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
 use Shopware\Core\Framework\Routing\RoutingException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Storefront\Framework\Page\StorefrontSearchResult;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @deprecated tag:v6.6.0 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader instead
+ */
 #[Package('storefront')]
 class ProductReviewLoader
 {
-    private const LIMIT = 10;
-    private const DEFAULT_PAGE = 1;
-    private const FILTER_LANGUAGE = 'filter-language';
-
     /**
      * @internal
      */
-    public function __construct(
-        private readonly AbstractProductReviewRoute $route,
-        private readonly EventDispatcherInterface $eventDispatcher
-    ) {
+    public function __construct(private readonly CoreProductReviewLoader $coreProductReviewLoader)
+    {
     }
 
     /**
@@ -47,124 +33,13 @@ class ProductReviewLoader
      */
     public function load(Request $request, SalesChannelContext $context): ReviewLoaderResult
     {
-        $productId = $request->get('parentId') ?? $request->get('productId');
-        if (!$productId) {
-            throw RoutingException::missingRequestParameter('productId');
-        }
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ProductReviewLoader will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader instead'
+        );
 
-        $criteria = $this->createCriteria($request, $context);
-
-        $reviews = $this->route
-            ->load($productId, $request, $context, $criteria)
-            ->getResult();
-
-        $reviews = StorefrontSearchResult::createFrom($reviews);
-
-        $this->eventDispatcher->dispatch(new ProductReviewsLoadedEvent($reviews, $context, $request));
-
-        $reviewResult = ReviewLoaderResult::createFrom($reviews);
-        $reviewResult->setProductId($request->get('productId'));
-        $reviewResult->setParentId($request->get('parentId'));
-
-        $aggregation = $reviews->getAggregations()->get('ratingMatrix');
-        $matrix = new RatingMatrix([]);
-
-        if ($aggregation instanceof TermsResult) {
-            $matrix = new RatingMatrix($aggregation->getBuckets());
-        }
-        $reviewResult->setMatrix($matrix);
-        $reviewResult->setCustomerReview($this->getCustomerReview($productId, $context));
-        $reviewResult->setTotalReviews($matrix->getTotalReviewCount());
-
-        return $reviewResult;
-    }
-
-    private function createCriteria(Request $request, SalesChannelContext $context): Criteria
-    {
-        $limit = (int) $request->get('limit', self::LIMIT);
-        $page = (int) $request->get('p', self::DEFAULT_PAGE);
-        $offset = $limit * ($page - 1);
-
-        $criteria = new Criteria();
-        $criteria->setLimit($limit);
-        $criteria->setOffset($offset);
-        $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT);
-
-        $sorting = new FieldSorting('createdAt', 'DESC');
-        if ($request->get('sort', 'createdAt') === 'points') {
-            $sorting = new FieldSorting('points', 'DESC');
-        }
-
-        $criteria->addSorting($sorting);
-
-        if ($request->get('language') === self::FILTER_LANGUAGE) {
-            $criteria->addPostFilter(
-                new EqualsFilter('languageId', $context->getContext()->getLanguageId())
-            );
-        }
-
-        $this->handlePointsAggregation($request, $criteria, $context);
-
-        return $criteria;
-    }
-
-    /**
-     * get review by productId and customer
-     * a customer should only create one review per product, so if there are more than one
-     * review we only take one
-     *
-     * @throws InconsistentCriteriaIdsException
-     */
-    private function getCustomerReview(string $productId, SalesChannelContext $context): ?ProductReviewEntity
-    {
-        $customer = $context->getCustomer();
-
-        if (!$customer) {
-            return null;
-        }
-
-        $criteria = new Criteria();
-        $criteria->setLimit(1);
-        $criteria->setOffset(0);
-        $criteria->addFilter(new EqualsFilter('customerId', $customer->getId()));
-
-        $customerReviews = $this->route
-            ->load($productId, new Request(), $context, $criteria)
-            ->getResult();
-
-        return $customerReviews->first();
-    }
-
-    private function handlePointsAggregation(Request $request, Criteria $criteria, SalesChannelContext $context): void
-    {
-        $reviewFilters = [];
-        $points = $request->get('points', []);
-
-        if (\is_array($points) && \count($points) > 0) {
-            $pointFilter = [];
-            foreach ($points as $point) {
-                $pointFilter[] = new RangeFilter('points', [
-                    'gte' => $point - 0.5,
-                    'lt' => $point + 0.5,
-                ]);
-            }
-
-            $criteria->addPostFilter(new MultiFilter(MultiFilter::CONNECTION_OR, $pointFilter));
-        }
-
-        $reviewFilters[] = new EqualsFilter('status', true);
-        if ($context->getCustomer() !== null) {
-            $reviewFilters[] = new EqualsFilter('customerId', $context->getCustomer()->getId());
-        }
-
-        $criteria->addAggregation(
-            new FilterAggregation(
-                'customer-login-filter',
-                new TermsAggregation('ratingMatrix', 'points'),
-                [
-                    new MultiFilter(MultiFilter::CONNECTION_OR, $reviewFilters),
-                ]
-            )
+        return ReviewLoaderResult::createFrom(
+            $this->coreProductReviewLoader->load($request, $context)
         );
     }
 }

--- a/src/Storefront/Page/Product/Review/ProductReviewsLoadedCompatibilitySubscriber.php
+++ b/src/Storefront/Page/Product/Review/ProductReviewsLoadedCompatibilitySubscriber.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Product\Review;
+
+use Shopware\Core\Content\Product\SalesChannel\Review\Event\ProductReviewsLoadedEvent as CoreProductReviewsLoadedEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Framework\Page\StorefrontSearchResult;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @internal
+ *
+ * @deprecated tag:v6.6.0 - reason:remove-subscriber - will be removed without replacement, since \Shopware\Storefront\Page\Product\Review\Event\ProductReviewsLoadedEvent will be removed
+ */
+#[Package('storefront')]
+class ProductReviewsLoadedCompatibilitySubscriber implements EventSubscriberInterface
+{
+    /**
+     * @internal
+     */
+    public function __construct(private readonly EventDispatcher $eventDispatcher)
+    {
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            CoreProductReviewsLoadedEvent::class => 'onCoreProductReviewsLoaded',
+        ];
+    }
+
+    public function onCoreProductReviewsLoaded(CoreProductReviewsLoadedEvent $event): void
+    {
+        $this->eventDispatcher->dispatch(new ProductReviewsLoadedEvent(
+            StorefrontSearchResult::createFrom($event->getSearchResult()),
+            $event->getSalesChannelContext(),
+            $event->getRequest()
+        ));
+    }
+}

--- a/src/Storefront/Page/Product/Review/ProductReviewsLoadedEvent.php
+++ b/src/Storefront/Page/Product/Review/ProductReviewsLoadedEvent.php
@@ -5,11 +5,15 @@ namespace Shopware\Storefront\Page\Product\Review;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
 use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Framework\Page\StorefrontSearchResult;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @deprecated tag:v6.6.0 use Shopware\Core\Content\Product\SalesChannel\Review\Event\ProductReviewsLoadedEvent instead
+ */
 #[Package('storefront')]
 class ProductReviewsLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {
@@ -40,21 +44,41 @@ class ProductReviewsLoadedEvent extends NestedEvent implements ShopwareSalesChan
 
     public function getSearchResult(): StorefrontSearchResult
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ProductReviewsLoadedEvent will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewsLoadedEvent instead'
+        );
+
         return $this->searchResult;
     }
 
     public function getSalesChannelContext(): SalesChannelContext
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ProductReviewsLoadedEvent will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewsLoadedEvent instead'
+        );
+
         return $this->salesChannelContext;
     }
 
     public function getContext(): Context
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ProductReviewsLoadedEvent will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewsLoadedEvent instead'
+        );
+
         return $this->salesChannelContext->getContext();
     }
 
     public function getRequest(): Request
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ProductReviewsLoadedEvent will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewsLoadedEvent instead'
+        );
+
         return $this->request;
     }
 }

--- a/src/Storefront/Page/Product/Review/ReviewLoaderResult.php
+++ b/src/Storefront/Page/Product/Review/ReviewLoaderResult.php
@@ -4,9 +4,13 @@ namespace Shopware\Storefront\Page\Product\Review;
 
 use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewEntity;
 use Shopware\Core\Content\Product\SalesChannel\Review\RatingMatrix;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Framework\Page\StorefrontSearchResult;
 
+/**
+ * @deprecated tag:v6.6.0 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead
+ */
 #[Package('storefront')]
 class ReviewLoaderResult extends StorefrontSearchResult
 {
@@ -39,56 +43,111 @@ class ReviewLoaderResult extends StorefrontSearchResult
 
     public function getProductId(): string
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         return $this->productId;
     }
 
     public function setProductId(string $productId): void
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         $this->productId = $productId;
     }
 
     public function getReviews(): StorefrontSearchResult
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         return $this->reviews;
     }
 
     public function getMatrix(): RatingMatrix
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         return $this->matrix;
     }
 
     public function setMatrix(RatingMatrix $matrix): void
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         $this->matrix = $matrix;
     }
 
     public function getCustomerReview(): ?ProductReviewEntity
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         return $this->customerReview;
     }
 
     public function setCustomerReview(?ProductReviewEntity $customerReview): void
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         $this->customerReview = $customerReview;
     }
 
     public function getTotalReviews(): int
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         return $this->totalReviews;
     }
 
     public function setTotalReviews(int $totalReviews): void
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         $this->totalReviews = $totalReviews;
     }
 
     public function getParentId(): ?string
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         return $this->parentId;
     }
 
     public function setParentId(?string $parentId): void
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            '\Shopware\Storefront\Page\Product\Review\ReviewLoaderResult will be removed use \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult instead'
+        );
+
         $this->parentId = $parentId;
     }
 }

--- a/tests/integration/php/Core/Content/Product/SalesChannel/Review/ProductReviewLoaderTest.php
+++ b/tests/integration/php/Core/Content/Product/SalesChannel/Review/ProductReviewLoaderTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\Product\SalesChannel\Review;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\Framework\Test\TestDataCollection;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+class ProductReviewLoaderTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use SalesChannelApiTestBehaviour;
+
+    private TestDataCollection $ids;
+
+    private ProductReviewLoader $productReviewLoader;
+
+    protected function setUp(): void
+    {
+        $this->ids = new TestDataCollection();
+        $this->ids->set('customer-1', $this->createCustomer());
+        $this->ids->set('customer-2', $this->createCustomer());
+
+        $this->createProduct();
+        $this->createReviews();
+
+        $this->productReviewLoader = $this->getContainer()->get('Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader');
+
+        parent::setUp();
+    }
+
+    public function testLoadReviews(): void
+    {
+        $request = new Request();
+        $request->query->set('productId', $this->ids->get('product'));
+
+        $salesChannelContext = $this->createSalesChannelContext();
+
+        $reviewResponse = $this->productReviewLoader->load($request, $salesChannelContext);
+
+        static::assertCount(2, $reviewResponse->getEntities());
+        static::assertEquals(3., $reviewResponse->getMatrix()->getAverageRating());
+        static::assertNull($reviewResponse->getCustomerReview());
+    }
+
+    public function testLoadReviewsIncludingCustomerReview(): void
+    {
+        $request = new Request();
+        $request->query->set('productId', $this->ids->get('product'));
+
+        $salesChannelContext = $this->createSalesChannelContext();
+        $customer = new CustomerEntity();
+        $customer->setId($this->ids->get('customer-1'));
+        $salesChannelContext->assign(['customer' => $customer]);
+
+        $reviewResponse = $this->productReviewLoader->load($request, $salesChannelContext);
+
+        static::assertCount(2, $reviewResponse->getEntities());
+        static::assertEquals(3., $reviewResponse->getMatrix()->getAverageRating());
+
+        $customerReview = $reviewResponse->getCustomerReview();
+        static::assertNotNull($customerReview);
+        static::assertEquals($this->ids->get('review-1'), $customerReview->getId());
+    }
+
+    private function createProduct(): void
+    {
+        $this->getContainer()->get('product.repository')->create([[
+            'id' => $this->ids->create('product'),
+            'productNumber' => Uuid::randomHex(),
+            'stock' => 5,
+            'name' => 'Test',
+            'isCloseout' => true,
+            'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+            'tax' => ['id' => Uuid::randomHex(), 'name' => 'test', 'taxRate' => 19],
+            'manufacturer' => ['name' => 'test'],
+            'visibilities' => [
+                [
+                    'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                    'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL,
+                ],
+            ],
+        ]], Context::createDefaultContext());
+    }
+
+    private function createReviews(): void
+    {
+        $this->getContainer()->get('product_review.repository')->create([
+            [
+                'id' => $this->ids->create('review-1'),
+                'productId' => $this->ids->get('product'),
+                'customerId' => $this->ids->get('customer-1'),
+                'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                'status' => true,
+                'points' => 2,
+                'title' => 'foo1',
+                'content' => 'bar1',
+            ],
+            [
+                'id' => $this->ids->create('review-2'),
+                'productId' => $this->ids->get('product'),
+                'customerId' => $this->ids->get('customer-2'),
+                'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                'status' => true,
+                'points' => 4,
+                'title' => 'foo2',
+                'content' => 'bar2',
+            ],
+        ], Context::createDefaultContext());
+    }
+}

--- a/tests/unit/php/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEventTest.php
+++ b/tests/unit/php/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEventTest.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel\Review\Event;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewDefinition;
+use Shopware\Core\Content\Product\SalesChannel\Review\Event\ProductReviewsLoadedEvent;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Content\Product\SalesChannel\Review\Event\ProductReviewsLoadedEvent
+ */
+class ProductReviewsLoadedEventTest extends TestCase
+{
+    public function testInstance(): void
+    {
+        $context = Context::createDefaultContext();
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getContext')->willReturn($context);
+
+        $productReviewLoaderResult = new ProductReviewLoaderResult(
+            ProductReviewDefinition::ENTITY_NAME,
+            42,
+            new ProductReviewCollection(),
+            null,
+            new Criteria(),
+            $context
+        );
+
+        $request = new Request();
+
+        $event = new ProductReviewsLoadedEvent(
+            $productReviewLoaderResult,
+            $salesChannelContext,
+            $request
+        );
+
+        static::assertSame($productReviewLoaderResult, $event->getSearchResult());
+        static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+        static::assertSame($context, $event->getContext());
+        static::assertSame($request, $event->getRequest());
+    }
+}

--- a/tests/unit/php/Core/Content/Product/SalesChannel/Review/ProductReviewLoaderResultTest.php
+++ b/tests/unit/php/Core/Content/Product/SalesChannel/Review/ProductReviewLoaderResultTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Shopware\Core\Content\Product\SalesChannel\Review;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewEntity;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult;
+use Shopware\Core\Content\Product\SalesChannel\Review\RatingMatrix;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoaderResult
+ */
+final class ProductReviewLoaderResultTest extends TestCase
+{
+    public function testProductId(): void
+    {
+        $productReviewLoaderResult = $this->getProductReviewLoaderResult();
+
+        $productId = Uuid::randomHex();
+        $productReviewLoaderResult->setProductId($productId);
+
+        static::assertSame($productId, $productReviewLoaderResult->getProductId());
+    }
+
+    public function testParentId(): void
+    {
+        $productReviewLoaderResult = $this->getProductReviewLoaderResult();
+
+        $parentId = Uuid::randomHex();
+        $productReviewLoaderResult->setParentId($parentId);
+
+        static::assertSame($parentId, $productReviewLoaderResult->getParentId());
+    }
+
+    public function testMatrix(): void
+    {
+        $productReviewLoaderResult = $this->getProductReviewLoaderResult();
+
+        $matrix = new RatingMatrix([]);
+        $productReviewLoaderResult->setMatrix($matrix);
+
+        static::assertSame($matrix, $productReviewLoaderResult->getMatrix());
+    }
+
+    public function testCustomerReview(): void
+    {
+        $productReviewLoaderResult = $this->getProductReviewLoaderResult();
+
+        $review = new ProductReviewEntity();
+        $productReviewLoaderResult->setCustomerReview($review);
+
+        static::assertSame($review, $productReviewLoaderResult->getCustomerReview());
+    }
+
+    public function testTotalReviews(): void
+    {
+        $productReviewLoaderResult = $this->getProductReviewLoaderResult();
+
+        $totalReviews = 42;
+        $productReviewLoaderResult->setTotalReviews($totalReviews);
+
+        static::assertSame($totalReviews, $productReviewLoaderResult->getTotalReviews());
+    }
+
+    private function getProductReviewLoaderResult(): ProductReviewLoaderResult
+    {
+        return new ProductReviewLoaderResult(
+            ProductReviewDefinition::ENTITY_NAME,
+            42,
+            new ProductReviewCollection(),
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
+    }
+}

--- a/tests/unit/php/Core/Content/Product/SalesChannel/Review/ProductReviewLoaderTest.php
+++ b/tests/unit/php/Core/Content/Product/SalesChannel/Review/ProductReviewLoaderTest.php
@@ -1,0 +1,363 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel\Review;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewCollection;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductReview\ProductReviewEntity;
+use Shopware\Core\Content\Product\ProductException;
+use Shopware\Core\Content\Product\SalesChannel\Review\AbstractProductReviewRoute;
+use Shopware\Core\Content\Product\SalesChannel\Review\Event\ProductReviewsLoadedEvent;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewRouteResponse;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResultCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Bucket\Bucket;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Bucket\TermsResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader
+ */
+class ProductReviewLoaderTest extends TestCase
+{
+    private MockObject&AbstractProductReviewRoute $route;
+
+    private MockObject&EventDispatcherInterface $eventDispatcher;
+
+    private ProductReviewLoader $productReviewLoader;
+
+    protected function setUp(): void
+    {
+        $this->route = $this->createMock(AbstractProductReviewRoute::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $this->productReviewLoader = new ProductReviewLoader(
+            $this->route,
+            $this->eventDispatcher
+        );
+    }
+
+    public function testLoadThrowsParameterExceptionWhenProductIdMissing(): void
+    {
+        $this->expectException(ProductException::class);
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $this->productReviewLoader->load(new Request(), $salesChannelContext);
+    }
+
+    public function testLoadWithoutCustomer(): void
+    {
+        $request = new Request();
+        $productId = Uuid::randomHex();
+        $parentId = Uuid::randomHex();
+        $request->request->add([
+            'productId' => $productId,
+            'parentId' => $parentId,
+        ]);
+
+        /** @var MockObject&SalesChannelContext $salesChannelContext */
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+
+        $salesChannelContext->expects(static::exactly(2))->method('getCustomer')->willReturn(null);
+
+        $review1 = $this->createReview();
+        $review2 = $this->createReview();
+        $reviewRouteResult = $this->createProductReviewRouteResponse([
+            $review1->getId() => $review1,
+            $review2->getId() => $review2,
+        ], $this->createRatingPointsAggregation([
+            5 => 1,
+            1 => 1,
+        ]));
+
+        $this->route
+            ->expects(static::once())
+            ->method('load')
+            ->with($parentId, static::isInstanceOf(Request::class), $salesChannelContext, static::isInstanceOf(Criteria::class))
+            ->willReturn($reviewRouteResult)
+        ;
+
+        $this->eventDispatcher
+            ->expects(static::once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(ProductReviewsLoadedEvent::class))
+        ;
+
+        $result = $this->productReviewLoader->load($request, $salesChannelContext);
+        $matrix = $result->getMatrix();
+
+        static::assertSame(6.0, $matrix->getPointSum());
+        static::assertSame(2, $matrix->getTotalReviewCount());
+
+        static::assertSame($productId, $result->getProductId());
+        static::assertSame($parentId, $result->getParentId());
+        static::assertNull($result->getCustomerReview());
+
+        static::assertSame(2, $result->getTotal());
+        static::assertCount(2, $result->getElements());
+        static::assertArrayHasKey($review1->getId(), $result->getElements());
+        static::assertArrayHasKey($review2->getId(), $result->getElements());
+    }
+
+    public function testLoadWithCustomerAndLanguageFilter(): void
+    {
+        $request = new Request();
+        $productId = Uuid::randomHex();
+        $request->request->add([
+            'productId' => $productId,
+            'language' => 'filter-language',
+        ]);
+
+        /** @var MockObject&SalesChannelContext $salesChannelContext */
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $context = Context::createDefaultContext();
+        $customer = new CustomerEntity();
+        $customer->setId(Uuid::randomHex());
+        $customer->setFirstName('Max');
+        $customer->setLastName('Mustermann');
+        $customer->setEmail('foo@example.com');
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+
+        $salesChannelContext->expects(static::exactly(2))->method('getCustomer')->willReturn($customer);
+        $salesChannelContext->expects(static::once())->method('getContext')->willReturn($context);
+
+        $review = $this->createReview();
+        $reviewRouteResult = $this->createProductReviewRouteResponse([
+            $review->getId() => $review,
+        ]);
+
+        $customerReview = $this->createReview();
+        $customerReviewRouteResult = $this->createProductReviewRouteResponse([
+            $customerReview->getId() => $customerReview,
+        ]);
+
+        $this->route
+            ->expects(static::exactly(2))
+            ->method('load')
+            ->with($productId, static::isInstanceOf(Request::class), $salesChannelContext, static::isInstanceOf(Criteria::class))
+            ->will(static::onConsecutiveCalls($reviewRouteResult, $customerReviewRouteResult))
+        ;
+
+        $result = $this->productReviewLoader->load($request, $salesChannelContext);
+        static::assertSame($productId, $result->getProductId());
+        static::assertNull($result->getParentId());
+        static::assertSame($customerReview, $result->getCustomerReview());
+
+        static::assertSame(1, $result->getTotal());
+        static::assertCount(1, $result->getElements());
+        static::assertArrayHasKey($review->getId(), $result->getElements());
+    }
+
+    public function testCriteriaWithPointsAndInvalidSorting(): void
+    {
+        $request = new Request();
+        $productId = Uuid::randomHex();
+        $request->request->add([
+            'productId' => $productId,
+            'points' => [2, 3],
+            'sort' => 'invalidSorting',
+        ]);
+
+        /** @var MockObject&SalesChannelContext $salesChannelContext */
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+
+        $salesChannelContext->expects(static::exactly(2))->method('getCustomer')->willReturn(null);
+
+        $review = $this->createReview();
+        $reviewRouteResult = $this->createProductReviewRouteResponse([
+            $review->getId() => $review,
+        ]);
+
+        $this->route
+            ->expects(static::once())
+            ->method('load')
+            ->with(
+                $productId,
+                static::isInstanceOf(Request::class),
+                $salesChannelContext,
+                static::callback(function (Criteria $criteria) {
+                    $postFilters = $criteria->getPostFilters();
+                    static::assertCount(1, $postFilters);
+
+                    $postFilter = reset($postFilters);
+                    static::assertInstanceOf(MultiFilter::class, $postFilter);
+                    static::assertCount(2, $postFilter->getFields());
+                    static::assertContains('points', $postFilter->getFields());
+
+                    /** @var MultiFilter $postFilter */
+                    $queries = $postFilter->getQueries();
+                    static::assertCount(2, $queries);
+
+                    foreach ($queries as $query) {
+                        static::assertInstanceOf(RangeFilter::class, $query);
+
+                        /** @var RangeFilter $query */
+                        static::assertTrue($query->hasParameter(RangeFilter::GTE));
+                        static::assertTrue($query->hasParameter(RangeFilter::LT));
+
+                        static::assertContains([
+                            (float) $query->getParameter(RangeFilter::GTE),
+                            (float) $query->getParameter(RangeFilter::LT),
+                        ], [[1.5, 2.5], [2.5, 3.5]]);
+                    }
+
+                    $sortings = $criteria->getSorting();
+                    static::assertCount(1, $sortings);
+
+                    $sorting = reset($sortings);
+                    static::assertInstanceOf(FieldSorting::class, $sorting);
+
+                    static::assertSame('createdAt', $sorting->getField());
+                    static::assertSame('DESC', $sorting->getDirection());
+
+                    return true;
+                })
+            )
+            ->willReturn($reviewRouteResult)
+        ;
+
+        $this->eventDispatcher
+            ->expects(static::once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(ProductReviewsLoadedEvent::class))
+        ;
+
+        $result = $this->productReviewLoader->load($request, $salesChannelContext);
+        static::assertSame($productId, $result->getProductId());
+        static::assertNull($result->getParentId());
+        static::assertNull($result->getCustomerReview());
+
+        static::assertSame(1, $result->getTotal());
+        static::assertCount(1, $result->getElements());
+        static::assertArrayHasKey($review->getId(), $result->getElements());
+    }
+
+    public function testCriteriaRequestParameters(): void
+    {
+        $request = new Request();
+        $productId = Uuid::randomHex();
+        $request->request->add([
+            'productId' => $productId,
+            'limit' => 7,
+            'p' => 3,
+            'sort' => 'points',
+        ]);
+
+        /** @var MockObject&SalesChannelContext $salesChannelContext */
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId(Uuid::randomHex());
+
+        $salesChannelContext->expects(static::exactly(2))->method('getCustomer')->willReturn(null);
+
+        $review = $this->createReview();
+        $reviewRouteResult = $this->createProductReviewRouteResponse([
+            $review->getId() => $review,
+        ]);
+
+        $this->route
+            ->expects(static::once())
+            ->method('load')
+            ->with(
+                $productId,
+                static::isInstanceOf(Request::class),
+                $salesChannelContext,
+                static::callback(function (Criteria $criteria) {
+                    $postFilters = $criteria->getPostFilters();
+                    static::assertCount(0, $postFilters);
+
+                    static::assertSame(7, $criteria->getLimit());
+                    static::assertSame(14, $criteria->getOffset()); // (3 - 1) * 7
+
+                    $sortings = $criteria->getSorting();
+                    static::assertCount(1, $sortings);
+
+                    $sorting = reset($sortings);
+                    static::assertInstanceOf(FieldSorting::class, $sorting);
+
+                    static::assertSame('points', $sorting->getField());
+                    static::assertSame('DESC', $sorting->getDirection());
+
+                    return true;
+                })
+            )
+            ->willReturn($reviewRouteResult)
+        ;
+
+        $this->eventDispatcher
+            ->expects(static::once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(ProductReviewsLoadedEvent::class))
+        ;
+
+        $result = $this->productReviewLoader->load($request, $salesChannelContext);
+        static::assertSame($productId, $result->getProductId());
+        static::assertNull($result->getParentId());
+        static::assertNull($result->getCustomerReview());
+
+        static::assertSame(1, $result->getTotal());
+        static::assertCount(1, $result->getElements());
+        static::assertArrayHasKey($review->getId(), $result->getElements());
+    }
+
+    private function createReview(): ProductReviewEntity
+    {
+        $review = new ProductReviewEntity();
+        $review->setId(Uuid::randomHex());
+
+        return $review;
+    }
+
+    /**
+     * @param array<string, ProductReviewEntity> $reviews
+     */
+    private function createProductReviewRouteResponse(array $reviews, ?TermsResult $ratingMatrix = null): ProductReviewRouteResponse
+    {
+        $aggregationCollection = null;
+        if ($ratingMatrix !== null) {
+            $aggregationCollection = new AggregationResultCollection(['ratingMatrix' => $ratingMatrix]);
+        }
+
+        return new ProductReviewRouteResponse(new EntitySearchResult(
+            ProductReviewDefinition::ENTITY_NAME,
+            \count($reviews),
+            new ProductReviewCollection($reviews),
+            $aggregationCollection,
+            new Criteria(),
+            Context::createDefaultContext()
+        ));
+    }
+
+    /**
+     * @param array<int, int> $points
+     */
+    private function createRatingPointsAggregation(array $points): TermsResult
+    {
+        $buckets = [];
+        foreach ($points as $rating => $count) {
+            $buckets[] = new Bucket((string) $rating, $count, null);
+        }
+
+        return new TermsResult('ratingMatrix', $buckets);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently if the product has variants and an assigned shopping experience layout only the reviews of that variant are displayed.

### 2. What does this change do, exactly?
Use the loading mechanism of the `ProductReviewLoader` to load the reviews. 

This PR is based on https://github.com/shopware/platform/pull/2387 since the widget route loads the template for the normal product page.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-19689

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2389"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

