### PR TITLE
fix: disable input if search function is disabled

### DIFF
--- a/changelog/_unreleased/2022-10-14-disable-input-if-search-function-is-disabled.md
+++ b/changelog/_unreleased/2022-10-14-disable-input-if-search-function-is-disabled.md
@@ -1,0 +1,8 @@
+---
+title: Disable input if search function is disabled
+author: Stefan Poensgen
+author_email: mail@stefanpoensgen.de
+author_github: @stefanpoensgen
+---
+# Administration
+* Disable the search input in sw-single-select component when the search function is disabled. 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.html.twig
@@ -51,6 +51,7 @@
                 :class="inputClasses"
                 type="text"
                 :placeholder="placeholder"
+                :disabled="disableSearchFunction"
                 @input="onInputSearchTerm"
             >
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-single-select/sw-single-select.scss
@@ -12,6 +12,11 @@
             display: block;
             padding: 12px 8px;
         }
+
+        &:disabled {
+            background-color: $color-white;
+            border-color: $color-white;
+        }
     }
 
     .sw-single-select__selection-text {


### PR DESCRIPTION
### 1. Why is this change necessary?
If you disable the search function in the sw-single-select component you won't expect to see an annoying cursor waiting for your input.

### 2. What does this change do, exactly?
Sets the existing input field according to the value of "disableSearchFunction"

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2770"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

