### PR TITLE
NEXT-24952 - Prevent unfiltered cms demo category media search

### DIFF
--- a/changelog/_unreleased/2023-01-31-prevent-unfiltered-cms-demo-category-media-search.md
+++ b/changelog/_unreleased/2023-01-31-prevent-unfiltered-cms-demo-category-media-search.md
@@ -1,0 +1,9 @@
+---
+title: Prevent unfiltered cms demo category media search
+issue: NEXT-24952
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `loadDemoCategory` function in `sw-cms-detail` component to prevent demo category media search if media id is not set.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -524,6 +524,11 @@ export default {
             Shopware.State.commit('cmsPageState/setCurrentDemoEntity', category);
 
             this.loadDemoCategoryProducts(category);
+
+            if (!category.mediaId) {
+                return;
+            }
+
             this.loadDemoCategoryMedia(category);
         },
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Because if the loaded demo category does not have a media assigned to it, all media items are requested on the cms detail page. The huge response blocks operations and freezes the Administration for some seconds.

### 2. What does this change do, exactly?
It prevents the media request if the demo category media is not set.

### 3. Describe each step to reproduce the issue or behaviour.
Open the Administration of a shop with many media items, make sure none of the categories has a media set and create a cms **category** page. After some seconds (the duration of loading the media response) the Administration freezes for some seconds.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-24952

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2958"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

