### PR TITLE
Change order of sw-multi-select values

### DIFF
--- a/changelog/_unreleased/2022-08-26-change-sw-multi-select-values-order.md
+++ b/changelog/_unreleased/2022-08-26-change-sw-multi-select-values-order.md
@@ -1,0 +1,10 @@
+---
+title: Change order of sw-multi-select values to the order it was selected
+issue: -
+author: Jolan De Nef
+author_email: jolan.denef@meteor.be
+author_github: JolanDeNef
+---
+# Administration
+* The order of selected values in sw-multi-select is now in order of user selection input.
+---

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-multi-select/index.js
@@ -109,8 +109,8 @@ Component.register('sw-multi-select', {
                 return [];
             }
 
-            return this.options.filter((item) => {
-                return this.currentValue.includes(this.getKey(item, this.valueProperty));
+            return this.currentValue.map((value) => {
+                return this.options.find((optionValue) => this.getKey(optionValue, this.valueProperty) === value);
             }).slice(0, this.limit);
         },
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The order of values shown in the sw-multi-select component is not the one based on user selection input, but based on the order of the optional values. In the database however, these values are saved in order of user selection input. This is somewhat strange behaviour.

### 2. What does this change do, exactly?
This changes will show selected values in order of user selection input.

### 3. Describe each step to reproduce the issue or behaviour.
- Fill in a custom field, try out the order of the selection
- Values will be shown in order of options
- When saved, order of options in database is the order of user selection input. This is also the order sent to storefront. In administration it is still the order of the options
- Values shown and values saved should be the same here, so users can use this component to save specific orders.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
