### PR TITLE
Remove useless selection feature on shipping prices

### DIFF
--- a/changelog/_unreleased/2022-10-10-remove-actionless-selection-from-shipping-method-price-rules.md
+++ b/changelog/_unreleased/2022-10-10-remove-actionless-selection-from-shipping-method-price-rules.md
@@ -1,0 +1,8 @@
+---
+title: Remove selection for shipping prices as there are no actions for the selection
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Removed selection feature on shipping prices as there is no action related to the selection

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.html.twig
@@ -102,6 +102,7 @@
         v-if="showDataGrid"
         :data-source="priceGroup.prices"
         :columns="ruleColumns"
+        :show-selection="false"
         :show-settings="true"
         :compact-mode="true"
     >


### PR DESCRIPTION
### 1. Why is this change necessary?

You can select pricing items and then have no items to do with that.

<img width="982" alt="image" src="https://user-images.githubusercontent.com/1133593/194781449-fa672ccf-f087-45e1-be82-61d4229d7ce5.png">

I could add a bulk action instead but what should I do?

### 2. What does this change do, exactly?

Deactivate selections on the pricing table.

<img width="982" alt="image" src="https://user-images.githubusercontent.com/1133593/194781471-fef229b2-0987-4fe3-a51a-68dc6a934fc2.png">

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
