### PR TITLE
Fix empty configuration is placed by std_object

### DIFF
--- a/src/Core/System/SystemConfig/Service/ConfigurationService.php
+++ b/src/Core/System/SystemConfig/Service/ConfigurationService.php
@@ -103,9 +103,6 @@ class ConfigurationService
                 }
 
                 unset($field['type'], $field['name']);
-                if ($field === []) {
-                    $field = new \stdClass();
-                }
                 $newField['config'] = $field;
                 $card['elements'][$j] = $newField;
             }


### PR DESCRIPTION
### 1. Why is this change necessary?
Shopware accesses the config fields as array. 

[Example1 - ThemeCompilerEnrichScssVarSubscriber](https://github.com/shopware/platform/blob/24b0936d01ffde44f93f512613eb57fde5fae073/src/Storefront/Theme/Subscriber/ThemeCompilerEnrichScssVarSubscriber.php#L77)

[Example2- ConfigurationService](https://github.com/shopware/platform/blob/917ac4779c3ae63b4270b7b6767f123dc3b5a72a/src/Core/System/SystemConfig/Service/ConfigurationService.php#L186)

The problem is, if the field is empty, Shopware assigns an empty class to it:
```php
if ($field === []) {
    $field = new \stdClass();
}
```
https://github.com/shopware/platform/blob/917ac4779c3ae63b4270b7b6767f123dc3b5a72a/src/Core/System/SystemConfig/Service/ConfigurationService.php#L106


This is the case, if you define a plugin config like this:
```
<input-field type="textarea">
    <name>text</name>
</input-field>
```

It then crashed in the ThemeCompilerEnrichScssVarSubscriber and ConfigurationService because the $field is assigned a new \stdClass(); which does not support array access:
```
	In ConfigurationService.php line 190:
	                                               
	  [Error]                                      
	  Cannot use object of type stdClass as array  
	                                               
```

This fixed following issues:
https://issues.shopware.com/issues/NEXT-22311
https://issues.shopware.com/issues/NEXT-22261