### PR TITLE
fix: Only consider active users if more than one user was found

### DIFF
--- a/changelog/_unreleased/2022-04-26-no-login-error-if-more-than-one-inactive-customer-is-found.md
+++ b/changelog/_unreleased/2022-04-26-no-login-error-if-more-than-one-inactive-customer-is-found.md
@@ -1,0 +1,9 @@
+---
+title: No login error if more than one inactive customer is found
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed login logic to only consider active customers in the check if more than one customer was found

--- a/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
@@ -185,8 +185,10 @@ class LoginRoute extends AbstractLoginRoute
         $result = $this->customerRepository->search($criteria, $context->getContext());
 
         $result = $result->filter(static function (CustomerEntity $customer) use ($context) {
-            // Skip guest users
-            if ($customer->getGuest()) {
+            $isConfirmed = !$customer->getDoubleOptInRegistration() || $customer->getDoubleOptInConfirmDate();
+
+            // Skip guest and not active users
+            if ($customer->getGuest() || (!$customer->getActive() && $isConfirmed)) {
                 return null;
             }
 

--- a/src/Core/Checkout/Test/Customer/SalesChannel/LoginRouteTest.php
+++ b/src/Core/Checkout/Test/Customer/SalesChannel/LoginRouteTest.php
@@ -112,6 +112,30 @@ class LoginRouteTest extends TestCase
         static::assertArrayHasKey('contextToken', $response);
     }
 
+    public function testValidLoginWithOneInactive(): void
+    {
+        $email = Uuid::randomHex() . '@example.com';
+        $password = 'shopware';
+        // Inactive user with different password
+        $this->createCustomer($password . 'fooBar', $email, null, false);
+        // Active user with correct password
+        $this->createCustomer($password, $email);
+
+        $this->browser
+            ->request(
+                'POST',
+                '/store-api/account/login',
+                [
+                    'email' => $email,
+                    'password' => $password,
+                ]
+            );
+
+        $response = json_decode($this->browser->getResponse()->getContent(), true);
+
+        static::assertArrayHasKey('contextToken', $response);
+    }
+
     public function testLoginWithInvalidBoundSalesChannelId(): void
     {
         static::expectException(UnauthorizedHttpException::class);
@@ -270,7 +294,7 @@ class LoginRouteTest extends TestCase
         );
     }
 
-    private function createCustomer(string $password, ?string $email = null, ?string $boundSalesChannelId = null): string
+    private function createCustomer(string $password, ?string $email = null, ?string $boundSalesChannelId = null, bool $active = true): string
     {
         $customerId = Uuid::randomHex();
         $addressId = Uuid::randomHex();
@@ -322,6 +346,7 @@ class LoginRouteTest extends TestCase
             'salutationId' => $this->getValidSalutationId(),
             'customerNumber' => '12345',
             'boundSalesChannelId' => $boundSalesChannelId,
+            'active' => $active,
         ];
 
         $this->customerRepository->create([$customer], $this->ids->context);

--- a/src/Core/Checkout/Test/Customer/SalesChannel/RegisterRouteTest.php
+++ b/src/Core/Checkout/Test/Customer/SalesChannel/RegisterRouteTest.php
@@ -357,6 +357,7 @@ class RegisterRouteTest extends TestCase
         static::assertArrayNotHasKey('contextToken', $response);
         static::assertArrayHasKey('errors', $response);
         static::assertSame('CHECKOUT__CUSTOMER_IS_INACTIVE', $response['errors'][0]['code']);
+        static::assertSame('401', $response['errors'][0]['status']);
 
         $criteria = new Criteria([$customerId]);
         /** @var CustomerEntity $customer */


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently if there is an inactive user for the current sales channel the customer cannot login anymore, if there was a newly created account.

### 2. What does this change do, exactly?
Change the logic how that is checked.

**Note** Maybe the logic should be changed altogether and the `InactiveCustomerException` should not be thrown anymore. This would simplify the code, and I am not sure if there is any additional use of such a message.

### 3. Describe each step to reproduce the issue or behaviour.
See the added test case.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
