### PR TITLE
Implement small performance improvement

### DIFF
--- a/src/Storefront/Controller/ContextController.php
+++ b/src/Storefront/Controller/ContextController.php
@@ -120,7 +120,7 @@ class ContextController extends StorefrontController
             $route = 'frontend.home.page';
         }
 
-        $params = $request->request->get('redirectParameters', json_encode([]));
+        $params = $request->request->get('redirectParameters', []);
 
         if (\is_string($params)) {
             $params = json_decode($params, true);


### PR DESCRIPTION
Parsing `[]` to a string and back to an object is quiet inefficient.

As far as I have seen, this is only present in the `switchLanguage` language, which isn't called often, so it should not effect performance by a lot.

I have run a few tests, to compare the speed:
(the overhead of the for loop is ignored here, so we get an average amount of the execution time)

with json_encode:
```php
$stime = microtime(true);

for($cnt = 0; $cnt < 10000; $cnt++) {
  $param = json_encode([]);
  if(is_string($param)) {
    $param = json_decode($param);
  }
}

$etime = microtime(true); 
echo "exec time:" . ($etime - $stime);
// outputs ~2.3 milliseconds
```

without json_encode:
```php
$stime = microtime(true);

for($cnt = 0; $cnt < 10000; $cnt++) {
  $param = [];
  if(is_string($param)) {
    $param = json_decode($param);
  }
}

$etime = microtime(true); 
echo "exec time:" . ($etime - $stime);
// outputs ~0.17 milliseconds
```