### PR TITLE
Add warning when not every sales channel language has a domain

### DIFF
--- a/changelog/_unreleased/2022-10-15-add-warning-when-not-every-sales-channel-language-has-a-domain.md
+++ b/changelog/_unreleased/2022-10-15-add-warning-when-not-every-sales-channel-language-has-a-domain.md
@@ -1,0 +1,8 @@
+---
+title: Add warning when not every sales channel language has a domain
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added an alert (warning or info depending on the severeness) in the sales channel settings to the language selection, that encourages you to add a domain for each language

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
@@ -83,6 +83,7 @@
       "warningDisabledPaymentMethod": "Einige der Zahlungsmethoden, die diesem Vertriebskanal zugeordnet sind, sind derzeit nicht verfügbar. Bitte überprüfen Sie Ihre <a href=\"{paymentSettingsLink}\">Einstellungen</a> für diese Zahlungsarten:<br /><b>{separatedList}</b>",
       "warningDisabledShippingMethod": "Die Versandart <b>{name}</b> ist nicht aktiv. | Die Versandarten <b>{name}</b> und <b>{addition}</b> sind nicht aktiv.",
       "warningDisabledAddition": "{amount} weitere",
+      "warningUnservedLanguage": "Die Sprache {list} ist keiner Domain zugewiesen. Um den vollen Funktionsumfang der Sprache zu nutzen, muss eine Domain mit dieser Sprache angelegt werden. | Diese Sprachen {list} sind keiner Domain zugewiesen. Um den vollen Funktionsumfang aller Sprache zu nutzen, muss eine Domain je Sprache angelegt werden.",
       "textDeleteInfo": "Achtung: Hiermit löschst Du diesen Verkaufskanal vollständig! Der Verkaufskanal wird danach nicht mehr in der Shopware Administration verfügbar sein und kann auch nicht wiederhergestellt werden. Alle vorhandenen Bestellungen bleiben jedoch erhalten. Auch ausgespielte Kataloge werden durch diese Aktion nicht verändert.",
       "buttonDelete": "Verkaufskanal löschen",
       "deleteModalTitle": "Verkaufskanal löschen",

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
@@ -83,6 +83,7 @@
       "warningDisabledPaymentMethod": "Some of the payment methods assigned to this Sales Channel are currently not available. Please check your <a href=\"{paymentSettingsLink}\">settings</a> for these payment methods:<br/> <b>{separatedList}</b>",
       "warningDisabledShippingMethod": "The shipping method <b>{name}</b> is not active. | The shipping methods <b>{name}</b> and <b>{addition}</b> are not active.",
       "warningDisabledAddition": "{amount} others",
+      "warningUnservedLanguage": "The language {list} is not assigned to a domain. Create a domain with this language to use its full potential. | The languages {list} are not assigned to any domain. Create a domain for each language to use their full potential.",
       "textDeleteInfo": "Careful, you are about to delete this Sales Channel permanently! If you proceed, the Sales Channel and all its settings will no longer be available. However, deleting the Sales Channel will not affect existing orders and categories.",
       "buttonDelete": "Delete Sales Channel",
       "deleteModalTitle": "Delete Sales Channel",

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -175,6 +175,19 @@ Component.register('sw-sales-channel-detail-base', {
                 .find(shippingMethod => shippingMethod.id === this.salesChannel.shippingMethodId) ? 'warning' : 'info';
         },
 
+        unservedLanguages() {
+            return this.salesChannel.languages?.filter(
+                language => (this.salesChannel.domains?.filter(
+                    domain => domain.languageId === language.id,
+                ) || []).length === 0,
+            ) ?? [];
+        },
+
+        unservedLanguageVariant() {
+            return this.unservedLanguages
+                .find(language => language.id === this.salesChannel.languageId) ? 'warning' : 'info';
+        },
+
         storefrontDomainsLoaded() {
             return this.storefrontDomains.length > 0;
         },
@@ -661,6 +674,14 @@ Component.register('sw-sales-channel-detail-base', {
                 addition: collection.length > 2
                     ? this.$tc('sw-sales-channel.detail.warningDisabledAddition', 1, { amount: collection.length - 1 })
                     : collection.last().translated[property].replaceAll('|', '&vert;'),
+            };
+
+            return this.$tc(snippet, collection.length, data);
+        },
+
+        buildUnservedLanguagesAlert(snippet, collection, property = 'name') {
+            const data = {
+                list: collection.map((item) => item[property]).join(', '),
             };
 
             return this.$tc(snippet, collection.length, data);

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -202,6 +202,14 @@
         />
         {% endblock %}
 
+        <sw-alert
+            v-if="unservedLanguages.length > 0"
+            :variant="unservedLanguageVariant"
+            :title="$tc('global.default.' + unservedLanguageVariant)"
+        >
+            <span v-html="buildUnservedLanguagesAlert('sw-sales-channel.detail.warningUnservedLanguage', unservedLanguages)"></span>
+        </sw-alert>
+
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_sales_channel_detail_base_general_input_languages %}
         <sw-sales-channel-defaults-select


### PR DESCRIPTION
### 1. Why is this change necessary?

When someone expects features to work but all it was is a missing domain for a language, then you might need a hint about this necessity.

### 2. What does this change do, exactly?

<img width="913" alt="image" src="https://user-images.githubusercontent.com/1133593/196007605-1a615c5c-737d-4397-b056-87af791dc865.png">

It is an info when it is about the default language. Otherwise an info alert.

<img width="911" alt="image" src="https://user-images.githubusercontent.com/1133593/196007607-144d61f9-1c3c-4c2c-8af9-a511af9915f9.png">

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a single language sales channel
2. Expand into other languages
3. Select new language in sales channel settings
4. Go to the storefront and try to switch to the new language
5. Desperately

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2773"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

