### PR TITLE
Shipping price calculation accessible

### DIFF
--- a/changelog/_unreleased/2022-09-16-allow-delivery-build-with-given-shipping-method.md
+++ b/changelog/_unreleased/2022-09-16-allow-delivery-build-with-given-shipping-method.md
@@ -1,0 +1,10 @@
+---
+title: allow-delivery-build-with-given-shipping-method
+issue: NEXT-23265
+author: j.steinkamp
+author_email: j.steinkamp@basecom.de
+author_github: jonthn4
+---
+# Core
+* add public method inside `\Shopware\Core\Checkout\Cart\Delivery\DeliveryBuilder` to build delivery based on specific given shipping method
+___

--- a/src/Core/Checkout/Cart/Delivery/DeliveryBuilder.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryBuilder.php
@@ -32,6 +32,11 @@ class DeliveryBuilder
         /** @var ShippingMethodEntity $shippingMethod */
         $shippingMethod = $data->get($key);
 
+        return $this->buildByUsingShippingMethod($cart, $shippingMethod, $context);
+    }
+
+    public function buildByUsingShippingMethod(Cart $cart, ShippingMethodEntity $shippingMethod, SalesChannelContext $context): DeliveryCollection
+    {
         $delivery = $this->buildSingleDelivery($shippingMethod, $cart->getLineItems(), $context);
 
         if (!$delivery) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Improvement for shopware extension development. 
Currently it is only possible to calculate the shipping method prices based on current rules and advanced prices, when changing the selected shipping method of the current context and by that, triggering the whole cart collect/process logic. This means it is not possible, to show the customer the calculated prices of all the currently available shipping methods in checkout, at least not without running into performance issues.

### 2. What does this change do, exactly?
Adds a public method inside the DeliveryBuilder for building a deliveries based on a specific given shipping method

### 3. Describe each step to reproduce the issue or behaviour.
Recalculate a cart with each available shipping method to get the calculated price of the shipping method based on cart and rules. This causes performance issues.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-23265

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
