### PR TITLE
Remove final flag from entity search result

### DIFF
--- a/changelog/_unreleased/2022-09-22-remove-final-flag-from-entity-search-result-class.md
+++ b/changelog/_unreleased/2022-09-22-remove-final-flag-from-entity-search-result-class.md
@@ -1,0 +1,8 @@
+---
+title: Remove final flag from entity search result class
+author: Jolan De Nef
+author_email: jolan.denef@meteor.be
+author_github: JolanDeNef
+___
+# Core
+* Remove final flag from entity search result class

--- a/changelog/_unreleased/2022-09-22-remove-final-flag-from-entity-search-result-class.md
+++ b/changelog/_unreleased/2022-09-22-remove-final-flag-from-entity-search-result-class.md
@@ -5,4 +5,4 @@ author_email: jolan.denef@meteor.be
 author_github: JolanDeNef
 ___
 # Core
-* Remove final flag from entity search result class
+* Remove final flag from entity search result class in order to allow extendability of the EntitySearchResult

--- a/src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
@@ -9,8 +9,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Aggreg
 use Shopware\Core\Framework\Struct\StateAwareTrait;
 
 /**
- * @final
- *
  * @extends EntityCollection<Entity>
  */
 class EntitySearchResult extends EntityCollection


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The EntitySearchResult class should be easily extendable. Third party plugin makers should be able to extend this class for their own entities. 
E.g.: A plugin has a ReceiptEntity that is also searchable and needs more functionality than the EntitySearchResult provides. In that case we would like to create a ReceiptSearchResult.


### 2. What does this change do, exactly?
This change removes the @final flag from the EntitySearchResult class, so the class is easier extendable for third party entities. 


### 3. Describe each step to reproduce the issue or behaviour.
Try to extend the class, it works, but php helpers (psalm, phpstan, ...) will complain because it is 'final'


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
