### PR TITLE
Add $definitionClass type / extend constructor

### DIFF
--- a/changelog/_unreleased/2022-12-01-optimize-entity-type.md
+++ b/changelog/_unreleased/2022-12-01-optimize-entity-type.md
@@ -1,0 +1,13 @@
+---
+title: Optimize EntityType
+issue:
+flag:
+author: Jan Matthiesen
+author_email: jm@netinventors.de
+author_github: jmatthiesen81
+---
+
+# Core
+* Added more specifying type declaration PHP dockblocks.
+* Added class member definition `\Shopware\Core\Framework\Event\EventData\EntityType::$definitionClass` to improve code quality.
+* Changed class constructor `\Shopware\Core\Framework\Event\EventData\EntityType::__construct` to add the possibility to pass an object of `\Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition` to the constructor.

--- a/src/Core/Framework/Event/EventData/EntityType.php
+++ b/src/Core/Framework/Event/EventData/EntityType.php
@@ -2,17 +2,26 @@
 
 namespace Shopware\Core\Framework\Event\EventData;
 
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+
 class EntityType implements EventDataType
 {
     public const TYPE = 'entity';
 
     /**
-     * @var string
+     * @var class-string<EntityDefinition>
      */
-    private $definitionClass;
+    private string $definitionClass;
 
-    public function __construct(string $definitionClass)
+    /**
+     * @param class-string<EntityDefinition>|EntityDefinition $definitionClass
+     */
+    public function __construct(string|EntityDefinition $definitionClass)
     {
+        if ($definitionClass instanceof EntityDefinition) {
+            $definitionClass = $definitionClass::class;
+        }
+
         $this->definitionClass = $definitionClass;
     }
 

--- a/src/Core/Framework/Test/Event/EventData/EntityTypeTest.php
+++ b/src/Core/Framework/Test/Event/EventData/EntityTypeTest.php
@@ -21,5 +21,6 @@ class EntityTypeTest extends TestCase
         ];
 
         static::assertEquals($expected, (new EntityType($definition))->toArray());
+        static::assertEquals($expected, (new EntityType(new CustomerDefinition()))->toArray());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

This pull request improves the code quality and reduces the possiblity using  the EntityType constructor in a wrong way.

### 2. What does this change do, exactly?

* This pull request adds some more specifying type declaration PHP dockblocks. 
* This pull request adds the type definition of the class member `\Shopware\Core\Framework\Event\EventData\EntityType::$definitionClass`
* This pull request extends the class constructor `\Shopware\Core\Framework\Event\EventData\EntityType::__construct` to add the possibility to pass an object of `\Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition` to the constructor

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2870"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

