### PR TITLE
Add title for extension description to show complete text

### DIFF
--- a/changelog/_unreleased/2022-10-12-show-extension-description-on-hover.md
+++ b/changelog/_unreleased/2022-10-12-show-extension-description-on-hover.md
@@ -1,0 +1,8 @@
+---
+title: Show extension description on hover in administration extension listing
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added native tooltip on extension description to make all extension description visible even if it is shortened to a single line 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/sw-extension-card-base.html.twig
@@ -65,7 +65,10 @@
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_extension_card_base_info_description %}
-        <section class="sw-extension-card-base__info-description">
+        <section
+            class="sw-extension-card-base__info-description"
+            :title="description"
+        >
             {{ description }}
         </section>
         {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

<img width="888" alt="image" src="https://user-images.githubusercontent.com/1133593/195206167-8473966e-58f5-4f31-99b0-e9a5f9f79af1.png">

In addition: the extension description is encouraged to be long when using Frosh Plugin Dev tools as it used for marketing shenanigans.

### 2. What does this change do, exactly?

Use native html features for tooltips. So on hover you see the text.

<img width="864" alt="image" src="https://user-images.githubusercontent.com/1133593/195206303-c55678dc-d62c-4dd5-948d-18c3469f0f1c.png">

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2760"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

