### PR TITLE
Fix group literal for settings item

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/factory/module.factory.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/module.factory.ts
@@ -69,7 +69,7 @@ interface Navigation {
 }
 
 interface SettingsItem {
-    group: 'shop' | 'system' | 'plugin',
+    group: 'shop' | 'system' | 'plugins',
     to: string,
     icon?: string,
     iconComponent: unknown,


### PR DESCRIPTION
### 1. Why is this change necessary?

There is a mismatch between the `allowedTabs` in [settings-item.init.ts](https://github.com/shopware/platform/blob/469a7fc7c7a60eea6ae0863f54cb489bc0cbf31c/src/Administration/Resources/app/administration/src/app/init/settings-item.init.ts#L4) and the corresponding literal type, defined in [module.factory.ts](https://github.com/shopware/platform/blob/469a7fc7c7a60eea6ae0863f54cb489bc0cbf31c/src/Administration/Resources/app/administration/src/core/factory/module.factory.ts#L36)

### 2. What does this change do, exactly?

I simply changed the literal type to reflect the allowedTabs.

### 3. Describe each step to reproduce the issue or behaviour.

I don't think there is any more explanation needed.

### 4. Please link to the relevant issues (if any).

None

I did not provide a changelog, because this is such a small change to a ts interface (which really is only relevant for developers). If you really need one, just let me know.
