### PR TITLE
Update base.html.twig

### DIFF
--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block base_html %}
-<html lang="{{ app.request.locale }}"
+<html lang="{{ page.header.activeLanguage.translationCode.code|lower }}"
       itemscope="itemscope"
       itemtype="https://schema.org/WebPage">
 {% endblock %}


### PR DESCRIPTION
Fixing an issue, when having locales with same language snippet set. App.Locale is somehow filled by snippet set ISO code, which is problematic, when using the same snippet set for two different countries (e.g. de-AT and de-DE).

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
