### PR TITLE
Implement Copy Button for Tracking Code

### DIFF
--- a/changelog/_unreleased/2022-11-25-add-copy-to-clipboard-button-for-tracking-codes.md
+++ b/changelog/_unreleased/2022-11-25-add-copy-to-clipboard-button-for-tracking-codes.md
@@ -1,0 +1,11 @@
+---
+title:          New Copy to Clipboard Button for Tracking Codes
+author:         Lucas Breiner
+author_email:   l.breiner@imi.de
+author_github:  @Lucas-Schmukas
+---
+
+# Core
+* Add methode to chain the tracking codes for the clipboard in src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js
+* Add copy to clipboard button to src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.html.twig
+* Adjust the copy to clipboard button dimensions in src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.scss

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/index.js
@@ -235,6 +235,10 @@ export default {
 
             return urlTemplate ? urlTemplate.replace('%s', encodeURIComponent(trackingCode)) : '';
         },
+
+        renderTrackingCodeList(trackingCodes) {
+            return trackingCodes.join(', ');
+        },
     },
 
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.html.twig
@@ -387,8 +387,7 @@
                             >{{ trackingCode }}</sw-button>
                             <sw-field-copyable
                                 :copyable-text="renderTrackingCodeList(delivery.trackingCodes)"
-                                >
-                            </sw-field-copyable>
+                            />
                             {% endblock %}
                         </dd>
                         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.html.twig
@@ -385,6 +385,10 @@
                                 :link="renderTrackingUrl(trackingCode, delivery.shippingMethod)"
                                 :disabled="!renderTrackingUrl(trackingCode, delivery.shippingMethod)"
                             >{{ trackingCode }}</sw-button>
+                            <sw-field-copyable
+                                :copyable-text="renderTrackingCodeList(delivery.trackingCodes)"
+                                >
+                            </sw-field-copyable>
                             {% endblock %}
                         </dd>
                         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-user-card/sw-order-user-card.scss
@@ -95,6 +95,11 @@ $sw-order-user-card-link: $color-shopware-brand-500;
         }
     }
 
+    .sw-field-copyable.sw-icon {
+        width: 16px;
+        height: 16px;
+    }
+
     .sw-order-user-card__tracking-code-link {
         &:not(:last-child) {
             margin-right: 0.25rem;


### PR DESCRIPTION
### 1. Why is this change necessary?
It was not possible to copy the tracking codes in the order details of the admin panel, which felt quite strange.
Why shouldn't I be able to copy it?

### 2. What does this change do, exactly?
By clicking the button, the tracking codes will be copied to clipboard in the following scheme:
`code1, code2, code3, ...`

### 3. Image

![grafik](https://user-images.githubusercontent.com/89397256/204024002-f451f1cb-b507-43d5-b93e-d4a79bf3f968.png)

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [no] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [no] I have written or adjusted the documentation according to my changes
- [no] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2863"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

