### PR TITLE
fix: Only call default if it exists

### DIFF
--- a/changelog/_unreleased/2022-10-15-prevent-execution-of-undefined-function-in-sw-tabs.md
+++ b/changelog/_unreleased/2022-10-15-prevent-execution-of-undefined-function-in-sw-tabs.md
@@ -1,0 +1,9 @@
+---
+title: Prevent execution of undefined function in sw-tabs
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Prevent execution of `this.$scopedSlots.default()` if there is no default slot in the administration component `sw-tabs`

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.js
@@ -198,7 +198,7 @@ Component.register('sw-tabs', {
             this.recalculateSlider();
 
             // check if tab bar contains items with url routes
-            if (this.$scopedSlots.default()?.[0]?.componentOptions?.propsData?.route) {
+            if (this.$scopedSlots.default && this.$scopedSlots.default()?.[0]?.componentOptions?.propsData?.route) {
                 this.hasRoutes = true;
             }
         },


### PR DESCRIPTION
### 1. Why is this change necessary?
The default slot is not always set, so this can load to an JavaScript error.

### 2. What does this change do, exactly?
Prevent the undefined function call.

### 3. Describe each step to reproduce the issue or behaviour.
Create an empty `<sw-tabs>` element in the administration.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2772"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

