### PR TITLE
NEXT-22748 - Fix permanent offcanvas button in cms el product descrip…

### DIFF
--- a/changelog/_unreleased/2022-10-09-fix-close-offcanvas-button-in-cms-element-product-description-reviews.md
+++ b/changelog/_unreleased/2022-10-09-fix-close-offcanvas-button-in-cms-element-product-description-reviews.md
@@ -1,0 +1,8 @@
+title: Fix permanently visible offcanvas close button in cms element 'product description reviews'
+author: Lisa Meister
+author_email: lisa.meister.93@gmx.de
+author_github: Lilibell
+---
+
+# Storefront
+* move class `product-detail-tabs` from `cms-block-product-description-reviews.html.twig` to `cms-element-product-description-reviews`

--- a/src/Storefront/Resources/views/storefront/block/cms-block-product-description-reviews.html.twig
+++ b/src/Storefront/Resources/views/storefront/block/cms-block-product-description-reviews.html.twig
@@ -1,7 +1,7 @@
 {% block block_product_description_review %}
     {% set element = block.slots.getSlot('content') %}
 
-    <div class="col-12 product-detail-tabs" data-cms-element-id="{{ element.id }}">
+    <div class="col-12" data-cms-element-id="{{ element.id }}">
         {% block block_product_description_reviews_inner %}
             {% sw_include "@Storefront/storefront/element/cms-element-" ~ element.type ~ ".html.twig" ignore missing %}
         {% endblock %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-product-description-reviews.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-product-description-reviews.html.twig
@@ -9,7 +9,7 @@
     {% set reviewTabContent = "review-tab-" ~ product.id ~ "-pane" %}
 
     {% if element.data.product %}
-        <div class="cms-element-{{ element.type }}{% if config.alignment.value %} has-vertical-alignment{% endif %}">
+        <div class="product-detail-tabs cms-element-{{ element.type }}{% if config.alignment.value %} has-vertical-alignment{% endif %}">
             {% if config.alignment.value %}
                 <div class="cms-element-alignment{% if config.alignment.value == "center" %} align-self-center{% elseif config.alignment.value == "flex-end" %} align-self-end{% else %} align-self-start{% endif %}">
             {% endif %}


### PR DESCRIPTION
# 1. Why is this change necessary?
If the cms element `Product descriptions & reviews` is placed in a block OTHER than `Product description & reviews`,
the button "Close menu" is permanently displayed in the tab content because the class `product-detail-tabs` from the
block is missing.

### 2. What does this change do, exactly?
Move the class `product-detail-tabs` from `cms-block-product-description-reviews` to `cms-element-product-description-reviews`
to make sure it is never missing.

### 3. Describe each step to reproduce the issue or behaviour.
1. In the layout editor (administration) place a block other than 'Product description & reviews' and change one of the
elements to 'Product description & reviews'

Before:
<img width="1388" alt="Bildschirmfoto 2022-10-09 um 21 05 52" src="https://user-images.githubusercontent.com/69088922/194776095-560a8f89-4cef-4836-891f-f1a1cbda2352.png">

After:
<img width="1363" alt="Bildschirmfoto 2022-10-09 um 21 05 26" src="https://user-images.githubusercontent.com/69088922/194776107-cda847bf-ca70-4b5f-ba9e-dac76e081974.png">

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-22748

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

