### PR TITLE
fix Exception::__construct() in TreeBuildingNavigationRoute.php

### DIFF
--- a/changelog/_unreleased/2022-07-07-fix-Exception__construct-in-TreeBuildingNavigationRoute.php.md
+++ b/changelog/_unreleased/2022-07-07-fix-Exception__construct-in-TreeBuildingNavigationRoute.php.md
@@ -1,0 +1,13 @@
+---
+title:              Fix date-picker.plugin locale defaulting to de       # Required
+issue:              -                              # Required
+author:             Private                          # Optional for shopware employees, Required for external developers
+author_email:       enacrt@gmail.com                   # Optional for shopware employees, Required for external developers
+author_github:      @nacrt                                 # Optional
+---
+# Storefront
+*  Fix `date-picker.plugin` locale defaulting to `de`
+__
+# Upgrade Information
+
+When desiring a `data-date-picker`, `locale` will now need to be specified if the desired output language is not `de`

--- a/changelog/_unreleased/2022-07-07-fix-Exception__construct-in-TreeBuildingNavigationRoute.php.md
+++ b/changelog/_unreleased/2022-07-07-fix-Exception__construct-in-TreeBuildingNavigationRoute.php.md
@@ -1,6 +1,6 @@
 ---
 title:              fix Exception::__construct() in TreeBuildingNavigationRoute.php       # Required
-issue:              -                              # Required
+issue:              https://issues.shopware.com/issues/NEXT-22353                              # Required
 author:             Private                          # Optional for shopware employees, Required for external developers
 author_email:       enacrt@gmail.com                   # Optional for shopware employees, Required for external developers
 author_github:      @nacrt                                 # Optional

--- a/changelog/_unreleased/2022-07-07-fix-Exception__construct-in-TreeBuildingNavigationRoute.php.md
+++ b/changelog/_unreleased/2022-07-07-fix-Exception__construct-in-TreeBuildingNavigationRoute.php.md
@@ -1,13 +1,9 @@
 ---
-title:              Fix date-picker.plugin locale defaulting to de       # Required
+title:              fix Exception::__construct() in TreeBuildingNavigationRoute.php       # Required
 issue:              -                              # Required
 author:             Private                          # Optional for shopware employees, Required for external developers
 author_email:       enacrt@gmail.com                   # Optional for shopware employees, Required for external developers
 author_github:      @nacrt                                 # Optional
 ---
-# Storefront
-*  Fix `date-picker.plugin` locale defaulting to `de`
-__
-# Upgrade Information
-
-When desiring a `data-date-picker`, `locale` will now need to be specified if the desired output language is not `de`
+# Core
+*  fix ``Exception::__construct()`` in TreeBuildingNavigationRoute.php

--- a/src/Core/Content/Category/SalesChannel/TreeBuildingNavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/TreeBuildingNavigationRoute.php
@@ -154,7 +154,7 @@ class TreeBuildingNavigationRoute extends AbstractNavigationRoute
                 return $salesChannelEntity->getServiceCategoryId();
             case 'footer-navigation':
                 if ($salesChannelEntity->getFooterCategoryId() === null) {
-                    throw new \RuntimeException('Footer category, for sales channel %s, is not set', $salesChannelEntity->getTranslation('name'));
+                    throw new \RuntimeException(\sprintf('Footer category, for sales channel %s, is not set', $salesChannelEntity->getTranslation('name')));
                 }
 
                 return $salesChannelEntity->getFooterCategoryId();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The original code incorrectly creates a RuntimeException.
By adding the missing ``\sprintf`` method, this is fixed.
Just a few lines above, you can see an example of how it is done correctly
https://github.com/shopware/platform/blob/5b530db01e462b04a9e33438e95d35d73dfbe651/src/Core/Content/Category/SalesChannel/TreeBuildingNavigationRoute.php#L151

### 2. What does this change do, exactly?
![grafik](https://user-images.githubusercontent.com/37629791/177714007-9e083791-c4a5-4afa-a540-3ffb89dc94b5.png)
becomes the intended
![grafik](https://user-images.githubusercontent.com/37629791/177714330-77197e5b-dfda-426b-b42f-a690b33aa9b0.png)

### 3. Describe each step to reproduce the issue or behaviour.
This was done by following the ``Shopware PWA installation`` lesson on the ``Shopware 6 Frontend Development - with Jisse Reitsma`` course.

### 4. Please link to the relevant issues (if any).
[NEXT-22353](https://issues.shopware.com/issues/NEXT-22353)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
