### PR TITLE
removed unnecessary translation and sanitize from the children label

### DIFF
--- a/changelog/_unreleased/2022-04-26-take-childlineitem-label-as-it-is.md
+++ b/changelog/_unreleased/2022-04-26-take-childlineitem-label-as-it-is.md
@@ -1,0 +1,11 @@
+---
+title: Take childLineItem label as it is
+issue: 
+author: Dominik Mank
+author_email: d.mank@web-fabric.de
+author_github: dominikmank
+---
+
+# Storefront
+* removed unnecessary sanitize from the children label
+

--- a/src/Storefront/Resources/views/storefront/page/checkout/checkout-aside-item-children.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/checkout-aside-item-children.html.twig
@@ -73,9 +73,7 @@
                                             {% block page_checkout_aside_item_child_headline_label %}
                                                 <div class="cart-aside-item-child-label-bullet">
                                                     <div class="swag-fade-container swag-fade-container-shrinked">
-                                                        {% set label = nestedLineItem.label|trans|sw_sanitize %}
-                                                        {% set label = label !== '' ? label : nestedLineItem.label %}
-                                                        {{ label }}
+                                                        {{ nestedLineItem.label|trans }}
                                                     </div>
                                                     <a href="#" class="swag-fading-link-more swag-fade-link-hidden">{{ 'checkout.lineItemShowMore'|trans|sw_sanitize }}</a>
                                                     <a href="#" class="swag-fading-link-less swag-fade-link-hidden">{{ 'checkout.lineItemShowLess'|trans|sw_sanitize }}</a>

--- a/src/Storefront/Resources/views/storefront/page/checkout/checkout-item-children.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/checkout-item-children.html.twig
@@ -73,9 +73,7 @@
                                             {% block page_checkout_item_child_headline_label %}
                                                 <div class="cart-item-child-label-bullet">
                                                     <div class="swag-fade-container swag-fade-container-shrinked">
-                                                        {% set label = nestedLineItem.label|trans|sw_sanitize %}
-                                                        {% set label = label !== '' ? label : nestedLineItem.label %}
-                                                        {{ label }}
+                                                        {{ nestedLineItem.label|trans }}
                                                     </div>
                                                     <a href="#" class="swag-fading-link-more swag-fade-link-hidden">{{ 'checkout.lineItemShowMore'|trans|sw_sanitize }}</a>
                                                     <a href="#" class="swag-fading-link-less swag-fade-link-hidden">{{ 'checkout.lineItemShowLess'|trans|sw_sanitize }}</a>

--- a/src/Storefront/Test/Framework/Twig/LineItemLabelTranslateTest.php
+++ b/src/Storefront/Test/Framework/Twig/LineItemLabelTranslateTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Shopware\Storefront\Test\Framework\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+class LineItemLabelTranslateTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    /**
+     * @dataProvider labelRenderingDataProvider
+     */
+    public function testLabelRendering(string $label, string $expected)
+    {
+        $template = <<<TWIG
+{% set label = item.label|trans({}, 'storefront') %}
+{{ label }}
+TWIG;
+
+        $context = Context::createDefaultContext();
+
+        $item = new LineItem('test', 'test');
+        $item->setLabel($label);
+
+        $result = $this->getContainer()->get(StringTemplateRenderer::class)
+            ->render($template, ['item' => $item], $context);
+
+        static::assertEquals($expected, $result);
+    }
+
+    public function labelRenderingDataProvider(): \Generator
+    {
+        yield 'Test normal label' => ['Some cool product name', 'Some cool product name'];
+        yield 'Test with special chars' => ['Some cool ! % & product name', 'Some cool ! % &amp; product name'];
+        yield 'Test existing snippet' => ['general.homeLink', 'Home'];
+        yield 'Test none existing snippet' => ['general.homeLink-foo', 'general.homeLink-foo'];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
currently child items with special characters are getting sanitized, which leads to wrong output like "Milk & tea" will be displayed as "Milk &amp; tea". Also it should behave like the default line item view.

### 2. What does this change do, exactly?
It changes the logic to the same behaviour as for line items without children

### 3. Describe each step to reproduce the issue or behaviour.
create a product with a child (i think it's not possible in shopware yet with default installation) which name has special characters. 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
