### PR TITLE
Add customer changed email event

### DIFF
--- a/changelog/_unreleased/2022-11-04-add-customer-changed-email-event.md
+++ b/changelog/_unreleased/2022-11-04-add-customer-changed-email-event.md
@@ -1,0 +1,14 @@
+---
+title: Add customer changed email event
+issue: N/A
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@iodigital.com
+---
+# Core
+* Changed class `BusinessEvents` in `src/Core/Framework/Event/BusinessEvents.php` to add new const.
+* Changed function `change` in `src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php` to dispatch event.
+* Added `src/Core/Checkout/Customer/Event/CustomerChangedEmailEvent.php` for new event.
+
+# Storefront
+* Changed function `saveEmail` in `src/Storefront/Controller/AccountProfileController.php` to dispatch event.
+* Changed service `Shopware\Storefront\Controller\AccountProfileController` to add `event_dispatcher`.

--- a/src/Core/Checkout/Customer/Event/CustomerChangedEmailEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerChangedEmailEvent.php
@@ -1,0 +1,95 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Event;
+
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\BusinessEventInterface;
+use Shopware\Core\Framework\Event\CustomerAware;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
+use Shopware\Core\Framework\Event\MailAware;
+use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CustomerChangedEmailEvent extends Event implements BusinessEventInterface, SalesChannelAware, ShopwareSalesChannelEvent, CustomerAware, MailAware
+{
+    public const EVENT_NAME = 'checkout.customer.changed-email';
+
+    /**
+     * @var CustomerEntity
+     */
+    private $customer;
+
+    /**
+     * @var SalesChannelContext
+     */
+    private $salesChannelContext;
+
+    /**
+     * @var RequestDataBag
+     */
+    private $requestDataBag;
+
+    public function __construct(SalesChannelContext $salesChannelContext, CustomerEntity $customer, RequestDataBag $requestDataBag)
+    {
+        $this->customer = $customer;
+        $this->salesChannelContext = $salesChannelContext;
+        $this->requestDataBag = $requestDataBag;
+    }
+
+    public function getName(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public function getCustomer(): CustomerEntity
+    {
+        return $this->customer;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelContext->getSalesChannel()->getId();
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getRequestDataBag(): RequestDataBag
+    {
+        return $this->requestDataBag;
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add('customer', new EntityType(CustomerDefinition::class));
+    }
+
+    public function getCustomerId(): string
+    {
+        return $this->getCustomer()->getId();
+    }
+
+    public function getMailStruct(): MailRecipientStruct
+    {
+        return new MailRecipientStruct(
+            [
+                $this->customer->getEmail() => $this->customer->getFirstName() . ' ' . $this->customer->getLastName(),
+            ]
+        );
+    }
+}

--- a/src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/ChangeEmailRoute.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use Composer\Semver\Constraint\ConstraintInterface;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Event\CustomerChangedEmailEvent;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerEmailUnique;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerPasswordMatches;
 use Shopware\Core\Framework\Context;
@@ -80,6 +81,11 @@ class ChangeEmailRoute extends AbstractChangeEmailRoute
         ];
 
         $this->customerRepository->update([$customerData], $context->getContext());
+
+        $requestDataBag->set('password', null);
+
+        $event = new CustomerChangedEmailEvent($context, $customer, $requestDataBag);
+        $this->eventDispatcher->dispatch($event);
 
         return new SuccessResponse();
     }

--- a/src/Core/Framework/Event/BusinessEvents.php
+++ b/src/Core/Framework/Event/BusinessEvents.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Event;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerAccountRecoverRequestEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerBeforeLoginEvent;
+use Shopware\Core\Checkout\Customer\Event\CustomerChangedEmailEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerChangedPaymentMethodEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerDeletedEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerDoubleOptInRegistrationEvent;
@@ -73,6 +74,12 @@ final class BusinessEvents
      * @Event("Shopware\Core\Checkout\Order\Event\OrderPaymentMethodChangedEvent")
      */
     public const CHECKOUT_ORDER_PAYMENT_METHOD_CHANGED = OrderPaymentMethodChangedEvent::EVENT_NAME;
+
+    /**
+     * @Event("Shopware\Core\Checkout\Customer\Event\CustomerChangedEmailEvent")
+     */
+
+    public const CHECKOUT_CUSTOMER_CHANGED_EMAIL = CustomerChangedEmailEvent::EVENT_NAME;
 
     /**
      * @Event("Shopware\Core\Checkout\Customer\Event\CustomerAccountRecoverRequestEvent")

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -54,6 +54,7 @@
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\ChangeEmailRoute"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\DeleteCustomerRoute"/>
             <argument type="service" id="logger"/>
+            <argument type="service" id="event_dispatcher"/>
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

When connecting with external data systems it can be handy to know when a customer changes their email address in Shopware. This also sets the foundation for a new email template that can be send to the old email address to inform the customer that their email address is changed + what the new email address is

### 2. What does this change do, exactly?

Adds a new event that dispatches when customer changes their email address in Shopware

### 3. Describe each step to reproduce the issue or behaviour.

N/A

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2826"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

