### PR TITLE
Avoid error on order create when listPrice rule is empty

### DIFF
--- a/changelog/_unreleased/2022-08-16-fix-list-price-rule-constraints.md
+++ b/changelog/_unreleased/2022-08-16-fix-list-price-rule-constraints.md
@@ -1,0 +1,10 @@
+---
+title: Fix constraints for LineItemListPriceRule
+issue: https://github.com/shopware/platform/issues/2653
+author: Daniel Wolf | Micha Hobert
+author_email: daniel.wolf@8mylez.com | michahobert@gmail.com
+author_github: supus | Isengo1989
+---
+# Core
+## Rule
+* Add missing IsNull-constraint for "amount" field in Shopware\Core\Checkout\Cart\Rule\LineItemListPriceRule to prevent a WriteException when persiting an order with a promotion using this rule with operator "empty".

--- a/src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
@@ -62,9 +62,10 @@ class LineItemListPriceRule extends Rule
         ];
 
         if ($this->operator === self::OPERATOR_EMPTY) {
-          $constraints['amount'] = new EqualTo([
-                'value' => 0
+            $constraints['amount'] = new EqualTo([
+                'value' => 0,
             ]);
+
             return $constraints;
         }
 
@@ -102,6 +103,6 @@ class LineItemListPriceRule extends Rule
             $listPriceAmount = $listPrice->getPrice();
         }
 
-        return RuleComparison::numeric($listPriceAmount, (float)$this->amount, $this->operator);
+        return RuleComparison::numeric($listPriceAmount, (float) $this->amount, $this->operator);
     }
 }

--- a/src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemListPriceRule.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Rule\RuleComparison;
 use Shopware\Core\Framework\Rule\RuleConfig;
 use Shopware\Core\Framework\Rule\RuleConstraints;
 use Shopware\Core\Framework\Rule\RuleScope;
+use Symfony\Component\Validator\Constraints\EqualTo;
 
 class LineItemListPriceRule extends Rule
 {
@@ -61,6 +62,9 @@ class LineItemListPriceRule extends Rule
         ];
 
         if ($this->operator === self::OPERATOR_EMPTY) {
+          $constraints['amount'] = new EqualTo([
+                'value' => 0
+            ]);
             return $constraints;
         }
 
@@ -98,6 +102,6 @@ class LineItemListPriceRule extends Rule
             $listPriceAmount = $listPrice->getPrice();
         }
 
-        return RuleComparison::numeric($listPriceAmount, (float) $this->amount, $this->operator);
+        return RuleComparison::numeric($listPriceAmount, (float)$this->amount, $this->operator);
     }
 }

--- a/src/Core/Checkout/Test/Cart/Rule/LineItemListPriceRuleTest.php
+++ b/src/Core/Checkout/Test/Cart/Rule/LineItemListPriceRuleTest.php
@@ -58,6 +58,15 @@ class LineItemListPriceRuleTest extends TestCase
         static::assertArrayHasKey('operator', $ruleConstraints, 'Rule Constraint operator is not defined');
     }
 
+    public function testGetEmptyOperatorConstraints(): void
+    {
+        $this->rule->assign(['operator' => Rule::OPERATOR_EMPTY]);
+
+        $ruleConstraints = $this->rule->getConstraints();
+
+        static::assertArrayHasKey('amount', $ruleConstraints, 'Rule Constraint amount is not defined when checking for empty listPrice');
+    }
+
     /**
      * @dataProvider getMatchingRuleTestData
      */


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
**INFO**: This is a pickup from https://github.com/shopware/platform/pull/2654 - since it was closed I reopend it. Hope this is okay this way

to prevent a WriteException when persisting an order with a promotion using the LineItemListPriceRule with the empty-operator.

### 2. What does this change do, exactly?
I added a missing Constraint for the "amount" field

### 3. Describe each step to reproduce the issue or behaviour.

create a new promotion (no promotion code to apply automatically)
add a new discount, only applied to certain products => rule "Item with liste price => at least one => is empty"
apply to all items
percentage => 10
=> the goal is to create a promotion that automatically applies to all non-discounted products
go to checkout and order a non discounted product (make sure the promotion applies)
the order cannot be saved => an error is thrown (WriteException)

4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2758"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

