### PR TITLE
Better compatibility of admin with browser extensions

### DIFF
--- a/changelog/_unreleased/2022-07-27-admin-notification-bar-compatability.md
+++ b/changelog/_unreleased/2022-07-27-admin-notification-bar-compatability.md
@@ -1,0 +1,10 @@
+---
+title: Better compat with extensions that display notification bars in admin
+issue: -
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Administration
+* Notification bars that are displayed (i.e. from Bitwarden) on top of the admin panel, no longer render the menu unusable.
+---

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
@@ -490,7 +490,7 @@ Component.register('sw-admin-menu', {
 
             target.classList.add('is--flyout-enabled');
             this.flyoutStyle = {
-                top: `${target.getBoundingClientRect().top}px`,
+                top: `${target.getBoundingClientRect().top - document.getElementById('app').getBoundingClientRect().top}px`,
             };
 
             this.flyoutEntries = this.getChildren(entry);
@@ -555,7 +555,7 @@ Component.register('sw-admin-menu', {
             }
 
             this.flyoutStyle = {
-                top: `${target.getBoundingClientRect().top}px`,
+                top: `${target.getBoundingClientRect().top - document.getElementById('app').getBoundingClientRect().top}px`,
             };
 
             // Remove previous flyout enabled


### PR DESCRIPTION
There are some browser extensions like Bitwarden which insert a diff on top of the body. This causes a very annoying shift in the menu, making navigation items unreachable when the notification is displayed.


### 1. Why is this change necessary?

Better compat with extensions like Bitwarden password manager.

### 2. What does this change do, exactly?

This commit fixes this by checking the bounding rect of the #app container (which in standard cases is 0)

### 3. Describe each step to reproduce the issue or behaviour.

1. install bitwarden chrome browser extension and login to bitwarden
2. login to shopware admin
3. top-bar appears
4. do not close the top-bar
5. try to use the shopwar emenu

Without the fix: 
![image](https://user-images.githubusercontent.com/1087128/181083197-7727aafb-30b8-4683-9cce-208e9ce7cb88.png)
This is the HTML structure of the bitwarden extension:
![image](https://user-images.githubusercontent.com/1087128/181083233-092dfdfd-8007-4fa3-adfb-a019c0728112.png)
With the fix:
![image](https://user-images.githubusercontent.com/1087128/181083253-58f8f96f-dc5d-42c1-9f76-d5a2ca12d3dd.png)

With the fix - and  notification closed:
![image](https://user-images.githubusercontent.com/1087128/181083284-c855030e-d9b3-415c-830c-5dcd4855e4f7.png)

### 5. Checklist

- [untestable :-)] I have written tests and verified that they fail without my change
- [not yet, first want to see if this has changes to be merged] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [not needed] I have written or adjusted the documentation according to my changes
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


### Remark & Market research

I am not 100% sure if this should be fixed in Shopware or bitwarden, but I did not notice it on other websites in Bitwarden, so I think it's quite shopware specific.

I was curious if that happens for the popular LastPass extension as well -> it does not, because it uses a different approach and overlays the prompt in the top right corner instead of shifting the page contents down.

From the other point of view: The Magento admin menu does not suffer this incompatibility because the flyout is aligned on top without such a javascript. The WordPress menu looks similar, but also does not have this problem.