### PR TITLE
Add order comment indicator in order overview

### DIFF
--- a/changelog/_unreleased/2022-11-04-add-order-comment-indicator.md
+++ b/changelog/_unreleased/2022-11-04-add-order-comment-indicator.md
@@ -1,0 +1,10 @@
+---
+title: Add order comment indicator in order overview
+issue: N/A
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@iodigital.com
+author_github: MelvinAchterhuis
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig`, added block with button and tooltip.
+* Changed `src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.scss`, added styling

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -125,6 +125,20 @@
                         {{ $tc('sw-order.list.labelManualOrder') }}
                     </sw-label>
                     {% endblock %}
+
+                    {% block sw_order_list_grid_tooltip_order_comment %}
+                        <sw-button
+                            v-if="item.customerComment"
+                            v-tooltip="{ message: item.customerComment }"
+                            class="sw-order-list__tooltip-order-comment"
+                            size="x-small"
+                        >
+                            <sw-icon
+                                name="default-communication-speech-bubbles"
+                                size="14px"
+                            />
+                        </sw-button>
+                    {% endblock %}
                 </template>
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.scss
@@ -22,7 +22,8 @@ $sw-order-list-color-success: $color-emerald-500;
         padding: 0 25px;
     }
 
-    .sw-order-list__manual-order-label {
+    .sw-order-list__manual-order-label,
+    .sw-order-list__tooltip-order-comment {
         margin-left: 12px;
         text-align: center;
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently it is not easy for the merchant to quickly see if the order has a comment.

### 2. What does this change do, exactly?

This PR adds an indicator in the order overview so the merchant can quickly see if an order has a comment

![image](https://user-images.githubusercontent.com/26538915/200002212-a259f7c0-056c-41f9-81f1-46fdf1987043.png)

### 3. Describe each step to reproduce the issue or behaviour.

N/A

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2829"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

