### PR TITLE
feat: add sales channel context restorer order criteria event

### DIFF
--- a/changelog/_unreleased/2022-08-09-add-sales-channel-context-restorer-order-criteria-event.md
+++ b/changelog/_unreleased/2022-08-09-add-sales-channel-context-restorer-order-criteria-event.md
@@ -1,0 +1,9 @@
+---
+title: Add event to modify order criteria in SalesChannelContextRestorer
+author: Stefan Poensgen
+author_email: mail@stefanpoensgen.de
+author_github: @stefanpoensgen
+---
+
+# Core
+* Add `Shopware\Core\System\SalesChannel\Event\SalesChannelContextRestorerOrderCriteriaEvent.php`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -38341,11 +38341,6 @@ parameters:
 			path: src/Core/System/Test/SalesChannel/Context/SalesChannelContextRestorerTest.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\Test\\\\SalesChannel\\\\Context\\\\SalesChannelContextRestorerTest\\:\\:\\$eventDispatcher \\(Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcher\\) does not accept Symfony\\\\Component\\\\HttpKernel\\\\Debug\\\\TraceableEventDispatcher\\.$#"
-			count: 1
-			path: src/Core/System/Test/SalesChannel/Context/SalesChannelContextRestorerTest.php
-
-		-
 			message: "#^Property Shopware\\\\Core\\\\System\\\\Test\\\\SalesChannel\\\\Context\\\\SalesChannelContextRestorerTest\\:\\:\\$events type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/System/Test/SalesChannel/Context/SalesChannelContextRestorerTest.php

--- a/src/Core/System/DependencyInjection/sales_channel.xml
+++ b/src/Core/System/DependencyInjection/sales_channel.xml
@@ -107,6 +107,7 @@
             <argument type="service" id="order.repository"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\CartRestorer"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\System\SalesChannel\Context\CartRestorer">

--- a/src/Core/System/SalesChannel/Event/SalesChannelContextRestorerOrderCriteriaEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelContextRestorerOrderCriteriaEvent.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\System\SalesChannel\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\NestedEvent;
+
+class SalesChannelContextRestorerOrderCriteriaEvent extends NestedEvent
+{
+    protected Context $context;
+
+    protected Criteria $criteria;
+
+    public function __construct(Criteria $criteria, Context $context)
+    {
+        $this->context = $context;
+        $this->criteria = $criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently there is no event to modify the criteria of the order entity

### 2. What does this change do, exactly?
Adds an event to modify the criteria

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
