### PR TITLE
Fix faulty pagination on custom field sets administration

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/page/sw-settings-custom-field-set-list/index.js
@@ -51,6 +51,8 @@ Component.register('sw-settings-custom-field-set-list', {
 
             const params = this.getMainListingParams();
 
+            criteria.limit = params.limit;
+            criteria.setPage(params.page);
             criteria.addFilter(Criteria.multi(
                 'OR',
                 [


### PR DESCRIPTION
### 1. Why is this change necessary?
In the administration panel, users have been unable to change pages, or change the page limit, when viewing the custom fields list.

### 2. What does this change do, exactly?
This change takes the page number and number of elements per page, chosen on the custom fields list, and passes them to the criteria element, used to get the custom field sets.

### 3. Describe each step to reproduce the issue or behaviour.
The error is replicated by having at least 26 custom field sets, and trying to change the pagination, or page limit of the custom field list in the administration

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-21376

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
