### PR TITLE
perf: Optimize logic in CartScopeDiscountPackager

### DIFF
--- a/changelog/_unreleased/2022-05-31-optimize-performance-of-cartscopediscountpackager.md
+++ b/changelog/_unreleased/2022-05-31-optimize-performance-of-cartscopediscountpackager.md
@@ -1,0 +1,9 @@
+---
+title: Optimize performance of CartScopeDiscountPackager
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Optimize logic in CartScopeDiscountPackager for performance, by not creating unnecessary clones of objects

--- a/src/Core/Checkout/DependencyInjection/promotion.xml
+++ b/src/Core/Checkout/DependencyInjection/promotion.xml
@@ -217,9 +217,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>
 
-        <service id="Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\CartScopeDiscountPackager">
-            <argument type="service" id="Shopware\Core\Checkout\Cart\LineItem\LineItemQuantitySplitter"/>
-        </service>
+        <service id="Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\CartScopeDiscountPackager"/>
 
         <service id="Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager\SetGroupScopeDiscountPackager">
             <argument type="service" id="Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder"/>

--- a/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/CartScopeDiscountPackager.php
+++ b/src/Core/Checkout/Promotion/Cart/Discount/ScopePackager/CartScopeDiscountPackager.php
@@ -3,14 +3,10 @@
 namespace Shopware\Core\Checkout\Promotion\Cart\Discount\ScopePackager;
 
 use Shopware\Core\Checkout\Cart\Cart;
-use Shopware\Core\Checkout\Cart\Exception\InvalidQuantityException;
-use Shopware\Core\Checkout\Cart\Exception\LineItemNotStackableException;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemQuantity;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemQuantityCollection;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
-use Shopware\Core\Checkout\Cart\LineItem\LineItemFlatCollection;
-use Shopware\Core\Checkout\Cart\LineItem\LineItemQuantitySplitter;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountLineItem;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackage;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\DiscountPackageCollection;
@@ -20,19 +16,6 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 class CartScopeDiscountPackager extends DiscountPackager
 {
-    /**
-     * @var LineItemQuantitySplitter
-     */
-    private $lineItemQuantitySplitter;
-
-    /**
-     * @internal
-     */
-    public function __construct(LineItemQuantitySplitter $lineItemQuantitySplitter)
-    {
-        $this->lineItemQuantitySplitter = $lineItemQuantitySplitter;
-    }
-
     public function getDecorated(): DiscountPackager
     {
         throw new DecorationPatternException(self::class);
@@ -48,44 +31,34 @@ class CartScopeDiscountPackager extends DiscountPackager
             return $lineItem->getType() === LineItem::PRODUCT_LINE_ITEM_TYPE && $lineItem->isStackable();
         });
 
-        $singleItems = $this->splitQuantities($allItems, $context);
-
-        $foundItems = [];
-
-        foreach ($singleItems as $cartLineItem) {
-            $item = new LineItemQuantity(
-                $cartLineItem->getId(),
-                $cartLineItem->getQuantity()
-            );
-
-            $foundItems[] = $item;
-        }
-
-        if ($foundItems === []) {
+        $discountPackage = $this->getDiscountPackage($allItems);
+        if ($discountPackage === null) {
             return new DiscountPackageCollection([]);
         }
 
-        $package = new DiscountPackage(new LineItemQuantityCollection($foundItems));
-
-        return new DiscountPackageCollection([$package]);
+        return new DiscountPackageCollection([$discountPackage]);
     }
 
-    /**
-     * @throws InvalidQuantityException
-     * @throws LineItemNotStackableException
-     */
-    private function splitQuantities(LineItemCollection $cartItems, SalesChannelContext $context): LineItemFlatCollection
+    private function getDiscountPackage(LineItemCollection $cartItems): ?DiscountPackage
     {
-        $items = [];
+        $discountItems = [];
+        foreach ($cartItems as $cartLineItem) {
+            for ($i = 1; $i <= $cartLineItem->getQuantity(); $i++) {
+                $item = new LineItemQuantity(
+                    $cartLineItem->getId(),
+                    1
+                );
 
-        foreach ($cartItems as $item) {
-            for ($i = 1; $i <= $item->getQuantity(); ++$i) {
-                $tmpItem = $this->lineItemQuantitySplitter->split($item, 1, $context);
-
-                $items[] = $tmpItem;
+                $discountItems[] = $item;
             }
         }
 
-        return new LineItemFlatCollection($items);
+        if (count($discountItems) === 0) {
+            return null;
+        }
+
+        return new DiscountPackage(
+            new LineItemQuantityCollection($discountItems)
+        );
     }
 }


### PR DESCRIPTION
to not create unnecessary clones of objects

### 1. Why is this change necessary?
At first I was quite confused if the logic was needed, but than I realized, that the code in the current form is probably an artifact. As I could not find any reason why the items should also be cloned for the package, as this reference is not used outside the class.

### 2. What does this change do, exactly?
Hopefully improves the performance (a tiny bit) and simplifies the logic. There should be no other change.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
