### PR TITLE
feat: add blocks to thumbnail.html.twig

### DIFF
--- a/changelog/_unreleased/2022-10-14-add-blocks-to-thumbnail.html.twig.md
+++ b/changelog/_unreleased/2022-10-14-add-blocks-to-thumbnail.html.twig.md
@@ -1,0 +1,12 @@
+---
+title: Add blocks to thumbnail.html.twig
+issue: 
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Storefront
+* Add block `thumbnail_utility` around entire content of `utilities/thumbnail.html.twig`
+* Add block `thumbnail_utility_img` around img tag of `utilities/thumbnail.html.twig`
+

--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -1,93 +1,98 @@
-{# activate load per default. If it is not activated only a data-src is set instead of the src tag. #}
-{% if load is not defined %}
-    {% set load = true %}
-{% endif %}
-
-{# By default no original image will be loaded as soon as thumbnails are available. #}
-{# When set to true the orginal image will be loaded when the viewport is greater than the largest available thumbnail. #}
-{% if loadOriginalImage is not defined %}
-    {% set loadOriginalImage = false %}
-{% endif %}
-
-{# By default the srcset sizes will be calculated automatically if `columns` are present and no `sizes` are configured. #}
-{# When set to false the sizes attribute will not be generated automatically. #}
-{% if autoColumnSizes is not defined %}
-    {% set autoColumnSizes = true %}
-{% endif %}
-
-{% if attributes is not defined %}
-    {% set attributes = {} %}
-{% endif %}
-
-{% if attributes.alt is not defined and media.translated.alt is defined %}
-    {% set attributes = attributes|merge({'alt': media.translated.alt}) %}
-{% endif %}
-
-{% if attributes.title is not defined and media.translated.title is defined %}
-    {% set attributes = attributes|merge({'title': media.translated.title}) %}
-{% endif %}
-
-{# uses cms block column count and all available thumbnails to determine the correct image size for the current viewport #}
-{% if media.thumbnails|length > 0 %}
-    {% if autoColumnSizes and columns and sizes is not defined %}
-        {# set image size for every viewport #}
-        {% set sizes = {
-            'xs': (theme_config('breakpoint.sm') - 1) ~'px',
-            'sm': (theme_config('breakpoint.md') - 1) ~'px',
-            'md': ((theme_config('breakpoint.lg') - 1) / columns)|round(0, 'ceil') ~'px',
-            'lg': ((theme_config('breakpoint.xl') - 1) / columns)|round(0, 'ceil') ~'px'
-        } %}
-
-        {# set image size for largest viewport depending on the cms block sizing mode (boxed or full-width) #}
-        {% if layout == 'full-width' %}
-            {% set container = 100 %}
-            {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'vw'}) %}
-        {% else %}
-            {% set container = 1360 %}
-            {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'px'}) %}
-        {% endif %}
+{% block thumbnail_utility %}
+    {# activate load per default. If it is not activated only a data-src is set instead of the src tag. #}
+    {% if load is not defined %}
+        {% set load = true %}
     {% endif %}
 
-    {% set thumbnails = media.thumbnails|sort|reverse %}
+    {# By default no original image will be loaded as soon as thumbnails are available. #}
+    {# When set to true the orginal image will be loaded when the viewport is greater than the largest available thumbnail. #}
+    {% if loadOriginalImage is not defined %}
+        {% set loadOriginalImage = false %}
+    {% endif %}
 
-    {# generate srcset with all available thumbnails #}
-    {% set srcsetValue %}{% apply spaceless %}
-        {% if loadOriginalImage %}{{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% endif %}{% for thumbnail in thumbnails %}{{ thumbnail.url | sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
-    {% endapply %}{% endset %}
+    {# By default the srcset sizes will be calculated automatically if `columns` are present and no `sizes` are configured. #}
+    {# When set to false the sizes attribute will not be generated automatically. #}
+    {% if autoColumnSizes is not defined %}
+        {% set autoColumnSizes = true %}
+    {% endif %}
 
-    {# generate sizes #}
-    {% set sizesValue %}{% apply spaceless %}
-        {% set sizeFallback = 100 %}
+    {% if attributes is not defined %}
+        {% set attributes = {} %}
+    {% endif %}
 
-        {# set largest size depending on column count of cms block #}
-        {% if autoColumnSizes and columns %}
-            {% set sizeFallback = (sizeFallback / columns)|round(0, 'ceil') %}
-        {% endif %}
+    {% if attributes.alt is not defined and media.translated.alt is defined %}
+        {% set attributes = attributes|merge({'alt': media.translated.alt}) %}
+    {% endif %}
 
-        {% set breakpoint = {
-            'xs': theme_config('breakpoint.xs'),
-            'sm': theme_config('breakpoint.sm'),
-            'md': theme_config('breakpoint.md'),
-            'lg': theme_config('breakpoint.lg'),
-            'xl': theme_config('breakpoint.xl')
-        } %}
+    {% if attributes.title is not defined and media.translated.title is defined %}
+        {% set attributes = attributes|merge({'title': media.translated.title}) %}
+    {% endif %}
 
-        {% if thumbnails|first.width > breakpoint|reverse|first %}
-            {# @deprecated tag:v6.5.0 - Variable `maxWidth` and parent condition will be removed #}
-            {% set maxWidth = thumbnails|first.width %}
-        {% endif %}
-
-        {% for key, value in breakpoint|reverse %}(min-width: {{ value }}px) {{ sizes[key] }}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
-    {% endapply %}{% endset %}
-{% endif %}
-<img {% if load %}src="{{ media|sw_encode_media_url }}" {% else %}data-src="{{ media|sw_encode_media_url }}" {% endif %}
+    {# uses cms block column count and all available thumbnails to determine the correct image size for the current viewport #}
     {% if media.thumbnails|length > 0 %}
-        {% if load %}srcset="{{ srcsetValue }}" {% else %}data-srcset="{{ srcsetValue }}" {% endif %}
-        {% if sizes['default'] %}
-        sizes="{{ sizes['default'] }}"
-        {% elseif sizes|length > 0 %}
-        sizes="{{ sizesValue }}"
+        {% if autoColumnSizes and columns and sizes is not defined %}
+            {# set image size for every viewport #}
+            {% set sizes = {
+                'xs': (theme_config('breakpoint.sm') - 1) ~'px',
+                'sm': (theme_config('breakpoint.md') - 1) ~'px',
+                'md': ((theme_config('breakpoint.lg') - 1) / columns)|round(0, 'ceil') ~'px',
+                'lg': ((theme_config('breakpoint.xl') - 1) / columns)|round(0, 'ceil') ~'px'
+            } %}
+
+            {# set image size for largest viewport depending on the cms block sizing mode (boxed or full-width) #}
+            {% if layout == 'full-width' %}
+                {% set container = 100 %}
+                {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'vw'}) %}
+            {% else %}
+                {% set container = 1360 %}
+                {% set sizes = sizes|merge({ 'xl': (container / columns)|round(0, 'ceil') ~'px'}) %}
+            {% endif %}
         {% endif %}
+
+        {% set thumbnails = media.thumbnails|sort|reverse %}
+
+        {# generate srcset with all available thumbnails #}
+        {% set srcsetValue %}{% apply spaceless %}
+            {% if loadOriginalImage %}{{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% endif %}{% for thumbnail in thumbnails %}{{ thumbnail.url | sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
+        {% endapply %}{% endset %}
+
+        {# generate sizes #}
+        {% set sizesValue %}{% apply spaceless %}
+            {% set sizeFallback = 100 %}
+
+            {# set largest size depending on column count of cms block #}
+            {% if autoColumnSizes and columns %}
+                {% set sizeFallback = (sizeFallback / columns)|round(0, 'ceil') %}
+            {% endif %}
+
+            {% set breakpoint = {
+                'xs': theme_config('breakpoint.xs'),
+                'sm': theme_config('breakpoint.sm'),
+                'md': theme_config('breakpoint.md'),
+                'lg': theme_config('breakpoint.lg'),
+                'xl': theme_config('breakpoint.xl')
+            } %}
+
+            {% if thumbnails|first.width > breakpoint|reverse|first %}
+                {# @deprecated tag:v6.5.0 - Variable `maxWidth` and parent condition will be removed #}
+                {% set maxWidth = thumbnails|first.width %}
+            {% endif %}
+
+            {% for key, value in breakpoint|reverse %}(min-width: {{ value }}px) {{ sizes[key] }}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
+        {% endapply %}{% endset %}
     {% endif %}
-    {% for key, value in attributes %}{% if value != '' %} {{ key }}="{{ value }}"{% endif %}{% endfor %}
-/>
+
+    {% block thumbnail_utility_img %}
+        <img {% if load %}src="{{ media|sw_encode_media_url }}" {% else %}data-src="{{ media|sw_encode_media_url }}" {% endif %}
+            {% if media.thumbnails|length > 0 %}
+                {% if load %}srcset="{{ srcsetValue }}" {% else %}data-srcset="{{ srcsetValue }}" {% endif %}
+                {% if sizes['default'] %}
+                sizes="{{ sizes['default'] }}"
+                {% elseif sizes|length > 0 %}
+                sizes="{{ sizesValue }}"
+                {% endif %}
+            {% endif %}
+            {% for key, value in attributes %}{% if value != '' %} {{ key }}="{{ value }}"{% endif %}{% endfor %}
+        />
+    {% endblock %}
+{% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Add extensibility to thumbnail.html.twig

### 2. What does this change do, exactly?
Add two WORKING blocks :-)

### 3. Describe each step to reproduce the issue or behaviour.
never add blocks around the variable setting like tested with https://github.com/shopware/platform/pull/786

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2765"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

