### PR TITLE
Prevent obsolete database operation in validators

### DIFF
--- a/src/Core/Checkout/Promotion/Validator/PromotionValidator.php
+++ b/src/Core/Checkout/Promotion/Validator/PromotionValidator.php
@@ -154,21 +154,29 @@ class PromotionValidator implements EventSubscriberInterface
         // the database. all private getters should only access the local in-memory list
         // to avoid additional database queries.
 
-        $promotionQuery = $this->connection->executeQuery(
-            'SELECT * FROM `promotion` WHERE `id` IN (:ids)',
-            ['ids' => $promotionIds],
-            ['ids' => Connection::PARAM_STR_ARRAY]
-        );
+        if ($promotionIds === []) {
+            $this->databasePromotions = [];
+        } else {
+            $promotionQuery = $this->connection->executeQuery(
+                'SELECT * FROM `promotion` WHERE `id` IN (:ids)',
+                ['ids' => $promotionIds],
+                ['ids' => Connection::PARAM_STR_ARRAY]
+            );
 
-        $this->databasePromotions = $promotionQuery->fetchAll();
+            $this->databasePromotions = $promotionQuery->fetchAll();
+        }
 
-        $discountQuery = $this->connection->executeQuery(
-            'SELECT * FROM `promotion_discount` WHERE `id` IN (:ids)',
-            ['ids' => $discountIds],
-            ['ids' => Connection::PARAM_STR_ARRAY]
-        );
+        if ($discountIds === []) {
+            $this->databaseDiscounts = [];
+        } else {
+            $discountQuery = $this->connection->executeQuery(
+                'SELECT * FROM `promotion_discount` WHERE `id` IN (:ids)',
+                ['ids' => $discountIds],
+                ['ids' => Connection::PARAM_STR_ARRAY]
+            );
 
-        $this->databaseDiscounts = $discountQuery->fetchAll();
+            $this->databaseDiscounts = $discountQuery->fetchAll();
+        }
     }
 
     /**

--- a/src/Core/Content/Product/Cart/ProductLineItemCommandValidator.php
+++ b/src/Core/Content/Product/Cart/ProductLineItemCommandValidator.php
@@ -113,6 +113,10 @@ class ProductLineItemCommandValidator implements EventSubscriberInterface
 
         $ids = array_values(array_filter($ids));
 
+        if ($ids === []) {
+            return [];
+        }
+
         $products = $this->connection->fetchAll(
             'SELECT LOWER(HEX(id)) as id FROM order_line_item WHERE id IN (:ids) AND type = \'product\'',
             ['ids' => $ids],


### PR DESCRIPTION
### 1. Why is this change necessary?

These event listeners are subscribed to `\Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\PreWriteValidationEvent` and will filter the events data for commands they want to act upon. So far, so good. But even when it is perfectly clear that there is nothing to act upon, these listeners will perform SELECT operations against the database. These queries will always return an empty result, so we can skip the queries altogether.

### 2. What does this change do, exactly?

If it is evident that the queries must return an empty result (because they are filtered against an empty list of primary keys), the query is skipped and an empty result is assumed.

### 3. Describe each step to reproduce the issue or behaviour.

1. So any write operation using the DAL.
2. Take a look at the performed database queries in the Symfony Profiler.
3. Notice a shitload of these queries:

```mysql
SELECT LOWER(HEX(id)) as id FROM order_line_item WHERE id IN (:ids) AND type = 'product'
```

```mysql
SELECT * FROM `promotion` WHERE `id` IN (:ids)
```

```mysql
SELECT * FROM `promotion_discount` WHERE `id` IN (:ids)
```

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
