### PR TITLE
Prevent dropdown close seems not necessary

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/listing/filter-base.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/listing/filter-base.plugin.js
@@ -21,20 +21,6 @@ export default class FilterBasePlugin extends Plugin {
         );
 
         this.listing.registerFilter(this);
-
-        this._preventDropdownClose();
-    }
-
-    _preventDropdownClose() {
-        const dropdownMenu = DomAccess.querySelector(this.el, this.options.dropdownSelector, false);
-
-        if (!dropdownMenu) {
-            return;
-        }
-
-        dropdownMenu.addEventListener('click', (event) => {
-            event.stopPropagation();
-        });
     }
 
     _validateMethods() {


### PR DESCRIPTION
It causes problems when trying to put nested collapsibles

See also:

https://stackoverflow.com/questions/72497610/stoppropagation-in-the-filter-sidebar-of-shopware-6-does-not-allow-nested-collap

### 1. Why is this change necessary?
When trying to put a nested collapsible, the stop propagation does not let us do this. Removing this code does not have a negative effect (seemingly)

### 2. What does this change do, exactly?

Remove the stopPropagation on the filters

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a collapsible for example in `@Storefront/storefront/component/listing/filter/filter-multi-select.html.twig` -> clicks do not have an effect
2. After removing this stopPropagation, the clicks have an effect

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
