### PR TITLE
fix: Pagination of reviews for variant products

### DIFF
--- a/changelog/_unreleased/2022-03-14-fix-pagination-of-reviews-for-variant-products.md
+++ b/changelog/_unreleased/2022-03-14-fix-pagination-of-reviews-for-variant-products.md
@@ -1,0 +1,8 @@
+---
+title: Fix pagination of reviews for variant products
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Fix pagination of reviews for variant products by considering the `parentId` in the form URL

--- a/src/Storefront/Resources/views/storefront/component/review/review.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review.html.twig
@@ -221,7 +221,7 @@
                                                 {% block component_review_list_paging_form %}
                                                     <div class="product-detail-review-pagination">
                                                         <form class="product-detail-review-pagination-form"
-                                                              action="{{ path('frontend.product.reviews', { productId: product.id }) }}"
+                                                              action="{{ path('frontend.product.reviews', { productId: product.id, parentId: product.parentId }) }}"
                                                               method="post"
                                                               data-form-ajax-submit="true"
                                                               data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>

--- a/src/Storefront/Resources/views/storefront/page/product-detail/review/review.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/review/review.html.twig
@@ -218,7 +218,7 @@
                                                 {% block page_product_detail_review_list_paging_form %}
                                                     <div class="product-detail-review-pagination">
                                                         <form class="product-detail-review-pagination-form"
-                                                              action="{{ path('frontend.product.reviews', { productId: reviews.productId }) }}"
+                                                              action="{{ path('frontend.product.reviews', { productId: reviews.productId, parentId: reviews.parentId }) }}"
                                                               method="post"
                                                               data-form-ajax-submit="true"
                                                               data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>


### PR DESCRIPTION
### 1. Why is this change necessary?
Based on https://github.com/shopware/platform/pull/2387 now as https://github.com/shopware/platform/commit/3755d5edd1aab72726cbe7cb81c975ca3777d755 has been merged, the pagination is still not working, i.e. if you have more than 10 reviews for a variant product, the second page will only show the reviews for that specific variant. Note it is correct at the other occurrence of the `frontend.product.reviews` URL in the same template.

### 2. What does this change do, exactly?
Set the parent id.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
