### PR TITLE
Fix state count in flow builder

### DIFF
--- a/changelog/_unreleased/2022-06-24-fix-state-count-in-flow-builder.md
+++ b/changelog/_unreleased/2022-06-24-fix-state-count-in-flow-builder.md
@@ -1,0 +1,9 @@
+---
+title: Fix state count bug in the flow-builder
+issue:
+author: Daniel Wolf
+author_email: daniel.wolf@8mylez.com
+author_github: supus
+---
+# Administration
+* Remove limit for state-criteria in `module/sw-flow/page/sw-flow-detail/index.js` to prevent missing states when total count is more than 25

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-detail/index.js
@@ -115,7 +115,7 @@ Component.register('sw-flow-detail', {
         },
 
         stateMachineStateCriteria() {
-            const criteria = new Criteria(1, 25);
+            const criteria = new Criteria(1, null);
             criteria.addSorting({ field: 'name', order: 'ASC' });
             criteria.addAssociation('stateMachine');
             criteria.addFilter(


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, there is not limit set to the criteria object. Becuase the default value is 25 here, a maximum count of 25 states is loaded when f.ex. selecting an order state in the flow-builder modals.

In some cases, custom states are added via third party plugins.

This fix is necessary to show the available states if the total count exceeds 25.

### 2. What does this change do, exactly?
Remove limit of state criteria objects.

### 3. Describe each step to reproduce the issue or behaviour.
- make sure there are more than 25 states (order, payment, delivery) in total
- create a new flow and select a trigger (e.g. when an order is placed)
- add an action => update order state
- in the modal, you can select the states for each category
- the count of all visible states here is currently only up to 25. If there are more than 25, they are missing here

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.