### PR TITLE
Add order tax status footnote

### DIFF
--- a/changelog/_unreleased/2022-10-21-add-order-tax-state-footnote-in-customer-order-history.md
+++ b/changelog/_unreleased/2022-10-21-add-order-tax-state-footnote-in-customer-order-history.md
@@ -1,0 +1,10 @@
+---
+title: Add order tax state footnote in customer's order history
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Added twig variable `isTaxStateSame` in block `page_account_order_item_detail_overview` that indicates whether the order's tax status is the same of the context's tax state 
+* Added new block `page_account_order_item_detail_table_footnote` after `page_account_order_item_detail_table_labels_summary` to display a footnote when the order has a different tax state indicated by `isTaxStateSame`
+* Extracted usage of `general.star` into `taxFootNote` variable in the blocks `component_line_item_total_price`, `component_line_item_unit_price` and `page_account_order_item_detail_list_item` to easily exchange it with the double `general.star` to build a footnote, that is not related to the global tax state hint in the footer

--- a/src/Storefront/Resources/app/storefront/src/scss/page/account/_order-detail.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/account/_order-detail.scss
@@ -13,7 +13,8 @@
 }
 
 .order-detail-content-header,
-.order-item-detail-footer {
+.order-item-detail-footer,
+.order-item-detail-footnote {
     padding-left: $order-grid-gutter-width / 2;
     padding-right: $order-grid-gutter-width / 2;
 }

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
@@ -1,4 +1,10 @@
 {% block component_line_item_total_price %}
+    {% set taxFootNote = "general.star"|trans|sw_sanitize %}
+
+    {% if not isTaxStateSame %}
+        {% set taxFootNote = ("general.star"|trans|sw_sanitize) ~ ("general.star"|trans|sw_sanitize) %}
+    {% endif %}
+
     {% block component_line_item_total_price_label %}
         <div class="line-item-total-price-label">
             {{ "checkout.cartHeaderTotalPrice"|trans|sw_sanitize }}
@@ -9,14 +15,14 @@
         <div class="line-item-total-price-value">
             {# Shipping costs discounts always have a price of 0, which might be confusing, therefore we do not show those #}
             {% if lineItem.payload.discountScope != 'delivery' %}
-                {{ lineItem.price.totalPrice|currency }}{{ "general.star"|trans|sw_sanitize }}
+                {{ lineItem.price.totalPrice|currency }}{{ taxFootNote }}
             {% endif %}
 
             {% set referencePrice = lineItem.price.referencePrice %}
             {% if referencePrice is not null and displayMode == 'offcanvas' %}
                 <br />
                 <small class="line-item-reference-price">
-                    ({{ referencePrice.price|currency }}{{ "general.star"|trans|sw_sanitize }} / {{ referencePrice.referenceUnit }}&nbsp;{{ referencePrice.unitName }})
+                    ({{ referencePrice.price|currency }}{{ taxFootNote }} / {{ referencePrice.referenceUnit }}&nbsp;{{ referencePrice.unitName }})
                 </small>
             {% endif %}
         </div>

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/unit-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/unit-price.html.twig
@@ -1,4 +1,10 @@
 {% block component_line_item_unit_price %}
+    {% set taxFootNote = "general.star"|trans|sw_sanitize %}
+
+    {% if not isTaxStateSame %}
+        {% set taxFootNote = ("general.star"|trans|sw_sanitize) ~ ("general.star"|trans|sw_sanitize) %}
+    {% endif %}
+
     {% block component_line_item_unit_price_label %}
         <div class="line-item-unit-price-label">
             {{ "checkout.cartHeaderUnitPrice"|trans|sw_sanitize }}
@@ -6,6 +12,6 @@
     {% endblock %}
 
     {% block component_line_item_unit_price_inner %}
-        {{ lineItem.price.unitPrice|currency }}{{ "general.star"|trans|sw_sanitize }}
+        {{ lineItem.price.unitPrice|currency }}{{ taxFootNote }}
     {% endblock %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail-list-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail-list-item.html.twig
@@ -3,6 +3,11 @@
 {% block page_account_order_item_detail_list_item %}
     {% set PROMOTION_LINE_ITEM_TYPE = constant('Shopware\\Core\\Checkout\\Cart\\LineItem\\LineItem::PROMOTION_LINE_ITEM_TYPE') %}
 
+    {% set taxFootNote = "general.star"|trans|sw_sanitize %}
+
+    {% if not isTaxStateSame %}
+        {% set taxFootNote = ("general.star"|trans|sw_sanitize) ~ ("general.star"|trans|sw_sanitize) %}
+    {% endif %}
 
     {% set isDiscount = (not lineItem.good and lineItem.price.totalPrice <= 0) %}
     {% set isNested = lineItem.children.count > 0 %}
@@ -139,7 +144,7 @@
 
                                                 {% block page_account_order_item_detail_referenceunit_content %}
                                                     <span class="order-price-reference-content">
-                                                        ({{ referencePrice.price|currency(order.currency.isoCode) }}{{ "general.star"|trans|sw_sanitize }} / {{ referencePrice.referenceUnit }} {{ referencePrice.unitName }})
+                                                        ({{ referencePrice.price|currency(order.currency.isoCode) }}{{ taxFootNote }} / {{ referencePrice.referenceUnit }} {{ referencePrice.unitName }})
                                                     </span>
                                                 {% endblock %}
 
@@ -189,7 +194,7 @@
                                     {% if lineItem.type == PROMOTION_LINE_ITEM_TYPE %}
                                         /
                                     {% else %}
-                                        {{ lineItem.unitPrice|currency(order.currency.isoCode) }}{{ "general.star"|trans|sw_sanitize }}
+                                        {{ lineItem.unitPrice|currency(order.currency.isoCode) }}{{ taxFootNote }}
                                     {% endif %}
                                 </span>
                             {% endblock %}
@@ -209,7 +214,7 @@
 
                         {% block page_account_order_item_detail_total_value %}
                             <span class="order-item-value order-item-total-value">
-                                {{ lineItem.totalPrice|currency(order.currency.isoCode) }}{{ "general.star"|trans|sw_sanitize }}
+                                {{ lineItem.totalPrice|currency(order.currency.isoCode) }}{{ taxFootNote }}
                             </span>
                         {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
@@ -1,4 +1,6 @@
 {% block page_account_order_item_detail_overview %}
+    {% set isTaxStateSame = order.taxStatus is same as (context.context.taxState) %}
+
     <div class="order-item-detail">
         <div class="collapse"
              id="order{{ order.orderNumber }}">
@@ -197,6 +199,21 @@
                                     </div>
                                 </div>
                             </div>
+                        {% endblock %}
+                        {% block page_account_order_item_detail_table_footnote %}
+                            {% if not isTaxStateSame %}
+                                <div class="order-item-detail-footnote">
+                                    {% if context.taxState == "gross" %}
+                                        {{ "general.star"|trans|sw_sanitize }}{{ "footer.excludeVat"|trans({
+                                            '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.shippingPaymentInfoPage') })
+                                        })|raw }}
+                                    {% else %}
+                                        {{ "general.star"|trans|sw_sanitize }}{{ "footer.includeVat"|trans({
+                                            '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.shippingPaymentInfoPage') })
+                                        })|raw }}
+                                    {% endif %}
+                                </div>
+                            {% endif %}
                         {% endblock %}
                     </div>
                 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

The hint in the footer about the prices, that are footnoted in the order history can be wrong, when different tax stated orders compared to the context tax state are displayed in the same order history.

### 2. What does this change do, exactly?

Add comparisons about the tax state and the tax status.

In the screenshot you can see a slightly modified order history page of a customer. I removed all parts that are not necessary to understand the issue.

1. We have a general footer claiming I am buying inclusive or exclusive VAT. This is taken from the context.taxState and applied to every price display
2. The first (bottom) order was taken with a different taxState than the second order (top) by changing the customer group
3. So my order history claims now, that the first order has a different taxStatus, than the context and therefore needs a different footnote about it.
4. To distinguish then I use a double asterisk **
5. This directly displayed under the order for simplicity of the solution

![image](https://user-images.githubusercontent.com/1133593/197138919-999fc9fa-c25c-4f83-991a-ff898090980f.png)


### 3. Describe each step to reproduce the issue or behaviour.

1. Register
6. Be in customer group for b2c
7. Buy
8. Get moved to different customer group for b2b
9. Buy
10. Open order history in admin
11. See different label in line item price column that displays the tax status
12. Open order history in storefront
13. See only an asterisk telling me the tax state of the context, not of the order
14. ![6xp4ye](https://user-images.githubusercontent.com/1133593/197081764-2fde1346-91da-481b-9040-a5d43926b05f.gif)


### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2796"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

