### PR TITLE
[HOCKETHON] Implement consideration of log configuration for plugins

### DIFF
--- a/changelog/_unreleased/2022-10-13-implement-configurable-plugin-log-handling.md
+++ b/changelog/_unreleased/2022-10-13-implement-configurable-plugin-log-handling.md
@@ -1,0 +1,9 @@
+---
+title: Implement consideration of log configuration for plugins
+issue: NEXT-0000
+author: Alexander Wink
+author_email: a.wink@kellerkinder.de
+author_github: @jinnoflife
+---
+# Core
+* Changed handling of LoggerFactory to consider log configuration

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -620,6 +620,7 @@ base-uri 'self';
         <!-- Util -->
         <service id="Shopware\Core\Framework\Log\LoggerFactory">
             <argument type="string">%kernel.logs_dir%/%%s_%kernel.environment%.log</argument>
+            <argument type="service" id="logger"/>
             <argument>%shopware.logger.file_rotation_count%</argument>
         </service>
 

--- a/src/Core/Framework/Log/LoggerFactory.php
+++ b/src/Core/Framework/Log/LoggerFactory.php
@@ -2,37 +2,73 @@
 
 namespace Shopware\Core\Framework\Log;
 
+use Monolog\Handler\NullHandler;
 use Monolog\Handler\RotatingFileHandler;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
 use Psr\Log\LoggerInterface;
+use Shopware\Core\Framework\Feature;
 
 class LoggerFactory
 {
     private string $rotatingFilePathPattern = '';
+
+    private LoggerInterface $logger;
 
     private int $defaultFileRotationCount;
 
     /**
      * @internal
      */
-    public function __construct(string $rotatingFilePathPattern, int $defaultFileRotationCount = 14)
+    public function __construct(string $rotatingFilePathPattern, LoggerInterface $logger, int $defaultFileRotationCount = 14)
     {
         $this->rotatingFilePathPattern = $rotatingFilePathPattern;
+        $this->logger = $logger;
         $this->defaultFileRotationCount = $defaultFileRotationCount;
     }
 
     /**
      * @param 100|200|250|300|400|500|550|600 $loggerLevel
      */
-    public function createRotating(string $filePrefix, ?int $fileRotationCount = null, int $loggerLevel = Logger::DEBUG): LoggerInterface
+    public function create(string $filePrefix, ?int $fileRotationCount = null, int $loggerLevel = Logger::DEBUG): LoggerInterface
     {
-        $filepath = sprintf($this->rotatingFilePathPattern, $filePrefix);
-
         $result = new Logger($filePrefix);
-        $result->pushHandler(new RotatingFileHandler($filepath, $fileRotationCount ?? $this->defaultFileRotationCount, $loggerLevel));
         $result->pushProcessor(new PsrLogMessageProcessor());
 
+        /**
+         * Use RotatingFileHandler as fallback if Nullhandler or none is given
+         * If RotatingFileHandler is given (default configuration) -> use "default" logic for splitted logs
+         */
+        if (!method_exists($this->logger, 'getHandlers')
+            || (
+                \count($this->logger->getHandlers() ?? 0) === 1
+                && (
+                    current($this->logger->getHandlers()) instanceof NullHandler
+                    || current($this->logger->getHandlers()) instanceof RotatingFileHandler
+                )
+            )
+        ) {
+            $filepath = sprintf($this->rotatingFilePathPattern, $filePrefix);
+
+            $result->pushHandler(new RotatingFileHandler($filepath, $fileRotationCount ?? $this->defaultFileRotationCount, $loggerLevel));
+
+            return $result;
+        }
+
+        $result->setHandlers($this->logger->getHandlers());
+
         return $result;
+    }
+
+    /**
+     * @deprecated tag:v6.5.0 - Will be removed, use `create` instead
+     *
+     * @param 100|200|250|300|400|500|550|600 $loggerLevel
+     */
+    public function createRotating(string $filePrefix, ?int $fileRotationCount = null, int $loggerLevel = Logger::DEBUG): LoggerInterface
+    {
+        Feature::triggerDeprecationOrThrow('v6.5.0.0', 'Use the create method instead');
+
+        return $this->create($filePrefix, $fileRotationCount, $loggerLevel);
     }
 }

--- a/tests/unit/php/Core/Framework/Log/LoggerFactoryTest.php
+++ b/tests/unit/php/Core/Framework/Log/LoggerFactoryTest.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Api\Command;
+
+use Monolog\Handler\NullHandler;
+use Monolog\Handler\RotatingFileHandler;
+use Monolog\Logger;
+use Shopware\Core\Framework\Log\LoggerFactory;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Framework\Log\LoggerFactory
+ */
+class LoggerFactoryTest extends \PHPUnit\Framework\TestCase
+{
+    public function testNullLogHandler(): void
+    {
+        $providedHandler = [new NullHandler()];
+        $mainLogger = new Logger('test_logger', $providedHandler);
+        $loggerFactory = new LoggerFactory('test_case', $mainLogger);
+
+        /** @var \Monolog\Logger $createdLogger */
+        $createdLogger = $loggerFactory->create('test_file_path');
+        $usedHandler = $createdLogger->getHandlers();
+
+        static::assertCount(1, $usedHandler);
+        static::assertInstanceOf(RotatingFileHandler::class, current($usedHandler), 'Handler differs from excpected');
+    }
+
+    public function testRotatingFileLogHandler(): void
+    {
+        $providedHandler = [new RotatingFileHandler('test')];
+        $mainLogger = new Logger('test_logger', $providedHandler);
+        $loggerFactory = new LoggerFactory('test_case', $mainLogger);
+
+        /** @var \Monolog\Logger $createdLogger */
+        $createdLogger = $loggerFactory->create('test_file_path');
+        $usedHandler = $createdLogger->getHandlers();
+
+        static::assertCount(1, $usedHandler);
+        static::assertInstanceOf(RotatingFileHandler::class, current($usedHandler), 'Handler differs from excpected');
+    }
+
+    public function testMultipleLogHandlers(): void
+    {
+        $providedHandler = [
+            new RotatingFileHandler('test'),
+            new NullHandler(),
+        ];
+        $mainLogger = new Logger('test_logger', $providedHandler);
+        $loggerFactory = new LoggerFactory('test_case', $mainLogger);
+
+        /** @var \Monolog\Logger $createdLogger */
+        $createdLogger = $loggerFactory->create('test_file_path');
+        $usedHandler = $createdLogger->getHandlers();
+
+        static::assertCount(\count($providedHandler), $usedHandler);
+        static::assertSame($providedHandler, $usedHandler, 'Handler differs from excpected');
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently plugins doesn't consider the configured log targets

### 2. What does this change do, exactly?
Write logs with configured handler instead of always using logrotate

### 3. Describe each step to reproduce the issue or behaviour.
Try to log somewhere else by using the LoggerFactory

### 4. Please link to the relevant issues (if any).
IDK any

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.