### PR TITLE
NEXT-13089: fix documents same dateformat

### DIFF
--- a/changelog/_unreleased/2022-03-31-fix-documents-same-dateformat.md
+++ b/changelog/_unreleased/2022-03-31-fix-documents-same-dateformat.md
@@ -1,0 +1,9 @@
+---
+title: Fix documents same dateformat
+issue: NEXT-13089
+author: Thomas Wunner
+author_email: acc@wunner-software.de
+author_github: @alpham8
+---
+# Core
+* changed behavior of delivery date locale date formatting to retrieve the right formatting from `order.language.locale` as all the other dates in company's address block on the right by keeping the inheritance chain intact

--- a/src/Core/Framework/Resources/views/documents/delivery_note.html.twig
+++ b/src/Core/Framework/Resources/views/documents/delivery_note.html.twig
@@ -47,7 +47,7 @@ The blocks from the templates in the /includes folder can be overwritten directl
 
 {% block document_side_info_contents %}
     {{ parent() }}
-    <tr><td>{% trans with {'%deliveryDate%': config.custom.deliveryDate|format_date('medium', locale=order.saleschannel.language.locale.code)} %}document.deliveryDate{% endtrans %}</td></tr>
+    <tr><td>{% trans with {'%deliveryDate%': config.custom.deliveryDate|format_date('medium', locale=order.language.locale.code)} %}document.deliveryDate{% endtrans %}</td></tr>
 {% endblock %}
 
 {% block document_line_item_table_shipping %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The delivery note pdf file has differences in date formatting at the company's sender block on the top right. So there's no reason why they should differ, because it's the same part of the delivery note.

### 2. What does this change do, exactly?
It fixes the order object tree to retrieve the right ICU locale, which is been read from the database. The other one doesn't get filled.

### 3. Describe each step to reproduce the issue or behaviour.
1st Navigate to your admin page and login.
2nd Go to orders => overview and select an specific order.
3rd Create a new delivery note. It's possible here to create as much delivery notes as wished. Please be aware that a delivery date is filled in that field. The field has to be filled for this reproduction. Then press generate.
4th Download your freshly generated delivery note and open it.
5th Verify that the delivery date is in old format, i. e. with `de-DE` locale: `31 Mar 2022` (note that it takes here the system's default internationalization)

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-13089

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
