### PR TITLE
Define Store API context route as service.

### DIFF
--- a/changelog/_unreleased/2022-11-17-define-store-api-context-route-as-service.md
+++ b/changelog/_unreleased/2022-11-17-define-store-api-context-route-as-service.md
@@ -1,0 +1,9 @@
+---
+title: Define Store API context route as service.
+issue: https://github.com/shopware/platform/issues/2845
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed `Shopware\Core\System\SalesChannel\SalesChannel\ContextRoute` service to be public.

--- a/src/Core/System/DependencyInjection/sales_channel.xml
+++ b/src/Core/System/DependencyInjection/sales_channel.xml
@@ -135,7 +135,7 @@
             <argument type="service" id="event_dispatcher"/>
         </service>
 
-        <service id="Shopware\Core\System\SalesChannel\SalesChannel\ContextRoute"/>
+        <service id="Shopware\Core\System\SalesChannel\SalesChannel\ContextRoute" public="true"/>
 
         <service id="Shopware\Core\System\SalesChannel\Command\SalesChannelCreateCommand">
             <argument type="service" id="payment_method.repository"/>


### PR DESCRIPTION
### 1. Why is this change necessary?

So the ContextRoute class is used as service by the Store API and not directly instantiated. Only this way dependency injection and service decorations work correctly.

### 2. What does this change do, exactly?

Adds the necessary tag to define a controller as a service. Optionally, it would also be possible to make the service public.

### 3. Describe each step to reproduce the issue or behaviour.

See linked issue.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2845

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2848"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

