### PR TITLE
Add validation to fromArray argument to prevent missing initialization of properties

### DIFF
--- a/changelog/_unreleased/2022-05-11-add-parameter-validation-for-extension-listing-to-identify-data-issues-easier.md
+++ b/changelog/_unreleased/2022-05-11-add-parameter-validation-for-extension-listing-to-identify-data-issues-easier.md
@@ -1,0 +1,8 @@
+---
+title: Add parameter validation for extension listing items to identify data issues easier
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+*  Added validation of array keys in `\Shopware\Core\Framework\Store\Struct\ExtensionStruct::fromArray` to prevent future access on uninitialized properties error

--- a/src/Core/Framework/Store/Struct/ExtensionStruct.php
+++ b/src/Core/Framework/Store/Struct/ExtensionStruct.php
@@ -65,7 +65,7 @@ class ExtensionStruct extends Struct
      *
      * @see AppEntity::$privacy
      */
-    protected ?string $privacyPolicyLink;
+    protected ?string $privacyPolicyLink = null;
 
     /**
      * languages property from store
@@ -135,8 +135,23 @@ class ExtensionStruct extends Struct
 
     protected bool $allowDisable = true;
 
+    /**
+     * @throws \InvalidArgumentException
+     */
     public static function fromArray(array $data): ExtensionStruct
     {
+        if (!isset($data['name'])) {
+            throw new \InvalidArgumentException('Entry "name" in payload missing');
+        }
+
+        if (!isset($data['label'])) {
+            throw new \InvalidArgumentException('Entry "label" in payload missing');
+        }
+
+        if (!isset($data['type'])) {
+            throw new \InvalidArgumentException('Entry "type" in payload missing');
+        }
+
         return (new self())->assign($data);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Somehow translations are not loaded correctly for an app. No one will notice until getLabel is accessed. So better check before. Thanks for @silviokennecke finding the origin of the access on uninitialized property issue.

### 2. What does this change do, exactly?

Set a prop that is nullable to null by default and check other inputs to prevent access to getters that are broken.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install a bad app
2. Extension listing in admin breaks
3. You can not uninstall bad app

Now it still breaks the admin but it is nicer as a dev to find the underlying issue.

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change

Why should I write tests when no one cares for the coverage?!

- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
