### PR TITLE
Initialize plugins in ajax modal

### DIFF
--- a/changelog/_unreleased/2022-11-03-ajax-modal-initialize-plugins.md
+++ b/changelog/_unreleased/2022-11-03-ajax-modal-initialize-plugins.md
@@ -1,0 +1,8 @@
+---
+title: Ajax Modal initialize plugins after loading
+issue: NEXT-23355
+author: Rune Laenen
+author_email: rune@laenen.me
+---
+# Storefront
+* Changed `src/plugin/ajax-modal/ajax-modal.plugin.js` to initialize plugins after finishing loading the content.

--- a/changelog/_unreleased/2022-11-03-ajax-modal-initialize-plugins.md
+++ b/changelog/_unreleased/2022-11-03-ajax-modal-initialize-plugins.md
@@ -1,6 +1,6 @@
 ---
 title: Ajax Modal initialize plugins after loading
-issue: NEXT-23355
+issue: NEXT-24007
 author: Rune Laenen
 author_email: rune@laenen.me
 ---

--- a/src/Storefront/Resources/app/storefront/src/plugin/ajax-modal/ajax-modal.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/ajax-modal/ajax-modal.plugin.js
@@ -116,6 +116,7 @@ export default class AjaxModalPlugin extends Plugin {
     _processResponse(response, loadingIndicatorUtil, pseudoModalUtil, modalBodyEl) {
         loadingIndicatorUtil.remove();
         pseudoModalUtil.updateContent(response);
+        PluginManager.initializePlugins();
         modalBodyEl.classList.remove(this.options.centerLoadingIndicatorClass);
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/ajax-modal/ajax-modal.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/ajax-modal/ajax-modal.plugin.js
@@ -130,7 +130,6 @@ export default class AjaxModalPlugin extends Plugin {
     _onModalOpen(pseudoModalUtil, classes) {
         const modal = pseudoModalUtil.getModal();
         modal.classList.add(...classes);
-        PluginManager.initializePlugins();
         this.$emitter.publish('ajaxModalOpen', { modal });
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently the AJAX modal runs the `PluginManager.initializePlugins()` function when opening the modal. When first opening the modal, the real content is not loaded yet, only a loader is shown. 

### 2. What does this change do, exactly?
It runs `PluginManager.initializePlugins()` also after loading in the real content, making it possible to use javascript plugins in the modal' content.

### 3. Describe each step to reproduce the issue or behaviour.
Try to use a javascript plugin (for example form ajax submit) in an ajax modal. It will not be initialized correctly.

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2823"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

