### PR TITLE
fix: Only load active app scripts

### DIFF
--- a/changelog/_unreleased/2022-04-28-only-load-active-app-scripts.md
+++ b/changelog/_unreleased/2022-04-28-only-load-active-app-scripts.md
@@ -1,0 +1,9 @@
+---
+title: Only load active app scripts
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Only load scripts which are active and where the apps are active as well

--- a/src/Core/Framework/Script/Execution/ScriptLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptLoader.php
@@ -82,7 +82,7 @@ class ScriptLoader implements EventSubscriberInterface
                    `app`.`version` AS appVersion
             FROM `script`
             LEFT JOIN `app` ON `script`.`app_id` = `app`.`id`
-            WHERE `script`.`hook` != 'include'
+            WHERE `script`.`hook` != 'include' AND `app`.`active` = 1 AND `script`.`active` = 1
             ORDER BY `app`.`created_at`, `app`.`id`, `script`.`name`
         ");
 
@@ -95,7 +95,7 @@ class ScriptLoader implements EventSubscriberInterface
                    IFNULL(`script`.`updated_at`, `script`.`created_at`) AS lastModified
             FROM `script`
             LEFT JOIN `app` ON `script`.`app_id` = `app`.`id`
-            WHERE `script`.`hook` = 'include'
+            WHERE `script`.`hook` = 'include' AND `app`.`active` = 1 AND `script`.`active` = 1
             ORDER BY `app`.`created_at`, `app`.`id`, `script`.`name`
         ");
 

--- a/src/Core/Framework/Test/Script/Execution/ScriptLoaderTest.php
+++ b/src/Core/Framework/Test/Script/Execution/ScriptLoaderTest.php
@@ -31,4 +31,24 @@ class ScriptLoaderTest extends TestCase
             $loader->get('include')
         );
     }
+
+    public function testGetInactiveScripts(): void
+    {
+        $this->loadAppsFromDir(__DIR__ . '/_fixtures', false);
+
+        $loader = $this->getContainer()->get(ScriptLoader::class);
+
+        static::assertCount(
+            0,
+            $loader->get('include-case')
+        );
+        static::assertCount(
+            0,
+            $loader->get('multi-script-case')
+        );
+        static::assertCount(
+            0,
+            $loader->get('include')
+        );
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently also scripts of apps which are not active are loaded.

### 2. What does this change do, exactly?
Do not load scripts which are set inactive or where the apps are disabled.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
