### PR TITLE
fix: remove deprecation from getPayload of RuleEntity

### DIFF
--- a/src/Core/Content/Rule/RuleEntity.php
+++ b/src/Core/Content/Rule/RuleEntity.php
@@ -138,9 +138,6 @@ class RuleEntity extends Entity
         $this->name = $name;
     }
 
-    /**
-     * @deprecated tag:v6.5.0 - reason:becomes-internal - Will be internal from 6.5.0 onward
-     */
     public function getPayload()
     {
         $this->checkIfPropertyAccessIsAllowed('payload');


### PR DESCRIPTION
### 1. Why is this change necessary?
We don't see any need to make it private. It's filled by [Subscriber](https://github.com/shopware/platform/blob/trunk/src/Core/Content/Rule/DataAbstractionLayer/RulePayloadSubscriber.php), and we need this information for own promotion-management and don't like to copy many lines of codes.

### 2. What does this change do, exactly?
we need the payload to make things easier :-)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
