### PR TITLE
Changing language-string for privacyNotice

### DIFF
--- a/changelog/_unreleased/2022-09-14-fix_tos-not-mandatory-for-contact.md
+++ b/changelog/_unreleased/2022-09-14-fix_tos-not-mandatory-for-contact.md
@@ -6,6 +6,6 @@ author_github: jonas-sfx
 ---
 # Storefront
 * Changed: `src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json`
-  * Language-String general.privacyNotice changed as long as TOS/T&Cs-agreement is not mandatory for contact/newsletter
+  * Added language-String contact.privacyNotice because TOS/T&Cs-agreement is not mandatory for contact/newsletter
 * Changed: `src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json`
-  *  Language-String general.privacyNotice changed (English Translation, same reason.)
+  * Added language-String contact.privacyNotice (English Translation, same reason.)

--- a/changelog/_unreleased/2022-09-14-fix_tos-not-mandatory-for-contact.md
+++ b/changelog/_unreleased/2022-09-14-fix_tos-not-mandatory-for-contact.md
@@ -1,0 +1,11 @@
+---
+title: Checkbox for Contact/Newsletter: agreeing 
+author: jonas-sfx
+author_email: jonas@sfxonline.de
+author_github: jonas-sfx
+---
+# Storefront
+* Changed: `src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json`
+  * Language-String general.privacyNotice changed as long as TOS/T&Cs-agreement is not mandatory for contact/newsletter
+* Changed: `src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json`
+  *  Language-String general.privacyNotice changed (English Translation, same reason.)

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -25,7 +25,7 @@
     "required": "*",
     "requiredFields": "Die mit einem Stern (*) markierten Felder sind Pflichtfelder.",
     "privacyTitle": "Datenschutz",
-    "privacyNotice": "Ich habe die <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Datenschutzbestimmungen\">Datenschutzbestimmungen</a> zur Kenntnis genommen und die <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%tosUrl%\" href=\"%tosUrl%\" title=\"AGB\">AGB</a> gelesen und bin mit ihnen einverstanden.",
+    "privacyNotice": "Ich habe die <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Datenschutzbestimmungen\">Datenschutzbestimmungen</a> zur Kenntnis genommen und erkenne diese an.",
     "privacyLink": "Datenschutz",
     "imprintLink": "Impressum",
     "404ErrorPageHeader": "Seite nicht gefunden",

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -25,7 +25,7 @@
     "required": "*",
     "requiredFields": "Die mit einem Stern (*) markierten Felder sind Pflichtfelder.",
     "privacyTitle": "Datenschutz",
-    "privacyNotice": "Ich habe die <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Datenschutzbestimmungen\">Datenschutzbestimmungen</a> zur Kenntnis genommen und erkenne diese an.",
+    "privacyNotice": "Ich habe die <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Datenschutzbestimmungen\">Datenschutzbestimmungen</a> zur Kenntnis genommen und die <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%tosUrl%\" href=\"%tosUrl%\" title=\"AGB\">AGB</a> gelesen und bin mit ihnen einverstanden.",
     "privacyLink": "Datenschutz",
     "imprintLink": "Impressum",
     "404ErrorPageHeader": "Seite nicht gefunden",
@@ -486,6 +486,7 @@
     "subjectPlaceholder": "Betreff eingeben ...",
     "commentLabel": "Kommentar",
     "commentPlaceholder": "Kommentar eingeben ...",
+    "privacyNotice": "Ich habe die <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Datenschutzbestimmungen\">Datenschutzbestimmungen</a> zur Kenntnis genommen und erkenne diese an.",
     "formSubmit": "Abschicken",
     "success": "Wir haben Ihre Kontaktanfrage erhalten und werden sie schnellstmöglich bearbeiten."
   },

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -25,7 +25,7 @@
     "required": "*",
     "requiredFields": "Fields marked with asterisks (*) are required.",
     "privacyTitle": "Privacy",
-    "privacyNotice": "By selecting continue you confirm that you have read our <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Data protection information\">data protection information</a> and accepted our <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%tosUrl%\" href=\"%tosUrl%\" title=\"general terms and conditions\">general terms and conditions</a>.",
+    "privacyNotice": "By selecting continue you confirm that you have read and agree to our <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Data protection information\">data protection information</a>.",
     "privacyLink": "Privacy policy",
     "imprintLink": "Imprint",
     "404ErrorPageHeader": "Page not found",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -25,7 +25,7 @@
     "required": "*",
     "requiredFields": "Fields marked with asterisks (*) are required.",
     "privacyTitle": "Privacy",
-    "privacyNotice": "By selecting continue you confirm that you have read and agree to our <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Data protection information\">data protection information</a>.",
+    "privacyNotice": "By selecting continue you confirm that you have read our <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Data protection information\">data protection information</a> and accepted our <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%tosUrl%\" href=\"%tosUrl%\" title=\"general terms and conditions\">general terms and conditions</a>.",
     "privacyLink": "Privacy policy",
     "imprintLink": "Imprint",
     "404ErrorPageHeader": "Page not found",
@@ -486,6 +486,7 @@
     "subjectPlaceholder": "Enter subject...",
     "commentLabel": "Comment",
     "commentPlaceholder": "Enter comment...",
+    "privacyNotice": "By selecting continue you confirm that you have read and agree to our <a data-toggle=\"modal\" data-bs-toggle=\"modal\" data-url=\"%privacyUrl%\" href=\"%privacyUrl%\" title=\"Data protection information\">data protection information</a>.",
     "formSubmit": "Submit",
     "success": "We have received your contact request and will process it as soon as possible."
   },

--- a/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
@@ -1,4 +1,8 @@
 {% block component_privacy_notice %}
+    {% set privacyNotice = 'contact.privacyNotice' %}
+    {% if controllerAction is same as ('checkoutRegisterPage') %}
+    {% set privacyNotice = 'general.privacyNotice' %}
+    {% endif %}
     <div class="form-text privacy-notice">
         {% block component_privacy_title %}
             <strong>{{ "general.privacyTitle"|trans|sw_sanitize }}</strong><br/>
@@ -21,7 +25,7 @@
                         <label class="custom-control-label no-validation"
                                for="acceptedDataProtection">
                             {# @deprecated tag:v6.5.0 - Translation parameter %url% will be removed, use %privacyUrl% and %tosUrl% instead #}
-                            {{ "general.privacyNotice"|trans({
+                            {{ privacyNotice|trans({
                                 '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') }),
                                 '%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') }),
                                 '%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage') })
@@ -36,7 +40,7 @@
                     {% block component_privacy_label %}
                         <label>
                             {# @deprecated tag:v6.5.0 - Translation parameter %url% will be removed, use %privacyUrl% and %tosUrl% instead #}
-                            {{ "general.privacyNotice"|trans({
+                            {{ privacyNotice|trans({
                                 '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') }),
                                 '%privacyUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.privacyPage') }),
                                 '%tosUrl%': path('frontend.cms.page',{ id: config('core.basicInformation.tosPage') })

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -16,11 +16,10 @@
 
         {% block cms_form_privacy_opt_in_label %}
             <label for="{{ identifierTemplate|format(_key) }}" class="{{ formCheckLabelClass }}">
-                {# @deprecated tag:v6.5.0 - Translation parameter %url% will be removed, use %privacyUrl% and %tosUrl% instead #}
-                {{ "general.privacyNotice"|trans({
+                {# @deprecated tag:v6.5.0 - Translation parameter %url% will be removed, use %privacyUrl% instead #}
+                {{ "contact.privacyNotice"|trans({
                     '%url%': path('frontend.cms.page', { id: config('core.basicInformation.privacyPage') }),
-                    '%privacyUrl%': path('frontend.cms.page', { id: config('core.basicInformation.privacyPage') }),
-                    '%tosUrl%': path('frontend.cms.page', { id: config('core.basicInformation.tosPage')} )
+                    '%privacyUrl%': path('frontend.cms.page', { id: config('core.basicInformation.privacyPage') })
                 })|raw }}
             </label>
         {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Agreeing to the TOS/T&Cs is not mandatory for newsletter-recipients/contact-form users.
By law this requirement is even to much.

### 2. What does this change do, exactly?
I just removed thid part out of a language-string.

### 3. Describe each step to reproduce the issue or behaviour.
You can see this Textblock in Contactforms or Newsletter-Registration-Forms next to a Checkbox that users have to activate.

### 4. Please link to the relevant issues (if any).
[NEXT-23192](https://issues.shopware.com/issues/NEXT-23192)

### 5. Checklist

- [✅ ] I have rebased my changes to remove merge conflicts
- [ ✗] I have written tests and verified that they fail without my change
- [ ✅] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [✗ ] I have written or adjusted the documentation according to my changes
- [ ✗] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ✅] I have read the contribution requirements and fulfil them.
