### PR TITLE
Updated argument

### DIFF
--- a/changelog/_unreleased/2022-10-28-change-instance-creation.md
+++ b/changelog/_unreleased/2022-10-28-change-instance-creation.md
@@ -1,0 +1,8 @@
+---
+title: Corrected parameters for new EntitySearchResult  
+author: Alexander Schmidt
+author_email: support@kiplingi.de
+author_github: @kiplingi
+---
+# Core
+* Changed `\Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult::createNew` to reflect actual search result count and not the one from original instance.

--- a/src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
@@ -195,7 +195,7 @@ class EntitySearchResult extends EntityCollection
     {
         return new static(
             $this->entity,
-            $this->total,
+            $elements->count(),
             $elements,
             $this->aggregations,
             $this->criteria,

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/EntitySearchResultTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/EntitySearchResultTest.php
@@ -34,6 +34,39 @@ class EntitySearchResultTest extends TestCase
         static::assertSame($page, $result->getPage());
     }
 
+    public function testSlice(): void
+    {
+        $entitySearchResult = $this->createEntitySearchResult();
+
+        $newInstance = $entitySearchResult->slice(2);
+
+        static::assertSame(ArrayEntity::class, $newInstance->getEntity());
+        static::assertSame(ArrayEntity::class, $newInstance->first()::class);
+        static::assertSame(8, $newInstance->getTotal());
+        static::assertSame($entitySearchResult->getAggregations(), $newInstance->getAggregations());
+        static::assertSame($entitySearchResult->getCriteria(), $newInstance->getCriteria());
+        static::assertSame($entitySearchResult->getContext(), $newInstance->getContext());
+    }
+
+    public function testFilter(): void
+    {
+        $entitySearchResult = $this->createEntitySearchResult();
+
+        $count = 0;
+
+        $newInstance = $entitySearchResult->filter(function () use (&$count){
+            return 5 < $count++;
+        });
+
+        static::assertSame(ArrayEntity::class, $newInstance->getEntity());
+        static::assertSame(ArrayEntity::class, $newInstance->first()::class);
+        static::assertSame(4, $newInstance->getTotal());
+        static::assertSame($entitySearchResult->getAggregations(), $newInstance->getAggregations());
+        static::assertSame($entitySearchResult->getCriteria(), $newInstance->getCriteria());
+        static::assertSame($entitySearchResult->getContext(), $newInstance->getContext());
+
+    }
+
     public function resultPageCriteriaDataProvider(): \Generator
     {
         yield [(new Criteria())->setLimit(5)->setOffset(0), 1];
@@ -42,5 +75,22 @@ class EntitySearchResultTest extends TestCase
         yield [(new Criteria())->setLimit(5)->setOffset(10), 3];
         yield [(new Criteria())->setLimit(5)->setOffset(11), 3];
         yield [(new Criteria())->setLimit(10)->setOffset(25), 3];
+    }
+
+    private function createEntitySearchResult(): EntitySearchResult
+    {
+        $entities = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $entities[] = new ArrayEntity(['id' => Uuid::randomHex()]);
+        }
+        $entityCollection = new EntityCollection($entities);
+        return new EntitySearchResult(
+            ArrayEntity::class,
+            $entityCollection->count(),
+            $entityCollection,
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        );
     }
 }

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/EntitySearchResultTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/EntitySearchResultTest.php
@@ -41,7 +41,7 @@ class EntitySearchResultTest extends TestCase
         $newInstance = $entitySearchResult->slice(2);
 
         static::assertSame(ArrayEntity::class, $newInstance->getEntity());
-        static::assertSame(ArrayEntity::class, $newInstance->first()::class);
+        static::assertSame(ArrayEntity::class, get_class($newInstance->first()));
         static::assertSame(8, $newInstance->getTotal());
         static::assertSame($entitySearchResult->getAggregations(), $newInstance->getAggregations());
         static::assertSame($entitySearchResult->getCriteria(), $newInstance->getCriteria());
@@ -59,7 +59,7 @@ class EntitySearchResultTest extends TestCase
         });
 
         static::assertSame(ArrayEntity::class, $newInstance->getEntity());
-        static::assertSame(ArrayEntity::class, $newInstance->first()::class);
+        static::assertSame(ArrayEntity::class, get_class($newInstance->first()));
         static::assertSame(4, $newInstance->getTotal());
         static::assertSame($entitySearchResult->getAggregations(), $newInstance->getAggregations());
         static::assertSame($entitySearchResult->getCriteria(), $newInstance->getCriteria());

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/EntitySearchResultTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/EntitySearchResultTest.php
@@ -41,7 +41,7 @@ class EntitySearchResultTest extends TestCase
         $newInstance = $entitySearchResult->slice(2);
 
         static::assertSame(ArrayEntity::class, $newInstance->getEntity());
-        static::assertSame(ArrayEntity::class, get_class($newInstance->first()));
+        static::assertSame(ArrayEntity::class, \get_class($newInstance->first()));
         static::assertSame(8, $newInstance->getTotal());
         static::assertSame($entitySearchResult->getAggregations(), $newInstance->getAggregations());
         static::assertSame($entitySearchResult->getCriteria(), $newInstance->getCriteria());
@@ -54,17 +54,16 @@ class EntitySearchResultTest extends TestCase
 
         $count = 0;
 
-        $newInstance = $entitySearchResult->filter(function () use (&$count){
-            return 5 < $count++;
+        $newInstance = $entitySearchResult->filter(function () use (&$count) {
+            return $count++ > 5;
         });
 
         static::assertSame(ArrayEntity::class, $newInstance->getEntity());
-        static::assertSame(ArrayEntity::class, get_class($newInstance->first()));
+        static::assertSame(ArrayEntity::class, \get_class($newInstance->first()));
         static::assertSame(4, $newInstance->getTotal());
         static::assertSame($entitySearchResult->getAggregations(), $newInstance->getAggregations());
         static::assertSame($entitySearchResult->getCriteria(), $newInstance->getCriteria());
         static::assertSame($entitySearchResult->getContext(), $newInstance->getContext());
-
     }
 
     public function resultPageCriteriaDataProvider(): \Generator
@@ -80,10 +79,11 @@ class EntitySearchResultTest extends TestCase
     private function createEntitySearchResult(): EntitySearchResult
     {
         $entities = [];
-        for ($i = 1; $i <= 10; $i++) {
+        for ($i = 1; $i <= 10; ++$i) {
             $entities[] = new ArrayEntity(['id' => Uuid::randomHex()]);
         }
         $entityCollection = new EntityCollection($entities);
+
         return new EntitySearchResult(
             ArrayEntity::class,
             $entityCollection->count(),


### PR DESCRIPTION
### 1. Why is this change necessary?
The count of a new instance is set to the one from the original, which might be wrong, e.g. if it was filtered.

### 2. What does this change do, exactly?
The function to initialize a new class is updated. Now the actual count is given to the new object, instead the existing one.

### 3. Describe each step to reproduce the issue or behaviour.
Filter an EntitySearchResult, 'count' will return a wrong total.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2813"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

