### PR TITLE
fixes next-20792

### DIFF
--- a/changelog/_unreleased/2022-06-22-fixes-storefront-display-options-for-variants-in-the-administration-if-there-are-more-then-100-groups.md
+++ b/changelog/_unreleased/2022-06-22-fixes-storefront-display-options-for-variants-in-the-administration-if-there-are-more-then-100-groups.md
@@ -1,0 +1,9 @@
+---
+title: fixes storefront display options for variants in the administration if there are more then 100 groups
+issue: NEXT-20792
+author: Dominik Mank
+author_email: d.mank@web-fabric.de
+author_github: dominikmank
+
+# Administration
+* Removed the limit for the group repository, so that they will be loaded all for further usages

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/index.js
@@ -133,9 +133,8 @@ Component.register('sw-product-detail-variants', {
         loadGroups() {
             return new Promise((resolve) => {
                 this.$nextTick().then(() => {
-                    const groupCriteria = new Criteria(1, 25);
+                    const groupCriteria = new Criteria(1, null);
                     groupCriteria
-                        .setLimit(100)
                         .setPage(1);
 
                     this.groupRepository.search(groupCriteria).then((searchResult) => {


### PR DESCRIPTION
fixes storefront display options for variants in the administration if there are more then 100 groups the click on storefront-representation or use variant filters.

### 1. Why is this change necessary?
because you can't filter the variants and can't change any settings in "storefront representation"

### 2. What does this change do, exactly?
fixes this behaviour and only asks for the groups which are currently used by the parent article

### 3. Describe each step to reproduce the issue or behaviour.
see next-20792
* have more then 100 property groups
* add an variant with the 101 one
* wonder that the storefront representation is loading endlessly

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-20792

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
