### PR TITLE
Ensure the directory to export JWT keys into does exist

### DIFF
--- a/changelog/_unreleased/2022-07-14-ensure-directories-for-private-and-public-keys-exist.md
+++ b/changelog/_unreleased/2022-07-14-ensure-directories-for-private-and-public-keys-exist.md
@@ -1,0 +1,8 @@
+---
+title: Ensure the directory to generate JWT public / private keys is, does exist.
+author: Johannes Przymusinski
+author_email: johannes.przymusinski@jop-software.de
+author_github: cngJo
+---
+# Core
+* Create the directory a JWT private / public key should be generated in, if it does not exist already.

--- a/src/Core/Maintenance/System/Service/JwtCertificateGenerator.php
+++ b/src/Core/Maintenance/System/Service/JwtCertificateGenerator.php
@@ -19,6 +19,17 @@ class JwtCertificateGenerator
             throw new JwtCertificateGenerationException('Failed to generate key');
         }
 
+        // Ensure that the directories we should generate the public / private key exist.
+        $privateKeyDirectory = dirname($privateKeyPath);
+        if (!is_dir($privateKeyDirectory)) {
+            mkdir($privateKeyDirectory, 0777, true);
+        }
+
+        $publicKeyDirectory = dirname($publicKeyPath);
+        if (!is_dir($publicKeyDirectory)) {
+            mkdir($publicKeyDirectory, 0777, true);
+        }
+
         // export private key
         $result = openssl_pkey_export_to_file($key, $privateKeyPath, $passphrase);
         if ($result === false) {

--- a/src/Core/Maintenance/Test/System/Service/JwtCertificateGeneratorTest.php
+++ b/src/Core/Maintenance/Test/System/Service/JwtCertificateGeneratorTest.php
@@ -19,18 +19,26 @@ class JwtCertificateGeneratorTest extends TestCase
 
     private string $publicPath;
 
+    private string $dirname;
+
     public function setUp(): void
     {
         $this->jwtCertificateGenerator = $this->getContainer()->get(JwtCertificateGenerator::class);
 
         $this->privatePath = __DIR__ . '/private.pem';
         $this->publicPath = __DIR__ . '/public.pem';
+
+        $this->dirname = "does-not-exist";
     }
 
     public function tearDown(): void
     {
         unlink($this->privatePath);
         unlink($this->publicPath);
+
+        if (is_dir($this->dirname)) {
+            rmdir($this->dirname);
+        }
     }
 
     public function testGenerate(): void
@@ -95,5 +103,18 @@ class JwtCertificateGeneratorTest extends TestCase
             1,
             openssl_verify($data, $signature, $publicCertificate)
         );
+    }
+
+    public function testGenerateInNonExistingDirectory(): void
+    {
+        // Update variables to point to a non-existing directory
+        $this->privatePath = __DIR__ . $this->dirname . "/private.pem";
+        $this->publicPath = __DIR__ . $this->dirname . "/public.pem";
+
+        static::assertFalse(is_dir($this->dirname));
+
+        // We can just call the other test methods, so we don't need to repeat their code.
+        $this->testGenerate();
+        $this->testGenerateWithoutPassphrase();
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently the `JwtCertificateGenerator` assumes that the directory to export the generated key into does exist.
If it does not, the call to `openssl_pkey_export_to_file` fails and a `JwtCertificateGenerationException('Could not export private key to file')` gets thrown.

By default the key gets generated into `config/jwt` which exists in the `shopware/development` and `shopware/production` templates. We use a slightly different setup method for shopware 6 based on `shopware/production` as a composer dependency.

In this setup it can occur that after first install the `config/jwt` directory does not exist. 

Even tho the setup method we use is not official supported, i guess it makes sense anyway to "harden" the implementation of `JwtCertificateGenerator`, because its not `internal` and therefore might get used in other places in the future or by extensions.

### 2. What does this change do, exactly?
The `JwtCertificateGenerator::generate` method now extracts the `dirname` form the given `$privateKeyPath` and `$publicKeyPath`, checks weather that directory exists and creates it recursively otherwise.

### 3. Describe each step to reproduce the issue or behaviour.
**Programatic**
1. Call `JwtCertificateGenerator::generate("/path/does/not/exist/private.jwt", "/path/does/not/exist/public.jwt")`

**With a shopware template**
1. Delete the `config/jwt` directory and execute the `system:generate-jwt-secret` command

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
