### PR TITLE
Add reading streams from media to FileLoader and MediaService

### DIFF
--- a/changelog/_unreleased/2022-04-29-add-load-media-file-stream-to-media-service-and-file-loader.md
+++ b/changelog/_unreleased/2022-04-29-add-load-media-file-stream-to-media-service-and-file-loader.md
@@ -1,0 +1,9 @@
+---
+title: Add loadMediaFileStream to MediaService and FileLoader
+author: JoshuaBehrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added `\Shopware\Core\Content\Media\File\FileLoader::loadMediaFileStream` as companion to `\Shopware\Core\Content\Media\File\FileLoader::loadMediaFile` but it returns a stream for better memory management options with big files
+* Added `\Shopware\Core\Content\Media\MediaService::loadFileStream` as companion to `\Shopware\Core\Content\Media\MediaService::loadFile` but it returns a stream for better memory management options with big files

--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -127,6 +127,7 @@
             <argument type="service" id="shopware.filesystem.private"/>
             <argument type="service" id="Shopware\Core\Content\Media\Pathname\UrlGeneratorInterface"/>
             <argument type="service" id="media.repository"/>
+            <argument type="service" id="Nyholm\Psr7\Factory\Psr17Factory"/>
         </service>
 
         <service id="Shopware\Core\Content\Media\File\FileNameProvider" class="Shopware\Core\Content\Media\File\WindowsStyleFileNameProvider">

--- a/src/Core/Content/Media/MediaService.php
+++ b/src/Core/Content/Media/MediaService.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Media;
 
+use Psr\Http\Message\StreamInterface;
 use Shopware\Core\Content\Media\File\FileFetcher;
 use Shopware\Core\Content\Media\File\FileLoader;
 use Shopware\Core\Content\Media\File\FileSaver;
@@ -115,6 +116,11 @@ class MediaService
     public function loadFile(string $mediaId, Context $context): string
     {
         return $this->fileLoader->loadMediaFile($mediaId, $context);
+    }
+
+    public function loadFileStream(string $mediaId, Context $context): StreamInterface
+    {
+        return $this->fileLoader->loadMediaFileStream($mediaId, $context);
     }
 
     public function fetchFile(Request $request, ?string $tempFile = null): MediaFile

--- a/src/Core/Content/Test/Media/File/FileLoaderTest.php
+++ b/src/Core/Content/Test/Media/File/FileLoaderTest.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Test\Media\File;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\File\FileFetcher;
+use Shopware\Core\Content\Media\File\FileLoader;
+use Shopware\Core\Content\Media\File\FileSaver;
+use Shopware\Core\Content\Test\Media\MediaFixtures;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+final class FileLoaderTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use MediaFixtures;
+
+    public const TEST_IMAGE = __DIR__ . '/../fixtures/shopware-logo.png';
+
+    private FileLoader $fileLoader;
+
+    private FileFetcher $fileFetcher;
+
+    private FileSaver $fileSaver;
+
+    private EntityRepositoryInterface $mediaRepository;
+
+    protected function setUp(): void
+    {
+        $this->fileLoader = $this->getContainer()->get(FileLoader::class);
+        $this->fileFetcher = $this->getContainer()->get(FileFetcher::class);
+        $this->fileSaver = $this->getContainer()->get(FileSaver::class);
+    }
+
+    public function testLoadMediaFile(): void
+    {
+        $context = Context::createDefaultContext();
+        $blob = \file_get_contents(self::TEST_IMAGE);
+        $mediaFile = $this->fileFetcher->fetchBlob($blob, 'png', 'image/png');
+        $mediaId = Uuid::randomHex();
+        $this->fileSaver->persistFileToMedia($mediaFile, $mediaId . '.png', $mediaId, $context);
+
+        static::assertSame($blob, $this->fileLoader->loadMediaFile($mediaId, $context));
+
+        $this->mediaRepository->delete([$mediaId], $context);
+    }
+
+    public function testLoadMediaFileStream(): void
+    {
+        $context = Context::createDefaultContext();
+        $blob = \file_get_contents(self::TEST_IMAGE);
+        $mediaFile = $this->fileFetcher->fetchBlob($blob, 'png', 'image/png');
+        $mediaId = Uuid::randomHex();
+        $this->fileSaver->persistFileToMedia($mediaFile, $mediaId . '.png', $mediaId, $context);
+
+        static::assertSame($blob, (string) $this->fileLoader->loadMediaFileStream($mediaId, $context));
+
+        $this->mediaRepository->delete([$mediaId], $context);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

When you want to access the filesystem and need to process big files, you want a stream and not a string.

### 2. What does this change do, exactly?

Expose stream related methods from the flysystem API.

### 3. Describe each step to reproduce the issue or behaviour.

1. Make a file download for private media
2. Request a file that is bigger in size than your allowed php memory limit
3. php-fpm wins "best titanic impression" contest

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
