### PR TITLE
Change sw-context-button default z-index

### DIFF
--- a/changelog/_unreleased/2022-10-09-change-context-menu-button-default-z-index.md
+++ b/changelog/_unreleased/2022-10-09-change-context-menu-button-default-z-index.md
@@ -1,0 +1,8 @@
+title: Change default z-index of context menu button
+author: Lisa Meister
+author_email: lisa.meister.93@gmx.de
+author_github: Lilibell
+---
+
+# Administration
+*  change default z-index of `sw-context-button` to match the variable `$z-index-context-menu`

--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-button/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-button/index.js
@@ -94,7 +94,7 @@ Component.register('sw-context-button', {
         zIndex: {
             type: Number,
             required: false,
-            default: 9000,
+            default: 1100,
         },
     },
 


### PR DESCRIPTION
### 1. Why is this change necessary?
A default z-index of 9000 on the `sw-context-button` popover causes the tooltip to disappear under the modal

### 2. What does this change do, exactly?
Change the default z-index for `sw-context-button` (which is applied on the popover) to 1100 to match with the variable `$z-index-context-menu`

Before:
<img width="253" alt="Bildschirmfoto 2022-10-09 um 19 53 46" src="https://user-images.githubusercontent.com/69088922/194772001-ced08fa4-da9f-463f-9979-207e8861e75f.png">

After:
<img width="253" alt="Bildschirmfoto 2022-10-09 um 19 52 47" src="https://user-images.githubusercontent.com/69088922/194771928-8398712a-08ef-4e99-a487-932725749f75.png">

### 3. Describe each step to reproduce the issue or behaviour.
1. Navigate to Shopping Experiences in the administration
2. Open the options for one of your applied layouts ("...") and hover over the "delete" option

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

