### PR TITLE
Change background color to transparent for rtf again

### DIFF
--- a/changelog/_unreleased/2023-01-29-rich-text-editor-transparent-in-cms-block-text-on-image.md
+++ b/changelog/_unreleased/2023-01-29-rich-text-editor-transparent-in-cms-block-text-on-image.md
@@ -1,0 +1,9 @@
+---
+title: Make rich text editor background transparent again in the administration CMS stage
+issue: NEXT-24201
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Changed background color to transparent for the `.sw-text-editor__content` when the text editor is placed in a CMS block as it could have a background image

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.scss
@@ -45,6 +45,14 @@
     }
 }
 
+.sw-cms-stage-block {
+    .sw-text-editor {
+        .sw-text-editor__content {
+            background: transparent;
+        }
+    }
+}
+
 .sw-cms-section {
     position: relative;
     background-repeat: no-repeat;


### PR DESCRIPTION
### 1. Why is this change necessary?

I once created a [pull request](https://github.com/shopware/platform/pull/2720) and it broke [something](https://issues.shopware.com/issues/NEXT-24201).

### 2. What does this change do, exactly?

Make the text editor background transparent for blocks as they have to preview text on background images. In other places it is unlikely so I set it only there to be transparent.

### 3. Describe each step to reproduce the issue or behaviour.

See issue https://issues.shopware.com/issues/NEXT-24201

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-24201

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
