### PR TITLE
Typed property Shopware\\Core\\Framework\\Script\\Api\\StoreApiCacheK…

### DIFF
--- a/src/Core/Framework/Script/Api/StoreApiCacheKeyHook.php
+++ b/src/Core/Framework/Script/Api/StoreApiCacheKeyHook.php
@@ -30,7 +30,7 @@ class StoreApiCacheKeyHook extends OptionalFunctionHook implements SalesChannelC
 
     private string $name;
 
-    private ?string $cacheKey;
+    private ?string $cacheKey = '';
 
     public function __construct(string $name, array $request, array $query, SalesChannelContext $salesChannelContext)
     {


### PR DESCRIPTION
…eyHook::$cacheKey must not be accessed before initialization

I created a simple local app with an App Script `Resources/scripts/store-api-swag-example/hello.twig` to test out the custom endpoint behaviour. It is run in a Shopware 6.4.10.0 instance running on PHP 8.0. The App Script has the following contents:
```html
{% block response %}
    {% set response = services.response.json({ 'foo': 'bar' }) %}
    {% do hook.setResponse(response) %}
{% endblock %}
```

Note that I'm not implementing the `cache_key` block (aka function) because this is marked as *optional* in the following guide: https://developer.shopware.com/docs/resources/references/app-reference/script-reference/script-hooks-reference#custom-api-endpoint

Calling upon this endpoint triggers the following error: `Typed property Shopware\\Core\\Framework\\Script\\Api\\StoreApiCacheKeyHook::$cacheKey must not be accessed before initialization`. The error itself is actually caused by some incorrect PHP behaviour where typed properties marked as optional (in this case, `?string $cacheKey`) actually need to be initialized and can't be null - this issue at least occurs in my PHP 8.0 environment.

There are various possible fixes:

1) Require the App Script to implement the `cache_key` anyway, even though it is an empty string. But this would complicate things.

2) Use the fix in this PR to simply set the `cache_key` to be an empty string by default. However, this also means that the optional marker `?` makes less sense. Having the `cache_key` as an empty string (instead of `null`) works fine for me. It is picked up by other application parts correctly.

3) Upgrade to PHP 8.1 because things are fixed there.

To me, option 2 seems to be most solid.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
