### PR TITLE
add current context to the event dispatched on cart restore

### DIFF
--- a/changelog/_unreleased/2022-09-16-add-current-context-to-event-dispatched-on-cart-restore.md
+++ b/changelog/_unreleased/2022-09-16-add-current-context-to-event-dispatched-on-cart-restore.md
@@ -1,0 +1,10 @@
+---
+title: Add current SalesChannelContext to the SalesChannelContextRestoredEvent
+author: stuzzo
+author_email: stuzzo@gmail.com
+author_github: stuzzo
+---
+
+# Core
+
+* Modified the SalesChannelContextRestoredEvent to return also the current context in addition to the future / restored one 

--- a/src/Core/System/SalesChannel/Context/CartRestorer.php
+++ b/src/Core/System/SalesChannel/Context/CartRestorer.php
@@ -82,7 +82,7 @@ class CartRestorer
         $cartWithErrors->setErrors($errors);
         $this->cartService->setCart($cartWithErrors);
 
-        $this->eventDispatcher->dispatch(new SalesChannelContextRestoredEvent($customerContext));
+        $this->eventDispatcher->dispatch(new SalesChannelContextRestoredEvent($customerContext, $currentContext));
 
         return $customerContext;
     }

--- a/src/Core/System/SalesChannel/Event/SalesChannelContextRestoredEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelContextRestoredEvent.php
@@ -13,9 +13,15 @@ class SalesChannelContextRestoredEvent extends NestedEvent
      */
     protected $restoredContext;
 
-    public function __construct(SalesChannelContext $restoredContext)
+    /**
+     * @var SalesChannelContext|null
+     */
+    protected $currentContext;
+
+    public function __construct(SalesChannelContext $restoredContext, SalesChannelContext $currentContext = null)
     {
         $this->restoredContext = $restoredContext;
+        $this->currentContext = $currentContext;
     }
 
     public function getRestoredSalesChannelContext(): SalesChannelContext
@@ -26,5 +32,10 @@ class SalesChannelContextRestoredEvent extends NestedEvent
     public function getContext(): Context
     {
         return $this->restoredContext->getContext();
+    }
+
+    public function getCurrentContext(): ?SalesChannelContext
+    {
+        return $this->currentContext;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

To be able in a SalesChannelContextRestoredEvent subscriber to retrieve the current context in addition to the new customer context created in the restore function. 

### 2. What does this change do, exactly?

Add the current context to the SalesChannelContextRestoredEvent.

### 3. Describe each step to reproduce the issue or behavior.

- Add a subscriber to the SalesChannelContextRestoredEvent
- Execute a cart restore, e.g. Do a login from the API
- Verify that you will be able to retrieve the two contexts related to SalesChannelContextRestoredEvent

### 4. Please link to the relevant issues (if any).

[GitHub ISSUE-2679](https://github.com/shopware/platform/issues/2679)
[Shopware NEXT-23274](https://issues.shopware.com/issues/NEXT-23274)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them.
