### PR TITLE
Fix issue when the same placeholder for the CRSF token is used more than once in a template

### DIFF
--- a/changelog/_unreleased/2022-03-18-fix-issue-with-multiple-crsf-placeholders.md
+++ b/changelog/_unreleased/2022-03-18-fix-issue-with-multiple-crsf-placeholders.md
@@ -1,0 +1,10 @@
+---
+title: Fix issue when the same placeholder for the CRSF token is used more than once in a template
+issue: NEXT-20694
+flag:
+author: Alexander Schneider
+author_email: alexanderschneider85@gmail.com
+author_github: GM-Alex
+---
+# Core
+*  Fix issue when the same placeholder for the CRSF token is used more than once in a template

--- a/src/Storefront/Framework/Csrf/CsrfPlaceholderHandler.php
+++ b/src/Storefront/Framework/Csrf/CsrfPlaceholderHandler.php
@@ -74,17 +74,23 @@ class CsrfPlaceholderHandler
             $this->requestStack->push($request);
         }
 
+        $processedIdents = [];
+
         // https://regex101.com/r/fefx3V/1
         $content = preg_replace_callback(
             '/' . self::CSRF_PLACEHOLDER . '(?<intent>[^#]*)#/',
-            function ($matches) use ($response, $request) {
-                $token = $this->getToken($matches['intent']);
+            function ($matches) use ($response, $request, &$processedIdents) {
+                $intent = $matches['intent'];
+                $token = $processedIdents[$intent] ?? null;
 
-                $cookie = Cookie::create('csrf[' . $matches['intent'] . ']', $token);
-
-                $cookie->setSecureDefault($request->isSecure());
-
-                $response->headers->setCookie($cookie);
+                // Don't generate the token and set the cookie again
+                if ($token === null) {
+                    $token = $this->getToken($intent);
+                    $cookie = Cookie::create('csrf[' . $intent . ']', $token);
+                    $cookie->setSecureDefault($request->isSecure());
+                    $response->headers->setCookie($cookie);
+                    $processedIdents[$intent] = $token;
+                }
 
                 return $token;
             },

--- a/src/Storefront/Test/Framework/Csrf/CsrfPlaceholderHandlerTest.php
+++ b/src/Storefront/Test/Framework/Csrf/CsrfPlaceholderHandlerTest.php
@@ -10,6 +10,8 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\Loader\LoaderInterface;
@@ -48,8 +50,24 @@ class CsrfPlaceholderHandlerTest extends TestCase
         $request->setSession(new Session(new MockArraySessionStorage()));
         $this->getContainer()->get('request_stack')->push($request);
 
-        $csrfPlaceholderHandler = $this->createCsrfPlaceholderHandler();
-
+        $tokenManager = $this->createPartialMock(
+            CsrfTokenManagerInterface::class,
+            [
+                'getToken',
+                'refreshToken',
+                'removeToken',
+                'isTokenValid',
+            ]
+        );
+        $tokenManager->expects(static::exactly(3))
+            ->method('getToken')
+            ->willReturnCallback(
+                fn ($tokenId) => new CsrfToken(
+                    $tokenId,
+                    bin2hex(random_bytes(32))
+                )
+            );
+        $csrfPlaceholderHandler = $this->createCsrfPlaceholderHandler(true, 'twig', $tokenManager);
         $response = new Response($this->getContentWithCsrfPLaceholder(), 200, ['Content-Type' => 'text/html']);
 
         $expectedContent = file_get_contents(__DIR__ . '/fixtures/Storefront/Resources/views/csrfTest/csrfTestRendered.html.twig');
@@ -136,10 +154,13 @@ class CsrfPlaceholderHandlerTest extends TestCase
         return $template->render();
     }
 
-    private function createCsrfPlaceholderHandler(bool $csrfEnabled = true, string $csrfMode = 'twig')
-    {
+    private function createCsrfPlaceholderHandler(
+        bool $csrfEnabled = true,
+        string $csrfMode = 'twig',
+        ?CsrfTokenManagerInterface $tokenManager = null
+    ) {
         return new CsrfPlaceholderHandler(
-            $this->getContainer()->get('security.csrf.token_manager'),
+            $tokenManager ?? $this->getContainer()->get('security.csrf.token_manager'),
             $csrfEnabled,
             $csrfMode,
             $this->getContainer()->get('request_stack'),

--- a/src/Storefront/Test/Framework/Csrf/fixtures/Storefront/Resources/views/csrfTest/csrfTest.html.twig
+++ b/src/Storefront/Test/Framework/Csrf/fixtures/Storefront/Resources/views/csrfTest/csrfTest.html.twig
@@ -3,6 +3,10 @@
 </form>
 
 <form>
+    {{ sw_csrf('token1') }}
+</form>
+
+<form>
     {{ sw_csrf('token2', {'mode': 'input'}) }}
 </form>
 

--- a/src/Storefront/Test/Framework/Csrf/fixtures/Storefront/Resources/views/csrfTest/csrfTestRendered.html.twig
+++ b/src/Storefront/Test/Framework/Csrf/fixtures/Storefront/Resources/views/csrfTest/csrfTestRendered.html.twig
@@ -3,6 +3,10 @@
 </form>
 
 <form>
+    <input type="hidden" name="_csrf_token" value="1b4dfebfc2584cf58b63c72c20d521d0token1#">
+</form>
+
+<form>
     <input type="hidden" name="_csrf_token" value="1b4dfebfc2584cf58b63c72c20d521d0token2#">
 </form>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The CRSF cookie is set twice with different token if a place holder exists twice in the content. For example if you have the language selection twice in the template one of them doesn't work properly.

### 2. What does this change do, exactly?

The change checks if the token and the token for the ident is already created and use this instead of generating a new token and set the cookie again.

### 3. Describe each step to reproduce the issue or behaviour.

Place the language selection twice in the template.

### 4. Please link to the relevant issues (if any).

None

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
