### PR TITLE
refactor: Change the way the line item links are handled

### DIFF
--- a/changelog/_unreleased/2023-02-12-improve-handling-to-link-line-items-to-custom-links.md
+++ b/changelog/_unreleased/2023-02-12-improve-handling-to-link-line-items-to-custom-links.md
@@ -1,0 +1,11 @@
+---
+title: Improve handling to link line items to custom links
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Add the possibility to link line items to custom links in `storefront/component/line-item/element/image.html.twig` and `storefront/component/line-item/element/label.html.twig` using the variables `lineItemLink` and `lineItemModalLink`
+* Deprecate boolean variable `productLink` from templates `storefront/component/line-item/element/image.html.twig` and `storefront/component/line-item/element/label.html.twig`
+* Use the new Bootstrap 5 AJAX modals for showing items on the confirm page

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/image.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/image.html.twig
@@ -35,14 +35,23 @@
         {% endif %}
     {% endset %}
 
-    {% if productLink %}
-        <a href="{{ seoUrl('frontend.detail.page', { 'productId': lineItem.referencedId }) }}"
+    {# @deprecated productLink variable will be removed without replacement, directly set lineItemLink and lineItemModalLink #}
+    {% if productLink and not lineItemLink %}
+        {% set lineItemLink = seoUrl('frontend.detail.page', { 'productId': lineItem.referencedId }) %}
+
+        {% if controllerAction is same as('confirmPage') %}
+            {% set lineItemModalLink = path('widgets.quickview.minimal', { 'productId': lineItem.referencedId }) %}
+        {% endif %}
+    {% endif %}
+
+    {% if lineItemLink %}
+        <a href="{{ lineItemLink }}"
            class="line-item-img-link"
            title="{{ label }}"
-            {% if controllerAction is same as('confirmPage') %}
-                data-toggle="modal"
+            {% if lineItemModalLink %}
+                data-ajax-modal="modal"
                 data-modal-class="quickview-modal"
-                data-url="{{ path('widgets.quickview.minimal', { 'productId': lineItem.referencedId }) }}"
+                data-url="{{ lineItemModalLink }}"
             {% endif %}
         >
             {{ thumbnail }}

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/label.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/label.html.twig
@@ -2,14 +2,23 @@
     {% set label = lineItem.label|trans|sw_sanitize %}
     {% set label = label !== '' ? label : lineItem.label %}
 
-    {% if productLink %}
-        <a href="{{ seoUrl('frontend.detail.page', { 'productId': lineItem.referencedId }) }}"
+    {# @deprecated productLink variable will be removed without replacement, directly set lineItemLink and lineItemModalLink #}
+    {% if productLink and not lineItemLink %}
+        {% set lineItemLink = seoUrl('frontend.detail.page', { 'productId': lineItem.referencedId }) %}
+
+        {% if controllerAction is same as('confirmPage') %}
+            {% set lineItemModalLink = path('widgets.quickview.minimal', { 'productId': lineItem.referencedId }) %}
+        {% endif %}
+    {% endif %}
+
+    {% if lineItemLink %}
+        <a href="{{ lineItemLink }}"
            class="line-item-label"
            title="{{ label }}"
-            {% if controllerAction is same as('confirmPage') %}
-                data-toggle="modal"
+            {% if lineItemModalLink %}
+                data-ajax-modal="modal"
                 data-modal-class="quickview-modal"
-                data-url="{{ path('widgets.quickview.minimal', { 'productId': lineItem.referencedId }) }}"
+                data-url="{{ lineItemModalLink }}"
             {% endif %}
         >
             {{ label|u.truncate(60, '...', false)|raw }}

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
@@ -26,14 +26,18 @@
             {% block component_line_item_type_product_col_info %}
                 <div class="line-item-info">
                     <div class="row line-item-row">
+                        {% set showLineItemModal = controllerAction is same as('confirmPage') %}
 
                         {% if nestingLevel < 1 %}
                             {% block component_line_item_type_product_image %}
                                 <div class="col-auto line-item-info-img">
                                     <div class="line-item-img-container">
                                         {% block component_line_item_type_product_image_inner %}
+                                            {# @deprecated productLink variable will be removed without replacement, directly set lineItemLink and lineItemModalLink #}
                                             {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
-                                                productLink: true
+                                                productLink: true,
+                                                lineItemLink: seoUrl('frontend.detail.page', { 'productId': lineItem.referencedId }),
+                                                lineItemModalLink: showLineItemModal ? path('widgets.quickview.minimal', { 'productId': lineItem.referencedId }) : false,
                                             } %}
                                         {% endblock %}
                                     </div>
@@ -45,8 +49,11 @@
                             <div class="line-item-details">
                                 <div class="line-item-details-container">
                                     {% block component_line_item_type_product_label %}
+                                        {# @deprecated productLink variable will be removed without replacement, directly set lineItemLink and lineItemModalLink #}
                                         {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' with {
-                                            productLink: true
+                                            productLink: true,
+                                            lineItemLink: seoUrl('frontend.detail.page', { 'productId': lineItem.referencedId }),
+                                            lineItemModalLink: showLineItemModal ? path('widgets.quickview.minimal', { 'productId': lineItem.referencedId }) : false,
                                         } %}
                                     {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is impossible, without copying a large portion of code, to create line items with links, which do not point on the product detail page. Furthermore on the confirm page the AJAX modal is not used to show the products.

### 2. What does this change do, exactly?
Use the updated syntax for the Bootstrap 5 modal and change the variables, which are meant to link to the products.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2974"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

