### PR TITLE
NEXT-21181 - implement ProductCrossSellingCriteriaLoadEvent

### DIFF
--- a/changelog/_unreleased/2022-04-19-add-crossselling-criteria-load-event.md
+++ b/changelog/_unreleased/2022-04-19-add-crossselling-criteria-load-event.md
@@ -1,0 +1,9 @@
+---
+title: Implement Criteria Load Event for CrossSellings  
+issue: NEXT-21181  
+author: Björn Herzke  
+author_email: bjoern.herzke@brandung.de  
+author_github: wrongspot  
+---
+# Core
+* Added `Shopware\Core\Content\Product\Events\ProductCrossSellingCriteriaLoadEvent`, which allows to manipulate criteria object on crossSellings loads.

--- a/src/Core/Content/Product/Events/ProductCrossSellingCriteriaLoadEvent.php
+++ b/src/Core/Content/Product/Events/ProductCrossSellingCriteriaLoadEvent.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Events;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class ProductCrossSellingCriteriaLoadEvent extends Event implements ShopwareSalesChannelEvent
+{
+    protected Criteria $criteria;
+
+    protected SalesChannelContext $salesChannelContext;
+
+    public function __construct(Criteria $criteria, SalesChannelContext $salesChannelContext)
+    {
+        $this->criteria = $criteria;
+        $this->salesChannelContext = $salesChannelContext;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
@@ -7,6 +7,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSell
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingEntity;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\Events\ProductCrossSellingCriteriaLoadEvent;
 use Shopware\Core\Content\Product\Events\ProductCrossSellingIdsCriteriaEvent;
 use Shopware\Core\Content\Product\Events\ProductCrossSellingsLoadedEvent;
 use Shopware\Core\Content\Product\Events\ProductCrossSellingStreamCriteriaEvent;
@@ -21,7 +22,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\Annotation\Entity;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -123,6 +123,10 @@ class ProductCrossSellingRoute extends AbstractProductCrossSellingRoute
             ->addFilter(new EqualsFilter('product.id', $productId))
             ->addFilter(new EqualsFilter('active', 1))
             ->addSorting(new FieldSorting('position', FieldSorting::ASCENDING));
+
+        $this->eventDispatcher->dispatch(
+            new ProductCrossSellingCriteriaLoadEvent($criteria, $context)
+        );
 
         /** @var ProductCrossSellingCollection $crossSellings */
         $crossSellings = $this->crossSellingRepository


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
As a developer i don't have the possibility to add filters or associations on crossSelling load.

### 2. What does this change do, exactly?
it adds an event which allows you to customize the criteria object

### 3. Describe each step to reproduce the issue or behaviour.
- Create a CrossSelling Entity Extension
- Try to Filter CrossSelling Elements by Extension Values 
 
### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-21181

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
