### PR TITLE
Add default folder to sw-media-field

### DIFF
--- a/changelog/_unreleased/2022-05-18-add-default-folder-property-to-sw-media-field.md
+++ b/changelog/_unreleased/2022-05-18-add-default-folder-property-to-sw-media-field.md
@@ -1,0 +1,8 @@
+---
+title: Add default folder to sw-media-field
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added property `defaultFolder` to `sw-media-field` and forward it to `sw-media-upload-v2` and limit suggestion to matching folder

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/index.js
@@ -39,6 +39,15 @@ Component.register('sw-media-field', {
             required: false,
             default: null,
         },
+
+        defaultFolder: {
+            type: String,
+            required: false,
+            validator(value) {
+                return value.length > 0;
+            },
+            default: null,
+        },
     },
 
     data() {
@@ -125,6 +134,10 @@ Component.register('sw-media-field', {
                         Criteria.contains('fileExtension', this.searchTerm),
                     ],
                 ));
+            }
+
+            if (this.defaultFolder) {
+                criteria.addFilter(Criteria.equals('mediaFolder.defaultFolder.entity', this.defaultFolder));
             }
 
             try {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-field/sw-media-field.html.twig
@@ -92,6 +92,7 @@
                 <sw-media-upload-v2
                     v-if="showUploadField"
                     variant="regular"
+                    :default-folder="defaultFolder"
                     :allow-multi-select="false"
                     :upload-tag="uploadTag"
                     :disabled="disabled"


### PR DESCRIPTION
### 1. Why is this change necessary?
When I use sw-media-field which is the easiest way to work with media relations, I want to define which folder uploaded files are dropped into.

### 2. What does this change do, exactly?
Add the same property of a component used within sw-media-field to forward it.

### 3. Describe each step to reproduce the issue or behaviour.
1. Look for easy way to handle media relation easily
2. Find sw-media-field
3. Add default folder for new media relation
4. Can't put the new media automatically into the right folder

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
