### PR TITLE
Fix log message contain real flow id

### DIFF
--- a/src/Core/Content/Flow/Dispatching/FlowDispatcher.php
+++ b/src/Core/Content/Flow/Dispatching/FlowDispatcher.php
@@ -155,7 +155,7 @@ class FlowDispatcher implements EventDispatcherInterface
             throw new ServiceNotFoundException(FlowExecutor::class);
         }
 
-        foreach ($flows as $flowId => $flow) {
+        foreach ($flows as $flow) {
             try {
                 /** @var Flow $payload */
                 $payload = $flow['payload'];
@@ -164,7 +164,7 @@ class FlowDispatcher implements EventDispatcherInterface
                 $this->logger->error(
                     "Could not execute flow with error message:\n"
                     . 'Flow name: ' . $flow['name'] . "\n"
-                    . 'Flow id: ' . $flowId . "\n"
+                    . 'Flow id: ' . $flow['id'] . "\n"
                     . 'Sequence id: ' . $e->getSequenceId() . "\n"
                     . $e->getMessage() . "\n"
                     . 'Error Code: ' . $e->getCode() . "\n"
@@ -173,7 +173,7 @@ class FlowDispatcher implements EventDispatcherInterface
                 $this->logger->error(
                     "Could not execute flow with error message:\n"
                     . 'Flow name: ' . $flow['name'] . "\n"
-                    . 'Flow id: ' . $flowId . "\n"
+                    . 'Flow id: ' . $flow['id'] . "\n"
                     . $e->getMessage() . "\n"
                     . 'Error Code: ' . $e->getCode() . "\n"
                 );


### PR DESCRIPTION
### 1. Why is this change necessary?

In log files you can find:

> Could not execute flow with error message: Flow name: Hier könnte dein Flowname stehen Flow id: 0 Typed property ...\CustomerGroupChangedEvent::$mailRecipientStruct must not be accessed before initialization Error Code: 0

Which can happen when you have invalid code or during prototyping solutions. The crucial part is the "Flow id" in the message.

### 2. What does this change do, exactly?

Change the variable that is used to build the message containing the primary key of the flow so the message reads

> Could not execute flow with error message: Flow name: Hier könnte dein Flowname stehen Flow id: 0123456789abcdef0123456789abcdef Typed property ...\CustomerGroupChangedEvent::$mailRecipientStruct must not be accessed before initialization Error Code: 0


### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
