### PR TITLE
Added routerlinks to primary columns in mail-template-lists

### DIFF
--- a/changelog/_unreleased/2022-10-06-add-mail-template-detail-routes.md
+++ b/changelog/_unreleased/2022-10-06-add-mail-template-detail-routes.md
@@ -1,0 +1,9 @@
+---
+title: Added detail routes on primary columns in `sw-mail-template-list` and `sw-mail-header-footer-list` component
+author: Ioannis Pourliotis
+author_email: dev@pourliotis.de
+author_github: @PheysX
+---
+# Administration
+* Added detail route on primary column in `sw-mail-template-list` component
+* Added detail route on primary column in `sw-mail-header-footer-list` component

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-header-footer-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-header-footer-list/index.js
@@ -89,6 +89,7 @@ Component.register('sw-mail-header-footer-list', {
                 dataIndex: 'name',
                 label: 'sw-mail-header-footer.list.columnName',
                 allowResize: true,
+                routerLink: 'sw.mail.template.detail_head_foot',
                 primary: true,
             }, {
                 property: 'description',

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/component/sw-mail-template-list/index.js
@@ -78,6 +78,7 @@ Component.register('sw-mail-template-list', {
                 dataIndex: 'mailTemplateType.name',
                 label: 'sw-mail-template.list.columnMailType',
                 allowResize: true,
+                routerLink: 'sw.mail.template.detail',
                 primary: true,
             }, {
                 property: 'description',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
- To switch faster to detail view
- the user expects it

### 2. What does this change do, exactly?
Added routerLink property to columns in  `sw-mail-template-list` &  `sw-mail-header-footer-list` component.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
