### PR TITLE
ci: Only lint php files if the pull request contains php files

### DIFF
--- a/.github/workflows/01-php-lint.yml
+++ b/.github/workflows/01-php-lint.yml
@@ -5,6 +5,11 @@ on:
       branches:
           - trunk
     pull_request:
+      paths:
+        - composer.json
+        - 'changelog/**/*.md'
+        - 'src/**/snippet/**/*.json'
+        - '**.php'
 
 jobs:
   build:

--- a/.gitlab/stages/10-lint.yml
+++ b/.gitlab/stages/10-lint.yml
@@ -153,10 +153,9 @@ PHP lint:
         - !reference [.rules, run]
         - changes:
               - composer.json
-              - .bc-exclude.php
               - 'changelog/**/*.md'
               - 'src/**/snippet/**/*.json'
-              - '**/*.php'
+              - '**.php'
     before_script:
         - composer update --no-interaction
     script:


### PR DESCRIPTION
### 1. Why is this change necessary?
To have fewer action runs if unrelated (and to save CO2).

### 2. What does this change do, exactly?
Currently the php linting is done for each PR even if the PR does not contain any changed php files. This changes that behavior to only run linting of the PHP if the PR contains a changed php file, similar as in the JS linting:
https://github.com/shopware/platform/blob/trunk/.github/workflows/01-lint-admin.yml#L9
https://github.com/shopware/platform/blob/trunk/.github/workflows/01-lint-storefront.yml#L9

### 3. Describe each step to reproduce the issue or behaviour.
Create a PR without a changed php file.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

### 6. Additional
- I am not sure if this PR requires a changelog as well, if so please let me know
- Something similar can be done with the unit tests, but there it is more complicated since they are in the same workflow

<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2778"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

