### PR TITLE
Fix typo in deprecated flag comment

### DIFF
--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
@@ -199,7 +199,7 @@ The subscription is only successful, if the /newsletter/confirm route is called 
      */
     public function subscribe(RequestDataBag $dataBag, SalesChannelContext $context, bool $validateStorefrontUrl = true): NoContentResponse
     {
-        /* @feature-deprecated (flag:FEATURE_NEXT_16200) remove the if conditio, keep its body */
+        /* @feature-deprecated (flag:FEATURE_NEXT_16200) remove the if condition, keep its body */
         if (Feature::isActive('FEATURE_NEXT_16200')) {
             $doubleOptInDomain = $this->systemConfigService->getString(
                 'core.newsletter.doubleOptInDomain',


### PR DESCRIPTION
### 1. Why is this change necessary?
To reduce confusio when reading.

### 2. What does this change do, exactly?
Add an n in a comment

### 3. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
