### PR TITLE
fixing missing company phone in document

### DIFF
--- a/src/Core/Checkout/Document/DocumentConfiguration.php
+++ b/src/Core/Checkout/Document/DocumentConfiguration.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Shopware\Core\Checkout\Document;
 
@@ -110,6 +112,11 @@ class DocumentConfiguration extends Struct
      * @var string|null
      */
     protected $companyUrl;
+
+    /**
+     * @var string|null
+     */
+    protected $companyPhone;
 
     /**
      * @var string|null


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The document configuration value companyPhone can be set by the Admin UI, but is not accessible by code.

### 2. What does this change do, exactly?
Adding variable $companyPhone to class DocumentConfiguration so you can access it.

### 3. Describe each step to reproduce the issue or behaviour.
`$documentConfiguration->companyPhone`

throws an error 

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2672 (thanks to @applifaction)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


---
First pull request ever. Hope everything is alright 🙌