### PR TITLE
Fix: Escape Comments in Product Comparison Templates

### DIFF
--- a/changelog/_unreleased/2022-10-14-excape-comments-in-product-comparison-templates.md
+++ b/changelog/_unreleased/2022-10-14-excape-comments-in-product-comparison-templates.md
@@ -1,0 +1,10 @@
+---
+title: Escape Comments in Product Comparison Templates
+author: d.popovic
+author_email: darko.popovic@ditegra.de
+author_github: dpopov00
+---
+# Core
+* Changed `src\Administration\Resources\app\administration\webpack.config.js` comment removal to escape {#- -#} because it is necessary for correct creation of CSV Product Comparison Templates (because of this comments Twig ignores the trailing newline)
+* old: search: /\{#[\s\S]*?#\}/gm,
+* new: search: /^(?!\{#-)\{#[\s\S]*?#\}/gm (still remove comments, but skip if they are in this combination "{#-" )

--- a/src/Administration/Resources/app/administration/webpack.config.js
+++ b/src/Administration/Resources/app/administration/webpack.config.js
@@ -251,7 +251,7 @@ const baseConfig = ({ pluginPath, pluginFilepath }) => ({
                                   replace: '',
                               },
                               {
-                                  search: /\{#[\s\S]*?#\}/gm,
+                                  search: /^(?!\{#-)\{#[\s\S]*?#\}/gm,
                                   replace: '',
                               }
                           ],


### PR DESCRIPTION
### 1. Why is this change necessary?
In the last version, all comments are removed in administration minified js.
That is reasonable, but comments have an important role in Product Comparison Templates - Twig ignores the trailing newline.
This fixes the issue for Product Comparison Templates.

### 2. What does this change do, exactly?
Change to delete comments broke default behavior for Product Comparison Templates. 
Default CSV templates (Billiger.csv & Idealo.csv) and templates from custom plugins depend on comments to get a finished template when creating a Product Comparison Sales Channel with a template.
It is a simple change in RegExp, to skip comments which are built like this {#- -#}.
{#- -#} is a correct way to ignore trailing newline and I presume no one leaves comments like this in any other case, so the new functionality is kept (to remove comments) and preserving the comments in the product comparison templates at the same time.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create Clean Shopware Environment.
2. Create Dynamic Product Group
3. Create Product Comparison Sales Channel
4. Choose Billiger Template and fill rest of the required fields
5. Templates are incorrect ({#- -#} are missing which leads to an error in CSV file).


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2768"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

