### PR TITLE
Allow order address custom fields changes

### DIFF
--- a/changelog/_unreleased/2022-01-28-fix-malformed-utf8-characters-error-sync-api.md
+++ b/changelog/_unreleased/2022-01-28-fix-malformed-utf8-characters-error-sync-api.md
@@ -1,0 +1,8 @@
+---
+title:              Fix 'Malformed UTF-8 characters, possibly incorrectly encoded' Error
+issue:              
+author:             Alessandro Aussems
+author_email:       me@alessandroaussems.be                
+---
+# Core
+* Add `createResponse` in `src/Core/Framework/Api/Controller/SyncController.php` that adds the **JSON_INVALID_UTF8_SUBSTITUTE** encoding option to the response

--- a/changelog/_unreleased/changelog/_unreleased/2022-06-30-allow-order-address-custom-fields-changes.md
+++ b/changelog/_unreleased/changelog/_unreleased/2022-06-30-allow-order-address-custom-fields-changes.md
@@ -1,0 +1,9 @@
+---
+title: Allow order address custom fields changes
+author: Alessandro Aussems
+author_email: me@alessandroaussems.be
+author_github: alessandroaussems
+---
+# Administration
+* Added `sw-custom-field-set-renderer` to `sw-order-address-modal`
+* Load custom field sets for `sw-order-address-modal`

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/index.js
@@ -47,6 +47,7 @@ Component.register('sw-order-address-modal', {
             availableAddresses: [],
             selectedAddressId: 0,
             isLoading: false,
+            addressCustomFieldSets: [],
         };
     },
 
@@ -70,6 +71,10 @@ Component.register('sw-order-address-modal', {
         orderCustomer() {
             return this.order.orderCustomer;
         },
+
+        customFieldSetRepository() {
+            return this.repositoryFactory.create('custom_field_set');
+        }
     },
 
     created() {
@@ -81,6 +86,14 @@ Component.register('sw-order-address-modal', {
             if (this.orderCustomer && this.orderCustomer.customerId) {
                 this.getCustomerInfo();
             }
+
+            const customFieldSetCriteria = new Criteria(1, 25);
+            customFieldSetCriteria.addFilter(Criteria.equals('relations.entityName', 'customer_address'))
+                .addAssociation('customFields');
+
+            this.customFieldSetRepository.search(customFieldSetCriteria).then((customFieldSets) => {
+                this.addressCustomFieldSets = customFieldSets;
+            });
         },
 
         getCustomerInfo() {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/sw-order-address-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-modal/sw-order-address-modal.html.twig
@@ -40,6 +40,11 @@
                     :customer="orderCustomer"
                     :countries="countries"
                 />
+                <sw-custom-field-set-renderer
+                    :entity="address"
+                    variant="tabs"
+                    :sets="addressCustomFieldSets"
+                />
                 {% endblock %}
             </div>
             <div v-if="active==='addresses'">

--- a/src/Core/Framework/Api/Controller/SyncController.php
+++ b/src/Core/Framework/Api/Controller/SyncController.php
@@ -156,13 +156,22 @@ a list of identifiers can be provided.",
         });
 
         if (Feature::isActive('FEATURE_NEXT_15815')) {
-            return new JsonResponse($result, Response::HTTP_OK);
+            return $this->createResponse($result, Response::HTTP_OK);
         }
 
         if ($behavior->failOnError() && !$result->isSuccess()) {
-            return new JsonResponse($result, Response::HTTP_BAD_REQUEST);
+            return $this->createResponse($result, Response::HTTP_BAD_REQUEST);
         }
 
-        return new JsonResponse($result, Response::HTTP_OK);
+        return $this->createResponse($result, Response::HTTP_OK);
+    }
+
+    private function createResponse(SyncResult $result, int $statusCode = 200): JsonResponse
+    {
+        $response = new JsonResponse(null, $statusCode);
+        $response->setEncodingOptions(JSON_INVALID_UTF8_SUBSTITUTE);
+        $response->setData($result);
+
+        return $response;
     }
 }

--- a/src/Core/Framework/Api/Controller/SyncController.php
+++ b/src/Core/Framework/Api/Controller/SyncController.php
@@ -169,7 +169,7 @@ a list of identifiers can be provided.",
     private function createResponse(SyncResult $result, int $statusCode = 200): JsonResponse
     {
         $response = new JsonResponse(null, $statusCode);
-        $response->setEncodingOptions(JSON_INVALID_UTF8_SUBSTITUTE);
+        $response->setEncodingOptions(\JSON_INVALID_UTF8_SUBSTITUTE);
         $response->setData($result);
 
         return $response;


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when an order_address is created all the custom fields are copied from the customer_address. However for a customer_address you can update/change the custom fields and for an order_address you can't


### 2. What does this change do, exactly?
Includes custom field sets from an customer_address on the order_address modal. This way these fields can be changed in the administration


### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
