### PR TITLE
Remove warning about v6_5 folder missing

### DIFF
--- a/changelog/_unreleased/2022-04-21-remove-warning-for-6-5-not-yet-released-migrations.md
+++ b/changelog/_unreleased/2022-04-21-remove-warning-for-6-5-not-yet-released-migrations.md
@@ -1,0 +1,8 @@
+---
+title: Remove warning for loading not yet released Shopware 6.5 migrations 
+author: Joshua Behrens
+author_email: code@joshua-behren.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Added existence check before loading Shopware 6.5 migration source to prevent a migration loading warning

--- a/src/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPass.php
+++ b/src/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPass.php
@@ -22,7 +22,11 @@ class StorefrontMigrationReplacementCompilerPass implements CompilerPassInterfac
         $migrationSourceV4->addMethodCall('addDirectory', [$migrationPath . '/V6_4', 'Shopware\Storefront\Migration\V6_4']);
         $migrationSourceV3->addMethodCall('addReplacementPattern', ['#^(Shopware\\\\Storefront\\\\Migration\\\\)V6_4\\\\([^\\\\]*)$#', '$1$2']);
 
-        $migrationSourceV5 = $container->getDefinition(MigrationSource::class . '.core.V6_5');
-        $migrationSourceV5->addMethodCall('addDirectory', [$migrationPath . '/V6_5', 'Shopware\Storefront\Migration\V6_5']);
+        $migrationPathV5 = $migrationPath . '/V6_5';
+        
+        if (\is_dir($migrationPathV5)) {
+            $migrationSourceV5 = $container->getDefinition(MigrationSource::class . '.core.V6_5');
+            $migrationSourceV5->addMethodCall('addDirectory', [$migrationPathV5, 'Shopware\Storefront\Migration\V6_5']);
+        }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The migration system prepares itself for v6_5 migrations. If this directory does not exist, you will find yourself a warning that it does not exist. Well, it is super clear that it does not exist. It is not shipped. This directory is only introduced when you update shopware in your vendor folder. With this I assume a cache clear as well. So the container is rebuild and the new path is then added to the migration system. So we can just check for the folder and get the warning removed.

### 2. What does this change do, exactly?

Checks for path existence before adding it to the migration paths.

### 3. Describe each step to reproduce the issue or behaviour.

1. Run shopware migrations

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
