### PR TITLE
Replace nbsp with 0x20 space

### DIFF
--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-modal/sw-theme-modal.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-modal/sw-theme-modal.html.twig
@@ -6,7 +6,7 @@
 
                 {% block sw_theme_modal_header_title %}
                     <div class="sw-theme-modal__header-title">
-                        {{ $tc('sw-theme-manager.themeModal.headline') }}
+                        {{ $tc('sw-theme-manager.themeModal.headline') }}
                     </div>
                 {% endblock %}
 
@@ -56,10 +56,10 @@
         {% block sw_theme_modal_footer %}
             <template slot="modal-footer">
                 <sw-button @click="closeModal">
-                    {{ $tc('sw-theme-manager.themeModal.actionCancel') }}
+                    {{ $tc('sw-theme-manager.themeModal.actionCancel') }}
                 </sw-button>
                 <sw-button @click="selectLayout" variant="primary">
-                    {{ $tc('sw-theme-manager.themeModal.actionConfirm') }}
+                    {{ $tc('sw-theme-manager.themeModal.actionConfirm') }}
                 </sw-button>
             </template>
         {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

It is not really but it looked weird when I stumbled upon this.

I don't expect this to need a changelog. Just a small tidy up.

### 2. What does this change do, exactly?

I replaced raw nbsp with a regular space.

<img width="435" alt="image" src="https://user-images.githubusercontent.com/1133593/194170829-a3452d87-c85a-4bf4-8cf7-65495d5e8bd2.png">

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
