### PR TITLE
removed unnecessary array from VersionManager::createVersion()

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -162,11 +162,6 @@ class VersionManager
 
     public function createVersion(EntityDefinition $definition, string $id, WriteContext $context, ?string $name = null, ?string $versionId = null): string
     {
-        $primaryKey = [
-            'id' => $id,
-            'versionId' => Defaults::LIVE_VERSION,
-        ];
-
         $versionId = $versionId ?? Uuid::randomHex();
         $versionData = ['id' => $versionId];
 
@@ -178,7 +173,7 @@ class VersionManager
             $this->entityWriter->upsert($this->versionDefinition, [$versionData], $context);
         });
 
-        $affected = $this->cloneEntity($definition, $primaryKey['id'], $primaryKey['id'], $versionId, $context, new CloneBehavior(), false);
+        $affected = $this->cloneEntity($definition, $id, $id, $versionId, $context, new CloneBehavior(), false);
 
         $versionContext = $context->createWithVersionId($versionId);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

There is an array creation (`$primaryKey`) but that's actually not necessary. Probably this method has been previously refactored and the array `$primaryKey` was left behind. Only the `$id` variable is necessary for the logic 🙂🙂🙂

<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2783"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

