### PR TITLE
make the used HttpCache-class customizable (similar to Kernel-class)

### DIFF
--- a/changelog/_unreleased/2022-07-05-make-used-httpcache-class-customizable.md
+++ b/changelog/_unreleased/2022-07-05-make-used-httpcache-class-customizable.md
@@ -1,0 +1,9 @@
+---
+title: make used HttpCache-class customizable
+issue: tba
+author: Sven Herrmann
+author_email: sven.herrmann@ianeo.de
+author_github: @SvenHerrmann
+---
+# Core
+* Added static property `$httpCacheClass` to `src/Core/HttpKernel.php` to make the used HttpCache-class customizable (similar to Kernel-class)

--- a/src/Core/HttpKernel.php
+++ b/src/Core/HttpKernel.php
@@ -37,6 +37,11 @@ class HttpKernel
     protected static $kernelClass = Kernel::class;
 
     /**
+     * @var class-string<HttpCache>
+     */
+    protected static $httpCacheClass = HttpCache::class;
+
+    /**
      * @var ClassLoader|null
      */
     protected $classLoader;
@@ -147,7 +152,7 @@ class HttpKernel
         $enabled = $container->hasParameter('shopware.http.cache.enabled')
             && $container->getParameter('shopware.http.cache.enabled');
         if ($enabled && $container->has(CacheStore::class)) {
-            $kernel = new HttpCache($kernel, $container->get(CacheStore::class), null, ['debug' => $this->debug]);
+            $kernel = new static::$httpCacheClass($kernel, $container->get(CacheStore::class), null, ['debug' => $this->debug]);
         }
 
         $response = $kernel->handle($transformed, $type, $catch);

--- a/src/Core/HttpKernel.php
+++ b/src/Core/HttpKernel.php
@@ -39,7 +39,7 @@ class HttpKernel
     /**
      * @var class-string<HttpCache>
      */
-    protected static $httpCacheClass = HttpCache::class;
+    protected static string $httpCacheClass = HttpCache::class;
 
     /**
      * @var ClassLoader|null


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
I'd like to exchange the used HttpCache-class.

### 2. What does this change do, exactly?
It introduces an new property to Core\HttpKernel which can be set similar to the already existing $kernelClass-property.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
