### PR TITLE
fix: correct namespace

### DIFF
--- a/tests/unit/php/Core/Checkout/Payment/Cart/PaymentMethodValidatorTest.php
+++ b/tests/unit/php/Core/Checkout/Payment/Cart/PaymentMethodValidatorTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace SShopware\Tests\Unit\Core\Checkout\Payment\Cart;
+namespace Shopware\Tests\Unit\Core\Checkout\Payment\Cart;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;


### PR DESCRIPTION
There should be just one `S`, you know the reasons 😆 

<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2838"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

