### PR TITLE
Fix sw-datepicker uses timezones for date values

### DIFF
--- a/changelog/_unreleased/2022-11-08-fix-sw-datepicker-uses-timezones-for-date.md
+++ b/changelog/_unreleased/2022-11-08-fix-sw-datepicker-uses-timezones-for-date.md
@@ -1,0 +1,9 @@
+---
+title: Fix sw-datepicker uses timezones for date
+issue: NEXT-21597
+author: Silvio Kennecke
+author_email: development@silvio-kennecke.de
+author_github: @silviokennecke
+---
+# Administration
+* Changed `sw-datepicker` component to not use timezones for date values

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-datepicker/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-datepicker/index.js
@@ -202,7 +202,12 @@ Component.register('sw-datepicker', {
                 }
 
                 // convert from user timezone (represented as UTC) to UTC timezone
-                const utcDate = zonedTimeToUtc(new Date(newValue), this.userTimeZone);
+                let utcDate = zonedTimeToUtc(new Date(newValue), this.userTimeZone);
+
+                // ensure date values are always in UTC
+                if (this.dateType === 'date') {
+                    utcDate = new Date(`${newValue}Z`);
+                }
 
                 // emit the UTC time so that the v-model value always work in UTC time (which is needed for the server)
                 this.$emit('input', utcDate.toISOString());

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-datepicker/sw-datepicker.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-datepicker/sw-datepicker.spec.js
@@ -101,6 +101,40 @@ describe('src/app/component/form/sw-datepicker', () => {
         expect(wrapper.find('label').text()).toEqual('Label from slot');
     });
 
+    it('should use UTC for date values', async () => {
+        Shopware.State.get('session').currentUser = {
+            timeZone: 'Europe/Berlin'
+        };
+
+        wrapper = await createWrapper({
+            propsData: {
+                dateType: 'date'
+            }
+        });
+
+        wrapper.vm.emitValue('2022-01-01T00:00:00');
+
+        expect(wrapper.emitted().input).toBeTruthy();
+        expect(wrapper.emitted().input[0]).toEqual(['2022-01-01T00:00:00.000Z']);
+    });
+
+    it('should convert datetime values to UTC', async () => {
+        Shopware.State.get('session').currentUser = {
+            timeZone: 'Europe/Berlin'
+        };
+
+        wrapper = await createWrapper({
+            propsData: {
+                dateType: 'datetime'
+            }
+        });
+
+        wrapper.vm.emitValue('2022-01-01T00:00:00');
+
+        expect(wrapper.emitted().input).toBeTruthy();
+        expect(wrapper.emitted().input[0]).toEqual(['2021-12-31T23:00:00.000Z']);
+    });
+
     it('should not show the actual user timezone as a hint when it is not a datetime', async () => {
         Shopware.State.get('session').currentUser = {
             timeZone: 'Europe/Berlin'


### PR DESCRIPTION
### 1. Why is this change necessary?
When picking a date using the `sw-datepicker` component, you might result in a stored date one day in the past (depending on your timezone).

### 2. What does this change do, exactly?
It ensures that the `sw-datepicker` does not pay attention to the user's timezone if only a date (without time) is selected. 

### 3. Describe each step to reproduce the issue or behaviour.
1. set your admin user to the timezone "Europe/Berlin"
2. open an order
3. create an invoice
4. set the invoice date to a date of your choice
5. save the invoice

The invoice date will now be one day before your selected date.

### 4. Please link to the relevant issues (if any).

- https://issues.shopware.com/issues/NEXT-21597
- https://issues.shopware.com/issues/NEXT-19136

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2833"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

