### PR TITLE
Fix promotion custom fields

### DIFF
--- a/changelog/_unreleased/2022-04-19-fix-promotion-custom-fields.md
+++ b/changelog/_unreleased/2022-04-19-fix-promotion-custom-fields.md
@@ -1,0 +1,9 @@
+---
+title: Fix promotion custom fields
+issue: NEXT-21236
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `createdComponent` function in `sw-promotion-v2-detail-base` component to load custom fields before returning from the function in case of individual code type.

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/index.js
@@ -88,6 +88,8 @@ Component.register('sw-promotion-v2-detail-base', {
                 return;
             }
 
+            this.loadCustomFieldSets();
+
             if (this.promotion.useCodes && this.promotion.useIndividualCodes) {
                 this.setNewCodeType(this.CODE_TYPES.INDIVIDUAL);
                 this.initialSort();
@@ -96,7 +98,6 @@ Component.register('sw-promotion-v2-detail-base', {
             }
 
             this.setNewCodeType(this.promotion.useCodes ? this.CODE_TYPES.FIXED : this.CODE_TYPES.NONE);
-            this.loadCustomFieldSets();
         },
 
         initialSort() {


### PR DESCRIPTION
### 1. Why is this change necessary?
Because using custom fields with individual codes is not working.

### 2. What does this change do, exactly?
Loading custom fields before returning from the function in case of individual codes.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a custom field set with a custom field for promotions.
2. Create a promotion with individual codes.
3. Reopen the promotion.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-21236

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
