### PR TITLE
fix sw-page back button position

### DIFF
--- a/changelog/_unreleased/2022-10-09-fix-sw-page-back-button-position.md
+++ b/changelog/_unreleased/2022-10-09-fix-sw-page-back-button-position.md
@@ -1,0 +1,9 @@
+---
+title: Fix sw-page back button position
+issue: -
+author: Silvio Kennecke
+author_email: development@silvio-kennecke.de
+author_github: @silviokennecke
+---
+# Administration
+* Fixed `back-btn-container` position on `sw-page` to correctly position the container if `showSearchBar` is false. 

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.html.twig
@@ -53,7 +53,8 @@
 
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_page_smart_bar_back_btn %}
-            <div class="sw-page__back-btn-container">
+            <div class="sw-page__back-btn-container"
+                 :style="smartBarContentStyle">
                 <slot name="smart-bar-back">
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_page_slot_smart_bar_back %}


### PR DESCRIPTION
### 1. Why is this change necessary?

When `showSearchBar` on `sw-page` is set to false, the back button stays in the wrong row in the header.

<img width="1216" alt="Bildschirm­foto 2022-10-09 um 19 24 49" src="https://user-images.githubusercontent.com/17751219/194770819-e1899717-eb6a-458f-8460-599408308bc4.png">

### 2. What does this change do, exactly?

Adds `grid-row` style to back button, if `onSearchBar` at `sw-page` equals false.

<img width="1214" alt="Bildschirm­foto 2022-10-09 um 19 24 18" src="https://user-images.githubusercontent.com/17751219/194770809-8da4634c-25ae-406e-a073-01484844065a.png">

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a new page using `sw-page` component.
2. Set `showSearchBar` on `sw-page` component to false.

### 4. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
