### PR TITLE
fix: Language inheritance for translation locale code

### DIFF
--- a/changelog/_unreleased/2022-05-03-fix-language-inheritance-of-translation-locale-code.md
+++ b/changelog/_unreleased/2022-05-03-fix-language-inheritance-of-translation-locale-code.md
@@ -1,0 +1,9 @@
+---
+title: Fix language inheritance of translation locale code
+issue: NA
+author: Stepahn Franck
+author_email: stephan@vierpunkt.de
+author_github: @stephan4p
+---
+# Core
+* Changed Shopware\Core\System\Locale\LanguageLocaleCodeProvider to respect the inheritance of the languages for the locale codes

--- a/src/Core/System/Language/LanguageLoader.php
+++ b/src/Core/System/Language/LanguageLoader.php
@@ -17,8 +17,10 @@ class LanguageLoader implements LanguageLoaderInterface
     public function loadLanguages(): array
     {
         $data = $this->connection->createQueryBuilder()
-            ->select(['LOWER(HEX(language.id)) AS array_key, LOWER(HEX(language.id)) AS id, locale.code, LOWER(HEX(language.parent_id)) parentId'])
+            ->select(['LOWER(HEX(language.id)) AS array_key, LOWER(HEX(language.id)) AS id, IFNULL(locale.code, parentLocale.code) as code, LOWER(HEX(language.parent_id)) parentId'])
             ->from('language')
+            ->leftJoin('language', 'language', 'parent', 'language.parent_id = parent.id')
+            ->leftJoin('language', 'locale', 'parentLocale', 'parent.translation_code_id = parentLocale.id')
             ->leftJoin('language', 'locale', 'locale', 'language.translation_code_id = locale.id')
             ->execute()
             ->fetchAll();

--- a/src/Core/System/Test/Locale/LanguageLocaleCodeProviderTest.php
+++ b/src/Core/System/Test/Locale/LanguageLocaleCodeProviderTest.php
@@ -4,9 +4,14 @@ namespace Locale;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Routing\Exception\LanguageNotFoundException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 
 class LanguageLocaleCodeProviderTest extends TestCase
@@ -15,9 +20,15 @@ class LanguageLocaleCodeProviderTest extends TestCase
 
     private LanguageLocaleCodeProvider $languageLocaleProvider;
 
+    private EntityRepositoryInterface $languageRepository;
+
+    private Context $context;
+
     public function setUp(): void
     {
         $this->languageLocaleProvider = $this->getContainer()->get(LanguageLocaleCodeProvider::class);
+        $this->languageRepository = $this->getContainer()->get('language.repository');
+        $this->context = Context::createDefaultContext();
     }
 
     public function testGetLocaleForLanguageId(): void
@@ -40,5 +51,69 @@ class LanguageLocaleCodeProviderTest extends TestCase
             Defaults::LANGUAGE_SYSTEM => 'en-GB',
             $deDeLanguage => 'de-DE',
         ], $this->languageLocaleProvider->getLocalesForLanguageIds([Defaults::LANGUAGE_SYSTEM, $deDeLanguage]));
+    }
+
+    public function testGetLocaleInheritance(): void
+    {
+        $deDeLanguage = $this->getDeDeLanguage();
+
+        $inheritedLanguageId = Uuid::randomHex();
+        $this->languageRepository->create([
+            [
+                'id' => $inheritedLanguageId,
+                'localeId' => $deDeLanguage->getLocaleId(),
+                'translationCodeId' => null,
+                'name' => 'Test language',
+                'parentId' => $deDeLanguage->getId(),
+            ],
+        ], $this->context);
+
+        static::assertEquals(
+            $deDeLanguage->getTranslationCode()->getCode(),
+            $this->languageLocaleProvider->getLocaleForLanguageId($inheritedLanguageId)
+        );
+    }
+
+    public function testGetLocaleInheritanceList(): void
+    {
+        $deDeLanguage = $this->getDeDeLanguage();
+
+        $inheritedLanguageId = Uuid::randomHex();
+        $this->languageRepository->create([
+            [
+                'id' => $inheritedLanguageId,
+                'localeId' => $deDeLanguage->getLocaleId(),
+                'translationCodeId' => null,
+                'name' => 'Test language',
+                'parentId' => $deDeLanguage->getId(),
+            ],
+        ], $this->context);
+
+        static::assertEquals(
+            [
+                Defaults::LANGUAGE_SYSTEM => 'en-GB',
+                $deDeLanguage->getId() => $deDeLanguage->getTranslationCode()->getCode(),
+                $inheritedLanguageId => $deDeLanguage->getTranslationCode()->getCode(),
+            ],
+            $this->languageLocaleProvider->getLocalesForLanguageIds([
+                Defaults::LANGUAGE_SYSTEM,
+                $deDeLanguage->getId(),
+                $inheritedLanguageId,
+            ])
+        );
+    }
+
+    private function getDeDeLanguage(): LanguageEntity
+    {
+        $repository = $this->getContainer()->get('language.repository');
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('language.translationCode.code', 'de-DE'));
+        $criteria->addAssociation('translationCode');
+
+        /** @var LanguageEntity $language */
+        $language = $repository->search($criteria, $this->context)->first();
+
+        return $language;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The translation locale codes are not inherited

### 2. What does this change do, exactly?
Inherit the translation locale code

### 3. Describe each step to reproduce the issue or behaviour.
Add a new Language in Shopware and set a parent language. At the return, you have an empty translation code.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
