### PR TITLE
Implement language switch and smart buttons added by Extension SDK

### DIFF
--- a/changelog/_unreleased/2023-02-03-implement-language-switch-and-smart-bar-buttons-for-main-module-in-app.md
+++ b/changelog/_unreleased/2023-02-03-implement-language-switch-and-smart-bar-buttons-for-main-module-in-app.md
@@ -1,0 +1,11 @@
+---
+title: Implement language switch and smart bar buttons for main module in App
+issue: -
+author: Vu Le
+author_email: vu.le@shapeandshift.dev
+author_github: crisalder2806
+---
+# Administration
+* Added `smartBarButtonAdd` message handler in `app/init/main-module.init.ts` to handle adding language switch and smart buttons from `Admin Extension SDK`
+* Added `sw_extension_sdk_module_smart_bar_buttons`, `sw_extension_sdk_module_language_switch` blocks in `sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.html.twig` to render language switch and smart bar buttons added by `Admin Extension SDK`
+* Changed `sw-extension-component-section/sw-extension-component-section.html.twig` to render tabs inside `card` component section 

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -43,7 +43,7 @@
     "@babel/preset-typescript": "7.18.6",
     "@babel/runtime": "7.19.4",
     "@lhci/cli": "0.9.0",
-    "@shopware-ag/admin-extension-sdk": "3.0.1",
+    "@shopware-ag/admin-extension-sdk": "3.0.4",
     "@shopware-ag/eslint-config-base": "2.0.0",
     "@shopware-ag/meteor-icon-kit": "5.0.0",
     "@shopware-ag/webpack-copy-after-build": "1.0.1",

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/index.ts
@@ -21,6 +21,24 @@ Shopware.Component.register('sw-extension-component-section', {
         positionId: (currentComponent) => currentComponent.positionIdentifier as string,
     },
 
+    data() {
+        return {
+            activeTabName: '',
+        };
+    },
+
+    methods: {
+        setActiveTab(name: string) {
+            this.activeTabName = name;
+        },
+
+        getActiveTab(componentSection: ComponentSectionEntry) {
+            return this.activeTabName
+                ? componentSection.props.tabs.find(tab => tab.name === this.activeTabName)
+                : componentSection.props.tabs[0];
+        },
+    },
+
     props: {
         positionIdentifier: {
             type: String,

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.html.twig
@@ -8,7 +8,35 @@
             :title="componentSection.props.title"
             :subtitle="componentSection.props.subtitle"
         >
+
+            <template
+                v-if="componentSection.props?.tabs"
+                #tabs
+            >
+                <sw-tabs
+                    position-identifier=""
+                    @new-item-active="setActiveTab($event.name)"
+                >
+                    <sw-tabs-item
+                        v-for="tab in componentSection.props.tabs"
+                        :key="tab.name"
+                        :active-tab="getActiveTab(componentSection).name"
+                        :name="tab.name"
+                    >
+                        {{ tab.label }}
+                    </sw-tabs-item>
+                </sw-tabs>
+            </template>
+
             <sw-iframe-renderer
+                v-if="componentSection.props?.tabs && getActiveTab(componentSection)"
+                :key="getActiveTab(componentSection).name"
+                :src="componentSection.src"
+                :location-id="getActiveTab(componentSection)?.locationId"
+            />
+
+            <sw-iframe-renderer
+                v-if="componentSection.props?.locationId && !componentSection.props?.tabs"
                 :src="componentSection.src"
                 :location-id="componentSection.props.locationId"
             />

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.spec.js
@@ -1,0 +1,142 @@
+/**
+ * @package admin
+ */
+
+import { mount } from '@vue/test-utils';
+import 'src/app/component/extension-api/sw-extension-component-section';
+import 'src/app/component/base/sw-card';
+import 'src/app/component/base/sw-tabs';
+import 'src/app/component/base/sw-tabs-item';
+import Vue from 'vue';
+
+describe('src/app/component/extension-api/sw-extension-component-section', () => {
+    let wrapper = null;
+    let stubs;
+
+    async function createWrapper() {
+        return mount(await Shopware.Component.build('sw-extension-component-section'), {
+            propsData: {
+                positionIdentifier: 'test-position',
+            },
+            stubs,
+        });
+    }
+
+    beforeAll(async () => {
+        stubs = {
+            'sw-card': await Shopware.Component.build('sw-card'),
+            'sw-tabs': await Shopware.Component.build('sw-tabs'),
+            'sw-tabs-item': await Shopware.Component.build('sw-tabs-item'),
+            'sw-ignore-class': true,
+            'sw-iframe-renderer': {
+                template: '<div></div>'
+            },
+        };
+    });
+
+    beforeEach(async () => {
+        Vue.set(Shopware.State.get('extensionComponentSections'), 'identifier', {});
+    });
+
+    afterEach(() => {
+        if (wrapper) {
+            wrapper.destroy();
+            wrapper = null;
+        }
+    });
+
+    it('should be a Vue.js component', async () => {
+        wrapper = await createWrapper();
+        expect(wrapper.vm).toBeTruthy();
+    });
+
+    it('should not render tabs in card section', async () => {
+        Shopware.State.commit('extensionComponentSections/addSection', {
+            component: 'card',
+            positionId: 'test-position',
+            props: {
+                title: 'test-card',
+                subtitle: 'test-card-description',
+            },
+        });
+
+        wrapper = await createWrapper();
+        await flushPromises();
+
+        const tabs = wrapper.find('.sw-tabs');
+        expect(tabs.exists()).toBe(false);
+    });
+
+    it('should render tabs in card section', async () => {
+        Shopware.State.commit('extensionComponentSections/addSection', {
+            component: 'card',
+            positionId: 'test-position',
+            props: {
+                title: 'test-card',
+                subtitle: 'test-card-description',
+                tabs: [
+                    {
+                        name: 'tab-1',
+                        label: 'Tab 1',
+                        locationId: 'tab-1',
+                    },
+                    {
+                        name: 'tab-2',
+                        label: 'Tab 2',
+                        locationId: 'tab-2',
+                    },
+                ],
+            },
+        });
+
+        wrapper = await createWrapper();
+        await flushPromises();
+
+        const tabs = wrapper.findAll('.sw-tabs-item');
+        expect(tabs.length).toBe(2);
+
+        const activeTabs = wrapper.findAll('.sw-tabs-item--active');
+        expect(activeTabs.length).toBe(1);
+
+        const activeTab = activeTabs.at(0);
+        expect(activeTab.text()).toEqual('Tab 1');
+    });
+
+    it('should switch tab when clicking', async () => {
+        Shopware.State.commit('extensionComponentSections/addSection', {
+            component: 'card',
+            positionId: 'test-position',
+            props: {
+                title: 'test-card',
+                subtitle: 'test-card-description',
+                tabs: [
+                    {
+                        name: 'tab-1',
+                        label: 'Tab 1',
+                        locationId: 'tab-1',
+                    },
+                    {
+                        name: 'tab-2',
+                        label: 'Tab 2',
+                        locationId: 'tab-2',
+                    },
+                ],
+            },
+        });
+
+        wrapper = await createWrapper();
+        await flushPromises();
+
+        // Default active tab
+        const defaultIframe = wrapper.findComponent(stubs['sw-iframe-renderer']);
+        expect(defaultIframe.vm.$attrs['location-id']).toEqual('tab-1');
+
+        // Click the 2nd tab
+        const tabItems = wrapper.findAll('.sw-tabs-item');
+        await tabItems.at(1).trigger('click');
+
+        // Check tab content
+        const activeIframe = wrapper.findComponent(stubs['sw-iframe-renderer']);
+        expect(activeIframe.vm.$attrs['location-id']).toEqual('tab-2');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/app/init/main-module.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/main-module.init.ts
@@ -30,4 +30,8 @@ export default function initMainModules(): void {
             });
         });
     });
+
+    Shopware.ExtensionAPI.handle('smartBarButtonAdd', (configuration) => {
+        Shopware.State.commit('extensionSdkModules/addSmartBarButton', configuration);
+    });
 }

--- a/src/Administration/Resources/app/administration/src/app/state/extension-sdk-module.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/state/extension-sdk-module.store.ts
@@ -1,10 +1,10 @@
 /**
  * @package admin
  */
-
 /* Is covered by E2E tests */
 /* istanbul ignore file */
 import type { Module } from 'vuex';
+import type { smartBarButtonAdd } from '@shopware-ag/admin-extension-sdk/es/ui/mainModule';
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export type ExtensionSdkModule = {
@@ -13,10 +13,13 @@ export type ExtensionSdkModule = {
     baseUrl: string,
     locationId: string,
     displaySearchBar: boolean,
+    displayLanguageSwitch: boolean,
 };
 
 interface ExtensionSdkModuleState {
     modules: ExtensionSdkModule[],
+
+    smartBarButtons: smartBarButtonAdd[],
 }
 
 const ExtensionSdkModuleStore: Module<ExtensionSdkModuleState, VuexRootState> = {
@@ -24,14 +27,19 @@ const ExtensionSdkModuleStore: Module<ExtensionSdkModuleState, VuexRootState> = 
 
     state: (): ExtensionSdkModuleState => ({
         modules: [],
+        smartBarButtons: [],
     }),
 
     actions: {
-        addModule({ state }, { heading, locationId, displaySearchBar, baseUrl }: ExtensionSdkModule): Promise<string> {
+        addModule(
+            { state },
+            { heading, locationId, displaySearchBar, displayLanguageSwitch, baseUrl }: ExtensionSdkModule,
+        ): Promise<string> {
             const staticElements = {
                 heading,
                 locationId,
                 displaySearchBar,
+                displayLanguageSwitch,
                 baseUrl,
             };
 
@@ -46,6 +54,12 @@ const ExtensionSdkModuleStore: Module<ExtensionSdkModuleState, VuexRootState> = 
             }
 
             return Promise.resolve(id);
+        },
+    },
+
+    mutations: {
+        addSmartBarButton(state, button: smartBarButtonAdd) {
+            state.smartBarButtons.push(button);
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/index.js
@@ -32,6 +32,15 @@ Shopware.Component.register('sw-extension-sdk-module', {
         showSearchBar() {
             return this.module?.displaySearchBar ?? true;
         },
+
+        showLanguageSwitch() {
+            return !!this.module?.displayLanguageSwitch;
+        },
+
+        smartBarButtons() {
+            return Shopware.State.get('extensionSdkModules').smartBarButtons
+                .filter(button => button.locationId === this.module?.locationId);
+        },
     },
 
     watch: {
@@ -64,5 +73,11 @@ Shopware.Component.register('sw-extension-sdk-module', {
         if (this.loadingTimeOut) {
             window.clearTimeout(this.loadingTimeOut);
         }
+    },
+
+    methods: {
+        onChangeLanguage(languageId) {
+            Shopware.State.commit('context/setApiLanguageId', languageId);
+        },
     },
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.html.twig
@@ -10,6 +10,22 @@
         {% endblock %}
     </template>
 
+    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+    {% block sw_extension_sdk_module_smart_bar_buttons %}
+    <template #smart-bar-actions>
+        <sw-button
+            v-for="button in smartBarButtons"
+            :id="button.buttonId"
+            :key="button.buttonId"
+            :disabled="button.disabled"
+            :variant="button.variant"
+            @click="button.onClickCallback"
+        >
+            {{ button.label }}
+        </sw-button>
+    </template>
+    {% endblock %}
+
     <template #content>
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_extension_sdk_module_content %}
@@ -34,5 +50,18 @@
         {% endblock %}
         {% endblock %}
     </template>
+
+    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+    {% block sw_extension_sdk_module_language_switch %}
+    <template
+        v-if="showLanguageSwitch"
+        #language-switch
+    >
+        <sw-language-switch
+            :change-global-language="true"
+            @on-change="onChangeLanguage"
+        />
+    </template>
+    {% endblock %}
 </sw-page>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/sw-extension-sdk-module.spec.js
@@ -1,5 +1,6 @@
 import { createLocalVue, shallowMount } from '@vue/test-utils';
 import swExtensionSdkModule from 'src/module/sw-extension-sdk/page/sw-extension-sdk-module';
+import 'src/app/component/base/sw-button';
 
 Shopware.Component.register('sw-extension-sdk-module', swExtensionSdkModule);
 
@@ -7,6 +8,7 @@ const module = {
     heading: 'jest',
     locationId: 'jest',
     displaySearchBar: true,
+    displayLanguageSwitch: true,
     baseUrl: 'http://example.com',
 };
 
@@ -23,6 +25,8 @@ async function createWrapper() {
             'sw-loader': true,
             'sw-my-apps-error-page': true,
             'sw-iframe-renderer': true,
+            'sw-language-switch': true,
+            'sw-button': await Shopware.Component.build('sw-button'),
         },
     });
 }
@@ -61,5 +65,38 @@ describe('src/module/sw-extension-sdk/page/sw-extension-sdk-module', () => {
             setTimeout(r, 7100);
         });
         expect(wrapper.vm.timedOut).toBe(false);
+    });
+
+    it('should show language switch', async () => {
+        await Shopware.State.dispatch('extensionSdkModules/addModule', module);
+
+        expect(wrapper.findComponent('sw-language-switch-stub').exists()).toBe(true);
+    });
+
+    it('should show smart bar button', async () => {
+        const spy = jest.fn();
+
+        await Shopware.State.dispatch('extensionSdkModules/addModule', module);
+        Shopware.State.commit('extensionSdkModules/addSmartBarButton', {
+            locationId: 'jest',
+            buttonId: 'test-button-1',
+            label: 'Test button 1',
+            variant: 'primary',
+            onClickCallback: () => spy()
+        });
+
+        await wrapper.vm.$nextTick();
+
+        const smartBarButton = wrapper.find('button');
+
+        expect(smartBarButton.exists()).toBe(true);
+
+        expect(smartBarButton.text()).toBe('Test button 1');
+        expect(smartBarButton.attributes().id).toBe('test-button-1');
+        expect(smartBarButton.classes('sw-button--primary')).toBe(true);
+
+        // Test if callback function is called
+        await smartBarButton.trigger('click');
+        expect(spy).toBeCalledTimes(1);
     });
 });

--- a/tests/e2e/cypress/e2e/administration/sdk-plugin/ui/component-section.cy.js
+++ b/tests/e2e/cypress/e2e/administration/sdk-plugin/ui/component-section.cy.js
@@ -50,4 +50,26 @@ describe('SDK Tests: Component section', ()=> {
         cy.getSDKiFrame('location-index')
             .should('be.visible');
     });
+
+    it('@sdk: add a component section with tabs', { tags: ['ct-admin'] }, ()=> {
+        cy.log('Go to specifications tab');
+
+        cy.contains('.sw-tabs-item', 'Specifications')
+            .click();
+
+        cy.contains('.sw-card__title', 'Card tabs tests');
+        cy.contains('.sw-card__subtitle', 'Testing if the the card tabs work correctly');
+
+        cy.getSDKiFrame('card-tabs')
+            .should('be.visible');
+
+        cy.contains('.sw-tabs-item', 'Tab 1');
+        cy.getSDKiFrame('card-tab-1')
+            .should('be.visible');
+
+        // Switch the tab and check tab content
+        cy.contains('.sw-tabs-item', 'Tab 2').click();
+        cy.getSDKiFrame('card-tab-2')
+            .should('be.visible');
+    });
 });

--- a/tests/e2e/cypress/fixtures/TestPlugin/src/Resources/app/administration/src/base/mainCommands.ts
+++ b/tests/e2e/cypress/fixtures/TestPlugin/src/Resources/app/administration/src/base/mainCommands.ts
@@ -13,6 +13,28 @@ ui.componentSection.add({
 
 ui.componentSection.add({
     component: 'card',
+    positionId: 'sw-product-properties__after',
+    props: {
+        title: 'Card tabs tests',
+        subtitle: 'Testing if the the card tabs work correctly',
+        locationId: 'card-tabs',
+        tabs: [
+            {
+                name: 'card-tab-1',
+                label: 'Tab 1',
+                locationId: 'card-tab-1',
+            },
+            {
+                name: 'card-tab-2',
+                label: 'Tab 2',
+                locationId: 'card-tab-2',
+            },
+        ],
+    }
+})
+
+ui.componentSection.add({
+    component: 'card',
     positionId: 'ui-tabs-product-example-tab',
     props: {
         title: 'Hello in the new tab',

--- a/tests/e2e/cypress/fixtures/TestPlugin/src/Resources/app/administration/src/viewRenderer.ts
+++ b/tests/e2e/cypress/fixtures/TestPlugin/src/Resources/app/administration/src/viewRenderer.ts
@@ -25,9 +25,13 @@ const app = new Vue({
         'UiModalsModalContent': () => import('./views/ui/modals/modal-content'),
         // location/general
         'LocationIndex': () => import('./views/location/index'),
+        'CardTab1': () => import('./views/card-tabs/tab-1'),
+        'CardTab2': () => import('./views/card-tabs/tab-2'),
     },
     template: `
         <LocationIndex v-if="location.is('location-index')"></LocationIndex>
+        <CardTab1 v-else-if="location.is('card-tab-1')"></CardTab1>
+        <CardTab2 v-else-if="location.is('card-tab-2')"></CardTab2>
         <UiModals v-else-if="location.is('ui-modals')"></UiModals>
         <UiModalsModalContent v-else-if="location.is('ui-modals-modal-content')"></UiModalsModalContent>
         <UiMainModuleAddMainModule v-else-if="location.is('ui-main-module-add-main-module')"></UiMainModuleAddMainModule>

--- a/tests/e2e/cypress/fixtures/TestPlugin/src/Resources/app/administration/src/views/card-tabs/tab-1.ts
+++ b/tests/e2e/cypress/fixtures/TestPlugin/src/Resources/app/administration/src/views/card-tabs/tab-1.ts
@@ -1,0 +1,10 @@
+import Vue from 'vue';
+
+export default Vue.extend({
+    template: `
+        <div>
+        <p>Tab 1</p>
+        </div>
+    `,
+});
+

--- a/tests/e2e/cypress/fixtures/TestPlugin/src/Resources/app/administration/src/views/card-tabs/tab-2.ts
+++ b/tests/e2e/cypress/fixtures/TestPlugin/src/Resources/app/administration/src/views/card-tabs/tab-2.ts
@@ -1,0 +1,10 @@
+import Vue from 'vue';
+
+export default Vue.extend({
+    template: `
+        <div>
+        <p>Tab 2</p>
+        </div>
+    `,
+});
+


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
1. Currently, there's no way to add, for example, a language switch or some buttons to the smart bar of the main module.
2. When adding a component section, the iframe will always get rendered inside `sw-card__content` class, which is sometimes not the perfect case.


### 2. What does this change do, exactly?
1. Add language switch and smart bar buttons:
- To add a language switch, or some buttons to the smart bar of the main module, I need to implement from the Admin Extension SDK to send the signal to Shopware. This will be in a separate [PR](https://github.com/shopware/admin-extension-sdk/pull/65) to the Admin extension SDK repo.
- Shopware side will receive the signal and render corresponding elements.
2. Adding a component section outside of the card content:
- Adding one more prop to render different iframe at different locationId when using `ui.componentSection.add`
- New prop: `tabs` to render different tab on different locationId inside the card.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2965"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

