### PR TITLE
NEXT-21273 media link chooser 

### DIFF
--- a/changelog/_unreleased/2024-05-14-add-media-option-to-cms-link-selector.md
+++ b/changelog/_unreleased/2024-05-14-add-media-option-to-cms-link-selector.md
@@ -1,0 +1,12 @@
+---
+title: Add Media Option to CMS Link Selector
+issue: NEXT-21273
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Administration
+* Added option to choose media files in CMS link selector, links stay functional even if the file contents or name change.
+___
+# Storefront
+* Added `\Shopware\Core\Content\Media\MediaUrlPlaceholderHandler` to replace the ID based URL in the storefront. 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/index.ts
@@ -8,7 +8,7 @@ const { Component } = Shopware;
 const { Criteria, EntityCollection } = Shopware.Data;
 
 type ButtonVariant = 'primary' | 'primary-sm' | 'secondary' | 'secondary-sm';
-type LinkCategories = 'link' | 'detail' | 'navigation' | 'email' | 'phone';
+type LinkCategories = 'link' | 'detail' | 'navigation' | 'media' | 'email' | 'phone';
 interface TextEditorLinkMenuConfig {
     title: string,
     icon: string,
@@ -157,9 +157,11 @@ Component.register('sw-text-editor-link-menu', {
         async parseLink(link: string, detectedLinkType: string): Promise<{ type: LinkCategories, target: string }> {
             const slicedLink = link.slice(0, -1).split('/');
 
-            if (link.startsWith(this.seoUrlReplacePrefix) && ['navigation', 'detail'].includes(slicedLink[1])) {
+            if (link.startsWith(this.seoUrlReplacePrefix) && ['navigation', 'detail', 'mediaId'].includes(slicedLink[1])) {
                 if (slicedLink[1] === 'navigation') {
                     this.categoryCollection = await this.getCategoryCollection(slicedLink[2]);
+                } else if (slicedLink[1] === 'mediaId') {
+                    slicedLink[1] = 'media';
                 }
                 return { type: slicedLink[1] as LinkCategories, target: slicedLink[2] };
             }
@@ -198,6 +200,8 @@ Component.register('sw-text-editor-link-menu', {
                     return `${this.seoUrlReplacePrefix}/detail/${this.linkTarget}#`;
                 case 'navigation':
                     return `${this.seoUrlReplacePrefix}/navigation/${this.linkTarget}#`;
+                case 'media':
+                    return `${this.seoUrlReplacePrefix}/mediaId/${this.linkTarget}#`;
                 case 'email':
                     return `mailto:${this.linkTarget}`;
                 case 'phone':

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.html.twig
@@ -23,6 +23,9 @@
             <option value="navigation">
                 {{ $tc('sw-text-editor-toolbar.link.labelCategory') }}
             </option>
+            <option value="media">
+                {{ $tc('sw-text-editor-toolbar.link.labelMedia') }}
+            </option>
             <option value="email">
                 {{ $tc('sw-text-editor-toolbar.link.labelEmail') }}
             </option>
@@ -97,6 +100,17 @@
             @selection-remove="removeCategorySelection"
         />
         {% endblock %}
+        {% endblock %}
+
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_text_editor_toolbar_button_link_menu_content_type_inputs_media %}
+        <sw-media-field
+            v-else-if="linkCategory === 'media'"
+            v-model:value="linkTarget"
+            :label="$tc('sw-text-editor-toolbar.link.linkTo')"
+            :criteria="entityFilter"
+            single-select
+        />
         {% endblock %}
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -1190,6 +1190,7 @@
       "labelLink": "Link",
       "labelProduct": "Produkt",
       "labelCategory":"Kategorie",
+      "labelMedia": "Datei",
       "labelEmail": "E-Mail-Adresse",
       "labelPhoneNumber": "Telefonnummer",
       "placeholderPhoneNumber": "Telefonnummer eingeben ...",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -1190,6 +1190,7 @@
       "labelLink": "Link",
       "labelProduct": "Product",
       "labelCategory":"Category",
+      "labelMedia": "File",
       "labelEmail": "Email address",
       "labelPhoneNumber": "Phone number",
       "placeholderPhoneNumber": "Enter phone number...",

--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -244,6 +244,11 @@
             <argument type="service" id="Shopware\Core\Content\Media\File\FileFetcher"/>
         </service>
 
+        <service id="Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface" class="Shopware\Core\Content\Media\MediaUrlPlaceholderHandler" public="true">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Content\Media\Core\Application\AbstractMediaUrlGenerator"/>
+        </service>
+
         <service id="Shopware\Core\Content\Media\Cms\DefaultMediaResolver">
             <argument type="service" id="shopware.filesystem.public"/>
         </service>

--- a/src/Core/Content/Media/MediaUrlPlaceholderHandler.php
+++ b/src/Core/Content/Media/MediaUrlPlaceholderHandler.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Media;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Media\Core\Params\UrlParams;
+use Shopware\Core\Content\Media\Core\Params\UrlParamsSource;
+use Shopware\Core\Content\Media\Infrastructure\Path\MediaUrlGenerator;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Profiling\Profiler;
+
+#[Package('buyers-experience')]
+class MediaUrlPlaceholderHandler implements MediaUrlPlaceholderHandlerInterface
+{
+    final public const DOMAIN_PLACEHOLDER = '124c71d524604ccbad6042edce3ac799';
+
+    private const PREFIX = '/mediaId/';
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly MediaUrlGenerator $mediaUrlGenerator
+    ) {
+    }
+
+    public function replace(string $content): string
+    {
+        return Profiler::trace('media-url-replacer', function () use ($content) {
+            $matches = [];
+
+            if (preg_match_all('/' . self::DOMAIN_PLACEHOLDER . preg_quote(self::PREFIX, '/') . '[^#]*#/', $content, $matches)) {
+                $seoMapping = $this->createMediaMapping($matches[0]);
+
+                return (string) preg_replace_callback('/' . self::DOMAIN_PLACEHOLDER . preg_quote(self::PREFIX, '/') . '[^#]*#/', static function (array $match) use ($seoMapping) {
+                    return $seoMapping[$match[0]] ?? $match[0];
+                }, $content);
+            }
+
+            return $content;
+        });
+    }
+
+    /**
+     * @param array<string> $matches
+     *
+     * @return array<string>
+     */
+    private function createMediaMapping(array $matches): array
+    {
+        if (empty($matches)) {
+            return [];
+        }
+
+        $mediaIds = [];
+        foreach ($matches as $item) {
+            $mediaIds[] = Uuid::fromHexToBytes(substr($item, \strlen(self::DOMAIN_PLACEHOLDER) + \strlen(self::PREFIX), -1));
+        }
+        $query = new QueryBuilder($this->connection);
+        $query->setTitle('media_url::replacement');
+        $query->addSelect(['id', 'path', 'updated_at', 'created_at']);
+        $query->from('media');
+        $query->andWhere('id IN (:mediaIds)');
+        $query->setParameter('mediaIds', $mediaIds, ArrayParameterType::BINARY);
+
+        $mediaUrls = $query->executeQuery()->fetchAllAssociative();
+
+        $urlParams = [];
+        foreach ($mediaUrls as $record) {
+            $id = Uuid::fromBytesToHex($record['id']);
+            $urlParams[$id] = new UrlParams(
+                $id,
+                UrlParamsSource::MEDIA,
+                $record['path'],
+                new \DateTime($record['updated_at'] ?? $record['created_at']),
+            );
+        }
+        $urls = $this->mediaUrlGenerator->generate($urlParams);
+
+        $mapping = [];
+        foreach ($urls as $id => $url) {
+            $key = self::DOMAIN_PLACEHOLDER . self::PREFIX . $id . '#';
+            $mapping[$key] = $url;
+        }
+
+        return $mapping;
+    }
+}

--- a/src/Core/Content/Media/MediaUrlPlaceholderHandlerInterface.php
+++ b/src/Core/Content/Media/MediaUrlPlaceholderHandlerInterface.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Media;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('buyers-experience')]
+interface MediaUrlPlaceholderHandlerInterface
+{
+    public function replace(string $content): string;
+}

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Controller;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Error\Error;
 use Shopware\Core\Checkout\Cart\Error\ErrorRoute;
+use Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Log\Package;
@@ -57,6 +58,7 @@ abstract class StorefrontController extends AbstractController
         $services[SystemConfigService::class] = SystemConfigService::class;
         $services[TemplateFinder::class] = TemplateFinder::class;
         $services[SeoUrlPlaceholderHandlerInterface::class] = SeoUrlPlaceholderHandlerInterface::class;
+        $services[MediaUrlPlaceholderHandlerInterface::class] = MediaUrlPlaceholderHandlerInterface::class;
         $services[ScriptExecutor::class] = ScriptExecutor::class;
         $services['translator'] = TranslatorInterface::class;
         $services[RequestTransformerInterface::class] = RequestTransformerInterface::class;
@@ -96,9 +98,12 @@ abstract class StorefrontController extends AbstractController
         $host = $request->attributes->get(RequestTransformer::STOREFRONT_URL);
 
         $seoUrlReplacer = $this->container->get(SeoUrlPlaceholderHandlerInterface::class);
+        $mediaUrlReplacer = $this->container->get(MediaUrlPlaceholderHandlerInterface::class);
         $content = $response->getContent();
 
         if ($content !== false) {
+            $content = $mediaUrlReplacer->replace($content);
+
             $response->setContent(
                 $seoUrlReplacer->replace($content, $host, $salesChannelContext)
             );

--- a/tests/unit/Core/Content/Media/MediaUrlPlaceholderHandlerTest.php
+++ b/tests/unit/Core/Content/Media/MediaUrlPlaceholderHandlerTest.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Media;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Result;
+use League\Flysystem\Filesystem;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\Infrastructure\Path\MediaUrlGenerator;
+use Shopware\Core\Content\Media\MediaUrlPlaceholderHandler;
+use Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('buyers-experience')]
+#[CoversClass(MediaUrlPlaceholderHandler::class)]
+class MediaUrlPlaceholderHandlerTest extends TestCase
+{
+    private MockObject&Connection $connection;
+
+    private MediaUrlPlaceholderHandlerInterface $mediaUrlPlaceholderHandler;
+
+    private const MEDIA1_ID = 'ade8de5aba434c6c8b871e7785d57596';
+    private const MEDIA2_ID = 'f120665e491849d38f1a94e912fbc7e3';
+    private const MEDIA3_ID = 'b897b4b7c8394387ac88341951816613';
+    private const PRODUCT_ID = 'ad518375caa8445caad158291c0c5234';
+    private const DATETIME = '2024-05-14 13:37:00';
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->createMock(Connection::class);
+        $this->connection->method('getDatabasePlatform')->willReturn($this->createMock(AbstractPlatform::class));
+
+        $fileSystemOperator = $this->createMock(Filesystem::class);
+        $fileSystemOperator->expects(static::any())->method('publicUrl')->willReturnCallback(function ($path) {
+            return 'http://foo.text:8000/' . $path;
+        });
+
+        $this->mediaUrlPlaceholderHandler = new MediaUrlPlaceholderHandler(
+            $this->connection,
+            new MediaUrlGenerator($fileSystemOperator)
+        );
+    }
+
+    /**
+     * @return iterable<string, array<string, string>>
+     */
+    public static function replaceDataProvider(): iterable
+    {
+        yield 'one url' => [
+            'content' => 'Test content with url ' . MediaUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . '/mediaId/' . self::MEDIA1_ID . '#.',
+            'expected' => 'Test content with url http://foo.text:8000/media/12/34/cat.pdf?ts=' . strtotime(self::DATETIME) . '.',
+        ];
+
+        yield 'two urls' => [
+            'content' => 'Test URL 1: ' . MediaUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . '/mediaId/' . self::MEDIA1_ID . '# and URL 2: '
+                . MediaUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . '/mediaId/' . self::MEDIA2_ID . '#',
+            'expected' => 'Test URL 1: http://foo.text:8000/media/12/34/cat.pdf?ts=' . strtotime(self::DATETIME) . ' and URL 2: http://foo.text:8000/media/56/78/dog.pdf?ts=' . strtotime(self::DATETIME),
+        ];
+
+        yield 'two equal urls' => [
+            'content' => 'Test URL 1: ' . MediaUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . '/mediaId/' . self::MEDIA1_ID . '# and URL 2: '
+                . MediaUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . '/mediaId/' . self::MEDIA1_ID . '#',
+            'expected' => 'Test URL 1: http://foo.text:8000/media/12/34/cat.pdf?ts=' . strtotime(self::DATETIME) . ' and URL 2: http://foo.text:8000/media/12/34/cat.pdf?ts=' . strtotime(self::DATETIME),
+        ];
+
+        yield 'product urls left untouched' => [
+            'content' => 'Test URL 1: ' . MediaUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . '/mediaId/' . self::MEDIA1_ID . '# and URL 2: ' . MediaUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . '/detail/' . self::PRODUCT_ID . '#',
+            'expected' => 'Test URL 1: http://foo.text:8000/media/12/34/cat.pdf?ts=' . strtotime(self::DATETIME) . ' and URL 2: ' . MediaUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . '/detail/' . self::PRODUCT_ID . '#',
+        ];
+
+        yield 'handle not found' => [
+            'content' => 'Test URL 1: ' . MediaUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . '/mediaId/' . self::MEDIA3_ID,
+            'expected' => 'Test URL 1: ' . MediaUrlPlaceholderHandler::DOMAIN_PLACEHOLDER . '/mediaId/' . self::MEDIA3_ID,
+        ];
+    }
+
+    #[DataProvider('replaceDataProvider')]
+    public function testReplace(string $content, string $expected): void
+    {
+        $result = $this->createMock(Result::class);
+        $result->expects(static::any())->method('fetchAllAssociative')->willReturn([
+            [
+                'id' => Uuid::fromHexToBytes(self::MEDIA1_ID),
+                'path' => 'media/12/34/cat.pdf',
+                'created_at' => self::DATETIME,
+                'updated_at' => self::DATETIME,
+            ],
+            [
+                'id' => Uuid::fromHexToBytes(self::MEDIA2_ID),
+                'path' => 'media/56/78/dog.pdf',
+                'created_at' => self::DATETIME,
+                'updated_at' => self::DATETIME,
+            ],
+        ]);
+        $this->connection->method('executeQuery')->willReturn($result);
+        static::assertSame($expected, $this->mediaUrlPlaceholderHandler->replace($content));
+    }
+}

--- a/tests/unit/Storefront/Controller/StorefrontControllerTest.php
+++ b/tests/unit/Storefront/Controller/StorefrontControllerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Error\Error;
 use Shopware\Core\Checkout\Cart\Error\GenericCartError;
+use Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Context;
@@ -83,6 +84,9 @@ class StorefrontControllerTest extends TestCase
             ->with('<html lang="en">test</html>', 'foo', $context)
             ->willReturn('<html lang="en">test</html>');
 
+        $mediaUrlHandler = $this->createMock(MediaUrlPlaceholderHandlerInterface::class);
+        $mediaUrlHandler->method('replace')->willReturnArgument(0);
+
         $templateFinder = static::createMock(TemplateFinder::class);
         $templateFinder
             ->expects(static::once())
@@ -96,6 +100,7 @@ class StorefrontControllerTest extends TestCase
         $container->set('twig', $twig);
         $container->set(TemplateFinder::class, $templateFinder);
         $container->set(SeoUrlPlaceholderHandlerInterface::class, $seoUrlReplacer);
+        $container->set(MediaUrlPlaceholderHandlerInterface::class, $mediaUrlHandler);
         $container->set(SystemConfigService::class, static::createMock(SystemConfigService::class));
 
         $this->controller->setContainer($container);

--- a/tests/unit/Storefront/Framework/Twig/Extension/IconCacheTwigFilterTest.php
+++ b/tests/unit/Storefront/Framework/Twig/Extension/IconCacheTwigFilterTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Storefront\Framework\Twig\Extension;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Adapter\Twig\Extension\NodeExtension;
 use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\BundleHierarchyBuilder;
@@ -81,6 +82,11 @@ class IconCacheTwigFilterTest extends TestCase
         $placeholder->method('replace')->willReturnArgument(0);
 
         $container->set(SeoUrlPlaceholderHandlerInterface::class, $placeholder);
+
+        $mediaUrlHandler = $this->createMock(MediaUrlPlaceholderHandlerInterface::class);
+        $mediaUrlHandler->method('replace')->willReturnArgument(0);
+
+        $container->set(MediaUrlPlaceholderHandlerInterface::class, $mediaUrlHandler);
 
         return $container;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

We want to use the media library to provide PDF files for download on CMS pages. While there are special plugins for this, sometimes a simple link would do.

current process:

1. go to media library
2. find the PDF
3. use copy link
4. go to CMS page
5. click the "link" button
6. choose URL option
7. paste the link, remove the base URL (for better portability between development and production instances)

A better approach would be to be able to directly link to media files in place.

1. I click the link button
2. I choose "media file in the dropdown"
3.  I get a media browser popup to choose the media entity

That chooser is already present for products and there it replaces the base URL by a UUID placeholder. This should then happen also for media files.

### 2. What does this change do, exactly?

Add the chooser for the new type "media link". This generates a mediaId/$UUID link which is replaced in the SeoUrlHandler with the real media path.

### 3. Describe each step to reproduce the issue or behaviour.

see 1.

### 4. Please link to the relevant issues (if any).

#boostday https://issues.shopware.com/issues/NEXT-21273

blocked by: https://github.com/shopware/platform/pull/2692

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes -> https://docs.shopware.com/en/shopware-6-en/content/ShoppingExperiences#blocks under "Insert Link"
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
- [x] add translations
- [x] linter fixes
- [x] add tests



<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2685"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

