### PR TITLE
Fix sentence with module naming

### DIFF
--- a/changelog/_unreleased/2022-10-08-fix-casing-for-module-mentioning-in-global-admin-search.md
+++ b/changelog/_unreleased/2022-10-08-fix-casing-for-module-mentioning-in-global-admin-search.md
@@ -1,0 +1,10 @@
+---
+title: Fix casing for module mentioning in global admin search
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added `entityNameLower` variable to `global.sw-search-more-results.labelShowResultsInModuleV2` to allow translations to use the original casing of an entity or a lower case version
+* Changed `entityName` in `global.sw-search-more-results.labelShowResultsInModuleV2` to be the original casing instead of always lower case as it is more common to have upper-cased nouns
+* Changed `global.sw-search-more-results.labelShowResultsInModuleV2` to use `entityNameLower` instead of `entityName` to keep lower cased entity name

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-more-results/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-more-results/index.js
@@ -76,10 +76,15 @@ Component.register('sw-search-more-results', {
         },
 
         searchContent() {
+            const entityName = this.$tc(`global.entities.${this.entity}`, 0);
+
             return this.$tc(
                 'global.sw-search-more-results.labelShowResultsInModuleV2',
                 0,
-                { entityName: this.$tc(`global.entities.${this.entity}`, 0).toLowerCase() },
+                {
+                    entityName: entityName,
+                    entityNameLower: entityName.toLowerCase(),
+                },
             );
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -597,7 +597,7 @@
     },
     "sw-search-more-results": {
       "labelShowResultsInModule": "Show results in module({count})",
-      "labelShowResultsInModuleV2": "Show all matching results in {entityName}..."
+      "labelShowResultsInModuleV2": "Show all matching results in {entityNameLower}..."
     },
     "sw-tagged-field": {
       "text-default-placeholder": "Press the enter key to add values."


### PR DESCRIPTION
### 1. Why is this change necessary?

Languages are casing nouns differently.

### 2. What does this change do, exactly?

Enable to change casing of a text in the admin by add two cased variants of a replaced input.
Adjustment of an English snippet to use that new casing as assumed, that there are less languages that use small casing for nouns than unchanged casing.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use the global admin search and type in SW
2. A lot of products get listed:
3. ![image](https://user-images.githubusercontent.com/1133593/194695762-0207a620-7d9e-4a46-956d-6863d153cfb0.png)
4. \> duden_are_thrown_through_the_rooms.png
5. Client calls and asks why it says "Alle 16 Suchtreffer in produkte anzeigen... " and why it writes "produkte" lower cased and everywhere else like it should be
6. Me seeing the `.toLowerCase()`
7. Me here doing the pull request
8. <img width="279" alt="image" src="https://user-images.githubusercontent.com/1133593/194696028-c7e5728f-3616-4f74-8678-babeb0172a19.png">

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
