### PR TITLE
NEXT-00000 - Include `DocumentGenerateOperation`s in `DocumentOrderEvent`s

### DIFF
--- a/changelog/_unreleased/2022-11-21-extend-document-renderer-events.md
+++ b/changelog/_unreleased/2022-11-21-extend-document-renderer-events.md
@@ -1,0 +1,9 @@
+---
+title: Extend document renderer events
+issue: NEXT-00000
+author: Felix Brucker
+author_email: felix@felixbrucker.com
+author_github: felixbrucker
+---
+# Core
+* Extended the `Shopware\Core\Checkout\Document\Event\DocumentOrderEvent` with the corresponding `Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation`s for the orders.

--- a/src/Core/Checkout/Document/Event/DocumentOrderEvent.php
+++ b/src/Core/Checkout/Document/Event/DocumentOrderEvent.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Document\Event;
 
+use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Framework\Context;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -10,12 +11,29 @@ abstract class DocumentOrderEvent extends Event
 {
     private OrderCollection $orders;
 
+    /**
+     * @var DocumentGenerateOperation[]
+     */
+    private array $operations;
+
     private Context $context;
 
-    public function __construct(OrderCollection $orders, Context $context)
+    /**
+     * @param DocumentGenerateOperation[] $operations
+     */
+    public function __construct(OrderCollection $orders, array $operations, Context $context)
     {
         $this->orders = $orders;
+        $this->operations = $operations;
         $this->context = $context;
+    }
+
+    /**
+     * @return DocumentGenerateOperation[]
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
     }
 
     public function getContext(): Context

--- a/src/Core/Checkout/Document/Renderer/CreditNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/CreditNoteRenderer.php
@@ -115,7 +115,7 @@ final class CreditNoteRenderer extends AbstractDocumentRenderer
             }
         }
 
-        $this->eventDispatcher->dispatch(new CreditNoteOrdersEvent($orders, $context));
+        $this->eventDispatcher->dispatch(new CreditNoteOrdersEvent($orders, $operations, $context));
 
         foreach ($orders as $order) {
             $orderId = $order->getId();

--- a/src/Core/Checkout/Document/Renderer/DeliveryNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/DeliveryNoteRenderer.php
@@ -88,7 +88,7 @@ final class DeliveryNoteRenderer extends AbstractDocumentRenderer
             /** @var OrderCollection $orders */
             $orders = $this->orderRepository->search($criteria, $context)->getEntities();
 
-            $this->eventDispatcher->dispatch(new DeliveryNoteOrdersEvent($orders, $context));
+            $this->eventDispatcher->dispatch(new DeliveryNoteOrdersEvent($orders, $operations, $context));
 
             foreach ($orders as $order) {
                 $orderId = $order->getId();

--- a/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
@@ -88,7 +88,7 @@ final class InvoiceRenderer extends AbstractDocumentRenderer
             /** @var OrderCollection $orders */
             $orders = $this->orderRepository->search($criteria, $context)->getEntities();
 
-            $this->eventDispatcher->dispatch(new InvoiceOrdersEvent($orders, $context));
+            $this->eventDispatcher->dispatch(new InvoiceOrdersEvent($orders, $operations, $context));
 
             foreach ($orders as $order) {
                 $orderId = $order->getId();

--- a/src/Core/Checkout/Document/Renderer/StornoRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/StornoRenderer.php
@@ -114,7 +114,7 @@ final class StornoRenderer extends AbstractDocumentRenderer
 
         // TODO: future implementation (only fetch required data and associations)
 
-        $this->eventDispatcher->dispatch(new StornoOrdersEvent($orders, $context));
+        $this->eventDispatcher->dispatch(new StornoOrdersEvent($orders, $operations, $context));
 
         foreach ($orders as $order) {
             $orderId = $order->getId();

--- a/src/Core/Checkout/Test/Document/Renderer/CreditNoteRendererTest.php
+++ b/src/Core/Checkout/Test/Document/Renderer/CreditNoteRendererTest.php
@@ -143,6 +143,8 @@ class CreditNoteRendererTest extends TestCase
         );
 
         static::assertInstanceOf(CreditNoteOrdersEvent::class, $caughtEvent);
+        static::assertCount(1, $caughtEvent->getOperations());
+        static::assertSame($operation, $caughtEvent->getOperations()[$orderId] ?? null);
         static::assertCount(1, $caughtEvent->getOrders());
         $order = $caughtEvent->getOrders()->get($orderId);
         static::assertNotNull($order);

--- a/src/Core/Checkout/Test/Document/Renderer/DeliveryNoteRendererTest.php
+++ b/src/Core/Checkout/Test/Document/Renderer/DeliveryNoteRendererTest.php
@@ -85,6 +85,8 @@ class DeliveryNoteRendererTest extends TestCase
         );
 
         static::assertInstanceOf(DeliveryNoteOrdersEvent::class, $caughtEvent);
+        static::assertCount(1, $caughtEvent->getOperations());
+        static::assertSame($operation, $caughtEvent->getOperations()[$orderId] ?? null);
         static::assertCount(1, $caughtEvent->getOrders());
         static::assertInstanceOf(RendererResult::class, $processedTemplate);
         static::assertArrayHasKey($orderId, $processedTemplate->getSuccess());

--- a/src/Core/Checkout/Test/Document/Renderer/StornoRendererTest.php
+++ b/src/Core/Checkout/Test/Document/Renderer/StornoRendererTest.php
@@ -123,6 +123,8 @@ class StornoRendererTest extends TestCase
         );
 
         static::assertInstanceOf(StornoOrdersEvent::class, $caughtEvent);
+        static::assertCount(1, $caughtEvent->getOperations());
+        static::assertSame($operation, $caughtEvent->getOperations()[$orderId] ?? null);
         static::assertCount(1, $caughtEvent->getOrders());
         $order = $caughtEvent->getOrders()->get($orderId);
         static::assertNotNull($order);

--- a/tests/integration/php/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
+++ b/tests/integration/php/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
@@ -90,6 +90,8 @@ class InvoiceRendererTest extends TestCase
         );
 
         static::assertInstanceOf(InvoiceOrdersEvent::class, $caughtEvent);
+        static::assertCount(1, $caughtEvent->getOperations());
+        static::assertSame($operationInvoice, $caughtEvent->getOperations()[$orderId] ?? null);
         static::assertCount(1, $caughtEvent->getOrders());
         $order = $caughtEvent->getOrders()->get($orderId);
         static::assertNotNull($order);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently when trying to extend or modify the functionality of the "new" document renderer classes we do not have a single point where we have both, the order entity to be passed into the template renderer, as well as the document config for this order. As such it is impossible to modify the order or part of it based on the document config.

### 2. What does this change do, exactly?

This PR extends the `DocumentOrderEvent` to include the respective `DocumentGenerateOperation`s for the passed orders, so that when extending for example the `DeliveryNoteRenderer` via the `DeliveryNoteOrdersEvent` we can modify the order entities based on their respective operations.

### 3. Describe each step to reproduce the issue or behaviour.

Try to extend the `DeliveryNoteRenderer` to filter specific products and adjust their quantities on the resulting template using the document config `custom` field.


### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2878"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

