### PR TITLE
Fix Change sorting of availability for best variant calculation

### DIFF
--- a/changelog/_unreleased/2023-01-11-bugfix-find-best-variant-set-available-sort-to-desc.md
+++ b/changelog/_unreleased/2023-01-11-bugfix-find-best-variant-set-available-sort-to-desc.md
@@ -1,0 +1,9 @@
+---
+title: Change the sorting of availability from ASC to DESC for best variant calculation (product detail page) 
+issue: 2924
+author: Markus Schmid (AREA-NET GmbH)
+author_email: info@area-net.de
+author_github: area-net-gmbh
+---
+# Administration
+* Changed availability sorting in `findBestVariant()` method in `src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php` 

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -172,7 +172,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
         $criteria = (new Criteria())
             ->addFilter(new EqualsFilter('product.parentId', $productId))
             ->addSorting(new FieldSorting('product.price'))
-            ->addSorting(new FieldSorting('product.available', 'DESC'))
+            ->addSorting(new FieldSorting('product.available', FieldSorting::DESCENDING))
             ->setLimit(1);
 
         $criteria->setTitle('product-detail-route::find-best-variant');

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -172,7 +172,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
         $criteria = (new Criteria())
             ->addFilter(new EqualsFilter('product.parentId', $productId))
             ->addSorting(new FieldSorting('product.price'))
-            ->addSorting(new FieldSorting('product.available'))
+            ->addSorting(new FieldSorting('product.available', 'DESC'))
             ->setLimit(1);
 
         $criteria->setTitle('product-detail-route::find-best-variant');


### PR DESCRIPTION
### 1. Why is this change necessary?
On the storefront product detail page, the cheapest **NOT AVAILABLE** variant is preselected (and not the **cheapest available**), if there is no variant in the admin storefront presentation is defined.

### 2. What does this change do, exactly?
Change the sorting of availability from ASC to DESC for best variant calculation

### 3. Describe each step to reproduce the issue or behaviour.
- One product with variants and one not available variant (with cheapest price).
- Select "main product" in the storefront presentation and clear "main variant" selection
- open the product detail page in the storefront: The **not available** variant with the cheapest price is preselected.

### 4. Please link to the relevant issues (if any).
#2924

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2925"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

