### PR TITLE
Fix: Checkout Error with Combination of Promotion and Rules

### DIFF
--- a/changelog/_unreleased/2022-11-04-fix--checkout-error-with-combination-of-promotion-and-rules.md
+++ b/changelog/_unreleased/2022-11-04-fix--checkout-error-with-combination-of-promotion-and-rules.md
@@ -1,0 +1,11 @@
+---
+title: Checkout Error with a combination of Promotion and Rule Builder
+author: d.popovic
+author_email: darko.popovic@ditegra.de
+author_github: dpopov00
+---
+# Core
+* Changed `src\Core\Framework\DataAbstractionLayer\FieldSerializer\PriceDefinitionFieldSerializer.php`
+* Rule 'Item with price/list price percentage ratio||Position mit prozentualen Preis/Streichpreis Verhältnis' has an option "Is empty" and in that case "amount" field is null.
+* Inside PriceDefinitionFieldSerializer.php '$violationList->addAll($this->validateConsistence($basePath, $validations, $data));', both fields (operator and amount) are sent to the validateConsistence() and because the amount is null, checkout fails
+* Fix to unset the amount field (if the operator is 'empty') before it is passed to validateConsistence()

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
@@ -202,6 +202,12 @@ class PriceDefinitionFieldSerializer extends JsonFieldSerializer
             if (!$rule instanceof Container) {
                 $rule->assign($data);
                 $validations = $rule->getConstraints();
+                $config = $rule->getVars() ?? [];
+                if(is_array($config) && array_key_exists('operator', $config) && array_key_exists('amount', $config)) {
+                    if($config['operator'] === 'empty' && $config['amount'] === null) {
+                        unset($data['amount']);
+                    }
+                }
                 $violationList->addAll($this->validateConsistence($basePath, $validations, $data));
             }
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
- Because it **breaks** the checkout finish process in a combination of promotion and rules with the '**is empty**' operator.
- Rules have an 'is empty' option, but it is not handled well in the checkout process.
- Situations, where the promotion excludes discounted products (with **list price**), are pretty common, and I think this error should be handled pretty fast, because there should be a way to do it out of the box.
- Although this is noticed on "Item with price/list percentage ratio" condition, I guess the same behavior will be for all conditions that have 'is empty' option.

### 2. What does this change do, exactly?
- This solution is probably not the best way to handle this issue, but it is a pretty solid workaround with only a few lines of code and it targets only situations when the operator is empty and the amount is null. Take a look and decide if this is acceptable or if you have a better idea. (maybe not to pass amount at all in combination with empty)

### 3. Describe each step to reproduce the issue or behaviour.
Idea is to create a promotion for all products, but exclude discounted products.

1. **Create a clean Shopware environment**
2. **Create a Rule in Rule Builder**:
    - **Name**: All Products without SALE
    - **Priority**: 50
    - **Condition**: Item with price/list price percentage ratio > At least one > Is empty
    - Optionally you can add more conditions 
3. **Create new Promotion**:
   - General Tab:
       - **Name**: 10% Rabatt
       - **Priority**: 50
       - **Active**: TRUE
       - **Fixed promotion code**: test10
   - Conditions Tab:
       - Sales Channel: Storefront
   - Discounts Tab:
       - **Apply to**: Cart
       - **Apply to a specific range of products only**: TRUE
       - **Product rules**: Select our "All Products without SALE" rule
       - **Apply to**: All items
       - **Type**: Percentage
       - **Value**: 10
4. **Add list price to one product**
5. **Add product with list price to the cart**
6. **Add another product without list price to the cart**
7. **Enter promotion code**: test10
8. **Go through the checkout** => everything should be correct during the process
9. **Finish the order** => Checkout finish fails (Error)
 
 





<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2827"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

