### PR TITLE
Fix documents footer for bank information

### DIFF
--- a/src/Core/Framework/Resources/views/documents/includes/footer.html.twig
+++ b/src/Core/Framework/Resources/views/documents/includes/footer.html.twig
@@ -41,7 +41,7 @@ All blocks of this template are available in the template which renders this tem
                 {% block document_footer_second_column %}
                     <ul>
                         {% block document_footer_bank_account %}
-                            {% if config.companyName %}<li class="bold">{{ 'document.bankAccount'|trans|sw_sanitize }}</li>{% endif %}
+                            {% if config.bankName %}<li class="bold">{{ 'document.bankAccount'|trans|sw_sanitize }}</li>{% endif %}
                         {% endblock %}
                         {% block document_footer_bank_name %}
                             {% if config.bankName %}<li>{{ config.bankName }}</li>{% endif %}


### PR DESCRIPTION
Show "Bankverbindung" (banking information) only if the bank is added. I guess it is a typo/copy paste error.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Because showing "banking information" if no bank is specified but the company name doesn't make sense.

### 2. What does this change do, exactly?
Show "Bank information" on documents in the footer only if the bank name is set

### 3. Describe each step to reproduce the issue or behaviour.
Add company name to document configuration, set NO bank information, still the headline is shown. I'll attach an example PDF.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
[invoice_1000.pdf](https://github.com/shopware/platform/files/9139987/invoice_1000.pdf)

