### PR TITLE
Fix deprecation of Connection::executeUpdate in InheritanceUpdaterTrait

### DIFF
--- a/changelog/_unreleased/2022-10-23-fix-deprecation-in-inheritance-updater-trait.md
+++ b/changelog/_unreleased/2022-10-23-fix-deprecation-in-inheritance-updater-trait.md
@@ -1,0 +1,8 @@
+---
+title: Fix use of deprecated Connection::executeUpdate in InheritanceUpdaterTrait
+author: Johannes Przymusinski
+author_email: johannes.przymusinski@jop-software.de
+author_github: cngJo
+---
+# Core
+* Connection::executeUpdate is deprecated, use the replacement Connection::executeStatement

--- a/src/Core/Framework/Migration/InheritanceUpdaterTrait.php
+++ b/src/Core/Framework/Migration/InheritanceUpdaterTrait.php
@@ -14,6 +14,6 @@ trait InheritanceUpdaterTrait
             'ALTER TABLE `#table#` ADD COLUMN `#column#` binary(16) NULL'
         );
 
-        $connection->executeUpdate($sql);
+        $connection->executeStatement($sql);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
`Shopware\Core\Framework\Migration\InheritanceUpdaterTrait::updateInheritance` calls the deprecated `Doctrine\DBAL\Connection::executeUpdate` method.

This can safely be resolved because the method is alredy deprecated in version 2.13.8 which is the minimum supported version according to `composer.json`
Source: https://github.com/doctrine/dbal/blob/2.13.8/lib/Doctrine/DBAL/Connection.php#L1479

### 2. What does this change do, exactly?
It updates `InheritanceUpdaterTrait` to call `Doctrine\DBAL\Connection::executeStatement` instead of the deprecated `Doctrine\DBAL\Connection::executeUpdate`.

`executeUpdate` intern just calles `executeStatement` and triggers a deprecation. Therefore it should be safe to just directly use `executeStatement` instead.

### 3. Describe each step to reproduce the issue or behaviour.

Call `updateInheritance` on `Shopware\Core\Framework\Migration\InheritanceUpdaterTrait`.

### 4. Please link to the relevant issues (if any).
Deprecation of `Connection::executeUpdate`: https://github.com/doctrine/dbal/pull/4163

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
  _I'm not sure how to test that a deprecation is (not) triggered. I'd be willing to create a test for this if there is a way._
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2798"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

