### PR TITLE
Add info about customer number swap in admin

### DIFF
--- a/changelog/_unreleased/2022-22-18-add-info-that-the-customer-number-was-changed-due-to-a-reservation-conflict.md
+++ b/changelog/_unreleased/2022-22-18-add-info-that-the-customer-number-was-changed-due-to-a-reservation-conflict.md
@@ -1,0 +1,9 @@
+---
+title: Show info in administration about customer number conflict resulting in a new customer number
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added `sw-customer.detail.messageSaveInfoNumberChange` snippet with a message about a new customer number
+* Added info alert to `sw-customer-create`, when the newly created customer received a new customer number when multiple customers reserved the same number

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-create/index.js
@@ -143,6 +143,8 @@ Component.register('sw-customer-create', {
 
                 this.isSaveSuccessful = false;
                 let numberRangePromise = Promise.resolve();
+                const oldCustomerNumber = this.customer.customerNumber;
+
                 if (this.customerNumberPreview === this.customer.customerNumber) {
                     numberRangePromise = this.numberRangeService
                         .reserve('customer', this.customer.salesChannelId).then((response) => {
@@ -160,6 +162,17 @@ Component.register('sw-customer-create', {
                     this.customerRepository.save(this.customer).then(() => {
                         this.isLoading = false;
                         this.isSaveSuccessful = true;
+
+                        const newCustomerNumber = this.customer.customerNumber;
+
+                        if (oldCustomerNumber !== newCustomerNumber) {
+                            this.createNotificationInfo({
+                                message: this.$tc('sw-customer.detail.messageSaveInfoNumberChange', 1, {
+                                    oldCustomerNumber,
+                                    newCustomerNumber,
+                                }),
+                            });
+                        }
                     }).catch(() => {
                         this.createNotificationError({
                             message: this.$tc('sw-customer.detail.messageSaveError'),

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de-DE.json
@@ -223,6 +223,7 @@
       "buttonEdit": "Bearbeiten",
       "tabGeneral": "Allgemein",
       "tabAddresses": "Adressen",
+      "messageSaveInfoNumberChange": "Durch parallele Kundenregistrierungen ist die vorgeschlagene Kundennummer abgelaufen. Der Kunde hat die neu generierte Kundennummer '{newCustomerNumber}' bekommen. Vorher: '{oldCustomerNumber}'.",
       "messageSaveError": "Der Kunde konnte nicht gespeichert werden.",
       "messageSaveSuccess": "Der Kunde \"{name}\" wurde erfolgreich gespeichert.",
       "notificationPasswordErrorMessage": "Die eingegebenen Passwörter stimmen nicht überein.",

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en-GB.json
@@ -223,6 +223,7 @@
       "buttonEdit": "Edit",
       "tabGeneral": "General",
       "tabAddresses": "Addresses",
+      "messageSaveInfoNumberChange": "Due to simultaneous registration, the customer got a newly generated customer number. The customer received the following newly generated number '{newCustomerNumber}'. Previous: '{oldCustomerNumber}'.",
       "messageSaveError": "Customer could not be saved.",
       "messageSaveSuccess": "Customer \"{name}\" has been saved.",
       "notificationPasswordErrorMessage": "The submitted passwords do not match.",


### PR DESCRIPTION
### 1. Why is this change necessary?

When your attention leaves the customer create form in the admin right after saving the new entry, you might miss THAT THE CUSTOMER NUMBER JUST CHANGED.
The change itself is very good and important, but that missing alert is quite important.

### 2. What does this change do, exactly?

![image](https://user-images.githubusercontent.com/1133593/196291323-d49d94f7-56c1-442d-9c4c-c82ab136aa5c.png)

### 3. Describe each step to reproduce the issue or behaviour.

1. Have a moment of high-frequent registrations, that also take place in the admin
2. Be a support agent
3. Create customer accounts via admin
4. Shop just launched
5. Lots of new customers arrive
6. Phone rings 
7. "Hello, this is Telefonman, I go immer ran"
8. In that phone call you pass the customer number to the person calling
9. Save form and say goodbye
10. ![3 minutes later](https://user-images.githubusercontent.com/1133593/196292638-d15f85c8-11a9-4e3d-a328-da01907c5a2e.png)
11. Get support case in where a customer claims having a different customer number than told
12. GDPR thoughts arise! \
![alarm mode activated](https://user-images.githubusercontent.com/1133593/196292850-02fd37a4-5999-4461-95e2-009572f36132.png)
13. WEE WOO! IS THIS CUSTOMER DATA FROM A DIFFERENT CUSTOMER?
14. No it is just Shopware doing Shopware things 🙃

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2776"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

