### PR TITLE
Fix customer custom field sorting in admin

### DIFF
--- a/changelog/_unreleased/2022-10-27-sort-customer-custom-fields-after-position-config.md
+++ b/changelog/_unreleased/2022-10-27-sort-customer-custom-fields-after-position-config.md
@@ -1,0 +1,9 @@
+---
+title: Add customFieldPosition sorting to Customer customFields
+issue: ???
+author: Lyubomir Mladenov
+author_email: lubo@wexo.dk
+author_github: @wexollm
+---
+# Administration
+* Add sorting to `customFieldSetCriteria()` in `module/sw-customer/view/sw-customer-detail-base/index.js` to sort after `config.customFieldPosition`.

--- a/changelog/_unreleased/2022-10-27-sort-customer-custom-fields-after-position-config.md
+++ b/changelog/_unreleased/2022-10-27-sort-customer-custom-fields-after-position-config.md
@@ -1,6 +1,6 @@
 ---
 title: Add customFieldPosition sorting to Customer customFields
-issue: ???
+issue: NEXT-23912
 author: Lyubomir Mladenov
 author_email: lubo@wexo.dk
 author_github: @wexollm

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-base/index.js
@@ -44,6 +44,8 @@ Component.register('sw-customer-detail-base', {
 
             criteria
                 .addFilter(Criteria.equals('relations.entityName', 'customer'));
+            criteria.getAssociation('customFields')
+                .addSorting(Criteria.naturalSorting('config.customFieldPosition'));
 
             return criteria;
         },


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
CustomFields are one of the most and easy ways to add additional information. When creating customFields there is an option  to add position, which right now is not taken into account on the Customer detail view.

### 2. What does this change do, exactly?
It adds additional sorting to the customField on Customer detail view where the position set in the customField is used for sorting the customFields.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a customField set and create multiple custom fields

2. Give options to the custom field like (10, 20, 30 ..etc)

3. Save

Expected result:
See the position of the customField in Customer detail sorted after the position given when customFields beeing created

Instead a random positioning of the customFields is present

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2811"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

