### PR TITLE
fix: sw-card overflow and overlap elements

### DIFF
--- a/changelog/_unreleased/2022-10-01-fix-sw-card-overflow-and-overlap-elements.md
+++ b/changelog/_unreleased/2022-10-01-fix-sw-card-overflow-and-overlap-elements.md
@@ -1,0 +1,9 @@
+---
+title: Fix sw-card overflow and overlap elements
+issue: NEXT-22733
+author: Stephan Franck
+author_email: stephan@vierpunkt.de
+author_github: stephan4p
+---
+# Administration
+* Change dropshadow from CSS `filter` to `box-shadow` to resolve an stacking context problem if an elements overflow the card and follow by a card

--- a/src/Administration/Resources/app/administration/src/app/assets/scss/mixins.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/mixins.scss
@@ -84,5 +84,5 @@
 }
 
 @mixin drop-shadow-default() {
-    filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 8%)) drop-shadow(0 2px 1px rgba(0, 0, 0, 6%)) drop-shadow(0 1px 3px rgba(0, 0, 0, 10%));
+    box-shadow: 0 1px 3px rgb(0 0 0 / 8%), 0 2px 3px rgb(0 0 0 / 6%), 0 1px 5px rgb(0 0 0 / 10%);
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The filter drop shadow in administration creates a stacking-context and can conflict with some situations when an element in sw-card is overflowing and follow by another sw-card
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context

### 2. What does this change do, exactly?
Change the mixins `drop-shadow-default()` drop shadow function from `filter` to `box-shadow`

### 3. Describe each step to reproduce the issue or behaviour.
I have this problem on Shopware extensions that have a sw-card after another that have a media field
![image](https://user-images.githubusercontent.com/40059275/193413120-b7608350-259f-45b4-9222-a3aac3e5879e.png)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
