### PR TITLE
NEXT-24393 Cronjob Product Export Generafür Product Comparison Sales Channels

### DIFF
--- a/changelog/_unreleased/2022-11-30-fix-product-export-for-product-comparison.md
+++ b/changelog/_unreleased/2022-11-30-fix-product-export-for-product-comparison.md
@@ -7,3 +7,5 @@ author_github: jbk@alphanauten.de
 ---
 # Core
 * Changed File "src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php", on Line 128, changed Equals Filter to Equals Any and Added Product Comparison Sales Channel Id 
+* Changed File "src/Core/Content/ProductExport/Service/ProductExportGenerator.php", added a new way to count the total and removed the old iteration call for the total count. This will give an accurate total based on the filtering of $isIncludeVariants.
+* Changed File "src/Core/Content/ProductExport/Service/ProductExportGenerator.php", on Line 146, allows Sales Channels of type Product Comparison

--- a/changelog/_unreleased/2022-11-30-fix-product-export-for-product-comparison.md
+++ b/changelog/_unreleased/2022-11-30-fix-product-export-for-product-comparison.md
@@ -6,32 +6,4 @@ author_email: jbk@alphanauten.de
 author_github: jbk@alphanauten.de
 ---
 # Core
-*
-___
-# API
-*
-___
-# Administration
-*
-___
-# Storefront
-*
-___
-# Upgrade Information
-## Topic 1
-### Topic 1a
-### Topic 1b
-## Topic 2
-___
-# Next Major Version Changes
-## Breaking Change 1:
-* Do this
-## Breaking Change 2:
-change
-```
-static
-```
-to
-```
-self
-```
+* Changed File "src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php", on Line 128, changed Equals Filter to Equals Any and Added Product Comparison Sales Channel Id 

--- a/changelog/_unreleased/2022-11-30-fix-product-export-for-product-comparison.md
+++ b/changelog/_unreleased/2022-11-30-fix-product-export-for-product-comparison.md
@@ -1,0 +1,37 @@
+---
+title: Fix Product Export for Product Comparison
+issue: NEXT-24393
+author: Jeremy Bastian Kemmler
+author_email: jbk@alphanauten.de
+author_github: jbk@alphanauten.de
+---
+# Core
+*
+___
+# API
+*
+___
+# Administration
+*
+___
+# Storefront
+*
+___
+# Upgrade Information
+## Topic 1
+### Topic 1a
+### Topic 1b
+## Topic 2
+___
+# Next Major Version Changes
+## Breaking Change 1:
+* Do this
+## Breaking Change 2:
+change
+```
+static
+```
+to
+```
+self
+```

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -87,7 +87,15 @@ final class ProductExportGenerateTaskHandler extends ScheduledTaskHandler
     {
         $criteria = new Criteria();
         $criteria
-            ->addFilter(new EqualsFilter('typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT))
+            ->addFilter(
+                new EqualsAnyFilter(
+                    'typeId', 
+                    [
+                        Defaults::SALES_CHANNEL_TYPE_STOREFRONT,
+                        Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON
+                    ]
+                )
+            )
             ->addFilter(new EqualsFilter('active', true));
 
         /**

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportGenerateTaskHandler.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Shopware\Core\Framework\Uuid\Uuid;

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandler.php
@@ -143,7 +143,7 @@ final class ProductExportPartialGenerationHandler implements MessageSubscriberIn
             $productExportPartialGeneration->getSalesChannelId()
         );
 
-        if ($context->getSalesChannel()->getTypeId() !== Defaults::SALES_CHANNEL_TYPE_STOREFRONT) {
+        if ($context->getSalesChannel()->getTypeId() !== Defaults::SALES_CHANNEL_TYPE_STOREFRONT && $context->getSalesChannel()->getTypeId() !== Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON) {
             throw new SalesChannelNotFoundException();
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Product Comparison Sales Channels are not generated when set to "generate by cronjob".

### 2. What does this change do, exactly?
This change allows the cronjob  "product_export_generate_task" to generate a task to generate the product comparison export.

### 3. Describe each step to reproduce the issue or behaviour.

1.  Create Sales Channel type Product Comparison
2. Set generation interval to 2 minutes or higher
3. Set Generate by Cronjob as active
4. Call the File to be generated first
5. Add a new Product
6. Wait the Interval Duration
7. Call the Export File again

### 4. Please link to the relevant issues (if any).
[NEXT-24393](https://issues.shopware.com/issues/NEXT-24393)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
-> I have tested it and it fails without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
-> No need to adjust the documentation
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2868"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

