### PR TITLE
Add missing salutation to password reset

### DIFF
--- a/changelog/_unreleased/2022-03-30-add-salutation-association-to-customer-recovery.md
+++ b/changelog/_unreleased/2022-03-30-add-salutation-association-to-customer-recovery.md
@@ -1,0 +1,10 @@
+---
+title: Salutation missing in email template
+issue: NEXT-20355
+author: Marcin Kaczor
+author_email: marcink@codepro.space
+author_github: CodeproSpace
+---
+
+# Core
+* Add salutation association to customer recovery `\Shopware\Core\Checkout\Customer\SalesChannel\SendPasswordRecoveryMailRoute`

--- a/src/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRoute.php
@@ -133,7 +133,7 @@ Returns a success indicating a successful initialisation of the reset flow.",
 
         $customerIdCriteria = new Criteria();
         $customerIdCriteria->addFilter(new EqualsFilter('customerId', $customerId));
-        $customerIdCriteria->addAssociation('customer');
+        $customerIdCriteria->addAssociation('customer.salutation');
 
         $repoContext = $context->getContext();
 


### PR DESCRIPTION
### 1. Why is this change necessary?
This is the solution to the problem of missing salutation in the password reset email template. 

### 2. What does this change do, exactly?
My code adds an association to the customer when resetting the password. Thanks to this, we can contact you personally in the e-mail template.

### 3. Describe each step to reproduce the issue or behaviour.
Just reset customer password and try use salutation in mail template.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-20355

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
