### PR TITLE
Fix for using the correct shipping/payment method if the current sele…

### DIFF
--- a/changelog/_unreleased/2022-03-24-context-switch-checkout-confirm.md
+++ b/changelog/_unreleased/2022-03-24-context-switch-checkout-confirm.md
@@ -3,6 +3,7 @@ title: Correct payment/shipping method is set on runtime when context is switche
 author: Ing. Jens Göckus
 author_email: jgoeckus@gmail.com
 author_github: JensGck
+issue: https://issues.shopware.com/issues/SW-26623
 ---
 # Storefront
 * Changed  `get` method in `\Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade`, to fix context switching.

--- a/changelog/_unreleased/2022-03-24-context-switch-checkout-confirm.md
+++ b/changelog/_unreleased/2022-03-24-context-switch-checkout-confirm.md
@@ -1,0 +1,8 @@
+---
+title: Correct payment/shipping method is set on runtime when context is switched
+author: Ing. Jens Göckus
+author_email: jgoeckus@gmail.com
+author_github: JensGck
+---
+# Storefront
+* Changed  `get` method in `\Shopware\Storefront\Checkout\Cart\SalesChannel\StorefrontCartFacade`, to fix context switching.

--- a/src/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacade.php
+++ b/src/Storefront/Checkout/Cart/SalesChannel/StorefrontCartFacade.php
@@ -70,7 +70,7 @@ class StorefrontCartFacade
             return $originalCart;
         }
 
-        $updatedContext = clone $originalContext;
+        $updatedContext = $originalContext;
         $updatedContext->assign([
             'shippingMethod' => $contextShippingMethod,
             'paymentMethod' => $contextPaymentMethod,

--- a/src/Storefront/Test/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
+++ b/src/Storefront/Test/Checkout/Cart/SalesChannel/StorefrontCartFacadeTest.php
@@ -191,8 +191,8 @@ class StorefrontCartFacadeTest extends TestCase
             static::assertCount(1, $changedShippingMethodErrors);
             /** @var ShippingMethodChangedError $shippingMethodChangedError */
             $shippingMethodChangedError = $changedShippingMethodErrors->first();
-            static::assertSame($salesChannelContext->getShippingMethod()->getName(), $shippingMethodChangedError->getOldShippingMethodName());
-            static::assertNotSame($salesChannelContext->getShippingMethod()->getName(), $shippingMethodChangedError->getNewShippingMethodName());
+            static::assertSame($salesChannelContext->getShippingMethod()->getName(), $shippingMethodChangedError->getNewShippingMethodName());
+            static::assertNotSame($salesChannelContext->getShippingMethod()->getName(), $shippingMethodChangedError->getOldShippingMethodName());
         } elseif ($blockShippingMethod) {
             static::assertSame(1, $shippingMethodBlockedCount);
         }
@@ -203,8 +203,8 @@ class StorefrontCartFacadeTest extends TestCase
             static::assertCount(1, $changedPaymentMethodErrors);
             /** @var PaymentMethodChangedError $paymentMethodChangedError */
             $paymentMethodChangedError = $changedPaymentMethodErrors->first();
-            static::assertSame($salesChannelContext->getPaymentMethod()->getName(), $paymentMethodChangedError->getOldPaymentMethodName());
-            static::assertNotSame($salesChannelContext->getPaymentMethod()->getName(), $paymentMethodChangedError->getNewPaymentMethodName());
+            static::assertSame($salesChannelContext->getPaymentMethod()->getName(), $paymentMethodChangedError->getNewPaymentMethodName());
+            static::assertNotSame($salesChannelContext->getPaymentMethod()->getName(), $paymentMethodChangedError->getOldPaymentMethodName());
         } elseif ($blockPaymentMethod) {
             static::assertSame(1, $paymentMethodBlockedCount);
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
It's necessary that the correct shipping/payment method is selected if the context changed.

### 2. What does this change do, exactly?
It applies the context changes on runtime.

### 3. Describe each step to reproduce the issue or behaviour.

1. Go to checkout page (storefront) and select a payment (or shipping) method.
2. Head over to the backend/administration  area of the shop and deactivate the selected payment (shipping) method.
3. Back again to the checkout page (storefront) and refresh it.
4. The default payment (shipping) method is not selected correctly (see attached video)

### 4. Please link to the relevant issues (if any).
[SW-26623](https://issues.shopware.com/issues/SW-26623)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

https://user-images.githubusercontent.com/4333324/159887731-e4863752-f9f6-4eec-a4e8-61f16a6acf1c.mp4


