### PR TITLE
NEXT-23512 - Fix CMS service collect function for array values

### DIFF
--- a/changelog/_unreleased/2023-01-31-fix-cms-service-collect-function-for-array-values.md
+++ b/changelog/_unreleased/2023-01-31-fix-cms-service-collect-function-for-array-values.md
@@ -1,0 +1,9 @@
+---
+title: Fix CMS service collect function for array values
+issue: NEXT-23512
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `getCollectFunction` function in `cmsService` to work with array values by flattening the wrapping array.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.js
@@ -282,7 +282,7 @@ function getCollectFunction() {
                 entityCount += 1;
 
                 const entityData = {
-                    value: [elem.config[configKey].value],
+                    value: [elem.config[configKey].value].flat(),
                     key: configKey,
                     searchCriteria: entity.criteria ? entity.criteria : new Criteria(1, 25),
                     ...entity,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Because data collection for CMS elements with entity multi select configs (array values) is not working. The array of entity ids is wrapped into another array which leads to a malformed request payload by parsing the criteria object (ids separated by "," instead of "|"). The component is not filled with the correct data as a result.

### 2. What does this change do, exactly?
Flatten the value in the collect function to prevent array nesting.

### 3. Describe each step to reproduce the issue or behaviour.
Create a cms page with the product slider element, assign some products and reload the page.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-23512

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2959"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

