### PR TITLE
AddSorting

### DIFF
--- a/changelog/_unreleased/2022-09-06-add-better-sorting-to-plugin-list-command.md
+++ b/changelog/_unreleased/2022-09-06-add-better-sorting-to-plugin-list-command.md
@@ -1,0 +1,9 @@
+---
+title: Add sorting to plugin:list command
+issue: NEXT-23112
+author: Micha Hobert
+author_email: info@the-cake-shop.de
+author_github: Isengo1989
+---
+# Core
+* Adding sorting criteria to the plugin:list command

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Plugin\PluginCollection;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -52,6 +53,7 @@ class PluginListCommand extends Command
         $context = Context::createDefaultContext();
 
         $criteria = new Criteria();
+        $criteria->addSorting(new FieldSorting('name', FieldSorting::ASCENDING));
         $filter = $input->getOption('filter');
         if ($filter) {
             $criteria->addFilter(new MultiFilter(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The natural sorting of "humans" is ascending by names. The current sorting of the list is not very readable for most of us or does not come natural. Finding a plugin by filter is nice, but sometimes a quick overview of the list is wanted.


### 2. What does this change do, exactly?
Adds a ascending **name** sorting to the plugin list.


### 3. Describe each step to reproduce the issue or behaviour.
See above. Plugins get sorted by names 

1. Adding Info Plugin
2. Benefit Slider Plugin
3. Super Duper Plugin

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-23112

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [] I have written or adjusted the documentation according to my changes
- [] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
