### PR TITLE
Add missing types to CustomFieldTypes

### DIFF
--- a/changelog/_unreleased/2022-09-28- add-missing-types-to-CustomFieldTypes.md
+++ b/changelog/_unreleased/2022-09-28- add-missing-types-to-CustomFieldTypes.md
@@ -1,0 +1,10 @@
+---
+title: Add missing types to CustomFieldTypes
+issue: NEXT-23461
+author: Linus Jolmes
+author_email: l.jolmes@gmx.de
+author_github: LinoJo
+---
+# Core
+* Add missing types to CustomFieldTypes
+___

--- a/changelog/_unreleased/2022-09-28-add-missing-types-to-CustomFieldTypes.md
+++ b/changelog/_unreleased/2022-09-28-add-missing-types-to-CustomFieldTypes.md
@@ -1,6 +1,6 @@
 ---
 title: Add missing types to CustomFieldTypes
-issue: NEXT-23461
+issue: NEXT-23477
 author: Linus Jolmes
 author_email: l.jolmes@gmx.de
 author_github: LinoJo

--- a/src/Core/System/CustomField/CustomFieldTypes.php
+++ b/src/Core/System/CustomField/CustomFieldTypes.php
@@ -5,12 +5,15 @@ namespace Shopware\Core\System\CustomField;
 final class CustomFieldTypes
 {
     public const BOOL = 'bool';
+    public const CHECKBOX = 'checkbox'
     public const COLORPICKER = 'colorpicker';
+    public const DATE = 'date';
     public const DATETIME = 'datetime';
     public const ENTITY = 'entity';
     public const FLOAT = 'float';
     public const INT = 'int';
     public const JSON = 'json';
+    public const NUMBER = 'number';
     public const PRICE = 'price';
     public const HTML = 'html';
     public const MEDIA = 'media';


### PR DESCRIPTION
### 1. Why is this change necessary?
Types are missing in CustomFieldTypes

### 2. What does this change do, exactly?
Add types to src/Core/System/CustomField/CustomFieldTypes.php:
- checkbox
- date
- number

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
