### PR TITLE
refactor delivery time units

### DIFF
--- a/changelog/_unreleased/2022-06-09-refactor-delivery-time-units.md
+++ b/changelog/_unreleased/2022-06-09-refactor-delivery-time-units.md
@@ -1,0 +1,13 @@
+---
+title: Refactor delivery time units
+issue: n.a.
+author: Silvio Kennecke
+author_github: @silviokennecke
+---
+
+# Administration
+* Changed `sw-settings-delivery-time-detail` component to support unit `hour`
+
+# Core
+* Changed `\Shopware\Core\System\DeliveryTime\DeliveryTimeEntity` to add missing unit constants
+* Changed `\Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryDate::createFromDeliveryTime` to use constants instead of hardcoded values

--- a/changelog/_unreleased/2022-06-09-refactor-delivery-time-units.md
+++ b/changelog/_unreleased/2022-06-09-refactor-delivery-time-units.md
@@ -1,6 +1,6 @@
 ---
 title: Refactor delivery time units
-issue: n.a.
+issue: NEXT-21958
 author: Silvio Kennecke
 author_github: @silviokennecke
 ---

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/page/sw-settings-delivery-time-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/page/sw-settings-delivery-time-detail/index.js
@@ -53,6 +53,9 @@ Component.register('sw-settings-delivery-time-detail', {
 
         deliveryTimeUnits() {
             return [{
+                value: 'hour',
+                label: this.$tc('sw-settings-delivery-time.detail.selectionUnitHour'),
+            }, {
                 value: 'day',
                 label: this.$tc('sw-settings-delivery-time.detail.selectionUnitDay'),
             }, {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/snippet/de-DE.json
@@ -31,6 +31,7 @@
       "labelUnit": "Einheit",
       "labelMin": "Minimum",
       "labelMax": "Maximum",
+      "selectionUnitHour": "Stunde",
       "selectionUnitDay": "Tag",
       "selectionUnitWeek": "Woche",
       "selectionUnitMonth": "Monat",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-delivery-times/snippet/en-GB.json
@@ -31,6 +31,7 @@
       "labelUnit": "Unit",
       "labelMin": "Minimum",
       "labelMax": "Maximum",
+      "selectionUnitHour": "Hour",
       "selectionUnitDay": "Day",
       "selectionUnitWeek": "Week",
       "selectionUnitMonth": "Month",

--- a/src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
+++ b/src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Cart\Delivery\Struct;
 
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Struct\Struct;
+use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
 
 class DeliveryDate extends Struct
 {
@@ -29,13 +30,13 @@ class DeliveryDate extends Struct
     public static function createFromDeliveryTime(DeliveryTime $deliveryTime): self
     {
         switch ($deliveryTime->getUnit()) {
-            case 'hour':
+            case DeliveryTimeEntity::DELIVERY_TIME_HOUR:
                 return new self(
                     self::create('PT' . $deliveryTime->getMin() . 'H'),
                     self::create('PT' . $deliveryTime->getMax() . 'H')
                 );
 
-            case 'day':
+            case DeliveryTimeEntity::DELIVERY_TIME_DAY:
                 return new self(
                     self::create('P' . $deliveryTime->getMin() . 'D'),
                     self::create('P' . $deliveryTime->getMax() . 'D')
@@ -43,20 +44,20 @@ class DeliveryDate extends Struct
 
             // NEXT-21735 - This is covered randomly
             // @codeCoverageIgnoreStart
-            case 'week':
+            case DeliveryTimeEntity::DELIVERY_TIME_WEEK:
                 return new self(
                     self::create('P' . $deliveryTime->getMin() . 'W'),
                     self::create('P' . $deliveryTime->getMax() . 'W')
                 );
             // @codeCoverageIgnoreEnd
 
-            case 'month':
+            case DeliveryTimeEntity::DELIVERY_TIME_MONTH:
                 return new self(
                     self::create('P' . $deliveryTime->getMin() . 'M'),
                     self::create('P' . $deliveryTime->getMax() . 'M')
                 );
 
-            case 'year':
+            case DeliveryTimeEntity::DELIVERY_TIME_YEAR:
                 return new self(
                     self::create('P' . $deliveryTime->getMin() . 'Y'),
                     self::create('P' . $deliveryTime->getMax() . 'Y')

--- a/src/Core/System/DeliveryTime/DeliveryTimeEntity.php
+++ b/src/Core/System/DeliveryTime/DeliveryTimeEntity.php
@@ -13,9 +13,11 @@ class DeliveryTimeEntity extends Entity
 {
     use EntityIdTrait;
     use EntityCustomFieldsTrait;
+    public const DELIVERY_TIME_HOUR = 'hour';
     public const DELIVERY_TIME_DAY = 'day';
     public const DELIVERY_TIME_WEEK = 'week';
     public const DELIVERY_TIME_MONTH = 'month';
+    public const DELIVERY_TIME_YEAR = 'year';
 
     /**
      * @var string|null


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To add missing constants, remove hard-coded values and add missing support for all available options in the administration.

### 2. What does this change do, exactly?
- The core defines delivery time units which are hard-coded in `DeliveryDate::createFromDeliveryTime`
- Also, the constants in `DeliveryTimeEntity` did not cover all available units.
- Additionally, the administration didn't allow the user to set delivery times by hour, which was added, too.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
