### PR TITLE
fix: Compatibility to use the storefront watcher with an non empty URI

### DIFF
--- a/changelog/_unreleased/2023-02-11-storefront-watcher-with-an-uri.md
+++ b/changelog/_unreleased/2023-02-11-storefront-watcher-with-an-uri.md
@@ -1,0 +1,9 @@
+---
+title: Storefront watcher with an URI
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Compatibility to use the storefront watcher with an non empty URI

--- a/src/Storefront/Resources/app/storefront/build/proxy-server-hot/index.js
+++ b/src/Storefront/Resources/app/storefront/build/proxy-server-hot/index.js
@@ -7,9 +7,14 @@
 const { createServer, request } = require('http');
 const { spawn } = require('child_process');
 
-module.exports = function createProxyServer({ appPort, originalHost, proxyHost, proxyPort }) {
+module.exports = function createProxyServer({ schema, appPort, originalHost, proxyHost, proxyPort, uri }) {
     const proxyUrl = proxyPort !== 80 && proxyPort !== 443 ? `${proxyHost}:${proxyPort}`: proxyHost;
     const originalUrl = appPort !== 80 && appPort !== 443 ? `${originalHost}:${appPort}` : originalHost;
+
+    let fullProxyUrl = `${schema}://${proxyUrl}/${uri || ''}`;
+    if (fullProxyUrl.charAt(fullProxyUrl.length - 1) !== '/') {
+        fullProxyUrl += '/';
+    }
 
     // Create the HTTP proxy
     const server = createServer((client_req, client_res) => {
@@ -71,9 +76,9 @@ module.exports = function createProxyServer({ appPort, originalHost, proxyHost, 
     }).listen(proxyPort);
 
     // open the browser with the proxy url
-    openBrowserWithUrl(proxyUrl);
+    openBrowserWithUrl(fullProxyUrl);
 
-    return Promise.resolve({ server, proxyUrl });
+    return Promise.resolve({ server, proxyUrl: fullProxyUrl });
 };
 
 function openBrowserWithUrl(url) {

--- a/src/Storefront/Resources/app/storefront/build/start-hot-reload.js
+++ b/src/Storefront/Resources/app/storefront/build/start-hot-reload.js
@@ -10,20 +10,23 @@ server.then(() => {
     const proxyPort = process.env.STOREFRONT_PROXY_PORT;
 
     // first value of array is the http protocol
-    const [schema, domainWithPort] = fullUrl.split('://');
+    const [schema, domainWithPortAndUri] = fullUrl.split('://');
+    const [domainWithPort, ...uri] = domainWithPortAndUri.split('/');
     const [domain, port] = domainWithPort.split(':');
 
     const proxyServerOptions = {
+        schema,
         originalHost: domain,
         appPort: port || 80,
         proxyHost: proxyUrl.hostname,
         proxyPort: parseInt(proxyPort || 9998),
+        uri: uri.join('/'),
     };
 
     // starting the proxy server
     createProxyServer(proxyServerOptions).then(({ proxyUrl } ) => {
         console.log('############');
-        console.log(`Storefront proxy server started at ${schema}://${proxyUrl}`);
+        console.log(`Storefront proxy server started at ${proxyUrl}`);
         console.log('############');
         console.log('\n');
     });


### PR DESCRIPTION
### 1. Why is this change necessary?
My `APP_URL` looks for example like this: `http://127.0.0.1/sw/platform/public`. Currently the storefront watcher fails with the message that it cannot resolve the hostname `127.0.0.1/sw/platform/public`:
![grafik](https://user-images.githubusercontent.com/6317761/218275583-fe4c0d3a-966b-40b7-9833-6ef9d81b8774.png)

Additionally the URL was not correctly opened, as the protocol was missing, which is fixed by this change as well.

### 2. What does this change do, exactly?
Parse the URL correctly in the storefront watcher script, and include an URI.

### 3. Describe each step to reproduce the issue or behaviour.
Start the storefront watcher using an URL like: `http://127.0.0.1/sw/platform/public`.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2973"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

