### PR TITLE
NEXT-17040 - Added custom fields to landingpage front-end

### DIFF
--- a/changelog/_unreleased/2022-03-15-add-custom-fields-to-landingpage.md
+++ b/changelog/_unreleased/2022-03-15-add-custom-fields-to-landingpage.md
@@ -1,0 +1,10 @@
+---
+title: Add custom fields to landing page on front-end 
+issue: NEXT-17040
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@iodigital.com
+author_github: @MelvinAchterhuis
+---
+# Storefront
+* Added `EntityCustomFieldsTrait` to `src/Storefront/Page/LandingPage/LandingPage.php`.
+* Added `setCustomFields` to `src/Storefront/Page/LandingPage/LandingPageLoader.php`

--- a/src/Storefront/Page/LandingPage/LandingPage.php
+++ b/src/Storefront/Page/LandingPage/LandingPage.php
@@ -4,10 +4,13 @@ namespace Shopware\Storefront\Page\LandingPage;
 
 use Shopware\Core\Content\Cms\CmsPageEntity;
 use Shopware\Core\Content\LandingPage\LandingPageDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
 use Shopware\Storefront\Page\Page;
 
 class LandingPage extends Page
 {
+    use EntityCustomFieldsTrait;
+
     /**
      * @var CmsPageEntity|null
      */

--- a/src/Storefront/Page/LandingPage/LandingPageLoader.php
+++ b/src/Storefront/Page/LandingPage/LandingPageLoader.php
@@ -63,6 +63,7 @@ class LandingPageLoader
         $metaInformation->setMetaDescription($landingPage->getMetaDescription() ?? '');
         $metaInformation->setMetaKeywords($landingPage->getKeywords() ?? '');
         $page->setMetaInformation($metaInformation);
+        $page->setCustomFields($landingPage->getCustomFields());
 
         $this->eventDispatcher->dispatch(
             new LandingPageLoadedEvent($page, $context, $request)


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently it is possible to assign custom fields to landing pages. However it is not possible to access the custom fields through Twig at the moment.

### 2. What does this change do, exactly?

Adds the translated custom fields to the `page` variable, so it can be accessed through `page.customFields`.

### 3. Describe each step to reproduce the issue or behaviour.

Assign a custom field to a landing page. Dump `page`. Custom fields are accessible through Twig.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-17040

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
