### PR TITLE
Fix typo in default english HTML version of the password change email

### DIFF
--- a/changelog/_unreleased/2022-06-27-fix-typo.md
+++ b/changelog/_unreleased/2022-06-27-fix-typo.md
@@ -1,0 +1,8 @@
+---
+title: Fix typo in default english HTML version of the password change email
+issue: NEXT-00000
+author: Léo Cunéaz
+author_github: inem0o
+---
+# Storefront
+* Replace "passwort" with "password" for the english HTML version of the password change email

--- a/src/Core/Migration/Fixtures/mails/password_change/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/password_change/en-html.html.twig
@@ -5,7 +5,7 @@
         there has been a request to reset you Password in the Shop {{ salesChannel.translated.name }}
         Please confirm the link below to specify a new password.<br/>
         <br/>
-        <a href="{{ resetUrl }}">Reset passwort</a><br/>
+        <a href="{{ resetUrl }}">Reset password</a><br/>
         <br/>
         This link is valid for the next 2 hours. After that you have to request a new confirmation link.<br/>
         If you do not want to reset your password, please ignore this email. No changes will be made.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Fix typo in default english HTML version of the password change email

### 2. What does this change do, exactly?
Replace the word "passwort" with "password"

### 3. Describe each step to reproduce the issue or behaviour.
use the forgot password feature

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
