### PR TITLE
feat: Add BeforeCartMergeEvent

### DIFF
--- a/changelog/_unreleased/2022-10-11-add-beforecartmergeevent.md
+++ b/changelog/_unreleased/2022-10-11-add-beforecartmergeevent.md
@@ -1,0 +1,9 @@
+---
+title: Add BeforeCartMergeEvent
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added `Shopware\Core\Checkout\Cart\Event\BeforeCartMergeEvent`, which is triggered before the guest cart is merged with the customer cart on login

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -28694,41 +28694,6 @@ parameters:
 		-
 			message: "#^Cannot call method getLineItems\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart\\|null\\.$#"
 			count: 2
-			path: src/Core/System/Test/SalesChannel/Context/CartRestorerTest.php
-
-		-
-			message: "#^Cannot call method getName\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart\\|null\\.$#"
-			count: 2
-			path: src/Core/System/Test/SalesChannel/Context/CartRestorerTest.php
-
-		-
-			message: "#^Cannot call method getQuantity\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\LineItem\\\\LineItem\\|null\\.$#"
-			count: 4
-			path: src/Core/System/Test/SalesChannel/Context/CartRestorerTest.php
-
-		-
-			message: "#^Cannot call method getToken\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart\\|null\\.$#"
-			count: 2
-			path: src/Core/System/Test/SalesChannel/Context/CartRestorerTest.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Test\\\\SalesChannel\\\\Context\\\\CartRestorerTest\\:\\:createSalesChannelContext\\(\\) has parameter \\$salesChannelData with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/System/Test/SalesChannel/Context/CartRestorerTest.php
-
-		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\Test\\\\SalesChannel\\\\Context\\\\CartRestorerTest\\:\\:\\$eventDispatcher \\(Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcher\\) does not accept Symfony\\\\Component\\\\HttpKernel\\\\Debug\\\\TraceableEventDispatcher\\.$#"
-			count: 1
-			path: src/Core/System/Test/SalesChannel/Context/CartRestorerTest.php
-
-		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\Test\\\\SalesChannel\\\\Context\\\\CartRestorerTest\\:\\:\\$events type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/System/Test/SalesChannel/Context/CartRestorerTest.php
-
-		-
-			message: "#^Cannot call method getLineItems\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart\\|null\\.$#"
-			count: 2
 			path: src/Core/System/Test/SalesChannel/Context/SalesChannelContextRestorerTest.php
 
 		-

--- a/src/Core/Checkout/Cart/Event/BeforeCartMergeEvent.php
+++ b/src/Core/Checkout/Cart/Event/BeforeCartMergeEvent.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Event;
+
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BeforeCartMergeEvent extends Event implements ShopwareSalesChannelEvent
+{
+    protected Cart $customerCart;
+
+    protected Cart $guestCart;
+
+    protected LineItemCollection $mergeableLineItems;
+
+    protected SalesChannelContext $context;
+
+    /**
+     * @internal
+     */
+    public function __construct(Cart $customerCart, Cart $guestCart, LineItemCollection $mergeableLineItems, SalesChannelContext $context)
+    {
+        $this->customerCart = $customerCart;
+        $this->guestCart = $guestCart;
+        $this->mergeableLineItems = $mergeableLineItems;
+        $this->context = $context;
+    }
+
+    public function getCustomerCart(): Cart
+    {
+        return $this->customerCart;
+    }
+
+    public function getGuestCart(): Cart
+    {
+        return $this->guestCart;
+    }
+
+    public function getMergeableLineItems(): LineItemCollection
+    {
+        return $this->mergeableLineItems;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->context;
+    }
+}

--- a/src/Core/System/SalesChannel/Context/CartRestorer.php
+++ b/src/Core/System/SalesChannel/Context/CartRestorer.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\System\SalesChannel\Context;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Checkout\Cart\Error\ErrorCollection;
+use Shopware\Core\Checkout\Cart\Event\BeforeCartMergeEvent;
 use Shopware\Core\Checkout\Cart\Event\CartMergedEvent;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
@@ -92,6 +93,13 @@ class CartRestorer
         $mergeableLineItems = $guestCart->getLineItems()->filter(function (LineItem $item) use ($customerCart) {
             return ($item->getQuantity() > 0 && $item->isStackable()) || !$customerCart->has($item->getId());
         });
+
+        $this->eventDispatcher->dispatch(new BeforeCartMergeEvent(
+            $customerCart,
+            $guestCart,
+            $mergeableLineItems,
+            $customerContext
+        ));
 
         $errors = $customerCart->getErrors();
         $customerCart->setErrors(new ErrorCollection());

--- a/tests/unit/php/Core/Checkout/Cart/Event/BeforeCartMergeEventTest.php
+++ b/tests/unit/php/Core/Checkout/Cart/Event/BeforeCartMergeEventTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Event;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\Event\BeforeCartMergeEvent;
+use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @internal
+ * @covers \Shopware\Core\Checkout\Cart\Event\BeforeCartMergeEvent
+ */
+class BeforeCartMergeEventTest extends TestCase
+{
+    public function testReturnsCorrectProperties(): void
+    {
+        $customerCart = new Cart('customerCart', 'customerCart');
+        $guestCart = new Cart('customerCart', 'customerCart');
+        $mergeableLineItems = new LineItemCollection();
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+
+        $context = Context::createDefaultContext();
+        $salesChannelContext->method('getContext')->willReturn($context);
+
+        $event = new BeforeCartMergeEvent(
+            $customerCart,
+            $guestCart,
+            $mergeableLineItems,
+            $salesChannelContext
+        );
+
+        static::assertSame($customerCart, $event->getCustomerCart());
+        static::assertSame($guestCart, $event->getGuestCart());
+        static::assertSame($mergeableLineItems, $event->getMergeableLineItems());
+        static::assertSame($salesChannelContext, $event->getSalesChannelContext());
+        static::assertSame($context, $event->getContext());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is impossible to remove non `clonable` exceptions from the `Cart`-extensions. We need this, as we implement some validations ourself as extensions (which for example are only displayed on the confirm page), and do not hide success messages, like that a product has been added, in the offcanvas cart. 
This leads to an error when a customer has such an error and the cart is cloned:
https://github.com/shopware/platform/blob/trunk/src/Core/System/SalesChannel/Context/CartRestorer.php#L99

### 2. What does this change do, exactly?
Add an event to remove such non-clonable extension from the cart.

### 3. Describe each step to reproduce the issue or behaviour.
Create an extension to a cart, which is not clonable.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2759"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

