### PR TITLE
Fix NEXT-20977 when sw-text-editor is used within sw-modal

### DIFF
--- a/changelog/_unreleased/2022-07-11-add-dynamic-positioning-on-link-flyout-within-modals.md
+++ b/changelog/_unreleased/2022-07-11-add-dynamic-positioning-on-link-flyout-within-modals.md
@@ -1,0 +1,10 @@
+---
+title: Add dynamic positioning on link flyout, when sw-text-editor is used within sw-modal
+issue: NEXT-20977
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Changed `positionLinkMenu` method in `sw-text-editor-toolbar-button/index.js` to expect other containers, that could limit the width and cut off the popup
+* Added `getFlyoutMenuContainerElement` method to `sw-text-editor-toolbar-button/index.js` to evaluate the closest container that cuts off a popup container

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar-button/index.js
@@ -153,9 +153,12 @@ Component.register('sw-text-editor-toolbar-button', {
             const linkIconRightBound = linkIcon.getBoundingClientRect().right;
 
             const linkFlyoutMenuRightBound = linkIconRightBound - linkIconWidth + flyoutLinkMenuWidth;
-            const windowRightBound = this.$device.getViewportWidth();
 
-            const isOutOfRightBound = windowRightBound - linkFlyoutMenuRightBound;
+            const containerElement = this.getFlyoutMenuContainerElement(flyoutLinkMenu);
+
+            const containerRightBound = containerElement.getBoundingClientRect().right;
+
+            const isOutOfRightBound = containerRightBound - linkFlyoutMenuRightBound;
 
             let flyoutLinkLeftOffset = 0;
             let arrowPosition = 10;
@@ -168,5 +171,11 @@ Component.register('sw-text-editor-toolbar-button', {
             flyoutLinkMenu.style.setProperty('--flyoutLinkLeftOffset', `${flyoutLinkLeftOffset}px`);
             flyoutLinkMenu.style.setProperty('--arrow-position', `${arrowPosition}px`);
         },
+
+        getFlyoutMenuContainerElement(element) {
+            const modalParent = element.closest('.sw-modal__body');
+
+            return modalParent || window.document.body;
+        }
     },
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
Because NEXT-20977 is not a complete solution.

### 2. What does this change do, exactly?
It does not expect that window is the limit for the sw-text-editor but anything else. Right now quite hardcoded to sw-modal but this is quite likely. If someone needs it somewhere else we now have a new method for it.

### 3. Describe each step to reproduce the issue or behaviour.
1. Open a CMS element config with a sw-text-editor
2. Write text that is quite close to the right side
3. Select it
4. Transform into a link
5. See a cut-off dialog
6. Try to scroll right with your touch pad
7. Realize you just have a mouse
8. Click on the horizontal scroll bar
9. Blur the focus of the link dialog
10. Link dialog goes
![image](https://user-images.githubusercontent.com/1133593/178322203-885e4fec-5064-4249-9338-1c7884f7dac1.png)

\> vanish-dialog.gif
![PR-to-amend-NEXT-20977](https://user-images.githubusercontent.com/1133593/178323442-30bf2c3c-9946-441d-b414-decbe279a410.gif)


### 4. Please link to the relevant issues.
Someone tried to solve it in NEXT-20977 quite good. But just with the focus on window. Rest of the original solution is good.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
