### PR TITLE
NEXT-20624 - Fix: Title is not save in customer address

### DIFF
--- a/changelog/_unreleased/2022-03-25-fix-title-is-not-save-in-customer_address-when-regisering-a-new-customer.md
+++ b/changelog/_unreleased/2022-03-25-fix-title-is-not-save-in-customer_address-when-regisering-a-new-customer.md
@@ -1,0 +1,9 @@
+---
+title: Fix title is not save in customer_address when regisering a new customer
+issue: NEXT-20624
+author: Huy Truong
+author_email: huytdq94@gmail.com
+author_github: Huy Truong
+---
+# Core
+* Added title while mapping address data in `Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute` class.

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -529,6 +529,7 @@ See the Guide ""Register a customer"" for more information on customer registrat
     private function mapAddressData(DataBag $addressData): array
     {
         $mappedData = $addressData->only(
+            'title',
             'firstName',
             'lastName',
             'salutationId',

--- a/src/Core/Checkout/Test/Customer/SalesChannel/RegisterRouteTest.php
+++ b/src/Core/Checkout/Test/Customer/SalesChannel/RegisterRouteTest.php
@@ -69,6 +69,7 @@ class RegisterRouteTest extends TestCase
 
     public function testRegistration(): void
     {
+        $registrationData = $this->getRegistrationData();
         $this->browser
             ->request(
                 'POST',
@@ -76,12 +77,14 @@ class RegisterRouteTest extends TestCase
                 [],
                 [],
                 ['CONTENT_TYPE' => 'application/json'],
-                json_encode($this->getRegistrationData())
+                json_encode($registrationData)
             );
 
         $response = json_decode($this->browser->getResponse()->getContent(), true);
 
         static::assertSame('customer', $response['apiAlias']);
+        static::assertSame($registrationData['title'], $response['defaultBillingAddress']['title']);
+        static::assertSame($registrationData['shippingAddress']['title'], $response['defaultShippingAddress']['title']);
         static::assertNotEmpty($response['addresses']);
         static::assertNotEmpty($response['salutation']);
         static::assertNotEmpty($response['defaultBillingAddress']);
@@ -925,6 +928,7 @@ class RegisterRouteTest extends TestCase
                 'salutationId' => $this->getValidSalutationId(),
                 'firstName' => 'Test 2',
                 'lastName' => 'Example 2',
+                'title' => 'Prof.',
                 'street' => 'Examplestreet 111',
                 'zipcode' => '12341',
                 'city' => 'Berlin',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

`Customer title (Dr. Prof. etc.) is not transferred to the order_address when an order is placed. This means that the customer's title cannot be used in e-mails etc.`
### 2. What does this change do, exactly?

Save customer title to customer_address when registering a new customer
### 3. Describe each step to reproduce the issue or behavior.

Enable `Show title` setting in Admin -> Login/Registration setting then register a new customer
### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-20624

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
