### PR TITLE
Fix command "system:install" with an empty password

### DIFF
--- a/changelog/_unreleased/2022-03-28-fix-db-connection-without-password.md
+++ b/changelog/_unreleased/2022-03-28-fix-db-connection-without-password.md
@@ -1,0 +1,8 @@
+---
+title: Fix database connection without password.
+issue: ?
+author: Daniel Sturm
+author_github: dsturm
+---
+# Core
+* Removes the check against the password in `DatabaseConnectionInformation::asDsn` to fix a connection error if no password is needed.

--- a/changelog/_unreleased/2022-03-28-fix-db-connection-without-password.md
+++ b/changelog/_unreleased/2022-03-28-fix-db-connection-without-password.md
@@ -1,6 +1,6 @@
 ---
 title: Fix database connection without password.
-issue: ?
+issue: NEXT-20842
 author: Daniel Sturm
 author_github: dsturm
 ---

--- a/src/Core/Maintenance/System/Struct/DatabaseConnectionInformation.php
+++ b/src/Core/Maintenance/System/Struct/DatabaseConnectionInformation.php
@@ -98,7 +98,7 @@ class DatabaseConnectionInformation extends Struct
     {
         $dsn = sprintf(
             'mysql://%s%s:%s',
-            $this->username && $this->password ? ($this->username . ':' . rawurlencode($this->password) . '@') : '',
+            $this->username ? ($this->username . ':' . rawurlencode($this->password ?: '') . '@') : '',
             $this->hostname,
             $this->port
         );

--- a/src/Core/Maintenance/Test/System/Struct/DatabaseConnectionInformationTest.php
+++ b/src/Core/Maintenance/Test/System/Struct/DatabaseConnectionInformationTest.php
@@ -3,17 +3,17 @@
 namespace Shopware\Core\Maintenance\Test\System\Struct;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Maintenance\System\Struct\DatabaseConnectionInformation;
 
 class DatabaseConnectionInformationTest extends TestCase
 {
-    /**
-     * @backupGlobals enabled
-     */
+    use EnvTestBehaviour;
+
     public function testItDecodesSpecialCharsInDbPasswordsFromEnv(): void
     {
-        unset($_SERVER['DATABASE_URL'], $_ENV['DATABASE_URL']);
-        putenv('DATABASE_URL=mysql://user:ultra%3Fsecure%23@mysql:3306/test_db');
+        $this->setEnvVars(['DATABASE_URL' => 'mysql://user:ultra%3Fsecure%23@mysql:3306/test_db']);
+
         $dbConnectionInformation = DatabaseConnectionInformation::fromEnv();
 
         static::assertEquals('ultra?secure#', $dbConnectionInformation->getPassword());
@@ -31,13 +31,10 @@ class DatabaseConnectionInformationTest extends TestCase
         static::assertEquals('mysql://user:ultra%3Fsecure%23@mysql:3306/test_db', $dbConnectionInformation->asDsn());
     }
 
-    /**
-     * @backupGlobals enabled
-     */
     public function testItAllowsAnEmptyDbPassword(): void
     {
-        unset($_SERVER['DATABASE_URL'], $_ENV['DATABASE_URL']);
-        putenv('DATABASE_URL=mysql://user:@mysql:3306/test_db');
+        $this->setEnvVars(['DATABASE_URL' => 'mysql://user:@mysql:3306/test_db']);
+
         $dbConnectionInformation = DatabaseConnectionInformation::fromEnv();
 
         static::assertEquals('mysql://user:@mysql:3306/test_db', $dbConnectionInformation->asDsn());

--- a/src/Core/Maintenance/Test/System/Struct/DatabaseConnectionInformationTest.php
+++ b/src/Core/Maintenance/Test/System/Struct/DatabaseConnectionInformationTest.php
@@ -30,4 +30,16 @@ class DatabaseConnectionInformationTest extends TestCase
 
         static::assertEquals('mysql://user:ultra%3Fsecure%23@mysql:3306/test_db', $dbConnectionInformation->asDsn());
     }
+
+    /**
+     * @backupGlobals enabled
+     */
+    public function testItAllowsAnEmptyDbPassword(): void
+    {
+        unset($_SERVER['DATABASE_URL'], $_ENV['DATABASE_URL']);
+        putenv('DATABASE_URL=mysql://user:@mysql:3306/test_db');
+        $dbConnectionInformation = DatabaseConnectionInformation::fromEnv();
+
+        static::assertEquals('mysql://user:@mysql:3306/test_db', $dbConnectionInformation->asDsn());
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently using an empty password for the DB (which is the default using `laravel/valet`) will throw an error while running the `system:install` command.

### 2. What does this change do, exactly?
This PR removes the check for both, username AND password, in `Shopware\Core\Maintenance\System\Struct\DatabaseConnectionInformation::asDsn` to prevent the strip-out of both.

### 3. Describe each step to reproduce the issue or behaviour.
- Clone https://github.com/shopware/production/
- Set env value of DATABASE_URL without password (i.e. `mysql://root:@localhost:3306/shopware_db_name`)
- Run php bin/console system:install
- DSN will return as `mysql://localhost:3306`


### 4. Please link to the relevant issues (if any).
- #2373


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
