### PR TITLE
Fix cursor for disabled switch-field and radio-field

### DIFF
--- a/changelog/_unreleased/2022-10-14-fix-cursor-for-disabled-switch-and-radio-field.md
+++ b/changelog/_unreleased/2022-10-14-fix-cursor-for-disabled-switch-and-radio-field.md
@@ -1,0 +1,9 @@
+---
+title: Fix cursor for disabled switch-field and radio-field
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Changed cursor for state icon and label of `sw-switch-field` when it is disabled 
+* Changed cursor for state icon of `sw-radio-field` when it is disabled 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-radio-field/sw-radio-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-radio-field/sw-radio-field.scss
@@ -105,6 +105,14 @@ $sw-field--radio-color-border: $color-gray-300;
         }
     }
 
+    &.is--disabled {
+        .sw-field__radio-input {
+            input[type="radio"] {
+                cursor: not-allowed;
+            }
+        }
+    }
+
     .sw-field__radio-option-label {
         &.error--selection {
             color: $color-crimson-500;

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-switch-field/sw-switch-field.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-switch-field/sw-switch-field.scss
@@ -63,7 +63,7 @@ $sw-field--switch-color-error: $color-crimson-500;
             cursor: pointer;
 
             &:disabled {
-                cursor: auto;
+                cursor: not-allowed;
             }
 
             &:disabled ~ .sw-field__switch-state {
@@ -166,6 +166,14 @@ $sw-field--switch-color-error: $color-crimson-500;
 
             &:checked:disabled ~ .sw-field__switch-state {
                 background: $sw-field--switch-color-error;
+            }
+        }
+    }
+
+    &.is--disabled {
+        .sw-field__label {
+            label {
+                cursor: not-allowed;
             }
         }
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Right now the cursors on different togglable fields look like this:

![image](https://user-images.githubusercontent.com/1133593/195736396-4c6e5b9a-0923-4dac-903b-694f90a51c7c.png)

| field | icon cursor | label cursor |
| --- | --- | --- |
| checkbox-field | forbidden |  neutral |
| radio-field | action | forbidden |
| switch-field | neutral | action |

### 2. What does this change do, exactly?

Now they look like this:

![image](https://user-images.githubusercontent.com/1133593/195736425-34c1abc9-9a77-4624-a793-f45068d6c611.png)

| field | icon cursor | label cursor |
| --- | --- | --- |
| checkbox-field | forbidden |  neutral |
| radio-field | forbidden | forbidden |
| switch-field | forbidden | forbidden |

I still did not fix the checkbox-field label because somehow changing it was not working for me. If someone else can do this, nice.

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2764"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

