### PR TITLE
Fix apps breaking extension listing in administration

### DIFF
--- a/changelog/_unreleased/2022-05-11-fix-apps-break-extension-listing.md
+++ b/changelog/_unreleased/2022-05-11-fix-apps-break-extension-listing.md
@@ -1,0 +1,7 @@
+---
+title: Fix apps breaking extension listing in administration
+author: Silvio Kennecke
+author_github: @silviokennecke
+---
+# Core
+* load app label and description from translations in `\Shopware\Core\Framework\Store\Services\ExtensionLoader::prepareAppData`

--- a/changelog/_unreleased/2022-05-11-fix-apps-break-extension-listing.md
+++ b/changelog/_unreleased/2022-05-11-fix-apps-break-extension-listing.md
@@ -4,4 +4,4 @@ author: Silvio Kennecke
 author_github: @silviokennecke
 ---
 # Core
-* load app label and description from translations in `\Shopware\Core\Framework\Store\Services\ExtensionLoader::prepareAppData`
+* Changed `\Shopware\Core\Framework\Store\Services\ExtensionLoader::prepareAppData` to load app label and description from translations

--- a/changelog/_unreleased/2022-05-11-fix-apps-break-extension-listing.md
+++ b/changelog/_unreleased/2022-05-11-fix-apps-break-extension-listing.md
@@ -1,5 +1,6 @@
 ---
 title: Fix apps breaking extension listing in administration
+issue: NEXT-21573
 author: Silvio Kennecke
 author_github: @silviokennecke
 ---

--- a/src/Core/Framework/Store/Services/ExtensionLoader.php
+++ b/src/Core/Framework/Store/Services/ExtensionLoader.php
@@ -259,9 +259,9 @@ class ExtensionLoader
 
         $data = [
             'localId' => $app->getId(),
-            'description' => $app->getDescription(),
+            'description' => $app->getTranslation('description'),
             'name' => $app->getName(),
-            'label' => $app->getLabel(),
+            'label' => $app->getTranslation('label'),
             'producerName' => $app->getAuthor(),
             'license' => $app->getLicense(),
             'version' => $app->getVersion(),


### PR DESCRIPTION
### 1. Why is this change necessary?

When installing a bad app, this might break the extension listing in the administration.

This refers to @JoshuaBehrens PR #2478.

### 2. What does this change do, exactly?

In the `ExtensionLoader` the `prepareAppData` method fetches the name and description directly from the `AppEntity` object. Now it's using the `getTranslation($field)` method.

### 3. Describe each step to reproduce the issue or behaviour.

1. Install a bad app
2. Extension listing in admin breaks and states no plugins are installed

A look in the inspector reveals that `GET /api/_action/extension/installed` fails with an internal server error:
```json
{
	"errors": [
		{
			"code": "0",
			"status": "500",
			"title": "Internal Server Error",
			"detail": "Typed property Shopware\\Core\\Framework\\Store\\Struct\\ExtensionStruct::$label must not be accessed before initialization",
			"meta": {
				"trace": [
					{
						"file": "\/...\/vendor\/shopware\/core\/Framework\/Store\/Services\/ExtensionListingLoader.php",
						"line": 79,
						"function": "getLabel",
						"class": "Shopware\\Core\\Framework\\Store\\Struct\\ExtensionStruct",
						"type": "-\u003E"
					},
					{
						"function": "Shopware\\Core\\Framework\\Store\\Services\\{closure}",
						"class": "Shopware\\Core\\Framework\\Store\\Services\\ExtensionListingLoader",
						"type": "-\u003E"
					},
					{
						"file": "\/...\/vendor\/shopware\/core\/Framework\/Struct\/Collection.php",
						"line": 88,
						"function": "uasort"
					},
					{
						"file": "\/...\/vendor\/shopware\/core\/Framework\/Store\/Services\/ExtensionListingLoader.php",
						"line": 80,
						"function": "sort",
						"class": "Shopware\\Core\\Framework\\Struct\\Collection",
						"type": "-\u003E"
					},
					{
						"file": "\/...\/vendor\/shopware\/core\/Framework\/Store\/Services\/ExtensionListingLoader.php",
						"line": 31,
						"function": "sortCollection",
						"class": "Shopware\\Core\\Framework\\Store\\Services\\ExtensionListingLoader",
						"type": "-\u003E"
					},
					{
						"file": "\/...\/vendor\/shopware\/core\/Framework\/Store\/Services\/ExtensionDataProvider.php",
						"line": 70,
						"function": "load",
						"class": "Shopware\\Core\\Framework\\Store\\Services\\ExtensionListingLoader",
						"type": "-\u003E"
					},
					{
						"file": "\/...\/vendor\/shopware\/core\/Framework\/Store\/Api\/ExtensionStoreDataController.php",
						"line": 53,
						"function": "getInstalledExtensions",
						"class": "Shopware\\Core\\Framework\\Store\\Services\\ExtensionDataProvider",
						"type": "-\u003E"
					},
					{
						"file": "\/...\/vendor\/symfony\/http-kernel\/HttpKernel.php",
						"line": 156,
						"function": "getInstalledExtensions",
						"class": "Shopware\\Core\\Framework\\Store\\Api\\ExtensionStoreDataController",
						"type": "-\u003E"
					},
					{"...": "..."}
				],
				"file": "\/...\/vendor\/shopware\/core\/Framework\/Store\/Struct\/ExtensionStruct.php",
				"line": 173
			}
		}
	]
}
```

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
