### PR TITLE
Fix uploaded file mime content type verification in the sw-media-upload-v2 administration component

### DIFF
--- a/changelog/_unreleased/2022-14-11-fix-email-template-attachment-mime-content-type-verification.md
+++ b/changelog/_unreleased/2022-14-11-fix-email-template-attachment-mime-content-type-verification.md
@@ -1,0 +1,8 @@
+---
+title: Fix email template attachment mime content type check
+author: Bruno Di Miceli
+author_email: dimicelibruno@gmail.com
+author_github: @dimiceli
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js` so the uploaded files content mime types are correctly verified according to the accepted mime types 

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
@@ -450,10 +450,10 @@ Component.register('sw-media-upload-v2', {
                 return true;
             }
 
-            const fileTypes = this.fileAccept.split(',');
+            const fileTypes = this.fileAccept.split(',').map(s => s.trim());
 
             fileTypes.some(fileType => {
-                const fileAcceptType = fileType.split('/').map(s => s.trim());
+                const fileAcceptType = fileType.split('/');
                 const currentFileType = file?.type?.split('/') || file?.mimeType?.split('/');
 
                 if (fileAcceptType[0] !== currentFileType[0]) {

--- a/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/media/sw-media-upload-v2/index.js
@@ -452,21 +452,22 @@ Component.register('sw-media-upload-v2', {
 
             const fileTypes = this.fileAccept.split(',');
 
-            fileTypes.forEach(fileType => {
-                const fileAcceptType = fileType.split('/');
+            fileTypes.some(fileType => {
+                const fileAcceptType = fileType.split('/').map(s => s.trim());
                 const currentFileType = file?.type?.split('/') || file?.mimeType?.split('/');
 
                 if (fileAcceptType[0] !== currentFileType[0]) {
                     this.isCorrectFileType = false;
-                    return;
+                    return false;
                 }
 
                 if (fileAcceptType[1] === '*') {
                     this.isCorrectFileType = true;
-                    return;
+                    return true;
                 }
 
                 this.isCorrectFileType = fileAcceptType[1] === currentFileType[1];
+                return this.isCorrectFileType;
             });
 
             if (this.isCorrectFileType) {


### PR DESCRIPTION
Fix uploaded file mime content type verification in the sw-media-upload-v2 administration component

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The uploaded content type is checked with a forEach in the accepted types. But the foreach never break so eventually only the last accepted format is verified. So it is impossible to attach a pdf file with the template editor because the last accepted mime type tested is image/*.

There is a second problem. Accepted formats are retrieved with a split on a string that contains a comma-separated list. But this does not take into account the spaces after the commas that must be trimmed.

### 2. What does this change do, exactly?

This change replace the forEach by the some method, so as soon as a content type matches an accepted format the check stops. The accepted formats recovered with a split are trimmed.

### 3. Describe each step to reproduce the issue or behaviour.

Try to upload a pdf file attachment with the administration email template editor.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2840"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

