### PR TITLE
Fixed installing multiple plugins in TestBootstrapper.php

### DIFF
--- a/changelog/_unreleased/2022-10-10-fix-testbootstrapper-plugin-install.md
+++ b/changelog/_unreleased/2022-10-10-fix-testbootstrapper-plugin-install.md
@@ -1,0 +1,10 @@
+---
+title: Deprecate sw-promotion in favor for sw-promotion-v2
+issue: NEXT-
+author: Florian Liebig
+author_email: mail@florian-liebig.de
+author_github: florianliebig
+---
+
+# Core
+*  Fixed installing multiple plugin in TestBootstrapper.php#installPlugins

--- a/changelog/_unreleased/2022-10-10-fix-testbootstrapper-plugin-install.md
+++ b/changelog/_unreleased/2022-10-10-fix-testbootstrapper-plugin-install.md
@@ -1,5 +1,5 @@
 ---
-title: Deprecate sw-promotion in favor for sw-promotion-v2
+title: Fixed installing multiple plugin in TestBootstrapper
 issue: NEXT-
 author: Florian Liebig
 author_email: mail@florian-liebig.de

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -370,6 +370,7 @@ class TestBootstrapper
 
         $application = new Application($kernel);
         $installCommand = $application->find('plugin:install');
+        $definition = $installCommand->getDefinition();
 
         foreach ($this->activePlugins as $activePlugin) {
             $args = [
@@ -378,12 +379,8 @@ class TestBootstrapper
                 'plugins' => [$activePlugin],
             ];
 
-            if (array_key_exists('command', $installCommand->getDefinition()->getArguments())) {
-                $args['command'] = 'plugin:install';
-            }
-
             $returnCode = $installCommand->run(
-                new ArrayInput($args, $installCommand->getDefinition()),
+                new ArrayInput($args, $definition),
                 $this->getOutput()
             );
 

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -378,6 +378,10 @@ class TestBootstrapper
                 'plugins' => [$activePlugin],
             ];
 
+            if (array_key_exists('command', $installCommand->getDefinition()->getArguments())) {
+                $args['command'] = 'plugin:install';
+            }
+
             $returnCode = $installCommand->run(
                 new ArrayInput($args, $installCommand->getDefinition()),
                 $this->getOutput()


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Fixes Issue #2676  - in TestBoostrapper.php it shows the error 

```
Error in bootstrap script: Symfony\Component\Console\Exception\RuntimeException:
Not enough arguments (missing: "command").
#0 /var/www/html/project/vendor/symfony/console/Input/Input.php(42): Symfony\Component\Console\Input\Input->validate()
#1 /var/www/html/project/vendor/symfony/console/Input/ArrayInput.php(34): Symfony\Component\Console\Input\Input->__construct(Object(Symfony\Component\Console\Input\InputDefinition))
#2 /var/www/html/project/platform/src/Core/TestBootstrapper.php(373): Symfony\Component\Console\Input\ArrayInput->__construct(Array, Object(Symfony\Component\Console\Input\InputDefinition))
#3 /var/www/html/project/platform/src/Core/TestBootstrapper.php(82): Shopware\Core\TestBootstrapper->installPlugins()
...
```

When having more than 1 plugin in the TestCase


### 2. What does this change do, exactly?

The TestBootstrapper#installPlugins method makes use of the plugin:install command. Somehow when running that in a loop, the InstallCommand Definition seems to require the "command" argument. I am using an if check on the $installCommand->getDefinition()->getArguments() to check if the InstallCommand instance requires that argument.

### 3. Describe each step to reproduce the issue or behaviour.

#2676 describes a way to reproduce this: A custom made TestBoostrap.php in a custom plugin. The custom plugin has another plugin in the composer.json requirements.

My TestBoostrap.php looks like this:

```
use Shopware\Core\TestBootstrapper;

(new TestBootstrapper())
    ->setProjectDir(env('PROJECT_DIR'))
    ->setLoadEnvFile(true)
    ->setForceInstallPlugins(true)
    ->addActivePlugins('FroshPlatformThumbnailProcessor')
    ->addCallingPlugin(__DIR__ . '/composer.json')
    ->bootstrap()
    ->setClassLoader(require __DIR__ . '/vendor/autoload.php')
    ->getClassLoader();
```

Running a test on PHPUnit with that TestBoostrap causes the error initially.


### 4. Please link to the relevant issues (if any).

#2676

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2755"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

