### PR TITLE
Fix typo in FormScrollToInvalidFieldPlugin import

### DIFF
--- a/changelog/_unreleased/2022-05-06-fix-import-typo.md
+++ b/changelog/_unreleased/2022-05-06-fix-import-typo.md
@@ -1,0 +1,8 @@
+---
+title: Fix typo in FromScrollToInvalidFieldPlugin import
+issue: 
+author: Léo Cunéaz
+author_github: inem0o
+---
+# Storefront
+* Changed import for `FromScrollToInvalidFieldPlugin` to use the correct naming of the plugin

--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -51,7 +51,7 @@ import FormPreserverPlugin from 'src/plugin/forms/form-preserver.plugin';
 import FormValidationPlugin from 'src/plugin/forms/form-validation.plugin';
 import FormSubmitLoaderPlugin from 'src/plugin/forms/form-submit-loader.plugin';
 import FormFieldTogglePlugin from 'src/plugin/forms/form-field-toggle.plugin';
-import FromScrollToInvalidFieldPlugin from 'src/plugin/forms/form-scroll-to-invalid-field.plugin';
+import FormScrollToInvalidFieldPlugin from 'src/plugin/forms/form-scroll-to-invalid-field.plugin';
 import OffCanvasTabsPlugin from 'src/plugin/offcanvas-tabs/offcanvas-tabs.plugin';
 import BaseSliderPlugin from 'src/plugin/slider/base-slider.plugin';
 import GallerySliderPlugin from 'src/plugin/slider/gallery-slider.plugin';
@@ -127,7 +127,7 @@ PluginManager.register('CollapseCheckoutConfirmMethods', CollapseCheckoutConfirm
 PluginManager.register('FlyoutMenu', FlyoutMenuPlugin, '[data-flyout-menu]');
 PluginManager.register('OffcanvasMenu', OffcanvasMenuPlugin, '[data-offcanvas-menu]');
 PluginManager.register('FormValidation', FormValidationPlugin, '[data-form-validation]');
-PluginManager.register('FormScrollToInvalidField', FromScrollToInvalidFieldPlugin, 'form');
+PluginManager.register('FormScrollToInvalidField', FormScrollToInvalidFieldPlugin, 'form');
 PluginManager.register('FormSubmitLoader', FormSubmitLoaderPlugin, '[data-form-submit-loader]');
 PluginManager.register('FormFieldToggle', FormFieldTogglePlugin, '[data-form-field-toggle]');
 PluginManager.register('FormAutoSubmit', FormAutoSubmitPlugin, '[data-form-auto-submit]');


### PR DESCRIPTION

### 1. Why is this change necessary?
Add more consistency between all plugins imports and fix a typo

### 2. What does this change do, exactly?
Changed the import syntax of the plugin, FormScrollToInvalidFieldPlugin was imported as "FromScrollToInvalidFieldPlugin" with a typo


### 3. Describe each step to reproduce the issue or behaviour.
no real issue just malformed syntax


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
