### PR TITLE
Fix Plugin Template Order

### DIFF
--- a/changelog/2022-09-07-fix-plugin-template-order.md
+++ b/changelog/2022-09-07-fix-plugin-template-order.md
@@ -1,0 +1,8 @@
+---
+title: Fix Plugin Template Order
+author: Fayti1703
+author_email: fayti1703@protonmail.com
+author_github: Fayti1703
+---
+# Storefront
+* Changed `ThemeInheritanceBuilder->build` to fix the order in which plugin templates are loaded if a theme is active.

--- a/src/Storefront/Theme/Twig/ThemeInheritanceBuilder.php
+++ b/src/Storefront/Theme/Twig/ThemeInheritanceBuilder.php
@@ -43,6 +43,11 @@ class ThemeInheritanceBuilder implements ThemeInheritanceBuilderInterface
             $inheritance['@Plugins'][] = $bundle;
         }
 
+        /* Reverse the order here so our reversal after flattening doesn't
+         * collaterally invert our desired plugin order.
+         */
+        $inheritance['@Plugins'] = array_reverse($inheritance['@Plugins']);
+
         $flat = [];
         foreach ($inheritance as $namespace) {
             foreach ($namespace as $bundle) {

--- a/tests/unit/php/Storefront/Theme/Twig/ThemeInheritanceBuilderTest.php
+++ b/tests/unit/php/Storefront/Theme/Twig/ThemeInheritanceBuilderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Shopware\Tests\Unit\Storefront\Theme\Twig;
+
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationCollection;
+use Shopware\Storefront\Theme\StorefrontPluginRegistryInterface;
+use Shopware\Storefront\Theme\Twig\ThemeInheritanceBuilder;
+use PHPUnit\Framework\TestCase;
+
+class ThemeInheritanceBuilderTest extends TestCase {
+
+    private ThemeInheritanceBuilder $builder;
+
+    public function setUp(): void {
+        $this->builder = new ThemeInheritanceBuilder(new TestStorefrontPluginRegistry(
+            new StorefrontPluginConfigurationCollection([
+                new StorefrontPluginConfiguration("Storefront")
+            ])
+        ));
+    }
+
+    public function testBuildPreservesThePluginOrder() {
+        $result = $this->builder->build([
+            "ExtensionPlugin" => [],
+            "BasePlugin" => [],
+            "Storefront" => [],
+        ], [
+            "Storefront" => []
+        ]);
+
+
+        static::assertSame([
+            "ExtensionPlugin" => [],
+            "BasePlugin" => [],
+            "Storefront" => []
+        ], $result);
+	}
+}
+
+/** @internal */
+class TestStorefrontPluginRegistry implements StorefrontPluginRegistryInterface {
+
+    private StorefrontPluginConfigurationCollection $plugins;
+
+    public function __construct(StorefrontPluginConfigurationCollection $plugins) {
+        $this->plugins = $plugins;
+    }
+
+    public function getConfigurations(): StorefrontPluginConfigurationCollection {
+        return $this->plugins;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
If a plugin `B` provides a new storefront template file which is included via a bundle name that is not its own(\*) (e.g. CMS elements, which are always included with `@Storefront`), and another plugin `E` tries to extend it, `E`'s template is not loaded unless it is installed before `B` (which cannot happen if `E` declares `B` as one of its `composer.json` `require`ments).

(\* This is necessary because the template loader always loads from the provided bundle's template files last.)

### 2. What does this change do, exactly?
It corrects the order in which plugin template files are loaded. Without the Storefront `ThemeInheritanceBuilder`, plugin templates are loaded in reverse order of installation (so the last installed plugin's templates are loaded first). The `ThemeInheritanceBuilder` flips this order, seemingly by accident.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create and install a plugin `B` that defines a new CMS element (or provides any other new template file that is included via the `@Storefront` bundle)
2. Create and install a plugin `E` that extends the template from `B`.
3. Observe how `E`'s template is completely ignored.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.