### PR TITLE
fix: throw correct message in FileSaver

### DIFF
--- a/changelog/_unreleased/2022-08-08-throw-an-appropriate-error-message-in-filesaver.md
+++ b/changelog/_unreleased/2022-08-08-throw-an-appropriate-error-message-in-filesaver.md
@@ -1,6 +1,6 @@
 ---
 title: Throw an appropriate error message in FileSaver
-issue: 
+issue: NEXT-XXX
 author: tinect
 author_email: s.koenig@tinect.de
 author_github: tinect

--- a/changelog/_unreleased/2022-08-08-throw-an-appropriate-error-message-in-filesaver.md
+++ b/changelog/_unreleased/2022-08-08-throw-an-appropriate-error-message-in-filesaver.md
@@ -8,10 +8,11 @@ author_github: tinect
 
 # Core
 
-* Changed Content\Media\Exception\FileTypeNotSupportedException
-  * Added second parameter to specify the given extension
-  * Changed message to throw the relevant error with info about the extension
+* Deprecated Content\Media\Exception\FileTypeNotSupportedException, use FileExtensionNotSupportedException or ThumbnailNotSupportedException instead
+* Added Content\Media\Exception\FileExtensionNotSupportedException as replacement of FileTypeNotSupportedException
 * Added Content\Media\Exception\ThumbnailNotSupportedException for not supported file to generate thumbnail for
 * Changed Content\Media\Thumbnail\ThumbnailService
   * Changed method generateThumbnails to throw ThumbnailNotSupportedException instead of FileTypeNotSupportedException
   * Changed method updateThumbnails to throw ThumbnailNotSupportedException instead of FileTypeNotSupportedException
+* Changed Shopware\Core\Content\Media\File\FileSaver
+    * Changed method persistFileToMedia to throw FileExtensionNotSupportedException instead of FileTypeNotSupportedException

--- a/changelog/_unreleased/2022-08-08-throw-an-appropriate-error-message-in-filesaver.md
+++ b/changelog/_unreleased/2022-08-08-throw-an-appropriate-error-message-in-filesaver.md
@@ -1,0 +1,17 @@
+---
+title: Throw an appropriate error message in FileSaver
+issue: 
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Changed Content\Media\Exception\FileTypeNotSupportedException
+  * Added second parameter to specify the given extension
+  * Changed message to throw the relevant error with info about the extension
+* Added Content\Media\Exception\ThumbnailNotSupportedException for not supported file to generate thumbnail for
+* Changed Content\Media\Thumbnail\ThumbnailService
+  * Changed method generateThumbnails to throw ThumbnailNotSupportedException instead of FileTypeNotSupportedException
+  * Changed method updateThumbnails to throw ThumbnailNotSupportedException instead of FileTypeNotSupportedException

--- a/src/Core/Content/Media/Exception/FileExtensionNotSupportedException.php
+++ b/src/Core/Content/Media/Exception/FileExtensionNotSupportedException.php
@@ -7,19 +7,19 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * @deprecated tag:v6.5.0 - Will extend Shopware\Core\Framework\ShopwareHttpException instead
  */
-class ThumbnailNotSupportedException extends FileTypeNotSupportedException
+class FileExtensionNotSupportedException extends FileTypeNotSupportedException
 {
-    public function __construct(string $mediaId)
+    public function __construct(string $mediaId, string $extension)
     {
         parent::__construct(
-            'The file for media object with id {{ mediaId }} is not supported for creating thumbnails.',
-            ['mediaId' => $mediaId]
+            'The file extension "{{ extension }}" for media object with id {{ mediaId }} is not supported.',
+            ['mediaId' => $mediaId, 'extension' => $extension]
         );
     }
 
     public function getErrorCode(): string
     {
-        return 'CONTENT__MEDIA_FILE_NOT_SUPPORTED_FOR_THUMBNAIL';
+        return 'CONTENT__MEDIA_FILE_TYPE_NOT_SUPPORTED';
     }
 
     public function getStatusCode(): int

--- a/src/Core/Content/Media/Exception/FileTypeNotSupportedException.php
+++ b/src/Core/Content/Media/Exception/FileTypeNotSupportedException.php
@@ -9,14 +9,18 @@ use Symfony\Component\HttpFoundation\Response;
 class FileTypeNotSupportedException extends ShopwareHttpException
 {
     /**
-     * @deprecated tag:v6.5.0 - Parameter extension will be mandatory
+     * @deprecated tag:v6.5.0 - Parameter extension will be mandatory and typed as string
      */
-    public function __construct(string $mediaId, string $extension = '')
+    public function __construct(string $mediaId, ?string $extension = null)
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.5.0.0',
-            'parameter extension will be mandatory'
-        );
+        if ($extension === null) {
+            $extension = '';
+            Feature::triggerDeprecationOrThrow(
+                'v6.5.0.0',
+                'parameter extension will be mandatory and typed as string'
+            );
+        }
+
         parent::__construct(
             'The file extension "{{ extension }}" for media object with id {{ mediaId }} is not supported.',
             ['mediaId' => $mediaId, 'extension' => $extension]

--- a/src/Core/Content/Media/Exception/FileTypeNotSupportedException.php
+++ b/src/Core/Content/Media/Exception/FileTypeNotSupportedException.php
@@ -2,31 +2,14 @@
 
 namespace Shopware\Core\Content\Media\Exception;
 
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @deprecated tag:v6.5.0 - Will be removed. Use FileExtensionNotSupportedException or ThumbnailNotSupportedException instead
+ */
 class FileTypeNotSupportedException extends ShopwareHttpException
 {
-    /**
-     * @deprecated tag:v6.5.0 - Parameter extension will be mandatory and typed as string
-     */
-    public function __construct(string $mediaId, ?string $extension = null)
-    {
-        if ($extension === null) {
-            $extension = '';
-            Feature::triggerDeprecationOrThrow(
-                'v6.5.0.0',
-                'parameter extension will be mandatory and typed as string'
-            );
-        }
-
-        parent::__construct(
-            'The file extension "{{ extension }}" for media object with id {{ mediaId }} is not supported.',
-            ['mediaId' => $mediaId, 'extension' => $extension]
-        );
-    }
-
     public function getErrorCode(): string
     {
         return 'CONTENT__MEDIA_FILE_TYPE_NOT_SUPPORTED';

--- a/src/Core/Content/Media/Exception/FileTypeNotSupportedException.php
+++ b/src/Core/Content/Media/Exception/FileTypeNotSupportedException.php
@@ -2,16 +2,24 @@
 
 namespace Shopware\Core\Content\Media\Exception;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
 class FileTypeNotSupportedException extends ShopwareHttpException
 {
-    public function __construct(string $mediaId)
+    /**
+     * @deprecated tag:v6.5.0 - Parameter extension will be mandatory
+     */
+    public function __construct(string $mediaId, string $extension = '')
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.5.0.0',
+            'parameter extension will be mandatory'
+        );
         parent::__construct(
-            'The File for media object with id: {{ mediaId }} is not supported for creating thumbnails.',
-            ['mediaId' => $mediaId]
+            'The file extension "{{ extension }}" for media object with id {{ mediaId }} is not supported.',
+            ['mediaId' => $mediaId, 'extension' => $extension]
         );
     }
 

--- a/src/Core/Content/Media/Exception/ThumbnailNotSupportedException.php
+++ b/src/Core/Content/Media/Exception/ThumbnailNotSupportedException.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Media\Exception;
+
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+class ThumbnailNotSupportedException extends ShopwareHttpException
+{
+    public function __construct(string $mediaId)
+    {
+        parent::__construct(
+            'The file for media object with id {{ mediaId }} is not supported for creating thumbnails.',
+            ['mediaId' => $mediaId]
+        );
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'CONTENT_MEDIA_FILE_NOT_SUPPORTED_FOR_THUMBNAIL';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+}

--- a/src/Core/Content/Media/File/FileSaver.php
+++ b/src/Core/Content/Media/File/FileSaver.php
@@ -10,7 +10,7 @@ use Shopware\Core\Content\Media\Event\MediaFileExtensionWhitelistEvent;
 use Shopware\Core\Content\Media\Exception\CouldNotRenameFileException;
 use Shopware\Core\Content\Media\Exception\DuplicatedMediaFileNameException;
 use Shopware\Core\Content\Media\Exception\EmptyMediaFilenameException;
-use Shopware\Core\Content\Media\Exception\FileTypeNotSupportedException;
+use Shopware\Core\Content\Media\Exception\FileExtensionNotSupportedException;
 use Shopware\Core\Content\Media\Exception\IllegalFileNameException;
 use Shopware\Core\Content\Media\Exception\MediaNotFoundException;
 use Shopware\Core\Content\Media\Exception\MissingFileException;
@@ -122,7 +122,7 @@ class FileSaver
      * @throws EmptyMediaFilenameException
      * @throws IllegalFileNameException
      * @throws MediaNotFoundException
-     * @throws FileTypeNotSupportedException
+     * @throws FileExtensionNotSupportedException
      */
     public function persistFileToMedia(
         MediaFile $mediaFile,
@@ -393,7 +393,7 @@ class FileSaver
     }
 
     /**
-     * @throws FileTypeNotSupportedException
+     * @throws FileExtensionNotSupportedException
      */
     private function validateFileExtension(MediaFile $mediaFile, string $mediaId): void
     {
@@ -408,7 +408,7 @@ class FileSaver
             }
         }
 
-        throw new FileTypeNotSupportedException($mediaId, $fileExtension);
+        throw new FileExtensionNotSupportedException($mediaId, $fileExtension);
     }
 
     /**

--- a/src/Core/Content/Media/File/FileSaver.php
+++ b/src/Core/Content/Media/File/FileSaver.php
@@ -400,13 +400,15 @@ class FileSaver
         $event = new MediaFileExtensionWhitelistEvent($this->whitelist);
         $this->eventDispatcher->dispatch($event);
 
+        $fileExtension = mb_strtolower($mediaFile->getFileExtension());
+
         foreach ($event->getWhitelist() as $extension) {
-            if (mb_strtolower($mediaFile->getFileExtension()) === mb_strtolower($extension)) {
+            if ($fileExtension === mb_strtolower($extension)) {
                 return;
             }
         }
 
-        throw new FileTypeNotSupportedException($mediaId);
+        throw new FileTypeNotSupportedException($mediaId, $fileExtension);
     }
 
     /**

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -9,8 +9,8 @@ use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailCollectio
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity;
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeCollection;
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeEntity;
-use Shopware\Core\Content\Media\Exception\FileTypeNotSupportedException;
 use Shopware\Core\Content\Media\Exception\ThumbnailCouldNotBeSavedException;
+use Shopware\Core\Content\Media\Exception\ThumbnailNotSupportedException;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaType\ImageType;
@@ -124,7 +124,7 @@ class ThumbnailService
     /**
      * @deprecated tag:v6.5.0 - Will be removed, use `generate` instead
      *
-     * @throws FileTypeNotSupportedException
+     * @throws ThumbnailNotSupportedException
      * @throws ThumbnailCouldNotBeSavedException
      */
     public function generateThumbnails(MediaEntity $media, Context $context): int
@@ -168,7 +168,7 @@ class ThumbnailService
     }
 
     /**
-     * @throws FileTypeNotSupportedException
+     * @throws ThumbnailNotSupportedException
      * @throws ThumbnailCouldNotBeSavedException
      *
      * @deprecated tag:v6.5.0 - Parameter $strict will be mandatory in future implementation
@@ -253,7 +253,7 @@ class ThumbnailService
     }
 
     /**
-     * @throws FileTypeNotSupportedException
+     * @throws ThumbnailNotSupportedException
      * @throws ThumbnailCouldNotBeSavedException
      */
     private function createThumbnailsForSizes(
@@ -327,7 +327,7 @@ class ThumbnailService
     }
 
     /**
-     * @throws FileTypeNotSupportedException
+     * @throws ThumbnailNotSupportedException
      *
      * @return resource
      */
@@ -338,7 +338,7 @@ class ThumbnailService
         $file = $this->getFileSystem($media)->read($filePath);
         $image = @imagecreatefromstring($file);
         if ($image === false) {
-            throw new FileTypeNotSupportedException($media->getId());
+            throw new ThumbnailNotSupportedException($media->getId());
         }
 
         if (\function_exists('exif_read_data')) {
@@ -370,7 +370,7 @@ class ThumbnailService
         }
 
         if ($image === false) {
-            throw new FileTypeNotSupportedException($media->getId());
+            throw new ThumbnailNotSupportedException($media->getId());
         }
 
         return $image;

--- a/src/Core/Content/Test/Media/File/FileSaverTest.php
+++ b/src/Core/Content/Test/Media/File/FileSaverTest.php
@@ -7,7 +7,7 @@ use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity;
 use Shopware\Core\Content\Media\Event\MediaFileExtensionWhitelistEvent;
 use Shopware\Core\Content\Media\Exception\CouldNotRenameFileException;
 use Shopware\Core\Content\Media\Exception\DuplicatedMediaFileNameException;
-use Shopware\Core\Content\Media\Exception\FileTypeNotSupportedException;
+use Shopware\Core\Content\Media\Exception\FileExtensionNotSupportedException;
 use Shopware\Core\Content\Media\Exception\MediaNotFoundException;
 use Shopware\Core\Content\Media\Exception\MissingFileException;
 use Shopware\Core\Content\Media\File\FileSaver;
@@ -499,7 +499,7 @@ class FileSaverTest extends TestCase
 
     public function testMaliciousFileExtension(): void
     {
-        $this->expectException(FileTypeNotSupportedException::class);
+        $this->expectException(FileExtensionNotSupportedException::class);
 
         $tempFile = tempnam(sys_get_temp_dir(), '');
         copy(self::TEST_SCRIPT_FILE, $tempFile);

--- a/src/Core/Content/Test/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/src/Core/Content/Test/Media/Thumbnail/ThumbnailServiceTest.php
@@ -10,7 +10,7 @@ use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailCollectio
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity;
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeCollection;
 use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeEntity;
-use Shopware\Core\Content\Media\Exception\FileTypeNotSupportedException;
+use Shopware\Core\Content\Media\Exception\ThumbnailNotSupportedException;
 use Shopware\Core\Content\Media\MediaCollection;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaType\DocumentType;
@@ -133,7 +133,7 @@ class ThumbnailServiceTest extends TestCase
         $filePath = $this->urlGenerator->getRelativeMediaUrl($media);
         $this->getPublicFilesystem()->put($filePath, 'this is the content of the file, which is not a image');
 
-        $this->expectException(FileTypeNotSupportedException::class);
+        $this->expectException(ThumbnailNotSupportedException::class);
         $this->thumbnailService->updateThumbnails(
             $media,
             $this->context,


### PR DESCRIPTION
### 1. Why is this change necessary?
The current message thrown in FileSaver is wrong.

### 2. What does this change do, exactly?
- Adjust message for existing FileTypeNotSupportedException
- Add specific ThumbnailNotSupportedException for Thumbnail-related message

### 3. Describe each step to reproduce the issue or behaviour.
- Upload file with not supported file extension.
- Getting error `The file for media object with id {{ mediaId }} is not supported for creating thumbnails.`
- be surprised
- check why he wants to create thumbnails
- be surprised
- create PR

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
