### PR TITLE
Stop admin product editor to set negative stock to 0

### DIFF
--- a/changelog/_unreleased/2022-10-07-admin-product-stop-change-negative-stock-to-0.md
+++ b/changelog/_unreleased/2022-10-07-admin-product-stop-change-negative-stock-to-0.md
@@ -1,0 +1,8 @@
+---
+title: Stop admin product editor to change negative stock to 0
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Fixed admin product editor change negative stock to 0

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-form/sw-product-deliverability-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-deliverability-form/sw-product-deliverability-form.html.twig
@@ -12,7 +12,6 @@
             type="number"
             name="sw-field--product-stock"
             number-type="int"
-            :min="0"
             :disabled="!allowEdit"
             :label="$tc('sw-product.settingsForm.labelStock')"
             :placeholder="$tc('sw-product.settingsForm.placeholderStock')"


### PR DESCRIPTION
### 1. Why is this change necessary?

When you open a product in the admin the stock input field will apply its mininum value setting. So when you sell a product without respecting clearance but still using the negative stock info to see how many items have to be acquired/manufactured, you will never see the actual correct value once the product has been opened and saved.

### 2. What does this change do, exactly?

Remove minimum setting on stock field.

### 3. Describe each step to reproduce the issue or behaviour.

1. Sell product until stock under 0
2. Edit product without changing stock
3. Save
4. See stock of 0 with a newly recalculated available stock
5. <img width="488" alt="image" src="https://user-images.githubusercontent.com/1133593/194426595-a96e771a-177f-4765-8014-257acf9e0b5f.png">

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
