### PR TITLE
Add relative base url support

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/init/cms.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/cms.init.ts
@@ -7,8 +7,8 @@ export default function initializeCms(): void {
         const extension = Object.values(Shopware.State.get('extensions'))
             .find(ext => ext.baseUrl.startsWith(additionalInformation._event_.origin));
 
-        if (!extension) {
-            return;
+        if (extension && !element.src) {
+            element.src = extension.baseUrl;
         }
 
         Shopware.Service('cmsService').registerCmsElement({
@@ -18,7 +18,7 @@ export default function initializeCms(): void {
             previewComponent: 'sw-cms-el-preview-location-renderer',
             configComponent: 'sw-cms-el-config-location-renderer',
             appData: {
-                baseUrl: extension.baseUrl,
+                baseUrl: element.src,
             },
         });
     });


### PR DESCRIPTION
### 1. Why is this change necessary?

Add support for relative base url like:

```
        <base-app-url>admin/app/sdk</base-app-url>
```

Also apps with the same domain but different path names can also have problems.

### 2. What does this change do, exactly?

Use base url from sender, instead guess someone:

https://github.com/shopware/admin-extension-sdk/pull/67

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.


<a href="https://gitpod.io/#https://github.com/shopware/platform/pull/2978"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

