### PR TITLE
Fix storefront theme asset paths

### DIFF
--- a/changelog/_unreleased/2023-02-23-fix-storefront-theme-asset-paths.md
+++ b/changelog/_unreleased/2023-02-23-fix-storefront-theme-asset-paths.md
@@ -1,0 +1,11 @@
+---
+title: Fix storefront theme asset paths
+issue: X
+author: Benjamin Wittwer
+author_email: Discord.Benjamin@web.de
+author_github: Gecolay
+---
+# Storefront
+* Changed the image asset path in `listing.html.twig` to the new `asset('...', 'theme')` structure
+* Changed the image asset path in `error-404.html.twig` to the new `asset('...', 'theme')` structure
+* Changed the image asset path in `error-maintenance.html.twig` to the new `asset('...', 'theme')` structure

--- a/src/Storefront/Resources/views/storefront/component/wishlist/listing.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/wishlist/listing.html.twig
@@ -3,7 +3,7 @@
 {% block element_product_listing_col_empty %}
     <div class="cms-listing-col wishlist-listing-col col-12">
         {% block element_product_listing_col_empty_wishlist %}
-            <img src="{{ asset('bundles/storefront/assets/illustration/wishlist_empty.svg', 'asset') }}"
+            <img src="{{ asset('assets/illustration/wishlist_empty.svg', 'theme') }}"
                  alt="{{ "wishlist.wishlistEmptyDescription"|trans|striptags }}"
                  class="wishlist-listing-empty"/>
 

--- a/src/Storefront/Resources/views/storefront/page/error/error-404.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-404.html.twig
@@ -4,7 +4,7 @@
     <main class="content-main">
         {% block not_found_error_content %}
             <div class="container mt-5">
-                <img src="{{ asset('bundles/storefront/assets/illustration/404_error.svg', 'asset') }}"
+                <img src="{{ asset('assets/illustration/404_error.svg', 'theme') }}"
                      alt="{{ "general.404ErrorPageHeader"|trans|striptags }}"
                      class="rounded mx-auto d-block w-75"/>
 

--- a/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/error/error-maintenance.html.twig
@@ -54,7 +54,7 @@
                         {% else %}
                             {% block error_maintenance_main_fallback %}
                                 <div class="container mt-5">
-                                    <img src="{{ asset('bundles/storefront/assets/illustration/maintenance_mode.svg', 'asset') }}"
+                                    <img src="{{ asset('assets/illustration/maintenance_mode.svg', 'theme') }}"
                                          alt="{{ "general.maintenanceModeHeader"|trans|striptags }}"
                                          class="rounded mx-auto d-block w-75"/>
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The image assets from the maintenance, error-404 and wishlist-listing sections don't get copied into the bundles folder anymore. In the changelog (SW 6.5@RC) the new behavior is described but not used in this 3 sections.

### 2. What does this change do, exactly?
Fixes the path to the theme assets from the storefront theme.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a new Shopware 6.5 project with the production template (symfony flex)
- (Add a custom theme and enable it)
- Enable the maintenance mode
- You can't see the maintenance image on the maintenance page

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
