### PR TITLE
NEXT-17267 | Refresh button within the event log in Admin

### DIFF
--- a/changelog/_unreleased/2022-05-19-2022-05-19-refresh-button-within-the-event-log-in-admin.md
+++ b/changelog/_unreleased/2022-05-19-2022-05-19-refresh-button-within-the-event-log-in-admin.md
@@ -1,0 +1,9 @@
+---
+title: 2022-05-19-Refresh-button-within-the-event-log-in-Admin
+issue: NEXT-17267
+author: Alexander Pankow
+author_email: alexander.pankow@blackpoint.de
+author_github: LiaraAlis
+---
+# Administration
+* Added sidebar with refresh button in event log list in file `src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.html.twig`

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/page/sw-settings-logging-list/sw-settings-logging-list.html.twig
@@ -117,5 +117,19 @@
         {% endblock %}
     </template>
     {% endblock %}
+
+    {% block sw_settings_logging_list_sidebar %}
+    <template #sidebar>
+        <sw-sidebar class="sw-settings-logging-list__sidebar">
+            {% block sw_settings_logging_list_sidebar_refresh %}
+            <sw-sidebar-item
+                icon="default-arrow-360-left"
+                :title="$tc('sw-settings-logging.list.titleSidebarItemRefresh')"
+                @click="onRefresh"
+            />
+            {% endblock %}
+        </sw-sidebar>
+    </template>
+    {% endblock %}
 </sw-page>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/snippet/de-DE.json
@@ -18,7 +18,8 @@
       "levelError": "Fehler",
       "levelCritical": "Kritisch",
       "levelAlert": "Alarm",
-      "levelEmergency": "Notfall"
+      "levelEmergency": "Notfall",
+      "titleSidebarItemRefresh": "Aktualisieren"
     },
     "entryInfo": {
       "title": "Log-Informationen",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/snippet/en-GB.json
@@ -18,7 +18,8 @@
       "levelError": "Error",
       "levelCritical": "Critical",
       "levelAlert": "Alert",
-      "levelEmergency": "Emergency"
+      "levelEmergency": "Emergency",
+      "titleSidebarItemRefresh": "Refresh"
     },
     "entryInfo": {
       "title": "Log information",


### PR DESCRIPTION
### 1. Why is this change necessary?
It is easier to reload event log with a button instead of refreshing the whole page. :D

### 2. What does this change do, exactly?
This changes added a sidebar with a refresh button to the event log.

### 3. Describe each step to reproduce the issue or behaviour.
Open event log and try to refresh the log. There is no button to do this. You need to refresh the page via browser functions.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-17267

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
