### PR TITLE
fix: Remove rich snippet availability from price offers

### DIFF
--- a/changelog/_unreleased/2022-04-24-removed-rich-snippet-availability-from-price-offers.md
+++ b/changelog/_unreleased/2022-04-24-removed-rich-snippet-availability-from-price-offers.md
@@ -1,0 +1,8 @@
+---
+title: Removed rich snippet availability from price offers
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Removed possibly incorrect fixed `availability` from price offers if multiple prices are present, as the different prices are collected into an `AggregateOffer` which already has the correct `availability` defined

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
@@ -37,7 +37,6 @@
                                                 <th scope="row" class="product-block-prices-cell product-block-prices-cell-thin">
                                                     <meta itemprop="priceCurrency" content="{{ page.header.activeCurrency.translated.shortName }}" />
                                                     <meta itemprop="price" content="{{ price.unitPrice }}" />
-                                                    <link itemprop="availability" href="https://schema.org/InStock" />
 
                                                     {% if loop.last %}
                                                         {{ "detail.priceDataInfoFrom"|trans|sw_sanitize }}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-price.html.twig
@@ -37,7 +37,6 @@
                                                     <th scope="row" class="product-block-prices-cell product-block-prices-cell-thin">
                                                         <meta itemprop="priceCurrency" content="{{ page.header.activeCurrency.translated.shortName }}" />
                                                         <meta itemprop="price" content="{{ price.unitPrice }}" />
-                                                        <link itemprop="availability" href="https://schema.org/InStock" />
 
                                                         {% if loop.last %}
                                                             {{ "detail.priceDataInfoFrom"|trans|sw_sanitize }}


### PR DESCRIPTION
### 1. Why is this change necessary?
When more than one price is available and the different prices are collected into an AggregateOffer for each offer there is an additional, fixed `availability` set. This is one the one side possibly not correct, but also not necessary as the availability is defined in the parent offer.

### 2. What does this change do, exactly?
Remove the property.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
