### PR TITLE
Admin users can mark CMS blocks and CMS elements as favorites

### DIFF
--- a/changelog/_unreleased/2022-05-31-cms-favorites.md
+++ b/changelog/_unreleased/2022-05-31-cms-favorites.md
@@ -1,0 +1,15 @@
+---
+title: Admin users can mark CMS blocks and CMS elements as favourites
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added new property `expandChevronDirection` to `sw-sidebar-collapse` to control the icon direction for the icon in its collapsed state
+* Added new base class `UserConfigClass`, that is an extraction of a base class of the `SalesChannelFavoritesService` class to reduce duplicate code when building other dynamic user configurations
+* Added new class `CmsBlockFavoritesService` based on `UserConfigClass` as service by id `cmsBlockFavorites` to store user favourites for cms_block with the configuration key `cms-block-favorites`
+* Added new class `CmsElementFavoritesService` based on `UserConfigClass` as service by id `cmsElementFavorites` to store user favourites for cms_block with the configuration key `cms-element-favorites`
+* Added new button in `sw-cms-sidebar` within a new twig block `sw_cms_sidebar_block_overview_preview_favorite_action` to toggle user favourites for a cms block
+* Added default and dynamic cms block category for favourites. Its content are either entries provided by `cmsBlockFavorites` or an empty state
+* Changed display of CMS elements in `sw-cms-slot` by grouping them by their favourite state provided by `cmsElementFavorites` in collapsable panels
+* Added new overlay button with a heart icon to entries in `sw-cms-slot` to toggle a CMS elements' favourite state for the current user

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/index.js
@@ -6,6 +6,15 @@ const { Component } = Shopware;
 Component.extend('sw-sidebar-collapse', 'sw-collapse', {
     template,
 
+    props: {
+        expandChevronDirection: {
+            type: String,
+            required: false,
+            default: 'right',
+            validator: (value) => ['up', 'left', 'right', 'down'].indexOf(value) !== -1,
+        },
+    },
+
     computed: {
         expandButtonClass() {
             return {

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.html.twig
@@ -33,8 +33,8 @@
         @click="collapseItem"
     >
         <sw-icon
-            name="regular-chevron-right-xxs"
             class="sw-sidebar-collapse__button"
+            :name="'regular-chevron-' + expandChevronDirection + '-xxs'"
             :class="expandButtonClass"
         />
         <sw-icon

--- a/src/Administration/Resources/app/administration/src/core/service/support/user-config.class.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/support/user-config.class.ts
@@ -1,0 +1,133 @@
+const { Context, Data, Service, State } = Shopware;
+const { Criteria } = Data;
+
+enum USER_CONFIG_PERMISSIONS {
+    READ = 'user_config:read',
+    CREATE = 'user_config:create',
+    UPDATE = 'user_config:update'
+}
+
+interface CurrentUserObject {
+    id: string;
+    [index: string]: unknown;
+}
+
+interface UserConfigObject {
+    extensions: Record<string, unknown>;
+    id: string;
+    userId: string;
+    key: string;
+    value: string[];
+    isNew: () => boolean;
+}
+
+interface AclServiceInterface {
+    can(permission: string): boolean;
+}
+
+interface CriteriaInterface {
+    addFilter(filter: unknown): CriteriaInterface;
+    equals(field: string, value: string|number|boolean|null): unknown;
+}
+
+interface RepositorySearchResultInterface {
+    total: number;
+    first(): unknown;
+}
+
+interface RepositoryInterface {
+    create(context: unknown): unknown;
+    search(criteria: CriteriaInterface, context: unknown): Promise<RepositorySearchResultInterface>;
+    save(entity: unknown, context: unknown): Promise<void>;
+}
+
+abstract class UserConfigClass {
+    private userConfigRepository = <RepositoryInterface><unknown> Service('repositoryFactory').create('user_config');
+
+    private currentUserId = this.getCurrentUserId();
+
+    protected userConfig = this.createUserConfigEntity(this.getConfigurationKey());
+
+    private aclService = <AclServiceInterface> Service('acl');
+
+    constructor() {
+        void this.readUserConfig();
+    }
+
+    /**
+     * Copy user configuration into the service state.
+     */
+    protected abstract readUserConfig(): Promise<void>;
+
+    /**
+     * Copy the service state into the user configuration.
+     */
+    protected abstract setUserConfig(): void;
+
+    /**
+     * Returns the configuration key that is managed.
+     */
+    protected abstract getConfigurationKey(): string;
+
+    public refresh(): void {
+        this.userConfig = this.createUserConfigEntity(this.getConfigurationKey());
+        void this.readUserConfig();
+    }
+
+    protected async getUserConfig(): Promise<UserConfigObject> {
+        if (!this.aclService.can(USER_CONFIG_PERMISSIONS.READ)) {
+            void Promise.resolve(this.userConfig);
+        }
+
+        const response = await this.userConfigRepository.search(this.getCriteria(this.getConfigurationKey()), Context.api);
+        const userConfig = <UserConfigObject> (response.total ? response.first() : this.userConfig);
+
+        return this.handleEmptyUserConfig(userConfig);
+    }
+
+    protected async saveUserConfig(): Promise<void> {
+        if (!this.aclService.can(USER_CONFIG_PERMISSIONS.CREATE) || !this.aclService.can(USER_CONFIG_PERMISSIONS.UPDATE)) {
+            void Promise.resolve();
+        }
+
+        this.setUserConfig();
+
+        await this.userConfigRepository.save(this.userConfig, Context.api);
+        await this.readUserConfig();
+    }
+
+    private createUserConfigEntity(configKey : string): UserConfigObject {
+        const entity = <UserConfigObject> this.userConfigRepository.create(Context.api);
+
+        Object.assign(entity, {
+            userId: this.currentUserId,
+            key: configKey,
+            value: [],
+        });
+
+        return entity;
+    }
+
+    private handleEmptyUserConfig(userConfig: UserConfigObject): UserConfigObject {
+        if (!Array.isArray(userConfig.value)) {
+            userConfig.value = [];
+        }
+
+        return userConfig;
+    }
+
+    private getCriteria(configKey : string): CriteriaInterface {
+        const criteria = <CriteriaInterface><unknown> new Criteria(1, 25);
+
+        criteria.addFilter(Criteria.equals('key', configKey));
+        criteria.addFilter(Criteria.equals('userId', this.currentUserId));
+
+        return criteria;
+    }
+
+    private getCurrentUserId(): string {
+        return (State.get('session').currentUser as CurrentUserObject).id;
+    }
+}
+
+export { UserConfigClass as default };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
@@ -15,6 +15,7 @@ Component.register('sw-cms-sidebar', {
         'cmsService',
         'repositoryFactory',
         'feature',
+        'cmsBlockFavorites',
     ],
 
     mixins: [
@@ -132,10 +133,34 @@ Component.register('sw-cms-sidebar', {
             return this.pageConfigErrors.length > 0;
         },
 
+        cmsBlocksBySelectedBlockCategory() {
+            const result = Object.values(this.cmsBlocks).filter(b => b.hidden !== true);
+
+            if (this.currentBlockCategory === 'favorite') {
+                return result.filter(b => this.cmsBlockFavorites.isFavorite(b.name));
+            }
+
+            return result.filter(b => b.category === this.currentBlockCategory);
+        },
+
+        cmsBlockFavoritesTypes() {
+            return this.cmsBlockFavorites.getFavoriteBlockType();
+        },
+
         ...mapPropertyErrors('page', ['name']),
     },
 
+    created() {
+        this.createdComponent();
+    },
+
     methods: {
+        createdComponent() {
+            if (this.blockTypes.some(blockName => this.cmsBlockFavorites.isFavorite(blockName))) {
+                this.currentBlockCategory = 'favorite';
+            }
+        },
+
         onPageTypeChange() {
             this.$emit('page-type-change');
         },
@@ -487,6 +512,10 @@ Component.register('sw-cms-sidebar', {
             section.backgroundMedia = mediaItem;
 
             this.pageUpdate();
+        },
+
+        onToggleBlockFavorite(blockName) {
+            this.cmsBlockFavorites.update(!this.cmsBlockFavorites.isFavorite(blockName), blockName);
         },
 
         successfulUpload(media, section) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
@@ -141,6 +141,9 @@
                     :label="$tc('sw-cms.detail.label.blockCategorySelection')"
                 >
                     {% block sw_cms_sidebar_block_overview_category_options %}
+                    <option value="favorite">
+                        {{ $tc('sw-cms.detail.label.blockCategoryFavorite') }}
+                    </option>
                     <option value="text">
                         {{ $tc('sw-cms.detail.label.blockCategoryText') }}
                     </option>
@@ -171,21 +174,54 @@
             <div
                 class="sw-cms-sidebar__block-selection"
             >
+                <sw-empty-state
+                    icon="solid-heart"
+                    auto-height
+                    :absolute="false"
+                    v-if="cmsBlocksBySelectedBlockCategory.length === 0 && currentBlockCategory === 'favorite'"
+                >
+                    {{ $tc('sw-cms.detail.label.blockFavoriteEmptyState') }}
+                </sw-empty-state>
                 <!-- eslint-disable vue/no-use-v-if-with-v-for -->
                 <div
-                    v-for="block in cmsBlocks"
-                    v-if="block.category === currentBlockCategory && block.hidden !== true"
+                    v-for="block in cmsBlocksBySelectedBlockCategory"
                     :key="block.name"
+                    class="sw-cms-sidebar__block"
                 >
 
-                    <div
-                        v-draggable="{ dragGroup: 'cms-stage', data: { block }, onDrop: onBlockStageDrop }"
-                        class="sw-cms-sidebar__block-preview"
-                        :class="{ 'has--no-label': !block.label }"
-                    >
+                    <div class="sw-cms-sidebar__block-preview-with-actions">
+                        <div
+                            v-draggable="{ dragGroup: 'cms-stage', data: { block }, onDrop: onBlockStageDrop }"
+                            class="sw-cms-sidebar__block-preview"
+                            :class="{ 'has--no-label': !block.label }"
+                        >
 
-                        {% block sw_cms_sidebar_block_overview_preview_component %}
-                        <component :is="block.previewComponent" />
+                            {% block sw_cms_sidebar_block_overview_preview_component %}
+                            <component :is="block.previewComponent" />
+                            {% endblock %}
+                        </div>
+
+                        {% block sw_cms_sidebar_block_overview_preview_favorite_action %}
+                        <sw-button
+                            class="sw-cms-sidebar__block-favorite"
+                            size="small"
+                            @click="onToggleBlockFavorite(block.name)"
+                            square
+                            block
+                        >
+                            <sw-icon
+                                v-if="cmsBlockFavorites.isFavorite(block.name)"
+                                name="solid-heart"
+                                size="20"
+                                class="sw-cms-sidebar__icon-cms-block-favorite"
+                            />
+                            <sw-icon
+                                v-else
+                                name="regular-heart"
+                                size="20"
+                                class="sw-cms-sidebar__icon-cms-block-favorite"
+                            />
+                        </sw-button>
                         {% endblock %}
                     </div>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.scss
@@ -86,6 +86,20 @@
     &__navigator-confirm-modal-reminder {
         margin-top: 24px;
     }
+
+    .sw-cms-sidebar__block-preview-with-actions {
+        position: relative;
+
+        .sw-cms-sidebar__block-favorite {
+            right: 8px;
+            bottom: 8px;
+            position: absolute;
+
+            .sw-icon.sw-cms-sidebar__icon-cms-block-favorite {
+                color: $color-module-pink-800;
+            }
+        }
+    }
 }
 
 .sw-cms-sidebar__block-preview {
@@ -105,6 +119,10 @@
         box-shadow: none;
         border: 1px dashed $color-gray-300;
         background-color: $color-gray-50;
+
+        + .sw-cms-sidebar__block-favorite {
+            display: none;
+        }
     }
 
     &.is--drag-element,

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.js
@@ -6,7 +6,10 @@ const { Component } = Shopware;
 Component.register('sw-cms-slot', {
     template,
 
-    inject: ['cmsService'],
+    inject: [
+        'cmsService',
+        'cmsElementFavorites',
+    ],
 
     props: {
         element: {
@@ -48,6 +51,27 @@ Component.register('sw-cms-slot', {
 
         cmsElements() {
             return this.cmsService.getCmsElementRegistry();
+        },
+
+        groupedCmsElements() {
+            const result = [];
+            const elements = Object.values(this.cmsElements).sort((a, b) => a.name.localeCompare(b.name));
+            const favorites = elements.filter(e => this.cmsElementFavorites.isFavorite(e.name));
+            const nonFavorites = elements.filter(e => !this.cmsElementFavorites.isFavorite(e.name));
+
+            if (favorites.length) {
+                result.push({
+                    title: this.$t('sw-cms.elements.general.switch.groups.favorites'),
+                    items: favorites,
+                });
+            }
+
+            result.push({
+                title: this.$t('sw-cms.elements.general.switch.groups.all'),
+                items: nonFavorites,
+            });
+
+            return result;
         },
 
         componentClasses() {
@@ -109,6 +133,18 @@ Component.register('sw-cms-slot', {
             this.element.type = elementType;
             this.element.locked = false;
             this.showElementSelection = false;
+        },
+
+        onToggleElementFavorite(elementName) {
+            this.cmsElementFavorites.update(!this.cmsElementFavorites.isFavorite(elementName), elementName);
+        },
+
+        elementInElementGroup(element, elementGroup) {
+            if (elementGroup === 'favorite') {
+                return this.cmsElementFavorites.isFavorite(element.name);
+            }
+
+            return true;
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
@@ -99,38 +99,75 @@
         @modal-close="onCloseElementModal"
     >
         {% block sw_cms_slot_content_element_modal_selection %}
-        <div class="sw-cms-slot__element-selection">
-            {% block sw_cms_slot_content_element_modal_selection_element %}
-            <!-- eslint-disable vue/no-use-v-if-with-v-for vuejs-accessibility/click-events-have-key-events -->
-            <div
-                v-for="(element, index) in cmsElements"
-                v-if="!element.hidden && element.previewComponent"
-                :key="index"
-                class="element-selection__element-wrapper"
-                @click="onSelectElement(element.name)"
-            >
-                <div class="element-selection__element">
-                    {% block sw_cms_slot_content_element_modal_selection_element_component %}
-                    <component
-                        :is="element.previewComponent"
-                        class="sw-cms-slot__element-preview"
-                    />
-                    {% endblock %}
-
-                    {% block sw_cms_slot_content_element_modal_selection_element_overlay %}
-                    <div class="element-selection__overlay">
-                        <sw-icon
-                            name="regular-repeat"
-                            size="28"
-                        />
+        <div class="sw-cms-slot__modal-container">
+            {% block sw_cms_slot_content_element_modal_selection_groups %}
+                <sw-sidebar-collapse
+                    v-for="cmsElementGroup in groupedCmsElements"
+                    :key="cmsElementGroup.title"
+                    expand-on-loading
+                    expand-chevron-direction="up"
+                >
+                    <div slot="header">
+                        {{ $tc(cmsElementGroup.title) }}
                     </div>
-                    {% endblock %}
-                </div>
 
-                {% block sw_cms_slot_content_element_modal_selection_element_label %}
-                <span class="element-selection__label">{{ $tc(element.label) }}</span>
-                {% endblock %}
-            </div>
+                    <div slot="content">
+                        <div class="sw-cms-slot__element-selection">
+                        {% block sw_cms_slot_content_element_modal_selection_element %}
+                        <!-- eslint-disable vue/no-use-v-if-with-v-for vuejs-accessibility/click-events-have-key-events -->
+                        <div
+                            v-for="element in cmsElementGroup.items"
+                            v-if="!element.hidden && element.previewComponent"
+                            :key="element.name"
+                            class="element-selection__element-wrapper"
+                        >
+                            <div class="element-selection__element">
+                                {% block sw_cms_slot_content_element_modal_selection_element_component %}
+                                <component
+                                    :is="element.previewComponent"
+                                    class="sw-cms-slot__element-preview"
+                                />
+                                {% endblock %}
+
+                                {% block sw_cms_slot_content_element_modal_selection_element_overlay %}
+                                <div
+                                    class="element-selection__overlay element-selection__overlay-action-select"
+                                    @click="onSelectElement(element.name)"
+                                >
+                                    <sw-icon
+                                        name="regular-repeat"
+                                        size="28"
+                                    />
+                                </div>
+                                {% endblock %}
+
+                                {% block sw_cms_slot_content_element_modal_selection_element_overlay_favorite %}
+                                <div
+                                    class="element-selection__overlay element-selection__overlay-action-favorite"
+                                    @click="onToggleElementFavorite(element.name)"
+                                >
+                                    <sw-icon
+                                        v-if="cmsElementFavorites.isFavorite(element.name)"
+                                        name="solid-heart"
+                                        size="28"
+                                    />
+                                    <sw-icon
+                                        v-else
+                                        name="regular-heart"
+                                        size="28"
+                                    />
+                                </div>
+                                {% endblock %}
+                            </div>
+
+                            {% block sw_cms_slot_content_element_modal_selection_element_label %}
+                            <span class="element-selection__label">{{ $tc(element.label) }}</span>
+                            {% endblock %}
+                        </div>
+                        {% endblock %}
+                        </div>
+                    </div>
+                </sw-sidebar-collapse>
             {% endblock %}
         </div>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.scss
@@ -73,6 +73,14 @@
             color: $color-shopware-brand-500;
         }
     }
+
+    &__modal-container {
+        margin: -21px -30px -20px;
+
+        .sw-cms-slot__element-selection {
+            padding: 0 20px 16px;
+        }
+    }
 }
 
 .sw-cms-slot__config-modal {
@@ -114,7 +122,7 @@
         }
 
         .element-selection__overlay {
-            width: 100%;
+            width: 50%;
             height: 100%;
             display: none;
             align-content: center;
@@ -124,11 +132,17 @@
             margin: auto;
             position: absolute;
             top: 0;
-            left: 0;
-            right: 0;
             bottom: 0;
             background: rgba(255, 255, 255, 80%);
             border-radius: 5px;
+
+            &.element-selection__overlay-action-select {
+                left: 0;
+            }
+
+            &.element-selection__overlay-action-favorite {
+                right: 0;
+            }
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/index.js
@@ -1,6 +1,7 @@
 import './service/cms.service';
 import './service/cmsDataResolver.service';
 import './service/cms-block-favorites.service';
+import './service/cms-element-favorites.service';
 import './state/cms-page.state';
 import './mixin/sw-cms-element.mixin';
 import './mixin/sw-cms-state.mixin';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/index.js
@@ -1,5 +1,6 @@
 import './service/cms.service';
 import './service/cmsDataResolver.service';
+import './service/cms-block-favorites.service';
 import './state/cms-page.state';
 import './mixin/sw-cms-element.mixin';
 import './mixin/sw-cms-state.mixin';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-block-favorites.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-block-favorites.service.ts
@@ -1,0 +1,56 @@
+import Vue from 'vue';
+import UserConfigClass from '../../../core/service/support/user-config.class';
+
+const { Application } = Shopware;
+
+class CmsBlockFavoritesService extends UserConfigClass {
+    static USER_CONFIG_KEY = 'cms-block-favorites';
+
+    private state: { favorites: string[] } = Vue.observable({ favorites: [] });
+
+    public getFavoriteBlockNames(): string[] {
+        return this.state.favorites;
+    }
+
+    public isFavorite(cmsBlockName: string): boolean {
+        return this.state.favorites.includes(cmsBlockName);
+    }
+
+    public update(state: boolean, cmsBlockName: string): void {
+        if (state && !this.isFavorite(cmsBlockName)) {
+            this.state.favorites.push(cmsBlockName);
+        } else if (!state && this.isFavorite(cmsBlockName)) {
+            const index = this.state.favorites.indexOf(cmsBlockName);
+
+            this.state.favorites.splice(index, 1);
+        }
+
+        void this.saveUserConfig();
+    }
+
+    protected getConfigurationKey(): string {
+        return CmsBlockFavoritesService.USER_CONFIG_KEY;
+    }
+
+    protected async readUserConfig(): Promise<void> {
+        this.userConfig = await this.getUserConfig();
+        this.state.favorites = this.userConfig.value;
+    }
+
+    protected setUserConfig(): void {
+        this.userConfig.value = this.state.favorites;
+    }
+}
+
+let cmsBlockFavoritesService: CmsBlockFavoritesService;
+
+// @ts-expect-error
+Application.addServiceProvider('cmsBlockFavorites', () => {
+    if (!cmsBlockFavoritesService) {
+        cmsBlockFavoritesService = new CmsBlockFavoritesService();
+    }
+
+    return cmsBlockFavoritesService;
+});
+
+export { CmsBlockFavoritesService as default };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-element-favorites.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-element-favorites.service.ts
@@ -1,0 +1,56 @@
+import Vue from 'vue';
+import UserConfigClass from '../../../core/service/support/user-config.class';
+
+const { Application } = Shopware;
+
+class CmsElementFavoritesService extends UserConfigClass {
+    static USER_CONFIG_KEY = 'cms-element-favorites';
+
+    private state: { favorites: string[] } = Vue.observable({ favorites: [] });
+
+    public getFavoriteElementNames(): string[] {
+        return this.state.favorites;
+    }
+
+    public isFavorite(cmsElementName: string): boolean {
+        return this.state.favorites.includes(cmsElementName);
+    }
+
+    public update(state: boolean, cmsElementName: string): void {
+        if (state && !this.isFavorite(cmsElementName)) {
+            this.state.favorites.push(cmsElementName);
+        } else if (!state && this.isFavorite(cmsElementName)) {
+            const index = this.state.favorites.indexOf(cmsElementName);
+
+            this.state.favorites.splice(index, 1);
+        }
+
+        void this.saveUserConfig();
+    }
+
+    protected getConfigurationKey(): string {
+        return CmsElementFavoritesService.USER_CONFIG_KEY;
+    }
+
+    protected async readUserConfig(): Promise<void> {
+        this.userConfig = await this.getUserConfig();
+        this.state.favorites = this.userConfig.value;
+    }
+
+    protected setUserConfig(): void {
+        this.userConfig.value = this.state.favorites;
+    }
+}
+
+let cmsElementFavoritesService: CmsElementFavoritesService;
+
+// @ts-expect-error
+Application.addServiceProvider('cmsElementFavorites', () => {
+    if (!cmsElementFavoritesService) {
+        cmsElementFavoritesService = new CmsElementFavoritesService();
+    }
+
+    return cmsElementFavoritesService;
+});
+
+export { CmsElementFavoritesService as default };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -197,6 +197,12 @@
           "infoText": {
             "listingElement": "Die Produktdaten für dieses Element werden automatisiert über die Kategoriezuweisung befüllt. Der Inhalt zeigt nur eine ungefähre Vorschau."
           }
+        },
+        "switch": {
+          "groups": {
+            "all": "Alle Elemente",
+            "favorites": "Favorisierte Elemente"
+          }
         }
       },
       "image": {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -127,7 +127,7 @@
         "labelNavigation": "Navigation",
         "lockedNotification": "Dieses Layout ist gesperrt und kann nicht angepasst werden. Solltest Du dieses Standard-Template, an Deine eigenen Bedürfnisse anpassen möchtest, kannst du es einfach duplizieren und dann das Duplikat anpassen.",
         "headlineEmptyState": "Raum für Kreativität",
-        "claimEmptyState": "Stelle neue Layouts mithilfe von Sektionen zusammen. Wähle eine Sektion und füge einfach per Drag & Drop-Blöcke zu jeder Sektion hinzu und befülle die Blöcke dann mit deinem individuellen Inhalt."
+        "claimEmptyState": "Stelle neue Layouts mithilfe von Sektionen zusammen. Wähle eine Sektion und füge einfach per Drag & Drop Blöcke zu jeder Sektion hinzu und befülle die Blöcke dann mit deinem individuellen Inhalt."
       },
       "notification": {
         "pageInvalid": "Einige Fehler sind aufgetreten. Bitte überprüfe die Liste im Editor.",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -88,6 +88,7 @@
         "pageTypeProduct": "Produktseite",
         "demoEntity": "Vorschau-Datensatz",
         "blockCategorySelection": "Block-Kategorie",
+        "blockCategoryFavorite": "Favoriten",
         "blockCategoryText": "Text",
         "blockCategoryTextImage": "Text & Bild",
         "blockCategorySidebar": "Sidebar",
@@ -127,7 +128,8 @@
         "labelNavigation": "Navigation",
         "lockedNotification": "Dieses Layout ist gesperrt und kann nicht angepasst werden. Solltest Du dieses Standard-Template, an Deine eigenen Bedürfnisse anpassen möchtest, kannst du es einfach duplizieren und dann das Duplikat anpassen.",
         "headlineEmptyState": "Raum für Kreativität",
-        "claimEmptyState": "Stelle neue Layouts mithilfe von Sektionen zusammen. Wähle eine Sektion und füge einfach per Drag & Drop Blöcke zu jeder Sektion hinzu und befülle die Blöcke dann mit deinem individuellen Inhalt."
+        "claimEmptyState": "Stelle neue Layouts mithilfe von Sektionen zusammen. Wähle eine Sektion und füge einfach per Drag & Drop Blöcke zu jeder Sektion hinzu und befülle die Blöcke dann mit deinem individuellen Inhalt.",
+        "blockFavoriteEmptyState": "Hier stehen Deine Favoriten. Favorisiere Blöcke mit einem Klick auf das Herz und finde dadurch schnell Deine meistgenutzten Blöcke wieder."
       },
       "notification": {
         "pageInvalid": "Einige Fehler sind aufgetreten. Bitte überprüfe die Liste im Editor.",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -88,6 +88,7 @@
         "pageTypeProduct": "Product page",
         "demoEntity": "Preview entity",
         "blockCategorySelection": "Block category",
+        "blockCategoryFavorite": "Favorites",
         "blockCategoryText": "Text",
         "blockCategoryTextImage": "Text & images",
         "blockCategorySidebar": "Sidebar",
@@ -127,7 +128,8 @@
         "labelNavigation": "Navigation",
         "lockedNotification": "This is a locked default layout you may use for your content from the get-go. Note that you cannot edit this template! If you want to adapt the layout to your needs, just duplicate the layout and alter the duplicate.",
         "headlineEmptyState": "Space for creativity",
-        "claimEmptyState": "Create new layouts by choosing a section. Start by choosing a section type, drag & drop blocks into any section and fill in your content."
+        "claimEmptyState": "Create new layouts by choosing a section. Start by choosing a section type, drag & drop blocks into any section and fill in your content.",
+        "blockFavoriteEmptyState": "This is where you'll find your favourite blocks. Click the heart-shaped symbol next to a block to mark them as favourites and conveniently collect them in one place."
       },
       "notification": {
         "pageInvalid": "Errors occured. Please check the error list in the editor.",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -197,6 +197,12 @@
           "infoText": {
             "listingElement": "This element's product data is automatically loaded by the category associated with this layout. The content just shows a sample preview."
           }
+        },
+        "switch": {
+          "groups": {
+            "all": "All elements",
+            "favorites": "Favorite elements"
+          }
         }
       },
       "image": {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -88,7 +88,7 @@
         "pageTypeProduct": "Product page",
         "demoEntity": "Preview entity",
         "blockCategorySelection": "Block category",
-        "blockCategoryFavorite": "Favorites",
+        "blockCategoryFavorite": "Favourites",
         "blockCategoryText": "Text",
         "blockCategoryTextImage": "Text & images",
         "blockCategorySidebar": "Sidebar",
@@ -201,7 +201,7 @@
         "switch": {
           "groups": {
             "all": "All elements",
-            "favorites": "Favorite elements"
+            "favorites": "Favourite elements"
           }
         }
       },

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/service/sales-channel-favorites.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/service/sales-channel-favorites.service.ts
@@ -1,70 +1,12 @@
 import Vue from 'vue';
+import UserConfigClass from '../../../core/service/support/user-config.class';
 
-const { Application, Service, Context, State } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Application } = Shopware;
 
-enum USER_CONFIG_PERMISSIONS {
-    READ = 'user_config:read',
-    CREATE = 'user_config:create',
-    UPDATE = 'user_config:update'
-}
-
-interface CurrentUserObject {
-    id: string;
-    [index: string]: unknown;
-}
-
-interface UserConfigObject {
-    extensions: Record<string, unknown>;
-    id: string;
-    userId: string;
-    key: string;
-    value: string[];
-    isNew: () => boolean;
-}
-
-interface AclServiceInterface {
-    can(permission: string): boolean;
-}
-
-interface CriteriaInterface {
-    addFilter(filter: unknown): CriteriaInterface;
-    equals(field: string, value: string|number|boolean|null): unknown;
-}
-
-interface RepositorySearchResultInterface {
-    total: number;
-    first(): unknown;
-}
-
-interface RepositoryInterface {
-    create(context: unknown): unknown;
-    search(criteria: CriteriaInterface, context: unknown): Promise<RepositorySearchResultInterface>;
-    save(entity: unknown, context: unknown): Promise<void>;
-}
-
-class SalesChannelFavoritesService {
+class SalesChannelFavoritesService extends UserConfigClass {
     static USER_CONFIG_KEY = 'sales-channel-favorites';
 
-    private userConfigRepository = <RepositoryInterface><unknown> Service('repositoryFactory').create('user_config');
-
-    private currentUserId = this.getCurrentUserId();
-
-    private userConfig = this.createUserConfigEntity();
-
     private state: { favorites: string[] } = Vue.observable({ favorites: [] });
-
-    private aclService = <AclServiceInterface> Service('acl');
-
-    constructor() {
-        void this.initService();
-    }
-
-    private async initService(): Promise<void> {
-        this.userConfig = await this.getUserConfig();
-
-        this.state.favorites = this.userConfig.value;
-    }
 
     public getFavoriteIds(): string[] {
         return this.state.favorites;
@@ -86,64 +28,17 @@ class SalesChannelFavoritesService {
         void this.saveUserConfig();
     }
 
-    public refresh(): void {
-        this.userConfig = this.createUserConfigEntity();
-        void this.initService();
+    protected getConfigurationKey(): string {
+        return SalesChannelFavoritesService.USER_CONFIG_KEY;
     }
 
-    private async getUserConfig(): Promise<UserConfigObject> {
-        if (!this.aclService.can(USER_CONFIG_PERMISSIONS.READ)) {
-            void Promise.resolve(this.userConfig);
-        }
-
-        const response = await this.userConfigRepository.search(this.getCriteria(), Context.api);
-        const userConfig = <UserConfigObject> (response.total ? response.first() : this.userConfig);
-
-        return this.handleEmptyUserConfig(userConfig);
+    protected async readUserConfig(): Promise<void> {
+        this.userConfig = await this.getUserConfig();
+        this.state.favorites = this.userConfig.value;
     }
 
-    private async saveUserConfig(): Promise<void> {
-        if (!this.aclService.can(USER_CONFIG_PERMISSIONS.CREATE) || !this.aclService.can(USER_CONFIG_PERMISSIONS.UPDATE)) {
-            void Promise.resolve();
-        }
-
+    protected setUserConfig(): void {
         this.userConfig.value = this.state.favorites;
-
-        await this.userConfigRepository.save(this.userConfig, Context.api);
-        await this.initService();
-    }
-
-    private createUserConfigEntity(): UserConfigObject {
-        const entity = <UserConfigObject> this.userConfigRepository.create(Context.api);
-
-        Object.assign(entity, {
-            userId: this.currentUserId,
-            key: SalesChannelFavoritesService.USER_CONFIG_KEY,
-            value: [],
-        });
-
-        return entity;
-    }
-
-    private handleEmptyUserConfig(userConfig: UserConfigObject): UserConfigObject {
-        if (!Array.isArray(userConfig.value)) {
-            userConfig.value = [];
-        }
-
-        return userConfig;
-    }
-
-    private getCriteria(): CriteriaInterface {
-        const criteria = <CriteriaInterface><unknown> new Criteria(1, 25);
-
-        criteria.addFilter(Criteria.equals('key', SalesChannelFavoritesService.USER_CONFIG_KEY));
-        criteria.addFilter(Criteria.equals('userId', this.currentUserId));
-
-        return criteria;
-    }
-
-    private getCurrentUserId(): string {
-        return (State.get('session').currentUser as CurrentUserObject).id;
     }
 }
 

--- a/src/Administration/Resources/app/administration/test/app/component/sidebar/sw-sidebar-collapse.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/component/sidebar/sw-sidebar-collapse.spec.js
@@ -1,0 +1,70 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import 'src/app/component/base/sw-collapse';
+import 'src/app/component/sidebar/sw-sidebar-collapse';
+
+function createWrapper(propsData = {}) {
+    const localVue = createLocalVue();
+
+    return shallowMount(Shopware.Component.build('sw-sidebar-collapse'), {
+        localVue,
+        stubs: {
+            'sw-icon': {
+                props: [
+                    'name'
+                ],
+                template: '<span>{{ name }}</span>'
+            },
+            'sw-collapse': true
+        },
+        propsData: {
+            ...propsData
+        },
+        provide: {
+            cmsElementFavorites: {
+                isFavorite() {
+                    return false;
+                }
+            }
+        },
+        mocks: {
+            $tc: (snippetPath, count, values) => snippetPath + count + JSON.stringify(values)
+        }
+    });
+}
+
+describe('src/app/component/sidebar/sw-sidebar-collapse', () => {
+    /** @type Wrapper */
+    let wrapper;
+
+    beforeAll(async () => {});
+
+    beforeEach(() => {});
+
+    afterEach(async () => {
+        if (wrapper) await wrapper.destroy();
+    });
+
+    describe('no props', () => {
+        it('should be a Vue.JS component', async () => {
+            wrapper = await createWrapper({});
+
+            expect(wrapper.vm).toBeTruthy();
+        });
+
+        it('has a chevron pointing right', async () => {
+            wrapper = await createWrapper({});
+
+            expect(wrapper.find('.sw-sidebar-collapse__button').text()).toContain('right');
+        });
+    });
+
+    describe('prop expandChevronDirection down', () => {
+        it('has a chevron pointing down', async () => {
+            wrapper = await createWrapper({
+                expandChevronDirection: 'down'
+            });
+
+            expect(wrapper.find('.sw-sidebar-collapse__button').text()).toContain('down');
+        });
+    });
+});

--- a/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-sidebar.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-sidebar.spec.js
@@ -117,6 +117,11 @@ function createWrapper() {
                     save: () => {}
                 })
             },
+            cmsBlockFavorites: {
+                isFavorite() {
+                    return false;
+                }
+            },
             cmsService: {
                 getCmsBlockRegistry: () => {
                     return {

--- a/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-slot.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-slot.spec.js
@@ -24,6 +24,11 @@ function createWrapper() {
                         text: 'lorem'
                     }
                 })
+            },
+            cmsElementFavorites: {
+                isFavorite() {
+                    return false;
+                }
             }
         }
     });

--- a/src/Administration/Resources/app/administration/test/module/sw-cms/service/cms-block-favorites.service.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-cms/service/cms-block-favorites.service.spec.js
@@ -1,0 +1,123 @@
+import CmsBlockFavorites from 'src/module/sw-cms/service/cms-block-favorites.service';
+
+const responses = global.repositoryFactoryMock.responses;
+
+responses.addResponse({
+    method: 'Post',
+    url: '/search/user-config',
+    status: 200,
+    response: {
+        data: [{
+            id: '8badf7ebe678ab968fe88c269c214ea6',
+            userId: '8fe88c269c214ea68badf7ebe678ab96',
+            key: CmsBlockFavorites.USER_CONFIG_KEY,
+            value: []
+        }]
+    }
+});
+
+responses.addResponse({
+    method: 'Post',
+    url: '/user-config',
+    status: 200
+});
+
+describe('module/sw-cms/service/cms-block-favorites.service.spec.js', () => {
+    let service;
+
+    beforeEach(() => {
+        Shopware.State.get('session').currentUser = {
+            id: '8fe88c269c214ea68badf7ebe678ab96'
+        };
+
+        service = new CmsBlockFavorites();
+    });
+
+    afterEach(() => {
+        service = null;
+    });
+
+    it('getFavoriteBlockNames > should return favorites from internal state', () => {
+        const expected = ['foo', 'bar'];
+        service.state.favorites = expected;
+
+        expect(service.getFavoriteBlockNames()).toEqual(expected);
+    });
+
+    it('isFavorite > checks if given string is included in favorites', () => {
+        const expected = 'bar';
+        service.state.favorites = ['foo', 'bar'];
+
+        expect(service.isFavorite(expected)).toBeTruthy();
+    });
+
+    it('update > pushes new item to favorites and calls "saveUserConfig"', () => {
+        const newItem = 'biz';
+
+        service.saveUserConfig = jest.fn();
+        service.state.favorites = ['foo', 'bar'];
+
+        service.update(true, newItem);
+
+        expect(service.isFavorite(newItem)).toBeTruthy();
+        expect(service.saveUserConfig).toBeCalled();
+    });
+
+    it('update > removes existing item from favorites and calls "saveUserConfig"', () => {
+        const removedItem = 'bar';
+
+        service.saveUserConfig = jest.fn();
+        service.state.favorites = ['foo', 'bar'];
+
+        service.update(false, removedItem);
+
+        expect(service.isFavorite(removedItem)).toBeFalsy();
+        expect(service.saveUserConfig).toBeCalled();
+    });
+
+    it('update > does not add or remove items with a wrong state', () => {
+        const existingItem = 'foo';
+        const nonExistingItem = 'biz';
+
+        service.state.favorites = ['foo', 'bar'];
+
+        service.update(false, nonExistingItem);
+        expect(service.isFavorite(nonExistingItem)).toBeFalsy();
+
+        service.update(true, existingItem);
+        expect(service.isFavorite(existingItem)).toBeTruthy();
+    });
+
+    it('createUserConfigEntity > entity has specific values', () => {
+        const expectedValues = {
+            userId: Shopware.State.get('session').currentUser.id,
+            key: CmsBlockFavorites.USER_CONFIG_KEY,
+            value: []
+        };
+
+        const entity = service.createUserConfigEntity(CmsBlockFavorites.USER_CONFIG_KEY);
+
+        expect(entity).toMatchObject(expectedValues);
+    });
+
+    it('handleEmptyUserConfig > replaces the property "value" with an empty array', () => {
+        const userConfigMock = {
+            value: {}
+        };
+
+        service.handleEmptyUserConfig(userConfigMock);
+
+        expect(Array.isArray(userConfigMock.value)).toBeTruthy();
+    });
+
+    it('getCriteria > returns a criteria including specific filters', () => {
+        const criteria = service.getCriteria(CmsBlockFavorites.USER_CONFIG_KEY);
+
+        expect(criteria.filters).toContainEqual({ type: 'equals', field: 'key', value: CmsBlockFavorites.USER_CONFIG_KEY });
+        expect(criteria.filters).toContainEqual({ type: 'equals', field: 'userId', value: '8fe88c269c214ea68badf7ebe678ab96' });
+    });
+
+    it('getCurrentUserId > returns the userId of the current session user', () => {
+        expect(service.getCurrentUserId()).toEqual('8fe88c269c214ea68badf7ebe678ab96');
+    });
+});

--- a/src/Administration/Resources/app/administration/test/module/sw-cms/service/cms-element-favorites.service.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-cms/service/cms-element-favorites.service.spec.js
@@ -1,0 +1,123 @@
+import CmsElementFavorites from 'src/module/sw-cms/service/cms-element-favorites.service';
+
+const responses = global.repositoryFactoryMock.responses;
+
+responses.addResponse({
+    method: 'Post',
+    url: '/search/user-config',
+    status: 200,
+    response: {
+        data: [{
+            id: '8badf7ebe678ab968fe88c269c214ea6',
+            userId: '8fe88c269c214ea68badf7ebe678ab96',
+            key: CmsElementFavorites.USER_CONFIG_KEY,
+            value: []
+        }]
+    }
+});
+
+responses.addResponse({
+    method: 'Post',
+    url: '/user-config',
+    status: 200
+});
+
+describe('module/sw-cms/service/cms-block-favorites.service.spec.js', () => {
+    let service;
+
+    beforeEach(() => {
+        Shopware.State.get('session').currentUser = {
+            id: '8fe88c269c214ea68badf7ebe678ab96'
+        };
+
+        service = new CmsElementFavorites();
+    });
+
+    afterEach(() => {
+        service = null;
+    });
+
+    it('getFavoriteElementNames > should return favorites from internal state', () => {
+        const expected = ['foo', 'bar'];
+        service.state.favorites = expected;
+
+        expect(service.getFavoriteElementNames()).toEqual(expected);
+    });
+
+    it('isFavorite > checks if given string is included in favorites', () => {
+        const expected = 'bar';
+        service.state.favorites = ['foo', 'bar'];
+
+        expect(service.isFavorite(expected)).toBeTruthy();
+    });
+
+    it('update > pushes new item to favorites and calls "saveUserConfig"', () => {
+        const newItem = 'biz';
+
+        service.saveUserConfig = jest.fn();
+        service.state.favorites = ['foo', 'bar'];
+
+        service.update(true, newItem);
+
+        expect(service.isFavorite(newItem)).toBeTruthy();
+        expect(service.saveUserConfig).toBeCalled();
+    });
+
+    it('update > removes existing item from favorites and calls "saveUserConfig"', () => {
+        const removedItem = 'bar';
+
+        service.saveUserConfig = jest.fn();
+        service.state.favorites = ['foo', 'bar'];
+
+        service.update(false, removedItem);
+
+        expect(service.isFavorite(removedItem)).toBeFalsy();
+        expect(service.saveUserConfig).toBeCalled();
+    });
+
+    it('update > does not add or remove items with a wrong state', () => {
+        const existingItem = 'foo';
+        const nonExistingItem = 'biz';
+
+        service.state.favorites = ['foo', 'bar'];
+
+        service.update(false, nonExistingItem);
+        expect(service.isFavorite(nonExistingItem)).toBeFalsy();
+
+        service.update(true, existingItem);
+        expect(service.isFavorite(existingItem)).toBeTruthy();
+    });
+
+    it('createUserConfigEntity > entity has specific values', () => {
+        const expectedValues = {
+            userId: Shopware.State.get('session').currentUser.id,
+            key: CmsElementFavorites.USER_CONFIG_KEY,
+            value: []
+        };
+
+        const entity = service.createUserConfigEntity(CmsElementFavorites.USER_CONFIG_KEY);
+
+        expect(entity).toMatchObject(expectedValues);
+    });
+
+    it('handleEmptyUserConfig > replaces the property "value" with an empty array', () => {
+        const userConfigMock = {
+            value: {}
+        };
+
+        service.handleEmptyUserConfig(userConfigMock);
+
+        expect(Array.isArray(userConfigMock.value)).toBeTruthy();
+    });
+
+    it('getCriteria > returns a criteria including specific filters', () => {
+        const criteria = service.getCriteria(CmsElementFavorites.USER_CONFIG_KEY);
+
+        expect(criteria.filters).toContainEqual({ type: 'equals', field: 'key', value: CmsElementFavorites.USER_CONFIG_KEY });
+        expect(criteria.filters).toContainEqual({ type: 'equals', field: 'userId', value: '8fe88c269c214ea68badf7ebe678ab96' });
+    });
+
+    it('getCurrentUserId > returns the userId of the current session user', () => {
+        expect(service.getCurrentUserId()).toEqual('8fe88c269c214ea68badf7ebe678ab96');
+    });
+});

--- a/src/Administration/Resources/app/administration/test/module/sw-sales-channel/service/sales-channel-favorites.service.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-sales-channel/service/sales-channel-favorites.service.spec.js
@@ -95,7 +95,7 @@ describe('module/sw-sales-channel/service/sales-channel-favorites.service.spec.j
             value: []
         };
 
-        const entity = service.createUserConfigEntity();
+        const entity = service.createUserConfigEntity(SalesChannelFavoritesService.USER_CONFIG_KEY);
 
         expect(entity).toMatchObject(expectedValues);
     });
@@ -111,7 +111,7 @@ describe('module/sw-sales-channel/service/sales-channel-favorites.service.spec.j
     });
 
     it('getCriteria > returns a criteria including specific filters', () => {
-        const criteria = service.getCriteria();
+        const criteria = service.getCriteria(SalesChannelFavoritesService.USER_CONFIG_KEY);
 
         expect(criteria.filters).toContainEqual({ type: 'equals', field: 'key', value: SalesChannelFavoritesService.USER_CONFIG_KEY });
         expect(criteria.filters).toContainEqual({ type: 'equals', field: 'userId', value: '8fe88c269c214ea68badf7ebe678ab96' });

--- a/tests/e2e/cypress/integration/administration/content/sw-cms/add-product-review-after-login.spec.js
+++ b/tests/e2e/cypress/integration/administration/content/sw-cms/add-product-review-after-login.spec.js
@@ -62,7 +62,10 @@ describe('CMS: Check usage and editing of product description reviews element', 
         cy.get('.sw-cms-slot .sw-cms-slot__element-action').click();
         cy.get('.sw-cms-slot__element-selection').should('be.visible');
 
-        cy.get('.sw-cms-el-preview-product-description-reviews').click();
+        cy.get('.sw-cms-el-preview-product-description-reviews + .element-selection__overlay-action-select').first().invoke('show');
+        cy.get('.sw-cms-el-preview-product-description-reviews + .element-selection__overlay-action-select').first().should('be.visible');
+        cy.get('.sw-cms-el-preview-product-description-reviews + .element-selection__overlay-action-select').first().click();
+
 
         // Select a product
         cy.get('.sw-cms-slot .sw-cms-slot__settings-action').first().click();

--- a/tests/e2e/cypress/integration/administration/content/sw-cms/cms-favorites.spec.js
+++ b/tests/e2e/cypress/integration/administration/content/sw-cms/cms-favorites.spec.js
@@ -1,0 +1,87 @@
+// / <reference types="Cypress" />
+
+describe('CMS: Check if block favorites open first, when configured', () => {
+    beforeEach(() => {
+        cy.loginViaApi()
+            .then(() => {
+                return cy.createCmsFixture();
+            })
+            .then(() => {
+                cy.viewport(1920, 1080);
+                cy.openInitialPage(`${Cypress.env('admin')}#/sw/cms/index`);
+                cy.get('.sw-skeleton').should('not.exist');
+                cy.get('.sw-loader').should('not.exist');
+            });
+    });
+
+    it('@base @content: select block favorites and re-open editor to see effects', () => {
+        cy.get('.sw-cms-list-item--0').click();
+        cy.get('.sw-cms-section__empty-stage').should('be.visible');
+        cy.get('.sw-cms-section__empty-stage').click();
+        cy.get('#sw-field--currentBlockCategory').should('have.value', 'text');
+        cy.get('.sw-cms-sidebar__block-preview-with-actions .sw-button').first().click();
+
+        // re open
+        cy.get('.sw-cms-detail__back-btn').click()
+        cy.get('.sw-cms-list-item--0').click();
+        cy.get('.sw-cms-section__empty-stage').click();
+
+        cy.get('#sw-field--currentBlockCategory').should('have.value', 'favorite');
+
+        // unselect
+        cy.get('.sw-cms-sidebar__block-preview-with-actions .sw-button').first().click();
+
+        // re open
+        cy.get('.sw-cms-detail__back-btn').click()
+        cy.get('.sw-cms-list-item--0').click();
+        cy.get('.sw-cms-section__empty-stage').click();
+
+        cy.get('#sw-field--currentBlockCategory').should('have.value', 'text');
+    });
+
+    it('@base @content: select element favorites and re-open editor to see effects', () => {
+        cy.get('.sw-cms-list-item--0').click();
+
+        // Add a text block
+        cy.get('.sw-cms-section__empty-stage').click();
+        cy.get('#sw-field--currentBlockCategory').select('Text');
+        cy.get('.sw-cms-preview-text').should('be.visible');
+        cy.get('.sw-cms-preview-text').dragTo('.sw-cms-section__empty-stage');
+
+        // open switch dialog
+        cy.get('.sw-cms-block__config-overlay').invoke('show');
+        cy.get('.sw-cms-block__config-overlay').should('be.visible');
+        cy.get('.sw-cms-block__config-overlay').click();
+        cy.get('.sw-cms-block__config-overlay.is--active').should('be.visible');
+        cy.get('.sw-cms-slot .sw-cms-slot__overlay').invoke('show');
+        cy.get('.sw-cms-slot__element-action').click();
+
+        // all (no favorites)
+        cy.get('.sw-cms-slot__modal-container').find('.sw-sidebar-collapse__header').should('have.length', 1);
+
+        // favorite
+        cy.get('.element-selection__overlay-action-favorite').first().invoke('show');
+        cy.get('.element-selection__overlay-action-favorite').first().should('be.visible');
+        cy.get('.element-selection__overlay-action-favorite').first().click();
+
+        // close switch dialog
+        cy.get('.sw-modal__close').click();
+
+        // open switch dialog
+        cy.get('.sw-cms-block__config-overlay.is--active').should('be.visible');
+        cy.get('.sw-cms-slot .sw-cms-slot__overlay').invoke('show');
+        cy.get('.sw-cms-slot__element-action').click();
+
+        // favorites + all
+        cy.get('.sw-cms-slot__modal-container').find('.sw-sidebar-collapse__header').should('have.length', 2);
+
+        // unfavorite
+        cy.get('.sw-cms-slot__modal-container .sw-sidebar-collapse__header').first().scrollIntoView();
+        cy.get('.element-selection__overlay-action-favorite').first().invoke('show');
+        cy.get('.element-selection__overlay-action-favorite').first().should('be.visible');
+        cy.get('.element-selection__overlay-action-favorite').first().click();
+
+        // all (no favorites)
+        cy.get('.sw-cms-slot__modal-container').find('.sw-sidebar-collapse__header').should('have.length', 1);
+    });
+});

--- a/tests/e2e/cypress/integration/administration/content/sw-cms/edit-buy-box-elements.spec.js
+++ b/tests/e2e/cypress/integration/administration/content/sw-cms/edit-buy-box-elements.spec.js
@@ -64,7 +64,10 @@ describe('CMS: Check usage and editing of buy box elements', () => {
         // Replace current element with buy box element
         cy.get('.sw-cms-slot .sw-cms-slot__element-action').first().click();
         cy.get('.sw-cms-slot__element-selection').should('be.visible');
-        cy.get('.sw-cms-el-preview-buy-box').click();
+        cy.get('.sw-cms-el-preview-buy-box + .element-selection__overlay-action-select').first().invoke('show');
+        cy.get('.sw-cms-el-preview-buy-box + .element-selection__overlay-action-select').first().should('be.visible');
+        cy.get('.sw-cms-el-preview-buy-box + .element-selection__overlay-action-select').first().click();
+
 
         // Configure element product
         cy.get('.sw-cms-slot .sw-cms-slot__settings-action').click();

--- a/tests/e2e/cypress/integration/administration/content/sw-cms/edit-cross-selling-element.spec.js
+++ b/tests/e2e/cypress/integration/administration/content/sw-cms/edit-cross-selling-element.spec.js
@@ -120,7 +120,10 @@ describe('CMS: Check usage and editing of cross selling element', () => {
         cy.get('.sw-cms-slot .sw-cms-slot__element-action').click();
         cy.get('.sw-cms-slot__element-selection').should('be.visible');
 
-        cy.get('.sw-cms-el-preview-cross-selling').click();
+        cy.get('.sw-cms-el-preview-cross-selling + .element-selection__overlay-action-select').first().invoke('show');
+        cy.get('.sw-cms-el-preview-cross-selling + .element-selection__overlay-action-select').first().should('be.visible');
+        cy.get('.sw-cms-el-preview-cross-selling + .element-selection__overlay-action-select').first().click();
+
 
         // Select a product with cross selling data
         cy.get('.sw-cms-slot .sw-cms-slot__settings-action').first().click();

--- a/tests/e2e/cypress/integration/administration/content/sw-cms/edit-product-description-reviews-element.spec.js
+++ b/tests/e2e/cypress/integration/administration/content/sw-cms/edit-product-description-reviews-element.spec.js
@@ -55,7 +55,10 @@ describe('CMS: Check usage and editing of product description reviews element', 
         cy.get('.sw-cms-slot .sw-cms-slot__element-action').click();
         cy.get('.sw-cms-slot__element-selection').should('be.visible');
 
-        cy.get('.sw-cms-el-preview-product-description-reviews').click();
+        cy.get('.sw-cms-el-preview-product-description-reviews + .element-selection__overlay-action-select').first().invoke('show');
+        cy.get('.sw-cms-el-preview-product-description-reviews + .element-selection__overlay-action-select').first().should('be.visible');
+        cy.get('.sw-cms-el-preview-product-description-reviews + .element-selection__overlay-action-select').first().click();
+
 
         // Select a product
         cy.get('.sw-cms-slot .sw-cms-slot__settings-action').first().click();


### PR DESCRIPTION
### 1. Why is this change necessary?

When you get a lot CMS features from apps but don't use all of them you have to live with it. There is no way to get yourself a structure. Imagine you have someone writing blog entries. They unlikely need to use product listing filter. They still see and stumble upon it. Or you have a content editor that often likes to use a certain block for image and text but forgets which one to use after a week of holidays.
If you could just mark your own favorites and have a useful quick selection of your finest toolings.

See it in action

![PR-cms-fav-1](https://user-images.githubusercontent.com/1133593/179126462-e797a25c-4add-48c9-806f-a41796aee421.gif)

![PR-cms-fav-2](https://user-images.githubusercontent.com/1133593/179126479-d180cc7b-3529-41db-bf0b-103705cca4e0.gif)


### 2. What does this change do, exactly?
Technically a lot:

* We have two new technical settings on users that are similar to sales channel favorites
* Control the chevron direction of a collapsable
* Have new buttons placed to control and display cms favorites via new JS services
* Have display groups to highlight marked favorites


### 3. Describe each step to reproduce the issue or behaviour.

1. Buy and install a feature rich theme in the community store
2. Buy and install an app in the community store that adds bootstrap structural features
3. Buy and install an app in the community store that adds new types of CMS pages and thus adds new CMS blocks
4. Have like 15 block categories and a lot to scroll through when choosing a CMS element
5. Only use like 2 blocks or elements of each provider
6. Search the CMS elements or blocks every time again


### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have squashed any insignificant commits
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


### 5. Shoutout

Thanks to several nice persons at Shopware to support me at making this a solution, that matches the overall product. This includes some persons, whose GitHub names I don't know, and in any case @marcelbrode @marie-reckendrees @jleifeld @jkrzefski @itsdenisehere @GitEvil  🎉 
