### PR TITLE
Fixing CMS Image sliders when arrows are outside

### DIFF
--- a/changelog/_unreleased/2022-10-05-image-slider-arrows-outside.md
+++ b/changelog/_unreleased/2022-10-05-image-slider-arrows-outside.md
@@ -1,0 +1,8 @@
+---
+title: Fixing Styling for image sliders with arrows outside
+author: Joschi Mehta
+author_email: ninja@ig-academy.com
+author_github: @NinjaArmy
+---
+# Storefront
+* Image sliders with arrows outside showed the next/prev slides behind the arrows and on mobile devices the arrows were cut. Moved the arrows in place and took care of the overlapping in the slider.

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
@@ -34,6 +34,12 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     position: relative;
     height: 100%;
 
+    .arrows-outside {
+        .gallery-slider-item  {
+            padding: 0 25px;
+        }
+    }
+
     .gallery-slider-image {
         display: block;
     }
@@ -89,7 +95,7 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     left: 0;
 
     &.is-nav-prev-outside {
-        left: -10px;
+        left: 0;
     }
 }
 
@@ -97,7 +103,7 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     right: 0;
 
     &.is-nav-next-outside {
-        right: -10px;
+        right: 0;
     }
 }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
@@ -35,7 +35,7 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     height: 100%;
 
     .arrows-outside {
-        .gallery-slider-item  {
+        .gallery-slider-item-wrapper {
             padding: 0 25px;
         }
     }

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_image-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_image-slider.scss
@@ -14,7 +14,11 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
         display: block;
         width: 100%;
     }
-
+    .arrows-outside {
+        .image-slider-item  {
+            padding: 0 25px;
+        }
+    }
     .image-slider-item {
         display: grid;
         max-width: 100%;
@@ -56,7 +60,7 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     }
 
     &.is-nav-prev-outside {
-        left: -15px;
+        left: 0;
     }
 }
 
@@ -66,7 +70,7 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     }
 
     &.is-nav-next-outside {
-        right: -15px;
+        right: 0;
     }
 }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_image-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_image-slider.scss
@@ -15,7 +15,7 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
         width: 100%;
     }
     .arrows-outside {
-        .image-slider-item  {
+        .image-slider-item-wrapper  {
             padding: 0 25px;
         }
     }

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -146,6 +146,7 @@
                                                             {% for image in mediaItems %}
                                                                 {% block element_image_gallery_inner_item %}
                                                                     <div class="gallery-slider-item-container{% if sliderConfig.navigationArrows.value == "outside" %} arrows-outside {% endif %}">
+                                                                    <div class="gallery-slider-item-wrapper">
                                                                         <div class="gallery-slider-item is-{{ displayMode }} js-magnifier-container"{% if minHeight and  (displayMode == "cover" or displayMode == "contain" ) %} style="min-height: {{ minHeight }}"{% endif %}>
                                                                             {% set attributes = {
                                                                                 'class': 'img-fluid gallery-slider-image magnifier-image js-magnifier-image',
@@ -165,6 +166,7 @@
                                                                             {% sw_thumbnails 'gallery-slider-image-thumbnails' with {
                                                                                 media: image
                                                                             } %}
+                                                                        </div>
                                                                         </div>
                                                                     </div>
                                                                 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -145,7 +145,7 @@
                                                         {% block element_image_gallery_inner_items %}
                                                             {% for image in mediaItems %}
                                                                 {% block element_image_gallery_inner_item %}
-                                                                    <div class="gallery-slider-item-container">
+                                                                    <div class="gallery-slider-item-container{% if sliderConfig.navigationArrows.value == "outside" %} arrows-outside {% endif %}">
                                                                         <div class="gallery-slider-item is-{{ displayMode }} js-magnifier-container"{% if minHeight and  (displayMode == "cover" or displayMode == "contain" ) %} style="min-height: {{ minHeight }}"{% endif %}>
                                                                             {% set attributes = {
                                                                                 'class': 'img-fluid gallery-slider-image magnifier-image js-magnifier-image',

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
@@ -47,7 +47,7 @@
                                 {% endset %}
 
                                 {% block element_image_slider_inner_item %}
-                                    <div class="image-slider-item-container">
+                                    <div class="image-slider-item-container{% if sliderConfig.navigationArrows.value == "outside" %} arrows-outside {% endif %}">
                                         {% if image.url %}
                                             <a href="{{ image.url }}"
                                                class="image-slider-link"

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-slider.html.twig
@@ -48,6 +48,7 @@
 
                                 {% block element_image_slider_inner_item %}
                                     <div class="image-slider-item-container{% if sliderConfig.navigationArrows.value == "outside" %} arrows-outside {% endif %}">
+                                        <div class="image-slider-item-wrapper">
                                         {% if image.url %}
                                             <a href="{{ image.url }}"
                                                class="image-slider-link"
@@ -57,6 +58,7 @@
                                         {% else %}
                                             {{ imageElement }}
                                         {% endif %}
+                                        </div>
                                     </div>
                                 {% endblock %}
                             {% endfor %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
If you create an image slider or an gallery slider in the shopping experiences and set the navigation arrows to outside, you will see a part of the next and a part of the previous slide under the control arrows.
![image](https://user-images.githubusercontent.com/40269795/194155590-5bb7aa98-9452-4caf-813f-de7bac2b8780.png)


### 2. What does this change do, exactly?
Correcting the display of the cms image slider when the control arrows are outside. Added a bit css and a wrapper div to place the arrows at the correct position.

### 3. Describe each step to reproduce the issue or behaviour.
Go the the shopping experience and create a new layout. Drag and drop the image slider or the image gallery element into the layout and add a couple of images. Go to the configuration of the element and choose the outside option for the control arrows. Now take a look at the storefront and you should see the styling Issue. On the left and right side of the active slide image you see a part of the next and previous slide.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
