### PR TITLE
Fix: Form preserver iterates through wrong elements

### DIFF
--- a/changelog/_unreleased/2023-01-13-form-preserver-iterates-through-wrong-elements.md
+++ b/changelog/_unreleased/2023-01-13-form-preserver-iterates-through-wrong-elements.md
@@ -1,0 +1,9 @@
+---
+title: Form preserver iterates through wrong elements
+issue: https://github.com/shopware/platform/issues/2227
+author: Wanne Van Camp
+author_email: wanne.vancamp@meteor.be
+author_github: @wannevancamp
+---
+# Storefront
+* Changed formelement selector `this.el.children` to `this.el.elements` in `Resources/app/storefront/src/plugin/forms/form-preserver.plugin.js` to select the correct input fields.

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-preserver.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-preserver.plugin.js
@@ -61,7 +61,7 @@ export default class FormPreserverPlugin extends Plugin {
      * @private
      */
     _prepareElements() {
-        let formElements = this.el.children;
+        let formElements = this.el.elements;
         const outSideFormElements = DomAccess.querySelectorAll(document, `:not(form) > [form="${this.el.id}"]`, this.options.strictMode);
 
         formElements = Array.from(formElements);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
#2227

### 2. What does this change do, exactly?
#2227

### 3. Describe each step to reproduce the issue or behaviour.
#2227

### 4. Please link to the relevant issues (if any).
#2227

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2932"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

