### PR TITLE
Fix broken dependency injection for number ranges using redis

### DIFF
--- a/changelog/_unreleased/2022-10-11-fix-redis-for-number-ranges.md
+++ b/changelog/_unreleased/2022-10-11-fix-redis-for-number-ranges.md
@@ -1,0 +1,10 @@
+---
+title: Fix broken dependency injection for number ranges using redis
+issue: NEXT-
+author: Florian Liebig
+author_email: mail@florian-liebig.de
+author_github: florianliebig
+---
+
+# Core
+*  Fix broken dependency injection for number ranges using redis

--- a/src/Core/System/DependencyInjection/number_range.xml
+++ b/src/Core/System/DependencyInjection/number_range.xml
@@ -53,7 +53,7 @@
         </service>
 
         <service id="Shopware\Core\System\NumberRange\ValueGenerator\Pattern\IncrementStorage\IncrementRedisStorage">
-            <argument type="service" id="shopware.cart.redis"/>
+            <argument type="service" id="shopware.number_range.redis"/>
             <argument type="service" id="lock.factory"/>
             <argument type="service" id="number_range.repository"/>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Number range breaks when using redis for the IncrementRedisStorage

### 2. What does this change do, exactly?

Fix the dependency injection (seems to be a simple typo)


### 3. Describe each step to reproduce the issue or behaviour.

Setup "Redis" as number range increment storage via config

```
shopware:
  number_range:
    increment_storage: "Redis"
    redis_url: '%env(string:REDIS_URL)%/1'

```

### 4. Please link to the relevant issues (if any).

#2580 

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2756"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

