### PR TITLE
scripts-dev-mode-issue-NEXT-22292

### DIFF
--- a/changelog/_unreleased/2022-07-07-use-absolute-path.md
+++ b/changelog/_unreleased/2022-07-07-use-absolute-path.md
@@ -1,0 +1,9 @@
+---
+title: Use absolute path
+issue: NEXT-22292
+author: Alexander Schmidt
+author_email: support@kiplingi.de
+author_github: kiplingi
+---
+# Core
+* Changed from relative to absolute path, to prevent wrong loading in ScriptFileReader

--- a/src/Core/Framework/App/Lifecycle/Persister/ScriptPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/ScriptPersister.php
@@ -10,6 +10,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Script\ScriptCollection;
 use Shopware\Core\Framework\Script\ScriptEntity;
+use Symfony\Component\HttpKernel\KernelInterface;
+
 
 /**
  * @internal only for use by the app-system
@@ -22,14 +24,18 @@ class ScriptPersister
 
     private EntityRepositoryInterface $appRepository;
 
+    private KernelInterface $appKernel;
+
     public function __construct(
         ScriptFileReaderInterface $scriptReader,
         EntityRepositoryInterface $scriptRepository,
-        EntityRepositoryInterface $appRepository
+        EntityRepositoryInterface $appRepository,
+        KernelInterface $kernel
     ) {
         $this->scriptReader = $scriptReader;
         $this->scriptRepository = $scriptRepository;
         $this->appRepository = $appRepository;
+        $this->appKernel = $kernel;
     }
 
     public function updateScripts(string $appPath, string $appId, Context $context): void
@@ -116,9 +122,11 @@ class ScriptPersister
 
         $apps = $this->appRepository->search($criteria, Context::createDefaultContext())->getEntities();
 
+        $basePath = $this->appKernel->getProjectDir();
+
         /** @var AppEntity $app */
         foreach ($apps as $app) {
-            $this->updateScripts($app->getPath(), $app->getId(), Context::createDefaultContext());
+            $this->updateScripts($basePath . \DIRECTORY_SEPARATOR . $app->getPath(), $app->getId(), Context::createDefaultContext());
         }
     }
 

--- a/src/Core/Framework/App/Lifecycle/Persister/ScriptPersister.php
+++ b/src/Core/Framework/App/Lifecycle/Persister/ScriptPersister.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\Script\ScriptCollection;
 use Shopware\Core\Framework\Script\ScriptEntity;
 use Symfony\Component\HttpKernel\KernelInterface;
 
-
 /**
  * @internal only for use by the app-system
  */

--- a/src/Core/Framework/DependencyInjection/app.xml
+++ b/src/Core/Framework/DependencyInjection/app.xml
@@ -73,6 +73,7 @@
             <argument type="service" id="Shopware\Core\Framework\App\Lifecycle\ScriptFileReader"/>
             <argument type="service" id="script.repository"/>
             <argument type="service" id="app.repository"/>
+            <argument type="service" id="kernel"/>
         </service>
 
         <service id="Shopware\Core\Framework\App\Lifecycle\ScriptFileReader">


### PR DESCRIPTION
### 1. Why is this change necessary?
When environment is in dev, scripts got deleted because they where not found and deleted in cleanup.
Shopware\Core\Framework\App\Lifecycle\Persister\ScriptPersister::refresh is only called when in debug mode. It then uses a relative path to update the scripts. The ScriptFileReader seems to expects the absolute path, which is the case in e.g. app update events.

### 2. What does this change do, exactly?
Instead of using the relative path, the absolute one is used in the function call. Scripts are found this way.

### 3. Describe each step to reproduce the issue or behaviour.
Create an app with a script. Install it. When in dev mode the scripts get deleted from the database. 

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-22292

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
