### PR TITLE
NEXT-20219 - Changed empty h5 to div.h5 for seo purpose

### DIFF
--- a/changelog/_unreleased/2022-03-15-changed-empty-h5-to-div-h5-for-seo-purpose.md
+++ b/changelog/_unreleased/2022-03-15-changed-empty-h5-to-div-h5-for-seo-purpose.md
@@ -1,0 +1,10 @@
+---
+title: Changed empty h5 to div.h5 for seo purpose
+issue: NEXT-20219
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@iodigital.com
+author_github: @MelvinAchterhuis
+---
+# Storefront
+* Changed `h5` to `div.h5` in src/Storefront/Resources/views/storefront/component/pseudo-modal.html.twig`.
+* Added styling to `src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_modal.scss` 

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_modal.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_modal.scss
@@ -12,5 +12,6 @@ https://getbootstrap.com/docs/4.3/components/modal/
 
     .modal-title {
         margin: 0;
+        line-height: $modal-title-line-height;
     }
 }

--- a/src/Storefront/Resources/views/storefront/component/pseudo-modal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/pseudo-modal.html.twig
@@ -6,7 +6,7 @@
              role="document">
             <div class="modal-content">
                 <div class="modal-header only-close">
-                    <h5 class="modal-title js-pseudo-modal-template-title-element"></h5>
+                    <div class="modal-title js-pseudo-modal-template-title-element h5"></div>
                     <button type="button"
                             class="{{ modalCloseBtnClass }} close"
                             {{ dataBsDismissAttr }}="modal"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently on every page there is an empty `h5` because it's defined in `src/Storefront/Resources/views/storefront/component/pseudo-modal.html.twig`. For SEO purposes this shouldn't happen.

### 2. What does this change do, exactly?

Changes the `h5` to `div.h5` and adds styling to keep original line-height. 

### 3. Describe each step to reproduce the issue or behaviour.

Open console, search for `modal-title js-pseudo-modal-template-title-element`. See an empty `h5`

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-20219

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
