### PR TITLE
Ensure inactive categories are not linked in breadcrumbs

### DIFF
--- a/src/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtension.php
@@ -79,11 +79,17 @@ class BuildBreadcrumbExtension extends AbstractExtension
 
         $breadcrumb = [];
         foreach ($categoryIds as $categoryId) {
-            if ($categories->get($categoryId) === null) {
+            $category = $categories->get($categoryId);
+            if ($category === null) {
                 continue;
             }
 
-            $breadcrumb[$categoryId] = $categories->get($categoryId);
+            // prevent hyperlinking an inactive category
+            if ($category->getType() === 'page' && !$category->getActive()) {
+                $category->setType('folder');
+            }
+
+            $breadcrumb[$categoryId] = $category;
         }
 
         return $breadcrumb;

--- a/tests/e2e/cypress/integration/storefront/breadcrumb/breadcrumb.spec.js
+++ b/tests/e2e/cypress/integration/storefront/breadcrumb/breadcrumb.spec.js
@@ -42,6 +42,19 @@ describe('Test if breadcrumb works correctly', () => {
                     }
                 ]
             });
+
+            cy.createCategoryFixture({
+                name: 'Inactive category',
+                type: 'page',
+                active: false,
+                parentId: categoryId,
+                children: [
+                    {
+                        name: 'Sub 4',
+                        type: 'page'
+                    }
+                ]
+            });
         }).then(() => {
             cy.visit('/');
         });
@@ -68,5 +81,8 @@ describe('Test if breadcrumb works correctly', () => {
 
             cy.get('.cms-breadcrumb .breadcrumb').contains('Test category 3').should('have.prop', 'tagName' ).should('eq', 'A');
         });
+
+        cy.get('.nav-link.main-navigation-link').contains('Inactive category').should('not.exist');
+        cy.get('.cms-breadcrumb .breadcrumb').contains('Inactive category').should('not.have.prop', 'tagName' ).should('eq', 'A');
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Inactive categories are still linked in breadcrumbs. When the customer clicks on that link, they will see a 404 error page.

### 2. What does this change do, exactly?

In order to not link to inactive category pages, they are treated as folders.

### 3. Describe each step to reproduce the issue or behaviour.

Given the following category structure

* Category 1
  * Category 1.1 [inactive]
    * Category 1.1.1
* Category 2

Place an new product "Product A" in Category 1.1.1.
In "Category 2" display products from a dynamic product list that includes "Product A"

Then "Product A" will be listed in Category 2 and can be accessed by the customer.
The detail page will have the breadcrumb "Category 1 > Category 1.1 > Category 1.1.1", where each category is clickable.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
