### PR TITLE
Data protection links of googleReCaptcha now resolve properly in DE

### DIFF
--- a/changelog/_unreleased/2022-08-15-captcha-snippet.md
+++ b/changelog/_unreleased/2022-08-15-captcha-snippet.md
@@ -1,0 +1,10 @@
+---
+title: Data projection links of googleReCaptcha now resolve properly in DE
+issue: -
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Storefront
+* Data projection links of googleReCaptcha now resolve properly in DE 
+---

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -581,7 +581,7 @@
   },
   "captcha": {
     "googleReCaptcha": {
-      "dataProtectionInformation": "Diese Seite ist durch reCAPTCHA geschützt und es gelten die <a href=\\\"https://policies.google.com/privacy?hl=de\\\">Datenschutzrichtlinie</a> und <a href=\\\"https://policies.google.com/terms?hl=de\\\">Nutzungsbedingungen</a>."
+      "dataProtectionInformation": "Diese Seite ist durch reCAPTCHA geschützt und es gelten die <a href=\"https://policies.google.com/privacy?hl=de\">Datenschutzrichtlinie</a> und <a href=\"https://policies.google.com/terms?hl=de\">Nutzungsbedingungen</a>."
     },
     "basicCaptchaLabel" : "Bitte geben Sie die abgebildeten Zeichen ein*"
   },


### PR DESCRIPTION
* Slashes removed


### 1. Why is this change necessary?

In the the recaptcha Links are not resolved properly

### 2. What does this change do, exactly?
Remove 8 x `\` - that's it

### 3. Describe each step to reproduce the issue or behaviour.
Install Shopware, switch to DE, Enable recaptcha v2 or v3, 

Disclaimer looks like this:

Diese Seite ist durch reCAPTCHA geschützt und es gelten die [Datenschutzrichtlinie](https://www.example.de/de/Kontakt/Kontaktformular/%5C) und [Nutzungsbedingungen](https://www.example.de/de/Kontakt/Kontaktformular/%5C).

### 4. Please link to the relevant issues (if any).

please create

### 5. Checklist

- [would be overkill] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [not needed] I have written or adjusted the documentation according to my changes
- [not needed] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
