### PR TITLE
Remove shadow from admin sw-hero card

### DIFF
--- a/changelog/_unreleased/2022-10-19-remove-shadow-from-admin-sw-hero-card.md
+++ b/changelog/_unreleased/2022-10-19-remove-shadow-from-admin-sw-hero-card.md
@@ -1,0 +1,8 @@
+---
+title: Remove shadow from admin sw-card in hero mode
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Removed shadow from admin `sw-card` when used as hero

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-card/sw-card.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-card/sw-card.scss
@@ -18,7 +18,9 @@
     position: relative;
     color: $color-darkgray-200;
 
-    @include drop-shadow-default;
+    &:not(.sw-card--hero) {
+        @include drop-shadow-default;
+    }
 
     &__context-menu {
         position: absolute;


### PR DESCRIPTION
### 1. Why is this change necessary?

This is the first unintended contributor collaboration!

<img width="746" alt="image" src="https://user-images.githubusercontent.com/1133593/196579448-12954f06-5345-43df-abeb-55789a09159d.png">

So @stephan4p and I and some more like @tinect and @aragon999 noticed that sw cards are a bit weird. In detail when you change integrations in the admin you have a text shadow. This degrades text readability. @stephan4p already had a solution for a different but related issue: https://github.com/shopware/platform/pull/2716 but this still breaks my scenario. 

I might be bad at explaining. Let us have someone good at explaining plans explaining this

[![image](https://user-images.githubusercontent.com/1133593/196580947-d9f9d255-ceb5-483b-8127-d8ec74542089.png)](https://user-images.githubusercontent.com/1133593/196580884-67fabfd3-9e43-40c3-b842-63185ea79c0f.png)

Click on the image to enlarge to the details :)

### 2. What does this change do, exactly?

The shadow is not useful on hero sw-cards as they don't have a border in the first place, so I just disallow any type of drop shadow solution for this special card style.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open the integration settings
2. <img width="561" alt="image" src="https://user-images.githubusercontent.com/1133593/196581603-47abd581-2c75-4951-a9c3-426c6f19fd4a.png">

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2785"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

