### PR TITLE
Administration product properties - translating the column labels

### DIFF
--- a/changelog/_unreleased/2022-06-08-administration-product-properties-translating-the-columns-labels.md
+++ b/changelog/_unreleased/2022-06-08-administration-product-properties-translating-the-columns-labels.md
@@ -1,0 +1,10 @@
+---
+title: Administration product properties - translating the column labels
+issue: -
+author: Gabriel Audignon-Le Louët
+author_email: gabriel.audignon@gmail.com
+author_github: @gabriel-al
+---
+# Administration
+* Changed `propertyColumns` in `src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/index.js` so the labels now use the this.$tc function
+

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/index.js
@@ -78,13 +78,13 @@ Component.register('sw-product-properties', {
             return [
                 {
                     property: 'name',
-                    label: 'sw-product.properties.columnProperty',
+                    label: this.$tc('sw-product.properties.columnProperty'),
                     sortable: false,
                     routerLink: 'sw.property.detail',
                 },
                 {
                     property: 'values',
-                    label: 'sw-product.properties.columnValue',
+                    label: this.$tc('sw-product.properties.columnValue'),
                     sortable: false,
                 },
             ];


### PR DESCRIPTION
### 1. Why is this change necessary?
For internationalization purposes

### 2. What does this change do, exactly?
It applies the translation function on the labels in the properties display, in the administration

### 3. Describe each step to reproduce the issue or behaviour.
Connect to shopware administration, go to catalogues->products->specifications->properties.
Without the changes, the columns titles are not translated. 

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [not needed ] I have written tests and verified that they fail without my change
- [x ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [not needed ] I have written or adjusted the documentation according to my changes
- [not needed ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.
