### PR TITLE
Consider inheritance for product streams

### DIFF
--- a/changelog/_unreleased/2022-12-16-consider-inheritance-for-product-streams.md
+++ b/changelog/_unreleased/2022-12-16-consider-inheritance-for-product-streams.md
@@ -1,0 +1,15 @@
+---
+title: Consider inheritance for product streams
+issue: NEXT-23625
+flag:
+author: Miriam Hager
+author_email: miriam.hager@acris.at
+author_github: acris-mh
+---
+# Core
+*  Changed ProductStreamUpdater.php. Added new line at 100. Consider inheritance set to true for context.
+___
+
+# Upgrade Information
+## Consider inheritance for product streams
+### With this fix the product variants are indexed correctly in the product_stream_mapping table

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
@@ -97,6 +97,8 @@ class ProductStreamUpdater extends EntityIndexer
         }
 
         $criteria->setLimit(150);
+        $message->getContext()->setConsiderInheritance(true);
+
         $iterator = new RepositoryIterator(
             $this->repository,
             $message->getContext(),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Only the product where the variants were generated can be found in the product_stream_mapping with the specific product_stream_id of the dynamic product group. The variants can not be found.

### 2. What does this change do, exactly?
With this fix the product variants are indexed correctly in the product_stream_mapping table

### 3. Describe each step to reproduce the issue or behaviour.
1) create a product with variants 2) create a dynamic product group with the filter contains (the previously created product should be found by the filter) 3) check the preview from the dynamic products (the product with its variants should be listed) 4) check in the table product_stream_mapping if the dynamic product group exists 5) check in the table product_stream_mapping if the dynamic product group exists for a variant of the previously created product

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-23625

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2888"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

