### PR TITLE
Added extra check if invalid form field is at the bottom of the page to trigger the validity

### DIFF
--- a/changelog/_unreleased/2022-06-24-added-extra-check-if-invalid-form-field-is-at-the-bottom-of-the-page.md
+++ b/changelog/_unreleased/2022-06-24-added-extra-check-if-invalid-form-field-is-at-the-bottom-of-the-page.md
@@ -1,0 +1,11 @@
+---
+title: Added extra check if invalid form field is at the bottom of the page
+issue: 
+author: Lars Pauwels
+author_email: lars.pauwels@telenet.be
+author_github: @LarsPauwels
+---
+
+# Storefront
+* Added extra check to invalid fields to display the error message when de field is ate the bottom of the page.
+

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-scroll-to-invalid-field.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-scroll-to-invalid-field.plugin.js
@@ -207,6 +207,14 @@ export default class FormScrollToInvalidFieldPlugin extends Plugin {
             }
         });
 
+        const offset = this._getOffset();
+        const pageHeight = document.body.scrollHeight;
+        const viewportHeight = window.innerHeight;
+
+        if ((offset < (pageHeight - viewportHeight))) {
+            shouldScroll = false;
+        }
+
         return shouldScroll;
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The validity event won't trigger on invalid fields that are on the bottom of the page.

### 2. What does this change do, exactly?
Adds a extra check if the invalid field is at the bottom of the page or not.

### 3. Describe each step to reproduce the issue or behaviour.
1. Move the confirmOrderForm on the checkout confirm to the bottom on the page.
<img width="901" alt="image" src="https://user-images.githubusercontent.com/43349729/175498426-6faa7443-f6db-46b6-88b7-03936b4fec25.png">
2. Uncheck the checkbox and try to send the form. Then the checkbox won't show a validity.
3. When you scroll yourself a bit, then the validity will trigger.
