### PR TITLE
RepositoryIterator->fetchIds() with propertyName instead of storageName

### DIFF
--- a/changelog/_unreleased/2022-06-21-use-propertyName-repository-iterator.md
+++ b/changelog/_unreleased/2022-06-21-use-propertyName-repository-iterator.md
@@ -1,0 +1,8 @@
+---
+title: RepositoryIterator->fetchIds() with propertyName instead of storageName
+issue: NEXT-00000
+author: Léo Cunéaz
+author_github: inem0o
+---
+# Core
+* When feature 6.5.0.0 is enabled, use automatically the autoincrement field propertyName instead of the storageName in RepositoryIterator->fetchIds()

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Feature;
 
 class RepositoryIterator
 {
@@ -85,8 +86,7 @@ class RepositoryIterator
             throw new \RuntimeException('Expected string as last element of ids array');
         }
 
-        $increment = $ids->getDataFieldOfId($last, 'auto_increment');
-
+        $increment = $ids->getDataFieldOfId($last, Feature::isActive('v6.5.0.0') ? 'autoIncrement' : 'auto_increment');
         $this->criteria->setFilter('increment', new RangeFilter('autoIncrement', [RangeFilter::GT => $increment]));
 
         return $values;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When feature 6.5.0.0 is enabled, the RepositoryIterator using a repository with autoincrement does not fetch properly the ids because of the use of the "auto_increment" key as snake key.
Since 6.5.0.0 the keys of IdSearchResult should always be field's propertyName instead of storageName.


### 2. What does this change do, exactly?
Use the auto increment field propertyName instead of the storage_name when feature 6.5.0.0 is enabled

### 3. Describe each step to reproduce the issue or behaviour.
Enable feature 6.5.0.0 and try to use RepositoryIterator with a repository managing an entity with an autoincrement field


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
