### PR TITLE
Change bg color and border radius of  slider nav arrows outside

### DIFF
--- a/changelog/_unreleased/2022-10-01-change-slider-nav-arrow-outside-bg.md
+++ b/changelog/_unreleased/2022-10-01-change-slider-nav-arrow-outside-bg.md
@@ -1,0 +1,11 @@
+---
+title: Change background of slider navigation arrows positioned outside
+issue: #2456
+author: Lisa Meister
+author_email: lisa.meister.93@gmx.de
+
+___
+# Storefront
+* Change background color for elements with class `.base-slider-controls-prev.is-nav-prev-outside` 
+and `.base-slider-controls-next.is-nav-next-outside` to rgba($white, 0.8)
+* Change border radius of the above classes to match with their positioning

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_base-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_base-slider.scss
@@ -91,7 +91,7 @@ based on: https://github.com/ganlanyuan/tiny-slider
     &.is-nav-prev-outside,
     &.is-nav-next-outside {
         border: 0;
-        background: none;
+        background-color: rgba($white, 0.8);
     }
 
     &[disabled] {
@@ -102,10 +102,18 @@ based on: https://github.com/ganlanyuan/tiny-slider
 
 .base-slider-controls-prev {
     border-radius: 0 $border-radius $border-radius 0;
+
+    &.is-nav-prev-outside {
+        border-radius: $border-radius 0 0 $border-radius;
+    }
 }
 
 .base-slider-controls-next {
     border-radius: $border-radius 0 0 $border-radius;
+
+    &.is-nav-next-outside {
+        border-radius: 0 $border-radius $border-radius 0;
+    }
 }
 
 @include media-breakpoint-up(md) {


### PR DESCRIPTION
### 1. Why is this change necessary?
If an image slider with navigation arrows positioned "outside" is used on a section with a dark background,
the navigation arrows are no longer visible.

### 2. What does this change do, exactly?
Change the background color of navigation arrows positioned outside of an image slider to white.
Change the border radius to mirror the appearance of inside positioned arrows.

### 3. Describe each step to reproduce the issue or behaviour.
In the CMS Layout Editor, create a section with a dark background color or image. Place the CMS block "image slider" inside of it and set the "Arrow navigation" to "outside".

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2456

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2022-10-01-change-slider-nav-arrow-outside-bg.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
