### PR TITLE
Add static return type to Collection methods to support static analysis

### DIFF
--- a/changelog/_unreleased/2023-01-04-add-static-type-hints-on-collections-for-better-static-code-analysis.md
+++ b/changelog/_unreleased/2023-01-04-add-static-type-hints-on-collections-for-better-static-code-analysis.md
@@ -1,0 +1,8 @@
+---
+title: Add static as return value on EntityCollection methods for better static code analysis
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added PHPDoc @return type static to `\Shopware\Core\Framework\DataAbstractionLayer\EntityCollection::filterByProperty`, `\Shopware\Core\Framework\DataAbstractionLayer\EntityCollection::filterAndReduceByProperty` and `\Shopware\Core\Framework\DataAbstractionLayer\EntityCollection::getList` so it is understood as static instead of inherently mixed

--- a/src/Core/Framework/DataAbstractionLayer/EntityCollection.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityCollection.php
@@ -46,6 +46,12 @@ class EntityCollection extends Collection
         });
     }
 
+    /**
+     * tag v.6.6.0 Return type will be natively typed to `static`
+     *
+     * @return static
+     */
+    #[\ReturnTypeWillChange]
     public function filterByProperty(string $property, $value)
     {
         return $this->filter(
@@ -55,6 +61,12 @@ class EntityCollection extends Collection
         );
     }
 
+    /**
+     * tag v.6.6.0 Return type will be natively typed to `static`
+     *
+     * @return static
+     */
+    #[\ReturnTypeWillChange]
     public function filterAndReduceByProperty(string $property, $value)
     {
         $filtered = [];
@@ -100,6 +112,12 @@ class EntityCollection extends Collection
         }
     }
 
+    /**
+     * tag v.6.6.0 Return type will be natively typed to `static`
+     *
+     * @return static
+     */
+    #[\ReturnTypeWillChange]
     public function getList(array $ids)
     {
         return $this->createNew(array_intersect_key($this->elements, array_flip($ids)));

--- a/src/Core/Framework/Struct/Collection.php
+++ b/src/Core/Framework/Struct/Collection.php
@@ -123,8 +123,11 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
     /**
      * @param class-string $class
      *
+     * tag v.6.6.0 Return type will be natively typed to `static`
+     *
      * @return static
      */
+    #[\ReturnTypeWillChange]
     public function filterInstance(string $class)
     {
         return $this->filter(static function ($item) use ($class) {
@@ -133,16 +136,22 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
     }
 
     /**
+     * tag v.6.6.0 Return type will be natively typed to `static`
+     *
      * @return static
      */
+    #[\ReturnTypeWillChange]
     public function filter(\Closure $closure)
     {
         return $this->createNew(array_filter($this->elements, $closure));
     }
 
     /**
+     * tag v.6.6.0 Return type will be natively typed to `static`
+     *
      * @return static
      */
+    #[\ReturnTypeWillChange]
     public function slice(int $offset, ?int $length = null)
     {
         return $this->createNew(\array_slice($this->elements, $offset, $length, true));
@@ -217,8 +226,11 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
     /**
      * @param iterable<TElement> $elements
      *
+     * tag v.6.6.0 Return type will be natively typed to `static`
+     *
      * @return static
      */
+    #[\ReturnTypeWillChange]
     protected function createNew(iterable $elements = [])
     {
         return new static($elements);


### PR DESCRIPTION
### 1. Why is this change necessary?

psalm goes: weeeeeee you used filterByProperty and I don't know what I get from it :'(

### 2. What does this change do, exactly?

Adds hint about the return values of filterByProperty and similar methods.

### 3. Describe each step to reproduce the issue or behaviour.

Run this through psalm:

```php
$salesChannelContext->getSalesChannel()?->getDomains()?->filterByProperty('languageId', $salesChannelContext->getLanguageId())?->first()
```

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2910"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

