### PR TITLE
Skip first run wizard command

### DIFF
--- a/changelog/_unreleased/2022-10-17-add-command-to-skip-first-run-wizard.md
+++ b/changelog/_unreleased/2022-10-17-add-command-to-skip-first-run-wizard.md
@@ -1,0 +1,10 @@
+---
+title: Add command to skip first run wizard
+issue: N/A
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@gmail.com
+author_github: melvinachterhuis
+---
+# Core
+* Changed `Shopware/Core/Framework/DependencyInjection/store.xml` to inject new command
+* Added `Shopware/Core/Framework/Store/Command/StoreSkipFirstRunWizard.php` to skip the first run wizard through CLI

--- a/src/Core/Framework/DependencyInjection/store.xml
+++ b/src/Core/Framework/DependencyInjection/store.xml
@@ -99,7 +99,7 @@
             <tag name="console.command"/>
         </service>
 
-        <service id="Shopware\Core\Framework\Store\Command\StoreSkipFirstRunWizard">
+        <service id="Shopware\Core\Framework\Store\Command\StoreSkipFirstRunWizardCommand">
             <argument type="service" id="Shopware\Core\Framework\Store\Services\FirstRunWizardClient"/>
             <tag name="console.command"/>
         </service>

--- a/src/Core/Framework/DependencyInjection/store.xml
+++ b/src/Core/Framework/DependencyInjection/store.xml
@@ -99,6 +99,11 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="Shopware\Core\Framework\Store\Command\StoreSkipFirstRunWizard">
+            <argument type="service" id="Shopware\Core\Framework\Store\Services\FirstRunWizardClient"/>
+            <tag name="console.command"/>
+        </service>
+
         <service id="Shopware\Core\Framework\Store\Authentication\LocaleProvider">
             <argument type="service" id="user.repository"/>
         </service>

--- a/src/Core/Framework/Store/Command/StoreSkipFirstRunWizard.php
+++ b/src/Core/Framework/Store/Command/StoreSkipFirstRunWizard.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Store\Command;
+
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\Context;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Shopware\Core\Framework\Store\Services\FirstRunWizardClient;
+
+class StoreSkipFirstRunWizard extends Command
+{
+    public static $defaultName = 'store:skip-first-run-wizard';
+
+    private FirstRunWizardClient $frwClient;
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        FirstRunWizardClient $frwClient
+    ) {
+        $this->frwClient = $frwClient;
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+
+        $context = Context::createDefaultContext();
+
+        try {
+            $this->frwClient->finishFrw(false, $context);
+        } catch (\Exception $e) {
+            return Command::FAILURE;
+        }
+
+        $io->success('First run wizard skipped.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Core/Framework/Store/Command/StoreSkipFirstRunWizardCommand.php
+++ b/src/Core/Framework/Store/Command/StoreSkipFirstRunWizardCommand.php
@@ -6,11 +6,10 @@ use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Context;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Shopware\Core\Framework\Store\Services\FirstRunWizardClient;
 
-class StoreSkipFirstRunWizard extends Command
+class StoreSkipFirstRunWizardCommand extends Command
 {
     public static $defaultName = 'store:skip-first-run-wizard';
 

--- a/src/Core/Framework/Test/Store/Command/StoreSkipFirstRunWizardCommandTest.php
+++ b/src/Core/Framework/Test/Store/Command/StoreSkipFirstRunWizardCommandTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Store\Command;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Store\Command\StoreSkipFirstRunWizardCommand;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @internal
+ */
+class StoreSkipFirstRunWizardCommandTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testCommand(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(StoreSkipFirstRunWizardCommand::class));
+        $commandTester->execute([]);
+
+        static::assertEquals(0, $commandTester->getStatusCode());
+
+        $expected = 'First run wizard skipped.';
+        static::assertStringContainsString($expected, $commandTester->getDisplay());
+    }
+}

--- a/src/Core/Maintenance/System/Command/SystemInstallCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemInstallCommand.php
@@ -44,6 +44,7 @@ class SystemInstallCommand extends Command
             ->addOption('shop-locale', null, InputOption::VALUE_REQUIRED, 'Default language locale of the shop')
             ->addOption('shop-currency', null, InputOption::VALUE_REQUIRED, 'Iso code for the default currency of the shop')
             ->addOption('skip-jwt-keys-generation', null, InputOption::VALUE_NONE, 'Skips generation of jwt private and public key')
+            ->addOption('skip-first-run-wizard', null, InputOption::VALUE_NONE, 'Skips the first run wizard in the administration')
         ;
     }
 
@@ -144,6 +145,12 @@ class SystemInstallCommand extends Command
                     'theme-name' => 'Storefront',
                 ];
             }
+        }
+
+        if ($input->getOption('skip-first-run-wizard')) {
+            $commands[] = [
+                'command' => 'store:skip-first-run-wizard',
+            ];
         }
 
         $commands[] = [


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

When your store is deployed and you log in for the first time, you'll get that annoying first run wizard that can't be skipped in the administration. After completing the first run wizard and declining all the options you suddenly have `SwagPayPal` in `/custom/plugins/`, even though you declined it. This change adds the possibility to skip the first run wizard through CLI so you don't have to worry about that anymore

### 2. What does this change do, exactly?

Adds a new command `bin/console store:skip-first-run-wizard`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2781"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

