### PR TITLE
fix: Google analytics tracking of gclid

### DIFF
--- a/changelog/_unreleased/2022-03-31-fix-google-analytics-tracking-of-gclid.md
+++ b/changelog/_unreleased/2022-03-31-fix-google-analytics-tracking-of-gclid.md
@@ -1,0 +1,11 @@
+---
+title: Fix Google analytics tracking of gclid
+issue: NEXT-18984
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Change handling of initializing the Google Tag Manager from the callback function to the corresponding JavaScript plugin to take the `gclid` into account if one navigates to a different page
+* Add blocks `component_head_analytics_gtag` and `component_head_analytics_gtag_config` to the `@Storefront/storefront/component/analytics.html.twig` template
+* Deprecate block `component_head_analytics_tag_config`

--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -1,32 +1,35 @@
 {% block component_head_analytics %}
-    {% if context.salesChannel.analytics and context.salesChannel.analytics.isActive() %}
-        {% set trackingId = context.salesChannel.analytics.getTrackingId() %}
+    {% block component_head_analytics_gtag %}
+        {% if context.salesChannel.analytics and context.salesChannel.analytics.isActive() %}
+            {% set trackingId = context.salesChannel.analytics.getTrackingId() %}
 
-        <script>
-            window.gtagActive = true;
-            window.gtagURL = 'https://www.googletagmanager.com/gtag/js?id={{ trackingId }}'
-        </script>
+            <script>
+                {% block component_head_analytics_gtag_config %}
+                    window.gtagActive = true;
+                    window.gtagURL = 'https://www.googletagmanager.com/gtag/js?id={{ trackingId }}'
+                    window.controllerName = '{{ controllerName|lower }}';
+                    window.actionName = '{{ controllerAction|lower }}';
+                    window.trackOrders = '{{ context.salesChannel.analytics.isTrackOrders() }}';
+                    window.gtagTrackingId = '{{ trackingId }}';
+                    window.dataLayer = window.dataLayer || [];
+                    window.gtagConfig = {
+                        'anonymize_ip': '{{ context.salesChannel.analytics.isAnonymizeIp() }}',
+                        'cookie_domain': 'none',
+                        'cookie_prefix': '_swag_ga',
+                    };
 
+                    function gtag() { dataLayer.push(arguments); }
+                {% endblock %}
+            </script>
 
-        <script id="sw-google-tag-manager-init" type="javascript/blocked">
-            window.controllerName = '{{ controllerName|lower }}';
-            window.actionName = '{{ controllerAction|lower }}';
-            window.dataLayer = window.dataLayer || [];
-            window.trackOrders = '{{ context.salesChannel.analytics.isTrackOrders() }}';
-
-            function gtag() { dataLayer.push(arguments); }
-
-            {% block component_head_analytics_tag_config %}
-            window.gtagCallback = function gtagCallbackFunction() {
-                gtag('js', new Date());
-
-                gtag('config', '{{ trackingId }}', {
-                    'anonymize_ip': '{{ context.salesChannel.analytics.isAnonymizeIp() }}',
-                    'cookie_domain': 'none',
-                    'cookie_prefix': '_swag_ga',
-                });
-            };
-            {% endblock %}
-        </script>
-    {% endif %}
+            {# @deprecated tag:v6.5.0 - the gtag callback and #sw-google-tag-manager-init will be removed without replacement, since the logic moved into the google analytics plugin #}
+            {% if not feature('v6.5.0.0') %}
+                <script id="sw-google-tag-manager-init" type="javascript/blocked">
+                    {% block component_head_analytics_tag_config %}
+                        window.gtagCallback = function gtagCallbackFunction() {}
+                    {% endblock %}
+                </script>
+            {% endif %}
+        {% endif %}
+    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently if the customer navigates to the next page and came through Google with a `gclid` set, this id is not saved in any way and thus the click cannot be assigned to the ad.

### 2. What does this change do, exactly?
Save the `gclid` and resubmit it for further page views.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
[NEXT-18984](https://issues.shopware.com/issues/NEXT-18984)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
