### PR TITLE
Update RouteScope.php deprecation

### DIFF
--- a/src/Core/Framework/Routing/Annotation/RouteScope.php
+++ b/src/Core/Framework/Routing/Annotation/RouteScope.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Routing\Annotation;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationAnnotation;
 
 /**
- * @deprecated tag:v6.5.0 - Use route defaults with "_route_scope". Example: @Route(defaults={"_route_scope"={"storefront"})
+ * @deprecated tag:v6.5.0 - Use route defaults with "_routeScope". Example: @Route(defaults={"_routeScope"={"storefront"})
  * @Annotation
  *
  * @Attributes({

--- a/src/Core/Framework/Routing/Annotation/RouteScope.php
+++ b/src/Core/Framework/Routing/Annotation/RouteScope.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Routing\Annotation;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationAnnotation;
 
 /**
- * @deprecated tag:v6.5.0 - Use route defaults with "_routeScope". Example: @Route(defaults={"_routeScope"={"storefront"})
+ * @deprecated tag:v6.5.0 - Use route defaults with "_routeScope". Example: @Route(defaults={"_routeScope"={"storefront"}})
  * @Annotation
  *
  * @Attributes({


### PR DESCRIPTION
Fix param `_route_scope` of deprectaion

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To avoid error if you copy from the `@deprecated` section, error:
```
[Syntax Error] Expected Doctrine\Common\Annotations\DocLexer::T_CLOSE_CURLY_BRACES, got ')'
```
### 2. What does this change do, exactly?
Fix the `_routeScope` param as example of deprecation

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a controller
2. Add Docblock `@RouteScope(scopes={"storefront"})`
3. Go to RouteScope declaration: `\Shopware\Core\Framework\Routing\Annotation\RouteScope`
4. Copy the deprecated suggestion `@Route(defaults={"_routeScope"={"storefront"}})`
5. clean cache: `bin/console cache:clear`

Error
```
[Syntax Error] Expected Doctrine\Common\Annotations\DocLexer::T_CLOSE_CURLY_BRACES, got ')' at position 46 in class Interactiv4\Example\Storefront\Controller\ExampleController.
```
### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes: https://github.com/shopware/docs/pull/574
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
