### PR TITLE
Fixed a 6.5 feature flag bug where image magnifier didn't run on XXL viewports

### DIFF
--- a/changelog/_unreleased/2022-20-12-fix-magnifier-xxl-viewports.md
+++ b/changelog/_unreleased/2022-20-12-fix-magnifier-xxl-viewports.md
@@ -1,0 +1,9 @@
+---
+title: Fix image magnifier on XXL viewports
+issue: https://github.com/shopware/platform/pull/2894
+author: Jonas Søndergaard
+author_email: jonas@wexo.dk
+author_github: @Josniii
+---
+# Storefront
+* Fixed a 6.5 feature-flag bug where image magnifier didn't run on XXL viewports

--- a/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/magnifier/magnifier.plugin.js
@@ -130,6 +130,7 @@ export default class MagnifierPlugin extends Plugin {
         const allowedViewports = [
             ViewportDetection.isLG(),
             ViewportDetection.isXL(),
+            ViewportDetection.isXXL(),
         ];
 
         return allowedViewports.indexOf(true) !== -1;


### PR DESCRIPTION
### 1. Why is this change necessary?

Shopware 6.5 storefront will have a new XXL viewport which is currently not handled in the magnifier plugin. This means that the magnifier plugin will work on LG/XL screens, but then stop working when the screen gets bigger than XL.

### 2. What does this change do, exactly?

Adds XXL viewport to list of allowed viewports for the magnifier plugin.

### 3. Describe each step to reproduce the issue or behaviour.

On a shop running 6.5 feature flag, open a product page on a screen large enough to be classified as XXL. Hover the image - the magnifier plugin will not run. Reduce the screen size until it matches XL - the magnifier now runs.

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2894"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

