### PR TITLE
Support normalizer in HappyPathValidator

### DIFF
--- a/changelog/_unreleased/2022-04-25-added-normalizer-support-for-happy-path-validator.md
+++ b/changelog/_unreleased/2022-04-25-added-normalizer-support-for-happy-path-validator.md
@@ -1,0 +1,9 @@
+---
+title: Added normalizer support for HappyPathValidator
+issue: - 
+author: Pascal Jonasson
+author_email: github@jonasson.dev
+author_github: @pajonas
+---
+# Core
+* Added normalizer method `\Shopware\Core\Framework\Validation\HappyPathValidator::normalizeValueIfRequired()` in `HappyPathValidator` to correctly quick-check against normalized values.

--- a/src/Core/Framework/Test/Validation/HappyPathValidatorTest.php
+++ b/src/Core/Framework/Test/Validation/HappyPathValidatorTest.php
@@ -82,13 +82,13 @@ class HappyPathValidatorTest extends TestCase
         yield 'check not-blank against whitespace value without normalizer' => [
             new NotBlank(),
             ' ',
-            false
+            true
         ];
 
         yield 'check not-blank against whitespace value with trim-normalizer' => [
             new NotBlank(['normalizer' => 'trim']),
             ' ',
-            true
+            false
         ];
     }
 }

--- a/src/Core/Framework/Test/Validation/HappyPathValidatorTest.php
+++ b/src/Core/Framework/Test/Validation/HappyPathValidatorTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Test\Validation;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Validation\HappyPathValidator;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\ConstraintViolationInterface;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -15,7 +16,7 @@ class HappyPathValidatorTest extends TestCase
     /**
      * @dataProvider constraintDataProvider
      */
-    public function testRangeFilter(Constraint $constraint, $value, bool $isValid): void
+    public function testValidator(Constraint $constraint, $value, bool $isValid): void
     {
         $inner = $this->createMock(ValidatorInterface::class);
 
@@ -76,6 +77,18 @@ class HappyPathValidatorTest extends TestCase
             new Range(['min' => 11, 'max' => 20]),
             21,
             false,
+        ];
+
+        yield 'check not-blank against whitespace value without normalizer' => [
+            new NotBlank(),
+            ' ',
+            false
+        ];
+
+        yield 'check not-blank against whitespace value with trim-normalizer' => [
+            new NotBlank(['normalizer' => 'trim']),
+            ' ',
+            true
         ];
     }
 }

--- a/src/Core/Framework/Validation/HappyPathValidator.php
+++ b/src/Core/Framework/Validation/HappyPathValidator.php
@@ -113,10 +113,10 @@ class HappyPathValidator implements ValidatorInterface
     private function normalizeValueIfRequired($value, $constraint)
     {
         if(
-            $constraint instanceof Constraint &&
-            \property_exists($constraint, 'normalizer') &&
-            !empty($constraint->normalizer))
-        {
+            $constraint instanceof Constraint
+            && \property_exists($constraint, 'normalizer')
+            && !empty($constraint->normalizer)
+        ) {
             $normalizer = $constraint->normalizer;
 
             if (\is_callable($normalizer)) {

--- a/src/Core/Framework/Validation/HappyPathValidator.php
+++ b/src/Core/Framework/Validation/HappyPathValidator.php
@@ -110,8 +110,35 @@ class HappyPathValidator implements ValidatorInterface
      * @param string|int|float|bool|array|object|callable|resource|null $value
      * @param Constraint|Constraint[]|null                              $constraint
      */
+    private function normalizeValueIfRequired($value, $constraint)
+    {
+        if(
+            $constraint instanceof Constraint &&
+            \property_exists($constraint, 'normalizer') &&
+            !empty($constraint->normalizer))
+        {
+            $normalizer = $constraint->normalizer;
+
+            if (\is_callable($normalizer)) {
+                $value = $normalizer($value);
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param string|int|float|bool|array|object|callable|resource|null $value
+     * @param Constraint|Constraint[]|null                              $constraint
+     */
     private function validateConstraint($value, $constraint): bool
     {
+        // apply defined normalizers to check $value from constraint if defined
+        $value = $this->normalizeValueIfRequired(
+            $value,
+            $constraint
+        );
+
         switch (true) {
             case $constraint instanceof Uuid:
                 if ($value !== null && \is_string($value) && !\Shopware\Core\Framework\Uuid\Uuid::isValid($value)) {


### PR DESCRIPTION
## 1. Why is this change necessary?
It's currently not possible to normalize a value for the validator, because the HappyPathValidator thinks a further check via the real validator is not required. 

Explicit use case:
- want to check if a value is NotBlank and we do not consider a whitespace as a valid value
- use the NotBlank-Constraints normalizer-option with trim() function to ensure whitespaces are not considered a valid value
- the HappyPathValidator makes a quick check and decides it's not necessary to use the real validator (because it did not call the normalize callable, therefore the value was not empty)


## 2. What does this change do, exactly?
This change adds a normalizer call to normalize the value while still keeping the HappyPathValidator performance improvements. 

Technically:
If the normalizer-property exist within the constraint, the normalizer will be called and the returned value will be used for the HappyPathValidator checking.

## 3. Describe each step to reproduce the issue or behaviour.
Define a variable with only whitespace value and let it validate against a NotBlank-Constraint with "trim" as normalizer.

```php 
$value = '  ';
$validationErrors = $this->validator->validate(
    $value,
    new NotBlank(['normalizer' => 'trim'])
);
	
dump($validationErrors);
```

There will be no validation errors thus there should be.


## 4. Please link to the relevant issues (if any).
None


## 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a changelog file with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
