### PR TITLE
refactor: Deprecate static template configurations and fix the issue that meta descriptions were shortened

### DIFF
--- a/changelog/_unreleased/2022-06-16-deprecate-static-template-configurations.md
+++ b/changelog/_unreleased/2022-06-16-deprecate-static-template-configurations.md
@@ -1,0 +1,10 @@
+---
+title: Deprecate static template configurations
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Deprecate static unused configs `seo.descriptionMaxLength`, `cms.revocationNoticeCmsPageId`, `cms.taxCmsPageId`, `cms.tosCmsPageId` and `confirm.revocationNotice`
+* Allow 255 characters (instead of 150 characters) in the meta description, as indicated in the administration. Make sure to shorten long descriptions yourself

--- a/src/Storefront/Framework/Twig/TemplateConfigAccessor.php
+++ b/src/Storefront/Framework/Twig/TemplateConfigAccessor.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Storefront\Framework\Twig;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Theme\ThemeConfigValueAccessor;
@@ -35,6 +36,8 @@ class TemplateConfigAccessor
         $static = $this->getStatic();
 
         if (\array_key_exists($key, $static)) {
+            Feature::triggerDeprecationOrThrow('v6.5.0.0', "The config variable {$key} has been deprecated and will be removed in v6.5.0.0");
+
             return $static[$key];
         }
 
@@ -49,6 +52,9 @@ class TemplateConfigAccessor
         return $this->themeConfigAccessor->get($key, $context, $themeId);
     }
 
+    /**
+     * @deprecated tag:v6.5.0 - All of these configs will be removed and were never configurable by the user
+     */
     private function getStatic(): array
     {
         return [

--- a/src/Storefront/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/meta.html.twig
@@ -1,8 +1,8 @@
 {% block layout_head_inner %}
     {% set metaInformation = page.metaInformation %}
     {% set basicConfig = config('core.basicInformation') %}
-    {% set maxLength = config('seo.descriptionMaxLength') %}
-    {% set metaDescription = metaInformation.metaDescription|striptags|trim|u.truncate(maxLength ?? 160, '…') %}
+    {% set maxLength = 255 %}
+    {% set metaDescription = metaInformation.metaDescription|striptags|trim|u.truncate(maxLength, '…') %}
     {% set metaTitle = metaInformation.metaTitle|striptags|trim %}
     {% set metaKeywords = metaInformation.metaKeywords|striptags|trim %}
 

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -39,18 +39,16 @@
                         {% endblock %}
 
                         {% block page_checkout_confirm_revocation_notice %}
-                            {% if config('confirm.revocationNotice') %}
-                                <p class="revocation-notice">
-                                    {% block page_checkout_confirm_revocation_notice_link %}
-                                        <a href="{{ path('frontend.cms.page',{ id: config('core.basicInformation.revocationPage') }) }}"
-                                           {{ dataBsToggleAttr }}="modal"
-                                           title="{{ "checkout.confirmRevocationNotice"|trans|striptags }}"
-                                           data-url="{{ path('frontend.cms.page',{ id: config('core.basicInformation.revocationPage') }) }}">
-                                            {{ "checkout.confirmRevocationNotice"|trans|sw_sanitize }}
-                                        </a>
-                                    {% endblock %}
-                                </p>
-                            {% endif %}
+                            <p class="revocation-notice">
+                                {% block page_checkout_confirm_revocation_notice_link %}
+                                    <a href="{{ path('frontend.cms.page',{ id: config('core.basicInformation.revocationPage') }) }}"
+                                       {{ dataBsToggleAttr }}="modal"
+                                       title="{{ "checkout.confirmRevocationNotice"|trans|striptags }}"
+                                       data-url="{{ path('frontend.cms.page',{ id: config('core.basicInformation.revocationPage') }) }}">
+                                        {{ "checkout.confirmRevocationNotice"|trans|sw_sanitize }}
+                                    </a>
+                                {% endblock %}
+                            </p>
                         {% endblock %}
 
                         {% block page_checkout_confirm_tos_control %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently one can enter 255 characters of meta description in the administration, but only 150 are shown in the storefront. Furthermore there exist some static config variables, only used by the theme, which could not be changed.

### 2. What does this change do, exactly?
Deprecate the static config variables, remove their remaining occurrences and set the truncation length of the meta description to 255 as indicated in the administration.

### 3. Describe each step to reproduce the issue or behaviour.
Create a meta description longer than 150 characters.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
