### PR TITLE
Fix NEXT-23457: Wrong creation of int number custom fields

### DIFF
--- a/changelog/_unreleased/2022-10-06-fix-issue-next-23457.md
+++ b/changelog/_unreleased/2022-10-06-fix-issue-next-23457.md
@@ -1,0 +1,13 @@
+---
+title: Fix NEXT-23457: Fix saving number custom fields as type FLOAT instead of INT
+issue: NEXT-23457
+author: Florian Kasper
+author_email: fk@bitsandlikes.de
+author_github: fk-bitsandlikes
+---
+
+# Administration
+
+* Fix saving number custom fields as type FLOAT instead of INT
+  in file `src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-detail/index.js`
+  change order in merging data

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-detail/index.js
@@ -165,8 +165,8 @@ Component.register('sw-custom-field-detail', {
             }
 
             this.currentCustomField.config = {
-                ...this.currentCustomField.config,
                 ...this.fieldTypes[customFieldType].config,
+                ...this.currentCustomField.config,
             };
         },
     },


### PR DESCRIPTION
Fix for ticket **NEXT-23457**: "Create Custom Fields in admin as type INT fields create it as FLOAT fields"

### 1. Why is this change necessary?

When a custom field is created in the admin, a int number field is saved as type float.

The error is in the merge of the CustomFieldConfig, the order is wrong. In the current code, the current (changed) config is overwritten with the default config, but this also means that config values are overwritten that already exist, In this case the config value of customFieldType.

### 2. What does this change do, exactly?

The sequence during the merge was fixed. During the merge the values of the defaultconfig are taken and merged with the current settings.

### 3. Describe each step to reproduce the issue or behaviour.

- Click "New custom field" to open modal for creating custom field
- Configure a customfield of type number with number type int
- Click add
- Custom field was created with float as number type, check by open edit modal

### 4. Please link to the relevant issues (if any).

fix [NEXT-23457](https://issues.shopware.com/issues/NEXT-23457)


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
