### PR TITLE
replace password confirm modal with sw-verify-user-modal

### DIFF
--- a/changelog/_unreleased/2022-10-09_refactor-password-confirm-modals.md
+++ b/changelog/_unreleased/2022-10-09_refactor-password-confirm-modals.md
@@ -1,0 +1,10 @@
+---
+title: Refactor password confirm modals
+issue: -
+author: Silvio Kennecke
+author_email: development@silvio-kennecke.de
+author_github: @silviokennecke
+---
+# Administration
+* Changed `sw-profile-index` to use `sw-verify-user-modal` instead of a customized modal
+* Changed `sw-users-permissions-role-listing` to use `sw-verify-user-modal` instead of a customized modal

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.html.twig
@@ -98,6 +98,25 @@
             @verified="onSubmitConfirmPassword"
             @close="onCloseConfirmPasswordModal"
         />
+
+        {# @deprecated tag:v6.5.0 - will be removed #}
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_profile_index_content_confirm_password_modal_input__confirm_password %}
+        {% endblock %}
+
+        {# @deprecated tag:v6.5.0 - will be removed #}
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_profile_index_content_confirm_password_modal_footer %}
+        {# @deprecated tag:v6.5.0 - will be removed #}
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_profile_index_content_confirm_password_modal_actions_cancel %}
+        {% endblock %}
+        {# @deprecated tag:v6.5.0 - will be removed #}
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_profile_index_content_confirm_password_modal_actions_change %}
+        {% endblock %}
+        {% endblock %}
+
         {% endblock %}
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.html.twig
@@ -93,54 +93,11 @@
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_profile_index_content_confirm_password_modal %}
-        <sw-modal
+        <sw-verify-user-modal
             v-if="confirmPasswordModal"
-            :title="$tc('sw-profile.index.titleConfirmPasswordModal')"
-            variant="small"
-            @modal-close="onCloseConfirmPasswordModal"
-        >
-            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-            {% block sw_profile_index_content_confirm_password_modal_input__confirm_password %}
-            <sw-password-field
-                v-model="confirmPassword"
-                class="sw-settings-user-detail__confirm-password"
-                required
-                name="sw-field--confirm-password"
-                :password-toggle-able="true"
-                :copy-able="false"
-                :label="$tc('sw-profile.index.labelConfirmPassword')"
-                :placeholder="$tc('sw-profile.index.placeholderConfirmPassword')"
-                @keypress.enter="onSubmitConfirmPassword"
-            />
-            {% endblock %}
-
-            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-            {% block sw_profile_index_content_confirm_password_modal_footer %}
-            <template #modal-footer>
-                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                {% block sw_profile_index_content_confirm_password_modal_actions_cancel %}
-                <sw-button
-                    size="small"
-                    @click="onCloseConfirmPasswordModal"
-                >
-                    {{ $tc('sw-profile.index.labelButtonCancel') }}
-                </sw-button>
-                {% endblock %}
-
-                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                {% block sw_profile_index_content_confirm_password_modal_actions_change %}
-                <sw-button
-                    variant="primary"
-                    :disabled="!confirmPassword"
-                    size="small"
-                    @click="onSubmitConfirmPassword"
-                >
-                    {{ $tc('sw-profile.index.labelButtonConfirm') }}
-                </sw-button>
-                {% endblock %}
-            </template>
-            {% endblock %}
-        </sw-modal>
+            @verified="onSubmitConfirmPassword"
+            @close="onCloseConfirmPasswordModal"
+        />
         {% endblock %}
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/page/sw-profile-index/sw-profile-index.html.twig
@@ -99,22 +99,24 @@
             @close="onCloseConfirmPasswordModal"
         />
 
-        {# @deprecated tag:v6.5.0 - will be removed #}
+        {# @deprecated tag:v6.6.0 - will be removed #}
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_profile_index_content_confirm_password_modal_input__confirm_password %}
         {% endblock %}
 
-        {# @deprecated tag:v6.5.0 - will be removed #}
+        {# @deprecated tag:v6.6.0 - will be removed #}
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_profile_index_content_confirm_password_modal_footer %}
-        {# @deprecated tag:v6.5.0 - will be removed #}
+        {% endblock %}
+
+        {# @deprecated tag:v6.6.0 - will be removed #}
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_profile_index_content_confirm_password_modal_actions_cancel %}
         {% endblock %}
-        {# @deprecated tag:v6.5.0 - will be removed #}
+
+        {# @deprecated tag:v6.6.0 - will be removed #}
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_profile_index_content_confirm_password_modal_actions_change %}
-        {% endblock %}
         {% endblock %}
 
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/snippet/de-DE.json
@@ -15,8 +15,6 @@
       "labelUsernameField": "Benutzername",
       "labelEmailField": "E-Mail-Adresse",
       "labelTimezoneField": "Zeitzone",
-      "labelOldPassword": "Altes Passwort",
-      "placeholderOldPassword": "Altes Passwort eingeben ...",
       "labelNewPassword": "Neues Passwort",
       "placeholderNewPassword": "Neues Passwort eingeben ...",
       "labelNewPasswordConfirm": "Passwort bestätigen",
@@ -28,15 +26,7 @@
       "notificationSaveSuccessMessage": "Deine Profilinformationen wurden erfolgreich gespeichert.",
       "notificationSaveErrorMessage": "Deine Profilinformationen konnten nicht gespeichert werden.",
       "labelUploadAvatar": "Lade ein Profilbild hoch",
-      "labelUseAsAvatar": "Als Profilbild nutzen",
-      "placeholderNewPasswordConfirm": "Wiederhole Dein neues Passwort ...",
-      "placeholderNewPassword": "Gib ein neues Passwort ein ...",
-      "placeholderOldPassword": "Gib Dein altes Passwort ein ...",
-      "titleConfirmPasswordModal": "Passwort bestätigen",
-      "labelConfirmPassword": "Passwort",
-      "placeholderConfirmPassword": "Gib Dein aktuelles Passwort ein ...",
-      "labelButtonCancel": "Abbrechen",
-      "labelButtonConfirm": "Bestätigen"
+      "labelUseAsAvatar": "Als Profilbild nutzen"
     },
     "tabGeneral": {
       "title": "Allgemein"

--- a/src/Administration/Resources/app/administration/src/module/sw-profile/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/snippet/en-GB.json
@@ -15,8 +15,6 @@
       "labelUsernameField": "Username",
       "labelEmailField": "Email address",
       "labelTimezoneField": "Timezone",
-      "labelOldPassword": "Old password",
-      "placeholderOldPassword": "Enter old password...",
       "labelNewPassword": "New password",
       "placeholderNewPassword": "Enter new password...",
       "labelNewPasswordConfirm": "Confirm password",
@@ -28,12 +26,7 @@
       "notificationSaveSuccessMessage": "Profile information have been saved.",
       "notificationSaveErrorMessage": "Profile information could not be saved.",
       "labelUploadAvatar": "Upload avatar",
-      "labelUseAsAvatar": "Use as avatar",
-      "titleConfirmPasswordModal": "Confirm password",
-      "labelConfirmPassword": "Password",
-      "placeholderConfirmPassword": "Please enter your current password.",
-      "labelButtonCancel": "Cancel",
-      "labelButtonConfirm": "Confirm"
+      "labelUseAsAvatar": "Use as avatar"
     },
     "tabGeneral": {
       "title": "General"

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/index.js
@@ -29,8 +29,9 @@ export default {
             user: [],
             isLoading: false,
             itemToDelete: null,
+            confirmDeleteModal: false,
+            confirmPasswordModal: false,
             disableRouteParams: true,
-            confirmPassword: '',
             sortBy: 'username',
         };
     },
@@ -118,10 +119,23 @@ export default {
         },
 
         onDelete(user) {
+            this.confirmDeleteModal = true;
             this.itemToDelete = user;
         },
 
-        async onConfirmDelete(user) {
+        onCloseDeleteModal() {
+            this.confirmDeleteModal = false;
+        },
+
+        onConfirmDelete() {
+            this.onCloseDeleteModal();
+            this.confirmPasswordModal = true;
+        },
+
+        deleteUser(context) {
+            this.confirmPasswordModal = false;
+            const user = this.itemToDelete;
+
             const username = `${user.firstName} ${user.lastName} `;
             const titleDeleteSuccess = this.$tc('global.default.success');
             const messageDeleteSuccess = this.$tc(
@@ -143,30 +157,6 @@ export default {
                 return;
             }
 
-            let verifiedToken;
-            try {
-                verifiedToken = await this.loginService.verifyUserToken(this.confirmPassword);
-            } catch (e) {
-                this.createNotificationError({
-                    title: this.$tc(
-                        'sw-users-permissions.users.user-detail.passwordConfirmation.notificationPasswordErrorTitle',
-                    ),
-                    message: this.$tc(
-                        'sw-users-permissions.users.user-detail.passwordConfirmation.notificationPasswordErrorMessage',
-                    ),
-                });
-            } finally {
-                this.confirmPassword = '';
-            }
-
-            if (!verifiedToken) {
-                return;
-            }
-
-            this.confirmPasswordModal = false;
-            const context = { ...Shopware.Context.api };
-            context.authToken.access = verifiedToken;
-
             this.userRepository.delete(user.id, context).then(() => {
                 this.createNotificationSuccess({
                     title: titleDeleteSuccess,
@@ -179,11 +169,10 @@ export default {
                     message: messageDeleteError,
                 });
             });
-            this.onCloseDeleteModal();
         },
 
-        onCloseDeleteModal() {
-            this.itemToDelete = null;
+        onCloseConfirmPasswordModal() {
+            this.confirmPasswordModal = false;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/index.js
@@ -33,6 +33,9 @@ export default {
             confirmPasswordModal: false,
             disableRouteParams: true,
             sortBy: 'username',
+
+            // @deprecated tag:v6.6.0 - will be removed
+            confirmPassword: '',
         };
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
@@ -156,6 +156,11 @@
                 </p>
                 {% endblock %}
 
+                {# @deprecated tag:v6.5.0 - will be removed #}
+                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                {% block sw_settings_user_list_delete_modal_input__confirm_password %}
+                {% endblock %}
+
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_settings_user_list_delete_modal_footer %}
                 <template #modal-footer>

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
@@ -156,7 +156,7 @@
                 </p>
                 {% endblock %}
 
-                {# @deprecated tag:v6.5.0 - will be removed #}
+                {# @deprecated tag:v6.6.0 - will be removed #}
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_settings_user_list_delete_modal_input__confirm_password %}
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
@@ -144,7 +144,7 @@
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_settings_user_list_delete_modal %}
             <sw-modal
-                v-if="getItemToDelete(item)"
+                v-if="confirmDeleteModal && getItemToDelete(item)"
                 :title="$tc('global.default.warning')"
                 variant="small"
                 @modal-close="onCloseDeleteModal"
@@ -154,22 +154,6 @@
                 <p class="sw-settings-user-list__confirm-delete-text">
                     {{ $tc('sw-users-permissions.users.user-grid.textModalDelete', 0, { name: salutation(item) }) }}
                 </p>
-                {% endblock %}
-
-                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                {% block sw_settings_user_list_delete_modal_input__confirm_password %}
-                <sw-password-field
-                    v-model="confirmPassword"
-                    class="sw-settings-user-detail__confirm-password"
-                    required
-                    name="sw-field--confirm-password"
-                    :password-toggle-able="true"
-                    :copy-able="false"
-                    autocomplete="new-password"
-                    :label="$tc('sw-users-permissions.users.user-detail.passwordConfirmation.labelConfirmPassword')"
-                    :placeholder="$tc('sw-users-permissions.users.user-detail.passwordConfirmation.placeholderConfirmPassword')"
-                    @keypress.enter="onConfirmDelete(item)"
-                />
                 {% endblock %}
 
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
@@ -188,10 +172,9 @@
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_settings_user_list_delete_modal_confirm %}
                     <sw-button
-                        :disabled="!confirmPassword"
                         variant="danger"
                         size="small"
-                        @click="onConfirmDelete(item)"
+                        @click="onConfirmDelete"
                     >
                         {{ $tc('sw-users-permissions.users.user-grid.labelButtonDelete') }}
                     </sw-button>
@@ -202,6 +185,15 @@
             {% endblock %}
         </template>
     </sw-data-grid>
+    {% endblock %}
+
+    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+    {% block sw_settings_user_list_content_confirm_password_modal %}
+    <sw-verify-user-modal
+        v-if="confirmPasswordModal"
+        @verified="deleteUser"
+        @close="onCloseConfirmPasswordModal"
+    />
     {% endblock %}
     {% endblock %}
 </sw-card>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To change certain entities, a separate confirmation of the user's password is needed. Currently not all occurrences use the `sw-verify-user-modal`. This change refactors the relevant components to use the `sw-verify-user-modal`.

### 2. What does this change do, exactly?
* Changed `sw-profile-index` to use `sw-verify-user-modal` instead of a customized modal
* Changed `sw-users-permissions-role-listing` to use `sw-verify-user-modal` instead of a customized modal

### 3. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2748"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

