### PR TITLE
Make OrderFixture more realistic (include rounding keys)

### DIFF
--- a/src/Core/Checkout/Test/Customer/Rule/OrderFixture.php
+++ b/src/Core/Checkout/Test/Customer/Rule/OrderFixture.php
@@ -64,6 +64,8 @@ trait OrderFixture
                 'currencyFactor' => 1,
                 'salesChannelId' => TestDefaults::SALES_CHANNEL,
                 'orderDateTime' => '2019-04-01 08:36:43.267',
+                'itemRounding' = json_decode(json_encode(new CashRoundingConfig(2, 0.01, true)), true),
+                'totalRounding' = json_decode(json_encode(new CashRoundingConfig(2, 0.01, true)), true),
                 'deliveries' => [
                     [
                         'stateId' => $this->getContainer()->get(InitialStateIdLoader::class)->get(OrderDeliveryStates::STATE_MACHINE),


### PR DESCRIPTION
If we try to view the order created with this fixture data in the admin panel, the admin panel breaks with a nasty Vue JS error (tries to read decimals on null).

This improves this and makes developers live easier when debugging tests.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ not applicable] I have written tests and verified that they fail without my change
- [ will do ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ not necessary ] I have written or adjusted the documentation according to my changes
- [ not necessary ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
