### PR TITLE
fix handling of large and many custom-field-sets

### DIFF
--- a/changelog/_unreleased/2022-05-10-fix-loading-of-custom-fields-with-async.md
+++ b/changelog/_unreleased/2022-05-10-fix-loading-of-custom-fields-with-async.md
@@ -1,0 +1,10 @@
+---
+title: Fix many and huge custom-field-sets by loading the fields asynchronous
+issue: NEXT-21408
+author: Robert Schönthal
+author_email: robert.schoenthal@gmail.com
+author_github: digitalkaoz
+---
+# Administration
+* Changed Field-Set-Renderer to load only Fields for the current active tab `sw-custom-field-set-renderer`
+* Changed all Modules using this component to initally only load the set without its fields

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/index.js
@@ -169,8 +169,8 @@ Component.register('sw-custom-field-set-renderer', {
         },
 
         'entity.customFieldsSets': {
-            handler() {
-                this.onChangeCustomFieldSets();
+            handler(value) {
+                this.onChangeCustomFieldSets(value, () => null);
             },
         },
 
@@ -196,7 +196,7 @@ Component.register('sw-custom-field-set-renderer', {
     methods: {
         createdComponent() {
             this.initializeCustomFields();
-            this.onChangeCustomFieldSets();
+            this.onChangeCustomFieldSets(this.entity.customFieldSets || this.sets);
         },
 
         initializeCustomFields() {
@@ -331,9 +331,12 @@ Component.register('sw-custom-field-set-renderer', {
 
         customFieldSetCriteriaById() {
             const criteria = new Criteria(1, 1);
+            const customFieldsCriteria = new Criteria(1);
+
+            customFieldsCriteria.addSorting(Criteria.sort('config.customFieldsPosition'));
 
             criteria
-                .getAssociation('customFields');
+                .addAssociation('customFields', customFieldsCriteria);
 
             return criteria;
         },
@@ -362,6 +365,13 @@ Component.register('sw-custom-field-set-renderer', {
                 .then((updatedSets) => {
                     sets.splice(0, sets.length, ...updatedSets);
                     this.customFields = updatedSets;
+
+                    if (this.hasParent && this.entity.customFieldSets.length < 1) {
+                        this.parentEntity.customFieldSets = sets;
+                    } else {
+                        this.entity.customFieldSets = sets;
+                    }
+
                     cb(sets);
                 });
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.html.twig
@@ -76,7 +76,7 @@
             @new-item-active="(tab) => loadCustomFieldSet(tab.name)"
         >
             {% block sw_custom_field_set_renderer_card_tabs %}
-            <template v-slot="{ active }">
+            <template #default="{ active }">
                 <template v-for="set in visibleCustomFieldSets">
                     <sw-tabs-item
                         :key="`sw-tab--${set.id}`"
@@ -103,8 +103,12 @@
                         :class="'sw-custom-field-set-renderer-tab-content__' + set.name"
                     >
                         {% block sw_custom_field_set_renderer_card_form_renderer %}
-                        <sw-skeleton v-if="!set.customFields || !set.customFields.length" style="width:100%" />
-                        <template v-for="customField in set.customFields" v-else>
+                        <sw-skeleton v-if="!set.customFields || !set.customFields.length"
+                                     style="width:100%"
+                        />
+                        <template v-for="customField in set.customFields"
+                                  v-else
+                        >
                             <sw-inherit-wrapper
                                 v-if="entity && customField.config"
                                 :key="customField.name"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.html.twig
@@ -76,7 +76,7 @@
             @new-item-active="(tab) => loadCustomFieldSet(tab.name)"
         >
             {% block sw_custom_field_set_renderer_card_tabs %}
-            <template slot-scope="{ active }">
+            <template v-slot="{ active }">
                 <template v-for="set in visibleCustomFieldSets">
                     <sw-tabs-item
                         :key="`sw-tab--${set.id}`"
@@ -85,7 +85,7 @@
                         :class="'sw-tab--name-' + set.name"
                         :active-tab="active"
                     >
-                        {{ getInlineSnippet(set.config.label) || set.name }}
+                        {{ set.config ? getInlineSnippet(set.config.label) : set.name }}
                     </sw-tabs-item>
                 </template>
             </template>

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/sw-custom-field-set-renderer.html.twig
@@ -71,17 +71,17 @@
             ref="tabComponent"
             class="sw-custom-field-set-renderer__card-tabs"
             variant="minimal"
-            :default-item="visibleCustomFieldSets[0].name"
+            :default-item="visibleCustomFieldSets[0].id"
             :position-identifier="'sw-custom-field-set-renderer'"
+            @new-item-active="(tab) => loadCustomFieldSet(tab.name)"
         >
             {% block sw_custom_field_set_renderer_card_tabs %}
             <template slot-scope="{ active }">
                 <template v-for="set in visibleCustomFieldSets">
                     <sw-tabs-item
-                        v-if="set.customFields"
                         :key="`sw-tab--${set.id}`"
                         variant="minimal"
-                        :name="set.name"
+                        :name="set.id"
                         :class="'sw-tab--name-' + set.name"
                         :active-tab="active"
                     >
@@ -98,13 +98,13 @@
             >
                 <template v-for="set in visibleCustomFieldSets">
                     <div
-                        v-if="set.customFields"
-                        v-show="active === set.name"
-                        :key="set.name"
+                        v-show="active === set.id"
+                        :key="set.id"
                         :class="'sw-custom-field-set-renderer-tab-content__' + set.name"
                     >
                         {% block sw_custom_field_set_renderer_card_form_renderer %}
-                        <template v-for="customField in set.customFields">
+                        <sw-skeleton v-if="!set.customFields || !set.customFields.length" style="width:100%" />
+                        <template v-for="customField in set.customFields" v-else>
                             <sw-inherit-wrapper
                                 v-if="entity && customField.config"
                                 :key="customField.name"

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/index.js
@@ -56,12 +56,9 @@ Component.register('sw-bulk-edit-customer', {
         },
 
         customFieldSetCriteria() {
-            const criteria = new Criteria(1, 100);
+            const criteria = new Criteria(1);
 
             criteria.addFilter(Criteria.equals('relations.entityName', 'customer'));
-            criteria
-                .getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true));
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/index.js
@@ -60,12 +60,9 @@ Component.register('sw-bulk-edit-order', {
         },
 
         customFieldSetCriteria() {
-            const criteria = new Criteria(1, 100);
+            const criteria = new Criteria(1);
 
             criteria.addFilter(Criteria.equals('relations.entityName', 'order'));
-            criteria
-                .getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true));
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
@@ -80,12 +80,9 @@ Component.register('sw-bulk-edit-product', {
             return Object.values(this.bulkEditProduct).some(field => field.isChanged) || this.bulkEditSelected.length > 0;
         },
         customFieldSetCriteria() {
-            const criteria = new Criteria(1, 100);
+            const criteria = new Criteria(1);
 
             criteria.addFilter(Criteria.equals('relations.entityName', 'product'));
-            criteria
-                .getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true));
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -134,23 +134,17 @@ Component.register('sw-category-detail', {
         },
 
         customFieldSetCriteria() {
-            const criteria = new Criteria(1, 100);
+            const criteria = new Criteria(1);
 
             criteria.addFilter(Criteria.equals('relations.entityName', 'category'));
-            criteria
-                .getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true));
 
             return criteria;
         },
 
         customFieldSetLandingPageCriteria() {
-            const criteria = new Criteria(1, 100);
+            const criteria = new Criteria(1);
 
             criteria.addFilter(Criteria.equals('relations.entityName', 'landing_page'));
-            criteria
-                .getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true));
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js
@@ -117,9 +117,8 @@ Component.register('sw-customer-detail-addresses', {
                 return;
             }
 
-            const customFieldSetCriteria = new Criteria(1, 25);
-            customFieldSetCriteria.addFilter(Criteria.equals('relations.entityName', 'customer_address'))
-                .addAssociation('customFields');
+            const customFieldSetCriteria = new Criteria();
+            customFieldSetCriteria.addFilter(Criteria.equals('relations.entityName', 'customer_address'));
 
             this.customFieldSetRepository.search(customFieldSetCriteria).then((customFieldSets) => {
                 this.customerAddressCustomFieldSets = customFieldSets;

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-base/index.js
@@ -44,9 +44,6 @@ Component.register('sw-customer-detail-base', {
             criteria
                 .addFilter(Criteria.equals('relations.entityName', 'customer'));
 
-            criteria.getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition'));
-
             return criteria;
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-manufacturer/page/sw-manufacturer-detail/index.js
@@ -67,14 +67,11 @@ Component.register('sw-manufacturer-detail', {
         },
 
         customFieldSetCriteria() {
-            const criteria = new Criteria(1, 100);
+            const criteria = new Criteria();
+            criteria.setPage(1);
             criteria.addFilter(
                 Criteria.equals('relations.entityName', 'product_manufacturer'),
             );
-
-            criteria.getAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true))
-                .setLimit(100);
 
             return criteria;
         },
@@ -143,7 +140,7 @@ Component.register('sw-manufacturer-detail', {
             this.customFieldSetRepository
                 .search(this.customFieldSetCriteria)
                 .then((result) => {
-                    this.customFieldSets = result.filter((set) => set.customFields.length > 0);
+                    this.customFieldSets = result;
                 });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
@@ -74,13 +74,9 @@ Component.register('sw-media-quickinfo', {
 
         async getCustomFieldSets() {
             const criteria = new Criteria(1, 100)
-                .addFilter(Criteria.equals('relations.entityName', 'media'))
-                .addAssociation('customFields')
-                .addSorting(Criteria.sort('config.customFieldPosition', 'ASC', true))
-                .setLimit(100);
+                .addFilter(Criteria.equals('relations.entityName', 'media'));
 
-            const searchResult = await this.customFieldSetRepository.search(criteria);
-            this.customFieldSets = searchResult.filter(set => set.customFields.length > 0);
+            this.customFieldSets = await this.customFieldSetRepository.search(criteria);
         },
 
         async onSaveCustomFields(item) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-base/index.js
@@ -214,11 +214,7 @@ Component.register('sw-order-detail-base', {
         },
 
         customFieldSetCriteria() {
-            const customFieldsCriteria = new Criteria(1, 100);
-            customFieldsCriteria.addSorting(Criteria.sort('config.customFieldsPosition'));
-
-            const criteria = new Criteria(1, 100);
-            criteria.addAssociation('customFields', customFieldsCriteria);
+            const criteria = new Criteria(1);
             criteria.addFilter(Criteria.equals('relations.entityName', 'order'));
 
             return criteria;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/index.js
@@ -125,11 +125,7 @@ Component.register('sw-order-detail-details', {
         },
 
         customFieldSetCriteria() {
-            const customFieldsCriteria = new Criteria(1, 100);
-            customFieldsCriteria.addSorting(Criteria.sort('config.customFieldsPosition'));
-
-            const criteria = new Criteria(1, 100);
-            criteria.addAssociation('customFields', customFieldsCriteria);
+            const criteria = new Criteria(1);
             criteria.addFilter(Criteria.equals('relations.entityName', 'order'));
 
             return criteria;

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/index.js
@@ -321,23 +321,28 @@ Component.register('sw-product-stream-detail', {
         },
 
         getProductCustomFields() {
-            const customFieldsCriteria = new Criteria(1, 25);
-            customFieldsCriteria.addFilter(Criteria.equals('relations.entityName', 'product'))
-                .addAssociation('customFields')
-                .addAssociation('relations');
+            const customFieldsCriteria = new Criteria();
+            customFieldsCriteria.addFilter(Criteria.equals('relations.entityName', 'product'));
 
             return this.customFieldSetRepository.search(customFieldsCriteria, Context.api).then((customFieldSets) => {
+                const singleCriteria = new Criteria();
+                singleCriteria
+                    .addAssociation('customFields')
+                    .addAssociation('relations');
+
                 customFieldSets.forEach((customFieldSet) => {
-                    const customFields = customFieldSet.customFields
-                        .reduce((acc, customField) => {
-                            acc[customField.name] = this.mapCustomFieldType({
-                                type: customField.type,
-                                value: `customFields.${customField.name}`,
-                                label: this.getCustomFieldLabel(customField),
-                            });
-                            return acc;
-                        }, {});
-                    Object.assign(this.productCustomFields, customFields);
+                    this.customFieldSetRepository.get(customFieldSet.id, Context.api, singleCriteria).then(set => {
+                        const customFields = set.customFields
+                            .reduce((acc, customField) => {
+                                acc[customField.name] = this.mapCustomFieldType({
+                                    type: customField.type,
+                                    value: `customFields.${customField.name}`,
+                                    label: this.getCustomFieldLabel(customField),
+                                });
+                                return acc;
+                            }, {});
+                        Object.assign(this.productCustomFields, customFields);
+                    });
                 });
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -526,30 +526,6 @@ Component.register('sw-product-detail', {
             ]);
         },
 
-        fullyLoadCustomFields() {
-            const criteria = new Criteria(1, 1);
-            criteria
-                .getAssociation('customFields');
-
-            Shopware.State.commit('swProductDetail/setLoading', ['customFieldSets', true]);
-            const updatedFields = this.product.customFieldSets.map((fieldSet) => {
-                if (fieldSet.customFields.length === 0) {
-                    return this.customFieldSetRepository.get(fieldSet.id, Shopware.Context.api, criteria).then((res) => {
-                        Shopware.State.commit('swProductDetail/setCustomFields', res);
-                        return res;
-                    });
-                }
-                return Promise.resolve(fieldSet);
-            });
-
-            Promise.all(updatedFields).then(fields => {
-                this.product.customFields = fields;
-            }).finally(() => {
-                Shopware.State.commit('swProductDetail/setLoading', ['customFieldSets', false]);
-            });
-        },
-
-
         createState() {
             // set local mode
             Shopware.State.commit('swProductDetail/setLocalMode', true);
@@ -644,8 +620,6 @@ Component.register('sw-product-detail', {
                 } else {
                     Shopware.State.commit('swProductDetail/setParentProduct', {});
                 }
-
-                this.fullyLoadCustomFields();
 
                 Shopware.State.commit('swProductDetail/setLoading', ['product', false]);
             });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/state.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/state.js
@@ -143,6 +143,15 @@ export default {
             state.apiContext = apiContext;
         },
 
+        setCustomFields(state, fieldSet) {
+            state.customFieldSets = state.customFieldSets.map(set => {
+                if (set.id === fieldSet.id) {
+                    return fieldSet;
+                }
+                return set;
+            });
+        },
+
         setLocalMode(state, value) {
             state.localMode = value;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-specifications/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-specifications/index.js
@@ -26,7 +26,7 @@ Component.register('sw-product-detail-specifications', {
                 return false;
             }
 
-            return this.customFieldSets.some(set => set.customFields.length > 0);
+            return true;
         },
 
         showCustomFieldsCard() {

--- a/src/Administration/Resources/app/administration/test/module/sw-bulk-edit/page/sw-bulk-edit-customer.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-bulk-edit/page/sw-bulk-edit-customer.spec.js
@@ -37,6 +37,8 @@ import 'src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-process';
 import 'src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-success';
 import 'src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-error';
 import 'src/app/component/base/sw-modal';
+import 'src/app/component/base/sw-tabs';
+import 'src/app/component/base/sw-tabs-item';
 
 const routes = [
     {
@@ -155,7 +157,9 @@ function createWrapper(isResponseError = false) {
             'sw-icon': true,
             'sw-help-text': true,
             'sw-alert': true,
-            'sw-label': true
+            'sw-label': true,
+            'sw-tabs': Shopware.Component.build('sw-tabs'),
+            'sw-tabs-item': Shopware.Component.build('sw-tabs-item'),
         },
         props: {
             title: 'Foo bar'
@@ -165,7 +169,14 @@ function createWrapper(isResponseError = false) {
             repositoryFactory: {
                 create: () => {
                     return {
-                        create: () => {
+                        create: (entity) => {
+                            if (entity === 'custom_field_set') {
+                                return {
+                                    search: () => Promise.resolve([{ id: 'field-set-id-1' }]),
+                                    get: () => Promise.resolve({ id: '' })
+                                };
+                            }
+
                             return {
                                 id: '1a2b3c',
                                 name: 'Test Customer'

--- a/src/Administration/Resources/app/administration/test/module/sw-bulk-edit/page/sw-bulk-edit-order.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-bulk-edit/page/sw-bulk-edit-order.spec.js
@@ -38,6 +38,8 @@ import 'src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-process';
 import 'src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-success';
 import 'src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-error';
 import 'src/app/component/base/sw-modal';
+import 'src/app/component/base/sw-tabs';
+import 'src/app/component/base/sw-tabs-item';
 
 const routes = [
     {
@@ -147,7 +149,10 @@ function createWrapper(isResponseError = false) {
             'sw-icon': true,
             'sw-help-text': true,
             'sw-alert': true,
-            'sw-label': true
+            'sw-label': true,
+            'sw-tabs': Shopware.Component.build('sw-tabs'),
+            'sw-tabs-item': Shopware.Component.build('sw-tabs-item'),
+
         },
         props: {
             title: 'Foo bar'
@@ -157,7 +162,14 @@ function createWrapper(isResponseError = false) {
             repositoryFactory: {
                 create: () => {
                     return {
-                        create: () => {
+                        create: (entity) => {
+                            if (entity === 'custom_field_set') {
+                                return {
+                                    search: () => Promise.resolve([{ id: 'field-set-id-1' }]),
+                                    get: () => Promise.resolve({ id: '' })
+                                };
+                            }
+
                             return {
                                 id: '1a2b3c',
                                 name: 'Test order'

--- a/src/Administration/Resources/app/administration/test/module/sw-bulk-edit/page/sw-bulk-edit-product.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-bulk-edit/page/sw-bulk-edit-product.spec.js
@@ -48,6 +48,8 @@ import 'src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-process';
 import 'src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-success';
 import 'src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-error';
 import 'src/app/component/base/sw-modal';
+import 'src/app/component/base/sw-tabs';
+import 'src/app/component/base/sw-tabs-item';
 
 const routes = [
     {
@@ -205,7 +207,8 @@ function createWrapper(productEntityOverride) {
             'sw-product-detail-context-prices': true,
             'sw-category-tree-field': true,
             'sw-bulk-edit-product-media': true,
-            'sw-tabs': true,
+            'sw-tabs': Shopware.Component.build('sw-tabs'),
+            'sw-tabs-item': Shopware.Component.build('sw-tabs-item'),
             'sw-alert': true,
             'sw-label': true,
             'sw-extension-component-section': true,
@@ -255,6 +258,13 @@ function createWrapper(productEntityOverride) {
                     if (entity === 'currency') {
                         return {
                             search: () => Promise.resolve([{ id: 'currencyId1', isSystemDefault: true }]),
+                            get: () => Promise.resolve({ id: '' })
+                        };
+                    }
+
+                    if (entity === 'custom_field_set') {
+                        return {
+                            search: () => Promise.resolve([{ id: 'field-set-id-1' }]),
                             get: () => Promise.resolve({ id: '' })
                         };
                     }

--- a/src/Administration/Resources/app/administration/test/module/sw-customer/view/sw-customer-detail-base.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-customer/view/sw-customer-detail-base.spec.js
@@ -3,6 +3,8 @@ import 'src/module/sw-customer/view/sw-customer-detail-base';
 import 'src/app/component/form/sw-custom-field-set-renderer';
 import 'src/app/component/form/sw-form-field-renderer';
 import 'src/app/component/utils/sw-inherit-wrapper';
+import 'src/app/component/base/sw-tabs';
+import 'src/app/component/base/sw-tabs-item';
 
 const customFields = [
     {
@@ -75,14 +77,13 @@ function createWrapper() {
                 template: '<div></div>'
             },
             'sw-custom-field-set-renderer': Shopware.Component.build('sw-custom-field-set-renderer'),
-            'sw-tabs': {
-                template: '<div><slot name="content"></slot></div>'
-            },
+            'sw-tabs': Shopware.Component.build('sw-tabs'),
+            'sw-tabs-item': Shopware.Component.build('sw-tabs-item'),
             'sw-form-field-renderer': Shopware.Component.build('sw-form-field-renderer'),
             'sw-field': {
                 template: '<div></div>'
             },
-            'sw-inherit-wrapper': Shopware.Component.build('sw-inherit-wrapper')
+            'sw-inherit-wrapper': Shopware.Component.build('sw-inherit-wrapper'),
         }
     });
 }
@@ -100,14 +101,6 @@ describe('module/sw-customer/view/sw-customer-detail-base.spec.js', () => {
 
     it('should be a Vue.js component', async () => {
         expect(wrapper.vm).toBeTruthy();
-    });
-
-    it('should have a criteria that sorts custom field by their position', async () => {
-        const customFieldSetCriteria = wrapper.vm.customFieldSetCriteria;
-        const customFieldSorting = customFieldSetCriteria.associations[0].criteria.sortings[0];
-
-        expect(customFieldSorting.order).toBe('ASC');
-        expect(customFieldSorting.field).toBe('config.customFieldPosition');
     });
 
     it('should sort custom fields by their position', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

Handling of more than 100 Custom-Field-Sets were broken. (For Sets which were not within the first 100 were unable to populate its fields.

### 2. What does this change do, exactly?

Fixes the described scenario. 
1. Fetches the Product Fieldset without a limit and its related fields. (increases performance when there are 500 custom-field-sets for products (approx. 15MB were transfered before the page was usable))
2. Populates only the attached Field-Sets with fields
3. when adding new Sets to the Product we fetch the associated fields for this set only.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create more than 100 Product Custom Field Sets (with at least 1 Field)
2. Create a product
3. Try to attach the 101st Field-Set

### 4. Please link to the relevant issues (if any).

#2448 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
