### PR TITLE
Attach instead of embed

### DIFF
--- a/changelog/_unreleased/2022-07-04-mail-attach.md
+++ b/changelog/_unreleased/2022-07-04-mail-attach.md
@@ -1,0 +1,10 @@
+---
+title: Attach instead of embed
+issue: NEXT-22241
+flag: FEATURE_NEXT_22241
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Core
+* Mail attachment use content-disposition: attachment instead of inline if feature flag

--- a/src/Core/Content/Mail/Service/MailFactory.php
+++ b/src/Core/Content/Mail/Service/MailFactory.php
@@ -55,13 +55,15 @@ class MailFactory extends AbstractMailFactory
             }
         }
 
+        $attach = Feature::isActive('FEATURE_NEXT_22241') ? 'attach' : 'embed';
+
         foreach ($attachments as $url) {
-            $mail->embed($this->filesystem->read($url) ?: '', basename($url), $this->filesystem->getMimetype($url) ?: null);
+            $mail->$attach($this->filesystem->read($url) ?: '', basename($url), $this->filesystem->getMimetype($url) ?: null);
         }
 
         if (isset($binAttachments)) {
             foreach ($binAttachments as $binAttachment) {
-                $mail->embed(
+                $mail->$attach(
                     $binAttachment['content'],
                     $binAttachment['fileName'],
                     $binAttachment['mimeType']


### PR DESCRIPTION
Attachments, especially PDFs should be attached to the emails, not embeded

### 1. Why is this change necessary?

Docs should be attached (content-disposition: attachment), not inlined

### 2. What does this change do, exactly?

Changes attachment type

### 3. Describe each step to reproduce the issue or behaviour.

1. Send mail to mailtrap for example
2. Attachments are not displayed

Might happen also in regular mail clients

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
