### PR TITLE
Add extension icon to distinguish app types

### DIFF
--- a/changelog/_unreleased/2022-10-03-add-extension-type-icon-in-extension-listing.md
+++ b/changelog/_unreleased/2022-10-03-add-extension-type-icon-in-extension-listing.md
@@ -1,0 +1,8 @@
+---
+title: Add extension type icon in extension listing
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added icon in extension listing to distinguish between app system based apps and plugin system based apps when planning shop updates

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -9,6 +9,13 @@
     <sw-loader v-if="isLoading" />
     {% endblock %}
 
+    <sw-icon
+        class="sw-extension-card-base__type_icon"
+        size="20"
+        :title="extension.type === 'plugin' ? $tc('sw-extension-store.component.sw-extension-card-base.extensionTypePlugin') : $tc('sw-extension-store.component.sw-extension-card-base.extensionTypeApp')"
+        :name="extension.type === 'plugin' ? 'regular-harddisk' : 'regular-cloud-upload'"
+    ></sw-icon>
+
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_extension_card_base_activation_switch %}
     <div class="sw-extension-card-base__switch">

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.scss
@@ -42,7 +42,7 @@
     .sw-meteor-card__content .sw-meteor-card__content-wrapper {
         display: grid;
         grid-column-gap: 32px;
-        grid-template-columns: 26px 60px 4fr 2fr minmax(min-content, 1fr) auto;
+        grid-template-columns: 20px 26px 60px 4fr 2fr minmax(min-content, 1fr) auto;
         align-items: center;
         padding: 10px 32px;
         border: none;

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/de-DE.json
@@ -239,6 +239,8 @@
         }
       },
       "sw-extension-card-base": {
+        "extensionTypePlugin": "Basierend auf dem Plugin-System",
+        "extensionTypeApp": "Basierend auf dem App-System",
         "subscriptionLabel": "Miete:",
         "inactiveLabel": "(inaktiv)",
         "purchasedLabel": "Gekauft am ",

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/en-GB.json
@@ -239,6 +239,8 @@
         }
       },
       "sw-extension-card-base": {
+        "extensionTypePlugin": "Based on plugin system",
+        "extensionTypeApp": "Based on app system",
         "subscriptionLabel": "Subscription:",
         "inactiveLabel": "(inactive)",
         "purchasedLabel": "Purchased on",


### PR DESCRIPTION
### 1. Why is this change necessary?

When you properly want to plan an update you want to see what is an app system based app which should update itself or what is something you have to check for updates and its changelog. To see what you have to check you want to know what you need to download.

### 2. What does this change do, exactly?

Add a column in the extension listing that displays a [cloud icon](https://github.com/shopware/meteor-icon-kit/discussions/26) or hard disk icon depending on the extension type.

<img width="593" alt="image" src="https://user-images.githubusercontent.com/1133593/193478362-3148c901-bc1e-4602-8951-03d4b50bd8f9.png">


### 3. Describe each step to reproduce the issue or behaviour.

1. Have a shop owner requesting an update
2. Investigate extensions
3. Don't know what which extension does
4. Check each in account.shopware.com
5. Be annoyed about the lots of work

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2721"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

