### PR TITLE
fix: Missing updated cookies when accepting all cookies

### DIFF
--- a/changelog/_unreleased/2022-04-04-fix-missing-updated-cookies-when-accepting-all-cookies.md
+++ b/changelog/_unreleased/2022-04-04-fix-missing-updated-cookies-when-accepting-all-cookies.md
@@ -1,0 +1,9 @@
+---
+title: Fix missing updated cookies when accepting all cookies
+issue: NEXT-19535
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Fix missing updated cookies in the JavaScript event `CookieConfiguration_Update` when accepting all cookies

--- a/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/cookie/cookie-configuration.plugin.js
@@ -197,6 +197,7 @@ export default class CookieConfiguration extends Plugin {
     _onOffCanvasOpened(callback) {
         this._registerOffCanvasEvents();
         this._setInitialState();
+        this._setInitialOffcanvasState();
         PluginManager.initializePlugins();
 
         if (typeof callback === 'function') {
@@ -214,14 +215,15 @@ export default class CookieConfiguration extends Plugin {
     }
 
     /**
-     * Get current cookie configuration and preselect coherent checkboxes
-     * Required cookies are already checked in the template
+     * Sets the `lastState` of the current cookie configuration, either passed as
+     * parameter `cookies`, otherwise it is loaded by parsing the DOM of the off
+     * canvas sidebar
      *
+     * @param {?Array} cookies
      * @private
      */
-    _setInitialState() {
-        const offCanvas = this._getOffCanvas();
-        const cookies = this._getCookies('all');
+    _setInitialState(cookies = null) {
+        cookies = cookies || this._getCookies('all');
         const activeCookies = [];
         const inactiveCookies = [];
 
@@ -238,6 +240,16 @@ export default class CookieConfiguration extends Plugin {
             active: activeCookies,
             inactive: inactiveCookies,
         };
+    }
+
+    /**
+     * Preselect coherent checkboxes in the off canvas sidebar
+     *
+     * @private
+     */
+    _setInitialOffcanvasState() {
+        const activeCookies = this.lastState.active;
+        const offCanvas = this._getOffCanvas();
 
         activeCookies.forEach(activeCookie => {
             const target = offCanvas.querySelector(`[data-cookie="${activeCookie}"]`);
@@ -436,7 +448,6 @@ export default class CookieConfiguration extends Plugin {
             return;
         }
 
-
         ElementLoadingIndicatorUtil.create(this.el);
 
         const url = window.router['frontend.cookie.offcanvas'];
@@ -475,10 +486,12 @@ export default class CookieConfiguration extends Plugin {
     /**
      * This will set and refresh all registered cookies.
      *
+     * @param {?Document} offCanvas
      * @private
      */
     _handleAcceptAll(offCanvas = null) {
         const allCookies = this._getCookies('all', offCanvas);
+        this._setInitialState(allCookies);
         const { cookiePreference } = this.options;
 
         allCookies.forEach(({ cookie, value, expiration }) => {
@@ -499,7 +512,7 @@ export default class CookieConfiguration extends Plugin {
      * Always excludes "required" cookies, since they are assumed to be set separately.
      *
      * @param type
-     * @param offCanvas
+     * @param {?Document} offCanvas
      * @returns {Array}
      * @private
      */

--- a/src/Storefront/Resources/app/storefront/test/plugin/cookie-configuration/cookie-configuration.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/cookie-configuration/cookie-configuration.plugin.test.js
@@ -49,6 +49,7 @@ describe('CookieConfiguration plugin tests', () => {
         plugin = new CookieConfiguration(container);
 
         plugin._setInitialState();
+        plugin._setInitialOffcanvasState();
     });
 
     afterEach(() => {
@@ -169,6 +170,7 @@ describe('CookieConfiguration plugin tests', () => {
         CookieStorage.setItem(optionalAndInactive[0], optionalAndInactive[0], 30);
 
         plugin._setInitialState();
+        plugin._setInitialOffcanvasState();
 
         expect(plugin.lastState.active).toEqual([...requiredAndActive, optionalAndInactive[0]]);
         expect(CookieStorage.getItem(optionalAndInactive[0])).toBeTruthy();


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, if the cookie accept all button is activated, the cookies are not correctly passed to the JavaScript event `CookieConfiguration_Update`.

### 2. What does this change do, exactly?
Set the initial state which is required to check for changed cookies. Note that the test actually checks this, but they worked since there in the `beforeEach` the method `_setInitialState` was called. Not sure if there is something in addition which should be changed.

### 3. Describe each step to reproduce the issue or behaviour.
Subscribe to the event `CookieConfiguration_Update` and see the cookies which are changed when accepting all cookies.
Furthermore another side effect of this, which we noticed was, that the `gclid` was not transmitted to Google Analytics, since the event was not fired with the correct changed cookies. This has been fixed in addition by this PR, which still is relevant since the user could navigate to another page: https://github.com/shopware/platform/pull/2416

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-19535
https://issues.shopware.com/issues/NEXT-20804

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
