### PR TITLE
Added media uploaded, written and deleted events

### DIFF
--- a/changelog/_unreleased/2023-01-06-added-media-uploaded-event.md
+++ b/changelog/_unreleased/2023-01-06-added-media-uploaded-event.md
@@ -1,0 +1,13 @@
+---
+title: added-media-uploaded-event
+issue: NEXT-
+author: Hung Mac
+author_email: hung@shapeandshift.dev
+author_github: hungmac-sw
+---
+# Core
+* Created a new event name `media.uploaded` in `Shopware/Core/Content/Media/Event/MediaUploadedEvent`, the webhook will be sending this event to the apps.
+* Added `MediaUploadedEvent` event dispatch to `Shopware/Core/Content/Media/Api/MediaUploadController::upload`, After the media is saved to the system successfully, it will be sending a webhook to the apps.
+* Changed `\Shopware\Core\Framework\Webhook\Hookable\HookableEventCollector` to make the written events of the `media` entity hookable.
+* Added new awareness interface: `Shopware\Core\Content\Flow\Dispatching\Aware\MediaUploadedAware`.
+* Added new classes storer: `Shopware\Core\Content\Flow\Dispatching\Storer\MediaUploadedStorer`.

--- a/src/Core/Content/DependencyInjection/flow.xml
+++ b/src/Core/Content/DependencyInjection/flow.xml
@@ -266,6 +266,10 @@
             <tag name="flow.storer"/>
         </service>
 
+        <service id="Shopware\Core\Content\Flow\Dispatching\Storer\MediaUploadedStorer">
+            <tag name="flow.storer"/>
+        </service>
+
         <service id="Shopware\Core\Content\Flow\Dispatching\FlowFactory" public="true">
             <argument type="tagged_iterator" tag="flow.storer"/>
         </service>

--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -179,6 +179,8 @@
             <argument type="service" id="Shopware\Core\Content\Media\File\FileSaver"/>
             <argument type="service" id="Shopware\Core\Content\Media\File\FileNameProvider"/>
             <argument type="service" id="Shopware\Core\Content\Media\MediaDefinition"/>
+            <argument type="service" id="event_dispatcher"/>
+
             <call method="setContainer">
                 <argument type="service" id="service_container"/>
             </call>

--- a/src/Core/Content/Flow/Dispatching/Aware/MediaUploadedAware.php
+++ b/src/Core/Content/Flow/Dispatching/Aware/MediaUploadedAware.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Flow\Dispatching\Aware;
+
+use Shopware\Core\Framework\Event\FlowEventAware;
+
+/**
+ * @package business-ops
+ */
+interface MediaUploadedAware extends FlowEventAware
+{
+    public const MEDIA_ID = 'mediaId';
+
+    public const MEDIA_UPLOADED = 'mediaUploaded';
+
+    public function getMediaId(): string;
+}

--- a/src/Core/Content/Flow/Dispatching/Storer/MediaUploadedStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/MediaUploadedStorer.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Flow\Dispatching\Storer;
+
+use Shopware\Core\Content\Flow\Dispatching\Aware\MediaUploadedAware;
+use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Event\FlowEventAware;
+
+/**
+ * @package business-ops
+ */
+class MediaUploadedStorer extends FlowStorer
+{
+    /**
+     * @param array<string, mixed> $stored
+     *
+     * @return array<string, mixed>
+     */
+    public function store(FlowEventAware $event, array $stored): array
+    {
+        if (!$event instanceof MediaUploadedAware || isset($stored[MediaUploadedAware::MEDIA_ID])) {
+            return $stored;
+        }
+
+        $stored[MediaUploadedAware::MEDIA_ID] = $event->getMediaId();
+
+        return $stored;
+    }
+
+    public function restore(StorableFlow $storable): void
+    {
+        if (!$storable->hasStore(MediaUploadedAware::MEDIA_ID)) {
+            return;
+        }
+
+        $storable->setData(MediaUploadedAware::MEDIA_ID, $storable->getStore(MediaUploadedAware::MEDIA_ID));
+    }
+}

--- a/src/Core/Content/Media/Event/MediaUploadedEvent.php
+++ b/src/Core/Content/Media/Event/MediaUploadedEvent.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Media\Event;
+
+use Shopware\Core\Content\Flow\Dispatching\Aware\MediaUploadedAware;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * @package content
+ */
+class MediaUploadedEvent extends Event implements MediaUploadedAware
+{
+    public const EVENT_NAME = 'media.uploaded';
+
+    private string $mediaId;
+
+    private Context $context;
+
+    public function __construct(string $mediaId, Context $context)
+    {
+        $this->mediaId = $mediaId;
+        $this->context = $context;
+    }
+
+    public function getName(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add('mediaId', new ScalarValueType(ScalarValueType::TYPE_STRING));
+    }
+
+    public function getMediaId(): string
+    {
+        return $this->mediaId;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+}

--- a/src/Core/Content/Test/Media/Api/MediaUploadControllerTest.php
+++ b/src/Core/Content/Test/Media/Api/MediaUploadControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Test\Media\Api;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\Event\MediaUploadedEvent;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaType\ImageType;
 use Shopware\Core\Content\Media\Pathname\UrlGeneratorInterface;
@@ -12,6 +13,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -90,6 +92,11 @@ class MediaUploadControllerTest extends TestCase
 
     public function testUploadFromBinaryUsesFileName(): void
     {
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+        $listener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $listener->expects(static::once())->method('__invoke');
+        $this->addEventListener($dispatcher, MediaUploadedEvent::class, $listener);
+
         $url = sprintf(
             '/api/_action/media/%s/upload',
             $this->mediaId
@@ -118,6 +125,11 @@ class MediaUploadControllerTest extends TestCase
 
     public function testUploadFromURL(): void
     {
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+        $listener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $listener->expects(static::once())->method('__invoke');
+        $this->addEventListener($dispatcher, MediaUploadedEvent::class, $listener);
+
         $baseUrl = EnvironmentHelper::getVariable('APP_URL') . '/media/shopware-logo.png';
 
         $url = sprintf(
@@ -154,6 +166,11 @@ class MediaUploadControllerTest extends TestCase
 
     public function testRenameMediaFileThrowsExceptionIfFileNameIsNotPresent(): void
     {
+        $dispatcher = $this->getContainer()->get('event_dispatcher');
+        $listener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $listener->expects(static::never())->method('__invoke');
+        $this->addEventListener($dispatcher, MediaUploadedEvent::class, $listener);
+
         $context = Context::createDefaultContext();
         $this->setFixtureContext($context);
         $media = $this->getPng();

--- a/src/Core/DevOps/Resources/generated/webhook-events-reference.md
+++ b/src/Core/DevOps/Resources/generated/webhook-events-reference.md
@@ -105,3 +105,5 @@
 |`order_address.deleted` | Triggers when a order_address is deleted | `order_address:read` | {"entity":"order_address","operation":"deleted","primaryKey":"array string","payload":"array"}
 |`document.written` | Triggers when a document is written | `document:read` | {"entity":"document","operation":"update insert","primaryKey":"array string","payload":"array"}
 |`document.deleted` | Triggers when a document is deleted | `document:read` | {"entity":"document","operation":"deleted","primaryKey":"array string","payload":"array"}
+|`media.written` | Triggers when a media is written | `media:read` | {"entity":"media","operation":"update insert","primaryKey":"array string","payload":"array"}
+|`media.deleted` | Triggers when a media is deleted | `media:read` | {"entity":"media","operation":"deleted","primaryKey":"array string","payload":"array"}

--- a/src/Core/Framework/Webhook/Hookable/HookableEventCollector.php
+++ b/src/Core/Framework/Webhook/Hookable/HookableEventCollector.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Document\DocumentDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductPrice\ProductPriceDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
@@ -37,6 +38,7 @@ class HookableEventCollector
         OrderDefinition::ENTITY_NAME,
         OrderAddressDefinition::ENTITY_NAME,
         DocumentDefinition::ENTITY_NAME,
+        MediaDefinition::ENTITY_NAME,
     ];
 
     private const PRIVILEGES = 'privileges';

--- a/tests/unit/php/Core/Content/Flow/Dispatching/Storer/MediaUploadedStorerTest.php
+++ b/tests/unit/php/Core/Content/Flow/Dispatching/Storer/MediaUploadedStorerTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Flow\Dispatching\Aware\MediaUploadedAware;
+use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Content\Flow\Dispatching\Storer\MediaUploadedStorer;
+use Shopware\Core\Content\Media\Event\MediaUploadedEvent;
+use Shopware\Core\Content\Test\Flow\TestFlowBusinessEvent;
+
+/**
+ * @package business-ops
+ *
+ * @internal
+ *
+ * @covers \Shopware\Core\Content\Flow\Dispatching\Storer\MediaUploadedStorer
+ */
+class MediaUploadedStorerTest extends TestCase
+{
+    private MediaUploadedStorer $storer;
+
+    public function setUp(): void
+    {
+        $this->storer = new MediaUploadedStorer();
+    }
+
+    public function testStoreWithAware(): void
+    {
+        $event = $this->createMock(MediaUploadedEvent::class);
+        $stored = [];
+        $stored = $this->storer->store($event, $stored);
+        static::assertArrayHasKey(MediaUploadedAware::MEDIA_ID, $stored);
+    }
+
+    public function testStoreWithNotAware(): void
+    {
+        $event = $this->createMock(TestFlowBusinessEvent::class);
+        $stored = [];
+        $stored = $this->storer->store($event, $stored);
+        static::assertArrayNotHasKey(MediaUploadedAware::MEDIA_ID, $stored);
+    }
+
+    public function testRestoreHasStored(): void
+    {
+        $mediaId = '34556f108ab14969a0dcf9d9522fd7df';
+
+        /** @var MockObject|StorableFlow $storable */
+        $storable = $this->createMock(StorableFlow::class);
+
+        $storable->expects(static::exactly(1))
+            ->method('hasStore')
+            ->willReturn(true);
+
+        $storable->expects(static::exactly(1))
+            ->method('getStore')
+            ->willReturn($mediaId);
+
+        $storable->expects(static::exactly(1))
+            ->method('setData')
+            ->with(MediaUploadedAware::MEDIA_ID, $mediaId);
+
+        $this->storer->restore($storable);
+    }
+
+    public function testRestoreEmptyStored(): void
+    {
+        /** @var MockObject|StorableFlow $storable */
+        $storable = $this->createMock(StorableFlow::class);
+
+        $storable->expects(static::exactly(1))
+            ->method('hasStore')
+            ->willReturn(false);
+
+        $storable->expects(static::never())
+            ->method('getStore');
+
+        $storable->expects(static::never())
+            ->method('setData');
+
+        $this->storer->restore($storable);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
A plugin or an app will know that we have new media uploaded or deleted on the system.

### 2. What does this change do, exactly?
I created a new `MediaUploadedEvent` event with the event name is `media.uploaded`.
Then I added it to the `MediaUploadController::upload` to dispatch the event when a media uploaded successfully.
Changed `\Shopware\Core\Framework\Webhook\Hookable\HookableEventCollector` to make the written events of the `media` entity hookable.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2915"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

