### PR TITLE
Use criteria sorting property in sw-entity-many-to-many-select

### DIFF
--- a/changelog/_unreleased/2022-03-18-pass-criteria-sorting-property-to-repository-search-call.md
+++ b/changelog/_unreleased/2022-03-18-pass-criteria-sorting-property-to-repository-search-call.md
@@ -1,0 +1,9 @@
+---
+title: Pass criteria sorting property to repository.search call in sw-entity-many-to-many-select
+issue: NEXT-20695
+author: Christian Sayenko
+author_email: christian@sayenko.dev
+author_github: @christian-sa
+---
+# Administration
+* Changed criteria passed to entity repository search call to include the `sortings` from the given criteria in `sw-entity-many-to-many-select`

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-many-to-many-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-many-to-many-select/index.js
@@ -200,6 +200,7 @@ Component.register('sw-entity-many-to-many-select', {
 
             if (this.criteria) {
                 this.searchCriteria.filters = this.criteria.filters;
+                this.searchCriteria.sortings = this.criteria.sortings;
             }
 
             return this.searchRepository.search(this.searchCriteria, Shopware.Context.api)


### PR DESCRIPTION
### 1. Why is this change necessary?
When you pass a criteria with sorting to the sw-entity-many-to-many-select component you expect the results to be sorted.

### 2. What does this change do, exactly?
It passes the sorting property from the given criteria to the repository.search call in the sw-entity-many-to-many-select component.

### 3. Describe each step to reproduce the issue or behaviour.
1. Use the sw-entity-many-to-many-select component
2. Pass a criteria with sorting as a prop
3. Wonder why the search results are not sorted like you specified.

### 5. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
