### PR TITLE
fix date-picker.plugin locale defaulting to de

### DIFF
--- a/changelog/_unreleased/2022-07-05-fix-date-picker.plugin-locale-defaulting-to-de.md
+++ b/changelog/_unreleased/2022-07-05-fix-date-picker.plugin-locale-defaulting-to-de.md
@@ -1,0 +1,13 @@
+---
+title:              Fix date-picker.plugin locale defaulting to de       # Required
+issue:              -                              # Required
+author:             Private                          # Optional for shopware employees, Required for external developers
+author_email:       enacrt@gmail.com                   # Optional for shopware employees, Required for external developers
+author_github:      @nacrt                                 # Optional
+---
+# Storefront
+*  Fix `date-picker.plugin` locale defaulting to `de`
+__
+# Upgrade Information
+
+When desiring a `data-date-picker`, `locale` will now need to be specified if the desired output language is not `de`

--- a/changelog/_unreleased/2022-07-05-fix-date-picker.plugin-locale-defaulting-to-de.md
+++ b/changelog/_unreleased/2022-07-05-fix-date-picker.plugin-locale-defaulting-to-de.md
@@ -1,6 +1,6 @@
 ---
 title:              Fix date-picker.plugin locale defaulting to de       # Required
-issue:              -                              # Required
+issue:              https://issues.shopware.com/issues/NEXT-22354                              # Required
 author:             Private                          # Optional for shopware employees, Required for external developers
 author_email:       enacrt@gmail.com                   # Optional for shopware employees, Required for external developers
 author_github:      @nacrt                                 # Optional

--- a/src/Storefront/Resources/app/storefront/src/plugin/date-picker/date-picker.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/date-picker/date-picker.plugin.js
@@ -127,7 +127,7 @@ export default class DatePickerPlugin extends Plugin {
      */
     generateFlatpickrOptions() {
         let localeIndex = 'default';
-        if (this.options.locale.substring(0, 2) !== 'en') {
+        if (this.options.locale !== 'default') {
             localeIndex = this.options.locale.substring(0, 2);
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
``date-picker.plugin`` defaults to ``de``. it is supposed to default to ``default`` aka ``en``

### 2. What does this change do, exactly?
``this.options.locale.substring(0,2)`` returns ``de`` when locale is ``default``. 
By checking if locale is ``not "default"`` and then substringing, we get the intended behavior

### 3. Describe each step to reproduce the issue or behaviour.
Assign ``data-date-picker`` to an input field

### 4. Please link to the relevant issues (if any).
[NEXT-22354](https://issues.shopware.com/issues/NEXT-22354)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
