### PR TITLE
fix NEXT-21982 fix double prefix on negativ shipping

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
@@ -30,7 +30,7 @@
                         </span>
 
                         <span class="col-5 pb-2 shipping-value shipping-cost">
-                            <strong>+ {{ activeShipping.shippingCosts.totalPrice|currency }}</strong>
+                            <strong>{{activeShipping.shippingCosts.totalPrice<0?'- ':'+ '}}{{ activeShipping.shippingCosts.totalPrice|abs|currency }}</strong>
                         </span>
                     </div>
                 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Confusing layout inside the offcanvas Cart with negative shipping value. (eg.  + -0,01€)

### 2. What does this change do, exactly?
Replace the + at the start of each line with - if value is below 0.

### 3. Describe each step to reproduce the issue or behaviour.
Add a promotion to the Cart that reduce the shipping price

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-21982

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
