### PR TITLE
Make format-utils use 2 decimal places for currency formatting by default

### DIFF
--- a/changelog/_unreleased/2022-03-30-currency-format-use-2-decimal-places.md
+++ b/changelog/_unreleased/2022-03-30-currency-format-use-2-decimal-places.md
@@ -1,0 +1,8 @@
+---
+title: Administration currency formatter util will now display only 2 decimal places by default
+author: Felix von WIRDUZEN
+author_email: felix@wirduzen.de
+author_github: wirduzen-felix
+---
+# Administration
+* Changed `maximumFractionDigits` default value to 2 in `src/core/service/utils/format.utils.ts` for currency formatting

--- a/src/Administration/Resources/app/administration/src/core/service/utils/format.utils.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/format.utils.ts
@@ -33,7 +33,7 @@ export function currency(val: number, sign: string, decimalPlaces: number, addit
         maximumFractionDigits: decimalPlaces,
     } : {
         minimumFractionDigits: 2,
-        maximumFractionDigits: 20,
+        maximumFractionDigits: 2,
     };
 
     const opts = {

--- a/src/Administration/Resources/app/administration/test/core/service/utils/format.utils.spec.js
+++ b/src/Administration/Resources/app/administration/test/core/service/utils/format.utils.spec.js
@@ -149,6 +149,10 @@ describe('src/core/service/utils/format.utils.js', () => {
 
             Shopware.Context.app.systemCurrencyISOCode = 'EUR';
         });
+
+        it('should only have a max of 2 digits', () => {
+            expect(currencyFilter(42.12345, 'EUR')).toBe('€42.12');
+        });
     });
 
     describe('toISODate', () => {

--- a/src/Administration/Resources/app/administration/test/core/service/utils/format.utils.spec.js
+++ b/src/Administration/Resources/app/administration/test/core/service/utils/format.utils.spec.js
@@ -150,7 +150,7 @@ describe('src/core/service/utils/format.utils.js', () => {
             Shopware.Context.app.systemCurrencyISOCode = 'EUR';
         });
 
-        it('should only have a max of 2 digits', () => {
+        it('should only have a max of 2 decimal places', () => {
             expect(currencyFilter(42.12345, 'EUR')).toBe('€42.12');
         });
     });


### PR DESCRIPTION
### 1. Why is this change necessary?
If you changed the net price of a product in the administration, this can lead to a gross price with many decimal places. This is fine on its own. However when these prices are displayed in the entity listing I think that the price should be rounded to 2 decimal places for displaying purposes. 
![image](https://user-images.githubusercontent.com/88590092/160770388-ff408c32-6bff-48d8-829f-d71409ec6971.png)

### 2. What does this change do, exactly?
This change makes the currency formatting util use 2 as the default value for the `maximumFractionDigits`. **This change only changes the formatter. The data set itself is not modified.**

### 3. Describe each step to reproduce the issue or behaviour.
Well, just modify the gross price to have a lot of decimal places.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
