### PR TITLE
Added property `companyPhone` to `DocumentConfiguration` which can be set by the Admin UI

### DIFF
--- a/changelog/_unreleased/2023-02-16-add-missing-company-phone-number-to-documentconfiguration.md
+++ b/changelog/_unreleased/2023-02-16-add-missing-company-phone-number-to-documentconfiguration.md
@@ -1,6 +1,6 @@
 ---
 title: Add missing company phone number to DocumentConfiguration
-issue: X
+issue: NEXT-25636
 author: Sven Mäurer
 author_email: s.maeurer@kellerkinder.de
 author_github: Zwaen91

--- a/changelog/_unreleased/2023-02-16-add-missing-company-phone-number-to-documentconfiguration.md
+++ b/changelog/_unreleased/2023-02-16-add-missing-company-phone-number-to-documentconfiguration.md
@@ -1,0 +1,9 @@
+---
+title: Add missing company phone number to DocumentConfiguration
+issue: X
+author: Sven Mäurer
+author_email: s.maeurer@kellerkinder.de
+author_github: Zwaen91
+---
+# Core
+* Added property `companyPhone` to `DocumentConfiguration` which can be set by the Admin UI

--- a/src/Core/Checkout/Document/DocumentConfiguration.php
+++ b/src/Core/Checkout/Document/DocumentConfiguration.php
@@ -122,6 +122,11 @@ class DocumentConfiguration extends Struct
     /**
      * @var string|null
      */
+    protected $companyPhone;
+
+    /**
+     * @var string|null
+     */
     protected $companyUrl;
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
The document configuration value companyPhone can be set by the Admin UI, but is not accessible by code.

### 2. What does this change do, exactly?
Adding variable `$companyPhone` to class `DocumentConfiguration` so you can access it.

### 3. Describe each step to reproduce the issue or behaviour.
Accessing `companyPhone` on an instance of `DocumentConfiguration`

### 4. Please link to the relevant issues (if any).
Issue https://github.com/shopware/platform/issues/2672
MR https://github.com/shopware/platform/pull/2715 Thanks to @heydavee for solving this issue last year. @mstegmeyer None of the company properties is having a getter/setter. Thats why they are left out.

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
