### PR TITLE
fix(maintenance-mode): is maintenance mode active by request

### DIFF
--- a/changelog/_unreleased/2022-10-03-2722-fix-maintenance-mode-logic.md
+++ b/changelog/_unreleased/2022-10-03-2722-fix-maintenance-mode-logic.md
@@ -1,0 +1,8 @@
+---
+title: Is maintenance mode active by request
+issue: NEXT-X
+author: AubreyHewes
+author_github: AubreyHewes
+---
+# Storefront
+* Fixed public method `Shopware\Storefront\Framework\Routing\MaintenanceModeResolver::isMaintenanceRequest` to actually use the correct logic and dogfood it in the other public methods.

--- a/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
+++ b/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
@@ -33,21 +33,28 @@ class MaintenanceModeResolver
             && !$this->isMaintenancePageRequest($request)
             && !$this->isXmlHttpRequest($request)
             && !$this->isErrorControllerRequest($request)
-            && $this->isMaintenanceModeActive($this->requestStack->getMainRequest())
-            && !$this->isClientAllowed($request);
+            && $this->isMaintenanceRequest($request);
     }
 
+    /**
+     * shouldRedirectToShop returns true, when the given request to the maintenance page should be redirected to the shop.
+     * This would be the case, for example, when the maintenance mode is not active or if it is active
+     * the client's IP address is listed in the maintenance mode whitelist.
+     */
     public function shouldRedirectToShop(Request $request): bool
     {
         return !$this->isXmlHttpRequest($request)
             && !$this->isErrorControllerRequest($request)
-            && (!$this->isMaintenanceModeActive($this->requestStack->getMainRequest())
-                || $this->isClientAllowed($request));
+            && !$this->isMaintenanceRequest($request);
     }
 
+    /**
+     * isMaintenanceRequest returns true, when the maintenance mode is active and the client's IP address
+     * is not listed in the maintenance mode whitelist.
+     */
     public function isMaintenanceRequest(Request $request): bool
     {
-        return $this->isMaintenanceModeActive($request) && $this->isClientAllowed($request);
+        return $this->isMaintenanceModeActive($request) && !$this->isClientAllowed($request);
     }
 
     private function isSalesChannelRequest(?Request $master): bool

--- a/src/Storefront/Test/Framework/Routing/MaintenanceModeResolverTest.php
+++ b/src/Storefront/Test/Framework/Routing/MaintenanceModeResolverTest.php
@@ -49,6 +49,43 @@ class MaintenanceModeResolverTest extends TestCase
         }
     }
 
+    /**
+     * Tests if the resolver redirects requests from the maintenance page to the shop correctly.
+     *
+     * @dataProvider maintenanceModeInactiveProvider
+     * @dataProvider maintenanceModeActiveProvider
+     */
+    public function testShouldRedirectToShop(Request $request, bool $shouldRedirect): void
+    {
+        $resolver = new MaintenanceModeResolver($this->getRequestStack($request));
+
+        if ($shouldRedirect) {
+            static::assertFalse(
+                $resolver->shouldRedirectToShop($request),
+                'Expected to be redirected from the maintenance page, but shouldRedirectToShop returned true.'
+            );
+        } else {
+            static::assertTrue(
+                $resolver->shouldRedirectToShop($request),
+                'Didn\'t expect to not be redirected from the maintenance page, but shouldRedirectToShop returned false.'
+            );
+        }
+    }
+
+    /**
+     * Test if the maintenance mode is active by request.
+     *
+     * @dataProvider maintenanceModeInactiveProvider
+     * @dataProvider maintenanceModeActiveProvider
+     */
+    public function testIsMaintenanceRequest(Request $request, bool $expected): void
+    {
+        static::assertEquals(
+            (new MaintenanceModeResolver($this->getRequestStack($request)))->isMaintenanceRequest($request),
+            $expected
+        );
+    }
+
     public function maintenanceModeInactiveProvider(): array
     {
         return [


### PR DESCRIPTION
fixes #2722

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Current logic is incorrect.

When reusing the `\Shopware\Storefront\Framework\Routing\MaintenanceModeResolver` service the public method `isMaintenanceRequest(Request $request): bool` should work; it currently does not; 
If maintenance is active and there are no whitelisted maintenance IPs.. it returns `false` !?.

https://github.com/shopware/platform/blob/5edba811cf465aad3926e6a386b932ab4e9b5660/src/Storefront/Framework/Routing/MaintenanceModeResolver.php#L48-L51

It seems the error is that the `isClientAllowed` should be negated?

* This method is also used in some caching classes (`Shopware\Storefront\Framework\Cache\CacheResponseSubscriber` and `Shopware\Storefront\Framework\Cache\CacheStore`) which possibly also do not work as expected. 
* This method is also not covered by any tests.

### 2. What does this change do, exactly?

This change ensures If maintenance is active and there are no whitelisted maintenance IPs.. this method returns `true`. 
Also it ensures the class dogfoods its own logic in other tested and untested public methods (which actually did it correctly; just this method did not do it correctly; so now can dogfood instead of duplicating).
Also adds tests for this public method.

### 3. Describe each step to reproduce the issue or behaviour.

1. Ensure the sales-channel maintenance ip-whitelist is empty.
1. Turn on maintenance mode. 
1. Inject the service and try the public method `isMaintenanceRequest(Request $request): bool` ... it returns `false`..!?

### 4. Please link to the relevant issues (if any).

 * https://github.com/shopware/platform/issues/2722

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
   -  [x] This should be generated from conventional commits.
-  [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
