### PR TITLE
Check if it's a resource before closing it

### DIFF
--- a/changelog/_unreleased/2022-10-26-only-close-resource-if-its-open.md
+++ b/changelog/_unreleased/2022-10-26-only-close-resource-if-its-open.md
@@ -1,0 +1,9 @@
+---
+title: Only close resource if it's open
+issue: NEXT-23947
+author: Steven de Vries
+author_email: info@stevendevries.nl
+author_github: @StevendeVries
+---
+# Core
+*  Changed method `copy()` in `src/Core/Framework/Plugin/Util/AssetService.php` to check if it's still a resource before closing.

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -170,7 +170,10 @@ class AssetService
             // @codeCoverageIgnoreEnd
 
             $this->filesystem->putStream($targetDir . '/' . $file->getRelativePathname(), $fs);
-            fclose($fs);
+
+            if (\is_resource($fs)) {
+                fclose($fs);
+            }
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
For our review/acceptance and production environment we make use of Google Storage to store assets, including those from a plugin. When activating a plugin the assets are copied to the public asset folder. Shopware (in version 6.4.16.x) makes the assumption it can open a file as a stream, send it to a filesystem and close it afterwards without checking if the filestream is still open. The Google Cloud storage adapter uses a Bucket entity which already closes the stream, resulting in an error when Shopware tries to close the stream (again).

### 2. What does this change do, exactly?
This change adds a check if the stream is still a resource before closing it.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add a google storage (`https://storage.googleapis.com/{your bucket}`) the to config (`filesystem.yml`)
2. Activate a plugin with assets using the CLI
3. See the error
```
In AssetService.php line 176:
                                                              
  fclose(): supplied resource is not a valid stream resource
```

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change (skipped due to static calls)
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes (no need imho)
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code (no need imho)
- [X] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2809"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

