### PR TITLE
Add flashbag cache in twig app variable

### DIFF
--- a/changelog/_unreleased/2022-09-17_allow-querying-multiple-times-the-flashbag-in-a-single-rendering.md
+++ b/changelog/_unreleased/2022-09-17_allow-querying-multiple-times-the-flashbag-in-a-single-rendering.md
@@ -1,0 +1,8 @@
+---
+title: Allow querying multiple times the flashbag in a single rendering
+author: JoshuaBehrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Added caching on the flashbag to allow for multiple calls on `app.flashes` for a single rendering call


### PR DESCRIPTION
### 1. Why is this change necessary?

As soon as you debug the flashbag in twig with e.g. a `{{ dump(app.flashes) }}` all renderings of future calls in the same render call of `app.flashes` are just empty. On the empty cart page it is also a bit annoying when you want to add some more messages as just errors are displayed next to the "empty cart" message but ALL messages are pulled from `app.flashes` to do that. As this can happen on other occasions as well I don't fix the empty cart page but allow the flashbag to hold the data a bit longer so the generic flashbag to alert block does not empty the flashbag at once.

### 2. What does this change do, exactly?

Any calls to `app.flashes` or `app.flashes('warning')` are cached in the app variable which is just used for a single response rendering and therefore only cached for a single response. The output is still the same.

I know the flashbag is designed to drop its content when the data is retrieved but I think it is rather a downside for Shopware as it is a gain.

### 3. Describe each step to reproduce the issue or behaviour.

1. Miss a message on the empty cart page
2. Debug with `{{ dump(app.flashes) }}`
3. See message
4. Change twig code to display flash message
5. See message in dump
6. See no alert

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2694"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

