### PR TITLE
Fix admin extension list issue when internet connection fails

### DIFF
--- a/changelog/_unreleased/2022-06-16-fix-extension-list-in-administration-during-shopware-community-store-api-communication-issues.md
+++ b/changelog/_unreleased/2022-06-16-fix-extension-list-in-administration-during-shopware-community-store-api-communication-issues.md
@@ -1,0 +1,8 @@
+---
+title: Fix extension list in administration during Shopware Community Store API communication issues 
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added exception catching in `\Shopware\Core\Framework\Store\Services\StoreClient` that previously blocked administration extension listing when checking for updates

--- a/src/Core/Framework/Store/Services/StoreClient.php
+++ b/src/Core/Framework/Store/Services/StoreClient.php
@@ -527,14 +527,18 @@ class StoreClient
             $headers = [];
         }
 
-        $response = $this->client->post(
-            $this->endpoints['my_plugin_updates'],
-            [
-                'query' => $query,
-                'headers' => $headers,
-                'json' => ['plugins' => $extensionList],
-            ]
-        );
+        try {
+            $response = $this->client->post(
+                $this->endpoints['my_plugin_updates'],
+                [
+                    'query' => $query,
+                    'headers' => $headers,
+                    'json' => ['plugins' => $extensionList],
+                ]
+            );
+        } catch (\Throwable $throwable) {
+            return [];
+        }
 
         $data = \json_decode($response->getBody()->getContents(), true);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When you have a bad internet connection your administration extension listing is behaving flaky when you develop locally.

### 2. What does this change do, exactly?

It catches and mutes an exception and returns an empty result instead, when asking for extension updates from the community store.

### 3. Describe each step to reproduce the issue or behaviour.

1. Local A record  `127.0.0.1 api.shopware.com` to simulate casual digital nomad in German cellular networks
2. Open admin extension listing
3. See no extensions 

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
