### PR TITLE
fix: move pointer to right position for webp animation detection

### DIFF
--- a/src/Core/Content/Media/TypeDetector/ImageTypeDetector.php
+++ b/src/Core/Content/Media/TypeDetector/ImageTypeDetector.php
@@ -90,6 +90,7 @@ class ImageTypeDetector implements TypeDetectorInterface
         $fh = fopen($filename, 'rb');
         fread($fh, 12);
         if (fread($fh, 4) === 'VP8X') {
+            fseek($fh, 20);
             $animationByte = fread($fh, 1);
             $result = (\ord($animationByte) >> 1) & 1 ? true : false;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This commit fixes a bug in shopware where almost any webp media image is flagged as "animated" even when it's not animated. This animated flag later prevents shopware from generating thumbnails so this fix is meaningful.

### 2. What does this change do, exactly?
Moves the pointer that identifies the animated flag to the right location.

### 3. Describe each step to reproduce the issue or behaviour.
Upload a webp image (from photoshop) to media section. The file will be flagged as "animated" and media:generate-thumbnails will skip the file.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
