### PR TITLE
Check against payloads with version ids that do not match context version id

### DIFF
--- a/changelog/_unreleased/2022-08-09-remove-version-id-from-entity-payloads-to-prioritize-context-version-id.md
+++ b/changelog/_unreleased/2022-08-09-remove-version-id-from-entity-payloads-to-prioritize-context-version-id.md
@@ -1,0 +1,8 @@
+---
+title: Remove versionId from entity payloads to prioritize context versionId
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed entity payload normalization to remove values for primary key version fields so the context version is used in any case

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
@@ -26,6 +26,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedByField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\JsonUpdateCommand;
@@ -83,6 +84,11 @@ class WriteCommandExtractor
 
         foreach ($definition->getPrimaryKeys() as $pkField) {
             $data = $pkField->getSerializer()->normalize($pkField, $data, $parameters);
+
+            if ($pkField instanceof VersionField) {
+                unset($data[$pkField->getPropertyName()]);
+            }
+
             $done[$pkField->getPropertyName()] = true;
         }
 

--- a/src/Core/Framework/Test/DataAbstractionLayer/Write/Entity/DefaultsDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Write/Entity/DefaultsDefinition.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToManyAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 
 /**
@@ -16,9 +17,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 class DefaultsDefinition extends EntityDefinition
 {
     public const SCHEMA = 'CREATE TABLE IF NOT EXISTS `defaults` (
-        `id` BINARY(16) NOT NULL PRIMARY KEY,
+        `id` BINARY(16) NOT NULL,
+        `version_id` BINARY(16) NOT NULL,
         `active` int(1) NOT NULL,
-        `created_at` DATETIME NOT NULL
+        `created_at` DATETIME NOT NULL,
+        PRIMARY KEY (`id`, `version_id`)
     )';
 
     public function getEntityName(): string
@@ -48,6 +51,7 @@ class DefaultsDefinition extends EntityDefinition
     {
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new PrimaryKey()),
+            (new VersionField())->addFlags(new PrimaryKey()),
             (new BoolField('active', 'active'))->addFlags(new Required()),
             new OneToManyAssociationField('children', DefaultsChildDefinition::class, 'defaults_id'),
         ]);

--- a/src/Core/Framework/Test/DataAbstractionLayer/Write/WriteCommandExtractorTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Write/WriteCommandExtractorTest.php
@@ -8,8 +8,11 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteCommandExtractor;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Write\Entity\DefaultsChildDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Write\Entity\DefaultsChildTranslationDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Write\Entity\DefaultsDefinition;
@@ -80,5 +83,31 @@ class WriteCommandExtractorTest extends TestCase
         static::assertSame($defaultsChildId, $defaultsChildTranslationWriteResult->getPayload()['defaultsChildId']);
         static::assertSame(Defaults::LANGUAGE_SYSTEM, $defaultsChildTranslationWriteResult->getPayload()['languageId']);
         static::assertSame('Default name', $defaultsChildTranslationWriteResult->getPayload()['name']);
+    }
+
+    public function testRemoveVersionIdsFromPayload(): void
+    {
+        /** @var WriteCommandExtractor $extractor */
+        $extractor = $this->getContainer()->get(WriteCommandExtractor::class);
+        $context = WriteContext::createFromContext(Context::createDefaultContext());
+        /** @var DefaultsDefinition $definition */
+        $definition = $this->getContainer()->get(DefaultsDefinition::class);
+
+        $normalized = $extractor->normalize(
+            $definition,
+            [
+                [
+                    'id' => '718c51859c5e4c938c1f231a27959e2c',
+                    'versionId' => 'ddabcd0483df441096e49acb81f52f1d',
+                ],
+            ],
+            new WriteParameterBag($definition, $context, '/', new WriteCommandQueue())
+        );
+
+        static::assertSame($normalized, [
+            [
+                'id' => '718c51859c5e4c938c1f231a27959e2c',
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

There is a plugin in the community store that clones an entity and updates the cloned entity with a payload that still refers to the live id but has a clone version id in the context. This is actually the plugins fault and I contacted the manufacturer about it. We cool. But how to prevent this early on?

Now the existence prefetch ONLY LOADS EXISTENCE WITH CONTEXT VERSION ID [see here](https://github.com/shopware/platform/pull/2646/files#diff-7f2b0ab91c268388107b9e5b64f05e9316ce4b5158ece1d6463d195ce1fe40f9L372-L375). But the existence checks VALIDATE EXISTENCE WITH PAYLOAD VERSION ID. So we have a conflict there resulting in a mismatch of "Do I need to update or create?".

I see two ways to fix:
1. Trust the payload. Prefetch with the payload version ids is easy to do, not that bad actually, but as Shopware expects at a lot of places to expect the version id in the context is right, we should not go this way.
2. This PR to trust the context. And if the context goes: well we have this version id, then I 


### 2. What does this change do, exactly?

Checks whether version ids are given in payload and flip tables, when they do not match the context version id.


### 3. Describe each step to reproduce the issue or behaviour.

1. Clone an entity to get a new version id
2. Use payload with live version id to run an update in a version scoped context
3. Get an exception that you run update but Shopware tries to insert
4. Look into DB with values from the payload
5. They exist. Why does Shopware THINK IT NEEDS TO CREATE?!


### 4. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. I need feedback

What does Shopware think about that? Am I approaching the issue correctly? I know, tests missing, changelog missing, exception looks like an untested IED. But I don't know what to do with it? If this plugin can fail, anyone working with the API can fail.

<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2646"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

