### PR TITLE
Show translated unit name in product-detail-price-unit

### DIFF
--- a/changelog/_unreleased/2022-10-19-show-translated-unit-name-in-product-detail-price-unit.md
+++ b/changelog/_unreleased/2022-10-19-show-translated-unit-name-in-product-detail-price-unit.md
@@ -1,0 +1,8 @@
+---
+title: Show translated unit name in product-detail-price-unit
+author: Julian Krzefski
+author_email: krzefski@heptacom.de
+author_github: jkrzefski
+---
+# Storefront
+* Changed `product.unit.name` to `product.unit.translated.name` in template blocks `buy_widget_price_unit_content` and `page_product_detail_price_unit_content`

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
@@ -136,7 +136,7 @@
 
                     {% block buy_widget_price_unit_content %}
                         <span class="price-unit-content">
-                            {{ product.purchaseUnit }} {{ product.unit.name }}
+                            {{ product.purchaseUnit }} {{ product.unit.translated.name }}
                         </span>
                     {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-price.html.twig
@@ -136,7 +136,7 @@
 
                     {% block page_product_detail_price_unit_content %}
                         <span class="price-unit-content">
-                            {{ page.product.purchaseUnit }} {{ page.product.unit.name }}
+                            {{ page.product.purchaseUnit }} {{ page.product.unit.translated.name }}
                         </span>
                     {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?

My default language is english and my storefront is set to german. I have a scale unit "liter" without a german translation. Now my product detail page looks like this:

![Bildschirmfoto 2022-10-19 um 16 43 13](https://user-images.githubusercontent.com/11394739/196723650-343aec44-dcbb-42d0-834f-3be828b666f6.png)

### 2. What does this change do, exactly?

This change makes the product detail page look like this:

![Bildschirmfoto 2022-10-19 um 16 46 52](https://user-images.githubusercontent.com/11394739/196724609-5026e4da-6c85-4913-93e1-2cbbfc826599.png)

### 3. Describe each step to reproduce the issue or behaviour.

See section 1.

### 4. Please link to the relevant issues (if any).

None.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2787"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

