### PR TITLE
NEXT-20875 - Fix product API does not output names of variants

### DIFF
--- a/changelog/_unreleased/2022-04-07-fixed-product-api-does-not-output-names-of-variants.md
+++ b/changelog/_unreleased/2022-04-07-fixed-product-api-does-not-output-names-of-variants.md
@@ -1,0 +1,9 @@
+---
+title: Fix product API does not output names of variants
+issue: NEXT-20875
+author: Huy Truong
+author_email: huy.truong@shapeandshift.dev
+author_github: huytdq94
+---
+# Core
+* Changed `loaded` function in `Shopware\Core\Content\Product\Subscriber\ProductSubscriber` class to set name of variant product if null.

--- a/src/Core/Content/Product/Subscriber/ProductSubscriber.php
+++ b/src/Core/Content/Product/Subscriber/ProductSubscriber.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Product\AbstractProductVariationBuilder;
 use Shopware\Core\Content\Product\AbstractPropertyGroupSorter;
 use Shopware\Core\Content\Product\AbstractSalesChannelProductBuilder;
 use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPriceContainer;
+use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\Product\ProductEvents;
 use Shopware\Core\Content\Product\SalesChannel\Price\AbstractProductPriceCalculator;
@@ -65,6 +66,22 @@ class ProductSubscriber implements EventSubscriberInterface
 
     public function loaded(EntityLoadedEvent $event): void
     {
+        $products = new ProductCollection($event->getEntities());
+
+        /** @var ProductEntity $product */
+        foreach ($event->getEntities() as $product) {
+            if ($product->getParentId() === null || $product->getName() !== null) {
+                continue;
+            }
+
+            $parentProduct = $products->get($product->getParentId());
+            if (!$parentProduct instanceof ProductEntity) {
+                continue;
+            }
+
+            $product->setName($parentProduct->getName());
+        }
+
         $this->entityLoaded($event->getEntities(), $event->getContext());
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The /api/product endpoint does not return names of variants if they are the same as the parents name.
### 2. What does this change do, exactly?

Full output of the variant data including the data inherited from the parent
### 3. Describe each step to reproduce the issue or behaviour.

Setup a product with a variant, do not adjust the name of the variant. Query the products at /api/product use Header sw-inheritance 1
### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-20875

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
