### PR TITLE
NEXT-19510: Fix tax calculation when setting shipping cost to 0 using adminstration

### DIFF
--- a/changelog/_unreleased/2022-09-06-fix-setting-shipping-cost-zero-in-admin.md
+++ b/changelog/_unreleased/2022-09-06-fix-setting-shipping-cost-zero-in-admin.md
@@ -1,0 +1,10 @@
+---
+title: fix-setting-shipping-cost-zero-in-admin
+issue: NEXT-19510
+author: Felix von WIRDUZEN
+author_email: felix@wirduzen.de
+author_github: @wirduzen-felix
+---
+# Core
+* Fixed a problem where the shipping cost was set to 0 but the shipping cost tax was not. Reverted changes from 
+commit `89b3ee8` in `DeliveryProcessor.php` and added additional condition in `DeliveryCalculator.php`

--- a/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryCalculator.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Checkout\Cart\Delivery;
 
 use Shopware\Core\Checkout\Cart\Cart;
-use Shopware\Core\Checkout\Cart\CartBehavior;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\Delivery;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryCollection;
 use Shopware\Core\Checkout\Cart\LineItem\CartDataCollection;
@@ -90,11 +89,11 @@ class DeliveryCalculator
          * $adminShippingFree is set to true, when the shipping cost is set to 0 from the administration
          */
         $adminShippingFree = false;
-        if(
+        if (
             $behavior
             && $behavior->hasPermission(DeliveryProcessor::SKIP_DELIVERY_PRICE_RECALCULATION)
             && $delivery->getShippingCosts()->getUnitPrice() === 0.0
-        ){
+        ) {
             $adminShippingFree = true;
         }
 

--- a/src/Core/Checkout/Cart/Delivery/DeliveryProcessor.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryProcessor.php
@@ -107,12 +107,6 @@ class DeliveryProcessor implements CartProcessorInterface, CartDataCollectorInte
 
                 $originalDelivery = $originalDeliveries->first();
 
-                if ($originalDelivery !== null && $originalDelivery->getShippingCosts()->getTotalPrice() === 0.0) {
-                    $toCalculate->setDeliveries($originalDeliveries);
-
-                    return;
-                }
-
                 if ($delivery !== null && $originalDelivery !== null) {
                     $originalDelivery->setShippingMethod($delivery->getShippingMethod());
 

--- a/src/Core/Checkout/Test/Cart/Delivery/DeliveryCalculatorTest.php
+++ b/src/Core/Checkout/Test/Cart/Delivery/DeliveryCalculatorTest.php
@@ -1920,7 +1920,9 @@ class DeliveryCalculatorTest extends TestCase
             )
         );
         $lineItem1->setPrice(
-            new CalculatedPrice(42, 42,
+            new CalculatedPrice(
+                42,
+                42,
                 new CalculatedTaxCollection([new CalculatedTax(42, 19, 42)]),
                 new TaxRuleCollection([new TaxRule(19)])
             )
@@ -1944,12 +1946,14 @@ class DeliveryCalculatorTest extends TestCase
 
         $cart = new Cart('test3', 'test3');
         $cart->setBehavior(new CartBehavior([
-            DeliveryProcessor::SKIP_DELIVERY_PRICE_RECALCULATION => true
+            DeliveryProcessor::SKIP_DELIVERY_PRICE_RECALCULATION => true,
         ]));
 
         /** @var Delivery $delivery */
         $delivery = $deliveries->first();
-        $delivery->setShippingCosts(new CalculatedPrice(0, 0,
+        $delivery->setShippingCosts(new CalculatedPrice(
+            0,
+            0,
             $delivery->getShippingCosts()->getCalculatedTaxes(),
             $delivery->getShippingCosts()->getTaxRules()
         ));

--- a/src/Core/Checkout/Test/Cart/Delivery/DeliveryProcessorTest.php
+++ b/src/Core/Checkout/Test/Cart/Delivery/DeliveryProcessorTest.php
@@ -123,6 +123,12 @@ class DeliveryProcessorTest extends TestCase
 
         $calculatedCart = new Cart('calculated', 'calculated');
 
+        $cartBehavior = new CartBehavior([
+            DeliveryProcessor::SKIP_DELIVERY_PRICE_RECALCULATION => true,
+        ]);
+
+        $calculatedCart->setBehavior($cartBehavior);
+
         $lineItem = new LineItem('test', LineItem::PRODUCT_LINE_ITEM_TYPE);
         $lineItem->setDeliveryInformation(new DeliveryInformation(5, 0, false));
         $lineItem->setPrice(new CalculatedPrice(5.0, 5.0, new CalculatedTaxCollection([
@@ -130,10 +136,6 @@ class DeliveryProcessorTest extends TestCase
         ]), new TaxRuleCollection()));
 
         $calculatedCart->setLineItems(new LineItemCollection([$lineItem]));
-
-        $cartBehavior = new CartBehavior([
-            DeliveryProcessor::SKIP_DELIVERY_PRICE_RECALCULATION => true,
-        ]);
 
         static::assertCount(0, $calculatedCart->getDeliveries());
 


### PR DESCRIPTION
**This needs to be merged before 6.4.15.0 is released as it contains a fix for a tax calculation bug introduced in said version.**

### 1. Why is this change necessary?
In commit [`89b3ee8`](https://github.com/shopware/platform/commit/89b3ee83c35e9cbb2a9cefb1f810fa13b90a79bd) a bug was introduced that leads to a mistake in the tax calculation when shipping cost is set to 0 using the administration. 

In order to allow users to change shipping costs to 0 using the administration, this commit changed the `DeliveryProcessor.php` to skip recalculation when the delivery cost is 0. This causes a mistake in tax calculation, because the DeliveryPosition now has a unit price of 0, but still has the old tax value (See screenshot below). 

![image](https://user-images.githubusercontent.com/88590092/188732271-21f06694-cd4f-49a5-b8f6-341d657436a7.png)

See how the tax calculation doesn't seem to make any sense in this example.

### 2. What does this change do, exactly?

This reverts some of the changes made in commit [`89b3ee8`](https://github.com/shopware/platform/commit/89b3ee83c35e9cbb2a9cefb1f810fa13b90a79bd) and moves the logic for allowing the user to set the shipping cost to zero into the `DeliveryCalculator.php`. 

### 3. Describe each step to reproduce the issue or behaviour.

This bug only exists in the current trunk version of shopware. When using this version:

1. Change shipping cost of an order to 0 in the administration
2. See how the tax calculation doesn't make any sense anymore 

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-19510

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
