### PR TITLE
NEXT-21558: Prevent seo url generation for link categories

### DIFF
--- a/changelog/_unreleased/2022-11-03-prevent-link-categories-from-generating-seo-urls.md
+++ b/changelog/_unreleased/2022-11-03-prevent-link-categories-from-generating-seo-urls.md
@@ -1,0 +1,10 @@
+---
+title: Prevent link categories from generating seo urls
+issue: NEXT-21558
+author: Felix von WIRDUZEN
+author_email: felix@wirduzen.de
+author_github: wirduzen-felix
+___
+# Storefront
+* Added additional filter to `src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php::prepareCriteria()`
+to prevent SeoUrl generation for link categories

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
@@ -56,8 +56,9 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
     {
         $criteria->addFilter(new MultiFilter(MultiFilter::CONNECTION_AND, [
             new EqualsFilter('active', true),
-            new NotFilter(NotFilter::CONNECTION_AND, [
+            new NotFilter(NotFilter::CONNECTION_OR, [
                 new EqualsFilter('type', CategoryDefinition::TYPE_FOLDER),
+                new EqualsFilter('type', CategoryDefinition::TYPE_LINK),
             ]),
         ]));
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently seo urls are being generated for link categories. This is entirely unnecessary and can even cause problems if other categories exist with the same name. Opening the generated seo url in the browser will result in a 404 error because these are not "real" categories.

### 2. What does this change do, exactly?
This change adds an additional equals filter to the `src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php`'s prepareCriteria() method, to ignore link categories.

### 3. Describe each step to reproduce the issue or behaviour.
Create a new link category. A new entry is created in the seo_url table.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-21558
c4f103479c2b7b4bd8f63b8636b1afd183aaaab6 already fixed the sitemap problem mentioned in this issue

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2824"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

