### PR TITLE
Prevent assignment of sales channel context to customer if permissions are set

### DIFF
--- a/changelog/_unreleased/2022-04-08-prevent-assignment-of-sales-channel-context-to-customer-if-permissions-are-set.md
+++ b/changelog/_unreleased/2022-04-08-prevent-assignment-of-sales-channel-context-to-customer-if-permissions-are-set.md
@@ -1,0 +1,9 @@
+---
+title: Prevent assignment of sales channel context to customer if permissions are set
+issue:
+author: Nils Evers
+author_email: evers.nils@gmail.com
+author_github: NilsEvers
+---
+# Core
+* Changed `\Shopware\Core\System\SalesChannel\SalesChannel\ContextSwitchRoute::switchContext` to only assign the `SalesChannelContext` to a customer if no permissions are set on the context. This prevents customers from being able to obtain permissions from an API call. 

--- a/src/Core/System/SalesChannel/SalesChannel/ContextSwitchRoute.php
+++ b/src/Core/System/SalesChannel/SalesChannel/ContextSwitchRoute.php
@@ -157,7 +157,12 @@ class ContextSwitchRoute extends AbstractContextSwitchRoute
         $this->validator->validate($parameters, $definition);
 
         $customer = $context->getCustomer();
-        $this->contextPersister->save($context->getToken(), $parameters, $context->getSalesChannel()->getId(), $customer ? $customer->getId() : null);
+        $this->contextPersister->save(
+            $context->getToken(),
+            $parameters,
+            $context->getSalesChannel()->getId(),
+            $customer && empty($context->getPermissions()) ? $customer->getId() : null
+        );
 
         $event = new SalesChannelContextSwitchEvent($context, $data);
         $this->eventDispatcher->dispatch($event);


### PR DESCRIPTION
### 1. Why is this change necessary?
When set context is called, the current context is merged with the context that is associated to the customer. This leads to several problems.

#### Scenario 1:  Leak of permissions
- Imagine we have two different applications both using the API with different permissions.
- App 1 creates a context with permission `allowPriceOverwrites`  for a customer.
- App 2 creates a context for the same customer with the permission `skipProductStockCalculation` .
- The context will now contain both permissions.
- In this scenario app 2 has no way of influencing the behaviour. This makes the api really unreliable and can even lead to security issues.
- The only way to get around the problem is if app 1 calls `switch customer`  again so that the context isn"t assigned to the customer anymore. But  again, app 2 has no influence on how app 1 uses the api.


#### Scenario 2: Customers get logged out and lose their basket when set context is called
- A customer is logged in and has some items in the cart.
- Meanwhile an employee is preparing a backend order for that same customer.
- as soon as he selects the customer for the order, the customer is logged out immediately and his basket is removed from the database, so it can not be restored on another device.
- The same issues can occur if two apps are working with the same customer, which again makes the api really unreliable.

### 2. What does this change do, exactly?
- Do not assign the context to the customer if it contains any permissions. This ultimately prevents the merge.

### 3. Possible other solutions
1. Add a flag to disable the assignment to the customer.
2. Extend the switch customer call to allow to set the context payload, like `billingAddressId`, `paymentMethodId`, etc. This means that set context no longer needs to be used by api calls, so every client retains control over his own context. 


### 4. Checklist
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
