### PR TITLE
Remove available stock indexing on order change

### DIFF
--- a/changelog/_unreleased/2022-12-02-improve-order-transition-performance-redundant-calculation.md
+++ b/changelog/_unreleased/2022-12-02-improve-order-transition-performance-redundant-calculation.md
@@ -1,0 +1,10 @@
+---
+title: Improve order transition performance by removing redundant calculation
+issue: NEXT-24671
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed `\Shopware\Core\Content\Product\DataAbstractionLayer\StockUpdater::updateStock` to also update sales in inverse direction and renamed it to `\Shopware\Core\Content\Product\DataAbstractionLayer\StockUpdater::updateStockAndSales` 
+* Removed and replaced calls to `\Shopware\Core\Content\Product\DataAbstractionLayer\StockUpdater::increaseStock`/`decreaseStock` to just call `::updateStockAndSales` on order state transition to skip heavy calculations within `\Shopware\Core\Content\Product\DataAbstractionLayer\StockUpdater::updateAvailableStockAndSales`, that recalculates indexed values, that are already on their correct value at that time 


### PR DESCRIPTION
### 0. Draft?

This is a draft because I need feedback on why we have this indexing? Isn't an increment enough until the next indexing? Maybe move the storage somewhere else like the message counting?

### 1. Why is this change necessary?

When you have lots of orders, you index your orders every time you set it to completed. When you have lots of orders you have a lot more order line items. When you have a lot of order line items, running `updateAvailableStockAndSales` needs to query a lot more on the database (index seems not to be very supportive here although some of the queried fields are not indexed and are likely to be non-unique). So when you have more orders, you update stocks more often; when you have more orders, you updating stocks takes longer. So having a lot of orders is a bad idea.

![an online shop should not have orders?! - why would you say something so controversial yet so brave?](https://user-images.githubusercontent.com/1133593/205268988-ccc4395c-bcf8-4702-bb89-eae26ebad6e9.png)

### 2. What does this change do, exactly?

It removes the updating of the available stock recalculation as this is already reduced on order placed and it is recalculated anytime a product is written.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have a lot of orders
2. I mean a lot of orders
3. Start crying when order status transition "complete" takes 1 minute because it contains multiple products that are ordered frequently
4. Complete orders a lot at the same time because having lots of orders means processing lot of orders at once

### 4. Please link to the relevant issues (if any).

There is something on the roadmap about the stock. Maybe there is a ticket related.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2871"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

