### PR TITLE
Update customer language on login

### DIFF
--- a/changelog/_unreleased/2022-08-22-update-customer-language-on-login.md
+++ b/changelog/_unreleased/2022-08-22-update-customer-language-on-login.md
@@ -1,0 +1,11 @@
+---
+title: Update customer language on login
+issue: https://issues.shopware.com/issues/NEXT-22927
+flag: 
+author: Alessandro Aussems
+author_email: me@alessandroaussems.be
+author_github: alessandroaussems
+___
+# Storefront
+* Update 'languageId' from customer on login (Fix NEXT-22927)
+* Added languageId to update data in LoginRoute.php

--- a/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
@@ -120,6 +120,7 @@ class LoginRoute extends AbstractLoginRoute
             [
                 'id' => $customer->getId(),
                 'lastLogin' => new \DateTimeImmutable(),
+                'languageId' => $context->getLanguageId(),
             ],
         ], $context->getContext());
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes: https://issues.shopware.com/issues/NEXT-22927


### 2. What does this change do, exactly?
Update languageId from customer to the active language from the shop on login


### 3. Describe each step to reproduce the issue or behaviour.
See: https://issues.shopware.com/issues/NEXT-22927

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-22927


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
