### PR TITLE
fix(translation): correct german word for email in newsletter subscription

### DIFF
--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -470,7 +470,7 @@
     "subscriptionRevokeSuccess": "Sie haben sich erfolgreich vom Newsletter abgemeldet.",
     "subscriptionConfirmationSuccess": "Ihr Newsletter-Abonnement wurde erfolgreich registriert.",
     "subscriptionConfirmationFailed": "Bei Ihrer Newsletter-Anmeldung ist etwas schief gelaufen. Bitte wenden Sie sich an den Support.",
-    "subscriptionCompleted": "Vielen Dank. Wir haben Ihre Email-Adresse eingetragen.",
+    "subscriptionCompleted": "Vielen Dank. Wir haben Ihre E-Mail-Adresse eingetragen.",
     "labelActionSelect": "Aktion",
     "labelMail": "E-Mail-Adresse",
     "labelFirstName": "Vorname",


### PR DESCRIPTION
### 1. Why is this change necessary?
... it's incorrect.
fun fact: German `Email` and English `e-mail` means `Glass-like, shiny coating on objects made of metal or similar.`. Please take care. 

### 2. What does this change do, exactly?
change "Email" to "E-Mail" in German text

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have not created a changelog file for this small thing. ~~I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes~~ 
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
