### PR TITLE
Fix duplicated plugins in storefront config collection

### DIFF
--- a/changelog/_unreleased/2022-09-27-fix-plugin-storefront-js-compiled-twice.md
+++ b/changelog/_unreleased/2022-09-27-fix-plugin-storefront-js-compiled-twice.md
@@ -1,0 +1,8 @@
+---
+title: Fix plugin storefront js code being compiled twice
+author: Maximilian Rüsch
+author_email: maximilian.ruesch@pickware.de
+author_github: maximilianruesch
+___
+# Storefront
+*  Ensures a previously activated plugin is not added twice to the list of plugins which should be recompiled during the following theme compilation. This list may already contain the plugin.

--- a/src/Storefront/Test/Theme/Subscriber/PluginLifecycleSubscriberTest.php
+++ b/src/Storefront/Test/Theme/Subscriber/PluginLifecycleSubscriberTest.php
@@ -13,6 +13,8 @@ use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Test\Plugin\PluginTestsHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\AbstractStorefrontPluginConfigurationFactory;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
+use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfigurationCollection;
 use Shopware\Storefront\Theme\StorefrontPluginRegistry;
 use Shopware\Storefront\Theme\Subscriber\PluginLifecycleSubscriber;
 use Shopware\Storefront\Theme\ThemeLifecycleHandler;
@@ -31,6 +33,88 @@ class PluginLifecycleSubscriberTest extends TestCase
     {
         parent::setUp();
         $this->addTestPluginToKernel('SwagTest');
+    }
+
+    public function testDoesNotAddPluginStorefrontConfigurationToConfigurationCollectionIfItIsAddedAlready(): void
+    {
+        $context = Context::createDefaultContext();
+        $event = new PluginPostActivateEvent(
+            $this->getPlugin(),
+            new ActivateContext(
+                $this->createMock(Plugin::class),
+                $context,
+                '6.1.0',
+                '1.0.0',
+                $this->createMock(MigrationCollection::class)
+            )
+        );
+        $storefrontPluginConfigMock = new StorefrontPluginConfiguration('SwagTest');
+        // Plugin storefront config is already added here
+        $storefrontPluginConfigCollection = new StorefrontPluginConfigurationCollection([$storefrontPluginConfigMock]);
+
+        $pluginConfigurationFactory = $this->createMock(AbstractStorefrontPluginConfigurationFactory::class);
+        $pluginConfigurationFactory->method('createFromBundle')->willReturn($storefrontPluginConfigMock);
+        $storefrontPluginRegistry = $this->createMock(StorefrontPluginRegistry::class);
+        $storefrontPluginRegistry->method('getConfigurations')->willReturn($storefrontPluginConfigCollection);
+        $handler = $this->createMock(ThemeLifecycleHandler::class);
+        $handler->expects(static::once())->method('handleThemeInstallOrUpdate')->with(
+            $storefrontPluginConfigMock,
+            // This ensures the plugin storefront config is not added twice
+            static::equalTo($storefrontPluginConfigCollection),
+            $context,
+        );
+
+        $subscriber = new PluginLifecycleSubscriber(
+            $storefrontPluginRegistry,
+            __DIR__,
+            $pluginConfigurationFactory,
+            $handler,
+            $this->createMock(ThemeLifecycleService::class)
+        );
+
+        $subscriber->pluginPostActivate($event);
+    }
+
+    public function testAddsThePluginStorefrontConfigurationToConfigurationCollectionIfItWasNotAddedAlready(): void
+    {
+        $context = Context::createDefaultContext();
+        $event = new PluginPostActivateEvent(
+            $this->getPlugin(),
+            new ActivateContext(
+                $this->createMock(Plugin::class),
+                $context,
+                '6.1.0',
+                '1.0.0',
+                $this->createMock(MigrationCollection::class)
+            )
+        );
+        $storefrontPluginConfigMock = new StorefrontPluginConfiguration('SwagTest');
+        // Plugin storefront config is not added here
+        $storefrontPluginConfigCollection = new StorefrontPluginConfigurationCollection([]);
+
+        $pluginConfigurationFactory = $this->createMock(AbstractStorefrontPluginConfigurationFactory::class);
+        $pluginConfigurationFactory->method('createFromBundle')->willReturn($storefrontPluginConfigMock);
+        $storefrontPluginRegistry = $this->createMock(StorefrontPluginRegistry::class);
+        $storefrontPluginRegistry->method('getConfigurations')->willReturn($storefrontPluginConfigCollection);
+        $collectionWithPluginConfig = clone $storefrontPluginConfigCollection;
+        $collectionWithPluginConfig->add($storefrontPluginConfigMock);
+        $handler = $this->createMock(ThemeLifecycleHandler::class);
+        $handler->expects(static::once())->method('handleThemeInstallOrUpdate')->with(
+            $storefrontPluginConfigMock,
+            // This ensures the plugin storefront config was added in the subscriber
+            static::equalTo($collectionWithPluginConfig),
+            $context,
+        );
+
+        $subscriber = new PluginLifecycleSubscriber(
+            $storefrontPluginRegistry,
+            __DIR__,
+            $pluginConfigurationFactory,
+            $handler,
+            $this->createMock(ThemeLifecycleService::class)
+        );
+
+        $subscriber->pluginPostActivate($event);
     }
 
     public function testThemeLifecycleIsNotCalledWhenDeactivatedUsingContextOnActivate(): void

--- a/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationCollection.php
+++ b/src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationCollection.php
@@ -9,6 +9,24 @@ use Shopware\Core\Framework\Struct\Collection;
  */
 class StorefrontPluginConfigurationCollection extends Collection
 {
+    public function __construct(iterable $elements = [])
+    {
+        parent::__construct([]);
+
+        foreach ($elements as $element) {
+            $this->validateType($element);
+
+            $this->set($element->getTechnicalName(), $element);
+        }
+    }
+
+    public function add($element): void
+    {
+        $this->validateType($element);
+
+        $this->set($element->getTechnicalName(), $element);
+    }
+
     public function getByTechnicalName(string $name): ?StorefrontPluginConfiguration
     {
         return $this->filter(function (StorefrontPluginConfiguration $config) use ($name) {

--- a/src/Storefront/Theme/Subscriber/PluginLifecycleSubscriber.php
+++ b/src/Storefront/Theme/Subscriber/PluginLifecycleSubscriber.php
@@ -183,7 +183,7 @@ class PluginLifecycleSubscriber implements EventSubscriberInterface
             $event->getPlugin()->getBaseClass()
         );
 
-        // add plugin configuration to the list of all active plugin configurations
+        // ensure plugin configuration is in the list of all active plugin configurations
         $configurationCollection = clone $this->storefrontPluginRegistry->getConfigurations();
         $configurationCollection->add($storefrontPluginConfig);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Previous to this change, any plugin containing JS code which is activated in the administration or via CLI will cause the minified JS code `all.js` to contain its JS code twice. This can be fixed by deactivating and activating another plugin which does not offer JS code but obviously this should not be used as permanent workaround.

### 2. What does this change do, exactly?

This change removes the duplicate addition of the previously activated plugin to the list of plugins which will be recompiled / added to the themes `all.js`, as this list already contains the plugin because it pulls all plugins / bundles from the container. This container is rebuilt previous to the event listened to, so it must already contain the plugin at that point. This causes storefront plugins (like pseudo-modals) to be registered twice which in extreme cases causes the storefront to stop loading.

### 3. Describe each step to reproduce the issue or behaviour.

1. Activate a plugin which offers JS code (minified or not)
2. Look inside the generated `all.js` of the theme, the plugin code is duplicated.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
