### PR TITLE
"aria-label" attribute missing

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-product-slider.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-product-slider.html.twig
@@ -60,13 +60,13 @@
                                              data-product-slider-controls="true">
                                             {% block element_product_slider_controls_items %}
                                                 <button
-                                                    class="base-slider-controls-prev product-slider-controls-prev{% if sliderConfig.border.value %} has-border{% endif %}">
+                                                    class="base-slider-controls-prev product-slider-controls-prev{% if sliderConfig.border.value %} has-border{% endif %}" aria-label="{{ 'general.previous'|trans|striptags }}">
                                                     {% block element_product_slider_controls_items_prev_icon %}
                                                         {% sw_icon 'arrow-head-left' %}
                                                     {% endblock %}
                                                 </button>
                                                 <button
-                                                    class="base-slider-controls-next product-slider-controls-next{% if sliderConfig.border.value %} has-border{% endif %}">
+                                                    class="base-slider-controls-next product-slider-controls-next{% if sliderConfig.border.value %} has-border{% endif %}" aria-label="{{ 'general.next'|trans|striptags }}">
                                                     {% block element_product_slider_controls_items_next_icon %}
                                                         {% sw_icon 'arrow-head-right' %}
                                                     {% endblock %}


### PR DESCRIPTION
Both buttons ("previous" and "next") should have an "aria-label" attribute!

### 1. Why is this change necessary?
Buttons should / must have a correct markup solutions!

### 2. What does this change do, exactly?
Implements an "aria-label" attribute vor each button

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2820"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

