### PR TITLE
Fix readability of sw-text-editor on zebra pattern in bulk edit

### DIFF
--- a/changelog/_unreleased/2022-10-02-rich-text-editor-in-admin-stays-readable-on-zebra-coloring-in-bulk-edit.md
+++ b/changelog/_unreleased/2022-10-02-rich-text-editor-in-admin-stays-readable-on-zebra-coloring-in-bulk-edit.md
@@ -1,0 +1,8 @@
+---
+title: Rich text editor in administration maintains readability when used on zebra coloring in bulk edit
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added background color white to `.sw-text-editor__content` so the text editor does not change to a dark color from the bulk edit zebra pattern to keep readable

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor.scss
@@ -115,6 +115,7 @@
     }
 
     .sw-text-editor__content {
+        background: $color-white;
         transition: 0.3s all ease;
         position: relative;
         display: flex;


### PR DESCRIPTION
### 1. Why is this change necessary?

<img width="945" alt="image" src="https://user-images.githubusercontent.com/1133593/193428796-286e6b56-316d-4884-8856-5c0534c4a3f2.png">

### 2. What does this change do, exactly?

It sets a fixed background color to the rich text editor so the background color where it is actually used does not affect readability of the text.

<img width="948" alt="image" src="https://user-images.githubusercontent.com/1133593/193428785-a3b9bcc5-c364-4245-b344-a198075aa963.png">

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a custom field set
2. Create two text editor custom fields
3. Assign the custom field set to something that can be edited in bulk
4. Edit the entity in bulk
5. Scroll to custom fields
6. See two differently good readable textareas

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
