### PR TITLE
NEXT-14471 - Add sw-api-compatibility to Access-Control-Allow-Headers

### DIFF
--- a/src/Core/Framework/Api/EventListener/CorsListener.php
+++ b/src/Core/Framework/Api/EventListener/CorsListener.php
@@ -54,6 +54,7 @@ class CorsListener implements EventSubscriberInterface
             PlatformRequest::HEADER_INDEXING_BEHAVIOR,
             PlatformRequest::HEADER_SINGLE_OPERATION,
             PlatformRequest::HEADER_INCLUDE_SEO_URLS,
+            PlatformRequest::HEADER_IGNORE_DEPRECATIONS,
         ];
 
         $response = $event->getResponse();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Requests to the API with the sw-api-compatibility header fail if the request origin is not the same as the API host.

### 2. What does this change do, exactly?
Add `sw-api-compatibility` to the `Access-Control-Allow-Headers` header.

### 3. Describe each step to reproduce the issue or behaviour.
Run the storefront using `./psh.phar storefront:hot-proxy`, go to `http://shopware.local:8000/admin`, log in and observe lot's of failed AJAX requests.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-14471

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2857"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

