### PR TITLE
Add company and VAT id to customer detail page in the administration

### DIFF
--- a/changelog/_unreleased/2023-02-16-add-company-and-vat-id-to-customer-detail-page-in-the-administration.md
+++ b/changelog/_unreleased/2023-02-16-add-company-and-vat-id-to-customer-detail-page-in-the-administration.md
@@ -1,6 +1,6 @@
 ---
 title: Add company and VAT id to customer detail page in the administration
-issue: X
+issue: NEXT-25637
 author: Sven Mäurer
 author_email: s.maeurer@kellerkinder.de
 author_github: Zwaen91

--- a/changelog/_unreleased/2023-02-16-add-company-and-vat-id-to-customer-detail-page-in-the-administration.md
+++ b/changelog/_unreleased/2023-02-16-add-company-and-vat-id-to-customer-detail-page-in-the-administration.md
@@ -1,0 +1,9 @@
+---
+title: Add company and VAT id to customer detail page in the administration
+issue: X
+author: Sven Mäurer
+author_email: s.maeurer@kellerkinder.de
+author_github: Zwaen91
+---
+# Administration
+* Added `company` and `vatId` to component `sw-customer-base-info`. It is only visible if customer account type is commercial.

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/index.js
@@ -2,6 +2,8 @@ import template from './sw-customer-base-info.html.twig';
 import './sw-customer-base-info.scss';
 import errorConfig from '../../error-config.json';
 
+import CUSTOMER from '../../constant/sw-customer.constant';
+
 /**
  * @package customer-order
  */
@@ -83,6 +85,10 @@ export default {
             'customer',
             [...errorConfig['sw.customer.detail.base'].customer],
         ),
+
+        isBusinessAccountType() {
+            return this.customer?.accountType === CUSTOMER.ACCOUNT_TYPE_BUSINESS;
+        },
     },
 
     watch: {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
@@ -15,6 +15,45 @@
         v-else
         class="sw-customer-base-info-columns"
     >
+        <template v-if="isBusinessAccountType && !customerEditMode">
+            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+            {% block sw_customer_base_metadata_company %}
+                <sw-description-list>
+                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                    {% block sw_customer_base_metadata_company_label %}
+                        <dt class="sw-customer-base-info__label">
+                            {{ $tc('sw-customer.baseInfo.labelCompany') }}
+                        </dt>
+                    {% endblock %}
+
+                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                    {% block sw_customer_base_metadata_company_content %}
+                        <dd>
+                            {{ customer.company }}
+                        </dd>
+                    {% endblock %}
+                </sw-description-list>
+            {% endblock %}
+
+            {% block sw_customer_base_metadata_vat_id %}
+                <sw-description-list>
+                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                    {% block sw_customer_base_metadata_vat_id_label %}
+                        <dt class="sw-customer-base-info__label">
+                            {{ $tc('sw-customer.baseInfo.labelVatId') }}
+                        </dt>
+                    {% endblock %}
+
+                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                    {% block sw_customer_base_metadata_vat_id_content %}
+                        <dd>
+                            {{ customer.vatIds[0] }}
+                        </dd>
+                    {% endblock %}
+                </sw-description-list>
+            {% endblock %}
+        </template>
+
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_customer_base_metadata_customer_group %}
         <sw-description-list>

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
@@ -16,42 +16,25 @@
         class="sw-customer-base-info-columns"
     >
         <template v-if="isBusinessAccountType && !customerEditMode">
-            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-            {% block sw_customer_base_metadata_company %}
-                <sw-description-list>
-                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                    {% block sw_customer_base_metadata_company_label %}
-                        <dt class="sw-customer-base-info__label">
-                            {{ $tc('sw-customer.baseInfo.labelCompany') }}
-                        </dt>
-                    {% endblock %}
+            <sw-description-list>
+                <dt class="sw-customer-base-info__label">
+                    {{ $tc('sw-customer.baseInfo.labelCompany') }}
+                </dt>
 
-                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                    {% block sw_customer_base_metadata_company_content %}
-                        <dd>
-                            {{ customer.company }}
-                        </dd>
-                    {% endblock %}
-                </sw-description-list>
-            {% endblock %}
+                <dd>
+                    {{ customer.company }}
+                </dd>
+            </sw-description-list>
 
-            {% block sw_customer_base_metadata_vat_id %}
-                <sw-description-list>
-                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                    {% block sw_customer_base_metadata_vat_id_label %}
-                        <dt class="sw-customer-base-info__label">
-                            {{ $tc('sw-customer.baseInfo.labelVatId') }}
-                        </dt>
-                    {% endblock %}
+            <sw-description-list>
+                <dt class="sw-customer-base-info__label">
+                    {{ $tc('sw-customer.baseInfo.labelVatId') }}
+                </dt>
 
-                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                    {% block sw_customer_base_metadata_vat_id_content %}
-                        <dd>
-                            {{ customer.vatIds[0] }}
-                        </dd>
-                    {% endblock %}
-                </sw-description-list>
-            {% endblock %}
+                <dd>
+                    {{ customer.vatIds[0] }}
+                </dd>
+            </sw-description-list>
         </template>
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/de-DE.json
@@ -126,6 +126,8 @@
       "labelActive": "Kontostatus",
       "labelAffiliateCode": "Affiliate-Code",
       "labelCampaignCode": "Kampagnen-Code",
+      "labelCompany": "Unternehmen",
+      "labelVatId": "USt-IdNr.",
       "contentActive": "Aktiv | Inaktiv",
       "emptyTextLogin": "Noch keine Anmeldung",
       "emptyTextBirthday": "keine Angabe",

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/snippet/en-GB.json
@@ -126,6 +126,8 @@
       "labelActive": "Account status",
       "labelAffiliateCode": "Affiliate code",
       "labelCampaignCode": "Campaign code",
+      "labelCompany": "Company",
+      "labelVatId": "VAT Reg.No.",
       "contentActive": "Active | Inactive",
       "emptyTextLogin": "No login yet",
       "emptyTextBirthday": "No information",


### PR DESCRIPTION
### 1. Why is this change necessary?
Company information like company name and VAT id are not visible on the customer detail page.

### 2. What does this change do, exactly?
Showing the company name and VAT id for commercial customers on the detail page.

### 3. Describe each step to reproduce the issue or behaviour.
1. Login to administration
2. Go to customer overview
3. Select a customer with commercial account type

### 4. Please link to the relevant issues (if any).
Issue https://github.com/shopware/platform/issues/2634

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

### Proof
<img width="965" alt="customer detail page company info" src="https://user-images.githubusercontent.com/7441106/219336095-a3655b0c-11c7-4620-8d30-47bab1712836.png">
