### PR TITLE
add only option to `dal:refresh:index` command

### DIFF
--- a/changelog/_unreleased/2022-09-16-add-skip-option-to-index.md
+++ b/changelog/_unreleased/2022-09-16-add-skip-option-to-index.md
@@ -1,0 +1,9 @@
+---
+title: add skip option to index
+author: Dominik Rott
+author_email: dominik.rott@motorgarten.de
+---
+
+# Core
+
+* Change command `\Shopware\Core\Framework\DataAbstractionLayer\Command\RefreshIndexCommand` add skip option to skip specific indexer

--- a/src/Core/Framework/DataAbstractionLayer/Command/RefreshIndexCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/RefreshIndexCommand.php
@@ -40,6 +40,7 @@ class RefreshIndexCommand extends Command implements EventSubscriberInterface
             ->setDescription('Refreshes the shop indices')
             ->addOption('use-queue', null, InputOption::VALUE_NONE, 'Ignore cache and force generation')
             ->addOption('skip', null, InputArgument::OPTIONAL, 'Comma separated list of indexer names to be skipped')
+            ->addOption('only', null, InputArgument::OPTIONAL, 'Comma separated list of indexer names to be generated')
         ;
     }
 
@@ -48,8 +49,9 @@ class RefreshIndexCommand extends Command implements EventSubscriberInterface
         $this->io = new ShopwareStyle($input, $output);
 
         $skip = \is_string($input->getOption('skip')) ? explode(',', $input->getOption('skip')) : [];
+        $only = \is_string($input->getOption('only')) ? explode(',', $input->getOption('only')) : [];
 
-        $this->registry->index($input->getOption('use-queue'), $skip);
+        $this->registry->index($input->getOption('use-queue'), $skip, $only);
 
         return self::SUCCESS;
     }

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
@@ -66,10 +66,14 @@ class EntityIndexerRegistry extends AbstractMessageHandler implements EventSubsc
         ];
     }
 
-    public function index(bool $useQueue, array $skip = []): void
+    public function index(bool $useQueue, array $skip = [], array $only = []): void
     {
         foreach ($this->indexer as $indexer) {
             if (\in_array($indexer->getName(), $skip, true)) {
+                continue;
+            }
+
+            if (\count($only) > 0 && !\in_array($indexer->getName(), $only, true)) {
                 continue;
             }
 

--- a/src/Core/Framework/Test/DataAbstractionLayer/Commands/RefreshIndexCommandTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Commands/RefreshIndexCommandTest.php
@@ -45,6 +45,14 @@ class RefreshIndexCommandTest extends TestCase
 
         static::assertStringNotContainsString('sales_channel.indexer', $message);
         static::assertStringNotContainsString('category.indexer', $message);
+
+        $commandTester = new CommandTester($this->refreshIndexCommand);
+        $commandTester->execute(['--only' => 'sales_channel.indexer']);
+
+        $message = $commandTester->getDisplay();
+
+        static::assertStringContainsString('sales_channel.indexer', $message);
+        static::assertStringNotContainsString('category.indexer', $message);
     }
 
     public function testExecuteWithSkipSeoUpdaterOption(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
The `dal:refresh:index` command only allows to skip indexes, this is to difficult if you want to regenerate only a specific index.

### 2. What does this change do, exactly?
add the `--only` option to the `dal:refresh:index` command, to generate only give index.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
