### PR TITLE
fix: Hide empty preview and description elements of sw-select-result

### DIFF
--- a/changelog/_unreleased/2022-10-15-hide-empty-preview-and-description-elements-of-sw-select-result.md
+++ b/changelog/_unreleased/2022-10-15-hide-empty-preview-and-description-elements-of-sw-select-result.md
@@ -1,0 +1,9 @@
+---
+title: Hide empty preview and description elements of sw-select-result
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Fix: Hide empty preview and description elements of sw-select-result for proper alignment of elements

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/index.js
@@ -64,8 +64,12 @@ Component.register('sw-select-result', {
             ];
         },
 
+        hasPreviewSlot() {
+            return !!this.$slots.preview || (this.$scopedSlots.preview && !!this.$scopedSlots.preview());
+        },
+
         hasDescriptionSlot() {
-            return !!this.$slots.description || !!this.$scopedSlots.description;
+            return !!this.$slots.description || (this.$scopedSlots.description && !!this.$scopedSlots.description());
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/sw-select-result.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result/sw-select-result.html.twig
@@ -9,7 +9,10 @@
 >
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_select_result_item_preview %}
-    <span class="sw-select-result__result-item-preview">
+    <span
+        v-if="hasPreviewSlot"
+        class="sw-select-result__result-item-preview"
+    >
         <slot name="preview"></slot>
     </span>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/sw-entity-single-select.html.twig
@@ -137,19 +137,18 @@
                     >
                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                         {% block sw_entity_multi_select_base_results_list_result_preview %}
-                        <template
-                            v-if="shouldShowActiveState"
-                            #preview
-                        >
-                            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                            {% block sw_entity_multi_select_base_results_list_result_active %}
-                            <sw-icon
-                                class="sw-entity-single-select__selection-active"
-                                size="6"
-                                :color="getActiveIconColor(item)"
-                                name="default-basic-shape-circle-filled"
-                            />
-                            {% endblock %}
+                        <template v-if="shouldShowActiveState">
+                            <slot name="preview">
+                                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                                {% block sw_entity_multi_select_base_results_list_result_active %}
+                                <sw-icon
+                                    class="sw-entity-single-select__selection-active"
+                                    size="6"
+                                    :color="getActiveIconColor(item)"
+                                    name="default-basic-shape-circle-filled"
+                                />
+                                {% endblock %}
+                            </slot>
                         </template>
                         {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the display of short select results in the administration is broken:
![grafik](https://user-images.githubusercontent.com/6317761/196000362-9bce7132-1ad1-4195-883e-f81e54a18aa9.png)


### 2. What does this change do, exactly?
With this change the superfluous elements are properly hidden. In the description there was a bug in the if statement, and for the preview slot there was no if.

### 3. Describe each step to reproduce the issue or behaviour.
Create a dynamic group and select a sales channel.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2771"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

Edit: ~~I am not sure what to do about the failing test. It works if the `shouldShowActiveState` is set to `true` when the wrapper is created, but~~
```
await wrapper.setProps({
    shouldShowActiveState: true
});
```
~~does not seem to show the preview.~~

Edit2: Thanks to @NiklasLimberg and @stefanpoensgen for the solution of the failing test :-)