### PR TITLE
Fix cascading DAL operations on associations, that use non id-named column as primary key

### DIFF
--- a/changelog/_unreleased/2022-08-10-fix-cascading-dal-operations-on-associations, that-use-non-id-named-column-as-primary-key.md
+++ b/changelog/_unreleased/2022-08-10-fix-cascading-dal-operations-on-associations, that-use-non-id-named-column-as-primary-key.md
@@ -1,0 +1,9 @@
+---
+title: Fix cascading DAL operations on associations, that use non id-named column as primary key
+flag: FEATURE_NEXT_14872
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: JoshuaBehrens
+---
+# Core
+* Changed fetching of primary keys in `\Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityForeignKeyResolver` to not rely on the name `id` of primary keys. Therefore, it allows other names for primary keys which are likely when you use foreign keys to other entities as primary key.

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageDefinition;
@@ -256,7 +257,10 @@ class EntityForeignKeyResolver
             /** @var Field $pk */
             $pk = $primaryKeys->first();
             $property = $pk->getPropertyName();
-            $affected = array_column($affected, $property);
+
+            if (!Feature::has('FEATURE_NEXT_14872') || $property === 'id') {
+                $affected = array_column($affected, $property);
+            }
         }
 
         // prevent circular reference for many to many


### PR DESCRIPTION
### 1. Why is this change necessary?

You create an entity extension on e.g. product. It looks like this:

```php
(new FkField('product_id', 'productId', ProductDefinition::class))->addFlags(new PrimaryKey(), new Required()),
(new ReferenceVersionField(ProductDefinition::class))->addFlags(new PrimaryKey(), new Required()),

(new OneToOneAssociationField('product', 'product_id', 'id', ProductDefinition::class, false))->addFlags(new CascadeDelete()),
```

This is super nice as you can refer to your extension entity by using the product id, you don't have to waste storage for ids that you just have to have something as primary key. Now you have a different entity extension (likely not important, it could be any association) and you try to delete an entry. Now the cascade deletion check tries to find everything that might be affected. As you hit on a product it will check every product association as they could be affected. Now the check has a section that says "you have one pk column? nice I will just store the values for the check later". Nice ok, but I have two primary key columns so I don't run in there 🤡 . Jokes on me. VersionFields are filtered out. So my complex key becomes a single scalar value, which has no column name assigned to it. Later on the primary key is looked up and cannot find a value by `productId`. It can't as it has been processed as it would've been called `id`. So if we don't expect single column primary keys to be called id, we are good.


### 2. What does this change do, exactly?

Only makes primary keys scalar single value if it is called `id`.


### 3. Please link to the relevant issues (if any).

I found NEXT-14872 which was so similar that I used the same feature flag.


### 4. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


### 5. Feedback needed

Is this even something you want to support? I mean you can add primary key flag to anything there, so I think so. I also thought about naming the fields `id` and `version_id` and make them fks to `product.id` and `product.version_id` but other portions in the code failed in the past when automatic associations where not named `$entityName . '_version_id'` so I tend to not do it.

How do I test a feature that you don't use yourself? I am unsure how I test this behaviour. Anything you can refer to as a reference for a good test like that?
