### PR TITLE
Fix unstable sort order in `ImportExport::export()` might lead to duplicate/missing entries

### DIFF
--- a/changelog/_unreleased/2022-08-18-fix-unstable-sort-order-in-export-might-lead-to-duplicate-missing-entries.md
+++ b/changelog/_unreleased/2022-08-18-fix-unstable-sort-order-in-export-might-lead-to-duplicate-missing-entries.md
@@ -1,0 +1,8 @@
+---
+title: Fix unstable sort order in `ImportExport::export()` which might lead to duplicate or missing entries
+issue: -
+author: Tobias Bachert
+author_email: tobias.bachert@horn-gmbh.com
+---
+# Core
+* Changed `ImportExport::export()` to use a tiebreaker sorting to avoid duplicate or missing entries if entries around `$exportLimit` compare as equal.

--- a/src/Core/Content/ImportExport/ImportExport.php
+++ b/src/Core/Content/ImportExport/ImportExport.php
@@ -297,6 +297,7 @@ class ImportExport
             // default sorting
             $criteria->addSorting(new FieldSorting('createdAt', FieldSorting::ASCENDING));
         }
+        $criteria->addSorting(new FieldSorting('id'));
 
         $criteria->setOffset($offset);
         $criteria->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
`ImportExport::export()` does not guarantee a stable order for the entities. Entities around `$exportLimit` might be exported a second time / skipped on the next call to `::export()` if they compare as equal according to the provided sorting.

### 2. What does this change do, exactly?
Adds a tiebreaker sorting to ensure a consistent order.

### 3. Describe each step to reproduce the issue or behaviour.
`ImportExportTest::testDefaultProperties()` can trigger this issue.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
