### PR TITLE
feat: Add block component_payment_method_description_text

### DIFF
--- a/changelog/_unreleased/2022-03-24-add-block-component_payment_method_description_text.md
+++ b/changelog/_unreleased/2022-03-24-add-block-component_payment_method_description_text.md
@@ -1,0 +1,9 @@
+---
+title: Add block component_payment_method_description_text
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Add block `component_payment_method_description_text` to template `@Storefront/storefront/component/payment/payment-method.html.twig`
+* Add `striptags` function to payment description which is shown in the corresponding title

--- a/src/Storefront/Resources/views/storefront/component/payment/payment-method.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/payment/payment-method.html.twig
@@ -39,12 +39,15 @@
                                     <strong>{{ payment.translated.name }}</strong>
                                     {% if payment.translated.description %}
                                         {% set paymentDescription = payment.translated.description|raw %}
+                                        {% set paymentDescriptionTitle = payment.translated.description|striptags|raw %}
 
                                         {% if not payment.id is same as(selectedPaymentMethodId) %}
                                             {% set paymentDescription = (paymentDescription|length > 75 ? paymentDescription[:75] ~ ' ...' : paymentDescription) %}
                                         {% endif %}
 
-                                        <p title="{{ payment.translated.description|raw }}">{{ paymentDescription }}</p>
+                                        {% block component_payment_method_description_text %}
+                                            <p title="{{ paymentDescriptionTitle }}">{{ paymentDescription }}</p>
+                                        {% endblock %}
                                     {% endif %}
                                 </div>
                             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to really modify the output of the payment description, another problem is that a lot payment provider plugins use the block `component_payment_method_description` to add a custom payment form. So it is not good to overwrite the full block as one needs to integrate the payment methods in the template additionally.

### 2. What does this change do, exactly?
Add an additional block.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
