### PR TITLE
NEXT-25253 - Add Sorting to DocumentMerger

### DIFF
--- a/changelog/_unreleased/2023-02-01-add-sorting-for-merged-documents.md
+++ b/changelog/_unreleased/2023-02-01-add-sorting-for-merged-documents.md
@@ -1,0 +1,8 @@
+---
+ title: Add sorting to merged Documents
+ author: Cedric Engler
+ author_email: cedric.engler@pickware.de
+ author_github: Ceddy610
+ ---
+ # Core
+ * Adds a default ascending sorting of merged documents in `DocumentMerger` by order number

--- a/changelog/_unreleased/2023-02-01-add-sorting-for-merged-documents.md
+++ b/changelog/_unreleased/2023-02-01-add-sorting-for-merged-documents.md
@@ -1,8 +1,9 @@
 ---
- title: Add sorting to merged Documents
- author: Cedric Engler
- author_email: cedric.engler@pickware.de
- author_github: Ceddy610
- ---
- # Core
- * Adds a default ascending sorting of merged documents in `DocumentMerger` by order number
+title: add-sorting-for-merged-documents
+issue: NEXT-25253
+author: Cedric Engler
+author_email: cedric.engler@pickware.de
+author_github: Ceddy610
+---
+# Core
+* Adds a default ascending sorting of merged documents in `DocumentMerger` by order number

--- a/src/Core/Checkout/Document/Service/DocumentMerger.php
+++ b/src/Core/Checkout/Document/Service/DocumentMerger.php
@@ -15,6 +15,7 @@ use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 
@@ -42,6 +43,7 @@ final class DocumentMerger
 
         $criteria = new Criteria($documentIds);
         $criteria->addAssociation('documentType');
+        $criteria->addSorting(new FieldSorting('order.orderNumber'));
 
         /** @var DocumentCollection $documents */
         $documents = $this->documentRepository->search($criteria, $context);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### Notice:
I did not add a test because testing the order of the documents is obscured by the fact that the order documents are merged into a single PDF and given a single new name. Therefore, the order of the actual pages inside that pdf can only be determined by using a new and complex PDF-Reader and parsing the content of the pages to get an idea of the sorting. This would rather exceed the scope of this PR for the small change.

### 1. Why is this change necessary?
If you try to download multiple documents, they appear in an unpredictable order by default.

### 2. What does this change do, exactly?
This change adds a default sorting of documents by `orderNumber` by default in the `DocumentMerger`

### 3. Describe each step to reproduce the issue or behavior.
Try downloading multiple documents in the bulk edit of orders.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-25253

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2963"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

