### PR TITLE
NEXT-18937 fix snippet special characters

### DIFF
--- a/changelog/_unreleased/2022-10-25-fixed-translation-cache-special-chars.md
+++ b/changelog/_unreleased/2022-10-25-fixed-translation-cache-special-chars.md
@@ -1,0 +1,9 @@
+---
+title: Fixed Translation Cache tag for special characters
+issue: NEXT-18937
+author: Florian Liebig
+author_email: mail@florian-liebig.de
+author_github: @florianliebig
+---
+# Core
+* Fixed Translation Cache tag for special characters in `Shopware\Core\Framework\Adapter\Translation\Translator`

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -84,7 +84,7 @@ class Translator extends AbstractTranslator
 
     public static function buildName(string $id): string
     {
-        if (false !== \strpbrk($id, ItemInterface::RESERVED_CHARACTERS)) {
+        if (\strpbrk($id, ItemInterface::RESERVED_CHARACTERS) !== false) {
             $id = \str_replace(\str_split(ItemInterface::RESERVED_CHARACTERS, 1), '_r_', $id);
         }
 

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -19,6 +19,7 @@ use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\Translator as SymfonyTranslator;
 use Symfony\Component\Translation\TranslatorBagInterface;
 use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Translation\LocaleAwareInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorTrait;
@@ -83,6 +84,10 @@ class Translator extends AbstractTranslator
 
     public static function buildName(string $id): string
     {
+        if (false !== \strpbrk($id, ItemInterface::RESERVED_CHARACTERS)) {
+            $id = \str_replace(str_split(ItemInterface::RESERVED_CHARACTERS, 1), '_r_', $id);
+        }
+
         return 'translator.' . $id;
     }
 

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -85,7 +85,7 @@ class Translator extends AbstractTranslator
     public static function buildName(string $id): string
     {
         if (false !== \strpbrk($id, ItemInterface::RESERVED_CHARACTERS)) {
-            $id = \str_replace(str_split(ItemInterface::RESERVED_CHARACTERS, 1), '_r_', $id);
+            $id = \str_replace(\str_split(ItemInterface::RESERVED_CHARACTERS, 1), '_r_', $id);
         }
 
         return 'translator.' . $id;

--- a/src/Core/Framework/Test/Translation/TranslatorTest.php
+++ b/src/Core/Framework/Test/Translation/TranslatorTest.php
@@ -302,4 +302,9 @@ class TranslatorTest extends TestCase
             'oldId' => $currentDeId,
         ]);
     }
+
+    public function testItReplacesReservedCharacter()
+    {
+        static::assertEquals('translator.<_r_strong>', Translator::buildName('</strong>'));
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The cache for translations seems to use the values of some elements for the cache key (e.g. "translator.Hagebuttenpulver BIO/KBA" contains reserved characters "{}()/\@:"). The Symfony CacheItem defines some reserved characters: https://github.com/symfony/symfony/blob/6.2/src/Symfony/Component/Cache/CacheItem.php#L110

There is no check in Snippets / Theme usage of snippets which restricts the use of those special characters. 

### 2. What does this change do, exactly?

The Translator::buildName seems to be a valid position for this fix. The only Class calling it seems to be https://github.com/shopware/platform/blob/v6.4.16.1/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php#L223 - so this might be another valid option

The approach replacing is to replace those special characters with "_r_" because just using and empty string might be dangerous (e.g when using other very similar snippets). My first idea was to use `htmlspcialcharacters` but the "/" is not included there.

### 3. Describe each step to reproduce the issue or behaviour.

Additional info at:

https://issues.shopware.com/issues/NEXT-18937
https://forum.shopware.com/t/contains-reserved-characters/90228

### 4. Please link to the relevant issues (if any).

Fixes https://issues.shopware.com/issues/NEXT-18937


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2806"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

