### PR TITLE
exclude link categories from sitemap

### DIFF
--- a/changelog/_unreleased/2022-05-14-remove-category-external-link-from-sitemap.md
+++ b/changelog/_unreleased/2022-05-14-remove-category-external-link-from-sitemap.md
@@ -1,0 +1,10 @@
+---
+title: Remove category external link from sitemap
+issue: 
+author: Marcin Kaczor
+author_email: marcink@codepro.space
+author_github: CodeproSpace
+---
+
+# Core
+* I added a condition where link categories are not got in sitemap `\Shopware\Core\Content\Sitemap\Provider\CategoryUrlProvider`

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -141,6 +141,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
         $query->andWhere('(' . implode(' OR ', $wheres) . ')');
         $query->andWhere('`category`.version_id = :versionId');
         $query->andWhere('`category`.active = 1');
+        $query->andWhere('`category`.type != :linkType');
 
         $excludedCategoryIds = $this->getExcludedCategoryIds($context);
         if (!empty($excludedCategoryIds)) {
@@ -149,6 +150,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
         }
 
         $query->setParameter('versionId', Uuid::fromHexToBytes(Defaults::LIVE_VERSION));
+        $query->setParameter('linkType', CategoryDefinition::TYPE_LINK);
 
         return $query->execute()->fetchAll();
     }

--- a/src/Core/Content/Test/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/src/Core/Content/Test/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -88,7 +88,7 @@ class CategoryUrlProviderTest extends TestCase
     public function testExcludeCategoryLink(): void
     {
         $urlResult = $this->getCategoryUrlProvider()->getUrls($this->salesChannelContext, 10);
-        static::assertSame(5, count($urlResult->getUrls()));
+        static::assertCount(5, $urlResult->getUrls());
     }
 
     private function getCategoryUrlProvider(): CategoryUrlProvider
@@ -142,7 +142,7 @@ class CategoryUrlProviderTest extends TestCase
                     [
                         'name' => 'Sub 5',
                         'active' => true,
-                        'type' => CategoryDefinition::TYPE_LINK
+                        'type' => CategoryDefinition::TYPE_LINK,
                     ],
                 ],
             ],

--- a/src/Core/Content/Test/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/src/Core/Content/Test/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -85,6 +85,12 @@ class CategoryUrlProviderTest extends TestCase
         static::assertNull($urlResult->getNextOffset());
     }
 
+    public function testExcludeCategoryLink(): void
+    {
+        $urlResult = $this->getCategoryUrlProvider()->getUrls($this->salesChannelContext, 10);
+        static::assertSame(5, count($urlResult->getUrls()));
+    }
+
     private function getCategoryUrlProvider(): CategoryUrlProvider
     {
         return new CategoryUrlProvider(
@@ -136,6 +142,7 @@ class CategoryUrlProviderTest extends TestCase
                     [
                         'name' => 'Sub 5',
                         'active' => true,
+                        'type' => CategoryDefinition::TYPE_LINK
                     ],
                 ],
             ],

--- a/src/Core/Content/Test/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/src/Core/Content/Test/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -88,7 +88,7 @@ class CategoryUrlProviderTest extends TestCase
     public function testExcludeCategoryLink(): void
     {
         $urlResult = $this->getCategoryUrlProvider()->getUrls($this->salesChannelContext, 10);
-        static::assertCount(5, $urlResult->getUrls());
+        static::assertCount(4, $urlResult->getUrls());
     }
 
     private function getCategoryUrlProvider(): CategoryUrlProvider


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently, all categories are submitted to the sitemap. Those that are external links as well. They return code 404 in the sitemap.

### 2. What does this change do, exactly?

I've added a condition that excludes link categories.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
