### PR TITLE
Fix list price rule constraints

### DIFF
--- a/changelog/_unreleased/2022-08-16-fix-list-price-rule-constraints.md
+++ b/changelog/_unreleased/2022-08-16-fix-list-price-rule-constraints.md
@@ -1,0 +1,10 @@
+---
+title: Fix constraints for LineItemListPriceRule
+issue:
+author: Daniel Wolf
+author_email: daniel.wolf@8mylez.com
+author_github: supus
+---
+# Core
+## Rule
+* Add missing IsNull-constraint for "amount" field in Shopware\Core\Checkout\Cart\Rule\LineItemListPriceRule to prevent a WriteException when persiting an order with a promotion using this rule with operator "empty".

--- a/src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Rule\RuleComparison;
 use Shopware\Core\Framework\Rule\RuleConfig;
 use Shopware\Core\Framework\Rule\RuleConstraints;
 use Shopware\Core\Framework\Rule\RuleScope;
-use Symfony\Component\Validator\Constraints\IsNull;
+use Symfony\Component\Validator\Constraints\EqualTo;
 
 class LineItemListPriceRule extends Rule
 {
@@ -58,11 +58,14 @@ class LineItemListPriceRule extends Rule
     public function getConstraints(): array
     {
         $constraints = [
-            'operator' => RuleConstraints::numericOperators(),
-            'amount' => new IsNull()
+            'operator' => RuleConstraints::numericOperators()
         ];
 
         if ($this->operator === self::OPERATOR_EMPTY) {
+            $constraints['amount'] = new EqualTo([
+                'value' => 0
+            ]);
+            
             return $constraints;
         }
 

--- a/src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Rule\RuleComparison;
 use Shopware\Core\Framework\Rule\RuleConfig;
 use Shopware\Core\Framework\Rule\RuleConstraints;
 use Shopware\Core\Framework\Rule\RuleScope;
+use Symfony\Component\Validator\Constraints\IsNull;
 
 class LineItemListPriceRule extends Rule
 {
@@ -58,6 +59,7 @@ class LineItemListPriceRule extends Rule
     {
         $constraints = [
             'operator' => RuleConstraints::numericOperators(),
+            'amount' => new IsNull()
         ];
 
         if ($this->operator === self::OPERATOR_EMPTY) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- to prevent a WriteException when persisting an order with a promotion using the LineItemListPriceRule with the empty-operator.


### 2. What does this change do, exactly?
- I added a missing Constraint for the "amount" field

### 3. Describe each step to reproduce the issue or behaviour.
- create a new promotion (no promotion code to apply automatically)
- add a new discount, only applied to certain products => rule "Item with liste price => at least one => is empty"
- apply to all items
- percentage => 10
=> the goal is to create a promotion that automatically applies to all non-discounted products
- go to checkout and order a non discounted product (make sure the promotion applies)
- the order cannot be saved => an error is thrown (WriteException)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
