### PR TITLE
[HOCKETHON] Add new state skipped for scheduled tasks

### DIFF
--- a/changelog/_unreleased/2022-10-14-add-new-state-skipped-for-scheduled-tasks.md
+++ b/changelog/_unreleased/2022-10-14-add-new-state-skipped-for-scheduled-tasks.md
@@ -1,0 +1,9 @@
+---
+title: Add new state skipped for scheduled Tasks
+issue: NEXT-00000
+author: Alexander Wink
+author_email: a.wink@kellerkinder.de
+author_github: @jinnoflife
+---
+# Core
+* Added `\Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition::STATUS_SKIPPED`

--- a/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskDefinition.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskDefinition.php
@@ -22,6 +22,8 @@ class ScheduledTaskDefinition extends EntityDefinition
 
     public const STATUS_QUEUED = 'queued';
 
+    public const STATUS_SKIPPED = 'skipped';
+
     public const STATUS_RUNNING = 'running';
 
     public const STATUS_FAILED = 'failed';

--- a/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskEntity.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskEntity.php
@@ -82,9 +82,10 @@ class ScheduledTaskEntity extends Entity
 
     public function isExecutionAllowed(): bool
     {
-        // If the status is failed execution is still allowed so retries are possible
+        // If the status is failed, skipped or queued, the execution is still allowed, so retries are possible
         return $this->status === ScheduledTaskDefinition::STATUS_QUEUED
-            || $this->status === ScheduledTaskDefinition::STATUS_FAILED;
+            || $this->status === ScheduledTaskDefinition::STATUS_FAILED
+            || $this->status === ScheduledTaskDefinition::STATUS_SKIPPED;
     }
 
     public function setStatus(string $status): void

--- a/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\MinAg
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\AggregationResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\MinResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
@@ -117,7 +118,10 @@ class TaskScheduler
                     RangeFilter::LT => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
                 ]
             ),
-            new EqualsFilter('status', ScheduledTaskDefinition::STATUS_SCHEDULED)
+            new EqualsAnyFilter('status', [
+                ScheduledTaskDefinition::STATUS_SCHEDULED,
+                ScheduledTaskDefinition::STATUS_SKIPPED,
+            ])
         );
 
         return $criteria;
@@ -148,7 +152,10 @@ class TaskScheduler
     {
         $criteria = new Criteria();
         $criteria->addFilter(
-            new EqualsFilter('status', ScheduledTaskDefinition::STATUS_SCHEDULED)
+            new EqualsAnyFilter('status', [
+                ScheduledTaskDefinition::STATUS_SCHEDULED,
+                ScheduledTaskDefinition::STATUS_SKIPPED,
+            ])
         )
         ->addAggregation(new MinAggregation('nextExecutionTime', 'nextExecutionTime'));
 


### PR DESCRIPTION
### 1. Why is this change necessary?
To allow tasks to be marked as skipped (simply to optimize monitoring)

### 2. What does this change do, exactly?
Add a new state for the scheduled_tasks

### 3. Describe each step to reproduce the issue or behaviour.
///

### 4. Please link to the relevant issues (if any).
///

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2767"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

