### PR TITLE
validate customer already confirmed

### DIFF
--- a/changelog/_unreleased/2022-10-14-fix-double-opt-in-account-reactivation.md
+++ b/changelog/_unreleased/2022-10-14-fix-double-opt-in-account-reactivation.md
@@ -6,4 +6,4 @@ author_email: development@silvio-kennecke.de
 author_github: @silviokennecke
 ---
 # Core
-* Changed `\Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute::confirm` to verify if the customer already confirmed the account
+* Changed `\Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute::confirm` to verify if the customer has to double-opt-in and whether the account is already confirmed

--- a/changelog/_unreleased/2022-10-14-fix-double-opt-in-account-reactivation.md
+++ b/changelog/_unreleased/2022-10-14-fix-double-opt-in-account-reactivation.md
@@ -1,0 +1,9 @@
+---
+title: Fix double opt-in account reactivation
+issue: -
+author: Silvio Kennecke
+author_email: development@silvio-kennecke.de
+author_github: @silviokennecke
+---
+# Core
+* Changed `\Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute::confirm` to verify if the customer already confirmed the account

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
@@ -25,6 +25,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParamete
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Validator\Constraints\EqualTo;
+use Symfony\Component\Validator\Constraints\IsNull;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -105,7 +106,7 @@ class RegisterConfirmRoute extends AbstractRegisterConfirmRoute
             $this->getBeforeConfirmValidation(hash('sha1', $customer->getEmail()))
         );
 
-        if ($customer->getActive()) {
+        if ($customer->getActive() || $customer->getDoubleOptInConfirmDate() !== null) {
             throw new CustomerAlreadyConfirmedException($customer->getId());
         }
 

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
@@ -25,7 +25,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParamete
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Validator\Constraints\EqualTo;
-use Symfony\Component\Validator\Constraints\IsNull;
+use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -102,7 +102,10 @@ class RegisterConfirmRoute extends AbstractRegisterConfirmRoute
         }
 
         $this->validator->validate(
-            ['em' => $dataBag->get('em')],
+            [
+                'em' => $dataBag->get('em'),
+                'doubleOptInRegistration' => $customer->getDoubleOptInRegistration(),
+            ],
             $this->getBeforeConfirmValidation(hash('sha1', $customer->getEmail()))
         );
 
@@ -179,6 +182,7 @@ class RegisterConfirmRoute extends AbstractRegisterConfirmRoute
     {
         $definition = new DataValidationDefinition('registration.opt_in_before');
         $definition->add('em', new EqualTo(['value' => $emHash]));
+        $definition->add('doubleOptInRegistration', new IsTrue());
 
         return $definition;
     }

--- a/tests/unit/php/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
+++ b/tests/unit/php/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Core\Checkout\Customer\SalesChannel;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
@@ -36,6 +37,11 @@ class RegisterConfirmRouteTest extends TestCase
     protected $context;
 
     /**
+     * @var MockObject|EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
+    /**
      * @var MockObject|EntityRepositoryInterface
      */
     protected $customerRepository;
@@ -46,6 +52,11 @@ class RegisterConfirmRouteTest extends TestCase
     protected $validator;
 
     /**
+     * @var Stub|SalesChannelContextServiceInterface
+     */
+    protected $salesChannelContextService;
+
+    /**
      * @var RegisterConfirmRoute
      */
     protected $route;
@@ -54,23 +65,25 @@ class RegisterConfirmRouteTest extends TestCase
     {
         parent::setUp();
         $this->context = $this->createMock(SalesChannelContext::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->customerRepository = $this->createMock(EntityRepositoryInterface::class);
         $this->validator = $this->createMock(DataValidator::class);
+        $this->salesChannelContextPersister = $this->createMock(SalesChannelContextPersister::class);
 
         $newSalesChannelContext = $this->createMock(SalesChannelContext::class);
         $newSalesChannelContext->method('getCustomer')->willReturn(new CustomerEntity());
 
-        $salesChannelContextService = $this->createStub(SalesChannelContextServiceInterface::class);
-        $salesChannelContextService
+        $this->salesChannelContextService = $this->createStub(SalesChannelContextServiceInterface::class);
+        $this->salesChannelContextService
             ->method('get')
             ->willReturn($newSalesChannelContext);
 
         $this->route = new RegisterConfirmRoute(
             $this->customerRepository,
-            $this->createMock(EventDispatcherInterface::class),
+            $this->eventDispatcher,
             $this->validator,
-            $this->createMock(SalesChannelContextPersister::class),
-            $salesChannelContextService
+            $this->salesChannelContextPersister,
+            $this->salesChannelContextService
         );
     }
 

--- a/tests/unit/php/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
+++ b/tests/unit/php/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
@@ -1,0 +1,199 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Customer\SalesChannel;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerCollection;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Exception\CustomerAlreadyConfirmedException;
+use Shopware\Core\Checkout\Customer\SalesChannel\CustomerResponse;
+use Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\Framework\Validation\DataValidationDefinition;
+use Shopware\Core\Framework\Validation\DataValidator;
+use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\Validator\Constraints\IsTrue;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ * @group rules
+ * @covers \Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute
+ */
+class RegisterConfirmRouteTest extends TestCase
+{
+    /**
+     * @var MockObject|SalesChannelContext
+     */
+    protected $context;
+
+    /**
+     * @var MockObject|SalesChannelRepositoryInterface
+     */
+    protected $customerRepository;
+
+    /**
+     * @var MockObject|DataValidator
+     */
+    protected $validator;
+
+    /**
+     * @var RegisterConfirmRoute
+     */
+    protected $route;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->context = $this->createMock(SalesChannelContext::class);
+        $this->customerRepository = $this->createMock(EntityRepositoryInterface::class);
+        $this->validator = $this->createMock(DataValidator::class);
+
+        $newSalesChannelContext = $this->createMock(SalesChannelContext::class);
+        $newSalesChannelContext->method('getCustomer')->willReturn(new CustomerEntity());
+
+        $salesChannelContextService = $this->createStub(SalesChannelContextServiceInterface::class);
+        $salesChannelContextService
+            ->method('get')
+            ->willReturn($newSalesChannelContext);
+
+        $this->route = new RegisterConfirmRoute(
+            $this->customerRepository,
+            $this->createMock(EventDispatcherInterface::class),
+            $this->validator,
+            $this->createMock(SalesChannelContextPersister::class),
+            $salesChannelContextService
+        );
+    }
+
+    public function testConfirmCustomer(): void
+    {
+        $customer = $this->mockCustomer();
+
+        $this->customerRepository->expects(static::exactly(2))
+            ->method('search')
+            ->willReturn(
+                new EntitySearchResult(
+                    'customer',
+                    1,
+                    new CustomerCollection([$customer]),
+                    null,
+                    new Criteria(),
+                    $this->context->getContext()
+                )
+            );
+
+        $confirmResult = $this->route->confirm($this->mockRequestDataBag(), $this->context);
+
+        static::assertInstanceOf(CustomerResponse::class, $confirmResult);
+    }
+
+    public function testConfirmCustomerNotDoubleOptIn(): void
+    {
+        $customer = $this->mockCustomer();
+        $customer->setDoubleOptInRegistration(false);
+
+        $this->customerRepository->expects(static::once())
+            ->method('search')
+            ->willReturn(
+                new EntitySearchResult(
+                    'customer',
+                    1,
+                    new CustomerCollection([$customer]),
+                    null,
+                    new Criteria(),
+                    $this->context->getContext()
+                )
+            );
+
+        $this->validator->expects(static::once())
+            ->method('validate')
+            ->willReturnCallback(function (array $data, DataValidationDefinition $definition): void {
+                $properties = $definition->getProperties();
+                static::assertArrayHasKey('doubleOptInRegistration', $properties);
+                static::assertContainsOnlyInstancesOf(IsTrue::class, $properties['doubleOptInRegistration']);
+
+                static::assertFalse($data['doubleOptInRegistration']);
+
+                throw new ConstraintViolationException(new ConstraintViolationList(), $data);
+            });
+
+        static::expectException(ConstraintViolationException::class);
+        $this->route->confirm($this->mockRequestDataBag(), $this->context);
+    }
+
+    public function testConfirmActivatedCustomer(): void
+    {
+        $customer = $this->mockCustomer();
+        $customer->setActive(true);
+
+        $this->customerRepository->expects(static::once())
+            ->method('search')
+            ->willReturn(
+                new EntitySearchResult(
+                    'customer',
+                    1,
+                    new CustomerCollection([$customer]),
+                    null,
+                    new Criteria(),
+                    $this->context->getContext()
+                )
+            );
+
+        static::expectException(CustomerAlreadyConfirmedException::class);
+        $this->route->confirm($this->mockRequestDataBag(), $this->context);
+    }
+
+    public function testConfirmConfirmedCustomer(): void
+    {
+        $customer = $this->mockCustomer();
+        $customer->setDoubleOptInConfirmDate(new \DateTime());
+
+        $this->customerRepository->expects(static::once())
+            ->method('search')
+            ->willReturn(
+                new EntitySearchResult(
+                    'customer',
+                    1,
+                    new CustomerCollection([$customer]),
+                    null,
+                    new Criteria(),
+                    $this->context->getContext()
+                )
+            );
+
+        static::expectException(CustomerAlreadyConfirmedException::class);
+        $this->route->confirm($this->mockRequestDataBag(), $this->context);
+    }
+
+    protected function mockCustomer(): CustomerEntity
+    {
+        $customer = new CustomerEntity();
+        $customer->setId('customer-1');
+        $customer->setActive(false);
+        $customer->setEmail('test@test.test');
+        $customer->setHash('hash');
+        $customer->setGuest(false);
+        $customer->setDoubleOptInRegistration(true);
+        $customer->setDoubleOptInEmailSentDate(new \DateTime());
+
+        return $customer;
+    }
+
+    protected function mockRequestDataBag(): RequestDataBag
+    {
+        return new RequestDataBag([
+            'hash' => 'hash',
+            'em' => hash('sha1', 'test@test.test'),
+        ]);
+    }
+}

--- a/tests/unit/php/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
+++ b/tests/unit/php/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
@@ -37,7 +37,7 @@ class RegisterConfirmRouteTest extends TestCase
     protected $context;
 
     /**
-     * @var MockObject|SalesChannelRepositoryInterface
+     * @var MockObject|EntityRepositoryInterface
      */
     protected $customerRepository;
 

--- a/tests/unit/php/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
+++ b/tests/unit/php/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
@@ -26,7 +26,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @internal
- * @group rules
  * @covers \Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute
  */
 class RegisterConfirmRouteTest extends TestCase
@@ -50,6 +49,11 @@ class RegisterConfirmRouteTest extends TestCase
      * @var MockObject|DataValidator
      */
     protected $validator;
+
+    /**
+     * @var MockObject|SalesChannelContextPersister
+     */
+    protected $salesChannelContextPersister;
 
     /**
      * @var Stub|SalesChannelContextServiceInterface

--- a/tests/unit/php/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
+++ b/tests/unit/php/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
@@ -18,7 +18,6 @@ use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceInterface;
-use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Validator\Constraints\IsTrue;
 use Symfony\Component\Validator\ConstraintViolationList;


### PR DESCRIPTION
### 1. Why is this change necessary?

When disabling a customer as a shop administrator, the customer can reactivate the account by clicking on the double opt-in link again.

### 2. What does this change do, exactly?

1. It validates if the customer has to double-opt-in (`customer.doubleOptInRegistration`).
2. It validates if the customer has already double-opt-in before the account gets activated (`customer.doubleOptInConfirmDate !== null`).

### 3. Describe each step to reproduce the issue or behaviour.

1. Enable double-opt-in for registration in system config (key `core.loginRegistration.doubleOptInRegistration`)
2. Register as customer
3. Activate your account
4. Disable the customer (`set customer.active = 0`) (could be the case when a shop owner wants to block the customer e.g. because of unpaid invoices)
5. Click the confirmation link again

Expected behaviour: The customer's account stays inactive.

Current behaviour: The customer's account gets activated.

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2769"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

