### PR TITLE
adding home link to flyout menu

### DIFF
--- a/changelog/_unreleased/2022-09-16-flyout-menu-home-link.md
+++ b/changelog/_unreleased/2022-09-16-flyout-menu-home-link.md
@@ -1,0 +1,8 @@
+---
+title: Menu item "Home" is missing in flyout menu (mobile view)
+author: Joschi Mehta
+author_email: ninja@ig-academy.com
+author_github: @NinjaArmy
+---
+# Storefront
+* Added the home menu item to the flyout menu

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_navigation-offcanvas.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_navigation-offcanvas.scss
@@ -40,3 +40,11 @@ Based on custom offcanvas component.
         font-weight: $font-weight-bold;
     }
 }
+
+.navigation-offcanvas-list .main-navigation-link {
+    color: $body-color;
+    &.active {
+        color: $primary;
+        font-weight: $font-weight-bold;
+    }
+}

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_navigation-offcanvas.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_navigation-offcanvas.scss
@@ -40,11 +40,3 @@ Based on custom offcanvas component.
         font-weight: $font-weight-bold;
     }
 }
-
-.navigation-offcanvas-list .main-navigation-link {
-    color: $body-color;
-    &.active {
-        color: $primary;
-        font-weight: $font-weight-bold;
-    }
-}

--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/categories.html.twig
@@ -20,6 +20,11 @@
             {% endif %}
 
             <ul class="list-unstyled navigation-offcanvas-list">
+                {% if isRoot %}
+                    {% set homeLabel = context.salesChannel.translated.homeName|default("general.homeLink"|trans) %}
+                    {{ block("layout_main_navigation_menu_home", "@Storefront/storefront/layout/navigation/navigation.html.twig") }}
+                {% endif %}
+                
                 {% if not isRoot and page.navigation.active.type != "folder" %}
                     {# @deprecated tag:v6.5.0 - Passed variable `item` will be removed. Variable `treeItem` will be passed instead. #}
                     {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/show-active-link.html.twig' with { item: active, treeItem: active } %}

--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/categories.html.twig
@@ -21,8 +21,23 @@
 
             <ul class="list-unstyled navigation-offcanvas-list">
                 {% if isRoot %}
-                    {% set homeLabel = context.salesChannel.translated.homeName|default("general.homeLink"|trans) %}
-                    {{ block("layout_main_navigation_menu_home", "@Storefront/storefront/layout/navigation/navigation.html.twig") }}
+                    {% block layout_main_navigation_menu_home %}
+                        {% set homeLabel = context.salesChannel.translated.homeName|default("general.homeLink"|trans) %}
+                        {% set isActive = page.navigationId == activeId %}
+                    
+                        {% if context.salesChannel.translated.homeEnabled %}
+                            <li class="navigation-offcanvas-list-item">
+                                <a class="navigation-offcanvas-link nav-item nav-link {% if isActive %} navigation-offcanvas-headline {% endif %}"
+                                    href="{{ path('frontend.home.page') }}"
+                                    itemprop="url"
+                                    title="{{ homeLabel|striptags }}">
+                                    <div class="main-navigation-link-text">
+                                        <span itemprop="name">{{ homeLabel|sw_sanitize }}</span>
+                                    </div>
+                                </a>
+                            </li>
+                        {% endif %}
+                    {% endblock %}
                 {% endif %}
                 
                 {% if not isRoot and page.navigation.active.type != "folder" %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

1. Why is this change necessary?
- The home link is missing in the flyout-menu according to this (issue)[https://github.com/shopwareBoostDay/platform/issues/379]
2. What does this change do, exactly?
- Adding the home option if it's configured to the flyout menu
3. Describe each step to reproduce the issue or behaviour.
- Open the shop on a mobile device and open the flyout menu. The home link is not visible
4. Please link to the relevant issues (if any).
- This [issue](https://github.com/shopwareBoostDay/platform/issues/379)

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
