### PR TITLE
Add required hint for vatId

### DIFF
--- a/changelog/_unreleased/2022-03-22-add-required-hint-to-vat-id.md
+++ b/changelog/_unreleased/2022-03-22-add-required-hint-to-vat-id.md
@@ -1,0 +1,9 @@
+---
+title: Add required hint to VAT id
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Added `required` attribute to `vatIds[]` input of addresses when `core.loginRegistration.vatIdFieldRequired` is enabled
+* Added required-asterisk to label pointing to `vatIds[]` when `core.loginRegistration.vatIdFieldRequired` is enabled

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal-vat-id.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal-vat-id.html.twig
@@ -6,7 +6,7 @@
     {% block component_address_form_company_vatId_label %}
         <label class="form-label"
                for="vatIds">
-            {{ "address.companyVatLabel"|trans|sw_sanitize }}
+            {{ "address.companyVatLabel"|trans|sw_sanitize }}{% if config('core.loginRegistration.vatIdFieldRequired') %}{{ "general.required"|trans|sw_sanitize }}{% endif %}
         </label>
     {% endblock %}
 
@@ -16,7 +16,9 @@
                id="vatIds"
                placeholder="{{ "address.companyVatPlaceholder"|trans|striptags }}"
                name="vatIds[]"
-               value="{{ activeRoute == 'frontend.account.profile.page' or (feature('FEATURE_NEXT_15957') and activeRoute == 'frontend.account.addressbook' and context.customer.guest) ? vatIds[0] : vatIds.get(0) }}">
+               value="{{ activeRoute == 'frontend.account.profile.page' or (feature('FEATURE_NEXT_15957') and activeRoute == 'frontend.account.addressbook' and context.customer.guest) ? vatIds[0] : vatIds.get(0) }}"
+               {% if config('core.loginRegistration.vatIdFieldRequired') %}required="required"{% endif %}
+        >
     {% endblock %}
 
     {% block component_address_form_company_vatId_input_error %}


### PR DESCRIPTION
### 1. Why is this change necessary?

You can set vat ids to be required, but you can't see it is required.

### 2. What does this change do, exactly?

It asks whether vat ids are required and displays the required asterisk.

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable vat ids are required feature
2. Have vat id in registration form
3. Don't see required star

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
