### PR TITLE
Added consideration of sorting via "position" for the output of the s…

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/shipping/shipping-fields.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/shipping/shipping-fields.html.twig
@@ -6,7 +6,7 @@
 {% block component_shipping_methods %}
     <div class="shipping-methods">
         {% block component_shipping_method %}
-            {% for shipping in page.shippingMethods[:visibleShippingMethodsLimit] %}
+            {% for shipping in page.shippingMethods[:visibleShippingMethodsLimit]|sort((a, b) => a.position <=> b.position) %}
                 {% sw_include '@Storefront/storefront/component/shipping/shipping-method.html.twig' %}
             {% endfor %}
 


### PR DESCRIPTION
Actually the Shopware 6 documentation mentions the possibility for sorting the shipping the methods. So far so good.
But the related twig template does not consider this. I added "|sort((a, b) => a.position <=> b.position)" to line #9 to make this work.

### 1. Why is this change necessary?
To make the sorting via Backend visible at the Frontend

### 2. What does this change do, exactly?
It does consider the output of the array sorted regarding the defined "position"

### 3. Describe each step to reproduce the issue or behaviour.
Currently: a wild unsorted output of the array. The defined value for each "position" is not be considered

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2819"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

