### PR TITLE
fix(sw-media-upload-v2): prevent isDragActive when disabled

### DIFF
--- a/changelog/_unreleased/2022-04-13-20220413-prevent-isdragactive-on-disabled-sw-media-upload-v2.md
+++ b/changelog/_unreleased/2022-04-13-20220413-prevent-isdragactive-on-disabled-sw-media-upload-v2.md
@@ -1,6 +1,6 @@
 ---
 title: 20220413-prevent-isDragActive-on-disabled-sw-media-upload-v2
-issue: -
+issue: NEXT-21175
 author: Rafael Kraut
 author_email: rk@vi-arise.com
 author_github: RafaelKr

--- a/changelog/_unreleased/2022-04-13-20220413-prevent-isdragactive-on-disabled-sw-media-upload-v2.md
+++ b/changelog/_unreleased/2022-04-13-20220413-prevent-isdragactive-on-disabled-sw-media-upload-v2.md
@@ -1,0 +1,9 @@
+---
+title: 20220413-prevent-isDragActive-on-disabled-sw-media-upload-v2
+issue: -
+author: Rafael Kraut
+author_email: rk@vi-arise.com
+author_github: RafaelKr
+---
+# Administration
+- Prevent isDragActive on disabled sw-media-upload-v2

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
@@ -253,6 +253,10 @@ Component.register('sw-media-upload-v2', {
         },
 
         onDragEnter() {
+            if (this.disabled) {
+                return;
+            }
+
             this.isDragActive = true;
         },
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When dragging an image into the Shopware CMS and there is a `sw-media-upload-v2` which is disabled it still will get the blue highlighting.


### 2. What does this change do, exactly?
This highlight prevents setting `this.isDragActive` to true when the component is disabled.

MISSING TEST: I currently don't know how to write a good test for this and don't have the time to investigate right now.


### 3. Describe each step to reproduce the issue or behaviour.
- Create a role without `category.editor` permission
- Create a user and assign that role
- Sign in with that user
- Go to a category
- Scroll to Section "Menu Settings" so the "Display image" is visible
- Drag an image into the window


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
