### PR TITLE
Fix GitHub issue 2700

### DIFF
--- a/changelog/_unreleased/2022-10-06-fix-github-issue-2700.md
+++ b/changelog/_unreleased/2022-10-06-fix-github-issue-2700.md
@@ -1,0 +1,12 @@
+---
+title: Fix Github Issue 2700
+issue: 2700
+author: FK
+author_email: fk@bitsandlikes.de
+author_github: fk-bitsandlikes
+---
+
+# Administration
+
+* Fix object unboxing in
+  file `src/Administration/Resources/app/administration/src/app/service/custom-field.service.js`,

--- a/src/Administration/Resources/app/administration/src/app/service/custom-field.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/custom-field.service.js
@@ -140,7 +140,7 @@ export default function createCustomFieldService() {
     }
 
     function upsertType(name, configuration) {
-        $typeStore[name] = { ...$typeStore[name], ...{ configuration } };
+        $typeStore[name] = { ...$typeStore[name], ...configuration };
     }
 
     function getTypes() {

--- a/src/Administration/Resources/app/administration/test/app/service/custom-field.service.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/service/custom-field.service.spec.js
@@ -2,7 +2,7 @@ import createCustomFieldService from 'src/app/service/custom-field.service';
 
 describe('src/app/service/custom-field.service.js', () => {
     let customFieldService;
-    let expectedTypeConfigs = {
+    const expectedTypeConfigs = {
         number: {
             configRenderComponent: 'sw-custom-field-type-number',
             type: 'int',
@@ -19,7 +19,7 @@ describe('src/app/service/custom-field.service.js', () => {
     });
 
     it('getTypeByName: get number type config', async () => {
-        expect(customFieldService.getTypeByName('number')).toEqual(customFieldService.getTypes()['number']);
+        expect(customFieldService.getTypeByName('number')).toEqual(customFieldService.getTypes().number);
     });
 
     it('getTypeByName: get unknown type config', async () => {
@@ -33,7 +33,7 @@ describe('src/app/service/custom-field.service.js', () => {
     it('upsertType: insert config of new type ', async () => {
         expect(customFieldService.getTypeByName('newType')).toBeUndefined();
 
-        let newTypeConfig = {
+        const newTypeConfig = {
             configRenderComponent: 'sw-custom-field-type-new-type',
             type: 'newType',
             config: {
@@ -41,7 +41,7 @@ describe('src/app/service/custom-field.service.js', () => {
                 type: 'newType',
             }
         };
-        customFieldService.upsertType('newType', newTypeConfig)
+        customFieldService.upsertType('newType', newTypeConfig);
 
         expect(customFieldService.getTypeByName('newType')).toEqual(newTypeConfig);
     });
@@ -49,7 +49,7 @@ describe('src/app/service/custom-field.service.js', () => {
     it('upsertType: upsert config', async () => {
         expect(customFieldService.getTypeByName('number')).toEqual(expectedTypeConfigs.number);
 
-        let newConfig = {
+        const newConfig = {
             ...expectedTypeConfigs.number,
             type: 'float',
             config: {
@@ -62,5 +62,4 @@ describe('src/app/service/custom-field.service.js', () => {
 
         expect(customFieldService.getTypeByName('number')).toEqual(newConfig);
     });
-
 });

--- a/src/Administration/Resources/app/administration/test/app/service/custom-field.service.spec.js
+++ b/src/Administration/Resources/app/administration/test/app/service/custom-field.service.spec.js
@@ -1,0 +1,66 @@
+import createCustomFieldService from 'src/app/service/custom-field.service';
+
+describe('src/app/service/custom-field.service.js', () => {
+    let customFieldService;
+    let expectedTypeConfigs = {
+        number: {
+            configRenderComponent: 'sw-custom-field-type-number',
+            type: 'int',
+            config: {
+                componentName: 'sw-field',
+                type: 'number',
+                numberType: 'float',
+            },
+        },
+    };
+
+    beforeEach(() => {
+        customFieldService = createCustomFieldService();
+    });
+
+    it('getTypeByName: get number type config', async () => {
+        expect(customFieldService.getTypeByName('number')).toEqual(customFieldService.getTypes()['number']);
+    });
+
+    it('getTypeByName: get unknown type config', async () => {
+        expect(customFieldService.getTypeByName('unknownType')).toBeUndefined();
+    });
+
+    it('getTypeByName: checking expected config', async () => {
+        expect(customFieldService.getTypeByName('number')).toEqual(expectedTypeConfigs.number);
+    });
+
+    it('upsertType: insert config of new type ', async () => {
+        expect(customFieldService.getTypeByName('newType')).toBeUndefined();
+
+        let newTypeConfig = {
+            configRenderComponent: 'sw-custom-field-type-new-type',
+            type: 'newType',
+            config: {
+                componentName: 'sw-field',
+                type: 'newType',
+            }
+        };
+        customFieldService.upsertType('newType', newTypeConfig)
+
+        expect(customFieldService.getTypeByName('newType')).toEqual(newTypeConfig);
+    });
+
+    it('upsertType: upsert config', async () => {
+        expect(customFieldService.getTypeByName('number')).toEqual(expectedTypeConfigs.number);
+
+        let newConfig = {
+            ...expectedTypeConfigs.number,
+            type: 'float',
+            config: {
+                ...expectedTypeConfigs.number.config,
+                numberType: 'float',
+            }
+        };
+
+        customFieldService.upsertType('number', newConfig);
+
+        expect(customFieldService.getTypeByName('number')).toEqual(newConfig);
+    });
+
+});


### PR DESCRIPTION
### 1. Why is this change necessary?

Calling upserType inserts a new type in the $typeStore in incorect structure

### 2. What does this change do, exactly?

Calling upserType inserts a new type in the $typeStore with correct structure

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

fix #2700 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
