### PR TITLE
No quantity information override

### DIFF
--- a/changelog/_unreleased/2022-05-23-no-override-quantity-information-productcartprocessor.md
+++ b/changelog/_unreleased/2022-05-23-no-override-quantity-information-productcartprocessor.md
@@ -1,0 +1,12 @@
+---
+title: No Override of the QuantityInformation inside the ProductCartProcessor
+issue: 
+flag: 
+author: Patrick Thimm
+author_email: patrick.thimm@sgs.com
+author_github: @ufcyg
+---
+
+# Core
+
+-   Changed `enrich()` inside `ProductCartProcessor.php` to only create a QuantityInformation object if necessary to prevent overriding existing settings

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Shopware\Core\Content\Product\Cart;
 
@@ -326,21 +328,24 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
             );
         }
 
-        $quantityInformation = new QuantityInformation();
+        //prevent quantity informations from being overwritten
+        if ($lineItem->getQuantityInformation() === null) {
+            $quantityInformation = new QuantityInformation();
 
-        $quantityInformation->setMinPurchase(
-            $product->getMinPurchase() ?? 1
-        );
+            $quantityInformation->setMinPurchase(
+                $product->getMinPurchase() ?? 1
+            );
 
-        $quantityInformation->setMaxPurchase(
-            $product->getCalculatedMaxPurchase()
-        );
+            $quantityInformation->setMaxPurchase(
+                $product->getCalculatedMaxPurchase()
+            );
 
-        $quantityInformation->setPurchaseSteps(
-            $product->getPurchaseSteps() ?? 1
-        );
+            $quantityInformation->setPurchaseSteps(
+                $product->getPurchaseSteps() ?? 1
+            );
 
-        $lineItem->setQuantityInformation($quantityInformation);
+            $lineItem->setQuantityInformation($quantityInformation);
+        }
 
         $purchasePrices = null;
         $purchasePricesCollection = $product->getPurchasePrices();
@@ -504,14 +509,18 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
 
     private function shouldPriceBeRecalculated(LineItem $lineItem, CartBehavior $behavior): bool
     {
-        if ($lineItem->getPriceDefinition() !== null
+        if (
+            $lineItem->getPriceDefinition() !== null
             && $lineItem->hasExtension(self::CUSTOM_PRICE)
-            && $behavior->hasPermission(self::ALLOW_PRODUCT_PRICE_OVERWRITES)) {
+            && $behavior->hasPermission(self::ALLOW_PRODUCT_PRICE_OVERWRITES)
+        ) {
             return false;
         }
 
-        if ($lineItem->getPriceDefinition() !== null
-            && $behavior->hasPermission(self::SKIP_PRODUCT_RECALCULATION)) {
+        if (
+            $lineItem->getPriceDefinition() !== null
+            && $behavior->hasPermission(self::SKIP_PRODUCT_RECALCULATION)
+        ) {
             return false;
         }
 

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -1,6 +1,4 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Shopware\Core\Content\Product\Cart;
 
@@ -509,18 +507,14 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
 
     private function shouldPriceBeRecalculated(LineItem $lineItem, CartBehavior $behavior): bool
     {
-        if (
-            $lineItem->getPriceDefinition() !== null
+        if ($lineItem->getPriceDefinition() !== null
             && $lineItem->hasExtension(self::CUSTOM_PRICE)
-            && $behavior->hasPermission(self::ALLOW_PRODUCT_PRICE_OVERWRITES)
-        ) {
+            && $behavior->hasPermission(self::ALLOW_PRODUCT_PRICE_OVERWRITES)) {
             return false;
         }
 
-        if (
-            $lineItem->getPriceDefinition() !== null
-            && $behavior->hasPermission(self::SKIP_PRODUCT_RECALCULATION)
-        ) {
+        if ($lineItem->getPriceDefinition() !== null
+            && $behavior->hasPermission(self::SKIP_PRODUCT_RECALCULATION)) {
             return false;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation? 
I believe not
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
I've tried to create children of lineitems in a plugin. The products those lineitems are referring to have Min/Max Purchase amounts aswell as the purchase step different from 1. Since the part i changed only runs now if no other information is already set from another source a different quantity information object can be used for a line item

### 2. What does this change do, exactly?
It prevents the ProductCartProcessor from overriding any previously set quantity informations on a line item

### 3. Describe each step to reproduce the issue or behaviour.
add a line item with QuantityInformation interferring with the defaults given by a product

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [-] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [-] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
