### PR TITLE
Add markAsTopseller option to elasticsearch document

### DIFF
--- a/changelog/_unreleased/2022-07-05-add-markastopseller-to-elasticsearch.md
+++ b/changelog/_unreleased/2022-07-05-add-markastopseller-to-elasticsearch.md
@@ -1,0 +1,9 @@
+---
+title: Add markAsTopseller field to elasticsearch document
+issue: 
+author: Kurt Inge Smådal
+author_email: kurt@flowretail.no
+author_github: kurtinge
+---
+# Elasticsearch
+* Added the field markAsTopseller to the elasticsarch document to be able to use it in Dynamic Product Groups

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -128,6 +128,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 'createdAt' => [
                     'type' => 'date',
                 ],
+                'markAsTopseller' => EntityMapper::BOOLEAN_FIELD,
                 'sales' => EntityMapper::INT_FIELD,
                 'stock' => EntityMapper::INT_FIELD,
                 'shippingFree' => EntityMapper::BOOLEAN_FIELD,
@@ -278,6 +279,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 ],
                 'releaseDate' => isset($item['releaseDate']) ? (new \DateTime($item['releaseDate']))->format('c') : null,
                 'createdAt' => isset($item['createdAt']) ? (new \DateTime($item['createdAt']))->format('c') : null,
+                'markAsTopseller' => (bool) $item['markAsTopseller'],
                 'optionIds' => $optionIds,
                 'options' => array_map(fn (string $optionId) => ['id' => $optionId, 'groupId' => $groups[$optionId], '_count' => 1], $optionIds),
                 'categoriesRo' => array_map(fn (string $categoryId) => ['id' => $categoryId, '_count' => 1], $categoriesRo),
@@ -472,6 +474,7 @@ SELECT
     IFNULL(p.width, pp.width) AS width,
     IFNULL(p.release_date, pp.release_date) AS releaseDate,
     IFNULL(p.created_at, pp.created_at) AS createdAt,
+    IFNULL(p.mark_as_topseller, pp.mark_as_topseller) AS markAsTopseller,
     IFNULL(p.category_tree, pp.category_tree) AS categoryIds,
     IFNULL(p.option_ids, pp.option_ids) AS optionIds,
     IFNULL(p.property_ids, pp.property_ids) AS propertyIds,


### PR DESCRIPTION
### 1. Why is this change necessary?
To be able to make Dynamic Product Groups on "Product promotion" the "markAsTopseller" field needs to be included in the Elasticsearch document.

### 2. What does this change do, exactly?
Add the field "markAsTopseller" to the elasticsearch document

### 3. Describe each step to reproduce the issue or behaviour.
- Enable "Product promotion" on a product
- Create a Dynamic Product Group with the rule "Marked as promoted" set to "Yes"
- Use the Dynamic Product Group on a category
- Go to the category in frontend, and the category will be empty.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
