### PR TITLE
Fix custom field sorting in admin

### DIFF
--- a/changelog/_unreleased/2022-07-13-sort-custom-field-sorting-in-admin-view.md
+++ b/changelog/_unreleased/2022-07-13-sort-custom-field-sorting-in-admin-view.md
@@ -1,0 +1,9 @@
+---
+title: Fix custom field sorting in admin view
+issue: NEXT-22370
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added sorting for `config.customFieldPosition` in association `customFields` to load `custom_field_set` when used in `sw-order-detail-general` and `sw-custom-field-set-renderer`

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-custom-field-set-renderer/index.js
@@ -335,12 +335,9 @@ Component.register('sw-custom-field-set-renderer', {
 
         customFieldSetCriteriaById() {
             const criteria = new Criteria(1, 1);
-            const customFieldsCriteria = new Criteria(1, null);
 
-            customFieldsCriteria.addSorting(Criteria.sort('config.customFieldsPosition'));
-
-            criteria
-                .addAssociation('customFields', customFieldsCriteria);
+            criteria.getAssociation('customFields')
+                .addSorting(Criteria.naturalSorting('config.customFieldPosition'));
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-general/index.js
@@ -154,11 +154,11 @@ Component.register('sw-order-detail-general', {
         },
 
         customFieldSetCriteria() {
-            const customFieldsCriteria = new Criteria(1, 100);
-            customFieldsCriteria.addSorting(Criteria.sort('config.customFieldsPosition'));
-
             const criteria = new Criteria(1, 100);
-            criteria.addAssociation('customFields', customFieldsCriteria);
+
+            criteria.addAssociation('customFields');
+            criteria.getAssociation('customFields')
+                .addSorting(Criteria.naturalSorting('config.customFieldPosition'));
             criteria.addFilter(Criteria.equals('relations.entityName', 'order'));
 
             return criteria;


### PR DESCRIPTION
### 1. Why is this change necessary?
Read https://issues.shopware.com/issues/NEXT-22370

### 2. What does this change do, exactly?
It fixes a typo. One might think at first glance. But it really just is missing the criteria added to the request. addAssociation in the js client does not add a criteria (not even the php criteria) so we just have the association but nothing in the criteria because it is a new and different criteria object.

### 3. Describe each step to reproduce the issue or behaviour.
See https://issues.shopware.com/issues/NEXT-22370

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-22370

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
