### PR TITLE
enable cms layout renaming from listing

### DIFF
--- a/changelog/_unreleased/2022-10-05-rename-cms-layout-from-listing.md
+++ b/changelog/_unreleased/2022-10-05-rename-cms-layout-from-listing.md
@@ -1,0 +1,15 @@
+---
+title: Rename CMS layouts from listing
+issue: #2678
+author: Lisa Meister
+author_email: lisa.meister.93@gmx.de
+author_github: Lilibell
+
+___
+# Administration
+* Add `sw-context-menu-item`for initiating layout rename to `sw-cms-list.html.twig`
+* Add `sw-modal` for choosing a new layout name to `sw-cms-list.html.twig`
+* Add props `showRenameModal` and `newName` to `sw-cms-list`
+* Add methods `onRenameCmsPage`, `onCloseRenameModal` and `onConfirmPageRename` to `sw-cms-list`
+* Add snippets `sw-cms.components.cmsListItem.modal.renameModalTitle`, `sw-cms.components.cmsListItem.modal.textRenameConfirm`,
+`sw-cms.components.cmsListItem.modal.buttonRename` and `sw-cms.components.cmsListItem.rename`

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/index.js
@@ -33,6 +33,8 @@ Component.register('sw-cms-list', {
             currentPageType: null,
             showMediaModal: false,
             currentPage: null,
+            showRenameModal: false,
+            newName: null,
             showDeleteModal: false,
             defaultMediaFolderId: null,
             listMode: 'grid',
@@ -404,6 +406,26 @@ Component.register('sw-cms-list', {
             this.currentPage.previewMediaId = image.id;
             this.saveCmsPage(this.currentPage);
             this.currentPage.previewMedia = image;
+        },
+
+        onRenameCmsPage(page) {
+            this.currentPage = page;
+            this.showRenameModal = true;
+        },
+
+        onCloseRenameModal() {
+            this.currentPage = null;
+            this.showRenameModal = false;
+        },
+
+        onConfirmPageRename() {
+            if (this.newName) {
+                this.currentPage.name = this.newName;
+                this.saveCmsPage(this.currentPage);
+                this.newName = null;
+            }
+            this.currentPage = null;
+            this.showRenameModal = false;
         },
 
         onDeleteCmsPage(page) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
@@ -390,6 +390,16 @@
                                     </sw-context-menu-item>
                                     {% endblock %}
 
+                                    {% block sw_cms_list_listing_list_item_option_rename %}
+                                        <sw-context-menu-item
+                                            :disabled="!acl.can('cms.editor')"
+                                            v-if="!cmsPage.locked"
+                                            @click="onRenameCmsPage(cmsPage)"
+                                        >
+                                            {{ $tc('sw-cms.components.cmsListItem.rename') }}
+                                        </sw-context-menu-item>
+                                    {% endblock %}
+
                                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                                     {% block sw_cms_list_listing_list_data_grid_actions_edit_delete %}
                                     <sw-context-menu-item
@@ -478,6 +488,48 @@
             @cancel="onCloseLayoutSetAsDefault"
             @close="onCloseLayoutSetAsDefault"
         />
+
+        {% block sw_cms_list_rename_modal %}
+            <sw-modal
+                v-if="showRenameModal"
+                :title="$tc('sw-cms.components.cmsListItem.modal.renameModalTitle')"
+                variant="small"
+                @modal-close="onCloseRenameModal"
+            >
+
+                {% block sw_cms_list_rename_modal_confirm_rename_input %}
+                    <div>{{ $tc('sw-cms.components.cmsListItem.modal.textRenameConfirm', 0,
+                        { pageName: currentPage.translated.name || currentPage.name }) }}</div>
+                    <sw-text-field
+                        v-model="newName"
+                        size="medium"
+                    />
+                {% endblock %}
+
+                {% block sw_cms_list_rename_modal_footer %}
+                    <template slot="modal-footer">
+                        {% block sw_cms_list_rename_modal_cancel %}
+                            <sw-button
+                                size="small"
+                                @click="onCloseRenameModal"
+                            >
+                                {{ $tc('sw-cms.components.cmsListItem.modal.buttonCancel') }}
+                            </sw-button>
+                        {% endblock %}
+
+                        {% block sw_cms_list_rename_modal_confirm %}
+                            <sw-button
+                                size="small"
+                                variant="primary"
+                                @click="onConfirmPageRename"
+                            >
+                                {{ $tc('sw-cms.components.cmsListItem.modal.buttonRename') }}
+                            </sw-button>
+                        {% endblock %}
+                    </template>
+                {% endblock %}
+            </sw-modal>
+        {% endblock %}
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_cms_list_delete_modal %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -738,18 +738,22 @@
       "cmsListItem": {
         "emptyText": "Kein Layout zugewiesen",
         "edit": "Bearbeiten",
+        "rename": "Umbenennen",
         "delete": "Löschen",
         "duplicate": "Duplizieren",
         "addPreviewImage": "Vorschau hinzufügen",
-        "setAsDefaultProductList": "Als Standard für Produktlistings festlegen", 
+        "setAsDefaultProductList": "Als Standard für Produktlistings festlegen",
         "setAsDefaultProductDetail": "Als Standard für Produkseiten festlegen",
         "defaultLayout": "Standardlayout",
-        "defaultLayoutProductList": "Standardlayout - Produktseite", 
+        "defaultLayoutProductList": "Standardlayout - Produktseite",
         "defaultLayoutProductDetail": "Standardlayout - Produktlisting",
         "removePreviewImage": "Vorschau entfernen",
         "notificationDeleteErrorMessage": "Das Layout ist noch mindestens einer Kategorie zugewiesen.",
         "modal": {
+          "renameModalTitle": "Layout umbenennen",
+          "textRenameConfirm": "Wähle einen neuen Namen für \"{pageName}\":",
           "textDeleteConfirm": "Möchtest Du das Layout \"{pageName}\" wirklich löschen?",
+          "buttonRename": "Umbenennen",
           "buttonCancel": "Abbrechen",
           "buttonDelete": "Löschen"
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -738,6 +738,7 @@
       "cmsListItem": {
         "emptyText": "No layout assigned",
         "edit": "Edit",
+        "rename": "Rename",
         "delete": "Delete",
         "duplicate": "Duplicate",
         "addPreviewImage": "Add preview image",
@@ -749,7 +750,10 @@
         "removePreviewImage": "Remove preview",
         "notificationDeleteErrorMessage": "The layout you want to delete is still assigned to at least one category.",
         "modal": {
+          "renameModalTitle": "Rename layout",
+          "textRenameConfirm": "Choose a new name for \"{pageName}\":",
           "textDeleteConfirm": "Are you sure you really want to delete the layout \"{pageName}\"?",
+          "buttonRename": "Rename",
           "buttonCancel": "Cancel",
           "buttonDelete": "Delete"
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
Having the option to rename layouts in the listing will make it easier and faster to manage layouts. It will no longer be necessary to navigate into the layout editor to change the name, which is tiresome espacially for copied layouts that will most likely be renamed.

### 2. What does this change do, exactly?
Add a button for renaming layouts to the layout options in the cms list (administration).

### 3. Describe each step to reproduce the issue or behaviour.
1. Navigate to Shopping Experiences in the administration
2. Open the options for one of your layouts ("...") and choose the "Rename" option
3. In the modal that will open, choose a new name for your layout and click the "rename" button at the bottom

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2678

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
