### PR TITLE
Fix reloading iframes that causes duplicated elements in App

### DIFF
--- a/changelog/_unreleased/2022-11-02-fix-rerender-iframe-issue.md
+++ b/changelog/_unreleased/2022-11-02-fix-rerender-iframe-issue.md
@@ -1,0 +1,8 @@
+---
+title: Fix reloading iframes that causes duplicated elements in App
+author: Vu Le
+author_email: lednguyenvu@gmail.com
+author_github: Vu Le
+---
+# Administration
+* Changed `extension` watcher in `extension-api/sw-iframe-renderer/index.ts` to only re-assign `signedIframeSrc` whenever there are changes in the extension data.

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-iframe-renderer/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-iframe-renderer/index.ts
@@ -1,6 +1,8 @@
 import template from './sw-iframe-renderer.html.twig';
 import type { Extension } from '../../../state/extensions.store';
 
+const { isEqual } = Shopware.Utils.types;
+
 /**
  * @private
  * @description This component renders iFrame views for extensions
@@ -93,7 +95,7 @@ Shopware.Component.register('sw-iframe-renderer', {
     watch: {
         extension: {
             immediate: true,
-            handler(extension) {
+            handler(extension, oldExtension) {
                 if (!extension || !this.extensionIsApp) {
                     return;
                 }
@@ -106,7 +108,10 @@ Shopware.Component.register('sw-iframe-renderer', {
                         return;
                     }
 
-                    this.signedIframeSrc = uri;
+                    // Reload iframe when extension data changes
+                    if (!isEqual(oldExtension, extension)) {
+                        this.signedIframeSrc = uri;
+                    }
                     // eslint-disable-next-line @typescript-eslint/no-empty-function
                 }).catch(() => {});
             },


### PR DESCRIPTION
### 1. Why is this change necessary?
When developing app system, when you navigate between the modules, the hidden iframe got rerendered even when the `extension` information does not change. This leads to the `shopware-extension-sdk` will re-create all existing elements and will eventually be duplicated.

### 2. What does this change do, exactly?
Compare the current extension data with the old data to make sure that the data really changes and re-assign the iframe src which will trigger an iframe reload.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add a `componentSection` in a page using `ui.componentSection.add`.
2. Navigate to another page. For example: `sw/category/index`.
3. Come back to the page where you add the component section.
4. Expected: it will show another component section (duplicated).


### 4. Please link to the relevant issues (if any).


### 5. Checklist
- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2816"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

