### PR TITLE
fix: `limits` key prevent using symfony standard rate limiter

### DIFF
--- a/changelog/_unreleased/2022-06-20-fix-using-standard-symfony-rate-limiter-on-shopware-default-definitions.md
+++ b/changelog/_unreleased/2022-06-20-fix-using-standard-symfony-rate-limiter-on-shopware-default-definitions.md
@@ -1,0 +1,9 @@
+---
+title: Fix using standard symfony rate limiter on shopware default definitions
+issue: NEXT-22045
+author: Stephan Niewerth
+author_email: snw@heise.de
+author_github: stephanniewerth
+---
+# Core
+* Additionally filters the `limits` configuration key when using a symfony standard rate limiter

--- a/src/Core/Framework/RateLimiter/RateLimiterFactory.php
+++ b/src/Core/Framework/RateLimiter/RateLimiterFactory.php
@@ -47,7 +47,7 @@ class RateLimiterFactory
 
         // prevent symfony errors due to customized values
         $this->config = \array_filter($this->config, static function ($key): bool {
-            return !\in_array($key, ['enabled', 'reset', 'cache_pool', 'lock_factory'], true);
+            return !\in_array($key, ['enabled', 'reset', 'cache_pool', 'lock_factory', 'limits'], true);
         }, \ARRAY_FILTER_USE_KEY);
 
         $sfFactory = new SymfonyRateLimiterFactory($this->config, $this->storage, $this->lockFactory);

--- a/src/Core/Framework/Test/RateLimiter/RateLimiterFactoryTest.php
+++ b/src/Core/Framework/Test/RateLimiter/RateLimiterFactoryTest.php
@@ -59,4 +59,39 @@ class RateLimiterFactoryTest extends TestCase
 
         static::assertInstanceOf(TokenBucketLimiter::class, $factory->create('example'));
     }
+
+    public function testFactoryShouldUseSymfonyFactoryOverrideDefaultConfig(): void
+    {
+        $factory = new RateLimiterFactory(
+            array_merge(
+                [
+                    'enabled' => true,
+                    'id' => 'test_limiter',
+                    'policy' => 'time_backoff',
+                    'reset' => '1 hour',
+                    'limits' => [
+                        [
+                            'limit' => 3,
+                            'interval' => '10 seconds',
+                        ],
+                        [
+                            'limit' => 5,
+                            'interval' => '30 seconds',
+                        ],
+                    ],
+                ],
+                [
+                    'enabled' => true,
+                    'id' => 'test_limiter',
+                    'policy' => 'token_bucket',
+                    'limit' => 3,
+                    'rate' => ['interval' => '60 seconds'],
+                ],
+            ),
+            $this->createMock(StorageInterface::class),
+            $this->createMock(LockFactory::class)
+        );
+
+        static::assertInstanceOf(TokenBucketLimiter::class, $factory->create('example'));
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To use a standard symfony rate limiter without errors on a standard rate limiter definition by shopware.

### 2. What does this change do, exactly?
It adds the `limits` key to the array_filter list to remove this configuration key, if a standard symfony rate limiter should be used.

### 3. Describe each step to reproduce the issue or behaviour.

Add the following to the `config/packages/shopware.yaml` file in your project:

```
shopware
    api:
        rate_limiter:
            oauth:
                enabled: true
                policy: 'sliding_window'
                limit: 2
                interval: '60 minutes'
```

This should activate the `sliding_window` rate limiter by symfony for a `oauth` route. If you want to login in administration you will get an error on the oauth/token route.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-22045

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
