### PR TITLE
Fix container parameter typo

### DIFF
--- a/changelog/_unreleased/2022-11-29-fix-typo-in-services-xml.md
+++ b/changelog/_unreleased/2022-11-29-fix-typo-in-services-xml.md
@@ -1,0 +1,8 @@
+---
+title: Fix typo services.xml
+author: Marco Gier (IANEO Solutions)
+author_email: marco.gier@ianeo.de
+author_github: marcogier
+---
+# Core
+* Fixed typo (double "%") in parameter injection src/Core/Framework/DependencyInjection/services.xml 

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -380,7 +380,7 @@ base-uri 'self';
 
         <service id="Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer">
             <argument type="service" id="twig"/>
-            <argument>%kernel.cache_dir%%</argument>
+            <argument>%kernel.cache_dir%</argument>
         </service>
 
         <service id="Shopware\Core\Framework\Adapter\Twig\TemplateIterator"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Removes tailing "%" for cache directories created by `Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer`

### 2. What does this change do, exactly?
Removes typo in services.xml parameter injection

### 3. Describe each step to reproduce the issue or behaviour.
Sending an test mail in the administration triggers the service and creates a cache directory with a tailing "%"

### 4. Please link to the relevant issues (if any).
[Issue 2860](https://github.com/shopware/platform/issues/2860)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2866"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

