### PR TITLE
Raise level of product not found error

### DIFF
--- a/changelog/_unreleased/2022-09-16_product-not-found-error-visible-when-missing-availability-clears-cart.md
+++ b/changelog/_unreleased/2022-09-16_product-not-found-error-visible-when-missing-availability-clears-cart.md
@@ -1,0 +1,8 @@
+---
+title: "Product not found" error was not visible, when missing availability of a product eventually clears the cart
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed level of `\Shopware\Core\Content\Product\Cart\ProductNotFoundError` from warning to error to display it on the cart page

--- a/src/Core/Content/Product/Cart/ProductNotFoundError.php
+++ b/src/Core/Content/Product/Cart/ProductNotFoundError.php
@@ -36,7 +36,7 @@ class ProductNotFoundError extends Error
 
     public function getLevel(): int
     {
-        return self::LEVEL_WARNING;
+        return self::LEVEL_ERROR;
     }
 
     public function blockOrder(): bool


### PR DESCRIPTION
### 1. Why is this change necessary?

1. Imagine being in a grocery store.
2. You see a banner at the entrance that there is a discount on bananas
3. You walk to the fruit isle and see three [hands](http://www.bananen-seite.de/Bananen/hand.html) of bananas left
4. You grab one, put it into your basket
5. You reach the register
6. Get in queue
7. Place the banana on the conveyor belt
8. The people in front of you are also buying bananas
9. They each pay and leave the store
10. You are excited: your chance to buy bananas for a few bucks off
11. Out of nowhere before the cashier could weight and scan the bananas, you see a bright white light
12. It is the bright sun outside. You stand in front of the grocery store, your basket is empty, there is no banana discount banner and you have no idea what just happened

### 2. What does this change do, exactly?

It raises the "product not found error"s level from warning to error as only errors are shown on the empty cart page. The other idea was to also display warnings, but there are a lot of warnings so the range of wrong possible seen errors there are too much that I can test them to be right.

### 3. Describe each step to reproduce the issue or behaviour.

1. Put a product as single line item in your cart
2. Go through checkout until confirm step
3. Deactivate product in admin (delete product OR remove visibility from the sales channel in question OR run out of stock)
4. Place order
5. Be confused because you just see an empty card page without any hint what just happened

### 4. Please link to the relevant issues (if any).

Before NEXT-22182 this was a 500 error so I really like @isengo1989 already took care of this, but we still have a confusing situation in place.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
