### PR TITLE
fix: Changed the arguments passed to `formatMailAddresses()` to fix passing multiple mail addresses for cc, bcc, reply and return path.

### DIFF
--- a/changelog/_unreleased/2023-02-21-fix-multiple-recipients-throwing-type-error.md
+++ b/changelog/_unreleased/2023-02-21-fix-multiple-recipients-throwing-type-error.md
@@ -1,0 +1,10 @@
+---
+title: Fix multiple recipients throwing type error.
+issue: X
+author: Sven Mäurer
+author_email: s.maeurer@kellerkinder.de
+author_github: Zwaen91
+---
+# Core
+* Changed the arguments passed to `formatMailAddresses()` to fix passing multiple mail addresses for cc, bcc, reply and return path.
+* Validate cc, bcc, reply and return path mail addresses.

--- a/changelog/_unreleased/2023-02-21-fix-multiple-recipients-throwing-type-error.md
+++ b/changelog/_unreleased/2023-02-21-fix-multiple-recipients-throwing-type-error.md
@@ -1,6 +1,6 @@
 ---
 title: Fix multiple recipients throwing type error.
-issue: X
+issue: NEXT-16644
 author: Sven Mäurer
 author_email: s.maeurer@kellerkinder.de
 author_github: Zwaen91

--- a/src/Core/Content/Mail/Service/MailFactory.php
+++ b/src/Core/Content/Mail/Service/MailFactory.php
@@ -70,19 +70,23 @@ class MailFactory extends AbstractMailFactory
         foreach ($additionalData as $key => $value) {
             switch ($key) {
                 case 'recipientsCc':
-                    $mail->addCc(...$this->formatMailAddresses([$value => $value]));
+                    $this->assertValidAddresses(array_keys($value));
+                    $mail->addCc(...$this->formatMailAddresses($value));
 
                     break;
                 case 'recipientsBcc':
-                    $mail->addBcc(...$this->formatMailAddresses([$value => $value]));
+                    $this->assertValidAddresses(array_keys($value));
+                    $mail->addBcc(...$this->formatMailAddresses($value));
 
                     break;
                 case 'replyTo':
-                    $mail->addReplyTo(...$this->formatMailAddresses([$value => $value]));
+                    $this->assertValidAddresses(array_keys($value));
+                    $mail->addReplyTo(...$this->formatMailAddresses($value));
 
                     break;
                 case 'returnPath':
-                    $mail->returnPath(...$this->formatMailAddresses([$value => $value]));
+                    $this->assertValidAddresses(array_keys($value));
+                    $mail->returnPath(...$this->formatMailAddresses($value));
             }
         }
 

--- a/src/Core/Content/Mail/Service/MailFactory.php
+++ b/src/Core/Content/Mail/Service/MailFactory.php
@@ -70,23 +70,27 @@ class MailFactory extends AbstractMailFactory
         foreach ($additionalData as $key => $value) {
             switch ($key) {
                 case 'recipientsCc':
-                    $this->assertValidAddresses(array_keys($value));
-                    $mail->addCc(...$this->formatMailAddresses($value));
+                    $mailAddresses = is_array($value) ? $value : [$value => $value];
+                    $this->assertValidAddresses(array_keys($mailAddresses));
+                    $mail->addCc(...$this->formatMailAddresses($mailAddresses));
 
                     break;
                 case 'recipientsBcc':
-                    $this->assertValidAddresses(array_keys($value));
-                    $mail->addBcc(...$this->formatMailAddresses($value));
+                    $mailAddresses = is_array($value) ? $value : [$value => $value];
+                    $this->assertValidAddresses(array_keys($mailAddresses));
+                    $mail->addBcc(...$this->formatMailAddresses($mailAddresses));
 
                     break;
                 case 'replyTo':
-                    $this->assertValidAddresses(array_keys($value));
-                    $mail->addReplyTo(...$this->formatMailAddresses($value));
+                    $mailAddresses = is_array($value) ? $value : [$value => $value];
+                    $this->assertValidAddresses(array_keys($mailAddresses));
+                    $mail->addReplyTo(...$this->formatMailAddresses($mailAddresses));
 
                     break;
                 case 'returnPath':
-                    $this->assertValidAddresses(array_keys($value));
-                    $mail->returnPath(...$this->formatMailAddresses($value));
+                    $mailAddresses = is_array($value) ? $value : [$value => $value];
+                    $this->assertValidAddresses(array_keys($mailAddresses));
+                    $mail->returnPath(...$this->formatMailAddresses($mailAddresses));
             }
         }
 

--- a/tests/unit/php/Core/Content/Mail/Service/MailFactoryTest.php
+++ b/tests/unit/php/Core/Content/Mail/Service/MailFactoryTest.php
@@ -28,7 +28,12 @@ class MailFactoryTest extends TestCase
         $contents = ['text/html' => 'Message'];
         $attachments = ['test'];
 
-        $additionalData = ['recipientsCc' => 'ccMailRecipient@example.com'];
+        $additionalData = [
+            'recipientsCc' => 'ccMailRecipient@example.com',
+            'recipientsBcc' => [
+                'bccMailRecipient@example.com' => 'bccMailRecipient',
+            ]
+        ];
         $binAttachments = [['content' => 'Content', 'fileName' => 'content.txt', 'mimeType' => 'application/txt']];
 
         $mail = $mailFactory->create(
@@ -59,5 +64,8 @@ class MailFactoryTest extends TestCase
         static::assertEquals($attachments, $mail->getAttachmentUrls());
 
         static::assertSame('ccMailRecipient@example.com', $mail->getCc()[0]->getAddress());
+
+        static::assertSame('bccMailRecipient', $mail->getBcc()[0]->getName());
+        static::assertSame('bccMailRecipient@example.com', $mail->getBcc()[0]->getAddress());
     }
 }

--- a/tests/unit/php/Core/Content/Mail/Service/MailFactoryTest.php
+++ b/tests/unit/php/Core/Content/Mail/Service/MailFactoryTest.php
@@ -33,7 +33,7 @@ class MailFactoryTest extends TestCase
             'recipientsBcc' => [
                 'bccMailRecipient1@example.com' => 'bccMailRecipient1',
                 'bccMailRecipient2@example.com' => 'bccMailRecipient2',
-            ]
+            ],
         ];
         $binAttachments = [['content' => 'Content', 'fileName' => 'content.txt', 'mimeType' => 'application/txt']];
 

--- a/tests/unit/php/Core/Content/Mail/Service/MailFactoryTest.php
+++ b/tests/unit/php/Core/Content/Mail/Service/MailFactoryTest.php
@@ -31,7 +31,8 @@ class MailFactoryTest extends TestCase
         $additionalData = [
             'recipientsCc' => 'ccMailRecipient@example.com',
             'recipientsBcc' => [
-                'bccMailRecipient@example.com' => 'bccMailRecipient',
+                'bccMailRecipient1@example.com' => 'bccMailRecipient1',
+                'bccMailRecipient2@example.com' => 'bccMailRecipient2',
             ]
         ];
         $binAttachments = [['content' => 'Content', 'fileName' => 'content.txt', 'mimeType' => 'application/txt']];
@@ -65,7 +66,9 @@ class MailFactoryTest extends TestCase
 
         static::assertSame('ccMailRecipient@example.com', $mail->getCc()[0]->getAddress());
 
-        static::assertSame('bccMailRecipient', $mail->getBcc()[0]->getName());
-        static::assertSame('bccMailRecipient@example.com', $mail->getBcc()[0]->getAddress());
+        static::assertSame('bccMailRecipient1', $mail->getBcc()[0]->getName());
+        static::assertSame('bccMailRecipient1@example.com', $mail->getBcc()[0]->getAddress());
+        static::assertSame('bccMailRecipient2', $mail->getBcc()[1]->getName());
+        static::assertSame('bccMailRecipient2@example.com', $mail->getBcc()[1]->getAddress());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Type error thrown when sending multiple mail addresses as cc, bcc, reply and return path to `/api/_action/mail-template/send`

### 2. What does this change do, exactly?
Fixing the type error caused by the creation of an array with the recipients array as key.

### 3. Describe each step to reproduce the issue or behaviour.
Request with the paylod below to `/api/_action/mail-template/send`
```
{
  "recipients": {
    "test1@example.com": "Test user 1",
    "test2@example.com": "Test user 2"
  },
  "salesChannelId": null,
  "contentHtml": "string",
  "contentPlain": "string",
  "subject": "string",
  "senderName": "string",
  "senderEmail": "test1@example.com",
  "recipientsBcc": {
    "test1@example.com": "Test user 1",
    "test2@example.com": "Test user 2"
  }
}
```

### 4. Please link to the relevant issues (if any).
Issue https://github.com/shopware/platform/issues/2862

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
