### PR TITLE
Optimize Taskhandler delete queries

### DIFF
--- a/changelog/_unreleased/2022-06-24-optimize-delete-queries.md
+++ b/changelog/_unreleased/2022-06-24-optimize-delete-queries.md
@@ -1,0 +1,9 @@
+---
+title: Optimize Delete queries on cart and version tables
+issue: Issue-2532
+author: Micha Hobert
+author_email: info@the-cake-shop.de
+author_github: Isengo1989
+---
+# Core
+* Adding a do-while loop and limit to the `DELETE` query in `CleanupCartTaskHandler` and `CleanupVersionTaskHandler` to 1000 entries. This is necessary when a scheduled task failed / was inactive for some time

--- a/src/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandler.php
+++ b/src/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandler.php
@@ -36,13 +36,15 @@ class CleanupCartTaskHandler extends ScheduledTaskHandler
         $time = new \DateTime();
         $time->modify(sprintf('-%s day', $this->days));
 
-        $this->connection->executeStatement(
-            <<<'SQL'
+        do {
+            $result = $this->connection->executeStatement(
+                <<<'SQL'
                 DELETE FROM cart
                     WHERE (updated_at IS NULL AND created_at <= :timestamp)
-                        OR (updated_at IS NOT NULL AND updated_at <= :timestamp);
+                        OR (updated_at IS NOT NULL AND updated_at <= :timestamp) LIMIT 1000;
             SQL,
-            ['timestamp' => $time->format(Defaults::STORAGE_DATE_TIME_FORMAT)]
-        );
+                ['timestamp' => $time->format(Defaults::STORAGE_DATE_TIME_FORMAT)]
+            );
+        } while ($result > 0);
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Version/Cleanup/CleanupVersionTaskHandler.php
+++ b/src/Core/Framework/DataAbstractionLayer/Version/Cleanup/CleanupVersionTaskHandler.php
@@ -36,14 +36,18 @@ class CleanupVersionTaskHandler extends ScheduledTaskHandler
         $time = new \DateTime();
         $time->modify(sprintf('-%s day', $this->days));
 
-        $this->connection->executeStatement(
-            'DELETE FROM version WHERE created_at <= :timestamp',
-            ['timestamp' => $time->format(Defaults::STORAGE_DATE_TIME_FORMAT)]
-        );
+        do {
+            $result = $this->connection->executeStatement(
+                'DELETE FROM version WHERE created_at <= :timestamp LIMIT 1000',
+                ['timestamp' => $time->format(Defaults::STORAGE_DATE_TIME_FORMAT)]
+            );
+        } while ($result > 0);
 
-        $this->connection->executeStatement(
-            'DELETE FROM version_commit WHERE created_at <= :timestamp',
-            ['timestamp' => $time->format(Defaults::STORAGE_DATE_TIME_FORMAT)]
-        );
+        do {
+            $result = $this->connection->executeStatement(
+                'DELETE FROM version_commit WHERE created_at <= :timestamp LIMIT 1000',
+                ['timestamp' => $time->format(Defaults::STORAGE_DATE_TIME_FORMAT)]
+            );
+        } while ($result > 0);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The two scheduled tasks can quickly fail due to innodb_lock_wait_timeout being 30-50s by default. For example on many systems tested deleting 1000 cart rows took min 3 to max 5 seconds. 


### 2. What does this change do, exactly?
Adding a do-while loop to execute the query with a limit of 1000 and repeating till executeStatement returns 0


### 3. Describe each step to reproduce the issue or behaviour.
Add 20.000 carts that are older then 120 days and try to run the scheduled task


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2532

### 5. Checklist

- [] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [] I have written or adjusted the documentation according to my changes
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
