### PR TITLE
fix: fetch associations in bulk edit

### DIFF
--- a/changelog/_unreleased/2022-10-16-fix-fetch-association-in-bulk-edit.md
+++ b/changelog/_unreleased/2022-10-16-fix-fetch-association-in-bulk-edit.md
@@ -1,0 +1,8 @@
+---
+title: Fix fetch association in bulk edit
+author: Stefan Poensgen
+author_email: mail@stefanpoensgen.de
+author_github: @stefanpoensgen
+---
+# Administration
+* Changed associtation fetching in bulk edit, to fix infinite loop

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-base.handler.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-base.handler.js
@@ -428,7 +428,7 @@ class BulkEditBaseHandler {
             }
         });
 
-        if (existAssociations.total > existAssociations.length) {
+        if (existAssociations.total > Object.keys(mappedExistAssociations).length) {
             return this._fetchOneToManyAssociated(fieldDefinition, change, page + 1, mappedExistAssociations);
         }
 
@@ -477,7 +477,7 @@ class BulkEditBaseHandler {
             mappedExistAssociations[key] = [association];
         });
 
-        if (mappingIds.total > existAssociations.length) {
+        if (mappingIds.total > Object.keys(mappedExistAssociations).length) {
             return this._fetchManyToManyAssociated(fieldDefinition, change, page + 1, mappedExistAssociations);
         }
 

--- a/src/Administration/Resources/app/administration/test/module/sw-bulk-edit/service/bulk-edit-product.handler.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-bulk-edit/service/bulk-edit-product.handler.spec.js
@@ -21,6 +21,10 @@ function getBulkEditProductHandler() {
     return handler;
 }
 
+function paginate(data, criteria) {
+    return data.slice((criteria.page - 1) * criteria.limit, criteria.page * criteria.limit);
+}
+
 describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => {
     it('is registered correctly', () => {
         const factory = getBulkEditApiFactory();
@@ -919,8 +923,20 @@ describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => 
 
             const spyRepository = jest.spyOn(handler.repositoryFactory, 'create').mockImplementation((entity) => {
                 return {
-                    search: async () => Promise.resolve(existAssociations[entity]),
-                    searchIds: async () => Promise.resolve({ data: existAssociations[entity] })
+                    search: async (criteria) => {
+                        const response = paginate(existAssociations[entity], criteria);
+                        response.total = existAssociations[entity].length;
+
+                        return Promise.resolve(response);
+                    },
+                    searchIds: async (criteria) => {
+                        const response = {
+                          data: paginate(existAssociations[entity], criteria),
+                          total: existAssociations[entity].length
+                        };
+
+                        return Promise.resolve(response);
+                    }
                 };
             });
 

--- a/src/Administration/Resources/app/administration/test/module/sw-bulk-edit/service/bulk-edit-product.handler.spec.js
+++ b/src/Administration/Resources/app/administration/test/module/sw-bulk-edit/service/bulk-edit-product.handler.spec.js
@@ -2,6 +2,7 @@ import BulkEditApiFactory from 'src/module/sw-bulk-edit/service/bulk-edit.api.fa
 import BulkEditProductHandler from 'src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler';
 
 const EntityDefinitionFactory = require('src/core/factory/entity-definition.factory').default;
+const highAssociationCount = 750;
 
 function getBulkEditApiFactory() {
     return new BulkEditApiFactory();
@@ -774,6 +775,43 @@ describe('module/sw-bulk-edit/service/handler/bulk-edit-product.handler', () => 
                             id: 'product_media_1'
                         }
                     ]
+                }
+            ],
+            [
+                'add more than 500 oneToMany association',
+                [{
+                    type: 'add',
+                    field: 'media',
+                    mappingReferenceField: 'mediaId',
+                    value: Array(highAssociationCount).fill(0).map((v,k) => ({ mediaId: `media_${k}` }))
+                }],
+                {
+                    'upsert-product_media': {
+                        action: 'upsert',
+                        entity: 'product_media',
+                        payload: Array(highAssociationCount).fill(0).map((v,k) => ({ productId: 'product_1', mediaId: `media_${k}` }))
+                    }
+                },
+                {
+                    product_media: Array(highAssociationCount).fill(0).map((v,k) => ({ id: `product_media_${k}`, productId: 'product_2', mediaId: `media_${k}` }))
+                }
+            ],
+            [
+                'add more than 500 manyToMany association',
+                [{
+                    type: 'add',
+                    field: 'categories',
+                    value: Array(highAssociationCount).fill(0).map((v,k) => ({ id: `category_${k}` }))
+                }],
+                {
+                    'upsert-product_category': {
+                        action: 'upsert',
+                        entity: 'product_category',
+                        payload: Array(highAssociationCount).fill(0).map((v,k) => ({ productId: 'product_1', categoryId: `category_${k}` }))
+                    }
+                },
+                {
+                    product_category: Array(highAssociationCount).fill(0).map((v,k) => ({ id: `product_category_${k}`, productId: 'product_2', categoryId: `category_${k}` }))
                 }
             ]
         ];


### PR DESCRIPTION
### 1. Why is this change necessary?
Fetching associations in bulk edit leads into an infinite loop if the repository search result is more then 500. In this case the methods self execute to paginate through the results. Unfortunately the condition wether the method should self execute or not, is always true. At this point you are stuck in an infinite loop.

### 2. What does this change do, exactly?
Fix the condition.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2774"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

