### PR TITLE
allowing all .twig files (for including xml files to)

### DIFF
--- a/src/Core/Framework/App/Template/TemplateLoader.php
+++ b/src/Core/Framework/App/Template/TemplateLoader.php
@@ -17,7 +17,7 @@ class TemplateLoader extends AbstractTemplateLoader
         'documents',
     ];
 
-    private const ALLOWED_FILE_EXTENSIONS = '*.html.twig';
+    private const ALLOWED_FILE_EXTENSIONS = '*.twig';
 
     /**
      * {@inheritdoc}

--- a/src/Core/Framework/Test/App/Manifest/_fixtures/test/Resources/views/storefront/page/sitemap/sitemap.xml.twig
+++ b/src/Core/Framework/Test/App/Manifest/_fixtures/test/Resources/views/storefront/page/sitemap/sitemap.xml.twig
@@ -1,0 +1,5 @@
+{% sw_extends '@Storefront/storefront/page/sitemap/sitemap.xml.twig' %}
+
+{% block sitemap %}
+    {{ parent() }}
+{% endblock %}

--- a/src/Core/Framework/Test/App/Template/TemplateLoaderTest.php
+++ b/src/Core/Framework/Test/App/Template/TemplateLoaderTest.php
@@ -30,7 +30,7 @@ class TemplateLoaderTest extends TestCase
         sort($templates);
 
         static::assertEquals(
-            ['storefront/layout/header/header.html.twig', 'storefront/layout/header/logo.html.twig'],
+            ['storefront/layout/header/header.html.twig', 'storefront/layout/header/logo.html.twig', 'storefront/page/sitemap/sitemap.xml.twig'],
             $templates
         );
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
**Because you cant modify for example the Sitemap.xml.twig file (so i cant make a custom Sitemap-Generator with Multilanguage functions...)**

### 2. What does this change do, exactly?
**allowing ALL files to template changes which ends with .twig (so this will also work for robot.txt for example)**

### 3. Describe each step to reproduce the issue or behaviour.
**try to extend the Sitemap.xml.twig and you will see the Template changes will not be recognized by Shopware**

### 4. Please link to the relevant issues (if any).
**(no issue created)**

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
