### PR TITLE
Fix block order sw-property-option-list

### DIFF
--- a/changelog/_unreleased/2022-06-09-fix-block-order-sw-property-option.md
+++ b/changelog/_unreleased/2022-06-09-fix-block-order-sw-property-option.md
@@ -1,0 +1,8 @@
+---
+title: Fix block order sw-property-option-list
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@iodigital.com
+author_github: @MelvinAchterhuis
+---
+# Administration
+* Replaced a `{% endblock %}` in `src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig` so it closes at the correct place.

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig
@@ -67,66 +67,67 @@
     {% endblock %}
 
     {% block sw_property_option_list_grid %}
-    <template #grid>
-        <sw-one-to-many-grid
-            ref="grid"
-            :is-loading="isLoading"
-            :collection="propertyGroup.options"
-            :columns="getGroupColumns()"
-            :full-page="false"
-            :local-mode="propertyGroup.isNew()"
-            :allow-inline-edit="allowInlineEdit"
-            :sort-by="sortBy"
-            :sort-direction="sortDirection"
-            @selection-change="onGridSelectionChanged"
-        >
+        <template #grid>
+            <sw-one-to-many-grid
+                ref="grid"
+                :is-loading="isLoading"
+                :collection="propertyGroup.options"
+                :columns="getGroupColumns()"
+                :full-page="false"
+                :local-mode="propertyGroup.isNew()"
+                :allow-inline-edit="allowInlineEdit"
+                :sort-by="sortBy"
+                :sort-direction="sortDirection"
+                @selection-change="onGridSelectionChanged"
+            >
 
-            <template #column-name="{ item, isInlineEdit }">
-                <template v-if="isInlineEdit">
-                    <sw-field
-                        v-model="item.name"
-                        size="small"
-                    />
+                <template #column-name="{ item, isInlineEdit }">
+                    <template v-if="isInlineEdit">
+                        <sw-field
+                            v-model="item.name"
+                            size="small"
+                        />
+                    </template>
+
+                    <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
+                    <a
+                        v-else
+                        class="sw-settings-option-detail__link"
+                        @click="onOptionEdit(item)"
+                    >
+                        {{ item.translated.name }}
+                    </a>
                 </template>
 
-                <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
-                <a
-                    v-else
-                    class="sw-settings-option-detail__link"
-                    @click="onOptionEdit(item)"
-                >
-                    {{ item.translated.name }}
-                </a>
-            </template>
-
-            {% block sw_settings_property_list_grid_columns_actions %}
-            <template #more-actions="{ item }">
-                {% block sw_settings_property_list_grid_columns_actions_edit %}
-                <sw-context-menu-item
-                    class="sw-property-option-list__edit-action"
-                    :disabled="!acl.can('property.editor')"
-                    @click="onOptionEdit(item)"
-                >
-                    {{ $tc('sw-property.list.contextMenuView') }}
-                </sw-context-menu-item>
+                {% block sw_settings_property_list_grid_columns_actions %}
+                <template #more-actions="{ item }">
+                    {% block sw_settings_property_list_grid_columns_actions_edit %}
+                    <sw-context-menu-item
+                        class="sw-property-option-list__edit-action"
+                        :disabled="!acl.can('property.editor')"
+                        @click="onOptionEdit(item)"
+                    >
+                        {{ $tc('sw-property.list.contextMenuView') }}
+                    </sw-context-menu-item>
+                    {% endblock %}
+                </template>
                 {% endblock %}
-            </template>
-            {% endblock %}
 
-            {% block sw_property_list_grid_columns_actions_delete %}
-            <template #delete-action="{ item }">
-                <sw-context-menu-item
-                    variant="danger"
-                    :disabled="!acl.can('property.editor')"
-                    @click="onSingleOptionDelete(item.id)"
-                >
-                    {{ $tc('sw-property.list.contextMenuDelete') }}
-                </sw-context-menu-item>
-            </template>
-            {% endblock %}
-        </sw-one-to-many-grid>
-        {% endblock %}
-    </template>
+                {% block sw_property_list_grid_columns_actions_delete %}
+                <template #delete-action="{ item }">
+                    <sw-context-menu-item
+                        variant="danger"
+                        :disabled="!acl.can('property.editor')"
+                        @click="onSingleOptionDelete(item.id)"
+                    >
+                        {{ $tc('sw-property.list.contextMenuDelete') }}
+                    </sw-context-menu-item>
+                </template>
+                {% endblock %}
+            </sw-one-to-many-grid>
+        </template>
+    {% endblock %}
+    
     {% block sw_property_option_list_detail %}
     <sw-property-option-detail
         v-if="currentOption"

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.html.twig
@@ -67,65 +67,65 @@
     {% endblock %}
 
     {% block sw_property_option_list_grid %}
-        <template #grid>
-            <sw-one-to-many-grid
-                ref="grid"
-                :is-loading="isLoading"
-                :collection="propertyGroup.options"
-                :columns="getGroupColumns()"
-                :full-page="false"
-                :local-mode="propertyGroup.isNew()"
-                :allow-inline-edit="allowInlineEdit"
-                :sort-by="sortBy"
-                :sort-direction="sortDirection"
-                @selection-change="onGridSelectionChanged"
-            >
+    <template #grid>
+        <sw-one-to-many-grid
+            ref="grid"
+            :is-loading="isLoading"
+            :collection="propertyGroup.options"
+            :columns="getGroupColumns()"
+            :full-page="false"
+            :local-mode="propertyGroup.isNew()"
+            :allow-inline-edit="allowInlineEdit"
+            :sort-by="sortBy"
+            :sort-direction="sortDirection"
+            @selection-change="onGridSelectionChanged"
+        >
 
-                <template #column-name="{ item, isInlineEdit }">
-                    <template v-if="isInlineEdit">
-                        <sw-field
-                            v-model="item.name"
-                            size="small"
-                        />
-                    </template>
-
-                    <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
-                    <a
-                        v-else
-                        class="sw-settings-option-detail__link"
-                        @click="onOptionEdit(item)"
-                    >
-                        {{ item.translated.name }}
-                    </a>
+            <template #column-name="{ item, isInlineEdit }">
+                <template v-if="isInlineEdit">
+                    <sw-field
+                        v-model="item.name"
+                        size="small"
+                    />
                 </template>
 
-                {% block sw_settings_property_list_grid_columns_actions %}
-                <template #more-actions="{ item }">
-                    {% block sw_settings_property_list_grid_columns_actions_edit %}
-                    <sw-context-menu-item
-                        class="sw-property-option-list__edit-action"
-                        :disabled="!acl.can('property.editor')"
-                        @click="onOptionEdit(item)"
-                    >
-                        {{ $tc('sw-property.list.contextMenuView') }}
-                    </sw-context-menu-item>
-                    {% endblock %}
-                </template>
+                <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events -->
+                <a
+                    v-else
+                    class="sw-settings-option-detail__link"
+                    @click="onOptionEdit(item)"
+                >
+                    {{ item.translated.name }}
+                </a>
+            </template>
+
+            {% block sw_settings_property_list_grid_columns_actions %}
+            <template #more-actions="{ item }">
+                {% block sw_settings_property_list_grid_columns_actions_edit %}
+                <sw-context-menu-item
+                    class="sw-property-option-list__edit-action"
+                    :disabled="!acl.can('property.editor')"
+                    @click="onOptionEdit(item)"
+                >
+                    {{ $tc('sw-property.list.contextMenuView') }}
+                </sw-context-menu-item>
                 {% endblock %}
+            </template>
+            {% endblock %}
 
-                {% block sw_property_list_grid_columns_actions_delete %}
-                <template #delete-action="{ item }">
-                    <sw-context-menu-item
-                        variant="danger"
-                        :disabled="!acl.can('property.editor')"
-                        @click="onSingleOptionDelete(item.id)"
-                    >
-                        {{ $tc('sw-property.list.contextMenuDelete') }}
-                    </sw-context-menu-item>
-                </template>
-                {% endblock %}
-            </sw-one-to-many-grid>
-        </template>
+            {% block sw_property_list_grid_columns_actions_delete %}
+            <template #delete-action="{ item }">
+                <sw-context-menu-item
+                    variant="danger"
+                    :disabled="!acl.can('property.editor')"
+                    @click="onSingleOptionDelete(item.id)"
+                >
+                    {{ $tc('sw-property.list.contextMenuDelete') }}
+                </sw-context-menu-item>
+            </template>
+            {% endblock %}
+        </sw-one-to-many-grid>
+    </template>
     {% endblock %}
     
     {% block sw_property_option_list_detail %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently the block is closed to early and makes extending the file a little harder

### 2. What does this change do, exactly?

Closes the block at the correct position

### 3. Describe each step to reproduce the issue or behaviour.

N/A

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
