### PR TITLE
Add type check on unrolling exceptions

### DIFF
--- a/changelog/_unreleased/2022-06-08-amend-api-exceptions-type-check-during-error-container-inspection.md
+++ b/changelog/_unreleased/2022-06-08-amend-api-exceptions-type-check-during-error-container-inspection.md
@@ -1,0 +1,8 @@
+---
+title: Amend API exceptions type check during error container inspection
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Fixed issue that occurs during API error response serialization when an exception has been pushed onto `\Shopware\Core\Framework\Api\Converter\Exceptions\ApiConversionException` that is not `instanceof \Shopware\Core\Framework\ShopwareHttpException`

--- a/src/Core/Framework/Api/Converter/Exceptions/ApiConversionException.php
+++ b/src/Core/Framework/Api/Converter/Exceptions/ApiConversionException.php
@@ -45,13 +45,16 @@ class ApiConversionException extends ShopwareHttpException
             /** @var ShopwareException $exception */
             foreach ($innerExceptions as $exception) {
                 $parameters = [];
+                $errorCode = 0;
+
                 if ($exception instanceof ShopwareException) {
                     $parameters = $exception->getParameters();
+                    $errorCode = $exception->getErrorCode();
                 }
 
                 $error = [
                     'status' => (string) $this->getStatusCode(),
-                    'code' => $exception->getErrorCode(),
+                    'code' => $errorCode,
                     'title' => Response::$statusTexts[Response::HTTP_BAD_REQUEST],
                     'detail' => $exception->getMessage(),
                     'source' => ['pointer' => $pointer],


### PR DESCRIPTION
### 1. Why is this change necessary?
When you add any throwable, that is not a shopware exception, to the exception container, this will fail.

### 2. What does this change do, exactly?
Checks a type before assuming a method's existence.

### 3. Describe each step to reproduce the issue or behaviour.
1. Tinker with Shopware
2. Find an issue
3. Add exception
4. Fail at reading exception via API

### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
