### PR TITLE
perf: faster mapping by using substr instead of str_replace

### DIFF
--- a/changelog/_unreleased/2022-09-19-improve-seourlplaceholderhandler-performance.md
+++ b/changelog/_unreleased/2022-09-19-improve-seourlplaceholderhandler-performance.md
@@ -1,0 +1,10 @@
+---
+title: Improve SeoUrlPlaceholderHandler performance
+issue: NEXT-23271
+author: Rafael Kraut
+author_email: rk@vi-arise.com
+author_github: RafaelKr
+---
+# Core
+* Use the generally faster substr instead of str_replace 
+___

--- a/src/Core/Content/Seo/SeoUrlPlaceholderHandler.php
+++ b/src/Core/Content/Seo/SeoUrlPlaceholderHandler.php
@@ -72,7 +72,9 @@ class SeoUrlPlaceholderHandler implements SeoUrlPlaceholderHandlerInterface
     {
         $mapping = [];
         foreach ($matches as $match) {
-            $mapping[$match] = str_replace(self::DOMAIN_PLACEHOLDER, '', rtrim($match, '#'));
+            // remove self::DOMAIN_PLACEHOLDER from start
+            // remove # from end
+            $mapping[$match] = substr($match, 32, -1);
         }
 
         return $mapping;

--- a/src/Core/Content/Seo/SeoUrlPlaceholderHandler.php
+++ b/src/Core/Content/Seo/SeoUrlPlaceholderHandler.php
@@ -98,7 +98,6 @@ class SeoUrlPlaceholderHandler implements SeoUrlPlaceholderHandlerInterface
         $query->setParameter('pathInfo', $mapping, Connection::PARAM_STR_ARRAY);
         $query->setParameter('languageId', Uuid::fromHexToBytes($context->getContext()->getLanguageId()));
         $query->setParameter('salesChannelId', Uuid::fromHexToBytes($context->getSalesChannelId()));
-        $query->addOrderBy('seo_url.sales_channel_id');
 
         $seoUrls = $query->execute()->fetchAll();
         foreach ($seoUrls as $seoUrl) {

--- a/src/Core/Content/Seo/SeoUrlPlaceholderHandler.php
+++ b/src/Core/Content/Seo/SeoUrlPlaceholderHandler.php
@@ -98,6 +98,7 @@ class SeoUrlPlaceholderHandler implements SeoUrlPlaceholderHandlerInterface
         $query->setParameter('pathInfo', $mapping, Connection::PARAM_STR_ARRAY);
         $query->setParameter('languageId', Uuid::fromHexToBytes($context->getContext()->getLanguageId()));
         $query->setParameter('salesChannelId', Uuid::fromHexToBytes($context->getSalesChannelId()));
+        $query->addOrderBy('seo_url.sales_channel_id');
 
         $seoUrls = $query->execute()->fetchAll();
         foreach ($seoUrls as $seoUrl) {


### PR DESCRIPTION
cc @keulinho 

### 1. Why is this change necessary?
This should bring a little performance improvement for every Storefront page load.

~~On my machine it's around 1.2ms per page load. I have an AMD Ryzen 7 5800H and pretty fast RAM, so on many servers there's probably even a bigger performance improvement.~~

The tiny improvement on my machine is now 0.1ms per page load. I have an AMD Ryzen 7 5800H and pretty fast RAM, so on many servers there's probably a tiny little bit more of a performance improvement.

### 2. What does this change do, exactly?
- Change a `str_replace` to `substr` which is generally faster
- ~~Remove an unnecessary `ORDER BY` from SQL query~~

### 3. Describe each step to reproduce the issue or behaviour.
Compare 'seo-url-replacer' in the Symfony Debug Bar Performance tab with and without the changes for the same page.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


I also tried to get some more improvement by replacing the `preg_match_all` and `preg_replace_callback` with other string function, but couldn't get it any faster with that. The slowest thing in the whole SeoUrlPlaceholderHandler `replace` method is the database query.