### PR TITLE
Add default language to avoid many failures in setups with 2+ languages

### DIFF
--- a/src/Core/DevOps/Locust/setup.php
+++ b/src/Core/DevOps/Locust/setup.php
@@ -86,7 +86,8 @@ FROM seo_url
 WHERE
   route_name = 'frontend.detail.page' AND
   is_deleted = 0 AND
-  is_canonical = 1
+  is_canonical = 1 AND
+  language_id = unhex('2fbb5fe2e29a4d70aa5854ce7ce3e20b')
 GROUP BY product.id
 " . $limit, [
     'versionId' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently on shops with example EN as a second language the urls are called without the /en and therefor fail

![image](https://user-images.githubusercontent.com/8600299/172815146-279fc569-ebe7-4e81-9f5d-735758c14d47.png)


### 2. What does this change do, exactly?
Adds a the default language DE till a proper language handling is added


### 3. Describe each step to reproduce the issue or behaviour.
Run the locust command on a shop with 2 languages

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [] I have written tests and verified that they fail without my change
- [] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [] I have written or adjusted the documentation according to my changes
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
