### PR TITLE
Added consider inheritance to the product indexer when handling product stream mappings

### DIFF
--- a/changelog/_unreleased/2022-10-20-consider-inheritance-in-product-stream-mapping.md
+++ b/changelog/_unreleased/2022-10-20-consider-inheritance-in-product-stream-mapping.md
@@ -1,6 +1,6 @@
 ---
 title: Consider Inheritance in Product Stream Mapping
-issue: NEXT-???
+issue: NEXT-23788
 author: Thomas Holm Thomsen
 author_email: thomas@wexo.dk
 author_github: @wexotht

--- a/changelog/_unreleased/2022-10-20-consider-inheritance-in-product-stream-mapping.md
+++ b/changelog/_unreleased/2022-10-20-consider-inheritance-in-product-stream-mapping.md
@@ -1,0 +1,9 @@
+---
+title: Consider Inheritance in Product Stream Mapping
+issue: NEXT-???
+author: Thomas Holm Thomsen
+author_email: thomas@wexo.dk
+author_github: @wexotht
+---
+# Core
+* Added consider inheritance to the product indexer when handling product stream mappings

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
@@ -173,6 +173,8 @@ class ProductStreamUpdater extends EntityIndexer
 
         $version = Uuid::fromHexToBytes(Defaults::LIVE_VERSION);
 
+        $considerInheritance = $context->considerInheritance();
+        $context->setConsiderInheritance(true);
         foreach ($streams as $stream) {
             $filter = json_decode((string) $stream['api_filter'], true);
             if (empty($filter)) {
@@ -203,6 +205,7 @@ class ProductStreamUpdater extends EntityIndexer
                 ]);
             }
         }
+        $context->setConsiderInheritance($considerInheritance);
 
         RetryableTransaction::retryable($this->connection, function () use ($ids, $insert): void {
             $this->connection->executeStatement(

--- a/src/Core/Content/Test/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/src/Core/Content/Test/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -6,11 +6,13 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\DataAbstractionLayer\ProductStreamMappingIndexingMessage;
 use Shopware\Core\Content\Product\DataAbstractionLayer\ProductStreamUpdater;
+use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Content\ProductStream\DataAbstractionLayer\ProductStreamIndexer;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
@@ -100,34 +102,163 @@ class ProductStreamUpdaterTest extends TestCase
         $this->productStreamUpdater->updateProducts([$productId], Context::createDefaultContext());
     }
 
+    public function testConsiderInheritanceVariants(): void
+    {
+        $activeStreamId = Uuid::randomHex();
+        $inActiveStreamId = Uuid::randomHex();
+
+        $writtenEvent = $this->productStreamRepository->create([
+            [
+                'id' => $activeStreamId,
+                'name' => 'test-inheritance',
+                'filters' => [
+                    [
+                        'type' => 'equals',
+                        'field' => 'active',
+                        'value' => '1',
+                    ]
+                ],
+            ],
+            [
+                'id' => $inActiveStreamId,
+                'name' => 'test-inheritance',
+                'filters' => [
+                    [
+                        'type' => 'equals',
+                        'field' => 'active',
+                        'value' => '0',
+                    ]
+                ],
+            ]
+        ], Context::createDefaultContext());
+
+        $productStreamIndexer = $this->getContainer()->get(ProductStreamIndexer::class);
+        $productStreamIndexer->handle(
+            $productStreamIndexer->update($writtenEvent)
+        );
+
+
+        $productId = Uuid::randomHex();
+        $products = [$this->getProductData($productId)];
+
+        // Get product data [variantId => active]
+        $variantIds = [
+            Uuid::randomHex() => null,
+            Uuid::randomHex() => false,
+            Uuid::randomHex() => true,
+        ];
+
+        foreach ($variantIds as $id => $active) {
+            $productData = $this->getProductData($id);
+            $productData["parentId"] = $productId;
+            $productData["active"] = $active;
+            $products[] = $productData;
+        }
+
+        // Create all (4) products at once (fastest)
+        $this->productRepository->create(
+            $products,
+            $this->salesChannel->getContext()
+        );
+
+        // Index both active & inactive product_stream
+        $this->productStreamUpdater->handle(new ProductStreamMappingIndexingMessage(
+            [$activeStreamId, $inActiveStreamId],
+            null,
+            $this->salesChannel->getContext()
+        ));
+
+
+        $productIds = array_keys($variantIds);
+        $productIds[] = $productId;
+
+        // Valid product_stream for active products.
+        $activeProducts = $this->productRepository->search(
+            (new Criteria($productIds))
+                ->addFilter(new EqualsFilter("streams.id", $activeStreamId))
+                ->addAssociation('streams'),
+            $this->salesChannel->getContext()
+        )->getEntities();
+        // Check product & stream count is correct
+        static::assertEquals(3, $activeProducts->count());
+        static::assertEquals(
+            3,
+            $activeProducts->filter(function (ProductEntity $product) use ($activeStreamId) {
+                return $product->getStreams()
+                    ->filterByProperty("id", $activeStreamId)
+                    ->first();
+            })->count()
+        );
+        // Check and ensure the opposite product_stream (inactive) weren't added
+        static::assertEquals(
+            0,
+            $activeProducts->filter(function (ProductEntity $product) use ($inActiveStreamId) {
+                return $product->getStreams()
+                    ->filterByProperty("id", $inActiveStreamId)
+                    ->first();
+            })->count()
+        );
+
+
+        // Valid product_stream for inactive products.
+        $inActiveProducts = $this->productRepository->search(
+            (new Criteria($productIds))
+                ->addFilter(new EqualsFilter("streams.id", $inActiveStreamId))
+                ->addAssociation('streams'),
+            $this->salesChannel->getContext()
+        )->getEntities();
+        // Check product & stream count is correct
+        static::assertEquals(1, $inActiveProducts->count());
+        static::assertEquals(
+            1,
+            $inActiveProducts->filter(function (ProductEntity $product) use ($inActiveStreamId) {
+                return $product->getStreams()
+                    ->filterByProperty("id", $inActiveStreamId)
+                    ->first();
+            })->count()
+        );
+        // Check and ensure the opposite product_stream (active) weren't added
+        static::assertEquals(
+            0,
+            $inActiveProducts->filter(function (ProductEntity $product) use ($activeStreamId) {
+                return $product->getStreams()
+                    ->filterByProperty("id", $activeStreamId)
+                    ->first();
+            })->count()
+        );
+    }
+
     private function createProduct(string $productId): void
     {
         $this->productRepository->create(
-            [
-                [
-                    'id' => $productId,
-                    'productNumber' => $productId,
-                    'stock' => 1,
-                    'name' => 'Test',
-                    'active' => true,
-                    'price' => [
-                        [
-                            'currencyId' => Defaults::CURRENCY,
-                            'gross' => 100,
-                            'net' => 9, 'linked' => false,
-                        ],
-                    ],
-                    'manufacturer' => ['name' => 'test'],
-                    'tax' => ['taxRate' => 19, 'name' => 'with id'],
-                    'visibilities' => [
-                        ['salesChannelId' => $this->salesChannel->getSalesChannel()->getId(), 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
-                    ],
-                    'categories' => [
-                        ['id' => Uuid::randomHex(), 'name' => 'Clothing'],
-                    ],
-                ],
-            ],
+            [$this->getProductData($productId)],
             $this->salesChannel->getContext()
         );
+    }
+
+    private function getProductData(string $productId): array
+    {
+        return [
+            'id' => $productId,
+            'productNumber' => $productId,
+            'stock' => 1,
+            'name' => 'Test',
+            'active' => true,
+            'price' => [
+                [
+                    'currencyId' => Defaults::CURRENCY,
+                    'gross' => 100,
+                    'net' => 9, 'linked' => false,
+                ],
+            ],
+            'manufacturer' => ['name' => 'test'],
+            'tax' => ['taxRate' => 19, 'name' => 'with id'],
+            'visibilities' => [
+                ['salesChannelId' => $this->salesChannel->getSalesChannel()->getId(), 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
+            ],
+            'categories' => [
+                ['id' => Uuid::randomHex(), 'name' => 'Clothing'],
+            ],
+        ];
     }
 }

--- a/src/Core/Content/Test/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
+++ b/src/Core/Content/Test/Product/DataAbstractionLayer/ProductStreamUpdaterTest.php
@@ -116,7 +116,7 @@ class ProductStreamUpdaterTest extends TestCase
                         'type' => 'equals',
                         'field' => 'active',
                         'value' => '1',
-                    ]
+                    ],
                 ],
             ],
             [
@@ -127,16 +127,15 @@ class ProductStreamUpdaterTest extends TestCase
                         'type' => 'equals',
                         'field' => 'active',
                         'value' => '0',
-                    ]
+                    ],
                 ],
-            ]
+            ],
         ], Context::createDefaultContext());
 
         $productStreamIndexer = $this->getContainer()->get(ProductStreamIndexer::class);
         $productStreamIndexer->handle(
             $productStreamIndexer->update($writtenEvent)
         );
-
 
         $productId = Uuid::randomHex();
         $products = [$this->getProductData($productId)];
@@ -150,8 +149,8 @@ class ProductStreamUpdaterTest extends TestCase
 
         foreach ($variantIds as $id => $active) {
             $productData = $this->getProductData($id);
-            $productData["parentId"] = $productId;
-            $productData["active"] = $active;
+            $productData['parentId'] = $productId;
+            $productData['active'] = $active;
             $products[] = $productData;
         }
 
@@ -168,14 +167,13 @@ class ProductStreamUpdaterTest extends TestCase
             $this->salesChannel->getContext()
         ));
 
-
         $productIds = array_keys($variantIds);
         $productIds[] = $productId;
 
         // Valid product_stream for active products.
         $activeProducts = $this->productRepository->search(
             (new Criteria($productIds))
-                ->addFilter(new EqualsFilter("streams.id", $activeStreamId))
+                ->addFilter(new EqualsFilter('streams.id', $activeStreamId))
                 ->addAssociation('streams'),
             $this->salesChannel->getContext()
         )->getEntities();
@@ -185,7 +183,7 @@ class ProductStreamUpdaterTest extends TestCase
             3,
             $activeProducts->filter(function (ProductEntity $product) use ($activeStreamId) {
                 return $product->getStreams()
-                    ->filterByProperty("id", $activeStreamId)
+                    ->filterByProperty('id', $activeStreamId)
                     ->first();
             })->count()
         );
@@ -194,16 +192,15 @@ class ProductStreamUpdaterTest extends TestCase
             0,
             $activeProducts->filter(function (ProductEntity $product) use ($inActiveStreamId) {
                 return $product->getStreams()
-                    ->filterByProperty("id", $inActiveStreamId)
+                    ->filterByProperty('id', $inActiveStreamId)
                     ->first();
             })->count()
         );
 
-
         // Valid product_stream for inactive products.
         $inActiveProducts = $this->productRepository->search(
             (new Criteria($productIds))
-                ->addFilter(new EqualsFilter("streams.id", $inActiveStreamId))
+                ->addFilter(new EqualsFilter('streams.id', $inActiveStreamId))
                 ->addAssociation('streams'),
             $this->salesChannel->getContext()
         )->getEntities();
@@ -213,7 +210,7 @@ class ProductStreamUpdaterTest extends TestCase
             1,
             $inActiveProducts->filter(function (ProductEntity $product) use ($inActiveStreamId) {
                 return $product->getStreams()
-                    ->filterByProperty("id", $inActiveStreamId)
+                    ->filterByProperty('id', $inActiveStreamId)
                     ->first();
             })->count()
         );
@@ -222,7 +219,7 @@ class ProductStreamUpdaterTest extends TestCase
             0,
             $inActiveProducts->filter(function (ProductEntity $product) use ($activeStreamId) {
                 return $product->getStreams()
-                    ->filterByProperty("id", $activeStreamId)
+                    ->filterByProperty('id', $activeStreamId)
                     ->first();
             })->count()
         );


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Rules which targets products based on the line item being in a dynamic product group (DPG) does not work for variant products which inherits data that is part of the DPG conditions.

Fx a DPG targeting all products with a specific manufacturer. Variants inheriting the manufacturer will not be added to the 
product_stream_mapping table which means that fx a promotion using a shopping cart rule which requires the product to be in the DPG does not work.

### 2. What does this change do, exactly?
During the product indexing, more specifically the product stream updater, the context is set to consider inheritance.
This ensures that variant products inheriting data in the DPG condition is added to the product_stream_mapping table as well.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a new DPG with a single condition: Manufacturer -> Is equal to -> "Some Manufacturer".
(Note that you need to have products with this mannufacturer which are variants and inherits the manufacturer from the parent / main product)
2. Create a rule with a single condition: Item in dynamic product group -> At least one -> Is one of -> "The DPG you just created"
3. Create a promotion with a shopping cart rule targeting your newly created rule from step 2. The discount should target the cart and use "Apply to a specific range of products only". The product rule should be your rule from step 2 again.
4. Confirm with the discount code in the frontend on a variant product with your chosen manufacturer that the discount code does not work.


Apply the fix from this merge request, reindex the product and then it works.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-23788

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2791"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

