### PR TITLE
Fix mismatching behaviour of snippet usage in form cms element

### DIFF
--- a/changelog/_unreleased/2023-01-19-fix-form-cms-element-snippet.md
+++ b/changelog/_unreleased/2023-01-19-fix-form-cms-element-snippet.md
@@ -1,0 +1,8 @@
+---
+title: Fix mismatching behaviour of snippet usage in form cms element
+author: Vincent Neubauer
+author_email: v.neubauer@vonmaehlen.com
+author_github: dallyger
+---
+# Storefront
+* Changed template `cms-element-form-infp-required` to sanitize snippet `general.requiredFields`

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-info-required.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-info-required.html.twig
@@ -1,5 +1,5 @@
 {% block cms_form_info_required_fields_content %}
     <div class="form-text mt-4 mb-2">
-        {{ "general.requiredFields"|trans }}
+        {{ "general.requiredFields"|trans|sw_sanitize }}
     </div>
 {% endblock %}


### PR DESCRIPTION
Every other place that uses the `general.requiredFields` snippet uses
`sw_sanitize`. This ensures, that this cms element behaves like every
other template, that uses this snippet, when it contains HTML tags like
`<small>...</small>`.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2939"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

