### PR TITLE
NEXT-20638 - Fix line item children smooth collapse

### DIFF
--- a/changelog/_unreleased/2022-03-17-fix-line-item-children-smooth-collapse.md
+++ b/changelog/_unreleased/2022-03-17-fix-line-item-children-smooth-collapse.md
@@ -1,0 +1,9 @@
+---
+title: Fix line item children smooth collapse
+issue: NEXT-20638
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@iodigital.com
+author_github: @MelvinAchterhuis
+---
+# Storefront
+* Refactored padding in `Storefront/Resources/app/storefront/src/scss/page/checkout/_cart-item-children.scss` for a smooth collapse.

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart-item-children.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart-item-children.scss
@@ -18,8 +18,8 @@
         }
     }
 
-    .cart-item-children-elements {
-        padding: 12px 0 0;
+    .cart-item-children-elements > div:first-of-type {
+        padding: 20px 4px 0
     }
 
     .cart-item-headline {

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart-item-children.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart-item-children.scss
@@ -19,7 +19,7 @@
     }
 
     .cart-item-children-elements > div:first-of-type {
-        padding: 20px 4px 0
+        padding: 20px 4px 0;
     }
 
     .cart-item-headline {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The collapse for the line item children currently isn't smooth because of wrong padding

![Screen Recording 2022-03-17 at 19 02 22](https://user-images.githubusercontent.com/26538915/158870390-f9d5b5b7-45a2-444b-9ff7-ff7758462e7a.gif)

### 2. What does this change do, exactly?

Refactors the styling so the collapse is smooth

### 3. Describe each step to reproduce the issue or behaviour.

Add line item with children to cart. When toggling the collapse you can see that it currently isn't smooth because of wrong padding (set on the collapse itself, instead of first div)

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-20638

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

