### PR TITLE
Fixes the problem that the customer cannot delete his account when the csrf token is generated via Ajax

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/profile/index.html.twig
@@ -464,6 +464,7 @@
 
                                                 {% block page_account_delete_account_confirm_modal_form %}
                                                     <form method="post"
+                                                          data-form-csrf-handler="true"
                                                           action="{{ path('frontend.account.profile.delete') }}"
                                                           data-form-submit-loader="true">
 


### PR DESCRIPTION
1. Why is this change necessary?
If the csrf token is generated via ajax, the customer cannot delete his account in his profile view.

2. What does this change do, exactly?
the attribute data-form-csrf-handler is added to the form for deleting the account.

3. Describe each step to reproduce the issue or behaviour.
In the profile view of an existing customer account, try to delete the customer account if csrf mode is set to ajax.

4. Please link to the relevant issues (if any).

5. Checklist

- []  I have written tests and verified that they fail without my change
- []  I have created a changelog file with all necessary information about my changes
- []  I have written or adjusted the documentation according to my changes
- []   This change has comments for package types, values, functions, and non-obvious lines of code
- []  I have read the contribution requirements and fulfil them.