### PR TITLE
added helpText for minHeight field of image slider elements

### DIFF
--- a/changelog/_unreleased/2022-10-04-image-slider-helptext.md
+++ b/changelog/_unreleased/2022-10-04-image-slider-helptext.md
@@ -1,0 +1,10 @@
+---
+title: Added helpText to the minHeight of the image slider elements
+author: Joschi Mehta
+author_email: ninja@ig-academy.com
+author_github: @NinjaArmy
+---
+# Administration
+* Added a small helpText to the minHeight field in the shopping world expierences to the image slider and image gallery element.
+# Storefront
+* If a user enters a value with spaces the input would not work. Trimmed the spaces out of the input so it will work even with a incorrect input.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
@@ -162,6 +162,7 @@
                             v-model="element.config.minHeight.value"
                             :label="$tc('sw-cms.elements.image.config.label.minHeight')"
                             :placeholder="$tc('sw-cms.elements.image.config.placeholder.enterMinHeight')"
+                            :help-text="$tc('sw-cms.elements.image.config.label.minHeightHelpText')"
                             :disabled="!['cover', 'contain'].includes(element.config.displayMode.value)"
                             @input="onChangeMinHeight"
                         />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.html.twig
@@ -108,6 +108,7 @@
                             v-model="element.config.minHeight.value"
                             :label="$tc('sw-cms.elements.image.config.label.minHeight')"
                             :placeholder="$tc('sw-cms.elements.image.config.label.minHeight')"
+                            :help-text="$tc('sw-cms.elements.image.config.label.minHeightHelpText')"
                             :disabled="element.config.displayMode.value !== 'cover'"
                             @input="onChangeMinHeight"
                         />

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -216,7 +216,7 @@
         "config": {
           "label": {
             "minHeight": "Minimale Höhe",
-            "minHeightHelpText": "Gebe   die Mindesthöhe in der gewünschten Einheit an. Zum Beispiel: 200px",
+            "minHeightHelpText": "Gebe die Mindesthöhe in der gewünschten Einheit an. Zum Beispiel: 200px",
             "linkNewTab": "Link in neuem Tab öffnen"
           },
           "placeholder": {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -216,6 +216,7 @@
         "config": {
           "label": {
             "minHeight": "Minimale Höhe",
+            "minHeightHelpText": "Gebe   die Mindesthöhe in der gewünschten Einheit an. Zum Beispiel: 200px",
             "linkNewTab": "Link in neuem Tab öffnen"
           },
           "placeholder": {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -216,6 +216,7 @@
         "config": {
           "label": {
             "minHeight": "Minimum height",
+            "minHeightHelpText": "Enter the minimum height with your desired unit. For example: 200px",
             "linkNewTab": "Open link in new tab"
           },
           "placeholder": {

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -13,7 +13,7 @@
         {% set keepAspectRatioOnZoom = sliderConfig.keepAspectRatioOnZoom.value %}
         {% set magnifierOverGallery = sliderConfig.magnifierOverGallery.value %}
         {% set zoomModal = sliderConfig.fullScreen.value %}
-        {% set minHeight = sliderConfig.minHeight.value %}
+        {% set minHeight = sliderConfig.minHeight.value|trim|replace({' ':''}) %}
         {% set displayMode = sliderConfig.displayMode.value %}
         {% set navigationArrows = sliderConfig.navigationArrows.value %}
         {% set navigationDots = sliderConfig.navigationDots.value %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
@@ -29,7 +29,7 @@
                             {% for image in element.data.sliderItems %}
 
                                 {% set imageElement %}
-                                    <div class="image-slider-item{% if loop.first != true %} is-not-first{% endif %} is-{{ sliderConfig.displayMode.value }}"{% if sliderConfig.minHeight.value and  sliderConfig.displayMode.value == "cover" %} style="min-height: {{ sliderConfig.minHeight.value }}"{% endif %}>
+                                    <div class="image-slider-item{% if loop.first != true %} is-not-first{% endif %} is-{{ sliderConfig.displayMode.value }}"{% if sliderConfig.minHeight.value and  sliderConfig.displayMode.value == "cover" %} style="min-height: {{ sliderConfig.minHeight.value|trim|replace({' ':''}) }}"{% endif %}>
                                         {% set attributes = {
                                             'class': 'img-fluid image-slider-image',
                                             'alt': (image.media.translated.alt ?: ''),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
You can set the minHeight of the image slider elements but if you don't add the unit, the minHeight will not work. The helpText gives an example of a valid input. If a user makes an input with spaces it also will not work. You can prevent that by trimming the spaces out of the input.

### 2. What does this change do, exactly?
Adding a helpText to the image slider and the gallery slider cms-element for the minHeight input and trimming spaces of  the input.

### 3. Describe each step to reproduce the issue or behaviour.
Create a new Layout in the shopping experience drag and drop the cms image slider or the gallery slider and set a min height of 200 and don't add a unit. The minHeight will not work because of the missing unit. Repeat this and now make an input with "200 px" this will also not work because of the blank space.

### 4. Please link to the relevant issues (if any).
See [this issue](https://github.com/shopware/platform/issues/2705)

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
