### PR TITLE
Remove prefix from delete call

### DIFF
--- a/changelog/_unreleased/2022-06-15-fix-double-cart-prefix-on-delete.md
+++ b/changelog/_unreleased/2022-06-15-fix-double-cart-prefix-on-delete.md
@@ -1,0 +1,9 @@
+---
+title: Fix double cart prefix on delete in redis cache adapter
+issue: NEXT-21987
+author: Micha Hobert
+author_email: info@the-cake-shop.de
+author_github: Isengo1989
+---
+# Core
+* Removed `self::PREFIX` from `$this->delete()` because the prefix is already added in the delete method

--- a/src/Core/Checkout/Cart/RedisCartPersister.php
+++ b/src/Core/Checkout/Cart/RedisCartPersister.php
@@ -91,7 +91,7 @@ class RedisCartPersister extends AbstractCartPersister
 
         $this->eventDispatcher->dispatch($event);
         if (!$event->shouldBePersisted()) {
-            $this->delete(self::PREFIX . $cart->getToken(), $context);
+            $this->delete($cart->getToken(), $context);
 
             return;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently the last item can not be removed from the cart when using the redis integration. This is due to the double prefix added

![image](https://user-images.githubusercontent.com/8600299/173668133-057dd9f5-a2f1-43da-92a7-bfd98704d840.png)


### 2. What does this change do, exactly?

Removes the extra prefix


### 3. Describe each step to reproduce the issue or behaviour.

1. Add redis cart integration
2. Add an item to the cart
3. Try to delete the item


### 4. Please link to the relevant issues (if any).
-


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
