### PR TITLE
Add app action buttons for category

### DIFF
--- a/changelog/_unreleased/2023-01-24-app-action-buttons-for-category.md
+++ b/changelog/_unreleased/2023-01-24-app-action-buttons-for-category.md
@@ -1,0 +1,9 @@
+---
+title: App action buttons for category
+issue: NEXT-25074
+author: Heiner Lohaus
+author_email: heiner@lohaus.eu
+author_github: hlohaus
+---
+# Administration
+* Added view `detail` on entity `category` for app action buttons

--- a/src/Administration/Resources/app/administration/src/module/sw-category/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/index.js
@@ -86,6 +86,9 @@ Module.register('sw-category', {
             path: 'index/:id',
             meta: {
                 privilege: 'category.viewer',
+                appSystem: {
+                    view: 'detail',
+                },
             },
             redirect: {
                 name: 'sw.category.detail.base',


### PR DESCRIPTION
### 1. Why is this change necessary?

Missing app action buttons for the category entity.

![app](https://user-images.githubusercontent.com/983577/214177247-3b6cb3e8-b713-4cb3-8a45-01541d80abbc.png)

### 2. What does this change do, exactly?

Adds a parameter to the js route.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-25074

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2946"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2948"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

