### PR TITLE
Api Responses in debug mode should return stacktrace

### DIFF
--- a/changelog/_unreleased/2022-11-09-add-stacktrace-to-api-response.md
+++ b/changelog/_unreleased/2022-11-09-add-stacktrace-to-api-response.md
@@ -1,5 +1,8 @@
 ---
 title: Add stacktrace to error responses from api in debug mode
+author:             Alexander Kludt
+author_email:       coding@aggrosoft.de
+author_github:      @kingschnulli
 ---
 
 # Core

--- a/changelog/_unreleased/2022-11-09-add-stacktrace-to-api-response.md
+++ b/changelog/_unreleased/2022-11-09-add-stacktrace-to-api-response.md
@@ -1,0 +1,7 @@
+---
+title: Add stacktrace to error responses from api in debug mode
+---
+
+# Core
+
+* If in debug mode, api responses will return full stack trace for errors in stack key

--- a/src/Core/Framework/Api/EventListener/ErrorResponseFactory.php
+++ b/src/Core/Framework/Api/EventListener/ErrorResponseFactory.php
@@ -19,7 +19,7 @@ class ErrorResponseFactory
         );
 
         $response->setEncodingOptions($response->getEncodingOptions() | \JSON_INVALID_UTF8_SUBSTITUTE);
-        $response->setData(['errors' => $this->getErrorsFromException($exception, $debug)]);
+        $response->setData(['errors' => $this->getErrorsFromException($exception, $debug), 'stack' => $debug ? $exception->getTrace() : null]);
 
         return $response;
     }

--- a/tests/unit/php/Core/Framework/Api/EventListener/ErrorResponseFactoryTest.php
+++ b/tests/unit/php/Core/Framework/Api/EventListener/ErrorResponseFactoryTest.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Shopware\Tests\Unit\Core\Framework\Api\EventListener;
 
@@ -19,8 +19,7 @@ class ErrorResponseFactoryTest extends \PHPUnit\Framework\TestCase
         $response = $factory->getResponseFromException(new \Exception('test'), true);
         $data = json_decode($response->getContent());
         static::assertArrayHasKey('stack', $data);
-        static::assertIsArray($data['stack'], $data);
-
+        static::assertIsArray($data['stack']);
     }
 
     public function testNoStackTraceForExceptionNotInDebugMode(): void
@@ -30,7 +29,6 @@ class ErrorResponseFactoryTest extends \PHPUnit\Framework\TestCase
         /* @var \Symfony\Component\HttpFoundation\JsonResponse $response */
         $response = $factory->getResponseFromException(new \Exception('test'), false);
         $data = json_decode($response->getContent());
-        static::assertNull($data['stack'], $response);
-
+        static::assertNull($data['stack']);
     }
 }

--- a/tests/unit/php/Core/Framework/Api/EventListener/ErrorResponseFactoryTest.php
+++ b/tests/unit/php/Core/Framework/Api/EventListener/ErrorResponseFactoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Shopware\Tests\Unit\Core\Framework\Api\EventListener;
+
+use Shopware\Core\Framework\Api\EventListener\ErrorResponseFactory;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Framework\Api\EventListener\ErrorResponseFactory
+ */
+class ErrorResponseFactoryTest extends \PHPUnit\Framework\TestCase
+{
+    public function testStackTraceForExceptionInDebugMode(): void
+    {
+        $factory = new ErrorResponseFactory();
+
+        /* @var \Symfony\Component\HttpFoundation\JsonResponse $response */
+        $response = $factory->getResponseFromException(new \Exception('test'), true);
+        $data = json_decode($response->getContent());
+        static::assertArrayHasKey('stack', $data);
+        static::assertIsArray($data['stack'], $data);
+
+    }
+
+    public function testNoStackTraceForExceptionNotInDebugMode(): void
+    {
+        $factory = new ErrorResponseFactory();
+
+        /* @var \Symfony\Component\HttpFoundation\JsonResponse $response */
+        $response = $factory->getResponseFromException(new \Exception('test'), false);
+        $data = json_decode($response->getContent());
+        static::assertNull($data['stack'], $response);
+
+    }
+}


### PR DESCRIPTION
When in debug mode, api responses should return the stack trace as well - this makes reasoning about the error easier when developing plugins.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Makes plugin development easier

### 2. What does this change do, exactly?
Adds stacktrace to error responses from api in debug mode

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2822"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

