### PR TITLE
Fix product detail promise resolution in administration

### DIFF
--- a/changelog/_unreleased/2023-01-08-fix-admin-product-detail-promise-resolution.md
+++ b/changelog/_unreleased/2023-01-08-fix-admin-product-detail-promise-resolution.md
@@ -1,0 +1,8 @@
+---
+title: Fix product detail promise resolution in administration
+issue: T.B.D.
+author: Simone Alers
+author_email: simone@inpout.nl
+---
+# Administration
+* Changed method `loadProduct()` in `module/sw-product/page/sw-product-detail/index.js` to return promise making `loadAll()` method resolve as intended. 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -610,7 +610,7 @@ export default {
         loadProduct() {
             Shopware.State.commit('swProductDetail/setLoading', ['product', true]);
 
-            this.productRepository.get(
+            return this.productRepository.get(
                 this.productId || this.product.id,
                 Shopware.Context.api,
                 this.productCriteria,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When extending the `sw-product-detail` component it is not possible to work with a resolution of the `loadProduct` promise, nor have consistent results with the promise returned by `loadAll`.

### 2. What does this change do, exactly?
It makes sure `loadAll()` works as intended and makes it possible to work with resolution of `loadProduct()`.

### 3. Describe each step to reproduce the issue or behaviour.
See linked issue

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2917

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


## Note
I have not written tests since I have no experience with cypress and this change seems trivial.

<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2918"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

