### PR TITLE
Added config to cms-element image for horizontal alignment

### DIFF
--- a/changelog/_unreleased/2022-10-01-cms-element-image-horizontal-align.md
+++ b/changelog/_unreleased/2022-10-01-cms-element-image-horizontal-align.md
@@ -1,0 +1,10 @@
+---
+title: Added horizontal alignment config to cms-image
+author: Joschi Mehta
+author_email: ninja@ig-academy.com
+author_github: @NinjaArmy
+---
+# Administration
+* Added config to the cms-element-image to align the image horizontally as well.
+# Storefront
+* In the Storefront you can now see the horizontal alignment if configured.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/index.js
@@ -37,6 +37,12 @@ Component.register('sw-cms-el-image', {
             };
         },
 
+        horizontalAlign() {
+            return {
+                'justify-content': this.element.config.horizontalAlign.value || null,
+            };
+        },
+
         mediaUrl() {
             const fallBackImageFileName = CMS.MEDIA.previewMountain.slice(CMS.MEDIA.previewMountain.lastIndexOf('/') + 1);
             const staticFallBackImage = this.assetFilter(`administration/static/img/cms/${fallBackImageFileName}`);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/sw-cms-el-image.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/sw-cms-el-image.html.twig
@@ -1,17 +1,19 @@
 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
 {% block sw_cms_element_image %}
-<div
-    class="sw-cms-el-image"
-    :class="displayModeClass"
-    :style="styles"
->
-    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-    {% block sw_cms_element_image_content %}
-    <img
-        :src="mediaUrl"
-        :style="imgStyles"
-        alt=""
+<div class="sw-cms-el-image-wrapper" :style="horizontalAlign">
+    <div
+        class="sw-cms-el-image"
+        :class="displayModeClass"
+        :style="styles"
     >
-    {% endblock %}
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_cms_element_image_content %}
+        <img
+            :src="mediaUrl"
+            :style="imgStyles"
+            alt=""
+        >
+        {% endblock %}
+    </div>
 </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/sw-cms-el-image.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/component/sw-cms-el-image.scss
@@ -1,34 +1,42 @@
 @import "~scss/variables";
 
-.sw-cms-el-image {
+.sw-cms-el-image-wrapper {
     display: flex;
-    max-width: 100%;
+    width: 100%;
+    &-center {
+        justify-content: center;
+    }
 
-    img {
-        display: block;
+    .sw-cms-el-image {
+        display: flex;
         max-width: 100%;
-    }
-
-    &.is--cover {
-        height: 100%;
-        width: 100%;
-        position: relative;
 
         img {
-            object-fit: cover;
-            width: 100%;
-            height: 100%;
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            bottom: 0;
+            display: block;
+            max-width: 100%;
         }
-    }
 
-    &.is--stretch {
-        img {
+        &.is--cover {
+            height: 100%;
             width: 100%;
+            position: relative;
+
+            img {
+                object-fit: cover;
+                width: 100%;
+                height: 100%;
+                position: absolute;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+            }
+        }
+
+        &.is--stretch {
+            img {
+                width: 100%;
+            }
         }
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/config/sw-cms-el-config-image.html.twig
@@ -99,6 +99,24 @@
     </sw-select-field>
     {% endblock %}
 
+    {% block sw_cms_element_image_config_horizontal_align %}
+    <sw-select-field
+        v-model="element.config.horizontalAlign.value"
+        :label="$tc('sw-cms.elements.general.config.label.horizontalAlign')"
+        :placeholder="$tc('sw-cms.elements.general.config.label.horizontalAlign')"
+    >
+        <option value="flex-start">
+            {{ $tc('sw-cms.elements.general.config.label.horizontalAlignLeft') }}
+        </option>
+        <option value="center">
+            {{ $tc('sw-cms.elements.general.config.label.horizontalAlignCenter') }}
+        </option>
+        <option value="flex-end">
+            {{ $tc('sw-cms.elements.general.config.label.horizontalAlignRight') }}
+        </option>
+    </sw-select-field>
+    {% endblock %}
+
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_cms_element_image_config_link %}
     <div class="sw-cms-el-config-image__link">

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image/index.js
@@ -40,5 +40,9 @@ Shopware.Service('cmsService').registerCmsElement({
             source: 'static',
             value: null,
         },
+        horizontalAlign: {
+            source: 'static',
+            value: null
+        }
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -191,7 +191,11 @@
             "displayModeContain": "Beinhalten",
             "autoSlide": "Automatischer Wechsel",
             "autoplayTimeout": "Verzögerung",
-            "speed": "Animationsverzögerung"
+            "speed": "Animationsverzögerung",
+            "horizontalAlign": "Horizontale Ausrichtung",
+            "horizontalAlignLeft": "Links",
+            "horizontalAlignCenter": "Mitte",
+            "horizontalAlignRight": "Rechts"
           },
           "helpText": {
             "autoSlide": "Der Bilderwechsel erfolgt automatisch nach den hier gemachten Vorgaben.",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -194,7 +194,11 @@
             "displayModeContain": "Contain",
             "autoSlide": "Auto slide",
             "autoplayTimeout": "Delay",
-            "speed": "Animation delay"
+            "speed": "Animation delay",
+            "horizontalAlign": "Horizontal align",
+            "horizontalAlignLeft": "Left",
+            "horizontalAlignCenter": "Center",
+            "horizontalAlignRight": "Right"
           },
           "helpText": {
             "autoSlide": "The slide will be slided automatically.",

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-element.scss
@@ -235,3 +235,16 @@ div.card-tabs .cms-card-header {
     padding-left: 0;
     padding-right: 0;
 }
+
+.cms-element-image-horizontal  {
+    &-left {
+        justify-content: flex-start;
+    }
+    &-center {
+        justify-content: center;
+    }
+    &-right {
+        justify-content: flex-end;
+    }
+    
+}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image.html.twig
@@ -1,7 +1,7 @@
 {% block element_image %}
     {% set config = element.fieldConfig.elements %}
 
-    <div class="cms-element-{{ element.type }}{% if config.verticalAlign.value %} has-vertical-alignment{% endif %}">
+    <div class="cms-element-{{ element.type }}{% if config.verticalAlign.value || config.horizontalAlign.value %} has-vertical-alignment {% endif %}{% if config.horizontalAlign.value == "center" %} cms-element-image-horizontal-center {% elseif config.horizontalAlign.value == "flex-end" %} cms-element-image-horizontal-right {% else %} cms-element-image-horizontal-left {% endif %}">
         {% block element_product_slider_alignment %}
             {% if config.verticalAlign.value %}
                 <div class="cms-element-alignment{% if config.verticalAlign.value == "center" %} align-self-center{% elseif config.verticalAlign.value == "flex-end" %} align-self-end{% else %} align-self-start{% endif %}">


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
At the moment it's not possible to center images in the shopping experiences. All images are horizontal centered to the left. There is no possibility to center the image or align it to the right.

### 2. What does this change do, exactly?
This change is adding a config field to the cms-element-image which allows you to horizontally align your images.

### 3. Describe each step to reproduce the issue or behaviour.
Create a shopping experience, add a image element to it and try to center the image horizontally. You can align the image vertically but there is no option to do center your image horizontally. At the moment you have to use a workaround to do so with css for example

### 4. Please link to the relevant issues (if any).
Also see [this issue](https://github.com/shopware/platform/issues/2706)

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
