### PR TITLE
fix: Register scheduled tasks on plugin updates

### DIFF
--- a/changelog/_unreleased/2022-10-07-register-scheduled-tasks-on-plugin-updates.md
+++ b/changelog/_unreleased/2022-10-07-register-scheduled-tasks-on-plugin-updates.md
@@ -1,0 +1,9 @@
+---
+title: Register scheduled tasks on plugin updates
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Register scheduled tasks on plugin updates

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Subscriber/PluginLifecycleSubscriber.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Subscriber/PluginLifecycleSubscriber.php
@@ -6,6 +6,7 @@ use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
 use Shopware\Core\Framework\Plugin\Event\PluginPostActivateEvent;
 use Shopware\Core\Framework\Plugin\Event\PluginPostDeactivateEvent;
+use Shopware\Core\Framework\Plugin\Event\PluginPostUpdateEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 
@@ -32,6 +33,7 @@ class PluginLifecycleSubscriber implements EventSubscriberInterface
         return [
             PluginPostActivateEvent::class => 'afterPluginStateChange',
             PluginPostDeactivateEvent::class => 'afterPluginStateChange',
+            PluginPostUpdateEvent::class => 'afterPluginStateChange',
         ];
     }
 

--- a/src/Core/Framework/Test/ScheduledTask/Subscriber/PluginLifecycleSubscriberTest.php
+++ b/src/Core/Framework/Test/ScheduledTask/Subscriber/PluginLifecycleSubscriberTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\MessageQueue\ScheduledTask\Registry\TaskRegistry;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\Subscriber\PluginLifecycleSubscriber;
 use Shopware\Core\Framework\Plugin\Event\PluginPostActivateEvent;
 use Shopware\Core\Framework\Plugin\Event\PluginPostDeactivateEvent;
+use Shopware\Core\Framework\Plugin\Event\PluginPostUpdateEvent;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnRestartSignalListener;
 
 /**
@@ -19,11 +20,13 @@ class PluginLifecycleSubscriberTest extends TestCase
     {
         $events = PluginLifecycleSubscriber::getSubscribedEvents();
 
-        static::assertCount(2, $events);
+        static::assertCount(3, $events);
         static::assertArrayHasKey(PluginPostActivateEvent::class, $events);
         static::assertEquals('afterPluginStateChange', $events[PluginPostActivateEvent::class]);
         static::assertArrayHasKey(PluginPostDeactivateEvent::class, $events);
         static::assertEquals('afterPluginStateChange', $events[PluginPostDeactivateEvent::class]);
+        static::assertArrayHasKey(PluginPostUpdateEvent::class, $events);
+        static::assertEquals('afterPluginStateChange', $events[PluginPostUpdateEvent::class]);
     }
 
     public function testRegisterScheduledTasks(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently new scheduled tasks are not registered when a plugin is updated, as it is stated in the documentation: https://developer.shopware.com/docs/guides/plugins/plugins/plugin-fundamentals/add-scheduled-task#executing-the-scheduled-task

### 2. What does this change do, exactly?
Register the scheduled tasks on a plugin update.

### 3. Describe each step to reproduce the issue or behaviour.
Install a plugin, create a new version, which now contains a scheduled task. You need to manually register the tasks by using `bin/console scheduled-task:register`.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
