### PR TITLE
Load admin snippets from all bundles that are not managed plugins

### DIFF
--- a/changelog/_unreleased/2022-04-26-load-administration-snippets-from-all-bundles.md
+++ b/changelog/_unreleased/2022-04-26-load-administration-snippets-from-all-bundles.md
@@ -1,0 +1,8 @@
+---
+title: Load administration snippets from all bundles
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added bundles as snippet source path to search trough to allow additional bundles to ship snippets for the administration

--- a/src/Administration/Snippet/SnippetFinder.php
+++ b/src/Administration/Snippet/SnippetFinder.php
@@ -27,7 +27,9 @@ class SnippetFinder implements SnippetFinderInterface
 
     private function getPluginPaths(): array
     {
+        $plugins = $this->kernel->getPluginLoader()->getPluginInstances()->all();
         $activePlugins = $this->kernel->getPluginLoader()->getPluginInstances()->getActives();
+        $bundles = $this->kernel->getBundles();
         $paths = [];
 
         foreach ($activePlugins as $plugin) {
@@ -37,6 +39,20 @@ class SnippetFinder implements SnippetFinderInterface
             }
 
             $paths[] = $pluginPath;
+        }
+
+        foreach ($bundles as $bundle) {
+            if (\in_array($bundle, $plugins, true)) {
+                continue;
+            }
+
+            $bundlePath = $bundle->getPath() . '/Resources/app/administration';
+
+            if (!file_exists($bundlePath)) {
+                continue;
+            }
+
+            $paths[] = $bundlePath;
         }
 
         return $paths;


### PR DESCRIPTION
### 1. Why is this change necessary?

I build a plugin that is divided into shopware bundles. That is nice as they behave as plugins, they have a views folder for the storefront, their admin and storefront javascript and css is delivered and compiled.... Just their admin snippets are not detected.

### 2. What does this change do, exactly?

All bundles of the kernel are evaluated for admin snippets. They are skipped when they are known to the plugin manager as this is already handled.

### 3. Describe each step to reproduce the issue or behaviour.

1. Make a plugin
2. Make a shopware bundle
3. Add the bundle to the additional plugin bundles
4. Add admin module with autoloaded snippet in the bundle
5. Open admin
6. See unresolvable translation paths

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
