### PR TITLE
disable permission checks for CryptKey when running on Windows (fixes #2904)

### DIFF
--- a/changelog/_unreleased/2023-01-30-fix-jwt-keys-permission-check-fail-on-windows.md
+++ b/changelog/_unreleased/2023-01-30-fix-jwt-keys-permission-check-fail-on-windows.md
@@ -1,0 +1,9 @@
+---
+title: Fix JWT keys permission check fail on Windows
+issue: NEXT-0000
+author: Raphael Mobis
+author_email: r.mobis@gmail.com
+author_github: rmobis
+---
+# Core
+* Disabled permission checks for inject JWT keys when running on Windows

--- a/src/Core/Framework/DependencyInjection/CompilerPass/WindowsCompatibilityCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/WindowsCompatibilityCompilerPass.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DependencyInjection\CompilerPass;
+
+use League\OAuth2\Server\CryptKey;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class WindowsCompatibilityCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (PHP_OS_FAMILY !== 'Windows') {
+            return;
+        }
+
+        $this->skipCryptKeyPermissionCheck($container);
+    }
+
+    /**
+     * Permission check always fails in Windows because it has a different permission system, so we
+     * disable have to disable it.
+     */
+    public function skipCryptKeyPermissionCheck(ContainerBuilder $container): void
+    {
+        $definitions = $container->getDefinitions();
+        $cryptKeyDefinitions = array_filter(
+            $definitions,
+            static fn(Definition $definition) => $definition->getClass() === CryptKey::class
+        );
+
+        foreach ($cryptKeyDefinitions as $definition) {
+            $arguments = $definition->getArguments();
+
+            if (!\array_key_exists('$passPhrase', $arguments)) {
+                $definition->setArgument('$passPhrase', null);
+            }
+
+            $definition->setArgument('$keyPermissionsCheck', false);
+        }
+    }
+}

--- a/src/Core/Framework/DependencyInjection/CompilerPass/WindowsCompatibilityCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/WindowsCompatibilityCompilerPass.php
@@ -16,7 +16,7 @@ class WindowsCompatibilityCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        if (PHP_OS_FAMILY !== 'Windows') {
+        if (\PHP_OS_FAMILY !== 'Windows') {
             return;
         }
 
@@ -32,7 +32,7 @@ class WindowsCompatibilityCompilerPass implements CompilerPassInterface
         $definitions = $container->getDefinitions();
         $cryptKeyDefinitions = array_filter(
             $definitions,
-            static fn(Definition $definition) => $definition->getClass() === CryptKey::class
+            static fn (Definition $definition) => $definition->getClass() === CryptKey::class
         );
 
         foreach ($cryptKeyDefinitions as $definition) {

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DependencyInjection\CompilerPass\RedisPrefixCompiler
 use Shopware\Core\Framework\DependencyInjection\CompilerPass\RouteScopeCompilerPass;
 use Shopware\Core\Framework\DependencyInjection\CompilerPass\TwigEnvironmentCompilerPass;
 use Shopware\Core\Framework\DependencyInjection\CompilerPass\TwigLoaderConfigCompilerPass;
+use Shopware\Core\Framework\DependencyInjection\CompilerPass\WindowsCompatibilityCompilerPass;
 use Shopware\Core\Framework\DependencyInjection\FrameworkExtension;
 use Shopware\Core\Framework\Increment\IncrementerGatewayCompilerPass;
 use Shopware\Core\Framework\Log\Package;
@@ -111,6 +112,7 @@ class Framework extends Bundle
         $container->addCompilerPass(new RateLimiterCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
         $container->addCompilerPass(new IncrementerGatewayCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
         $container->addCompilerPass(new RedisPrefixCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
+        $container->addCompilerPass(new WindowsCompatibilityCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
 
         if ($container->getParameter('kernel.environment') === 'test') {
             $container->addCompilerPass(new DisableRateLimiterCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Shopware uses `League\OAuth2\Server\CryptKey` from the `league/oauth2-server` package for handling its JWT keys. The maintainers of the package have to opted to, by default, check for filesystem permissions on any key loaded, for improved security. However, because Windows filesystem permission system is not compatible to *NIX's, that check always fails when running the code in Windows, so it has to be disabled.

### 2. What does this change do, exactly?
Disables permission checks when running on Windows by adding the `WindowsCompatibilityCompilerPass` which, when running on Windows, finds all definitions with class `League\OAuth2\Server\CryptKey` and sets it's `$keyPermissionsCheck` to `false`.

Because we're looking for the class and not the service ids (`shopware.(public|private)_key`), this does mean that future new uses of the class will be properly altered, but it also means it can interfere with definitions from outside the core. I think this is ok because, when running on Windows, there's no reason to enable those checks, but let me know if you'd prefer a more specific approach.

### 3. Describe each step to reproduce the issue or behaviour.
On a Windows 11 machine, with PHP v8.1.13, Symfony CLI v5.4.20 and Docker v20.10.21 installed, run the following commands, from this repository's `README.md`:

```bash
> composer create-project shopware/production:dev-flex project
> cd project
> docker compose up -d
> symfony console system:install --basic-setup --drop-database --create-database -f
> symfony server:start -d
```

Then, generate your secret files and remember to set the password to `shopware`:

```bash
> openssl genrsa -out ./config/jwt/private.pem -aes256 4096
> openssl rsa -pubout -in ./config/jwt/private.pem -out ./config/jwt/public.pem
```

Edit the `,env` file at the root to set `APP_ENV=dev` and finally, visit `localhost:8000/admin`. You should be greeted with the previously mentioned error.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2904

### 5. Checklist

#### 5.1 On Testing
I don't believe this would be possible unless we include a Windows pipeline.

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2953"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

