### PR TITLE
set shipping fee to 0.00 if this product.shippingFree is true.

### DIFF
--- a/changelog/_unreleased/2022-06-14-feature-free-shipping-products-in-feed.md
+++ b/changelog/_unreleased/2022-06-14-feature-free-shipping-products-in-feed.md
@@ -1,0 +1,9 @@
+---
+title: Google Product Feed - set shipping fee to 0.00 if this product.shippingFree checkbox is set.
+author: wolf128058
+author_email: jonas.hess@mailbox.org
+author_github: wolf128058
+---
+# Storefront
+* Changed: `src/Administration/Resources/app/administration/src/module/sw-sales-channel/product-export-templates/google-product-search-de/body.xml.twig`
+  * If the free-shipping-checkbox for this product is set, the shipping fees are set to 0.00 EUR (or whatever currency.isoCode you use), too.

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/product-export-templates/google-product-search-de/body.xml.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/product-export-templates/google-product-search-de/body.xml.twig
@@ -30,6 +30,10 @@
     <g:shipping>
         <g:country>DE</g:country>
         <g:service>Standard</g:service>
+        {% if product.shippingFree  %}
+        <g:price>0.00 {{ context.currency.isoCode }}</g:price>
+        {% else %}
         <g:price>4.95 {{ context.currency.isoCode }}{# change your default delivery costs #}</g:price>
+        {% endif %}
     </g:shipping>
 </item>


### PR DESCRIPTION
### 1. Why is this change necessary?
Because otherwise all products are listed under a hard coded fix shipping fee.
So at least the free-shipping checkbox has an impact and sets the shipping fee to 0.

### 2. What does this change do, exactly?
You have free shipping in your google feed if you use the corresponding checkbox.

### 3. Describe each step to reproduce the issue or behaviour.
![image](https://user-images.githubusercontent.com/946255/173670074-e2a6de64-f569-42d3-a7ec-9ce7892e6068.png)


### 4. Please link to the relevant issues (if any).
Did not open one. Fixed it in and tested it in one of my projects.

### 5. Checklist

- [✔] I have written tests and verified that they fail without my change
- [ ✔] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [✗] I have written or adjusted the documentation according to my changes
- [✗] This change has comments for package types, values, functions, and non-obvious lines of code
- [✔] I have read the contribution requirements and fulfil them.
