### PR TITLE
Compile theme only for active sales channels

### DIFF
--- a/changelog/_unreleased/2022-11-29-compile-themes-only-for-active-sales-channels.md
+++ b/changelog/_unreleased/2022-11-29-compile-themes-only-for-active-sales-channels.md
@@ -1,0 +1,8 @@
+---
+title: Compile theme only for active sales channels
+author: Lars Schröder (KielCoding)
+author_email: lars.schroeder@kielcoding.de
+author_github: larsbo
+---
+# Storefront
+* Add filter for active sales channels to criteria object inside Shopware\Storefront\Theme\ConfigLoader\DatabaseAvailableThemeProvider.php

--- a/src/Storefront/Theme/ConfigLoader/DatabaseAvailableThemeProvider.php
+++ b/src/Storefront/Theme/ConfigLoader/DatabaseAvailableThemeProvider.php
@@ -33,6 +33,7 @@ class DatabaseAvailableThemeProvider extends AbstractAvailableThemeProvider
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT));
+        $criteria->addFilter(new EqualsFilter('active', 1));
         $criteria->addAssociation('themes');
 
         /** @var SalesChannelCollection $result */


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If you have lots of sales channels for some reason like testing, design work, etc. the execution of the theme:compile command takes lots of (useless) time:
<img width="593" alt="Bildschirmfoto 2022-11-29 um 12 38 30" src="https://user-images.githubusercontent.com/754074/204519512-fba88ac1-e142-45e4-ae1d-20eb96c2099a.png">

### 2. What does this change do, exactly?
Compile themes only for active sales channels.

### 3. Describe each step to reproduce the issue or behaviour.
- Execute `theme:compile` command
- wait
- wait
- more wait
- still waiting...
- grap some mug of coffee
- wait
- and more waiting here
- maybe I should do some more productive stuff now?
- wait
- go outside, got shopping, plant a tree, build a house, oh wait, there was some process running on my computer...
- it's still running -.-
- and waiting
- ...
- process maybe finished someday maybe not - who knows? 😺 

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-21505

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2867"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

