### PR TITLE
refactor: make KernelTestBehaviour compatible with Symfony MailerAssertionsTrait

### DIFF
--- a/changelog/_unreleased/2023-01-12-make-kerneltestbehaviour-compatible-with-mailerassertionstrait.md
+++ b/changelog/_unreleased/2023-01-12-make-kerneltestbehaviour-compatible-with-mailerassertionstrait.md
@@ -1,0 +1,30 @@
+---
+title: Make KernelTestBehaviour compatible with Symfony MailerAssertionsTrait
+issue: -
+author: Rafael Kraut
+author_email: rk@vi-arise.com
+author_github: RafaelKr
+---
+# Core
+Change all `getKernel` and `getContainer` methods related to `KernelTestBehaviour` trait to `static`.
+
+This makes it compatible with `Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait`.  
+The MailerAssertionsTrait was introduces with Symfony 4.4  
+https://symfony.com/blog/new-in-symfony-4-4-phpunit-assertions-for-email-messages
+
+Also make the methods static in `Shopware\Tests\Bench` and `Shopware\Tests\Unit\Storefront\DependencyInjection\ReverseProxyCompilerPassTest`
+___
+# Upgrade Information
+## Changes to KernelTestBehaviour trait
+If you defined method `getKernel` and/or `getContainer` for anything using the  `Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour` trait, make them static:
+```php
+abstract protected function getKernel(): KernelInterface;
+
+abstract protected function getContainer(): ContainerInterface;
+```
+to
+```php
+abstract protected static function getKernel(): KernelInterface;
+
+abstract protected static function getContainer(): ContainerInterface;
+```

--- a/src/Core/Framework/DependencyInjection/services_test.xml
+++ b/src/Core/Framework/DependencyInjection/services_test.xml
@@ -118,6 +118,12 @@
         <service id="messenger.test_receiver_locator" alias="messenger.receiver_locator" public="true"/>
         <service id="messenger.bus.test_shopware" alias="messenger.bus.shopware" public="true"/>
 
+        <service id="mailer.mailer" class="Symfony\Component\Mailer\Mailer">
+            <argument type="service" id="mailer.transports" />
+            <argument type="service" id="messenger.default_bus" />
+            <argument type="service" id="debug.event_dispatcher" on-invalid="ignore" />
+        </service>
+
         <service id="test.browser" class="Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser" shared="false" public="true">
             <argument type="service" id="kernel" />
             <argument type="service" id="event_dispatcher"/>

--- a/src/Core/Framework/Test/App/AppSystemTestBehaviour.php
+++ b/src/Core/Framework/Test/App/AppSystemTestBehaviour.php
@@ -14,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait AppSystemTestBehaviour
 {
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     protected function getAppLoader(string $appDir): AppLoader
     {

--- a/src/Core/Framework/Test/App/CustomFieldTypeTestBehaviour.php
+++ b/src/Core/Framework/Test/App/CustomFieldTypeTestBehaviour.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait CustomFieldTypeTestBehaviour
 {
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     protected function importCustomField(string $manifestPath): CustomFieldEntity
     {

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/DataAbstractionLayerFieldTestBehaviour.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/DataAbstractionLayerFieldTestBehaviour.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait DataAbstractionLayerFieldTestBehaviour
 {
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     /**
      * @param class-string<EntityDefinition> ...$definitionClasses

--- a/src/Core/Framework/Test/Migration/MigrationTestBehaviour.php
+++ b/src/Core/Framework/Test/Migration/MigrationTestBehaviour.php
@@ -118,5 +118,5 @@ trait MigrationTestBehaviour
         $assertState($dbMigrations, $destructiveUntil, 'update_destructive');
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/Plugin/PluginTestsHelper.php
+++ b/src/Core/Framework/Test/Plugin/PluginTestsHelper.php
@@ -56,7 +56,7 @@ trait PluginTestsHelper
         );
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     private function addTestPluginToKernel(string $pluginName, bool $active = false): void
     {

--- a/src/Core/Framework/Test/TestCaseBase/AdminApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/AdminApiTestBehaviour.php
@@ -262,7 +262,7 @@ trait AdminApiTestBehaviour
         $browser->setServerParameter('_integration_id', $id);
     }
 
-    abstract protected function getKernel(): KernelInterface;
+    abstract protected static function getKernel(): KernelInterface;
 
     /**
      * @param string[] $scopes

--- a/src/Core/Framework/Test/TestCaseBase/BasicTestDataBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/BasicTestDataBehaviour.php
@@ -33,7 +33,7 @@ trait BasicTestDataBehaviour
         return $language->getId();
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     protected function getValidPaymentMethodId(?string $salesChannelId = null): string
     {

--- a/src/Core/Framework/Test/TestCaseBase/CacheTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/CacheTestBehaviour.php
@@ -22,5 +22,5 @@ trait CacheTestBehaviour
             ->reset();
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/TestCaseBase/CommandTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/CommandTestBehaviour.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
 
 trait CommandTestBehaviour
 {
-    abstract protected function getKernel(): KernelInterface;
+    abstract protected static function getKernel(): KernelInterface;
 
     protected function runCommand(Command $command, InputInterface $input, OutputInterface $output, ?KernelInterface $kernel = null): void
     {

--- a/src/Core/Framework/Test/TestCaseBase/CountryAddToSalesChannelTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/CountryAddToSalesChannelTestBehaviour.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 trait CountryAddToSalesChannelTestBehaviour
 {
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     abstract protected function getValidCountryId(?string $salesChannelId = TestDefaults::SALES_CHANNEL): string;
 

--- a/src/Core/Framework/Test/TestCaseBase/DatabaseTransactionBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/DatabaseTransactionBehaviour.php
@@ -67,5 +67,5 @@ trait DatabaseTransactionBehaviour
         }
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/TestCaseBase/FilesystemBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/FilesystemBehaviour.php
@@ -38,5 +38,5 @@ trait FilesystemBehaviour
         MemoryAdapterFactory::clearInstancesMemory();
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/TestCaseBase/KernelTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/KernelTestBehaviour.php
@@ -9,7 +9,7 @@ trait KernelTestBehaviour
 {
     use EventDispatcherBehaviour;
 
-    protected function getKernel(): Kernel
+    protected static function getKernel(): Kernel
     {
         return KernelLifecycleManager::getKernel();
     }
@@ -17,9 +17,9 @@ trait KernelTestBehaviour
     /**
      * This results in the test container, with all private services public
      */
-    protected function getContainer(): ContainerInterface
+    protected static function getContainer(): ContainerInterface
     {
-        $container = $this->getKernel()->getContainer();
+        $container = static::getKernel()->getContainer();
 
         if (!$container->has('test.service_container')) {
             throw new \RuntimeException('Unable to run tests against kernel without test.service_container');

--- a/src/Core/Framework/Test/TestCaseBase/QueueTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/QueueTestBehaviour.php
@@ -45,5 +45,5 @@ trait QueueTestBehaviour
         ]);
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/TestCaseBase/RequestStackTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/RequestStackTestBehaviour.php
@@ -30,5 +30,5 @@ trait RequestStackTestBehaviour
         return $requests;
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
@@ -130,7 +130,7 @@ trait SalesChannelApiTestBehaviour
         return $customerId;
     }
 
-    abstract protected function getKernel(): KernelInterface;
+    abstract protected static function getKernel(): KernelInterface;
 
     protected function getSalesChannelBrowser(): KernelBrowser
     {

--- a/src/Core/Test/FixtureLoader.php
+++ b/src/Core/Test/FixtureLoader.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Test\IdsCollection;
-use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -21,8 +20,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class FixtureLoader
 {
-    use BasicTestDataBehaviour;
-
     private ContainerInterface $container;
 
     private EntityWriterInterface $writer;
@@ -53,7 +50,7 @@ class FixtureLoader
 
         $content = $this->replaceIds($ids, $content);
         $this->sync(\json_decode($content, true, 512, \JSON_THROW_ON_ERROR));
-        $this->container->get(EntityIndexerRegistry::class)->index(false);
+        $this->getContainer()->get(EntityIndexerRegistry::class)->index(false);
 
         return $ids;
     }

--- a/src/Storefront/Test/Controller/StorefrontControllerTestBehaviour.php
+++ b/src/Storefront/Test/Controller/StorefrontControllerTestBehaviour.php
@@ -41,7 +41,7 @@ trait StorefrontControllerTestBehaviour
         return $data;
     }
 
-    abstract protected function getKernel(): KernelInterface;
+    abstract protected static function getKernel(): KernelInterface;
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 }

--- a/src/Storefront/Test/Page/StorefrontPageTestBehaviour.php
+++ b/src/Storefront/Test/Page/StorefrontPageTestBehaviour.php
@@ -251,7 +251,7 @@ trait StorefrontPageTestBehaviour
         });
     }
 
-    abstract protected function getContainer(): ContainerInterface;
+    abstract protected static function getContainer(): ContainerInterface;
 
     private function createCustomer(): CustomerEntity
     {

--- a/tests/performance/bench/BenchCase.php
+++ b/tests/performance/bench/BenchCase.php
@@ -33,7 +33,7 @@ abstract class BenchCase
         $this->getContainer()->get(Connection::class)->rollBack();
     }
 
-    public function getContainer(): ContainerInterface
+    public static function getContainer(): ContainerInterface
     {
         $container = KernelLifecycleManager::getKernel()->getContainer();
 

--- a/tests/unit/php/Storefront/DependencyInjection/ReverseProxyCompilerPassTest.php
+++ b/tests/unit/php/Storefront/DependencyInjection/ReverseProxyCompilerPassTest.php
@@ -105,7 +105,7 @@ class ReverseProxyCompilerPassTest extends TestCase
         static::assertInstanceOf(VarnishService::class, $dummy->get());
     }
 
-    public function getContainer(): ContainerBuilder
+    public static function getContainer(): ContainerBuilder
     {
         $container = new ContainerBuilder();
 


### PR DESCRIPTION
This is the successor PR to #2608

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This change makes the Shopware `KernelTestBehaviour` compatible with `Symfony\Bundle\FrameworkBundle\Test\MailerAssertionsTrait`
The MailerAssertionsTrait was introduced with Symfony 4.4 [symfony.com/blog/new-in-symfony-4-4-phpunit-assertions-for-email-messages](https://symfony.com/blog/new-in-symfony-4-4-phpunit-assertions-for-email-messages)

### 2. What does this change do, exactly?
- This changes all `getKernel` and `getContainer` method implementations and abstract definitions related to `KernelTestBehaviour` to static methods.
- Make the `getKernel` and `getContainer` methods static in `Shopware\Tests\Bench` and `Shopware\Tests\Unit\Storefront\DependencyInjection\ReverseProxyCompilerPassTest`.
- Remove unused `BasicTestDataBehaviour` trait from `FixtureLoader` as `getContainer` method can't be static in `FixtureLoader`.

### 3. Describe each step to reproduce the issue or behaviour.
Add `use MailerAssertionsTrait;` to your testclass and try to call any of the methods of it. For example `$this->getMailerMessages();`

This results in
`Error : Non-static method Vcore\MyPlugin\Test\Error\ErrorHandlerTest::getContainer() cannot be called statically`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2928"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

