### PR TITLE
Fixed a bug in Vector.clamp when polyfills aren't used

### DIFF
--- a/changelog/_unreleased/2022-10-26-prepare-vector-helper-for-use-without-ie-polyfills.md
+++ b/changelog/_unreleased/2022-10-26-prepare-vector-helper-for-use-without-ie-polyfills.md
@@ -1,0 +1,9 @@
+---
+title: Prepare Vector helper for use without IE polyfills
+issue: https://github.com/shopware/platform/pull/2805
+author: Jonas Søndergaard
+author_email: jonas@wexo.dk
+author_github: @Josniii
+---
+# Storefront
+* Fixed a bug in the vector implementation that caused the magnifier plugin to fail when running without IE 11 polyfills

--- a/src/Storefront/Resources/app/storefront/src/helper/vector.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/helper/vector.helper.js
@@ -182,7 +182,7 @@ class Vector {
             max = new this.constructor((new Array(this.dimension)).fill(max));
         }
 
-        return this.constructor(this.entries.map((e, index) => {
+        return new this.constructor(this.entries.map((e, index) => {
             if (e < min.entries[index]) {
                 return min.entries[index];
             }


### PR DESCRIPTION
### 1. Why is this change necessary?

I was messing around with removing IE 11 polyfills from the generated JS/CSS bundles since they take up more than 50% of the JS bundle from what I can tell, and will be gone in 6.5 anyways. I ran into a problem with the Vector helper; the magnifier plugin crashes because of an error if polyfills aren't present:
`Class constructor i cannot be invoked without 'new'`
This is a pretty simple thing to fix, however, and shouldn't cause issues with current behaviour. It needs to be fixed by 6.5 as I see it anyways.

### 2. What does this change do, exactly?

Call the constructor in `Vector.clamp` with `new`.

### 3. Describe each step to reproduce the issue or behaviour.

- Remove IE 11 polyfills from the codebase (i removed IE 11 from .babelrc.js and all the deprecated polyfills in polyfill-loader.helper.js)
- Rebuild JS
- Try using the magnifier plugin in Chrome. Will not work.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2805"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

