### PR TITLE
NEXT-20467 - fix(theme-manager-detail): correctly handle inheritance

### DIFF
--- a/changelog/_unreleased/2022-04-28-fix-theme-config-inheritance-toggle.md
+++ b/changelog/_unreleased/2022-04-28-fix-theme-config-inheritance-toggle.md
@@ -1,0 +1,12 @@
+---
+title: Fix Theme Config inheritance toggle
+issue: NEXT-20467
+author: Rafael Kraut
+author_email: rk@vi-arise.com
+author_github: RafaelKr
+---
+# Core
+* Method `getThemeConfiguration` of `ThemeService` now returns the correct `baseThemeFields` instead of the same fields which are already in `currentFields`
+___
+# Administration
+* The config inheritance toggle in the theme configuration was always enabled for all falsy values.  This is now solved by determining its state based on a dedicated `isInherited` property.

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-inherit-wrapper/index.js
@@ -15,6 +15,7 @@ const { Component } = Shopware;
  *     :customInheritationCheckFunction="function(value) => {return true;}"
  *     :customRestoreFunction="function(value) => {return null;}"
  *     :customRemoveInheritanceFunction="function(value) => {return null;}"
+ *     :customContext="{ entity }"
  *     :disabled="false"
  *     label="Your label"
  *     :isAssociation="false"
@@ -102,6 +103,12 @@ Component.register('sw-inherit-wrapper', {
             default: null,
         },
 
+        customContext: {
+            type: Object,
+            required: false,
+            default: undefined,
+        },
+
         helpText: {
             type: String,
             required: false,
@@ -149,7 +156,7 @@ Component.register('sw-inherit-wrapper', {
 
             // if customInheritationCheckFunction exists
             if (typeof this.customInheritationCheckFunction === 'function') {
-                return this.customInheritationCheckFunction(this.value);
+                return this.customInheritationCheckFunction(this.value, this.customContext);
             }
 
             // if association
@@ -184,7 +191,7 @@ Component.register('sw-inherit-wrapper', {
 
             // if customRestoreInheritanceFunction exists
             if (typeof this.customRestoreInheritanceFunction === 'function') {
-                this.updateValue(this.customRestoreInheritanceFunction(this.value), 'restore');
+                this.updateValue(this.customRestoreInheritanceFunction(this.value, this.customContext), 'restore');
                 return;
             }
 
@@ -206,7 +213,7 @@ Component.register('sw-inherit-wrapper', {
         removeInheritance(newValue = this.currentValue) {
             // if customRemoveInheritanceFunction exists
             if (typeof this.customRemoveInheritanceFunction === 'function') {
-                this.updateValue(this.customRemoveInheritanceFunction(newValue, this.value), 'remove');
+                this.updateValue(this.customRemoveInheritanceFunction(newValue, this.value, this.customContext), 'remove');
                 return;
             }
 

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/index.js
@@ -172,8 +172,12 @@ Component.register('sw-theme-manager-detail', {
             });
         },
 
-        checkInheritance(value) {
-            return !value;
+        checkInheritance(value, { fieldName }) {
+            return this.currentThemeConfig[fieldName].isInherited;
+        },
+
+        handleInheritanceInput(value, fieldName) {
+            this.currentThemeConfig[fieldName].isInherited = value === null;
         },
 
         getThemeConfig() {

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -257,6 +257,8 @@
                                                                                 :inherited-value="baseThemeConfig[fieldName].value"
                                                                                 :label="!field.label ? '' : field.label"
                                                                                 :customInheritationCheckFunction="checkInheritance"
+                                                                                :customContext="{ fieldName }"
+                                                                                @input="handleInheritanceInput($event, fieldName)"
                                                                         >
                                                                             <template #content="{ currentValue, updateCurrentValue, isInherited }">
                                                                                 <sw-field
@@ -282,6 +284,8 @@
                                                                                 :inherited-value="baseThemeConfig[fieldName].value"
                                                                                 :label="!field.label ? '' : field.label"
                                                                                 :customInheritationCheckFunction="checkInheritance"
+                                                                                :customContext="{ fieldName }"
+                                                                                @input="handleInheritanceInput($event, fieldName)"
                                                                         >
                                                                             <template #content="{ currentValue, updateCurrentValue, isInherited }">
                                                                                 <sw-field
@@ -310,6 +314,9 @@
                                                                                 :has-parent="theme.baseConfig?.fields?.[fieldName] == null"
                                                                                 :inherited-value="baseThemeConfig[fieldName].value"
                                                                                 :label="!field.label ? '' : field.label"
+                                                                                :customInheritationCheckFunction="checkInheritance"
+                                                                                :customContext="{ fieldName }"
+                                                                                @input="handleInheritanceInput($event, fieldName)"
                                                                         >
                                                                                 <template #content="{ currentValue, updateCurrentValue, isInherited, removeInheritance }">
                                                                                     <sw-media-upload-v2
@@ -337,6 +344,8 @@
                                                                             :inherited-value="baseThemeConfig[fieldName].value"
                                                                             :label="!field.label ? '' : field.label"
                                                                             :customInheritationCheckFunction="checkInheritance"
+                                                                            :customContext="{ fieldName }"
+                                                                            @input="handleInheritanceInput($event, fieldName)"
                                                                         >
                                                                             <template #content="{ currentValue, updateCurrentValue, isInherited }">
                                                                                 <sw-field
@@ -361,6 +370,8 @@
                                                                                 :inherited-value="baseThemeConfig[fieldName].value"
                                                                                 :label="!field.label ? '' : field.label"
                                                                                 :customInheritationCheckFunction="checkInheritance"
+                                                                                :customContext="{ fieldName }"
+                                                                                @input="handleInheritanceInput($event, fieldName)"
                                                                         >
                                                                             <template #content="{ currentValue, updateCurrentValue, isInherited }">
                                                                                 <sw-form-field-renderer

--- a/src/Storefront/Theme/ThemeService.php
+++ b/src/Storefront/Theme/ThemeService.php
@@ -249,7 +249,10 @@ class ThemeService
         $themeConfig['fields'] = $configFields;
 
         foreach ($themeConfig['fields'] as $field => $item) {
-            if ($this->fieldIsInherited($field, $configuredTheme)) {
+            $isInherited = $this->fieldIsInherited($field, $configuredTheme);
+            $themeConfig['currentFields'][$field]['isInherited'] = $isInherited;
+
+            if ($isInherited) {
                 $themeConfig['currentFields'][$field]['value'] = null;
             } elseif (\array_key_exists('value', $item)) {
                 $themeConfig['currentFields'][$field]['value'] = $item['value'];
@@ -257,10 +260,13 @@ class ThemeService
         }
 
         foreach ($themeConfig['fields'] as $field => $item) {
-            if ($this->fieldIsInherited($field, $baseThemeConfig)) {
+            $isInherited = $this->fieldIsInherited($field, $baseThemeConfig);
+            $themeConfig['baseThemeFields'][$field]['isInherited'] = $isInherited;
+
+            if ($isInherited) {
                 $themeConfig['baseThemeFields'][$field]['value'] = null;
             } elseif (\array_key_exists('value', $item)) {
-                $themeConfig['baseThemeFields'][$field]['value'] = $item['value'];
+                $themeConfig['baseThemeFields'][$field]['value'] = $baseThemeConfig['fields'][$field]['value'];
             }
         }
 


### PR DESCRIPTION
**I'd like to get some feedback from the Shopware developers if this is the right approach. If it is tests should be added for this. Would appreciate if the Shopware team could add them due to missing time currently.**

We now don't treat every falsy value as inherited anymore. We check if the value is intended to be inherited from the parent theme instead.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
https://issues.shopware.com/issues/NEXT-20467

### 2. What does this change do, exactly?
We now don't treat every falsy value as inherited anymore. We check if the value is intended to be inherited from the parent theme instead.

It also fixes that `baseThemeFields` really contains the values from base theme, not the ones from the current theme.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a theme (SwagParentTheme) and add a media and/or integer theme configuration field with default values. Examples:
  - header-bg-img: app/storefront/dist/assets/background/header-bg.png
  - header-margin: 40px
- Create a child theme (SwagChildTheme) with
```
"configInheritance": [
  "@Storefront",
  "@SwagParentTheme"
]
```
- Assign the child theme to a storefront
- Edit the configuration as follows:
  - header-bg-img: Remove the file
  - header-margin: Set to `0`

Saving will now store the correct values for the child theme configuration to the database. But when the configuration page reloads it shows both fields as inherited, so after the next save the values will get removed from the database again.
This commit fixes this behavior.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-20467

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
