### PR TITLE
Add a hint on newsletter registration message, that the user might already be registered

### DIFF
--- a/changelog/_unreleased/2023-02-10-improve-newsletter-registration-text.md
+++ b/changelog/_unreleased/2023-02-10-improve-newsletter-registration-text.md
@@ -6,4 +6,5 @@ author_email: a.menk@imi.de
 author_github: @amenk
 ---
 # Storefront
-* Add a hint on newsletter registration message, that the user might already be registered
+* Changed `src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json` by changing the content of the translation key `newsletter.subscriptionPersistedInfo` to add a hint on the newsletter registration message that the user might already be registered.
+* Changed `src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json` by changing the content of the translation key `newsletter.subscriptionPersistedInfo` to add a hint on the newsletter registration message that the user might already be registered.

--- a/changelog/_unreleased/2023-02-10-improve-newsletter-registration-text.md
+++ b/changelog/_unreleased/2023-02-10-improve-newsletter-registration-text.md
@@ -1,0 +1,9 @@
+---
+title: Improve newsletter registration text
+issue:
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: @amenk
+---
+# Storefront
+* Add a hint on newsletter registration message, that the user might already be registered

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -482,7 +482,7 @@
     "unsubscribeOption": "Newsletter abbestellen",
     "formSubmit": "Abonnieren",
     "subscriptionPersistedSuccess": "Sie haben gerade unseren Newsletter abonniert.\n Um die Registrierung abzuschließen, suchen Sie in Ihrer E-Mail-Box nach unserer Bestätigungsmail und klicken Sie auf den darin enthaltenen Link.",
-    "subscriptionPersistedInfo": "Sollten Sie keine Mail erhalten haben, wiederholen Sie den Vorgang oder wenden Sie sich an den Support.",
+    "subscriptionPersistedInfo": "Sollten Sie keine Mail erhalten haben, sind Sie eventuell bereits für den Newsletter registriert. Falls nicht, wiederholen Sie den Vorgang oder wenden Sie sich an den Support.",
     "subscriptionRevokeSuccess": "Sie haben sich erfolgreich vom Newsletter abgemeldet.",
     "subscriptionConfirmationSuccess": "Ihr Newsletter-Abonnement wurde erfolgreich registriert.",
     "subscriptionConfirmationFailed": "Bei Ihrer Newsletter-Anmeldung ist etwas schief gelaufen. Bitte wenden Sie sich an den Support.",

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -482,7 +482,7 @@
     "unsubscribeOption": "Newsletter abbestellen",
     "formSubmit": "Abonnieren",
     "subscriptionPersistedSuccess": "Sie haben gerade unseren Newsletter abonniert.\n Um die Registrierung abzuschließen, suchen Sie in Ihrer E-Mail-Box nach unserer Bestätigungsmail und klicken Sie auf den darin enthaltenen Link.",
-    "subscriptionPersistedInfo": "Sollten Sie keine Mail erhalten haben, sind Sie eventuell bereits für den Newsletter registriert. Falls nicht, wiederholen Sie den Vorgang oder wenden Sie sich an den Support.",
+    "subscriptionPersistedInfo": "Sollten Sie keine E-Mail erhalten, sind Sie eventuell bereits für den Newsletter angemeldet. Durchsuchen Sie Ihren Posteingang und Spamordner und wiederholen Sie gegebenenfalls die Anmeldung. Falls auch das nicht funktioniert, wenden Sie sich bitte an unseren Support.",
     "subscriptionRevokeSuccess": "Sie haben sich erfolgreich vom Newsletter abgemeldet.",
     "subscriptionConfirmationSuccess": "Ihr Newsletter-Abonnement wurde erfolgreich registriert.",
     "subscriptionConfirmationFailed": "Bei Ihrer Newsletter-Anmeldung ist etwas schief gelaufen. Bitte wenden Sie sich an den Support.",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -482,7 +482,7 @@
     "unsubscribeOption": "Unsubscribe from newsletter",
     "formSubmit": "Subscribe",
     "subscriptionPersistedSuccess": "You have just subscribed to our newsletter.\n To complete the sign-up process, search your inbox for our confirmation email and click on the link provided with it.",
-    "subscriptionPersistedInfo": "If you did not receive any email, please repeat the process or contact our support team.",
+    "subscriptionPersistedInfo": "If you did not receive any email, you might already be registered for our newsletter. If not, please repeat the process or contact our support team.",
     "subscriptionRevokeSuccess": "You have successfully unsubscribed from the newsletter.",
     "subscriptionConfirmationSuccess": "You have successfully subscribed to the newsletter.",
     "subscriptionConfirmationFailed": "Newsletter subscription did not work properly, please contact our support team.",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -482,7 +482,7 @@
     "unsubscribeOption": "Unsubscribe from newsletter",
     "formSubmit": "Subscribe",
     "subscriptionPersistedSuccess": "You have just subscribed to our newsletter.\n To complete the sign-up process, search your inbox for our confirmation email and click on the link provided with it.",
-    "subscriptionPersistedInfo": "If you did not receive any email, you might already be registered for our newsletter. If not, please repeat the process or contact our support team.",
+    "subscriptionPersistedInfo": "If you do not receive an email, you may already be subscribed to the newsletter. Check your inbox and spam folder and repeat the registration if necessary. If this does not work either, please contact our support.",
     "subscriptionRevokeSuccess": "You have successfully unsubscribed from the newsletter.",
     "subscriptionConfirmationSuccess": "You have successfully subscribed to the newsletter.",
     "subscriptionConfirmationFailed": "Newsletter subscription did not work properly, please contact our support team.",


### PR DESCRIPTION
### 1. Why is this change necessary?

During newsletter registration, no email is sent if the user trying to register is already registered. The current message does not reveal that and might lead to confusions.

### 2. What does this change do, exactly?

Make possible reasons for not receiving the email clearer in the message.

### 3. Describe each step to reproduce the issue or behaviour.

1. Register for the newsletter, confirm the registration
2. Try to register again

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2972"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

