### PR TITLE
test: Fix failing date test due to different locales

### DIFF
--- a/changelog/_unreleased/2022-10-18-fix-failing-date-test-due-to-different-locales.md
+++ b/changelog/_unreleased/2022-10-18-fix-failing-date-test-due-to-different-locales.md
@@ -1,0 +1,9 @@
+---
+title: Fix failing date test due to different locales
+issue: NA
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Fixed the `DateFormatHelper`-test, which could fail due to different browser locales and added some comments where the format matters

--- a/src/Storefront/Resources/app/storefront/src/helper/date.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/helper/date.helper.js
@@ -1,4 +1,15 @@
 export default class DateFormatHelper {
+    /**
+     * Note that val is parsed by the JavaScript Date object, which might
+     * yield, in the case of a string, different interpretations of the
+     * input value, based on the browser language, i.e. British vs US date
+     * formats, which might yield different results, c.f.:
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
+     * So if passing val as a string, if you want to be save use the
+     * ISO 8601 format  (YYYY-MM-DDTHH:mm:ss.sssZ)
+     *
+     * @param  {string|Date} val
+     */
     static format(val, options = {}) {
         if (val === null) {
             return '';

--- a/src/Storefront/Resources/app/storefront/src/plugin/date-format/date-format.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/date-format/date-format.plugin.js
@@ -4,9 +4,13 @@ import DateFormatHelper from 'src/helper/date.helper';
 /**
  * this plugin formats date and converts it to the local timezone
  * if the data attribute date-format is set
+ *
+ * This plugin utilizes the JavaScript Date object to parse the given
+ * value, so take different locales of the browser into account,
+ * which might yield different results, c.f.:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
  */
 export default class DateFormat extends Plugin {
-
     init() {
         let formatOpts = this.el.getAttribute('data-date-format');
         if (formatOpts.length > 0) {

--- a/src/Storefront/Resources/app/storefront/test/helper/date.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/date.helper.test.js
@@ -12,10 +12,10 @@ describe('date.helper.js', () => {
         expect(DateHelper.format(1/0)).toStrictEqual('');
         expect(DateHelper.format()).toStrictEqual('');
         expect(DateHelper.format('parse me')).toStrictEqual('');
-
     });
 
     test('it returns formatted date from date object', () => {
+        // Mon Feb 03 2020 09:00:00 GMT+0100
         const date = new Date(2020, 1, 3, 9, 0, 0);
         Object.defineProperty(navigator, 'language', {
             value: 'en-GB',
@@ -25,6 +25,6 @@ describe('date.helper.js', () => {
 
         expect(DateHelper.format(date.getTime())).toBe(expectedDate);
         expect(DateHelper.format(date)).toBe(expectedDate);
-        expect(DateHelper.format(expectedDate)).toBe(expectedDate);
+        expect(DateHelper.format(date.toISOString())).toBe(expectedDate);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
https://github.com/shopware/platform/actions/runs/3274605872/jobs/5388357128

### 2. What does this change do, exactly?
Do not use already formatted values to test the `DateFormatHelper`, as this might be wrong. In the test the formatted date might be interpreted differently, depending on the browser locale, see:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date

### 3. Describe each step to reproduce the issue or behaviour.
Run test suite.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2779"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

