### PR TITLE
NEXT-21846 - Added og:url meta to Storefront

### DIFF
--- a/changelog/_unreleased/2022-06-01-Added-og-url-meta.md
+++ b/changelog/_unreleased/2022-06-01-Added-og-url-meta.md
@@ -1,0 +1,6 @@
+---
+title: Added og:url meta to Storefront
+issue: <UNASSIGNED>
+---
+# Storefront
+* Added `og:url` meta in `@Storefront/storefront/layout/meta.html.twig`.

--- a/changelog/_unreleased/2022-06-01-Added-og-url-meta.md
+++ b/changelog/_unreleased/2022-06-01-Added-og-url-meta.md
@@ -1,6 +1,7 @@
 ---
 title: Added og:url meta to Storefront
 issue: <UNASSIGNED>
+author_email: simon.nitzsche@esera.de
 ---
 # Storefront
 * Added `og:url` meta in `@Storefront/storefront/layout/meta.html.twig`.

--- a/changelog/_unreleased/2022-06-01-Added-og-url-meta.md
+++ b/changelog/_unreleased/2022-06-01-Added-og-url-meta.md
@@ -1,6 +1,6 @@
 ---
 title: Added og:url meta to Storefront
-issue: <UNASSIGNED>
+issue: NEXT-21846
 author_email: simon.nitzsche@esera.de
 ---
 # Storefront

--- a/src/Storefront/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/meta.html.twig
@@ -31,6 +31,8 @@
             {% endblock %}
 
             {% block layout_head_meta_tags_opengraph %}
+                <meta property="og:url"
+                      content="{% block layout_head_meta_tags_url_og %}{{ seoUrl('frontend.navigation.page', { navigationId: page.navigationId }) }}{% endblock %}"/>
                 <meta property="og:type"
                       content="{% block layout_head_meta_tags_type_og %}website{% endblock %}"/>
                 <meta property="og:site_name"


### PR DESCRIPTION
### 1. Why is this change necessary?
The OpenGraph og:url property is missing.

### 2. What does this change do, exactly?
It will add the OpenGraph og:url meta property on every site.

### 3. Describe each step to reproduce the issue or behaviour.
Check the HTML output of any page

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
