### PR TITLE
Missing optional chaining when errors not exist

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
@@ -170,7 +170,7 @@ function handleErrorStates({ status, errors, error = null, data }) {
     }
 
     if (status === 403
-        && ['FRAMEWORK__STORE_SESSION_EXPIRED', 'FRAMEWORK__STORE_SHOP_SECRET_INVALID'].includes(errors[0]?.code)
+        && ['FRAMEWORK__STORE_SESSION_EXPIRED', 'FRAMEWORK__STORE_SHOP_SECRET_INVALID'].includes(errors?.[0]?.code)
     ) {
         Shopware.State.dispatch('notification/createNotification', {
             variant: 'warning',
@@ -307,7 +307,7 @@ function storeSessionExpiredInterceptor(client) {
         return response;
     }, (error) => {
         const { config, response } = error;
-        const code = response.data?.errors[0]?.code;
+        const code = response.data?.errors?.[0]?.code;
 
         if (config.storeSessionRequestRetries >= maxRetryLimit) {
             return Promise.reject(error);


### PR DESCRIPTION
### 1. Why is this change necessary?
When errors do not exist in the response, the code throws an error "TypeError: Cannot read properties of undefined(reading '0') "

### 2. What does this change do, exactly?
Proper optional chaining step by step


### 3. Describe each step to reproduce the issue or behaviour.
Create an api controller for admin and return JsonResponse with error code without errors data:
```
        return new JsonResponse(
            [
                'myCustomData' => 'msg to the user'
            ],
            400 // error code triggers the storeSessionExpiredInterceptor
        );

```

Theres no code explanantion, test or spec it just a proper language construct.

