### PR TITLE
ElementDataCollection iterable

### DIFF
--- a/changelog/_unreleased/2022-11-03-element-data-collection-iterable.md
+++ b/changelog/_unreleased/2022-11-03-element-data-collection-iterable.md
@@ -1,0 +1,8 @@
+---
+title: ElementDataCollection iterable
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.me
+---
+# Core
+* Implement \IteratorAggregate in `Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection` so the results can be looped.

--- a/changelog/_unreleased/2022-11-03-element-data-collection-iterable.md
+++ b/changelog/_unreleased/2022-11-03-element-data-collection-iterable.md
@@ -1,6 +1,5 @@
 ---
 title: ElementDataCollection iterable
-issue: /
 author: Rune Laenen
 author_email: rune@laenen.me
 ---

--- a/src/Core/Content/Cms/DataResolver/Element/ElementDataCollection.php
+++ b/src/Core/Content/Cms/DataResolver/Element/ElementDataCollection.php
@@ -4,7 +4,10 @@ namespace Shopware\Core\Content\Cms\DataResolver\Element;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 
-class ElementDataCollection
+/**
+ * @implements \IteratorAggregate<array-key, \Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult>
+ */
+class ElementDataCollection implements \IteratorAggregate, \Countable
 {
     protected array $searchResults = [];
 
@@ -16,5 +19,15 @@ class ElementDataCollection
     public function get(string $key): ?EntitySearchResult
     {
         return $this->searchResults[$key] ?? null;
+    }
+
+    public function getIterator(): \Traversable
+    {
+        yield from $this->searchResults;
+    }
+
+    public function count(): int
+    {
+        return \count($this->searchResults);
     }
 }

--- a/tests/unit/php/Core/Content/Cms/DataResolver/Element/ElementDataCollectionTest.php
+++ b/tests/unit/php/Core/Content/Cms/DataResolver/Element/ElementDataCollectionTest.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\DataResolver\Element;
+
+use Monolog\Test\TestCase;
+use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection
+ */
+class ElementDataCollectionTest extends TestCase
+{
+    public function testItIterates(): void
+    {
+        $collection = new ElementDataCollection();
+        $collection->add('a', new EntitySearchResult(
+            'product',
+            0,
+            new ProductCollection(),
+            null,
+            new Criteria(),
+            Context::createDefaultContext()
+        ));
+
+        static::assertInstanceOf(\IteratorAggregate::class, $collection);
+        static::assertCount(1, $collection);
+        static::assertContainsOnly(EntitySearchResult::class, $collection);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The ElementDataCollection object is currently not iterable. By making it so, it becomes possible to loop over all results.

**Use case**
When adding a decorator for a CmsElementResolver it is sometimes unknown what the name of the returned data is exactly.

For example in the ProductSlider CMS element, 3 different names are possible depending on the configuration. It is possible to generate the name according to the configuration again in the decorator, but it is easier and faster to loop over all results and check if the type is correct.

### 2. What does this change do, exactly?
Implements \IteratorAggregate so the object can be used in a foreach loop.

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2821"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

