### PR TITLE
Added option to skip assets compilation to system:update:finish command.

### DIFF
--- a/changelog/_unreleased/2022-06-03-added-option-to-skip-assets-compilation-to-system-update-finish-command.md
+++ b/changelog/_unreleased/2022-06-03-added-option-to-skip-assets-compilation-to-system-update-finish-command.md
@@ -1,0 +1,11 @@
+---
+title: Added option to skip assets compilation to system:update:finish command.
+issue: https://github.com/shopware/platform/issues/2366
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed `Shopware\Storefront\Theme\Subscriber\UpdateSubscriber` to check if the state `Shopware\Core\Framework\Plugin\PluginLifecycleService::STATE_SKIP_ASSET_BUILDING` exists.
+* Changed `Shopware\Core\Maintenance\System\Command\SystemUpdateFinishCommand` to add a new command option `--skip-asset-build`.
+* Changed `Shopware\Core\Maintenance\System\Command\SystemUpdateFinishCommand` to add the state `Shopware\Core\Framework\Plugin\PluginLifecycleService::STATE_SKIP_ASSET_BUILDING` if the `--skip-asset-build` option has been provided.

--- a/src/Storefront/Theme/Subscriber/UpdateSubscriber.php
+++ b/src/Storefront/Theme/Subscriber/UpdateSubscriber.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Theme\Subscriber;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Storefront\Theme\ThemeCollection;
@@ -50,6 +51,10 @@ class UpdateSubscriber implements EventSubscriberInterface
     {
         $context = $event->getContext();
         $this->themeLifecycleService->refreshThemes($context);
+
+        if ($context->hasState(PluginLifecycleService::STATE_SKIP_ASSET_BUILDING)) {
+            return;
+        }
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('active', true));


### PR DESCRIPTION
### 1. Why is this change necessary?

In order to skip unnecessary theme compilation on system:update:finish e.g. auto-deployments that do this automatically afterwards.

### 2. What does this change do, exactly?

See changelog and issue.

### 3. Describe each step to reproduce the issue or behaviour.

See issue/changelog.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2366

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
   - No test exists yet for the command itself and it wouldn't be that easy to test this specific behavior. In any case first a general test needs to be created.
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

Re-created previous PR: https://github.com/shopware/platform/pull/2379