### PR TITLE
Add information about read- and write protection to entity schema

### DIFF
--- a/changelog/_unreleased/2022-05-30-add-read-and-write-protection-to-entity-schema.md
+++ b/changelog/_unreleased/2022-05-30-add-read-and-write-protection-to-entity-schema.md
@@ -1,0 +1,12 @@
+---
+title: Add read and write protection to entity schema
+author: Joshua Behrens
+author_email: code@joshua-behrens
+author_github: @JoshuaBehrens
+---
+# Core
+* Added the keys `read-protected` and `write-protected` to entities returned from `\Shopware\Core\Framework\Api\ApiDefinition\Generator\EntitySchemaGenerator`
+___
+# API
+* Added the keys `read-protected` and `write-protected` to entities returned from `/api/_info/entity-schema.json` / `api.info.entity-schema`
+* Removed entities returned from `/api/_info/entity-schema.json` / `api.info.entity-schema` when they are read and write protected

--- a/src/Core/Framework/Test/Api/ApiDefinition/Generator/EntitySchemaGeneratorTest.php
+++ b/src/Core/Framework/Test/Api/ApiDefinition/Generator/EntitySchemaGeneratorTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Api\ApiDefinition\Generator;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\ApiDefinition\Generator\EntitySchemaGenerator;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\Test\Api\ApiDefinition\EntityDefinition\SimpleDefinition;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+/**
+ * @internal
+ */
+final class EntitySchemaGeneratorTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testAllEntriesHaveProtectionHints(): void
+    {
+        $definitionRegistry = new DefinitionInstanceRegistry(
+            $this->getContainer(),
+            ['simple' => SimpleDefinition::class],
+            ['simple' => 'simple.repository']
+        );
+
+        $generator = new EntitySchemaGenerator();
+        $definitions = $generator->getSchema($definitionRegistry->getDefinitions());
+
+        static::assertNotEmpty($definitions);
+
+        foreach ($definitions as $definition) {
+            static::assertArrayHasKey('write-protected', $definition);
+            static::assertArrayHasKey('read-protected', $definition);
+        }
+    }
+
+    public function testNoEntriesHaveBothProtectionHintsTrue(): void
+    {
+        $definitionRegistry = new DefinitionInstanceRegistry(
+            $this->getContainer(),
+            ['simple' => SimpleDefinition::class],
+            ['simple' => 'simple.repository']
+        );
+
+        $generator = new EntitySchemaGenerator();
+        $definitions = $generator->getSchema($definitionRegistry->getDefinitions());
+
+        foreach ($definitions as $definition) {
+            static::assertFalse($definition['write-protected'] && $definition['read-protected']);
+        }
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

I have an API client in HEPTAconnect to utilize the admin API. In there it is encouraged (sort of enforced) to use the sync API. Some entities are not working with sync API like `acl_role` as it is marked as write protected. We could check beforehand which entity is write-protected and we can try to redirect the sync API request to the exact endpoint `/api/acl-role` instead. Unfortunately these information are hidden so far from the outside and therefore can only be known, when you look into the definition's code. There is no way without stumbling into errors to find out which entities are write protected.

### 2. What does this change do, exactly?

Check for write and read protection flags on entity definition and add them to the entity schema endpoint.

### 3. Describe each step to reproduce the issue or behaviour.

1. Transfer acl_role via entity specific API route
2. Works. Let's do it efficient in one request
3. Use sync API for acl_role instead
4. Run into write protection issue
5. (ಠ_ಠ)

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
