### PR TITLE
refactor: make KernelTestBehaviour trait methods static

### DIFF
--- a/src/Core/Framework/Test/App/AppSystemTestBehaviour.php
+++ b/src/Core/Framework/Test/App/AppSystemTestBehaviour.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait AppSystemTestBehaviour
 {
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     protected function getAppLoader(string $appDir): AppLoader
     {

--- a/src/Core/Framework/Test/App/CustomFieldTypeTestBehaviour.php
+++ b/src/Core/Framework/Test/App/CustomFieldTypeTestBehaviour.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait CustomFieldTypeTestBehaviour
 {
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     protected function importCustomField(string $manifestPath): CustomFieldEntity
     {

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/DataAbstractionLayerFieldTestBehaviour.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/DataAbstractionLayerFieldTestBehaviour.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait DataAbstractionLayerFieldTestBehaviour
 {
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     /**
      * @param class-string<EntityDefinition> ...$definitionClasses

--- a/src/Core/Framework/Test/Migration/MigrationTestBehaviour.php
+++ b/src/Core/Framework/Test/Migration/MigrationTestBehaviour.php
@@ -118,5 +118,5 @@ trait MigrationTestBehaviour
         $assertState($dbMigrations, $destructiveUntil, 'update_destructive');
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/Plugin/PluginTestsHelper.php
+++ b/src/Core/Framework/Test/Plugin/PluginTestsHelper.php
@@ -55,7 +55,7 @@ trait PluginTestsHelper
         );
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     private function addTestPluginToKernel(string $pluginName, bool $active = false): void
     {

--- a/src/Core/Framework/Test/TestCaseBase/AdminApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/AdminApiTestBehaviour.php
@@ -261,7 +261,7 @@ trait AdminApiTestBehaviour
         $browser->setServerParameter('_integration_id', $id);
     }
 
-    abstract protected function getKernel(): KernelInterface;
+    abstract protected static function getKernel(): KernelInterface;
 
     protected function getBrowser(bool $authorized = true, array $scopes = [], ?array $permissions = null): TestBrowser
     {

--- a/src/Core/Framework/Test/TestCaseBase/BasicTestDataBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/BasicTestDataBehaviour.php
@@ -33,7 +33,7 @@ trait BasicTestDataBehaviour
         return $language->getId();
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     protected function getValidPaymentMethodId(?string $salesChannelId = null): string
     {

--- a/src/Core/Framework/Test/TestCaseBase/CacheTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/CacheTestBehaviour.php
@@ -22,5 +22,5 @@ trait CacheTestBehaviour
             ->reset();
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/TestCaseBase/CommandTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/CommandTestBehaviour.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 trait CommandTestBehaviour
 {
-    abstract protected function getKernel(): KernelInterface;
+    abstract protected static function getKernel(): KernelInterface;
 
     protected function runCommand(Command $command, InputInterface $input, OutputInterface $output, ?KernelInterface $kernel = null): void
     {

--- a/src/Core/Framework/Test/TestCaseBase/CountryAddToSalesChannelTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/CountryAddToSalesChannelTestBehaviour.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait CountryAddToSalesChannelTestBehaviour
 {
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     abstract protected function getValidCountryId(?string $salesChannelId = TestDefaults::SALES_CHANNEL): string;
 

--- a/src/Core/Framework/Test/TestCaseBase/DatabaseTransactionBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/DatabaseTransactionBehaviour.php
@@ -67,5 +67,5 @@ trait DatabaseTransactionBehaviour
         }
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/TestCaseBase/FilesystemBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/FilesystemBehaviour.php
@@ -44,5 +44,5 @@ trait FilesystemBehaviour
         MemoryAdapterFactory::clearInstancesMemory();
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/TestCaseBase/KernelTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/KernelTestBehaviour.php
@@ -9,7 +9,7 @@ trait KernelTestBehaviour
 {
     use EventDispatcherBehaviour;
 
-    protected function getKernel(): Kernel
+    protected static function getKernel(): Kernel
     {
         return KernelLifecycleManager::getKernel();
     }
@@ -17,9 +17,9 @@ trait KernelTestBehaviour
     /**
      * This results in the test container, with all private services public
      */
-    protected function getContainer(): ContainerInterface
+    protected static function getContainer(): ContainerInterface
     {
-        $container = $this->getKernel()->getContainer();
+        $container = static::getKernel()->getContainer();
 
         if (!$container->has('test.service_container')) {
             throw new \RuntimeException('Unable to run tests against kernel without test.service_container');

--- a/src/Core/Framework/Test/TestCaseBase/QueueTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/QueueTestBehaviour.php
@@ -56,5 +56,5 @@ trait QueueTestBehaviour
         ]);
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/TestCaseBase/RequestStackTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/RequestStackTestBehaviour.php
@@ -25,5 +25,5 @@ trait RequestStackTestBehaviour
         return $requests;
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
@@ -119,7 +119,7 @@ trait SalesChannelApiTestBehaviour
         return $customerId;
     }
 
-    abstract protected function getKernel(): KernelInterface;
+    abstract protected static function getKernel(): KernelInterface;
 
     protected function getSalesChannelBrowser(): KernelBrowser
     {

--- a/src/Storefront/Test/Controller/StorefrontControllerTestBehaviour.php
+++ b/src/Storefront/Test/Controller/StorefrontControllerTestBehaviour.php
@@ -43,7 +43,7 @@ trait StorefrontControllerTestBehaviour
         return $data;
     }
 
-    abstract protected function getKernel(): KernelInterface;
+    abstract protected static function getKernel(): KernelInterface;
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Storefront/Test/Page/StorefrontPageTestBehaviour.php
+++ b/src/Storefront/Test/Page/StorefrontPageTestBehaviour.php
@@ -260,7 +260,7 @@ trait StorefrontPageTestBehaviour
         });
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     private function createCustomer(): CustomerEntity
     {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

I created no Changelog yet, it should first be discussed if this change could have any negative side effects.

It's still possible to call `$this->getContainer()` in classes which have `use KernelTestBehaviour;`.
So the only sideeffect I can think of is if someone wrote an own trait which specify either
`abstract protected function getKernel(): KernelInterface;` or
 `abstract protected function getContainer(): ContainerInterface;`
the types don't match anymore, but still this should have no negative impact.

Edit: ~I converted this to a draft. Until https://github.com/shopware/platform/pull/2608#issuecomment-1188939079 is resolved this PR is useless.~
Edit 2: I found a workaround. Maybe this can be implemented in the Shopware core? See https://github.com/shopware/platform/pull/2608#issuecomment-1189112331

### 1. Why is this change necessary?
This change makes the Shopware KernelTestBehaviour compatible with `Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait`
The MailerAssertionsTrait was introduced with Symfony 4.4 https://symfony.com/blog/new-in-symfony-4-4-phpunit-assertions-for-email-messages


### 2. What does this change do, exactly?
This changes all `getKernel` and `getContainer` method implementations and abstract definitions related to `KernelTestBehaviour` to static methods.

Also make the methods static in `Shopware\Tests\Bench` and `Shopware\Tests\Unit\Storefront\DependencyInjection\ReverseProxyCompilerPassTest`.

### 3. Describe each step to reproduce the issue or behaviour.
Add `use MailerAssertionsTrait;` to your testclass and try to call any of the methods of it. For example `$this->getMailerMessages();`

This results in
`Error : Non-static method Vcore\MyPlugin\Test\Error\ErrorHandlerTest::getContainer() cannot be called statically`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
