### PR TITLE
Change translation items from Artikel to Einträge to reduce ambiguity to products

### DIFF
--- a/changelog/_unreleased/2023-01-05-reduce-german-ambiguity-on-items-in-administration-snippet.md
+++ b/changelog/_unreleased/2023-01-05-reduce-german-ambiguity-on-items-in-administration-snippet.md
@@ -1,0 +1,8 @@
+---
+title: Change translation items from Artikel to Einträge to reduce ambiguity to products
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Changed German translation for items in snippet `global.sw-data-grid.maximumSelectionExceed` from "Artikel" to "Einträge" as "Artikel" is rather used for an alternative translation of products

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -233,7 +233,7 @@
       "labelColumnHide": "Spalte ausblenden",
       "labelSelectionCount": "Ausgewählt:",
       "labelDeSelectAll": "Alle abwählen",
-      "maximumSelectionExceed": "Maximale Anzahl Artikel ausgewählt"
+      "maximumSelectionExceed": "Maximale Anzahl an Einträgen ausgewählt"
     },
     "sw-pagination": {
       "labelItemsPerPage": "Einträge pro Seite:"


### PR DESCRIPTION
### 1. Why is this change necessary?

When you use bulk edit of customers as an admin user with German UI language and select a lot of customers you see the text that too many Artikel are selected. Artikel is often used as alternative word for products. This makes it look wrong but Artikel is just a possible translation for item. To reduce that confusion just let use Eintrag for item instead of Artikel.

### 2. What does this change do, exactly?

Change Artikel (pl) to Einträge.

### 3. Describe each step to reproduce the issue or behaviour.

1. Be German :de: admin user
2. Have at least 1k of customers
3. Select all customers until you reach maximum
4. Be confused why you get a product related info text when selecting customers

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 5. Extra

Thanks for @jkrzefski for spotting this.

<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2911"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

