### PR TITLE
feat: Add twig blocks for image to the product box card template

### DIFF
--- a/changelog/_unreleased/2022-08-16-add-twig-blocks-for-image-to-the-product-box-card-template.md
+++ b/changelog/_unreleased/2022-08-16-add-twig-blocks-for-image-to-the-product-box-card-template.md
@@ -1,0 +1,9 @@
+---
+title: Add twig blocks for image to the product box card template
+issue: NA
+author: joschka
+author_email: joschka@swk-web.com
+author_github: @tschosch51
+---
+# Storefront
+* Added blocks `component_product_box_image_link`, `component_product_box_image_link_inner`, `component_product_box_image_thumbnail` and `component_product_box_image_placeholder` for image to the product box card template

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -27,32 +27,40 @@
                                 {% set displayMode = 'cover' %}
                             {% endif %}
 
-                            <a href="{{ seoUrl('frontend.detail.page', {'productId': id}) }}"
-                               title="{{ name }}"
-                               class="product-image-link is-{{ displayMode }}">
-                                {% if cover.url %}
-                                    {% set attributes = {
-                                        'class': 'product-image is-'~displayMode,
-                                        'alt': (cover.translated.alt ?: name),
-                                        'title': (cover.translated.title ?: name)
-                                    } %}
+                            {% block component_product_box_image_link %}
+                                <a href="{{ seoUrl('frontend.detail.page', {'productId': id}) }}"
+                                   title="{{ name }}"
+                                   class="product-image-link is-{{ displayMode }}">
+                                    {% block component_product_box_image_link_inner %}
+                                        {% if cover.url %}
+                                            {% set attributes = {
+                                                'class': 'product-image is-'~displayMode,
+                                                'alt': (cover.translated.alt ?: name),
+                                                'title': (cover.translated.title ?: name)
+                                            } %}
 
-                                    {% if displayMode == 'cover' or displayMode == 'contain' %}
-                                        {% set attributes = attributes|merge({ 'data-object-fit': displayMode }) %}
-                                    {% endif %}
+                                            {% if displayMode == 'cover' or displayMode == 'contain' %}
+                                                {% set attributes = attributes|merge({ 'data-object-fit': displayMode }) %}
+                                            {% endif %}
 
-                                    {% sw_thumbnails 'product-image-thumbnails' with {
-                                        media: cover,
-                                        sizes: sizes
-                                    } %}
-                                {% else %}
-                                    <div class="product-image-placeholder">
-                                        {% sw_icon 'placeholder' style {
-                                            'size': 'fluid'
-                                        } %}
-                                    </div>
-                                {% endif %}
-                            </a>
+                                            {% block component_product_box_image_thumbnail %}
+                                                {% sw_thumbnails 'product-image-thumbnails' with {
+                                                    media: cover,
+                                                    sizes: sizes
+                                                } %}
+                                            {% endblock %}
+                                        {% else %}
+                                            {% block component_product_box_image_placeholder %}
+                                                <div class="product-image-placeholder">
+                                                    {% sw_icon 'placeholder' style {
+                                                        'size': 'fluid'
+                                                    } %}
+                                                </div>
+                                            {% endblock %}
+                                        {% endif %}
+                                    {% endblock %}
+                                </a>
+                            {% endblock %}
 
                             {% if config('core.cart.wishlistEnabled') %}
                                 {% block component_product_box_wishlist_action %}
@@ -62,7 +70,6 @@
                                     } %}
                                 {% endblock %}
                             {% endif %}
-
                         </div>
                     {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
For better customization of the image in the theme

### 2. What does this change do, exactly?
Added blocks `component_product_box_image_link`, `component_product_box_image_link_inner`, `component_product_box_image_thumbnail` and `component_product_box_image_placeholder` for image to the product box card template

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/tschosch51/platform/blob/08d482d909e28378ca918793773cead33115d282/changelog/2022-08-16-add-twig-blocks-to-product-box-image) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
