### PR TITLE
Fix admin table editing for non-chromium users

### DIFF
--- a/changelog/_unreleased/2023-01-17-fix-admin-table-editor-toolbar-for-non-chrome-user.md
+++ b/changelog/_unreleased/2023-01-17-fix-admin-table-editor-toolbar-for-non-chrome-user.md
@@ -1,0 +1,8 @@
+---
+title: Fix administration table editor toolbar for non Chromium user
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Fixed `sw-text-editor-table-toolbar::getNode` so it refers to `anchorNode` of the selection instead of Chromium only `baseNode`

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-table-toolbar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-table-toolbar/index.js
@@ -245,11 +245,11 @@ Component.register('sw-text-editor-table-toolbar', {
             this.setSelectionRange();
             this.keepSelection();
 
-            if (!this.selection || !this.selection.baseNode) {
+            if (!this.selection || !this.selection.anchorNode) {
                 return null;
             }
 
-            let node = this.selection.baseNode;
+            let node = this.selection.anchorNode;
             if (node.nodeName === '#text') {
                 node = node.parentNode;
             }


### PR DESCRIPTION
### 1. Why is this change necessary?

The code is Chromium only so it does not work in Firefox and likely not Safari. https://stackoverflow.com/a/33586253/

### 2. What does this change do, exactly?

Use a w3c compatible selection property [anchorNode](https://developer.mozilla.org/en-US/docs/Web/API/Selection/anchorNode).

### 3. Describe each step to reproduce the issue or behaviour.

1. Open firefox
2. Log into admin
3. Open CMS
4. Place text block
5. Focus text block
6. Add table with "add table" dialog from toolbar
7. Can't add column
8. Click on cog
9. Click into table
10. See new toolbar
11. Click on an icon that looks like it adds a column
12. Nothing happens
13. Click all the other icons from the table toolbar
14. Still nothing happens
15. Regret opening external rich text editor
16. Copy content to RTE
17. Change table
18. Copy table
19. Paste into Shopware admin text editor

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2936"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

