### PR TITLE
fix: schema.org on sold-out products

### DIFF
--- a/changelog/_unreleased/2022-10-05-2022-10-05-fix-schemaorg-outofstock.md
+++ b/changelog/_unreleased/2022-10-05-2022-10-05-fix-schemaorg-outofstock.md
@@ -1,0 +1,23 @@
+---
+title: 2022-10-05-Fix-SchemaOrg-OutOfStock
+issue: NEXT-23528
+author: Jonas Hess
+author_email: jonas@sfxonline.de
+author_github: jonas-sfx
+---
+# Storefront
+
+According to the [Google Merchant Center Help](https://support.google.com/merchants/answer/6324448?hl=en) strucured product data tagged with LimitedAvailability is interpreded as on stock.
+
+In my opinion telling Google that this product is on stock after checking for product.isCloseout and product.availableStock < product.minPurchase is wrong.
+
+*The actual change is only:*
+
+In Twig-Block "component_delivery_information_soldout" I changed
+```
+<link itemprop="availability" href="http://schema.org/LimitedAvailability"/>
+```
+to
+```
+<link itemprop="availability" href="http://schema.org/OutOfStock"/>
+```

--- a/src/Storefront/Resources/views/storefront/component/delivery-information.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/delivery-information.html.twig
@@ -45,7 +45,7 @@
             {% endblock %}
         {% elseif product.isCloseout and product.availableStock < product.minPurchase %}
             {% block component_delivery_information_soldout %}
-                <link itemprop="availability" href="http://schema.org/LimitedAvailability"/>
+                <link itemprop="availability" href="http://schema.org/OutOfStock"/>
                 <p class="delivery-information delivery-soldout">
                     <span class="delivery-status-indicator bg-danger"></span>
                     {{ "detail.soldOut"|trans|sw_sanitize }}


### PR DESCRIPTION
### 1. Why is this change necessary?
Because sold out products should not be tagged as on stock.

### 2. What does this change do, exactly?
Told already in changelog-file.

### 3. Describe each step to reproduce the issue or behaviour.
Described in [Issue "NEXT-23528"](https://issues.shopware.com/issues/NEXT-23528)

### 4. Please link to the relevant issues (if any).
[NEXT-23528](https://issues.shopware.com/issues/NEXT-23528)

### 5. Checklist

- [✅] I have rebased my changes to remove merge conflicts
- [❌] I have written tests and verified that they fail without my change
- [✅] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [❌] I have written or adjusted the documentation according to my changes
- [❌] This change has comments for package types, values, functions, and non-obvious lines of code
- [✅] I have read the contribution requirements and fulfil them.
