### PR TITLE
Update log entry table to allow longer messages

### DIFF
--- a/changelog/_unreleased/2022-03-16-allow-long-log-messages-in-database.md
+++ b/changelog/_unreleased/2022-03-16-allow-long-log-messages-in-database.md
@@ -1,0 +1,9 @@
+---
+title: Fix order generation in demodata
+issue: NEXT-20621
+author: Maximilian Ruesch
+author_email: maximilian.ruesch@pickware.de
+author_github: maximilianruesch
+---
+# Core
+* Changed the `log_entry` table such that log messages longer than 255 characters can be saved.

--- a/src/Core/Framework/Log/LogEntryDefinition.php
+++ b/src/Core/Framework/Log/LogEntryDefinition.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\LongTextField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 
@@ -41,7 +42,7 @@ class LogEntryDefinition extends EntityDefinition
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
 
-            (new StringField('message', 'message'))->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new LongTextField('message', 'message'))->addFlags(new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             new IntField('level', 'level'),
             new StringField('channel', 'channel'),
             (new JsonField('context', 'context'))->addFlags(new SearchRanking(SearchRanking::MIDDLE_SEARCH_RANKING)),

--- a/src/Core/Migration/Test/Migration1647443222AllowLongLogEntryMessagesTest.php
+++ b/src/Core/Migration/Test/Migration1647443222AllowLongLogEntryMessagesTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\Test;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_4\Migration1647443222AllowLongLogEntryMessages;
+
+class Migration1647443222AllowLongLogEntryMessagesTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function setUp(): void
+    {
+        /** @var Connection $connection */
+        $connection = $this->getContainer()->get(Connection::class);
+        $connection->executeStatement('ALTER TABLE `log_entry` MODIFY COLUMN `message` VARCHAR(255) NOT NULL');
+    }
+
+    public function tearDown(): void
+    {
+        /** @var Connection $connection */
+        $connection = $this->getContainer()->get(Connection::class);
+        (new Migration1647443222AllowLongLogEntryMessages())->update($connection);
+    }
+
+    public function testLongMessagesInLogEntriesCanBeWritten(): void
+    {
+        /** @var Connection $connection */
+        $connection = $this->getContainer()->get(Connection::class);
+
+        (new Migration1647443222AllowLongLogEntryMessages())->update($connection);
+        $connection->beginTransaction();
+
+        $logEntryId = Uuid::randomBytes();
+        // This string is now 1000 characters long, well beyond the old limit of 255 characters
+        $longMessage = str_repeat('some-long-', 100);
+        $payload = [
+            'id' => $logEntryId,
+            'message' => $longMessage,
+            'level' => 500,
+            'channel' => 'some-test-channel',
+            'context' => json_encode([]),
+            'extra' => json_encode([]),
+            'updated_at' => null,
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ];
+
+        $connection->insert('log_entry', $payload);
+
+        $logEntry = $connection->fetchAssociative(
+            'SELECT `message` FROM `log_entry` WHERE `id` = :id',
+            ['id' => $logEntryId],
+        );
+
+        $connection->rollBack();
+        static::assertEquals($longMessage, $logEntry['message']);
+    }
+
+    public function testLogEntryMessageColumnIsCorrect(): void
+    {
+        /** @var Connection $connection */
+        $connection = $this->getContainer()->get(Connection::class);
+
+        (new Migration1647443222AllowLongLogEntryMessages())->update($connection);
+
+        $messageColumn = $connection->fetchAssociative('
+            SELECT DATA_TYPE
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE
+             TABLE_SCHEMA = :dbName AND
+             TABLE_NAME   = "log_entry" AND
+             COLUMN_NAME  = "message"
+        ', ['dbName' => $connection->getDatabase()]);
+
+        static::assertEquals('longtext', $messageColumn['DATA_TYPE']);
+    }
+
+    public function testMigrationCanRunMultipleTimes(): void
+    {
+        /** @var Connection $connection */
+        $connection = $this->getContainer()->get(Connection::class);
+
+        (new Migration1647443222AllowLongLogEntryMessages())->update($connection);
+        (new Migration1647443222AllowLongLogEntryMessages())->update($connection);
+
+        static::assertTrue(true);
+    }
+}

--- a/src/Core/Migration/V6_4/Migration1647443222AllowLongLogEntryMessages.php
+++ b/src/Core/Migration/V6_4/Migration1647443222AllowLongLogEntryMessages.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_4;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1647443222AllowLongLogEntryMessages extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1647443222;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('
+            ALTER TABLE `log_entry`
+                MODIFY COLUMN `message` LONGTEXT NOT NULL;
+        ');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Long messages in log entries (such as stack traces) which exceed 255 characters cannot be saved in the database. The creation of the row fails, as the data is too large to fit in the data cell. See the example below.

### 2. What does this change do, exactly?

This PR changes the datatype of the column `message` in the table `log_entry` from `VARCHAR(255)` to `LONGTEXT`, effectively removing the character limit. The "limit" now sits at roughly 4GB, which should be enough for even the longest stack traces.

### 3. Describe each step to reproduce the issue or behaviour.

1. Try to consume a message (in the message queue) which causes an exception, such that the serialized exception is longer than 255 characters.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


---
#### Small example for the kind of error message
```
bin/console messenger:consume -t 120 -m 1G

 [OK] Consuming messages from transports "default".

 [Exception]

In AbstractMySQLDriver.php line 128:

  An exception occurred while executing 'INSERT INTO log_entry (id, message, level, channel, context, extra, updated_at, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)' with param
  s ["\xc0\xc7\x0c\xdc\xa2\x37\x4e\x85\x9f\x88\x8e\xb3\x02\xd4\x99\x05", "Failed rendering string template using Twig: Failed rendering string template using Twig: Neither the
  property \"calculatedListingPrice\" nor one of the methods \"calculatedListingPrice()\", \"getcalculatedListingPrice()\"\/\"iscalculatedListingPrice()\"\/\"hascalculatedListi
  ngPrice()\" or \"__call()\" exist and have public access in class \"Shopware\\Core\\Content\\Product\\SalesChannel\\SalesChannelProductEntity\" in \"a521744fc19cf2df60ab0b052
  9f0c3a7\" at line 27.", 400, "business_events", "[]", "[]", null, "2022-03-04 09:20:40.873"]:

  SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'message' at row 1
```