### PR TITLE
Fixed typo in error code, expectations failed, not exceptions

### DIFF
--- a/changelog/_unreleased/2023-01-11-fix-typo-in-api-expectation-error-code.md
+++ b/changelog/_unreleased/2023-01-11-fix-typo-in-api-expectation-error-code.md
@@ -1,0 +1,8 @@
+---
+title: Fix typo in API expectation error code
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed constant return value of `\Shopware\Core\Framework\Api\Exception\ExceptionFailedException::getErrorCode` from `FRAMEWORK__API_EXCEPTION_FAILED` to `FRAMEWORK__API_EXPECTATION_FAILED`

--- a/src/Core/Framework/Api/Exception/ExceptionFailedException.php
+++ b/src/Core/Framework/Api/Exception/ExceptionFailedException.php
@@ -25,7 +25,7 @@ class ExceptionFailedException extends ShopwareHttpException
 
     public function getErrorCode(): string
     {
-        return 'FRAMEWORK__API_EXCEPTION_FAILED';
+        return 'FRAMEWORK__API_EXPECTATION_FAILED';
     }
 
     public function getStatusCode(): int


### PR DESCRIPTION
### 1. Why is this change necessary?

Super confusing to read when you try to understand the API, when it says, that an exception failed, but rather the expectations failed.

### 2. What does this change do, exactly?

Change a "constant" where value has a typo.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use Admin API
2. Send header for package expectations, that can not be fulfilled
3. Be confused about the error code

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2923"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

