### PR TITLE
fix: Misleading shipping cost display in offcanvas cart

### DIFF
--- a/changelog/_unreleased/2022-10-06-offcanvas-cart-shipping-cost-display.md
+++ b/changelog/_unreleased/2022-10-06-offcanvas-cart-shipping-cost-display.md
@@ -1,0 +1,10 @@
+---
+title: Add star to shipping costs in offcanvas cart
+issue: NEXT-21982
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Fix confusing/misleading display of negative shipping costs in the offcanvas cart, by just displaying a single `-` or `+`
+* Add star to shipping costs in offcanvas cart

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
@@ -30,7 +30,7 @@
                         </span>
 
                         <span class="col-5 pb-2 shipping-value shipping-cost">
-                            <strong>+ {{ activeShipping.shippingCosts.totalPrice|currency }}</strong>
+                            <strong>{{ activeShipping.shippingCosts.totalPrice < 0 ? '-' : '+' }} {{ activeShipping.shippingCosts.totalPrice|abs|currency }}{{ "general.star"|trans|sw_sanitize }}</strong>
                         </span>
                     </div>
                 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently if you have negative shipping costs they will be displayed by `+ - ...`. 

### 2. What does this change do, exactly?
This PR changes that behaviour to only display either a single `+` or `-` sign. Additionally the `*` is added to that price, as it is always a gross or net price, depending on the settings of the cart.

### 3. Describe each step to reproduce the issue or behaviour.
Add negative shipping costs and look at the offcanvas cart.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-21982

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
