### PR TITLE
Load migrations from all bundles that are shipped with the plugin

### DIFF
--- a/changelog/_unreleased/2022-04-28-load-migrations-from-additional-bundles.md
+++ b/changelog/_unreleased/2022-04-28-load-migrations-from-additional-bundles.md
@@ -1,0 +1,8 @@
+---
+title: Load migrations from additional bundles
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed content of the default migration collection of plugins. In addition, they now contain the migrations from bundles provided by `getAdditionalBundles`

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -5,15 +5,18 @@ namespace Shopware\Core\Framework\Plugin;
 use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Bundle;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Migration\Exception\UnknownMigrationSourceException;
 use Shopware\Core\Framework\Migration\MigrationCollection;
 use Shopware\Core\Framework\Migration\MigrationCollectionLoader;
 use Shopware\Core\Framework\Migration\MigrationSource;
+use Shopware\Core\Framework\Parameter\AdditionalBundleParameters;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Composer\CommandExecutor;
 use Shopware\Core\Framework\Plugin\Context\ActivateContext;
@@ -45,6 +48,7 @@ use Shopware\Core\Kernel;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle as SymfonyBundle;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 
 /**
@@ -110,12 +114,13 @@ class PluginLifecycleService
         $pluginBaseClass = $this->getPluginBaseClass($plugin->getBaseClass());
         $pluginVersion = $plugin->getVersion();
 
+        $migrations = $this->createMigrationCollection($pluginBaseClass);
         $installContext = new InstallContext(
             $pluginBaseClass,
             $shopwareContext,
             $this->shopwareVersion,
             $pluginVersion,
-            $this->createMigrationCollection($pluginBaseClass)
+            $migrations[$pluginBaseClass->getName()]
         );
 
         if ($plugin->getInstalledAt()) {
@@ -156,7 +161,7 @@ class PluginLifecycleService
 
         $pluginBaseClass->install($installContext);
 
-        $this->runMigrations($installContext);
+        $this->runMigrations($installContext, $migrations);
 
         $installDate = new \DateTime();
         $pluginData['installedAt'] = $installDate->format(Defaults::STORAGE_DATE_TIME_FORMAT);
@@ -201,12 +206,13 @@ class PluginLifecycleService
             $this->executor->remove($pluginComposerName, $plugin->getName());
         }
 
+        $migrations = $this->createMigrationCollection($pluginBaseClass);
         $uninstallContext = new UninstallContext(
             $pluginBaseClass,
             $shopwareContext,
             $this->shopwareVersion,
             $plugin->getVersion(),
-            $this->createMigrationCollection($pluginBaseClass),
+            $migrations[$pluginBaseClass->getName()],
             $keepUserData
         );
         $uninstallContext->setAutoMigrate(false);
@@ -254,13 +260,14 @@ class PluginLifecycleService
 
         $pluginBaseClassString = $plugin->getBaseClass();
         $pluginBaseClass = $this->getPluginBaseClass($pluginBaseClassString);
+        $migrations = $this->createMigrationCollection($pluginBaseClass);
 
         $updateContext = new UpdateContext(
             $pluginBaseClass,
             $shopwareContext,
             $this->shopwareVersion,
             $plugin->getVersion(),
-            $this->createMigrationCollection($pluginBaseClass),
+            $migrations[$pluginBaseClass->getName()],
             $plugin->getUpgradeVersion() ?? $plugin->getVersion()
         );
 
@@ -305,7 +312,7 @@ class PluginLifecycleService
             $this->assetInstaller->copyAssetsFromBundle($pluginBaseClassString);
         }
 
-        $this->runMigrations($updateContext);
+        $this->runMigrations($updateContext, $migrations);
 
         $updateVersion = $updateContext->getUpdatePluginVersion();
         $updateDate = new \DateTime();
@@ -340,13 +347,13 @@ class PluginLifecycleService
 
         $pluginBaseClassString = $plugin->getBaseClass();
         $pluginBaseClass = $this->getPluginBaseClass($pluginBaseClassString);
-
+        $migrations = $this->createMigrationCollection($pluginBaseClass);
         $activateContext = new ActivateContext(
             $pluginBaseClass,
             $shopwareContext,
             $this->shopwareVersion,
             $plugin->getVersion(),
-            $this->createMigrationCollection($pluginBaseClass)
+            $migrations[$pluginBaseClass->getName()]
         );
 
         if ($plugin->getActive()) {
@@ -365,18 +372,19 @@ class PluginLifecycleService
         }
 
         $pluginBaseClass = $this->getPluginInstance($pluginBaseClassString);
+        $migrations = $this->createMigrationCollection($pluginBaseClass);
         $activateContext = new ActivateContext(
             $pluginBaseClass,
             $shopwareContext,
             $this->shopwareVersion,
             $plugin->getVersion(),
-            $this->createMigrationCollection($pluginBaseClass)
+            $migrations[$pluginBaseClass->getName()]
         );
         $activateContext->setAutoMigrate(false);
 
         $pluginBaseClass->activate($activateContext);
 
-        $this->runMigrations($activateContext);
+        $this->runMigrations($activateContext, $migrations);
 
         if (!$shopwareContext->hasState(self::STATE_SKIP_ASSET_BUILDING)) {
             $this->assetInstaller->copyAssetsFromBundle($pluginBaseClassString);
@@ -424,12 +432,13 @@ class PluginLifecycleService
         $pluginBaseClassString = $plugin->getBaseClass();
         $pluginBaseClass = $this->getPluginInstance($pluginBaseClassString);
 
+        $migrations = $this->createMigrationCollection($pluginBaseClass);
         $deactivateContext = new DeactivateContext(
             $pluginBaseClass,
             $shopwareContext,
             $this->shopwareVersion,
             $plugin->getVersion(),
-            $this->createMigrationCollection($pluginBaseClass)
+            $migrations[$pluginBaseClass->getName()]
         );
         $deactivateContext->setAutoMigrate(false);
 
@@ -477,7 +486,10 @@ class PluginLifecycleService
         return $baseClass;
     }
 
-    private function createMigrationCollection(Plugin $pluginBaseClass): MigrationCollection
+    /**
+     * @return array<string, MigrationCollection>
+     */
+    private function createMigrationCollection(Plugin $pluginBaseClass): array
     {
         $migrationPath = str_replace(
             '\\',
@@ -490,28 +502,51 @@ class PluginLifecycleService
         );
 
         if (!is_dir($migrationPath)) {
-            return $this->migrationLoader->collect('null');
+            return [$pluginBaseClass->getName() => $this->migrationLoader->collect('null')];
         }
 
         $this->migrationLoader->addSource(new MigrationSource($pluginBaseClass->getName(), [
             $migrationPath => $pluginBaseClass->getMigrationNamespace(),
         ]));
 
-        $collection = $this->migrationLoader
-            ->collect($pluginBaseClass->getName());
+        $pluginLoader = $this->container->get(KernelPluginLoader::class);
+        $copy = new KernelPluginCollection($pluginLoader->getPluginInstances()->all());
+        $additionalBundleParameters = new AdditionalBundleParameters($pluginLoader->getClassLoader(), $copy, []);
 
-        $collection->sync();
+        $bundles = $pluginBaseClass->getAdditionalBundles($additionalBundleParameters);
+        [$preBundles, $postBundles] = $this->splitBundlesIntoPreAndPost($bundles);
+        /** @var SymfonyBundle[] $sortedBundles */
+        $sortedBundles = \array_merge(
+            \array_values($preBundles),
+            [$pluginBaseClass],
+            \array_values($postBundles),
+        );
 
-        return $collection;
+        $collections = [];
+
+        foreach ($sortedBundles as $bundle) {
+            try {
+                $collections[$bundle->getName()] = $this->migrationLoader->collect($bundle->getName());
+            } catch (UnknownMigrationSourceException $_) {
+            }
+        }
+
+        foreach ($collections as $collection) {
+            $collection->sync();
+        }
+
+        return $collections;
     }
 
-    private function runMigrations(InstallContext $context): void
+    private function runMigrations(InstallContext $context, array $migrationCollections): void
     {
         if (!$context->isAutoMigrate()) {
             return;
         }
 
-        $context->getMigrationCollection()->migrateInPlace();
+        foreach ($migrationCollections as $migrationCollection) {
+            $migrationCollection->migrateInPlace();
+        }
     }
 
     private function hasPluginUpdate(string $updateVersion, string $currentVersion): bool
@@ -598,5 +633,31 @@ class PluginLifecycleService
             (new Criteria())->addFilter(new EqualsAnyFilter('name', $names)),
             $context
         );
+    }
+
+    /**
+     * @param SymfonyBundle[] $bundles
+     *
+     * @see \Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader::splitBundlesIntoPreAndPost
+     *
+     * @return array<Bundle[]>
+     */
+    private function splitBundlesIntoPreAndPost(array $bundles): array
+    {
+        $pre = [];
+        $post = [];
+
+        foreach ($bundles as $index => $bundle) {
+            if (\is_int($index) && $index < 0) {
+                $pre[$index] = $bundle;
+            } else {
+                $post[$index] = $bundle;
+            }
+        }
+
+        \ksort($pre);
+        \ksort($post);
+
+        return [$pre, $post];
     }
 }

--- a/src/Core/Framework/Test/Plugin/PluginLifecycleServiceTest.php
+++ b/src/Core/Framework/Test/Plugin/PluginLifecycleServiceTest.php
@@ -26,6 +26,7 @@ use Shopware\Core\Framework\Plugin\Util\AssetService;
 use Shopware\Core\Framework\Plugin\Util\PluginFinder;
 use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Test\Migration\MigrationTestBehaviour;
+use Shopware\Core\Framework\Test\Plugin\_fixture\bundles\ShopwareBundleWithMigrations\ShopwareBundleWithMigrationsBundle;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -473,6 +474,15 @@ class PluginLifecycleServiceTest extends TestCase
         static::assertNull($pluginUninstalled->getInstalledAt());
         static::assertFalse($pluginUninstalled->getActive());
         static::assertCount($keepUserData ? 1 : 0, $themeRepo->search($criteria, $this->context)->getElements());
+    }
+
+    public function testMigrationsAreLoadedFromBundlesThatAreShippedWithPlugins(): void
+    {
+        $basePlugin = $this->pluginService->getPluginByName('SwagTestWithBundle', $this->context);
+        $this->pluginLifecycleService->installPlugin($basePlugin, $this->context);
+        $this->pluginLifecycleService->activatePlugin($basePlugin, $this->context);
+        /** @see \Shopware\Core\Framework\Test\Plugin\_fixture\bundles\ShopwareBundleWithMigrations\ShopwareBundleWithMigrationsBundle */
+        static::assertSame(1, $this->getMigrationCount('Shopware\Core\Framework\Test\Plugin\_fixture\bundles\ShopwareBundleWithMigrations'));
     }
 
     public function themeProvideData(): array

--- a/src/Core/Framework/Test/Plugin/_fixture/bundles/ShopwareBundleWithMigrations/Migration/Migration1.php
+++ b/src/Core/Framework/Test/Plugin/_fixture/bundles/ShopwareBundleWithMigrations/Migration/Migration1.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Plugin\_fixture\bundles\ShopwareBundleWithMigrations\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+final class Migration1 extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1;
+    }
+
+    public function update(Connection $connection): void
+    {
+        // It does not need to be implemented. Just exist.
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // It does not need to be implemented. Just exist.
+    }
+}

--- a/src/Core/Framework/Test/Plugin/_fixture/bundles/ShopwareBundleWithMigrations/ShopwareBundleWithMigrationsBundle.php
+++ b/src/Core/Framework/Test/Plugin/_fixture/bundles/ShopwareBundleWithMigrations/ShopwareBundleWithMigrationsBundle.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Plugin\_fixture\bundles\ShopwareBundleWithMigrations;
+
+use Shopware\Core\Framework\Bundle;
+
+/**
+ * @internal
+ */
+final class ShopwareBundleWithMigrationsBundle extends Bundle
+{
+}

--- a/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTestWithBundle/src/SwagTestWithBundle.php
+++ b/src/Core/Framework/Test/Plugin/_fixture/plugins/SwagTestWithBundle/src/SwagTestWithBundle.php
@@ -5,6 +5,7 @@ namespace SwagTestWithBundle;
 use Shopware\Core\Framework\Parameter\AdditionalBundleParameters;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Test\Plugin\_fixture\bundles\FooBarBundle;
+use Shopware\Core\Framework\Test\Plugin\_fixture\bundles\ShopwareBundleWithMigrations\ShopwareBundleWithMigrationsBundle;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 
 class SwagTestWithBundle extends Plugin
@@ -18,6 +19,8 @@ class SwagTestWithBundle extends Plugin
             new FrameworkBundle(),
             // is already provided by SwagTest and should not be loaded twice
             new FooBarBundle(),
+            // should provide a migration
+            new ShopwareBundleWithMigrationsBundle(),
         ];
     }
 }


### PR DESCRIPTION
### 0. Follow up

This is a follow up from #2455 but this time I added a changelog and tests.

### 1. Why is this change necessary?

When you add a bundle in the additional bundles, they shall be shopware bundles. Shopware bundles can have migrations. When I name dependent bundles, those should execute their migrations as well.

### 2. What does this change do, exactly?

I use the same strategy to load the additional bundles to get the additional migrations. As the migration source for a plugin is created at different places I could not change its content so it is not reliable to change.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a bundle with migrations
2. Refer to it in the additional bundles
3. Have code based on the migrations in the bundle
4. Your plugin bricked

### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-Implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
