### PR TITLE
Allow setup custom field rule bool values as string

### DIFF
--- a/changelog/_unreleased/2022-08-01-handle-bool-setup-as-string-in-customercustomfieldrule.md
+++ b/changelog/_unreleased/2022-08-01-handle-bool-setup-as-string-in-customercustomfieldrule.md
@@ -1,0 +1,9 @@
+---
+title: Handle bool setup as string in CustomerCustomFieldRule
+issue: 2622
+author: Leszek Prabucki
+author_email: leszek.prabucki@gmail.com
+author_github: l3l0
+---
+# Core
+* Allow setup custom field rule bool values as string (`'true'` or `'false'`). Changes in `getExpectedValue` of class `Shopware\Core\Checkout\Customer\Rule\CustomerCustomFieldRule`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1821,6 +1821,12 @@ parameters:
 			path: src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
 
 		-
+			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\CustomerCustomFieldRule\\:\\:isSwitchOrBoolField\\(\\) has parameter \\$renderedField with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
+
+
+		-
 			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\CustomerCustomFieldRule\\:\\:getConstraints\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1821,12 +1821,6 @@ parameters:
 			path: src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\CustomerCustomFieldRule\\:\\:isSwitchOrBoolField\\(\\) has parameter \\$renderedField with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
-
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Rule\\\\CustomerCustomFieldRule\\:\\:getConstraints\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php

--- a/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
@@ -160,8 +160,12 @@ class CustomerCustomFieldRule extends Rule
      */
     private function getExpectedValue($renderedFieldValue, array $renderedField)
     {
-        if (\in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH], true)) {
+        $isSwitchOrBoolField = \in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH], true);
+        if ($isSwitchOrBoolField && (is_bool($renderedFieldValue) || is_null($renderedFieldValue))) {
             return $renderedFieldValue ?? false; // those fields are initialized with null in the rule builder
+        }
+        if ($isSwitchOrBoolField && is_string($renderedFieldValue)) {
+            return mb_strtolower($renderedFieldValue) === 'true';
         }
 
         return $renderedFieldValue;

--- a/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
@@ -170,6 +170,9 @@ class CustomerCustomFieldRule extends Rule
         return $renderedFieldValue;
     }
 
+    /**
+     * @param array<string, string> $renderedField
+     */
     private function isSwitchOrBoolField(array $renderedField): bool
     {
         return \in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH], true);

--- a/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
@@ -161,7 +161,7 @@ class CustomerCustomFieldRule extends Rule
     private function getExpectedValue($renderedFieldValue, array $renderedField)
     {
         if ($this->isSwitchOrBoolField($renderedField) && is_string($renderedFieldValue)) {
-            return mb_strtolower($renderedFieldValue) === 'true';
+            return filter_var($renderedFieldValue, \FILTER_VALIDATE_BOOLEAN);
         }
         if ($this->isSwitchOrBoolField($renderedField)) {
             return $renderedFieldValue ?? false; // those fields are initialized with null in the rule builder

--- a/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
@@ -138,7 +138,7 @@ class CustomerCustomFieldRule extends Rule
      */
     private function getValue(array $customFields, array $renderedField)
     {
-        if (\in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH], true)) {
+        if ($this->isSwitchOrBoolField($renderedField)) {
             if (!empty($customFields) && \array_key_exists($this->renderedField['name'], $customFields)) {
                 return $customFields[$renderedField['name']];
             }
@@ -160,14 +160,18 @@ class CustomerCustomFieldRule extends Rule
      */
     private function getExpectedValue($renderedFieldValue, array $renderedField)
     {
-        $isSwitchOrBoolField = \in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH], true);
-        if ($isSwitchOrBoolField && (is_bool($renderedFieldValue) || is_null($renderedFieldValue))) {
-            return $renderedFieldValue ?? false; // those fields are initialized with null in the rule builder
-        }
-        if ($isSwitchOrBoolField && is_string($renderedFieldValue)) {
+        if ($this->isSwitchOrBoolField($renderedField) && is_string($renderedFieldValue)) {
             return mb_strtolower($renderedFieldValue) === 'true';
+        }
+        if ($this->isSwitchOrBoolField($renderedField)) {
+            return $renderedFieldValue ?? false; // those fields are initialized with null in the rule builder
         }
 
         return $renderedFieldValue;
+    }
+
+    private function isSwitchOrBoolField(array $renderedField): bool
+    {
+        return \in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH], true);
     }
 }

--- a/src/Core/Checkout/Test/Rule/Rule/Context/CustomerCustomFieldRuleTest.php
+++ b/src/Core/Checkout/Test/Rule/Rule/Context/CustomerCustomFieldRuleTest.php
@@ -73,6 +73,42 @@ class CustomerCustomFieldRuleTest extends TestCase
         static::assertTrue($this->rule->match($this->scope));
     }
 
+    public function testBooleanCustomFieldTrue(): void
+    {
+        $this->setupRule(true, 'bool');
+        $this->setCustomerCustomFields([
+            self::CUSTOM_FIELD_NAME => true,
+        ]);
+        static::assertTrue($this->rule->match($this->scope));
+    }
+
+    public function testBooleanCustomFieldTrueWhenIsRuleIsSetupAsString(): void
+    {
+        $this->setupRule('true', 'bool');
+        $this->setCustomerCustomFields([
+            self::CUSTOM_FIELD_NAME => true,
+        ]);
+        static::assertTrue($this->rule->match($this->scope));
+    }
+
+    public function testBooleanCustomFieldFalseWhenIsRuleIsSetupAsString(): void
+    {
+        $this->setupRule('false', 'bool');
+        $this->setCustomerCustomFields([
+            self::CUSTOM_FIELD_NAME => false,
+        ]);
+        static::assertTrue($this->rule->match($this->scope));
+    }
+
+    public function testBooleanCustomFieldInvalidAsString(): void
+    {
+        $this->setupRule('true', 'bool');
+        $this->setCustomerCustomFields([
+            self::CUSTOM_FIELD_NAME => false
+        ]);
+        static::assertFalse($this->rule->match($this->scope));
+    }
+
     public function testBooleanCustomFieldNull(): void
     {
         $this->setupRule(null, 'bool');

--- a/src/Core/Checkout/Test/Rule/Rule/Context/CustomerCustomFieldRuleTest.php
+++ b/src/Core/Checkout/Test/Rule/Rule/Context/CustomerCustomFieldRuleTest.php
@@ -82,27 +82,36 @@ class CustomerCustomFieldRuleTest extends TestCase
         static::assertTrue($this->rule->match($this->scope));
     }
 
-    public function testBooleanCustomFieldTrueWhenIsRuleIsSetupAsString(): void
+    /**
+     * @dataProvider getStringRuleValueWhichShouldBeConsideredAsTrueProvider
+     */
+    public function testBooleanCustomFieldTrueWhenIsRuleIsSetupAsString(string $value): void
     {
-        $this->setupRule('true', 'bool');
+        $this->setupRule($value, 'bool');
         $this->setCustomerCustomFields([
             self::CUSTOM_FIELD_NAME => true,
         ]);
         static::assertTrue($this->rule->match($this->scope));
     }
 
-    public function testBooleanCustomFieldFalseWhenIsRuleIsSetupAsString(): void
+    /**
+     * @dataProvider getStringRuleValueWhichShouldBeConsideredAsFalseProvider
+     */
+    public function testBooleanCustomFieldFalseWhenIsRuleIsSetupAsString(string $value): void
     {
-        $this->setupRule('false', 'bool');
+        $this->setupRule($value, 'bool');
         $this->setCustomerCustomFields([
             self::CUSTOM_FIELD_NAME => false,
         ]);
         static::assertTrue($this->rule->match($this->scope));
     }
 
-    public function testBooleanCustomFieldInvalidAsString(): void
+    /**
+     * @dataProvider getStringRuleValueWhichShouldBeConsideredAsTrueProvider
+     */
+    public function testBooleanCustomFieldInvalidAsString(string $value): void
     {
-        $this->setupRule('true', 'bool');
+        $this->setupRule($value, 'bool');
         $this->setCustomerCustomFields([
             self::CUSTOM_FIELD_NAME => false
         ]);
@@ -178,6 +187,35 @@ class CustomerCustomFieldRuleTest extends TestCase
             'testBooleanCustomFieldInvalid' => [false, 'bool', true, false],
             'testStringCustomField' => ['my_test_value', 'string', 'my_test_value', true],
             'testStringCustomFieldInvalid' => ['my_test_value', 'string', 'my_invalid_value', false],
+        ];
+    }
+
+    /**
+     * @return array<array<string>>
+     */
+    public function getStringRuleValueWhichShouldBeConsideredAsTrueProvider(): array
+    {
+        return [
+            ['yes'],
+            ['True'],
+            ['1'],
+            ['true'],
+            ['yes '],
+        ];
+    }
+
+    /**
+     * @return array<array<string>>
+     */
+    public function getStringRuleValueWhichShouldBeConsideredAsFalseProvider(): array
+    {
+        return [
+            ['no'],
+            ['False'],
+            ['0'],
+            ['false'],
+            ['no '],
+            ['some string'],
         ];
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

It allows to setup bool in  the rule builder and allows for comparison for such bool as string.

### 2. What does this change do, exactly?

If field type is bool or switch and passed `$renderedFieldValue` is string then we check if value is string `'true'` or not..

### 3. Describe each step to reproduce the issue or behavior.

1. Create a custom field for a customer with switch or bool type
2. create a rule for a payment method or something else which only should appear if the customer has the corresponding custom field set.
3. It will not appear even if the custom field is set.

Please check https://github.com/shopware/platform/issues/2622

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/platform/issues/2622

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
