### PR TITLE
Changed default sorting for export to autoIncrement and createdAt if available

### DIFF
--- a/changelog/_unreleased/2022-12-20-fix-export-of-entities-without-default-fields.md
+++ b/changelog/_unreleased/2022-12-20-fix-export-of-entities-without-default-fields.md
@@ -1,0 +1,9 @@
+---
+title: Fix export of entities without default fields
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed condition for using a default sorting on `createdAt` in `\Shopware\Core\Content\ImportExport\ImportExport::export` from "has no sorting yet" to "has no sorting yet and has createdAt in its definition" to ensure, that sorting by `createdAt` will work
+* Added new default sorting by `autoIncrement` to `\Shopware\Core\Content\ImportExport\ImportExport::export` as this is a sorting preferred identifier as it is reliably sortable with new entries and is unique


### PR DESCRIPTION
### 1. Why is this change necessary?

If you add a new profile to the Import/Export you can add entities but they fail to be exported if they don't have createdAt column. Which is super tricky to find out as dead message handling seems to sort-of mutes the exception :/ Not debug that further though.

### 2. What does this change do, exactly?

Check whether you have createdAt in the entity definition so it should be safe to sort on that. Add auto increment as preferred sorting as it is more reliable for sorting.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create an entity without createdAt/updatedAt
2. Overwrite admin component for new entity
3. Export that entity
4. Processing "takes ages" / "never finishes"

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2892"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

