### PR TITLE
CMS-Element: Apply defaultConfig & defaultData on replace

### DIFF
--- a/changelog/_unreleased/2022-10-06-apply-defaultconfig-&-defaultdata-on-cms-element-replace.md
+++ b/changelog/_unreleased/2022-10-06-apply-defaultconfig-&-defaultdata-on-cms-element-replace.md
@@ -1,5 +1,6 @@
 ---
 title: Apply defaultConfig & defaultData on CMS element replace
+issue: NEXT-23596
 author: Florian Kasper
 author_email: fk@bitsandlikes.de
 author_github: fk-bitsandlikes

--- a/changelog/_unreleased/2022-10-06-apply-defaultconfig-&-defaultdata-on-cms-element-replace.md
+++ b/changelog/_unreleased/2022-10-06-apply-defaultconfig-&-defaultdata-on-cms-element-replace.md
@@ -1,0 +1,11 @@
+---
+title: Apply defaultConfig & defaultData on CMS element replace
+author: Florian Kasper
+author_email: fk@bitsandlikes.de
+author_github: fk-bitsandlikes
+---
+
+# Administration
+
+* Apply defaultConfig & defaultData on CMS element replace
+  in`src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.js`,

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.js
@@ -2,6 +2,7 @@ import template from './sw-cms-slot.html.twig';
 import './sw-cms-slot.scss';
 
 const { Component } = Shopware;
+const { deepCopyObject } = Shopware.Utils.object;
 
 /**
  * @private since v6.5.0
@@ -105,11 +106,10 @@ Component.register('sw-cms-slot', {
         onCloseElementModal() {
             this.showElementSelection = false;
         },
-
-        onSelectElement(elementType) {
-            this.element.data = {};
-            this.element.config = {};
-            this.element.type = elementType;
+        onSelectElement(element) {
+            this.element.data = deepCopyObject(element?.defaultData || {});
+            this.element.config = deepCopyObject(element?.defaultConfig || {});
+            this.element.type = element.name;
             this.element.locked = false;
             this.showElementSelection = false;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/sw-cms-slot.html.twig
@@ -122,7 +122,7 @@
                 v-if="!element.hidden && element.previewComponent"
                 :key="index"
                 class="element-selection__element-wrapper"
-                @click="onSelectElement(element.name)"
+                @click="onSelectElement(element)"
             >
                 <div class="element-selection__element">
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-slot.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-slot.spec.js
@@ -1,4 +1,4 @@
-import {shallowMount, createLocalVue} from '@vue/test-utils';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
 import 'src/module/sw-cms/mixin/sw-cms-state.mixin';
 import 'src/module/sw-cms/component/sw-cms-slot';
 
@@ -28,7 +28,6 @@ function createWrapper() {
         }
     });
 }
-
 describe('module/sw-cms/component/sw-cms-slot', () => {
     it('should be a Vue.js component', async () => {
         const wrapper = createWrapper();
@@ -145,6 +144,4 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
             locked: false,
         });
     });
-
-
 });

--- a/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-slot.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-cms/component/sw-cms-slot.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
+import {shallowMount, createLocalVue} from '@vue/test-utils';
 import 'src/module/sw-cms/mixin/sw-cms-state.mixin';
 import 'src/module/sw-cms/component/sw-cms-slot';
 
@@ -28,6 +28,7 @@ function createWrapper() {
         }
     });
 }
+
 describe('module/sw-cms/component/sw-cms-slot', () => {
     it('should be a Vue.js component', async () => {
         const wrapper = createWrapper();
@@ -79,4 +80,71 @@ describe('module/sw-cms/component/sw-cms-slot', () => {
         expect(wrapper.find('.sw-cms-slot__settings-action').classes()).toContain('is--disabled');
         expect(wrapper.vm.tooltipDisabled.disabled).toBe(false);
     });
+
+    it('test onSelectElement', async () => {
+        const wrapper = createWrapper();
+        expect(wrapper.vm.element).toEqual({});
+
+        wrapper.vm.onSelectElement({
+            name: 'testElement',
+        });
+        expect(wrapper.vm.element).toEqual({
+            type: 'testElement',
+            config: {},
+            data: {},
+            locked: false,
+        });
+
+        wrapper.vm.onSelectElement({
+            name: 'testElement2',
+            defaultConfig: {
+                imageId: 1234567980,
+            },
+        });
+        expect(wrapper.vm.element).toEqual({
+            type: 'testElement2',
+            config: {
+                imageId: 1234567980,
+            },
+            data: {},
+            locked: false,
+        });
+
+        wrapper.vm.onSelectElement({
+            name: 'testElement3',
+            defaultData: {
+                text: 'Test text',
+            }
+        });
+        expect(wrapper.vm.element).toEqual({
+            type: 'testElement3',
+            config: {},
+            data: {
+                text: 'Test text',
+            },
+            locked: false,
+        });
+
+        wrapper.vm.onSelectElement({
+            name: 'testElement4',
+            defaultConfig: {
+                imageId: 1234567980,
+            },
+            defaultData: {
+                text: 'Test text',
+            },
+        });
+        expect(wrapper.vm.element).toEqual({
+            type: 'testElement4',
+            config: {
+                imageId: 1234567980,
+            },
+            data: {
+                text: 'Test text',
+            },
+            locked: false,
+        });
+    });
+
+
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
If a CMS element is created, it is created with the optional defaultConfig & defaultData.
If a CMS element is replaced, however, these are not currently transferred.

### 2. What does this change do, exactly?

When replacing the CMS element, the optional defaultConfig & defaultData are taken over.

### 3. Describe each step to reproduce the issue or behaviour.

~~Add a block with one element, then swap the element with another. defaultConfig and defaultData are not applied.~~

Updated guide to reproducing the issue:

1. Create a block of any type (I tested it with image & text)
2. Click the Replace button
3. Select the element with the same type
   This will reset the element (override with same element type, but defaultConfig & defaultData will be missing.

**Cause:**
When adding the CMS elements, the mixin method [cms-element#initElementConfig](https://github.com/shopware/platform/blob/cb82ce19d703ba4218b4fc11284240e36d63b94e/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.js#L52) is called in the respective vue created.

In the component the function [sw-cms-slot#onSelectElement](https://github.com/shopware/platform/blob/cb82ce19d703ba4218b4fc11284240e36d63b94e/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.js#L109) is used and not the initElementConfig, in which the defaultConfig & defaultData are initialized with empty object.




### 4. Please link to the relevant issues (if any).

No corresponding issue exists.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
