### PR TITLE
feat: Add SalesChannelRepositoryProcessCriteriaEvent

### DIFF
--- a/changelog/_unreleased/2022-07-24-add-saleschannelrepositoryprocesscriteriaevent.md
+++ b/changelog/_unreleased/2022-07-24-add-saleschannelrepositoryprocesscriteriaevent.md
@@ -1,0 +1,9 @@
+---
+title: Add SalesChannelRepositoryProcessCriteriaEvent
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Add Event `SalesChannelRepositoryProcessCriteriaEvent`

--- a/src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
+++ b/src/Core/System/SalesChannel/Entity/SalesChannelRepository.php
@@ -217,6 +217,9 @@ class SalesChannelRepository implements SalesChannelRepositoryInterface
 
     private function processCriteria(Criteria $topCriteria, SalesChannelContext $salesChannelContext): void
     {
+        $event = new SalesChannelRepositoryProcessCriteriaEvent($this->definition, $topCriteria, $salesChannelContext);
+        $this->eventDispatcher->dispatch($event, $event->getName());
+
         if (!$this->definition instanceof SalesChannelDefinitionInterface) {
             return;
         }

--- a/src/Core/System/SalesChannel/Entity/SalesChannelRepositoryProcessCriteriaEvent.php
+++ b/src/Core/System/SalesChannel/Entity/SalesChannelRepositoryProcessCriteriaEvent.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SalesChannel\Entity;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\GenericEvent;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class SalesChannelRepositoryProcessCriteriaEvent extends Event implements ShopwareSalesChannelEvent, GenericEvent
+{
+    private EntityDefinition $definition;
+
+    private Criteria $criteria;
+
+    private SalesChannelContext $salesChannelContext;
+
+    public function __construct(EntityDefinition $definition, Criteria $criteria, SalesChannelContext $salesChannelContext)
+    {
+        $this->definition = $definition;
+        $this->criteria = $criteria;
+        $this->salesChannelContext = $salesChannelContext;
+    }
+
+    public function getName(): string
+    {
+        return "sales_channel.{$this->definition->getEntityName()}.process_criteria";
+    }
+
+    public function getDefinition(): EntityDefinition
+    {
+        return $this->definition;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
We need to add a filter to the criteria for a specific definition when it is loaded in the sales channel. Currently we do it by decorating the corresponding repository `sales_channel.<definitionName>.repository`.
As the `SalesChannelRepository` will become final and has no implemented interface, this is not possible anymore, starting from Shopware v6.5.0.

### 2. What does this change do, exactly?
Add an event which allows to do the same as before.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
