### PR TITLE
Update delivery_note.html.twig

### DIFF
--- a/src/Core/Framework/Resources/views/documents/delivery_note.html.twig
+++ b/src/Core/Framework/Resources/views/documents/delivery_note.html.twig
@@ -47,7 +47,9 @@ The blocks from the templates in the /includes folder can be overwritten directl
 
 {% block document_side_info_contents %}
     {{ parent() }}
-    <tr><td>{% trans with {'%deliveryDate%': config.custom.deliveryDate|format_date('medium', locale=order.language.locale.code)} %}document.deliveryDate{% endtrans %}</td></tr>
+    {% block document_side_info_delivery_note_deliveryDate %}
+        <tr><td>{% trans with {'%deliveryDate%': config.custom.deliveryDate|format_date('medium', locale=order.language.locale.code)} %}document.deliveryDate{% endtrans %}</td></tr>
+    {% endblock %}
 {% endblock %}
 
 {% block document_line_item_table_shipping %}


### PR DESCRIPTION
Wrap deliveryDate into its own block to simplify removing it

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
I wanted to remove the delivery date from the delivery_note but couldn't just erase a block as in `document_side_info_storno_number` but instead had to copy the whole block.

### 2. What does this change do, exactly?
Add a block to easily remove its content

### 3. Describe each step to reproduce the issue or behaviour.
If one wants to remove the delivery date from the delivery_note you need to copy the block `document_side_info_contents` instead to just overwrite a small part of it.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
