### PR TITLE
fix: Default salutation in contact form

### DIFF
--- a/changelog/_unreleased/2022-05-31-fix-default-salutation-in-contact-form.md
+++ b/changelog/_unreleased/2022-05-31-fix-default-salutation-in-contact-form.md
@@ -1,0 +1,9 @@
+---
+title: Fix default salutation in contact form
+issue: NEXT-21624
+author: Stephan Franck
+author_email: stephan@vierpunkt.de
+author_github: @stephan4p
+---
+# Core
+* Changed `FormCmsElementResolver` to `enrich` salutations in the same way as the registration over `salutationRoute`

--- a/src/Core/Content/Cms/DataResolver/Element/FormCmsElementResolver.php
+++ b/src/Core/Content/Cms/DataResolver/Element/FormCmsElementResolver.php
@@ -6,20 +6,21 @@ use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
 use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
 use Shopware\Core\Content\Cms\DataResolver\Element;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\System\Salutation\SalutationCollection;
+use Shopware\Core\System\Salutation\SalesChannel\AbstractSalutationRoute;
+use Shopware\Core\System\Salutation\SalutationEntity;
+use Symfony\Component\HttpFoundation\Request;
 
 class FormCmsElementResolver extends Element\AbstractCmsElementResolver
 {
-    private EntityRepositoryInterface $salutationRepository;
+    private AbstractSalutationRoute $salutationRoute;
 
     /**
      * @internal
      */
-    public function __construct(EntityRepositoryInterface $salutationRepository)
+    public function __construct(AbstractSalutationRoute $salutationRoute)
     {
-        $this->salutationRepository = $salutationRepository;
+        $this->salutationRoute = $salutationRoute;
     }
 
     public function getType(): string
@@ -36,8 +37,12 @@ class FormCmsElementResolver extends Element\AbstractCmsElementResolver
     {
         $context = $resolverContext->getSalesChannelContext();
 
-        /** @var SalutationCollection $salutations */
-        $salutations = $this->salutationRepository->search(new Criteria(), $context->getContext())->getEntities();
+        $salutations = $this->salutationRoute->load(new Request(), $context, new Criteria())->getSalutations();
+
+        $salutations->sort(function (SalutationEntity $a, SalutationEntity $b) {
+            return $b->getSalutationKey() <=> $a->getSalutationKey();
+        });
+
         $slot->setData($salutations);
     }
 }

--- a/src/Core/Content/DependencyInjection/cms.xml
+++ b/src/Core/Content/DependencyInjection/cms.xml
@@ -48,7 +48,7 @@
 
         <service id="Shopware\Core\Content\Cms\DataResolver\Element\FormCmsElementResolver">
             <tag name="shopware.cms.data_resolver"/>
-            <argument type="service" id="salutation.repository"/>
+            <argument type="service" id="Shopware\Core\System\Salutation\SalesChannel\SalutationRoute"/>
         </service>
 
         <service id="Shopware\Core\Content\Cms\DataAbstractionLayer\FieldSerializer\SlotConfigFieldSerializer">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In contact form and newsletter form is the default salutation selectable as a not named Option

### 2. What does this change do, exactly?
Changes the procedure how the salutations are retrieved to salutationRoute same as in the registration form

### 3. Describe each step to reproduce the issue or behaviour.
Go to contact form an open the Salutation select. You will see an empty option

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-21624

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
