### PR TITLE
Consistency in Inherited TranslatedField CustomFields

### DIFF
--- a/changelog/_unreleased/2022-12-01-plain-customfield-values.md
+++ b/changelog/_unreleased/2022-12-01-plain-customfield-values.md
@@ -1,0 +1,9 @@
+---
+title: Set plain customFields value
+issue: NEXT-24415
+author: Fabian Boensch
+author_github: @En0Ma1259
+---
+# Core
+* Changed method `customFields()` in `Framework/DataAbstractionLayer/Dbal/EntityHydrator.php` to set non tranlated value.
+```

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -407,8 +407,15 @@ class EntityHydrator
             $entity->addTranslated($propertyName, $decoded);
 
             if ($inherited) {
-                $value = $customField->getSerializer()->decode($customField, $value);
-                $entity->assign([$propertyName => $value]);
+                $parentKey = $chain[1] . '.' . $propertyName;
+                $values = [
+                    $value,
+                    $row[$parentKey] ?? null
+                ];
+
+                $merged = $this->mergeJson(array_reverse($values, false));
+                $decoded = $customField->getSerializer()->decode($customField, $merged);
+                $entity->assign([$propertyName => $decoded]);
             }
 
             return;

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -407,7 +407,8 @@ class EntityHydrator
             $entity->addTranslated($propertyName, $decoded);
 
             if ($inherited) {
-                $entity->assign([$propertyName => $decoded]);
+                $value = $customField->getSerializer()->decode($customField, $value);
+                $entity->assign([$propertyName => $value]);
             }
 
             return;

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -407,10 +407,11 @@ class EntityHydrator
             $entity->addTranslated($propertyName, $decoded);
 
             if ($inherited) {
+                $key = $chain[0] . '.' . $propertyName;
                 $parentKey = $chain[1] . '.' . $propertyName;
                 $values = [
-                    $value,
-                    $row[$parentKey] ?? null
+                    $row[$key] ?? null,
+                    $row[$parentKey] ?? null,
                 ];
 
                 $merged = $this->mergeJson(array_reverse($values, false));

--- a/tests/unit/php/Core/Framework/DataAbstractionLayer/Dbal/EntityHydratorTest.php
+++ b/tests/unit/php/Core/Framework/DataAbstractionLayer/Dbal/EntityHydratorTest.php
@@ -200,6 +200,27 @@ class EntityHydratorTest extends TestCase
         $customFields = $first->get('customTranslated');
         static::assertSame('PARENT ENGLISH', $customFields['custom_test_text']);
         static::assertSame('0', $customFields['custom_test_check']);
+
+        $rows = [
+            [
+                'test.id' => $id,
+                'test.name' => 'example',
+                'test.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
+                'test.translation.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
+                'test.translation.fallback_1.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
+                'test.parent.translation.customTranslated' => '{"custom_test_text": "PARENT DEUTSCH"}',
+                'test.parent.translation.fallback_1.customTranslated' => '{"custom_test_text": null, "custom_test_check": "0"}',
+            ],
+        ];
+
+        $structs = $this->hydrator->hydrate(new EntityCollection(), $definition->getEntityClass(), $definition, $rows, 'test', $context);
+        $first = $structs->first();
+
+        $customFields = $first->get('customTranslated');
+        $translated = $first->getTranslation('customTranslated');
+        static::assertNull($customFields['custom_test_text'] ?? null);
+        static::assertSame('PARENT DEUTSCH', $translated['custom_test_text']);
+        static::assertSame('0', $customFields['custom_test_check']);
     }
 
     public function testCustomFieldHydrationWithTranslationWithoutInheritance(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Everywhere with an entity, the plain attribute value is the value from the database. Under translated is the translated/inherited value. Product customFields are different. There is no different between ex. "product.customFields" and "product.translated.customFields"

### 2. What does this change do, exactly?
Sets the not translated value to customFields attribute

### 3. Describe each step to reproduce the issue or behaviour.
An easy way to see the difference is to go to the Storefront and dumping different translatable values.

1. Storefront should be a different language than default.
2. Attribute should be null. In administration, the value is a field placeholder or a violet anchor

Ex. 
{{ dump(product.customFields) }}
{{ dump(product.translated.customFields) }}
{{ dump(product.name) }} -> null
 {{ dump(product.translated.name) }} -> "Test product" …

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-24415

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2869"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

