### PR TITLE
Remove unused data from cart before serialization

### DIFF
--- a/changelog/_unreleased/2022-05-14-clean-cart-before-serialization.md
+++ b/changelog/_unreleased/2022-05-14-clean-cart-before-serialization.md
@@ -1,0 +1,18 @@
+---
+title: Clean cart before serialization
+issue: -
+flag: v6.5.0.0
+author: Timo Helmke, Sebastian König
+author_email: t.helmke@kellerkinder.de
+author_github: t2oh4e
+---
+# Core
+* Custom fields in cart will now be removed when not used in cart rules
+___
+# Upgrade Information
+## Custom fields in cart
+Custom fields will now be removed from the cart for performance reasons. Add the to the allow list with CartBeforeSerializationEvent if you need them in cart.
+___
+# Next Major Version Changes
+## Custom fields in cart removed:
+* Add custom fields to custom field allow list in CartBeforeSerializationEvent if you need them in cart. Custom fields used in cart rules will not be removed by default.

--- a/src/Core/Checkout/Cart/CartPersister.php
+++ b/src/Core/Checkout/Cart/CartPersister.php
@@ -24,15 +24,18 @@ class CartPersister extends AbstractCartPersister
 
     private EventDispatcherInterface $eventDispatcher;
 
+    private CartSerializationCleaner $cartSerializationCleaner;
+
     private bool $compress;
 
     /**
      * @internal
      */
-    public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher, bool $compress)
+    public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher, CartSerializationCleaner $cartSerializationCleaner, bool $compress)
     {
         $this->connection = $connection;
         $this->eventDispatcher = $eventDispatcher;
+        $this->cartSerializationCleaner = $cartSerializationCleaner;
         $this->compress = $compress;
     }
 
@@ -167,6 +170,8 @@ class CartPersister extends AbstractCartPersister
 
         $cart->setErrors(new ErrorCollection());
         $cart->setData(null);
+
+        $this->cartSerializationCleaner->cleanupCart($cart);
 
         // @deprecated tag:v6.6.0 - remove else part
         if ($payloadExists) {

--- a/src/Core/Checkout/Cart/CartSerializationCleaner.php
+++ b/src/Core/Checkout/Cart/CartSerializationCleaner.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Checkout\Cart\Event\CartBeforeSerializationEvent;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Framework\Feature;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+class CartSerializationCleaner
+{
+    private Connection $connection;
+
+    private EventDispatcherInterface $eventDispatcher;
+
+    public function __construct(Connection $connection, EventDispatcherInterface $eventDispatcher)
+    {
+        $this->connection = $connection;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function cleanupCart(Cart $cart): void
+    {
+        if (!Feature::isActive('v6.5.0.0')) {
+            return;
+        }
+
+        $customFieldAllowList = $this->connection->fetchFirstColumn('SELECT JSON_UNQUOTE(JSON_EXTRACT(`value`, "$.renderedField.name")) as technical_name FROM rule_condition WHERE type = \'cartLineItemCustomField\';');
+
+        $event = new CartBeforeSerializationEvent($cart, $customFieldAllowList);
+        $this->eventDispatcher->dispatch($event);
+
+        $this->cleanupLineItems($cart->getLineItems(), $event->getCustomFieldAllowList());
+
+        foreach ($cart->getDeliveries() as $delivery) {
+            $this->cleanupLineItems($delivery->getPositions()->getLineItems(), $event->getCustomFieldAllowList());
+        }
+    }
+
+    private function cleanupLineItems(LineItemCollection $lineItems, array $customFieldAllowList): void
+    {
+        foreach ($lineItems as $lineItem) {
+            $this->cleanupLineItem($lineItem, $customFieldAllowList);
+        }
+    }
+
+    private function cleanupLineItem(LineItem $lineItem, array $customFieldAllowList): void
+    {
+        if ($lineItem->getCover()) {
+            $lineItem->getCover()->setThumbnailsRo('');
+        }
+
+        $this->cleanupCustomFields($lineItem, $customFieldAllowList);
+
+        foreach ($lineItem->getChildren() as $child) {
+            $this->cleanupLineItem($child, $customFieldAllowList);
+        }
+    }
+
+    private function cleanupCustomFields(LineItem $lineItem, array $customFieldAllowList): void
+    {
+        $customFields = $lineItem->getPayloadValue('customFields');
+        if (!$customFields) {
+            return;
+        }
+
+        if (\count($customFieldAllowList) === 0) {
+            $lineItem->setPayloadValue('customFields', []);
+
+            return;
+        }
+
+        $lineItem->setPayloadValue(
+            'customFields',
+            array_intersect_key(
+                $customFields,
+                array_combine(
+                    $customFieldAllowList,
+                    $customFieldAllowList
+                )
+            )
+        );
+    }
+}

--- a/src/Core/Checkout/Cart/Event/CartBeforeSerializationEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartBeforeSerializationEvent.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Event;
+
+use Shopware\Core\Checkout\Cart\Cart;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CartBeforeSerializationEvent extends Event
+{
+    protected Cart $cart;
+
+    private array $customFieldAllowList;
+
+    public function __construct(Cart $cart, array $customFieldAllowList)
+    {
+        $this->cart = $cart;
+        $this->customFieldAllowList = $customFieldAllowList;
+    }
+
+    public function getCart(): Cart
+    {
+        return $this->cart;
+    }
+
+    public function getCustomFieldAllowList(): array
+    {
+        return $this->customFieldAllowList;
+    }
+
+    public function setCustomFieldAllowList(array $customFieldAllowList): void
+    {
+        $this->customFieldAllowList = $customFieldAllowList;
+    }
+}

--- a/src/Core/Checkout/Cart/RedisCartPersister.php
+++ b/src/Core/Checkout/Cart/RedisCartPersister.php
@@ -26,6 +26,8 @@ class RedisCartPersister extends AbstractCartPersister
 
     private EventDispatcherInterface $eventDispatcher;
 
+    private CartSerializationCleaner $cartSerializationCleaner;
+
     private bool $compress;
 
     /**
@@ -33,10 +35,11 @@ class RedisCartPersister extends AbstractCartPersister
      *
      * @param \Redis|\RedisArray|\RedisCluster|RedisClusterProxy|RedisProxy|null $redis
      */
-    public function __construct($redis, EventDispatcherInterface $eventDispatcher, bool $compress)
+    public function __construct($redis, EventDispatcherInterface $eventDispatcher, CartSerializationCleaner $cartSerializationCleaner, bool $compress)
     {
         $this->redis = $redis;
         $this->eventDispatcher = $eventDispatcher;
+        $this->cartSerializationCleaner = $cartSerializationCleaner;
         $this->compress = $compress;
     }
 
@@ -125,6 +128,8 @@ class RedisCartPersister extends AbstractCartPersister
 
         $cart->setErrors(new ErrorCollection());
         $cart->setData(null);
+
+        $this->cartSerializationCleaner->cleanupCart($cart);
 
         $content = ['cart' => $cart, 'rule_ids' => $context->getRuleIds()];
 

--- a/src/Core/Checkout/DependencyInjection/cart.xml
+++ b/src/Core/Checkout/DependencyInjection/cart.xml
@@ -47,7 +47,13 @@
         <service id="Shopware\Core\Checkout\Cart\CartPersister">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\CartSerializationCleaner"/>
             <argument>%shopware.cart.compress%</argument>
+        </service>
+
+        <service id="Shopware\Core\Checkout\Cart\CartSerializationCleaner">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Cart\SalesChannel\CartService" public="true">
@@ -385,6 +391,7 @@
         <service id="Shopware\Core\Checkout\Cart\RedisCartPersister">
             <argument type="service" id="shopware.cart.redis"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\CartSerializationCleaner"/>
             <argument>%shopware.cart.compress%</argument>
         </service>
 

--- a/src/Core/Checkout/Test/Cart/CartSerializationCleanerTest.php
+++ b/src/Core/Checkout/Test/Cart/CartSerializationCleanerTest.php
@@ -1,0 +1,217 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Test\Cart;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartSerializationCleaner;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\Delivery;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryCollection;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryDate;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryPosition;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryPositionCollection;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\ShippingLocation;
+use Shopware\Core\Checkout\Cart\Event\CartBeforeSerializationEvent;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
+use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Test\TestCaseBase\EventDispatcherBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
+use Shopware\Core\System\Country\CountryEntity;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class CartSerializationCleanerTest extends TestCase
+{
+    use EventDispatcherBehaviour;
+    use KernelTestBehaviour;
+
+    /**
+     * @dataProvider cleanupCustomFieldsProvider
+     */
+    public function testLineItemCustomFields(Cart $cart, array $payloads = [], array $allowed = []): void
+    {
+        Feature::skipTestIfInActive('v6.5.0.0', $this);
+
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+
+        $listener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $listener->expects(static::once())->method('__invoke');
+
+        $this->addEventListener($dispatcher, CartBeforeSerializationEvent::class, $listener);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(static::once())->method('fetchFirstColumn')->willReturn($allowed);
+
+        $cleaner = new CartSerializationCleaner($connection, $dispatcher);
+        $cleaner->cleanupCart($cart);
+
+        $items = $cart->getLineItems()->getFlat();
+        foreach ($items as $item) {
+            static::assertArrayHasKey($item->getId(), $payloads);
+            static::assertEquals($payloads[$item->getId()], $item->getPayload());
+        }
+
+        $delivery = $cart->getDeliveries()->first();
+        $deliveryItems = $delivery !== null ? $delivery->getPositions()->getLineItems()->getFlat() : [];
+
+        foreach ($deliveryItems as $item) {
+            static::assertArrayHasKey($item->getId(), $payloads);
+            static::assertEquals($payloads[$item->getId()], $item->getPayload());
+        }
+    }
+
+    /**
+     * @dataProvider cleanupCoversProvider
+     */
+    public function testLineItemCovers(Cart $cart, ?MediaEntity $expectedCover): void
+    {
+        Feature::skipTestIfInActive('v6.5.0.0', $this);
+
+        $dispatcher = $this->createMock(EventDispatcher::class);
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(static::once())->method('fetchFirstColumn');
+
+        $cleaner = new CartSerializationCleaner($connection, $dispatcher);
+        $cleaner->cleanupCart($cart);
+
+        $items = $cart->getLineItems()->getFlat();
+        foreach ($items as $item) {
+            static::assertEquals($expectedCover, $item->getCover());
+        }
+    }
+
+    public function cleanupCustomFieldsProvider(): \Generator
+    {
+        yield 'Test empty cart' => [
+            new Cart('test', 'test'),
+            [],
+        ];
+
+        yield 'Test strip payload' => [
+            self::payloadCart('foo', ['customFields' => ['bar' => 1]]),
+            ['foo' => ['customFields' => []], 'foo-child' => ['customFields' => []]],
+        ];
+
+        yield 'Test allowed field' => [
+            self::payloadCart('foo', ['customFields' => ['bar' => 1]]),
+            ['foo' => ['customFields' => ['bar' => 1]], 'foo-child' => ['customFields' => ['bar' => 1]]],
+            ['bar'],
+        ];
+
+        yield 'Test multiple allowed fields' => [
+            self::payloadCart('foo', ['customFields' => ['bar' => 1, 'baz' => 2]]),
+            ['foo' => ['customFields' => ['bar' => 1, 'baz' => 2]], 'foo-child' => ['customFields' => ['bar' => 1, 'baz' => 2]]],
+            ['bar', 'baz'],
+        ];
+
+        yield 'Test allowed field with unkown key' => [
+            self::payloadCart('foo', ['customFields' => ['bar' => 1]]),
+            ['foo' => ['customFields' => []], 'foo-child' => ['customFields' => []]],
+            ['unknown_field'],
+        ];
+    }
+
+    public function cleanupCoversProvider(): \Generator
+    {
+        yield 'Test cover thumbnailRo cleanup' => [
+            self::coverCart('foo', 'test'),
+            (self::coverItem('foo', ''))->getCover(),
+        ];
+
+        yield 'Test cover thumbnailRo cleanup without ro data' => [
+            self::coverCart('foo', null),
+            (self::coverItem('foo', null))->getCover(),
+        ];
+
+        yield 'Test cover thumbnailRo cleanup without cover' => [
+            self::coverCart('foo', null, true),
+            null,
+        ];
+    }
+
+    private static function payloadItem(string $id, array $payload): LineItem
+    {
+        $item = new LineItem($id, 'foo');
+        $item->setPayload($payload);
+
+        $childItem = new LineItem($id . '-child', 'foo');
+        $childItem->setPayload($payload);
+
+        $item->addChild($childItem);
+
+        return $item;
+    }
+
+    private static function coverItem(string $id, ?string $thumbnailString, bool $skipCover = false): LineItem
+    {
+        $item = new LineItem($id, 'foo');
+        $childItem = new LineItem($id . 'child', 'foo');
+
+        $item->addChild($childItem);
+
+        if ($skipCover === true) {
+            return $item;
+        }
+
+        $cover = new MediaEntity();
+        if ($thumbnailString !== null) {
+            $cover->setThumbnailsRo($thumbnailString);
+        }
+
+        $item->setCover($cover);
+
+        $coverChild = new MediaEntity();
+        if ($thumbnailString !== null) {
+            $coverChild->setThumbnailsRo($thumbnailString);
+        }
+
+        $childItem->setCover($cover);
+
+        return $item;
+    }
+
+    private static function payloadCart(string $id, array $payload): Cart
+    {
+        $cart = (new Cart('test', 'test'))->add(self::payloadItem($id, $payload));
+        $cart->addDeliveries(self::itemDelivery(self::payloadItem($id, $payload)));
+
+        return $cart;
+    }
+
+    private static function coverCart(string $id, ?string $thumbnailString, bool $skipCover = false): Cart
+    {
+        $cart = (new Cart('test', 'test'))->add(self::coverItem($id, $thumbnailString, $skipCover));
+        $cart->addDeliveries(self::itemDelivery(self::coverItem($id, $thumbnailString, $skipCover)));
+
+        return $cart;
+    }
+
+    private static function itemDelivery(LineItem $lineItem): DeliveryCollection
+    {
+        $delivery = new Delivery(
+            new DeliveryPositionCollection(
+                [
+                    new DeliveryPosition(
+                        $lineItem->getId(),
+                        $lineItem,
+                        1,
+                        new CalculatedPrice(1.0, 1.0, new CalculatedTaxCollection(), new TaxRuleCollection()),
+                        new DeliveryDate(new \DateTimeImmutable(), new \DateTimeImmutable())
+                    ),
+                ]
+            ),
+            new DeliveryDate(new \DateTimeImmutable(), new \DateTimeImmutable()),
+            new ShippingMethodEntity(),
+            new ShippingLocation(new CountryEntity(), null, null),
+            new CalculatedPrice(1.0, 1.0, new CalculatedTaxCollection(), new TaxRuleCollection())
+        );
+
+        return new DeliveryCollection([$delivery]);
+    }
+}

--- a/src/Core/Checkout/Test/Cart/Command/CartMigrateCommandTest.php
+++ b/src/Core/Checkout/Test/Cart/Command/CartMigrateCommandTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartPersister;
+use Shopware\Core\Checkout\Cart\CartSerializationCleaner;
 use Shopware\Core\Checkout\Cart\Command\CartMigrateCommand;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
@@ -51,7 +52,7 @@ class CartMigrateCommandTest extends TestCase
         $redis = $factory->create((string) $url);
         $redis->flushAll();
 
-        $persister = new RedisCartPersister($redis, $this->getContainer()->get('event_dispatcher'), false);
+        $persister = new RedisCartPersister($redis, $this->getContainer()->get('event_dispatcher'), $this->getContainer()->get(CartSerializationCleaner::class), false);
         $persister->save($redisCart, $context);
 
         $command = new CartMigrateCommand($redis, $this->getContainer()->get(Connection::class), false, $factory);
@@ -60,6 +61,7 @@ class CartMigrateCommandTest extends TestCase
         $persister = new CartPersister(
             $this->getContainer()->get(Connection::class),
             $this->getContainer()->get('event_dispatcher'),
+            $this->getContainer()->get(CartSerializationCleaner::class),
             false
         );
 
@@ -93,7 +95,7 @@ class CartMigrateCommandTest extends TestCase
         $redis = $factory->create((string) $url);
         $redis->flushAll();
 
-        $persister = new RedisCartPersister($redis, $this->getContainer()->get('event_dispatcher'), $redisCompressed);
+        $persister = new RedisCartPersister($redis, $this->getContainer()->get('event_dispatcher'), $this->getContainer()->get(CartSerializationCleaner::class), $redisCompressed);
         $persister->save($redisCart, $context);
 
         $command = new CartMigrateCommand($redis, $this->getContainer()->get(Connection::class), $sqlCompressed, $factory);
@@ -102,6 +104,7 @@ class CartMigrateCommandTest extends TestCase
         $persister = new CartPersister(
             $this->getContainer()->get(Connection::class),
             $this->getContainer()->get('event_dispatcher'),
+            $this->getContainer()->get(CartSerializationCleaner::class),
             $sqlCompressed
         );
 
@@ -134,6 +137,7 @@ class CartMigrateCommandTest extends TestCase
         $persister = new CartPersister(
             $this->getContainer()->get(Connection::class),
             $this->getContainer()->get('event_dispatcher'),
+            $this->getContainer()->get(CartSerializationCleaner::class),
             $sqlCompressed
         );
 
@@ -149,7 +153,7 @@ class CartMigrateCommandTest extends TestCase
         $command = new CartMigrateCommand($redis, $this->getContainer()->get(Connection::class), $sqlCompressed, $factory);
         $command->run(new ArrayInput(['from' => 'sql']), new NullOutput());
 
-        $persister = new RedisCartPersister($redis, $this->getContainer()->get('event_dispatcher'), $redisCompressed);
+        $persister = new RedisCartPersister($redis, $this->getContainer()->get('event_dispatcher'), $this->getContainer()->get(CartSerializationCleaner::class), $redisCompressed);
         $redisCart = $persister->load($sqlCart->getToken(), $context);
 
         static::assertInstanceOf(Cart::class, $redisCart);

--- a/src/Core/Migration/Test/Migration1648709176CartCompressionTest.php
+++ b/src/Core/Migration/Test/Migration1648709176CartCompressionTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartPersister;
+use Shopware\Core\Checkout\Cart\CartSerializationCleaner;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
@@ -101,12 +102,14 @@ class Migration1648709176CartCompressionTest extends TestCase
         $compressed = new CartPersister(
             $this->getContainer()->get(Connection::class),
             $this->getContainer()->get('event_dispatcher'),
+            $this->getContainer()->get(CartSerializationCleaner::class),
             true
         );
 
         $uncompressed = new CartPersister(
             $this->getContainer()->get(Connection::class),
             $this->getContainer()->get('event_dispatcher'),
+            $this->getContainer()->get(CartSerializationCleaner::class),
             true
         );
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Because @OliverSkroblin said so. And because cart serialization no longer gets bloated with custom field data.
In a small test with 9 custom fields in a test environment we reduced the cart size by nearly 30%.

### 2. What does this change do, exactly?
Removes the unnecessary thumbnailsRo field from lineitems in cart.
Removes custom fields that are not used in cart rules from payload and delivery positions.
Introduces new event to allow custom fields to be persisted.

### 3. Describe each step to reproduce the issue or behaviour.
Put products in cart. Check serialized value in cart table. Find a lot of data.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
