### PR TITLE
Add twig blocks in CMS Element Category Navigation

### DIFF
--- a/changelog/_unreleased/2023-02-09-add-cms-element-category-navigation-twig-block.md
+++ b/changelog/_unreleased/2023-02-09-add-cms-element-category-navigation-twig-block.md
@@ -1,0 +1,9 @@
+---
+title: Add twig blocks in CMS Element Category Navigation
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.me
+author_github: @runelaenen
+---
+# Storefront
+* Added twig blocks `element_category_navigation`, `element_category_navigation_element` and `element_category_navigation_box` in `@Storefront/storefront/element/cms-element-category-navigation.html.twig`

--- a/src/Storefront/Resources/views/storefront/element/cms-element-category-navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-category-navigation.html.twig
@@ -1,10 +1,16 @@
-<div class="cms-element-{{ element.type }}">
-    {% set navigationResult1 = page.header.navigation.tree %}
-    {% set activeResult1 = page.header.navigation.active %}
-    <div class="category-navigation-box">
-        {% sw_include '@Storefront/storefront/layout/sidebar/category-navigation.html.twig' with {
-            navigationTree: page.header.navigation.tree,
-            activeResult: page.header.navigation.active
-        } only %}
+{% block element_category_navigation %}
+    <div class="cms-element-{{ element.type }}">
+        {% block element_category_navigation_element %}
+            {% set navigationResult1 = page.header.navigation.tree %}
+            {% set activeResult1 = page.header.navigation.active %}
+            <div class="category-navigation-box">
+                {% block element_category_navigation_box %}
+                    {% sw_include '@Storefront/storefront/layout/sidebar/category-navigation.html.twig' with {
+                        navigationTree: page.header.navigation.tree,
+                        activeResult: page.header.navigation.active
+                    } only %}
+                {% endblock %}
+            </div>
+        {% endblock %}
     </div>
-</div>
+{% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Without twig blocks it is not possible to properly override twig templates from apps or themes.

### 2. What does this change do, exactly?
Added twig blocks `element_category_navigation`, `element_category_navigation_element` and `element_category_navigation_box` in `@Storefront/storefront/element/cms-element-category-navigation.html.twig`

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2971"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

