### PR TITLE
Use data attribute instead of query selector

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/header/wishlist-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/wishlist-widget.plugin.js
@@ -63,7 +63,7 @@ export default class WishlistWidgetPlugin extends Plugin {
             this._reInitWishlistButton(event.detail.productId);
         });
 
-        const listingEl = DomAccess.querySelector(document, '.cms-element-product-listing-wrapper', false);
+        const listingEl = DomAccess.querySelector(document, '[data-listing]', false);
 
         if (listingEl) {
             const listingPlugin = window.PluginManager.getPluginInstanceFromElement(listingEl, 'Listing');


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When using related products, check if the listing plugin is loaded instead of a query selector
Otherwise the wishlist plugin js will break.

### 2. What does this change do, exactly?
It's a better check if the listing is available.
In version 6.4.17.1 it will break wishlist plugin js

### 3. Describe each step to reproduce the issue or behaviour.
Go to a PDP, the javascript will break with related products, so the wishlist bubble cannot be loaded.
Because the listing plugin cannot be loaded on the query selector.

It breaks here:
<pre>
listingPlugin.$emitter.subscribe('Listing/afterRenderResponse'
</pre>

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.
