### PR TITLE
Add document column blocks

### DIFF
--- a/changelog/_unreleased/2022-11-09-add-document-column-blocks.md
+++ b/changelog/_unreleased/2022-11-09-add-document-column-blocks.md
@@ -1,0 +1,9 @@
+---
+title:              New Template Blocks for document position columns
+author:             Alexander Kludt
+author_email:       coding@aggrosoft.de
+author_github:      @kingschnulli
+---
+
+# Core
+* Add new template blocks for document position columns in `src/Core/Framework/Resources/views/documents/includes/position.html.twig`

--- a/src/Core/Framework/Resources/views/documents/includes/position.html.twig
+++ b/src/Core/Framework/Resources/views/documents/includes/position.html.twig
@@ -20,20 +20,21 @@ All blocks of this template are available in the template which renders this tem
             {% block document_line_item_table_rows %}
                 {% block document_line_item_table_row_position %}
                     {% if config.displayLineItemPosition %}
-                        <td>{{ prefix ~ position }}</td>
+                        <td>{% block document_line_item_table_column_position %}{{ prefix ~ position }}{% endblock %}</td>
                     {% endif %}
                 {% endblock %}
 
                 {% block document_line_item_table_row_product_number %}
                     {% if lineItem.payload.productNumber %}
-                        <td>{{ lineItem.payload.productNumber }}</td>
+                        <td>{% block document_line_item_table_column_product_number %}{{ lineItem.payload.productNumber }}{% endblock %}</td>
                     {% else %}
-                        <td></td>
+                        <td>{% block document_line_item_table_column_product_number_empty %}{% endblock %}</td>
                     {% endif %}
                 {% endblock %}
 
                 {% block document_line_item_table_row_label %}
                     <td class="line-item-breakable">
+                    {% block document_line_item_table_column_label %}
                         {% if level > 0 %}
                             {% for i in 1..level %}
                                 <span class="wrapper-wrapper">
@@ -65,23 +66,24 @@ All blocks of this template are available in the template which renders this tem
                                 {% endif %}
                             {% endfor %}
                         {% endif %}
+                    {% endblock %}
                     </td>
                 {% endblock %}
 
                 {% block document_line_item_table_row_quantity %}
-                    <td class="align-right">{{ lineItem.quantity }}</td>
+                    <td class="align-right">{% block document_line_item_table_column_quantity %}{{ lineItem.quantity }}{% endblock %}</td>
                 {% endblock %}
 
                 {% block document_line_item_table_prices %}
                     {% if config.displayPrices %}
                         {% block document_line_item_table_row_tax_rate %}
-                            <td class="align-right">{% for tax in lineItem.price.taxRules %}{{ tax.taxRate }} % {% if loop.last %}{% else %}<br>{% endif %}{% endfor %}</td>
+                            <td class="align-right">{% block document_line_item_table_column_tax_rate %}{% for tax in lineItem.price.taxRules %}{{ tax.taxRate }} % {% if loop.last %}{% else %}<br>{% endif %}{% endfor %}{% endblock %}</td>
                         {% endblock %}
                         {% block document_line_item_row_table_unit_price %}
-                            <td class="align-right">{{ lineItem.unitPrice|currency(currencyIsoCode, languageId) }}</td>
+                            <td class="align-right">{% block document_line_item_column_table_unit_price %}{{ lineItem.unitPrice|currency(currencyIsoCode, languageId) }}{% endblock %}</td>
                         {% endblock %}
                         {% block document_line_item_table_row_total_price %}
-                            <td class="align-right">{{ lineItem.totalPrice|currency(currencyIsoCode, languageId) }}</td>
+                            <td class="align-right">{% block document_line_item_table_column_total_price %}{{ lineItem.totalPrice|currency(currencyIsoCode, languageId) }}{% endblock %}</td>
                         {% endblock %}
                     {% endif %}
                 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
There is no way of appending or prepending data to the default columns in document positions - e.g. append to label column.

### 2. What does this change do, exactly?
Add new blocks inside of table columns

### 3. Describe each step to reproduce the issue or behaviour.
Try extending document position label column, you either have to add a new column or overwrite the existing one

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2835"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

