### PR TITLE
Search term interpreter tuning.

### DIFF
--- a/changelog/_unreleased/2022-11-29-search-term-interpreter-tuning.md
+++ b/changelog/_unreleased/2022-11-29-search-term-interpreter-tuning.md
@@ -1,0 +1,10 @@
+---
+title: Search term interpreter tuning
+issue: NEXT-24384
+author: Adrian Bobowicz
+author_email: adrian@bobowicz.eu
+author_github: @abobowicz
+---
+
+# Core
+* Changed the score method of the Shopware\Core\Content\Product\SearchKeyword\ProductSearchTermInterpreter class.

--- a/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
+++ b/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
@@ -243,6 +243,10 @@ class ProductSearchTermInterpreter implements ProductSearchTermInterpreterInterf
             }
 
             foreach ($tokens as $token) {
+                if (false !== stripos($match, $token)) {
+                    ++$score;
+                }
+
                 /**
                  * @deprecated tag:v6.5.0 - if can be removed as php min version is higher, only keep else branch
                  */


### PR DESCRIPTION
A good search result was getting a low score using levenshtein function. E.g., the needle is DW0DW11457 and the haystack is DW0DW11457-0XU. This would get it a score of 4 which is too high to give it any advantage. Simple check if the given needle is in a haystack fix this.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The search was not returning correct results.

### 2. What does this change do, exactly?
This check is the search term that exists in keywords and if it is it bumps it's score a little.

### 3. Describe each step to reproduce the issue or behaviour.
This requires a very specific data, but you can check that the current search scoring function will not give any score to matching results - eg. search "DW0DW11457" and keyword "DW0DW11457-0XU"

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-24384

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2865"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

