### PR TITLE
Improve support for autowiring of entity repositories

### DIFF
--- a/changelog/_unreleased/2022-07-28-allow-autowiring-of-entity-repositories.md
+++ b/changelog/_unreleased/2022-07-28-allow-autowiring-of-entity-repositories.md
@@ -1,6 +1,7 @@
 ---
-title: Allow autowiring of `EntityRepository` type
+title: Allow autowiring of `EntityRepository` and `SalesChannelRepository` type
 issue: NEXT-22613
 ---
 # Core
 * Changed `\Shopware\Core\Framework\DependencyInjection\CompilerPass\EntityCompilerPass` to create autowiring aliases for the registered entity repositories also for `EntityRepository` type and not just for the deprecated `EntityRepositoryInterface`.
+* Changed `\Shopware\Core\System\DependencyInjection\CompilerPass\SalesChannelEntityCompilerPass` to create autowiring aliases for the registered entity sale channel repositories `SalesChannelRepository`.

--- a/src/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPass.php
+++ b/src/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPass.php
@@ -116,6 +116,8 @@ class SalesChannelEntityCompilerPass implements CompilerPassInterface
             if (isset($entityNames['fallBack'])) {
                 $repositoryNameMap[$entityNames['fallBack']] = $repositoryId;
             }
+
+            $container->registerAliasForArgument(SalesChannelRepository::class, $entityNames['entityName'] . '.repository', $repositoryId);
         }
 
         $definitionRegistry = $container->getDefinition(SalesChannelDefinitionInstanceRegistry::class);

--- a/tests/unit/php/Core/Framework/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPassTest.php
+++ b/tests/unit/php/Core/Framework/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPassTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DependencyInjection\CompilerPass;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\System\DependencyInjection\CompilerPass\SalesChannelEntityCompilerPass;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
+use Symfony\Component\Config\FileLocator;use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+
+/**
+ * @internal
+ * @covers SalesChannelEntityCompilerPass
+ */
+class SalesChannelEntityCompilerPassTest extends TestCase
+{
+    public function testEntityRepositoryAutowiring(): void
+    {
+        $container = new ContainerBuilder();
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../../Resources/config'));
+        $loader->load('test_entity_definition_compiled.xml');
+
+        $entityCompilerPass = new SalesChannelEntityCompilerPass();
+        $entityCompilerPass->process($container);
+
+        static::assertSame(
+            'sales_channel.country.repository',
+            (string)$container->getAlias(SalesChannelRepository::class . ' $countryRepository')
+        );
+        static::assertSame(
+            'sales_channel.country_state.repository',
+            (string)$container->getAlias(SalesChannelRepository::class . ' $countryStateRepository')
+        );
+    }
+}

--- a/tests/unit/php/Core/Framework/Resources/config/test_entity_definition.xml
+++ b/tests/unit/php/Core/Framework/Resources/config/test_entity_definition.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <defaults public="true"/>
+
+        <service id="Shopware\Core\System\Country\CountryDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\System\Country\SalesChannel\SalesChannelCountryDefinition">
+            <tag name="shopware.sales_channel.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\System\Country\Aggregate\CountryState\CountryStateDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\System\Country\Aggregate\CountryState\SalesChannel\SalesChannelCountryStateDefinition">
+            <tag name="shopware.sales_channel.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\System\Country\Aggregate\CountryStateTranslation\CountryStateTranslationDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\System\Country\Aggregate\CountryTranslation\CountryTranslationDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+    </services>
+</container>

--- a/tests/unit/php/Core/Framework/Resources/config/test_entity_definition_compiled.xml
+++ b/tests/unit/php/Core/Framework/Resources/config/test_entity_definition_compiled.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <defaults public="true"/>
+
+        <service id="Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegistry">
+            <argument type="string"/>
+            <argument type="string"/>
+            <argument type="string"/>
+            <argument type="string"/>
+        </service>
+
+        <service id="Shopware\Core\System\Country\CountryDefinition"
+                 class="Shopware\Core\System\Country\CountryDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\System\Country\SalesChannel\SalesChannelCountryDefinition"
+                 class="Shopware\Core\System\Country\SalesChannel\SalesChannelCountryDefinition">
+            <tag name="shopware.sales_channel.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\System\Country\Aggregate\CountryState\CountryStateDefinition"
+                 class="Shopware\Core\System\Country\Aggregate\CountryState\CountryStateDefinition">
+            <tag name="shopware.entity.definition"/>
+        </service>
+
+        <service id="Shopware\Core\System\Country\Aggregate\CountryState\SalesChannel\SalesChannelCountryStateDefinition"
+                 class="Shopware\Core\System\Country\Aggregate\CountryState\SalesChannel\SalesChannelCountryStateDefinition">
+            <tag name="shopware.sales_channel.entity.definition"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
### 1. Why is this change necessary?
Improve autowiring

### 2. What does this change do, exactly?
It adds a new compiler pass for the container.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
I can't create new, because they are 3 tracking scrip where throwing a exception.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
