### PR TITLE
EntityReader check if value is null (parentId)

### DIFF
--- a/changelog/_unreleased/2022-03-24-check-parent-null.md
+++ b/changelog/_unreleased/2022-03-24-check-parent-null.md
@@ -1,0 +1,9 @@
+---
+title: Check if parent is null
+issue: https://issues.shopware.com/issues/NEXT-20746
+author: Fabian Boensch
+author_email: f.boensch1@web.de
+author_github: En0Ma1259
+---
+# Core
+* Fix Array key on null. Check on parentId.

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -593,6 +593,9 @@ class EntityReader implements EntityReaderInterface
             }
 
             $parentId = $entity->get('parentId');
+            if ($parentId === null) {
+                continue;
+            }
 
             //extract mapping ids for the current entity
             $mappingIds = $mapping[$parentId];

--- a/src/Core/Framework/Test/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -2445,4 +2445,29 @@ class EntityReaderTest extends TestCase
             'variant-main',
         ];
     }
+
+    public function testLimitAssociation(): void
+    {
+        $ids = new IdsCollection();
+
+        $product = (new ProductBuilder($ids, 'p1'))
+            ->name('Test Product')
+            ->price(50, 50);
+
+
+        $productRepository = $this->getContainer()->get('product.repository');
+        $productRepository->create([
+            $product->build(),
+        ], $ids->context);
+
+        $criteria = new Criteria();
+        $criteria
+            ->getAssociation('media')
+            ->setLimit(1);
+
+        $product = $productRepository->search($criteria, $ids->context)->first();
+
+        static::assertInstanceOf(ProductEntity::class, $product);
+        static::assertCount(0, $product->getMedia());
+    }
 }

--- a/src/Core/Framework/Test/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -2454,13 +2454,14 @@ class EntityReaderTest extends TestCase
             ->name('Test Product')
             ->price(50, 50);
 
+        $ids->context->setConsiderInheritance(true);
 
         $productRepository = $this->getContainer()->get('product.repository');
         $productRepository->create([
             $product->build(),
         ], $ids->context);
 
-        $criteria = new Criteria();
+        $criteria = new Criteria([$ids->get('p1')]);
         $criteria
             ->getAssociation('media')
             ->setLimit(1);


### PR DESCRIPTION
### 1. Why is this change necessary?
Error message on product search

### 2. What does this change do, exactly?
Checks, if the parent id value is null

### 3. Describe each step to reproduce the issue or behaviour.

Product with no media
```
$criteria = new Criteria();
$criteria
  ->getAssociation('media')
  ->setLimit(2);

$this->productRepository->search($criteria, $context);
or
$this->salesChannelProductRepository->search($criteria, $context);
```

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
