### PR TITLE
Add structured for custom/plugins/{vendor}/{moduleName}

### DIFF
--- a/changelog/_unreleased/2022-05-11-vendor-structure-custom-plugins.md
+++ b/changelog/_unreleased/2022-05-11-vendor-structure-custom-plugins.md
@@ -1,0 +1,7 @@
+---
+title: vendor structure custom plugins
+author: Oscar Recio
+author_github: @osrecio
+---
+# Core
+*  Added the possibility to have vendor folders to have multiple modules in custom/plugins/{Vendor}/{ModuleName}

--- a/changelog/_unreleased/2022-05-11-vendor-structure-custom-plugins.md
+++ b/changelog/_unreleased/2022-05-11-vendor-structure-custom-plugins.md
@@ -2,6 +2,7 @@
 title: vendor structure custom plugins
 author: Oscar Recio
 author_github: @osrecio
+issue: NEXT-1234
 ---
 # Core
 *  Added the possibility to have vendor folders to have multiple modules in custom/plugins/{Vendor}/{ModuleName}

--- a/src/Core/Framework/Plugin/Util/PluginFinder.php
+++ b/src/Core/Framework/Plugin/Util/PluginFinder.php
@@ -52,14 +52,14 @@ class PluginFinder
 
         try {
             $filesystemPlugins = (new Finder())
-                ->directories()
-                ->depth(0)
+                ->depth('<=2')
                 ->in($pluginDir)
                 ->sortByName()
+                ->path('composer.json')
                 ->getIterator();
 
             foreach ($filesystemPlugins as $filesystemPlugin) {
-                $pluginPath = $filesystemPlugin->getRealPath();
+                $pluginPath = $filesystemPlugin->getPath();
 
                 try {
                     $package = $this->packageProvider->getPluginComposerPackage($pluginPath, $composerIO);
@@ -79,7 +79,7 @@ class PluginFinder
 
                 $plugins[$pluginName] = (new PluginFromFileSystemStruct())->assign([
                     'baseClass' => $pluginName,
-                    'path' => $filesystemPlugin->getPathname(),
+                    'path' => $pluginPath,
                     'managedByComposer' => false,
                     'composerPackage' => $package,
                 ]);

--- a/src/Core/Framework/Test/Plugin/Util/PluginFinderTest.php
+++ b/src/Core/Framework/Test/Plugin/Util/PluginFinderTest.php
@@ -35,7 +35,8 @@ class PluginFinderTest extends TestCase
             new ExceptionCollection(),
             new NullIO()
         );
-        static::assertCount(1, $plugins);
+        static::assertCount(2, $plugins);
         static::assertSame($plugins['Works\Works']->getBaseClass(), 'Works\Works');
+        static::assertSame($plugins['AlsoWorks\AlsoWorks']->getBaseClass(), 'AlsoWorks\AlsoWorks');
     }
 }

--- a/src/Core/Framework/Test/Plugin/Util/_fixture/Vendor/Module/composer.json
+++ b/src/Core/Framework/Test/Plugin/Util/_fixture/Vendor/Module/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "swag/test",
+    "description": "Test description",
+    "version": "v1.0.1",
+    "type": "shopware-platform-plugin",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "shopware AG",
+            "role": "Manufacturer"
+        }
+    ],
+    "require": {
+        "shopware/platform": "6.4.*@dev"
+    },
+    "extra": {
+        "shopware-plugin-class": "AlsoWorks\\AlsoWorks",
+        "label": {
+            "en-GB": "Test plugin",
+            "de-DE": "Test plugin"
+        }
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
When you have a project with multiples modules, this kind of structure is better to organize the plugins

### 2. What does this change do, exactly?
Add the posibility to have in path `custom/plugins` the next structure:
```
|-- Interactiv4
|   `-- Module1
|       `-- composer.json
|   `-- Module2
|       `-- composer.json
|   `-- Module3
|       `-- composer.json
|   `-- Module4
|       `-- composer.json
|-- Swag
|   `-- Module5
|       `-- composer.json
|-- Vendor3
|   `-- Module6
|       `-- composer.json
|   `-- Module8
|       `-- composer.json
|-- SwagExample
|  `-- composer.json
|`-- SwagPlatformDemoData
|   `-- composer.json
```

### 3. Describe each step to reproduce the issue or behaviour.
Is not an issue is an improvement or feature request :) 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/f6077a852f69d3582c307a4c5d19841ef9f63258/changelog/_unreleased/2022-05-11-vendor-structure-custom-plugins.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
