### PR TITLE
Added created/updated dates to product list grid

### DIFF
--- a/changelog/_unreleased/2022-10-10-add-created-at-and-updated-at-to-product-list-grid.md
+++ b/changelog/_unreleased/2022-10-10-add-created-at-and-updated-at-to-product-list-grid.md
@@ -1,0 +1,8 @@
+---
+title: Add createdAt and updatedAt column to product list grid
+author: Ioannis Pourliotis
+author_email: dev@pourliotis.de
+author_github: @PheysX
+---
+# Administration
+* Add `createdAt` and `updatedAt` columns to `sw-product-list` component.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/index.js
@@ -361,6 +361,16 @@ Component.register('sw-product-list', {
                 label: this.$tc('sw-product.list.columnAvailableStock'),
                 allowResize: true,
                 align: 'right',
+            }, {
+                property: 'createdAt',
+                label: this.$tc('sw-product.list.columnCreatedAt'),
+                allowResize: true,
+                visible: false,
+            }, {
+                property: 'updatedAt',
+                label: this.$tc('sw-product.list.columnUpdatedAt'),
+                allowResize: true,
+                visible: false,
             }];
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.html.twig
@@ -216,6 +216,20 @@
                 {% endblock %}
 
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                {% block sw_product_list_grid_columns_created_at %}
+                <template #column-createdAt="{ item }">
+                    {{ item.createdAt|date }}
+                </template>
+                {% endblock %}
+
+                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                {% block sw_product_list_grid_columns_updated_at %}
+                <template #column-updatedAt="{ item }">
+                    {{ item.updatedAt|date }}
+                </template>
+                {% endblock %}
+
+                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_product_list_grid_columns_actions %}
                 <template #more-actions="{ item }">
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.html.twig
@@ -215,14 +215,12 @@
                 </template>
                 {% endblock %}
 
-                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_product_list_grid_columns_created_at %}
                 <template #column-createdAt="{ item }">
                     {{ item.createdAt|date }}
                 </template>
                 {% endblock %}
 
-                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_product_list_grid_columns_updated_at %}
                 <template #column-updatedAt="{ item }">
                     {{ item.updatedAt|date }}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.html.twig
@@ -215,17 +215,13 @@
                 </template>
                 {% endblock %}
 
-                {% block sw_product_list_grid_columns_created_at %}
                 <template #column-createdAt="{ item }">
                     {{ item.createdAt|date }}
                 </template>
-                {% endblock %}
 
-                {% block sw_product_list_grid_columns_updated_at %}
                 <template #column-updatedAt="{ item }">
                     {{ item.updatedAt|date }}
                 </template>
-                {% endblock %}
 
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_product_list_grid_columns_actions %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -223,6 +223,8 @@
       "columnPrice": "Preis",
       "columnInStock": "Lagerbestand",
       "columnAvailableStock": "Verfügbar",
+      "columnCreatedAt": "Hinzugefügt am",
+      "columnUpdatedAt": "Aktualisiert am",
       "columnReleaseDate": "Erscheinungsdatum",
       "columnVisibilities": "Verkaufskanäle",
       "columnCategories": "Kategorien",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -223,6 +223,8 @@
       "columnPrice": "Price",
       "columnInStock": "In stock",
       "columnAvailableStock": "Available",
+      "columnCreatedAt": "Created at",
+      "columnUpdatedAt": "Updated at",
       "columnReleaseDate": "Release date",
       "columnVisibilities": "Sales Channels",
       "columnCategories": "Categories",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Related to this issue #2662 it could be helpful to see the created and updated date in product grid.


### 2. What does this change do, exactly?
Show optional createdAt and updatedAt columns in product list grid view.

![image](https://user-images.githubusercontent.com/28557712/194861101-3e2158d3-be9b-4e05-ab14-41372ef3e67a.png)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2754"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

