### PR TITLE
Add button to select all permissions for an entity

### DIFF
--- a/changelog/_unreleased/2022-10-04-select-all-button-in-acl-group-detail.md
+++ b/changelog/_unreleased/2022-10-04-select-all-button-in-acl-group-detail.md
@@ -1,0 +1,8 @@
+---
+title: Add button to select all detailed permissions for an entity row
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added button in `sw-users-permissions-detailed-permissions-grid` to select all detailed permissions for a single entity

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-detailed-permissions-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-detailed-permissions-grid/index.js
@@ -82,5 +82,13 @@ Component.register('sw-users-permissions-detailed-permissions-grid', {
 
             this.detailedPrivileges.push(identifier);
         },
+
+        enablePermissionsForEntity(entity) {
+            this.permissionTypes.forEach((permissionType) => {
+                if (!this.isEntityDisabled(entity, permissionType) && !this.isEntitySelected(entity, permissionType)) {
+                    this.changePermissionForEntity(entity, permissionType);
+                }
+            });
+        },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-detailed-permissions-grid/sw-users-permissions-detailed-permissions-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-detailed-permissions-grid/sw-users-permissions-detailed-permissions-grid.html.twig
@@ -27,6 +27,14 @@
                 {% endblock %}
             </div>
             {% endblock %}
+
+            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+            {% block sw_users_permissions_detailed_permissions_grid_header_roles_select_all %}
+            <div class="sw-users-permissions-detailed-permissions-grid__checkbox-wrapper">
+                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                {{ $tc('global.entities.all') }}
+            </div>
+            {% endblock %}
         </div>
         {% endblock %}
 
@@ -96,6 +104,20 @@
                         </div>
                     </div>
                 </div>
+                {% endblock %}
+            </div>
+            {% endblock %}
+
+            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+            {% block sw_users_permissions_detailed_permissions_grid_permissions_roles_select_all %}
+            <div class="sw-users-permissions-detailed-permissions-grid__checkbox-wrapper">
+                {% block sw_users_permissions_detailed_permissions_grid_permissions_roles_select_all_button %}
+                <sw-button
+                    size="x-small"
+                    @click="enablePermissionsForEntity(entity)"
+                >
+                    {{ $tc('global.entities.all') }}
+                </sw-button>
                 {% endblock %}
             </div>
             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

Not all ACL permissions are grouped well. So there are times where you have to manually assign them. And it is a lot of work, when you have to activate permissions for each type of an entity and for a lot of entities. So why don't just add an "all" button so you have at least less to click :) 

### 2. What does this change do, exactly?

Adds an "All" button at the end of a row, that activates each permission type on the entity.

<img width="496" alt="image" src="https://user-images.githubusercontent.com/1133593/193684512-c0211cb4-513b-44e3-8f95-876ce564e982.png">

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
