### PR TITLE
Add configuration to show and hide salutation in postal address

### DIFF
--- a/changelog/_unreleased/2022-10-01-add-document-config-to-show-hide-salutation-in-postal-address.md
+++ b/changelog/_unreleased/2022-10-01-add-document-config-to-show-hide-salutation-in-postal-address.md
@@ -1,0 +1,13 @@
+---
+title: Add document config to show/hide salutation in postal address
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added `displaySalutationInPostalAddress` to `\Shopware\Core\Checkout\Document\DocumentConfiguration::$displaySalutationInPostalAddress`
+* Added migration `\Shopware\Core\Migration\V6_4\Migration1664582400AddDocumentConfigDisplayingSalutationInPostalAddress` to enable `displaySalutationInPostalAddress` in every document configuration
+* Added check to `config.displaySalutationInPostalAddress` in `documents/includes/letter_header.html.twig` to display salutation in postal address by configuration
+___
+# Administration
+* Added checkbox with translation in `sw-settings-document.detail.labelDisplaySalutationInPostalAddress` to `sw-settings-document-detail` to edit `displaySalutationInPostalAddress`

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
@@ -144,6 +144,14 @@ Component.register('sw-settings-document-detail', {
                         helpText: this.$tc('sw-settings-document.detail.helpTextDisplayDocumentInCustomerAccount'),
                     },
                 },
+                {
+                    name: 'displaySalutationInPostalAddress',
+                    type: 'bool',
+                    config: {
+                        type: 'checkbox',
+                        label: this.$tc('sw-settings-document.detail.labelDisplaySalutationInPostalAddress'),
+                    },
+                },
             ],
             companyFormFields: [
                 {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/snippet/de-DE.json
@@ -66,6 +66,7 @@
       "disabledTypeSelect": "Der Dokumententyp globaler Dokumente kann nicht geändert werden.",
       "labelDisplayDocumentInCustomerAccount": "Dokument in \"Mein Konto\" Bereich anzeigen",
       "labelDisplayDivergentDeliveryAddress": "Abweichende Lieferadresse anzeigen",
+      "labelDisplaySalutationInPostalAddress": "Anrede in Postanschrift anzeigen",
       "helpTextDisplayDocumentInCustomerAccount": "Das Dokument wird dem Shopkunden unter Bestellungen im Kundenkonto angezeigt. Nur Dokumente die an den Kunden gesendet wurden, werden im Kundenkonto angezeigt.",
       "helpTextDisplayDeliveryCountries": "Alle ausgewählten Länder erhalten einen Hinweis zur \"innergemeinschaftlichen Lieferung\" auf den Rechnungsdokumenten."
     }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/snippet/en-GB.json
@@ -66,6 +66,7 @@
       "disabledTypeSelect": "The type of global documents cannot be changed.",
       "labelDisplayDocumentInCustomerAccount": "Display document in \"My account\"",
       "labelDisplayDivergentDeliveryAddress": "Display divergent delivery address",
+      "labelDisplaySalutationInPostalAddress": "Display salutation in postal address",
       "helpTextDisplayDocumentInCustomerAccount": "The document is displayed under \"Orders\" in the respective customer account. Note that only documents that have actually been sent to the customer are displayed in the customer account.",
       "helpTextDisplayDeliveryCountries": "Displays indication of \"intra community delivery\" on invoice documents for selected countries."
     }

--- a/src/Core/Checkout/Document/DocumentConfiguration.php
+++ b/src/Core/Checkout/Document/DocumentConfiguration.php
@@ -71,6 +71,8 @@ class DocumentConfiguration extends Struct
      */
     protected $displayLineItemPosition;
 
+    protected bool $displaySalutationInPostalAddress = true;
+
     /**
      * @var int|null
      */
@@ -247,6 +249,16 @@ class DocumentConfiguration extends Struct
     public function setPageOrientation(?string $pageOrientation): void
     {
         $this->pageOrientation = $pageOrientation;
+    }
+
+    public function getDisplaySalutationInPostalAddress(): bool
+    {
+        return $this->displaySalutationInPostalAddress;
+    }
+
+    public function setDisplaySalutationInPostalAddress(bool $displaySalutationInPostalAddress): void
+    {
+        $this->displaySalutationInPostalAddress = $displaySalutationInPostalAddress;
     }
 
     public function getPageSize(): ?string

--- a/src/Core/Framework/Resources/views/documents/includes/letter_header.html.twig
+++ b/src/Core/Framework/Resources/views/documents/includes/letter_header.html.twig
@@ -24,7 +24,7 @@ All blocks of this template are available in the template which renders this tem
                 {% if customer.customer.vatIds and billingAddress.country.companyTax.getEnabled and config.displayAdditionalNoteDelivery and billingAddress.country.id in config.deliveryCountries %}
                     {{ 'document.vatId'|trans({'%vatId%': customer.customer.vatIds|first})|sw_sanitize }}<br>
                 {% endif %}
-                {% if not notSpecified and billingAddress.salutation and billingAddress.salutation.id is not same as(constant('Shopware\\Core\\Defaults::SALUTATION')) %}{{ billingAddress.salutation.displayName ~ ' ' }}{% endif %}{{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
+                {% if config.displaySalutationInPostalAddress and not notSpecified and billingAddress.salutation and billingAddress.salutation.id is not same as(constant('Shopware\\Core\\Defaults::SALUTATION')) %}{{ billingAddress.salutation.displayName ~ ' ' }}{% endif %}{{ billingAddress.firstName }} {{ billingAddress.lastName }}<br>
                 {{ billingAddress.street }}<br>
                 {% if billingAddress.additionalAddressLine1 %}
                     {{ billingAddress.additionalAddressLine1 }}<br>

--- a/src/Core/Migration/V6_4/Migration1664582400AddDocumentConfigDisplayingSalutationInPostalAddress.php
+++ b/src/Core/Migration/V6_4/Migration1664582400AddDocumentConfigDisplayingSalutationInPostalAddress.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_4;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @deprecated tag:v6.5.0 - reason:becomes-internal - Migrations will be internal in v6.5.0
+ */
+class Migration1664582400AddDocumentConfigDisplayingSalutationInPostalAddress extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1664582400;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addDisplaySalutationInPostalAddressIntoDocumentConfig($connection);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+
+    private function addDisplaySalutationInPostalAddressIntoDocumentConfig(Connection $connection): void
+    {
+        $documentBaseConfigs = $connection->fetchAll('SELECT `document_base_config`.`id`, `document_base_config`.`config` FROM `document_base_config`');
+
+        foreach ($documentBaseConfigs as $documentBaseConfig) {
+            $invoiceConfig = json_decode($documentBaseConfig['config'] ?? '[]', true);
+            $invoiceConfig['displaySalutationInPostalAddress'] = true;
+
+            $connection->executeUpdate(
+                'UPDATE `document_base_config` SET `config` = :invoiceData WHERE `id` = :documentConfigId',
+                [
+                    'invoiceData' => json_encode($invoiceConfig),
+                    'documentConfigId' => $documentBaseConfig['id'],
+                ]
+            );
+        }
+    }
+}

--- a/tests/migration/Core/V6_4/Migration1664582400AddDocumentConfigDisplayingSalutationInPostalAddressTest.php
+++ b/tests/migration/Core/V6_4/Migration1664582400AddDocumentConfigDisplayingSalutationInPostalAddressTest.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_4;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_4\Migration1664582400AddDocumentConfigDisplayingSalutationInPostalAddress;
+
+/**
+ * @internal
+ * @covers \Shopware\Core\Migration\V6_4\Migration1664582400AddDocumentConfigDisplayingSalutationInPostalAddress
+ */
+class Migration1664582400AddDocumentConfigDisplayingSalutationInPostalAddressTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testDefaultValueForIntraCommunityShouldBeInsertedCorrect(): void
+    {
+        $this->rollBackMigration();
+
+        $documentBaseConfigs = $this->connection->fetchAll('SELECT `document_base_config`.`config` FROM `document_base_config`');
+
+        static::assertNotEmpty($documentBaseConfigs);
+
+        foreach ($documentBaseConfigs as $documentBaseConfig) {
+            $invoiceConfig = json_decode($documentBaseConfig['config'] ?? '[]', true);
+
+            static::assertArrayNotHasKey('displaySalutationInPostalAddress', $invoiceConfig);
+        }
+
+        $migration = new Migration1664582400AddDocumentConfigDisplayingSalutationInPostalAddress();
+        $migration->update($this->connection);
+
+        $documentBaseConfigs = $this->connection->fetchAll('SELECT `document_base_config`.`config` FROM `document_base_config`');
+
+        static::assertNotEmpty($documentBaseConfigs);
+
+        foreach ($documentBaseConfigs as $documentBaseConfig) {
+            $invoiceConfig = json_decode($documentBaseConfig['config'] ?? '[]', true);
+
+            static::assertArrayHasKey('displaySalutationInPostalAddress', $invoiceConfig);
+            static::assertTrue($invoiceConfig['displaySalutationInPostalAddress']);
+        }
+    }
+
+    private function rollBackMigration(): void
+    {
+        $documentBaseConfigs = $this->connection->fetchAll('SELECT `document_base_config`.`id`, `document_base_config`.`config` FROM `document_base_config`');
+
+        foreach ($documentBaseConfigs as $documentBaseConfig) {
+            $invoiceConfig = json_decode($documentBaseConfig['config'] ?? '[]', true);
+            unset($invoiceConfig['displaySalutationInPostalAddress']);
+
+            $this->connection->executeUpdate(
+                'UPDATE `document_base_config` SET `config` = :invoiceData WHERE `id` = :documentConfigId',
+                [
+                    'invoiceData' => json_encode($invoiceConfig),
+                    'documentConfigId' => $documentBaseConfig['id'],
+                ]
+            );
+        }
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

When you print and ship it it is sometimes weird to have salutational letter names in there.

### 2. What does this change do, exactly?

Add a config, enables it by default, change the template.

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2714"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

