### PR TITLE
Fix setting null-data on a StorefrontResponse

### DIFF
--- a/changelog/_unreleased/2022-11-09-fix-setting-null-data-while-expecting-array-on-a-storefront-response.md
+++ b/changelog/_unreleased/2022-11-09-fix-setting-null-data-while-expecting-array-on-a-storefront-response.md
@@ -1,0 +1,16 @@
+---
+title: Fix setting null-data while expecting array on a StorefrontResponse
+issue: NEXT-24082
+author: Stephan Niewerth
+author_email: snw@heise.de
+author_github: stephanniewerth
+---
+# Storefront
+* Added unit test for StorefrontResponse in `tests/unit/php/Storefront/Framework/Routing/StorefrontResponseTest.php`
+* Changed `src/Storefront/Framework/Routing/StorefrontResponse.php` to return an empty array on `getData()` if $data is `null`
+* Changed `src/Storefront/Framework/Routing/NotFound/NotFoundSubscriber.php` and `src/Storefront/Framework/Cache/CacheStore.php` to set StorefrontResponse data to an empty array
+* Deprecated `setData()` usage as to strictly type parameter `$data` as `array` in `src/Storefront/Framework/Routing/StorefrontResponse.php` with v6.5.0
+* Deprecated property `$data` will be natively typed to array and initilized with `[]` in `src/Storefront/Framework/Routing/StorefrontResponse.php` with v6.5.0
+* Deprecated property `$context` will be natively typed as `?SalesChannelContext` and initialized with `null` in `src/Storefront/Framework/Routing/StorefrontResponse.php` with v6.5.0
+* Deprecated null coalesce in `getData` can be removed if $data is natively typed in `src/Storefront/Framework/Routing/StorefrontResponse.php` with v6.5.0 */
+

--- a/src/Storefront/Framework/Cache/CacheStore.php
+++ b/src/Storefront/Framework/Cache/CacheStore.php
@@ -110,7 +110,7 @@ class CacheStore implements StoreInterface
         }
 
         if ($response instanceof StorefrontResponse) {
-            $response->setData(null);
+            $response->setData([]);
             $response->setContext(null);
         }
 

--- a/src/Storefront/Framework/Routing/NotFound/NotFoundSubscriber.php
+++ b/src/Storefront/Framework/Routing/NotFound/NotFoundSubscriber.php
@@ -150,7 +150,7 @@ class NotFoundSubscriber implements EventSubscriberInterface
 
             $item->tag($this->generateTags($name, $event->getRequest(), $context));
 
-            $response->setData(null);
+            $response->setData([]);
             $response->setContext(null);
 
             return $response;

--- a/src/Storefront/Framework/Routing/StorefrontResponse.php
+++ b/src/Storefront/Framework/Routing/StorefrontResponse.php
@@ -2,28 +2,44 @@
 
 namespace Shopware\Storefront\Framework\Routing;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Response;
 
 class StorefrontResponse extends Response
 {
     /**
+     * @deprecated tag:v6.5.0 - $data will be natively typed to array and initilized with `[]`
+     *
      * @var array
      */
     protected $data;
 
     /**
+     * @deprecated tag:v6.5.0 - $context will be natively typed as `?SalesChannelContext` and initialized with `null`
+     *
      * @var SalesChannelContext|null
      */
     protected $context;
 
     public function getData(): array
     {
-        return $this->data;
+        /** @deprecated tag:v6.5.0 - null coalesce can be removed if $data is natively typed */
+        return $this->data ?? [];
     }
 
+    /**
+     * @deprecated tag:v6.5.0 - parameter `$data` will be strictly typed to `array`
+     */
     public function setData(?array $data): void
     {
+        if ($data === null) {
+            Feature::triggerDeprecationOrThrow(
+                'v6.5.0.0',
+                sprintf('Parameter "data" in method "setData" will be strictly typed to "array" in class "%s".', static::class)
+            );
+        }
+
         $this->data = $data;
     }
 

--- a/src/Storefront/Test/Framework/Routing/NotFound/NotFoundSubscriberTest.php
+++ b/src/Storefront/Test/Framework/Routing/NotFound/NotFoundSubscriberTest.php
@@ -97,7 +97,13 @@ class NotFoundSubscriberTest extends TestCase
         );
         $subscriber->onError($event);
 
-        static::assertInstanceOf(Response::class, $event->getResponse());
+        /** @var StorefrontResponse $response */
+        $response = $event->getResponse();
+
+        static::assertInstanceOf(Response::class, $response);
+        static::assertInstanceOf(StorefrontResponse::class, $response);
+        static::assertEmpty($response->getData());
+        static::assertNull($response->getContext());
     }
 
     public function testOtherExceptionsDoesNotGetCached(): void

--- a/tests/unit/php/Storefront/Framework/Routing/StorefrontResponseTest.php
+++ b/tests/unit/php/Storefront/Framework/Routing/StorefrontResponseTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Framework\Routing;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\ShippingLocation;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
+use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
+use Shopware\Core\System\Country\CountryEntity;
+use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\System\Tax\TaxCollection;
+use Shopware\Storefront\Framework\Routing\StorefrontResponse;
+
+/**
+ * @internal
+ * @covers \Shopware\Storefront\Framework\Routing\StorefrontResponse
+ */
+class StorefrontResponseTest extends TestCase
+{
+    public function testInit(): void
+    {
+        $response = new StorefrontResponse();
+
+        static::assertIsArray($response->getData());
+        static::assertEmpty($response->getData());
+
+        static::assertNull($response->getContext());
+    }
+
+    public function testSetData(): void
+    {
+        $response = new StorefrontResponse();
+
+        $response->setData([]);
+        static::assertEmpty($response->getData());
+
+        /** @deprecated tag:v6.5.0 - This can be removed if parameter `$data` will be strictly typed to `array` in `setData` */
+        $this->expectDeprecationMessageMatches('/deprecated functionality:/');
+        $response->setData(null);
+    }
+
+    public function testSetContext(): void
+    {
+        $response = new StorefrontResponse();
+
+        $salesChannelContext = $this->createSalesChannelContext();
+        $response->setContext($salesChannelContext);
+        $retrievedSalesChannelContext = $response->getContext();
+
+        static::assertInstanceOf(SalesChannelContext::class, $retrievedSalesChannelContext);
+        static::assertEquals('foo', $retrievedSalesChannelContext->getToken());
+    }
+
+    private function createSalesChannelContext(): SalesChannelContext
+    {
+        return new SalesChannelContext(
+            Context::createDefaultContext(),
+            'foo',
+            'bar',
+            new SalesChannelEntity(),
+            new CurrencyEntity(),
+            new CustomerGroupEntity(),
+            new CustomerGroupEntity(),
+            new TaxCollection(),
+            new PaymentMethodEntity(),
+            new ShippingMethodEntity(),
+            new ShippingLocation(new CountryEntity(), null, null),
+            new CustomerEntity(),
+            new CashRoundingConfig(2, 0.01, true),
+            new CashRoundingConfig(2, 0.01, true)
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Removes inconsistency in getting and setting data on `StorefrontResponse`. If you've set null to data an try to fetch it, an exception is thrown.

Talked to @shyim about that.

### 2. What does this change do, exactly?

To Storefront:
* `src/Storefront/Framework/Routing/StorefrontResponse.php` only accept arrays on setting data (removes inconsistencies)
* Changed `src/Storefront/Framework/Routing/NotFound/NotFoundSubscriber.php` and `src/Storefront/Framework/Cache/CacheStore.php` to set StorefrontResponse data to empty arrays

### 3. Describe each step to reproduce the issue or behaviour.

If a url is unkown and handled by `NotFoundSubscriber` and you subscribed to `onResponse` event

```php
if ($response instanceof StorefrontResponse) {
    $context = $response->getContext(); # null
    $data = $response->getData(); # exception
```            

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-24082

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2836"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

