### PR TITLE
Refactor/customer login

### DIFF
--- a/changelog/_unreleased/2022-04-30-unify-login-route-and-account-service.md
+++ b/changelog/_unreleased/2022-04-30-unify-login-route-and-account-service.md
@@ -1,0 +1,14 @@
+---
+title: Unify login route and account service
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added `Shopware\Core\Checkout\Customer\Exception\CustomerOptinNotCompletedException` exception which replaces the `Shopware\Core\Checkout\Customer\Exception\InactiveCustomerException` and will only be thrown if the opt in has not been completed, use the error snippet `account.doubleOptinAccountAlert` starting from Shopware 6.5.0.0
+* Deprecated `Shopware\Core\Checkout\Customer\Exception\InactiveCustomerException` use `Shopware\Core\Checkout\Customer\Exception\BadCredentialsException` or `Shopware\Core\Checkout\Customer\Exception\CustomerOptinNotCompletedException` instead
+___
+# Upgrade Information
+## Double OptIn customers will be active by default
+If the double opt in feature for the customer registration is enabled the customer accounts will be set active by default starting from Shopware 6.5.0.0. The validation now only considers if the customer has the double opt in registration enabled, i.e. the database value `customer.double_opt_in_registration` equals `1` and if there exists an double opt in date in `customer.double_opt_in_confirm_date`.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1056,11 +1056,6 @@ parameters:
 			path: src/Core/Checkout/Customer/Rule/CustomerTagRule.php
 
 		-
-			message: "#^Parameter \\#2 \\$hash of function password_verify expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/SalesChannel/AccountService.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\ChangeEmailRoute\\:\\:tryValidateEqualtoConstraint\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php
@@ -1089,41 +1084,6 @@ parameters:
 			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\MergeWishlistProductRoute\\:\\:loadCustomerProducts\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Checkout/Customer/SalesChannel/MergeWishlistProductRoute.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\RegisterRoute\\:\\:getDomainUrls\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\RegisterRoute\\:\\:mapAddressData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\RegisterRoute\\:\\:mapBillingAddress\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\RegisterRoute\\:\\:mapCustomerData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\RegisterRoute\\:\\:mapShippingAddress\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\RegisterRoute\\:\\:setDoubleOptInData\\(\\) has parameter \\$customer with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\RegisterRoute\\:\\:setDoubleOptInData\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
 
 		-
 			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\ResetPasswordRoute\\:\\:tryValidateEqualtoConstraint\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"

--- a/src/Core/Checkout/Customer/Exception/CustomerOptinNotCompletedException.php
+++ b/src/Core/Checkout/Customer/Exception/CustomerOptinNotCompletedException.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class CustomerOptinNotCompletedException extends ShopwareHttpException
+{
+    /**
+     * @deprecated tag:v6.5.0 the $message parameter will be removed without replacement
+     */
+    public function __construct(string $id, ?string $message = null)
+    {
+        parent::__construct(
+            $message ?? 'The customer with the id "{{ customerId }}" has not completed the opt-in.',
+            ['customerId' => $id]
+        );
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'CHECKOUT__CUSTOMER_OPTIN_NOT_COMPLETED';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_UNAUTHORIZED;
+    }
+
+    public function getSnippetKey(): string
+    {
+        return 'account.doubleOptinAccountAlert';
+    }
+}

--- a/src/Core/Checkout/Customer/Exception/InactiveCustomerException.php
+++ b/src/Core/Checkout/Customer/Exception/InactiveCustomerException.php
@@ -2,31 +2,46 @@
 
 namespace Shopware\Core\Checkout\Customer\Exception;
 
-use Shopware\Core\Framework\ShopwareHttpException;
+use Shopware\Core\Framework\Feature;
 use Symfony\Component\HttpFoundation\Response;
 
-class InactiveCustomerException extends ShopwareHttpException
+/**
+ * @deprecated tag:v6.5.0 Will be removed without replacement, not in use any more. Use `BadCredentialsException` or `CustomerOptinNotCompletedException` instead
+ */
+class InactiveCustomerException extends CustomerOptinNotCompletedException
 {
     public function __construct(string $id)
     {
-        parent::__construct(
-            'The customer with the id "{{ customerId }}" is inactive.',
-            ['customerId' => $id]
-        );
+        parent::__construct($id, 'The customer with the id "{{ customerId }}" is inactive.');
     }
 
     public function getErrorCode(): string
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.5.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.5.0.0')
+        );
+
         return 'CHECKOUT__CUSTOMER_IS_INACTIVE';
     }
 
     public function getStatusCode(): int
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.5.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.5.0.0')
+        );
+
         return Response::HTTP_UNAUTHORIZED;
     }
 
     public function getSnippetKey(): string
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.5.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.5.0.0')
+        );
+
         return 'account.inactiveAccountAlert';
     }
 }

--- a/src/Core/Checkout/Customer/SalesChannel/AccountService.php
+++ b/src/Core/Checkout/Customer/SalesChannel/AccountService.php
@@ -10,14 +10,13 @@ use Shopware\Core\Checkout\Customer\Exception\AddressNotFoundException;
 use Shopware\Core\Checkout\Customer\Exception\BadCredentialsException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundByIdException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundException;
-use Shopware\Core\Checkout\Customer\Exception\InactiveCustomerException;
+use Shopware\Core\Checkout\Customer\Exception\CustomerOptinNotCompletedException;
 use Shopware\Core\Checkout\Customer\Password\LegacyPasswordVerifier;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\CartRestorer;
@@ -133,7 +132,7 @@ class AccountService
     /**
      * @throws CustomerNotFoundException
      * @throws BadCredentialsException
-     * @throws InactiveCustomerException
+     * @throws CustomerOptinNotCompletedException
      */
     public function getCustomerByLogin(string $email, string $password, SalesChannelContext $context): CustomerEntity
     {
@@ -149,16 +148,20 @@ class AccountService
             return $customer;
         }
 
-        if (!password_verify($password, $customer->getPassword())) {
+        if ($customer->getPassword() === null
+            || !password_verify($password, $customer->getPassword())) {
             throw new BadCredentialsException();
+        }
+
+        $isConfirmed = !$customer->getDoubleOptInRegistration() || $customer->getDoubleOptInConfirmDate();
+        if (!$isConfirmed) {
+            // Make sure to only throw this exception after it has been verified it was a valid login
+            throw new CustomerOptinNotCompletedException($customer->getId());
         }
 
         return $customer;
     }
 
-    /**
-     * @throws InactiveCustomerException
-     */
     private function loginByCustomer(CustomerEntity $customer, SalesChannelContext $context): string
     {
         $this->customerRepository->update([
@@ -184,14 +187,8 @@ class AccountService
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('email', $email));
-        if (!$includeGuest) {
-            $criteria->addFilter(new EqualsFilter('guest', false));
-        }
-        $criteria->addSorting(new FieldSorting('createdAt'));
-        $criteria->setLimit(1);
 
-        $customer = $this->fetchCustomer($criteria, $context);
-
+        $customer = $this->fetchCustomer($criteria, $context, $includeGuest);
         if ($customer === null) {
             throw new CustomerNotFoundException($email);
         }
@@ -199,11 +196,14 @@ class AccountService
         return $customer;
     }
 
+    /**
+     * @throws CustomerNotFoundByIdException
+     */
     private function getCustomerById(string $id, SalesChannelContext $context): CustomerEntity
     {
         $criteria = new Criteria([$id]);
-        $customer = $this->fetchCustomer($criteria, $context);
 
+        $customer = $this->fetchCustomer($criteria, $context, true);
         if ($customer === null) {
             throw new CustomerNotFoundByIdException($id);
         }
@@ -211,14 +211,58 @@ class AccountService
         return $customer;
     }
 
-    private function fetchCustomer(Criteria $criteria, SalesChannelContext $context): ?CustomerEntity
+    /**
+     * Add only filters to the $criteria for values which have an index in the database, e.g. id, or email,
+     * the rest should be done via PHP because it's a lot faster to filter a few entities on PHP side with
+     * the same email address, than to filter a huge numbers of rows in the DB on an not indexed column
+     * This method filters for the standard customer related constraints like active or the sales channel
+     * assignment.
+     */
+    private function fetchCustomer(Criteria $criteria, SalesChannelContext $context, bool $includeGuest = false): ?CustomerEntity
     {
-        $criteria->addFilter(new MultiFilter(MultiFilter::CONNECTION_OR, [
-            new EqualsFilter('boundSalesChannelId', null),
-            new EqualsFilter('boundSalesChannelId', $context->getSalesChannel()->getId()),
-        ]));
+        $criteria->setTitle('account-service::fetchCustomer');
 
-        return $this->customerRepository->search($criteria, $context->getContext())->first();
+        $result = $this->customerRepository->search($criteria, $context->getContext());
+        $result = $result->filter(static function (CustomerEntity $customer) use ($includeGuest, $context) {
+            // Skip not active users
+            if (!$customer->getActive()) {
+                $isConfirmed = !$customer->getDoubleOptInRegistration() || $customer->getDoubleOptInConfirmDate();
+
+                // Customers with double optin will be active by default starting at Shopware 6.5.0.0,
+                // remove complete if statement and always return null
+                if (Feature::isActive('v6.5.0.0') || $isConfirmed) {
+                    return null;
+                }
+            }
+
+            // Skip guest if not required
+            if (!$includeGuest && $customer->getGuest()) {
+                return null;
+            }
+
+            // If not bound, we still need to consider it
+            if ($customer->getBoundSalesChannelId() === null) {
+                return true;
+            }
+
+            // It is bound, but not to the current one. Skip it
+            if ($customer->getBoundSalesChannelId() !== $context->getSalesChannel()->getId()) {
+                return null;
+            }
+
+            return true;
+        });
+
+        // If there is more than one account we want to return the latest, this is important
+        // for guest accounts, real customer accounts should only occur once, otherwise the
+        // wrong password will be validated
+        if ($result->count() > 1) {
+            $result->sort(function (CustomerEntity $a, CustomerEntity $b) {
+                return $a->getCreatedAt() <=> $b->getCreatedAt();
+            });
+        }
+
+        return $result->first();
     }
 
     private function updatePasswordHash(string $password, CustomerEntity $customer, Context $context): void

--- a/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
@@ -2,23 +2,18 @@
 
 namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
-use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Event\CustomerBeforeLoginEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
 use Shopware\Core\Checkout\Customer\Exception\BadCredentialsException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerAuthThrottledException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundException;
+use Shopware\Core\Checkout\Customer\Exception\CustomerOptinNotCompletedException;
 use Shopware\Core\Checkout\Customer\Exception\InactiveCustomerException;
-use Shopware\Core\Checkout\Customer\Password\LegacyPasswordVerifier;
-use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\RateLimiter\Exception\RateLimitExceededException;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
-use Shopware\Core\Framework\Routing\Annotation\ContextTokenRequired;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\CartRestorer;
@@ -36,9 +31,9 @@ class LoginRoute extends AbstractLoginRoute
 {
     private EventDispatcherInterface $eventDispatcher;
 
-    private EntityRepositoryInterface $customerRepository;
+    private AccountService $accountService;
 
-    private LegacyPasswordVerifier $legacyPasswordVerifier;
+    private EntityRepositoryInterface $customerRepository;
 
     private CartRestorer $restorer;
 
@@ -51,15 +46,15 @@ class LoginRoute extends AbstractLoginRoute
      */
     public function __construct(
         EventDispatcherInterface $eventDispatcher,
+        AccountService $accountService,
         EntityRepositoryInterface $customerRepository,
-        LegacyPasswordVerifier $legacyPasswordVerifier,
         CartRestorer $restorer,
         RequestStack $requestStack,
         RateLimiter $rateLimiter
     ) {
         $this->eventDispatcher = $eventDispatcher;
+        $this->accountService = $accountService;
         $this->customerRepository = $customerRepository;
-        $this->legacyPasswordVerifier = $legacyPasswordVerifier;
         $this->restorer = $restorer;
         $this->requestStack = $requestStack;
         $this->rateLimiter = $rateLimiter;
@@ -96,21 +91,24 @@ class LoginRoute extends AbstractLoginRoute
         }
 
         try {
-            $customer = $this->getCustomerByLogin(
+            $customer = $this->accountService->getCustomerByLogin(
                 $email,
                 $data->get('password'),
                 $context
             );
         } catch (CustomerNotFoundException | BadCredentialsException $exception) {
             throw new UnauthorizedHttpException('json', $exception->getMessage());
+        } catch (CustomerOptinNotCompletedException $exception) {
+            /** @deprecated tag:v6.5.0 remove complete catch of `CustomerOptinNotCompletedException` */
+            if (!Feature::isActive('v6.5.0.0')) {
+                throw new InactiveCustomerException($exception->getParameters()['customerId']);
+            }
+
+            throw $exception;
         }
 
         if (isset($cacheKey)) {
             $this->rateLimiter->reset(RateLimiter::LOGIN_ROUTE, $cacheKey);
-        }
-
-        if (!$customer->getActive()) {
-            throw new InactiveCustomerException($customer->getId());
         }
 
         $context = $this->restorer->restore($customer->getId(), $context);
@@ -128,74 +126,5 @@ class LoginRoute extends AbstractLoginRoute
         $this->eventDispatcher->dispatch($event);
 
         return new ContextTokenResponse($newToken);
-    }
-
-    private function getCustomerByLogin(string $email, string $password, SalesChannelContext $context): CustomerEntity
-    {
-        $customer = $this->getCustomerByEmail($email, $context);
-
-        if ($customer->hasLegacyPassword()) {
-            if (!$this->legacyPasswordVerifier->verify($password, $customer)) {
-                throw new BadCredentialsException();
-            }
-
-            $this->updatePasswordHash($password, $customer, $context->getContext());
-
-            return $customer;
-        }
-
-        if (!password_verify($password, $customer->getPassword() ?? '')) {
-            throw new BadCredentialsException();
-        }
-
-        return $customer;
-    }
-
-    private function getCustomerByEmail(string $email, SalesChannelContext $context): CustomerEntity
-    {
-        $criteria = new Criteria();
-        $criteria->setTitle('login-route');
-        $criteria->addFilter(new EqualsFilter('customer.email', $email));
-
-        $result = $this->customerRepository->search($criteria, $context->getContext());
-
-        $result = $result->filter(static function (CustomerEntity $customer) use ($context) {
-            $isConfirmed = !$customer->getDoubleOptInRegistration() || $customer->getDoubleOptInConfirmDate();
-
-            // Skip guest and not active users
-            if ($customer->getGuest() || (!$customer->getActive() && $isConfirmed)) {
-                return null;
-            }
-
-            // If not bound, we still need to consider it
-            if ($customer->getBoundSalesChannelId() === null) {
-                return true;
-            }
-
-            // It is bound, but not to the current one. Skip it
-            if ($customer->getBoundSalesChannelId() !== $context->getSalesChannel()->getId()) {
-                return null;
-            }
-
-            return true;
-        });
-
-        if ($result->count() !== 1) {
-            throw new BadCredentialsException();
-        }
-
-        return $result->first();
-    }
-
-    private function updatePasswordHash(string $password, CustomerEntity $customer, Context $context): void
-    {
-        $this->customerRepository->update([
-            [
-                'id' => $customer->getId(),
-                'password' => $password,
-                'legacyPassword' => null,
-                'legacyEncoder' => null,
-            ],
-        ], $context);
     }
 }

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
@@ -12,8 +12,8 @@ use Shopware\Core\Checkout\Customer\Exception\NoHashProvidedException;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\Framework\Routing\Annotation\RouteScope;
 use Shopware\Core\Framework\Routing\Annotation\Since;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
@@ -109,20 +109,21 @@ class RegisterConfirmRoute extends AbstractRegisterConfirmRoute
             $this->getBeforeConfirmValidation(hash('sha1', $customer->getEmail()))
         );
 
-        if ($customer->getActive() || $customer->getDoubleOptInConfirmDate() !== null) {
+        if ((!Feature::isActive('v6.5.0.0') && $customer->getActive())
+            || $customer->getDoubleOptInConfirmDate() !== null) {
             throw new CustomerAlreadyConfirmedException($customer->getId());
         }
 
-        $this->customerRepository->update(
-            [
-                [
-                    'id' => $customer->getId(),
-                    'active' => true,
-                    'doubleOptInConfirmDate' => new \DateTimeImmutable(),
-                ],
-            ],
-            $context->getContext()
-        );
+        $customerUpdate = [
+            'id' => $customer->getId(),
+            'doubleOptInConfirmDate' => new \DateTimeImmutable(),
+        ];
+
+        if (!Feature::isActive('v6.5.0.0')) {
+            $customerUpdate['active'] = true;
+        }
+
+        $this->customerRepository->update([$customerUpdate], $context->getContext());
 
         $newToken = $this->contextPersister->replace($context->getToken(), $context);
 

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Validation\EntityExists;
 use Shopware\Core\Framework\Event\DataMappingEvent;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\Annotation\ContextTokenRequired;
 use Shopware\Core\Framework\Routing\Annotation\RouteScope;
@@ -260,6 +261,11 @@ class RegisterRoute extends AbstractRegisterRoute
         return $event;
     }
 
+    /**
+     * @param array<string, mixed> $customer
+     *
+     * @return array<string, mixed>
+     */
     private function setDoubleOptInData(array $customer, SalesChannelContext $context): array
     {
         $configKey = $customer['guest']
@@ -273,7 +279,12 @@ class RegisterRoute extends AbstractRegisterRoute
             return $customer;
         }
 
-        $customer['active'] = false;
+        // All customers will be active by default
+        if (Feature::isActive('v6.5.0.0')) {
+            $customer['active'] = true;
+        } else {
+            $customer['active'] = false;
+        }
         $customer['doubleOptInRegistration'] = true;
         $customer['doubleOptInEmailSentDate'] = new \DateTimeImmutable();
         $customer['hash'] = Uuid::randomHex();
@@ -339,6 +350,9 @@ class RegisterRoute extends AbstractRegisterRoute
         throw new ConstraintViolationException($violations, $data->all());
     }
 
+    /**
+     * @return array<string, string>
+     */
     private function getDomainUrls(SalesChannelContext $context): array
     {
         /** @var SalesChannelDomainCollection $salesChannelDomainCollection */
@@ -367,6 +381,9 @@ class RegisterRoute extends AbstractRegisterRoute
         ));
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function mapBillingAddress(DataBag $billing, Context $context): array
     {
         $billingAddress = $this->mapAddressData($billing);
@@ -377,6 +394,9 @@ class RegisterRoute extends AbstractRegisterRoute
         return $event->getOutput();
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function mapShippingAddress(DataBag $shipping, Context $context): array
     {
         $shippingAddress = $this->mapAddressData($shipping);
@@ -387,6 +407,9 @@ class RegisterRoute extends AbstractRegisterRoute
         return $event->getOutput();
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function mapCustomerData(DataBag $data, bool $isGuest, SalesChannelContext $context): array
     {
         $customer = [
@@ -469,6 +492,9 @@ class RegisterRoute extends AbstractRegisterRoute
         return $validation;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     private function mapAddressData(DataBag $addressData): array
     {
         $mappedData = $addressData->only(

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -131,8 +131,8 @@
 
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\LoginRoute" public="true">
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\AccountService"/>
             <argument type="service" id="customer.repository"/>
-            <argument type="service" id="Shopware\Core\Checkout\Customer\Password\LegacyPasswordVerifier"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\CartRestorer"/>
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack"/>
             <argument type="service" id="Shopware\Core\Framework\RateLimiter\RateLimiter"/>

--- a/src/Core/Checkout/Test/Customer/AccountServiceTest.php
+++ b/src/Core/Checkout/Test/Customer/AccountServiceTest.php
@@ -140,6 +140,30 @@ class AccountServiceTest extends TestCase
         static::assertEquals($context2->getSalesChannel()->getId(), $customer2->getSalesChannelId());
     }
 
+    public function testCustomerLoginByMailWithInactiveAccount(): void
+    {
+        $email = 'johndoe@example.com';
+
+        $context = $this->createSalesChannelContext([
+            'domains' => [
+                [
+                    'url' => 'http://test.de',
+                    'currencyId' => Defaults::CURRENCY,
+                    'languageId' => Defaults::LANGUAGE_SYSTEM,
+                    'snippetSetId' => $this->getRandomId('snippet_set'),
+                ],
+            ],
+        ]);
+        $this->createCustomerOfSalesChannel($context->getSalesChannel()->getId(), $email, true, false);
+        $activeCustomerId = $this->createCustomerOfSalesChannel($context->getSalesChannel()->getId(), $email);
+
+        $customer = $this->accountService->getCustomerByLogin($email, 'shopware', $context);
+        static::assertInstanceOf(CustomerEntity::class, $customer);
+        static::assertTrue($customer->getActive());
+        static::assertEquals($activeCustomerId, $customer->getId());
+        static::assertEquals($context->getSalesChannel()->getId(), $customer->getSalesChannelId());
+    }
+
     private function getCustomerFromToken(string $contextToken, string $salesChannelId): CustomerEntity
     {
         $salesChannelContextService = $this->getContainer()->get(SalesChannelContextService::class);
@@ -153,7 +177,7 @@ class AccountServiceTest extends TestCase
         return $customer;
     }
 
-    private function createCustomerOfSalesChannel(string $salesChannelId, string $email, bool $boundToSalesChannel = true): string
+    private function createCustomerOfSalesChannel(string $salesChannelId, string $email, bool $boundToSalesChannel = true, bool $active = true): string
     {
         $customerId = Uuid::randomHex();
         $addressId = Uuid::randomHex();
@@ -173,6 +197,7 @@ class AccountServiceTest extends TestCase
             'salesChannelId' => $salesChannelId,
             'defaultBillingAddressId' => $addressId,
             'defaultShippingAddressId' => $addressId,
+            'active' => $active,
             'addresses' => [
                 [
                     'id' => $addressId,

--- a/src/Core/Checkout/Test/Customer/SalesChannel/RegisterRouteTest.php
+++ b/src/Core/Checkout/Test/Customer/SalesChannel/RegisterRouteTest.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEve
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Event\NestedEventCollection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -388,8 +389,14 @@ class RegisterRouteTest extends TestCase
 
         static::assertArrayNotHasKey('contextToken', $response);
         static::assertArrayHasKey('errors', $response);
-        static::assertSame('CHECKOUT__CUSTOMER_IS_INACTIVE', $response['errors'][0]['code']);
-        static::assertSame('401', $response['errors'][0]['status']);
+
+        $optinError = $response['errors'][0];
+        static::assertSame('401', $optinError['status']);
+        if (Feature::isActive('v6.5.0.0')) {
+            static::assertSame('CHECKOUT__CUSTOMER_OPTIN_NOT_COMPLETED', $optinError['code']);
+        } else {
+            static::assertSame('CHECKOUT__CUSTOMER_IS_INACTIVE', $optinError['code']);
+        }
 
         $criteria = new Criteria([$customerId]);
         /** @var CustomerEntity $customer */

--- a/src/Core/Migration/V6_5/Migration1663402950SetDoubleOptinCustomerActive.php
+++ b/src/Core/Migration/V6_5/Migration1663402950SetDoubleOptinCustomerActive.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_5;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+class Migration1663402950SetDoubleOptinCustomerActive extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1663402950;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $query = <<<'SQL'
+            UPDATE
+                customer
+            SET
+                active = 1
+            WHERE
+                double_opt_in_registration = 1 AND double_opt_in_confirm_date IS NULL AND active = 0;
+        SQL;
+
+        $connection->executeStatement($query);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Storefront/Controller/AuthController.php
+++ b/src/Storefront/Controller/AuthController.php
@@ -6,8 +6,8 @@ use Shopware\Core\Checkout\Customer\Exception\BadCredentialsException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerAuthThrottledException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundByHashException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundException;
+use Shopware\Core\Checkout\Customer\Exception\CustomerOptinNotCompletedException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerRecoveryHashExpiredException;
-use Shopware\Core\Checkout\Customer\Exception\InactiveCustomerException;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractLoginRoute;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractLogoutRoute;
 use Shopware\Core\Checkout\Customer\SalesChannel\AbstractResetPasswordRoute;
@@ -210,8 +210,8 @@ class AuthController extends StorefrontController
 
                 return $this->createActionResponse($request);
             }
-        } catch (BadCredentialsException | UnauthorizedHttpException | InactiveCustomerException | CustomerAuthThrottledException $e) {
-            if ($e instanceof InactiveCustomerException) {
+        } catch (BadCredentialsException | UnauthorizedHttpException | CustomerOptinNotCompletedException | CustomerAuthThrottledException $e) {
+            if ($e instanceof CustomerOptinNotCompletedException) {
                 $errorSnippet = $e->getSnippetKey();
             }
 

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -216,6 +216,7 @@
     "addressDefaultNotChanged": "Standardadresse konnte nicht geändert werden.",
     "addressSaved": "Adresse erfolgreich gespeichert.",
     "inactiveAccountAlert": "Ihr Kundenkonto wurde noch nicht aktiviert. Wir haben Ihnen einen Aktivierungslink geschickt. Bitte prüfen Sie Ihr E-Mail-Postfach, um die Anmeldung abzuschließen!",
+    "doubleOptinAccountAlert": "Ihr Kundenkonto wurde noch nicht aktiviert. Wir haben Ihnen einen Aktivierungslink geschickt. Bitte prüfen Sie Ihr E-Mail-Postfach, um die Anmeldung abzuschließen!",
     "optInGuestAlert": "Vielen Dank für Ihr Interesse! Sie erhalten in Kürze eine Bestätigungs-E-Mail. Klicken Sie auf den darin enthaltenen Link, um Ihre E-Mail-Adresse zu bestätigen.",
     "optInRegistrationAlert": "Vielen Dank für Ihre Anmeldung! Sie erhalten in Kürze eine Bestätigungs-E-Mail. Klicken Sie auf den darin enthaltenen Link, um die Anmeldung abzuschließen.",
     "optInSuccessAlert": "Sofern die von Ihnen eingegebene E-Mail-Adresse registriert ist, haben wir Ihnen eine Bestätigungs-E-Mail gesendet.",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -216,6 +216,7 @@
     "addressDefaultNotChanged": "Default address could not be changed.",
     "addressSaved": "Address has been saved.",
     "inactiveAccountAlert": "Your customer account has not been activated yet. We have sent a confirmation email containing an activation link. Please check your inbox and click the link to complete the sign-up!",
+    "doubleOptinAccountAlert": "Your customer account has not been activated yet. We have sent a confirmation email containing an activation link. Please check your inbox and click the link to complete the sign-up!",
     "optInGuestAlert": "Thank you for your interest! You will receive a confirmation email shortly. Click on the link in it to confirm your email address.",
     "optInRegistrationAlert": "Thank you for signing up! You will receive a confirmation email shortly. Click on the link in it to complete the sign-up.",
     "optInSuccessAlert": "We just sent you a confirmation email.",

--- a/tests/integration/php/Core/Framework/RateLimiter/RateLimiterTest.php
+++ b/tests/integration/php/Core/Framework/RateLimiter/RateLimiterTest.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Psr7\ServerRequest;
 use League\OAuth2\Server\AuthorizationServer;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
-use Shopware\Core\Checkout\Customer\Password\LegacyPasswordVerifier;
+use Shopware\Core\Checkout\Customer\SalesChannel\AccountService;
 use Shopware\Core\Checkout\Customer\SalesChannel\LoginRoute;
 use Shopware\Core\Checkout\Test\Customer\Rule\OrderFixture;
 use Shopware\Core\Checkout\Test\Customer\SalesChannel\CustomerTestTrait;
@@ -123,8 +123,8 @@ class RateLimiterTest extends TestCase
     {
         $route = new LoginRoute(
             $this->getContainer()->get('event_dispatcher'),
+            $this->getContainer()->get(AccountService::class),
             $this->getContainer()->get('customer.repository'),
-            $this->getContainer()->get(LegacyPasswordVerifier::class),
             $this->getContainer()->get(CartRestorer::class),
             $this->getContainer()->get('request_stack'),
             $this->mockResetLimiter([

--- a/tests/migration/Core/V6_5/Migration1663402950SetDoubleOptinCustomerActiveTest.php
+++ b/tests/migration/Core/V6_5/Migration1663402950SetDoubleOptinCustomerActiveTest.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_5;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_5\Migration1663402950SetDoubleOptinCustomerActive;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Migration\V6_5\Migration1663402950SetDoubleOptinCustomerActive
+ */
+class Migration1663402950SetDoubleOptinCustomerActiveTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private Connection $connection;
+
+    public function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testMigration(): void
+    {
+        $migration = new Migration1663402950SetDoubleOptinCustomerActive();
+
+        $customerId = Uuid::randomBytes();
+        $customerAddressId = Uuid::randomBytes();
+        $now = new \DateTimeImmutable();
+
+        $countAffectedRows = $this->connection->insert('customer', [
+            'id' => $customerId,
+            'customer_group_id' => Uuid::fromHexToBytes(Defaults::FALLBACK_CUSTOMER_GROUP),
+            'default_payment_method_id' => $this->connection->fetchOne('SELECT id FROM `payment_method` WHERE `active` = 1'),
+            'sales_channel_id' => Uuid::fromHexToBytes(Defaults::SALES_CHANNEL),
+            'language_id' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
+            'default_billing_address_id' => $customerAddressId,
+            'default_shipping_address_id' => $customerAddressId,
+            'customer_number' => '123',
+            'first_name' => 'Bar',
+            'last_name' => 'Foo',
+            'email' => 'foo@bar.com',
+            'active' => 0,
+            'double_opt_in_registration' => 1,
+            'double_opt_in_email_sent_date' => $now->format('Y-m-d H:i:s'),
+            'guest' => 0,
+            'created_at' => $now->format('Y-m-d H:i:s'),
+        ]);
+
+        static::assertEquals(1, $countAffectedRows);
+
+        $migration->update($this->connection);
+
+        $result = $this->connection->fetchOne(
+            'SELECT active FROM  customer WHERE id = :customerId',
+            ['customerId' => $customerId]
+        );
+
+        static::assertEquals(1, $result);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently there are two places where the login logic is duplicated. Since this is a very critical part of the code (in my opinion), this should be as simple as possible, and the logic should be located at a single place.
Furthermore there was this performance optimization: https://github.com/shopware/platform/commit/11ec07f1e8e71a4722823f8c0f4847fb3059d6d7 which only made it in the `LoginRoute` but not the `AccountService`. This PR includes this change also for the `AccountService`.
As last thing I think it is not reasonable, that the double-opt-in is coupled to the `active` state of the customer. One reason is, that currently the Shop Owner can toggle the active flag, but not the double-opt-in. If he would enable that, he would probably assume, that this worked and the customer now can login, where in fact he cannot. Furthermore this complicates the code, since this needs to be distinguished.
Also the `InactiveCustomerException` might be misleading, since it will currently be also thrown, if the customer account is not active, where the message itself states, that the customer should confirm his account. This is of course not possible if the shop owner disabled the account, for some other reason. I am also not sure if such a thing should be visible in the API, personally I would not do it.

### 2. What does this change do, exactly?
See the changelog, but I tried to address all issues mentioned above. Additionally I replace all (hopefully) occurrences where the active check was performed, to check for the opt-in.

Furthermore this change includes the PR https://github.com/shopware/platform/pull/2447 to include the test from that change. I can rebase if this has been merged.

### 3. Describe each step to reproduce the issue or behaviour.
There is no real issue.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 6. Open questions from my side
- [x] What is the migration path for Shopware 6.5.0 for the existing customers in the database? I am not sure, in which migration the customers should be set to active, if they have double opt-in enabled. Is it a destructive or non-destructive migration for Shopware 6.5 or is it a destructive migration for Shopware 6.4?
- [x] Should the check if the opt-in has been confirmed be implemented directly into some other place, such that is more obvious that this needs to be checked?
- [x] Should the snippets be migrated, somehow?
- [ ] Are there any missing tests or something else I did not take into account?

After clearing up these questions, the PR should be ready (after I fixed the tests as well :) ).

<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2469"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

