### PR TITLE
Autofill sales channel domain create modal with options you likely will choose anyway

### DIFF
--- a/changelog/_unreleased/2022-10-13-auto-fill-sales-channel-domain-create-modal.md
+++ b/changelog/_unreleased/2022-10-13-auto-fill-sales-channel-domain-create-modal.md
@@ -1,0 +1,10 @@
+---
+title: Auto-fill domain settings for new sales channel domains created in the admin
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added pre-selection mechanism for URL taking the current URL, if not selected somewhere else
+* Added pre-selection mechanism for currency taking the only currency of the sales channel, when there is only one currency assigned to the sales channel
+* Added pre-selection mechanism for language taking the only language of the sales channel, when there is only one language assigned to the sales channel

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/index.js
@@ -222,8 +222,33 @@ Component.register('sw-sales-channel-detail-domains', {
         },
 
         onClickOpenCreateDomainModal() {
-            this.currentDomain = this.domainRepository.create(Context.api);
-            this.setCurrentDomainBackup(this.currentDomain);
+            const possiblyUnassignedUrl = window.location.origin;
+
+            this.verifyUrl({ url: possiblyUnassignedUrl })
+                .then(() => possiblyUnassignedUrl)
+                .catch(() => null)
+                .then((predictedUrl) => {
+                    const domain = this.domainRepository.create(Context.api);
+
+                    this.setCurrentDomainBackup(domain);
+
+                    domain.url = predictedUrl;
+
+                    if (this.salesChannel.currencies.length === 1) {
+                        const currency = this.salesChannel.currencies.first();
+
+                        domain.currency = currency;
+                        domain.currencyId = currency.id;
+                    }
+
+                    if (this.salesChannel.languages.length === 1) {
+                        const language = this.salesChannel.languages.first();
+                        domain.language = language;
+                        domain.languageId = language.id;
+                    }
+
+                    this.currentDomain = domain;
+                });
         },
 
         async onClickAddNewDomain() {

--- a/src/Administration/Resources/app/administration/test/module/sw-sales-channel/component/sw-sales-channel-detail-domains.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-sales-channel/component/sw-sales-channel-detail-domains.spec.js
@@ -207,6 +207,7 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-detail-domains'
         wrapper.vm.onClickOpenCreateDomainModal();
         await wrapper.vm.$nextTick();
 
+        expect(wrapper.find('.sw-sales-channel-detail-domains__domain-language-select').vm.$data.value).toBe(languages[0].id);
         expect(wrapper.find('.sw-sales-channel-detail-domains__domain-language-select').vm.$data.results).toBe(languages);
     });
 
@@ -229,6 +230,7 @@ describe('src/module/sw-sales-channel/component/sw-sales-channel-detail-domains'
         wrapper.vm.onClickOpenCreateDomainModal();
         await wrapper.vm.$nextTick();
 
+        expect(wrapper.find('.sw-sales-channel-detail-domains__domain-currency-select').vm.$data.value).toBe(currencies[0].id);
         expect(wrapper.find('.sw-sales-channel-detail-domains__domain-currency-select').vm.$data.results).toBe(currencies);
     });
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When you create a sales channel with a single language and currency you don't want to select this AGAIN. I mean there is auto completion for the default language and currency for the sales channel, why not for the domain as well.

### 2. What does this change do, exactly?

Before:

![image](https://user-images.githubusercontent.com/1133593/195454209-b15993d7-a1d8-4ccd-9efc-9babf12e31ee.png)

After:

![image](https://user-images.githubusercontent.com/1133593/195454222-367c998e-cd15-4cee-af5b-ff1a318f115d.png)

After (when there are multiple languages and currencies and you HAVE to choose one)

![image](https://user-images.githubusercontent.com/1133593/195454228-5994bd65-97ee-4de5-932c-8ba86360a8e4.png)

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2762"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

