### PR TITLE
only warm up products which are visible in the corresponding sales channels

### DIFF
--- a/src/Storefront/Framework/Cache/CacheWarmer/Product/ProductRouteWarmer.php
+++ b/src/Storefront/Framework/Cache/CacheWarmer/Product/ProductRouteWarmer.php
@@ -35,7 +35,10 @@ class ProductRouteWarmer implements CacheRouteWarmer
         $iterator = $this->iteratorFactory->createIterator($this->definition, $offset);
         $query = $iterator->getQuery();
         $query
-            ->innerJoin('`product`', '`product_visibility`', 'pv',
+            ->innerJoin(
+                '`product`', 
+                '`product_visibility`', 
+                'pv',
                 'pv.sales_channel_id = :salesChannelId
                 AND pv.product_id = `product`.id
                 AND pv.product_version_id = `product`.version_id


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The HTTP CacheWarmer wanted to warm up every product for every sales channel domain.
Neccessary are only the products which are visible in the corresponding sales channels.

### 2. What does this change do, exactly?
It filters the products by their visibility in the corresponding sales channels.

### 3. Describe each step to reproduce the issue or behaviour.
Create 2 sales channels and assign different, disjunct products to them.
Start the cache warmer and observe the generated warmup messages.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
