### PR TITLE
Order rule payload by rule_condition position

### DIFF
--- a/changelog/_unreleased/2023-03-01-add-order-by-position.md
+++ b/changelog/_unreleased/2023-03-01-add-order-by-position.md
@@ -1,0 +1,7 @@
+---
+ title: Add order by position on rule payload update
+ author: Fabian Boensch
+ author_github: @En0Ma1259
+ ---
+ # Core
+ * Added order by position on plain SQL-Query

--- a/src/Core/Content/Rule/DataAbstractionLayer/RulePayloadUpdater.php
+++ b/src/Core/Content/Rule/DataAbstractionLayer/RulePayloadUpdater.php
@@ -52,7 +52,7 @@ class RulePayloadUpdater implements EventSubscriberInterface
             FROM rule_condition rc
             LEFT JOIN app_script_condition rs ON rc.script_id = rs.id AND rs.active = 1
             WHERE rc.rule_id IN (:ids)
-            ORDER BY rc.rule_id',
+            ORDER BY rc.rule_id, rc.position',
             ['ids' => Uuid::fromHexToBytesList($ids)],
             ['ids' => ArrayParameterType::STRING]
         );


### PR DESCRIPTION
### 1. Why is this change necessary?
At some point, rules get quite complex. To have an "early return" the position of a condition can be useful. In the administration, a user can add a condition before or after another. The indexer don't care and will add rules random to the payload.

### Example
#### Adminitration order:
And-Rule with
1. SalesChannel check
2. Or-Condition with many sub-conditions

#### Order in Rule payload
1. SalesChannel check
2. Or-Condition with many sub-conditions

OR

1. Or-Condition with many sub-conditions
2. SalesChannel check

In this example the Or-Condition doesn't need to be validated, if the sales channel is not correct
Without this order by, it's not clear, which condition is checked first.

### 2. What does this change do, exactly?
Adds a second order parameter for rule payload generation

### 3. Describe each step to reproduce the issue or behaviour.
Create a rule with
1. And-Rule
2. First small condition (e.g. SalesChannel check, Customer is logged in)
5. Second computationally intensive conditions (e.g. complex delivery address conditions)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
