### PR TITLE
Add active state icon to payment provider selection

### DIFF
--- a/changelog/_unreleased/2022-06-07-add-active-state-icon-to-sales-channel-configuration-selects.md
+++ b/changelog/_unreleased/2022-06-07-add-active-state-icon-to-sales-channel-configuration-selects.md
@@ -1,0 +1,13 @@
+---
+title: Add active state icon sales channel configuration selects and add preview slot for selects
+issue: NEXT-21916
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added slot `preview` to `sw-select-result` to have a slot before the text for easier object placement and similar code structure to table cells
+* Added slot `result-label-preview` to `sw-entity-multi-select` to expose the `preview` slot from `sw-select-result` like the `result-label-property` slot
+* Added active state icon to `sw-sales-channel-defaults-select` as preview for the result item depending on new property `shouldShowActiveState` (defaults to false)
+* Changed `shouldShowActiveState` for payment method, country and shipping method configurations in `sw-sales-channel-detail-base`
+* Changed sorting of payment methods in `sw-sales-channel-detail-base` for payment methods selection from `position ASC` to `active DESC, position ASC`

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/sw-select-result.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/sw-select-result.html.twig
@@ -6,6 +6,12 @@
     @mouseenter="onMouseEnter"
     @click.stop="onClickResult"
 >
+    {% block sw_select_result_item_preview %}
+    <span class="sw-select-result__result-item-preview">
+        <slot name="preview"></slot>
+    </span>
+    {% endblock %}
+
     {% block sw_select_result_item_text_holder %}
     <span class="sw-select-result__result-item-text">
         {% block sw_select_result_item_text %}

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/sw-select-result.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/sw-select-result.scss
@@ -24,7 +24,7 @@ $sw-select-result-disabled-color-text: darken($color-gray-300, 15%);
         color: $color-darkgray-200;
     }
 
-    .sw-icon {
+    > .sw-icon {
         color: $sw-select-result-color-icon;
         flex-grow: 0;
         flex-shrink: 0;
@@ -56,10 +56,10 @@ $sw-select-result-disabled-color-text: darken($color-gray-300, 15%);
 
     &.has--description {
         display: grid;
-        grid-template-columns: auto 1fr auto;
+        grid-template-columns: auto auto 1fr auto;
 
         .sw-select-result__result-item-text {
-            order: 1;
+            order: 2;
         }
 
         &.is--active {
@@ -71,13 +71,13 @@ $sw-select-result-disabled-color-text: darken($color-gray-300, 15%);
         .sw-select-result__result-item-description {
             width: 100%;
             color: $color-gray-600;
-            order: 2;
+            order: 3;
             line-height: 14px;
             padding: 0 0 0 8px;
         }
 
         .sw-icon {
-            order: 3;
+            order: 4;
         }
 
         &.is--description-bottom {

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.html.twig
@@ -109,6 +109,14 @@
                         :description-position="descriptionPosition"
                         @item-select="addItem"
                     >
+                        {% block sw_entity_multi_select_base_results_list_result_preview %}
+                        <template #preview>
+                            <slot
+                                name="result-label-preview"
+                                v-bind="{ item, index, labelProperty, valueProperty: 'id', searchTerm, highlightSearchTerm, getKey }"
+                            ></slot>
+                        </template>
+                        {% endblock %}
                         {% block sw_entity_multi_select_base_results_list_result_label %}
                         <slot
                             name="result-label-property"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/index.js
@@ -1,3 +1,4 @@
+import './sw-sales-channel-defaults-select.scss';
 import template from './sw-sales-channel-defaults-select.html.twig';
 
 const { Component, Mixin } = Shopware;
@@ -67,6 +68,12 @@ Component.register('sw-sales-channel-defaults-select', {
             type: String,
             required: false,
             default: '',
+        },
+
+        shouldShowActiveState: {
+            type: Boolean,
+            required: false,
+            default: false,
         },
     },
 
@@ -201,6 +208,10 @@ Component.register('sw-sales-channel-defaults-select', {
 
         isDisabledItem(item) {
             return item.active === false;
+        },
+
+        getActiveIconColor(item) {
+            return this.isDisabledItem(item) ? '#d1d9e0' : '#37d046';
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/sw-sales-channel-defaults-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/sw-sales-channel-defaults-select.html.twig
@@ -14,7 +14,21 @@
             :entity-collection="propertyCollection"
             :criteria="criteria"
             @change="updateCollection"
-        />
+        >
+            <template
+                v-if="shouldShowActiveState"
+                #result-label-preview="{ item }"
+            >
+                {% block sw_sales_channel_defaults_select_active_state %}
+                <sw-icon
+                    class="sw-sales-channel-defaults-select__active-icon"
+                    size="6"
+                    :color="getActiveIconColor(item)"
+                    name="default-basic-shape-circle-filled"
+                />
+                {% endblock %}
+            </template>
+        </sw-entity-multi-select>
 
         <sw-entity-single-select
             :label-property="labelProperty"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/sw-sales-channel-defaults-select.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-defaults-select/sw-sales-channel-defaults-select.scss
@@ -1,0 +1,4 @@
+.sw-select-result .sw-sales-channel-defaults-select__active-icon {
+    margin-right: 10px;
+    display: block;
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -133,6 +133,7 @@ Component.register('sw-sales-channel-detail-base', {
         paymentMethodCriteria() {
             const criteria = new Criteria(1, 25);
 
+            criteria.addSorting(Criteria.sort('active', 'DESC'));
             criteria.addSorting(Criteria.sort('position', 'ASC'));
 
             return criteria;

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -183,6 +183,7 @@
             :disabled="!acl.can('sales_channel.editor')"
             :default-property-label="$tc('sw-sales-channel.detail.labelInputDefaultCountry')"
             :disabled-tooltip-message="$tc('sw-sales-channel.detail.tooltipDisabledCountry')"
+            should-show-active-state
         />
         {% endblock %}
 
@@ -229,6 +230,7 @@
             :disabled="!acl.can('sales_channel.editor')"
             :default-property-label="$tc('sw-sales-channel.detail.labelInputDefaultPaymentMethod')"
             :disabled-tooltip-message="$tc('sw-sales-channel.detail.tooltipDisabledPaymentMethod')"
+            should-show-active-state
         />
         {% endblock %}
 
@@ -252,6 +254,7 @@
             :disabled="!acl.can('sales_channel.editor')"
             :default-property-label="$tc('sw-sales-channel.detail.labelInputDefaultShippingMethod')"
             :disabled-tooltip-message="$tc('sw-sales-channel.detail.tooltipDisabledShippingMethod')"
+            should-show-active-state
         />
         {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?

https://github.com/shopware/shopware/pull/2251

![image](https://user-images.githubusercontent.com/1133593/172469115-fafe7439-994c-4892-af8c-d30a184e3b42.png)


### 2. What does this change do, exactly?

* Added slot `preview` to `sw-select-result` to have a slot before the text for easier object placement and similar code structure to table cells
* Added slot `result-label-preview` to `sw-entity-multi-select` to expose the `preview` slot from `sw-select-result` like the `result-label-property` slot
* Added active state icon to `sw-sales-channel-defaults-select` as preview for the result item depending on new property `showActiveState` (defaults to false)
* Changed `showActiveState` for payment method, country and shipping method configurations in `sw-sales-channel-detail-base`
* Changed sorting of payment methods in `sw-sales-channel-detail-base` for payment methods selection from `position ASC` to `active DESC, position ASC`


### 3. Describe each step to reproduce the issue or behaviour.

1. Install PayPal app from first run wizard (accidentally)
2. Remove PayPal app
3. Install Mollie app from store
4. Install Klarna app from store
5. Have 50+ payment methods
6. Don't know about the alert that pops up if you select a disabled payment method
7. Be confused where the right PayPal integration is


### 4. Please show me a preview of what it looks like

![image](https://user-images.githubusercontent.com/1133593/172468696-dbd2c3f3-7b9c-4440-b5d0-97a2b3c7330b.png)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
