### PR TITLE
NEXT-25374 - repair load custom seo url twig extensions

### DIFF
--- a/changelog/_unreleased/2023-02-12-fixing-seo-url-twig.md
+++ b/changelog/_unreleased/2023-02-12-fixing-seo-url-twig.md
@@ -1,0 +1,12 @@
+---
+title: repair load custom seo url twig extensions
+issue: NEXT-25374
+author: Björn Herzke
+author_email: bjoern.herzke@brandung.de
+author_github: wrongspot
+---
+# Core 
+* Add `Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory`
+* Changed `Shopware\Core\Content\Seo\SeoUrlGenerator::__construct` removed `TwigVariableParser` and use `TwigVariableParserFactory` instead
+* Changed `Shopware\Core\Content\ProductExport\Service\ProductExportGenerator::__construct` removed `TwigVariableParser` and use `TwigVariableParserFactory` instead
+* Deprecated direct usage of `Shopware\Core\Framework\Adapter\Twig\TwigVariableParser"` use `Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory` instead

--- a/src/Core/Content/DependencyInjection/product_export.xml
+++ b/src/Core/Content/DependencyInjection/product_export.xml
@@ -42,9 +42,10 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="string">%product_export.read_buffer_size%</argument>
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface"/>
-            <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParser"/>
+            <argument type="service" id="twig"/>
             <argument type="service" id="Shopware\Core\Content\Product\ProductDefinition"/>
             <argument type="service" id="Shopware\Core\System\Locale\LanguageLocaleCodeProvider"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory"/>
         </service>
 
         <service id="Shopware\Core\Content\ProductExport\Command\ProductExportGenerateCommand">

--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -19,6 +19,7 @@ use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
+use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\SalesChannelRepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -32,10 +33,13 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParamete
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment;
 
 #[Package('sales-channel')]
 class ProductExportGenerator implements ProductExportGeneratorInterface
 {
+    private readonly TwigVariableParser $twigVariableParser;
+
     /**
      * @internal
      */
@@ -51,10 +55,12 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
         private readonly Connection $connection,
         private readonly int $readBufferSize,
         private readonly SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler,
-        private readonly TwigVariableParser $twigVariableParser,
+        Environment $twig,
         private readonly ProductDefinition $productDefinition,
-        private readonly LanguageLocaleCodeProvider $languageLocaleProvider
+        private readonly LanguageLocaleCodeProvider $languageLocaleProvider,
+        TwigVariableParserFactory $parserFactory
     ) {
+        $this->twigVariableParser = $parserFactory->getParser($twig);
     }
 
     public function generate(ProductExportEntity $productExport, ExportBehavior $exportBehavior): ?ProductExportResult

--- a/src/Core/Content/Seo/SeoUrlGenerator.php
+++ b/src/Core/Content/Seo/SeoUrlGenerator.php
@@ -8,6 +8,7 @@ use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlMapping;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
 use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
+use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
@@ -31,6 +32,8 @@ class SeoUrlGenerator
 {
     final public const ESCAPE_SLUGIFY = 'slugifyurlencode';
 
+    private readonly TwigVariableParser $twigVariableParser;
+
     /**
      * @internal
      */
@@ -39,8 +42,9 @@ class SeoUrlGenerator
         private readonly RouterInterface $router,
         private readonly RequestStack $requestStack,
         private readonly Environment $twig,
-        private readonly TwigVariableParser $twigVariableParser
+        TwigVariableParserFactory $parserFactory
     ) {
+        $this->twigVariableParser = $parserFactory->getParser($twig);
     }
 
     /**

--- a/src/Core/Content/Test/ProductExport/Service/ProductExportGeneratorTest.php
+++ b/src/Core/Content/Test/ProductExport/Service/ProductExportGeneratorTest.php
@@ -22,7 +22,7 @@ use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilder;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Translation\Translator;
-use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
+use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -125,9 +125,10 @@ class ProductExportGeneratorTest extends TestCase
             $this->getContainer()->get(Connection::class),
             100,
             $this->getContainer()->get(SeoUrlPlaceholderHandlerInterface::class),
-            $this->getContainer()->get(TwigVariableParser::class),
+            $this->getContainer()->get('twig'),
             $this->getContainer()->get(ProductDefinition::class),
             $this->getContainer()->get(LanguageLocaleCodeProvider::class),
+            $this->getContainer()->get(TwigVariableParserFactory::class)
         );
 
         $exportGenerator->generate($productExport, $exportBehavior);
@@ -190,9 +191,10 @@ class ProductExportGeneratorTest extends TestCase
             $this->getContainer()->get(Connection::class),
             100,
             $this->getContainer()->get(SeoUrlPlaceholderHandlerInterface::class),
-            $this->getContainer()->get(TwigVariableParser::class),
+            $this->getContainer()->get('twig'),
             $this->getContainer()->get(ProductDefinition::class),
             $this->getContainer()->get(LanguageLocaleCodeProvider::class),
+            $this->getContainer()->get(TwigVariableParserFactory::class)
         );
 
         try {

--- a/src/Core/Framework/Adapter/Twig/TwigVariableParserFactory.php
+++ b/src/Core/Framework/Adapter/Twig/TwigVariableParserFactory.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Twig;
+
+use Shopware\Core\Framework\Log\Package;
+use Twig\Environment;
+
+#[Package('core')]
+class TwigVariableParserFactory
+{
+    public function getParser(Environment $twig): TwigVariableParser
+    {
+        return new TwigVariableParser($twig);
+    }
+}

--- a/src/Core/Framework/DependencyInjection/seo.xml
+++ b/src/Core/Framework/DependencyInjection/seo.xml
@@ -42,7 +42,7 @@
             <argument type="service" id="router.default"/>
             <argument type="service" id="request_stack"/>
             <argument type="service" id="shopware.seo_url.twig"/>
-            <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParser"/>
+            <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory"/>
         </service>
 
         <service id="Shopware\Core\Content\Seo\SeoUrlPersister">

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -427,7 +427,10 @@ base-uri 'self';
 
         <service id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParser">
             <argument type="service" id="twig" />
+            <deprecated package="shopware/core" version="6.6.0.0">tag:v6.6.0 - The %service_id% service will be removed in v6.6.0.0 use "TwigVariableParserFactory" instead.</deprecated>
         </service>
+
+        <service id="Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory"/>
 
         <service id="Shopware\Core\Framework\Routing\ApiRequestContextResolver">
             <argument type="service" id="Doctrine\DBAL\Connection"/>

--- a/tests/unit/php/Core/Framework/Adapter/Twig/TwigVariableParserFactoryTest.php
+++ b/tests/unit/php/Core/Framework/Adapter/Twig/TwigVariableParserFactoryTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Twig\TwigVariableParser;
+use Shopware\Core\Framework\Adapter\Twig\TwigVariableParserFactory;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class TwigVariableParserFactoryTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testgetParser(): void
+    {
+        $factory = $this->getContainer()->get(TwigVariableParserFactory::class);
+        $twig = new Environment(new ArrayLoader([]));
+
+        static::assertInstanceOf(TwigVariableParser::class, $factory->getParser($twig));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

There is a special `Twig\Environment` for generating seo urls, it's called `shopware.seo_url.twig`. The associated parser, but incorrectly uses standard twig, this means that validation always fails. 


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.

- create a custom twig extension
- register it with extension with tag `shopware.seo_url.twig.extension`
- try to use the new created filter in seo url template
- it will allways fail

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-25374

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2976"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

