### PR TITLE
fix TaxDetector handling with null values

### DIFF
--- a/changelog/_unreleased/2022-03-22-check-for-null-in-tax-detector.md
+++ b/changelog/_unreleased/2022-03-22-check-for-null-in-tax-detector.md
@@ -1,0 +1,9 @@
+---
+title: Check for null in tax detector
+issue: 
+author: Moritz Pietzschke
+author_email: mp@mopie.de
+author_github: pietzschke
+---
+# Core
+* Fix TaxDetector to check if null value is in VAT-ID ListField.

--- a/src/Core/Checkout/Cart/Tax/TaxDetector.php
+++ b/src/Core/Checkout/Cart/Tax/TaxDetector.php
@@ -59,7 +59,7 @@ class TaxDetector
             $regex = '/^' . $vatPattern . '$/i';
 
             foreach ($vatIds as $vatId) {
-                if (!preg_match($regex, $vatId)) {
+                if ($vatId === null || !preg_match($regex, $vatId)) {
                     return false;
                 }
             }

--- a/src/Core/Checkout/Cart/Tax/TaxDetector.php
+++ b/src/Core/Checkout/Cart/Tax/TaxDetector.php
@@ -49,7 +49,7 @@ class TaxDetector
         }
 
         $vatPattern = $shippingLocationCountry->getVatIdPattern();
-        $vatIds = $customer->getVatIds();
+        $vatIds = array_filter($customer->getVatIds());
 
         if (empty($vatIds)) {
             return false;
@@ -59,7 +59,7 @@ class TaxDetector
             $regex = '/^' . $vatPattern . '$/i';
 
             foreach ($vatIds as $vatId) {
-                if ($vatId === null || !preg_match($regex, $vatId)) {
+                if (!preg_match($regex, $vatId)) {
                     return false;
                 }
             }

--- a/src/Core/Checkout/Test/Cart/Tax/TaxDetectorTest.php
+++ b/src/Core/Checkout/Test/Cart/Tax/TaxDetectorTest.php
@@ -182,7 +182,7 @@ class TaxDetectorTest extends TestCase
     {
         $context = $this->createMock(SalesChannelContext::class);
 
-        $country = (new CountryEntity)->assign([
+        $country = (new CountryEntity())->assign([
             'customerTax' => new TaxFreeConfig(false),
             'companyTax' => new TaxFreeConfig(true),
             'vatIdPattern' => '...',
@@ -190,8 +190,8 @@ class TaxDetectorTest extends TestCase
         ]);
 
         $customer = (new CustomerEntity())->assign([
-             'company' => 'ABC Compay',
-             'vatIds' => [null],
+            'company' => 'ABC Compay',
+            'vatIds' => [null],
         ]);
 
         $context->expects(static::once())->method('getShippingLocation')->willReturn(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
TaxDetector checks if shopping is taxfree for specified countries and with a supplied vatid. 
If the vat_ids column is filled through api requests, null values are possible, e.g. `[null]`.

With null value the `preg_match` in [Line 62](https://github.com/shopware/platform/blob/1ba5736ad01484766c114f4af93aa55bf7b7cf4c/src/Core/Checkout/Cart/Tax/TaxDetector.php#L62) operates on a null value => TypeError + 500.

### 2. What does this change do, exactly?
Check in foreach loop if vatId is null.

### 3. Describe each step to reproduce the issue or behaviour.
Setup shipping country with tax free and customer with illegal vat_ids value: `[null]`.

This is possible to set via PATCH Request:
/api/customer/xxx
`
{
    "vatIds": [
        null
    ]
}
`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
