### PR TITLE
Less @internal API 

### DIFF
--- a/changelog/_unreleased/2023-03-09-final-storable-flow.md
+++ b/changelog/_unreleased/2023-03-09-final-storable-flow.md
@@ -1,0 +1,19 @@
+---
+title: Final storable flow
+issue: NEXT-25696
+author: Oliver Skroblin
+author_email: o.skroblin@shopware.com
+author_github: @OliverSkroblin
+---
+# Core
+* Removed `StorableFlow` @internal flag and define the class as final
+* Removed `FlowAction` @internal flag to allow external developers provide own flow actions
+* Removed `DemodataGeneratorInterface` @internal flag to provide own demo data generators via extensions
+* Changed `ContainerFacade` @internal flag to @final, due to the fact that apps already consum this service as public API
+* Removed `AbstractRuleLoader` @internal flag to allow decorating
+* Removed `AbstractFlowLoader` @internal flag to allow developers loading of flows by their own
+* Removed @internal flag of `EntityIndexerRegistry` to allow developers to use the service (including BC promise)
+* Removed @internal flag from `EntityIndexingMessage` DTO to allow developers to create entity indexing message by their own
+* Changed @internal flag for demo data domain classes which are required to add own demo data as developer. 
+* Changed @internal flag for `EntityScoreQueryBuilder` to @final to allow developers to use the service (including BC promise)
+* Changed @internal flag for `IncrementGatewayRegistry` to @final to allow developers to use the service (including BC promise)

--- a/changelog/_unreleased/2023-03-09-final-storable-flow.md
+++ b/changelog/_unreleased/2023-03-09-final-storable-flow.md
@@ -17,3 +17,4 @@ author_github: @OliverSkroblin
 * Changed @internal flag for demo data domain classes which are required to add own demo data as developer. 
 * Changed @internal flag for `EntityScoreQueryBuilder` to @final to allow developers to use the service (including BC promise)
 * Changed @internal flag for `IncrementGatewayRegistry` to @final to allow developers to use the service (including BC promise)
+* Added `\Shopware\Core\Framework\Util\Json` public api class for unified json encoding

--- a/changelog/_unreleased/2023-03-09-final-storable-flow.md
+++ b/changelog/_unreleased/2023-03-09-final-storable-flow.md
@@ -7,14 +7,17 @@ author_github: @OliverSkroblin
 ---
 # Core
 * Removed `StorableFlow` @internal flag and define the class as final
-* Removed `FlowAction` @internal flag to allow external developers provide own flow actions
-* Removed `DemodataGeneratorInterface` @internal flag to provide own demo data generators via extensions
+* Removed `FlowAction` @internal flag, to allow external developers provide own flow actions
+* Removed `DemodataGeneratorInterface` @internal flag, to provide own demo data generators via extensions
 * Changed `ContainerFacade` @internal flag to @final, due to the fact that apps already consum this service as public API
-* Removed `AbstractRuleLoader` @internal flag to allow decorating
-* Removed `AbstractFlowLoader` @internal flag to allow developers loading of flows by their own
-* Removed @internal flag of `EntityIndexerRegistry` to allow developers to use the service (including BC promise)
-* Removed @internal flag from `EntityIndexingMessage` DTO to allow developers to create entity indexing message by their own
-* Changed @internal flag for demo data domain classes which are required to add own demo data as developer. 
-* Changed @internal flag for `EntityScoreQueryBuilder` to @final to allow developers to use the service (including BC promise)
-* Changed @internal flag for `IncrementGatewayRegistry` to @final to allow developers to use the service (including BC promise)
+* Removed `AbstractRuleLoader` @internal flag, to allow decorating
+* Removed `AbstractFlowLoader` @internal flag, to allow developers loading of flows by their own
+* Removed @internal flag of `EntityIndexerRegistry`, to allow developers to use the service (including BC promise)
+* Removed @internal flag from `EntityIndexingMessage` DTO, to allow developers to create entity indexing message by their own
+* Changed @internal flag for demo data domain classes, which are required to add own demo data as developer. 
+* Changed @internal flag for `EntityScoreQueryBuilder`, to @final to allow developers to use the service (including BC promise)
+* Changed @internal flag for `IncrementGatewayRegistry`, to @final to allow developers to use the service (including BC promise)
 * Added `\Shopware\Core\Framework\Util\Json` public api class for unified json encoding
+* Removed @internal flag for `AppEntity` 
+* Removed @internal flag for `DocumentConfigLoader`, to allow developers to use the service (including BC promise)
+* Removed @internal flag for `OrderLineItemEntity::$promotion`, to allow developers to access the property

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -164,6 +164,13 @@ parameters:
                 - src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryDefinition.php
                 - src/Core/System/NumberRange/NumberRangeDefinition.php
 
+        - # NEXT-25276 - Needs to be fixed with the update ot PHPUnit 10
+            message: '#deprecated interface PHPUnit\\Framework\\TestListener#'
+            path: src/Core/Framework/Test/TestCaseBase/DatadogListener.php
+
+        # Internal deprecations of Shopware are handled in other places
+        - '#deprecated.*class Shopware\\#'
+
 services:
     -
         class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Deprecation\DeprecatedMethodsThrowDeprecationRule

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -164,13 +164,6 @@ parameters:
                 - src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryDefinition.php
                 - src/Core/System/NumberRange/NumberRangeDefinition.php
 
-        - # NEXT-25276 - Needs to be fixed with the update ot PHPUnit 10
-            message: '#deprecated interface PHPUnit\\Framework\\TestListener#'
-            path: src/Core/Framework/Test/TestCaseBase/DatadogListener.php
-
-        # Internal deprecations of Shopware are handled in other places
-        - '#deprecated.*class Shopware\\#'
-
 services:
     -
         class: Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\Deprecation\DeprecatedMethodsThrowDeprecationRule

--- a/src/Administration/Controller/UserConfigController.php
+++ b/src/Administration/Controller/UserConfigController.php
@@ -10,7 +10,6 @@ use Shopware\Core\Framework\Api\Controller\Exception\ExpectedUserHttpException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;

--- a/src/Administration/Controller/UserConfigController.php
+++ b/src/Administration/Controller/UserConfigController.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigDefinition;
 use Shopware\Core\System\User\Aggregate\UserConfig\UserConfigEntity;
@@ -104,7 +105,7 @@ class UserConfigController extends AbstractController
         $queue = new MultiInsertQueryQueue($this->connection, 250, false, true);
         foreach ($postUpdateConfigs as $key => $value) {
             $data = [
-                'value' => JsonFieldSerializer::encodeJson($value),
+                'value' => Json::encode($value),
                 'user_id' => Uuid::fromHexToBytes($userId),
                 'key' => $key,
                 'id' => Uuid::randomBytes(),

--- a/src/Core/Checkout/Cart/AbstractRuleLoader.php
+++ b/src/Core/Checkout/Cart/AbstractRuleLoader.php
@@ -6,9 +6,6 @@ use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @internal
- */
 #[Package('checkout')]
 abstract class AbstractRuleLoader
 {

--- a/src/Core/Checkout/Cart/CachedRuleLoader.php
+++ b/src/Core/Checkout/Cart/CachedRuleLoader.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\Cache\CacheInterface;
 
+/**
+ * @internal Depend on the AbstractRuleLoader which is the definition of public API for this scope
+ */
 #[Package('checkout')]
 class CachedRuleLoader extends AbstractRuleLoader
 {

--- a/src/Core/Checkout/Cart/Facade/ContainerFacade.php
+++ b/src/Core/Checkout/Cart/Facade/ContainerFacade.php
@@ -22,7 +22,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
  *
  * @script-service cart_manipulation
  *
- * @internal
+ * @final
  */
 #[Package('checkout')]
 class ContainerFacade extends ItemFacade

--- a/src/Core/Checkout/Cart/Order/Transformer/CartTransformer.php
+++ b/src/Core/Checkout/Cart/Order/Transformer/CartTransformer.php
@@ -6,6 +6,7 @@ use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -35,8 +36,8 @@ class CartTransformer
             $data['orderDateTime'] = (new \DateTimeImmutable())->format(Defaults::STORAGE_DATE_TIME_FORMAT);
         }
 
-        $data['itemRounding'] = json_decode(JsonFieldSerializer::encodeJson($context->getItemRounding()), true, 512, \JSON_THROW_ON_ERROR);
-        $data['totalRounding'] = json_decode(JsonFieldSerializer::encodeJson($context->getTotalRounding()), true, 512, \JSON_THROW_ON_ERROR);
+        $data['itemRounding'] = json_decode(Json::encode($context->getItemRounding()), true, 512, \JSON_THROW_ON_ERROR);
+        $data['totalRounding'] = json_decode(Json::encode($context->getTotalRounding()), true, 512, \JSON_THROW_ON_ERROR);
 
         return $data;
     }

--- a/src/Core/Checkout/Cart/Order/Transformer/CartTransformer.php
+++ b/src/Core/Checkout/Cart/Order/Transformer/CartTransformer.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Checkout\Cart\Order\Transformer;
 
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Util\Random;

--- a/src/Core/Checkout/Cart/RuleLoader.php
+++ b/src/Core/Checkout/Cart/RuleLoader.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
 /**
- * @internal
+ * @internal Depend on the AbstractRuleLoader which is the definition of public API for this scope
  */
 #[Package('checkout')]
 class RuleLoader extends AbstractRuleLoader

--- a/src/Core/Checkout/Document/Service/DocumentConfigLoader.php
+++ b/src/Core/Checkout/Document/Service/DocumentConfigLoader.php
@@ -14,9 +14,6 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
-/**
- * @internal
- */
 #[Package('customer-order')]
 final class DocumentConfigLoader implements EventSubscriberInterface, ResetInterface
 {
@@ -32,6 +29,9 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
     {
     }
 
+    /**
+     * @internal
+     */
     public static function getSubscribedEvents(): array
     {
         return [
@@ -65,6 +65,9 @@ final class DocumentConfigLoader implements EventSubscriberInterface, ResetInter
         return $this->configs[$documentType][$salesChannelId] = $config;
     }
 
+    /**
+     * @internal
+     */
     public function reset(): void
     {
         $this->configs = [];

--- a/src/Core/Checkout/Order/Aggregate/OrderLineItem/OrderLineItemEntity.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderLineItem/OrderLineItemEntity.php
@@ -163,9 +163,6 @@ class OrderLineItemEntity extends Entity
 
     protected ?OrderLineItemDownloadCollection $downloads = null;
 
-    /**
-     * @internal
-     */
     protected ?PromotionEntity $promotion = null;
 
     /**
@@ -449,33 +446,21 @@ class OrderLineItemEntity extends Entity
         $this->orderTransactionCaptureRefundPositions = $orderTransactionCaptureRefundPositions;
     }
 
-    /**
-     * @internal
-     */
     public function getPromotionId(): ?string
     {
         return $this->promotionId;
     }
 
-    /**
-     * @internal
-     */
     public function setPromotionId(?string $promotionId): void
     {
         $this->promotionId = $promotionId;
     }
 
-    /**
-     * @internal
-     */
     public function getPromotion(): ?PromotionEntity
     {
         return $this->promotion;
     }
 
-    /**
-     * @internal
-     */
     public function setPromotion(?PromotionEntity $promotion): void
     {
         $this->promotion = $promotion;

--- a/src/Core/Checkout/Payment/SalesChannel/CachedPaymentMethodRoute.php
+++ b/src/Core/Checkout/Payment/SalesChannel/CachedPaymentMethodRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -92,7 +93,7 @@ class CachedPaymentMethodRoute extends AbstractPaymentMethodRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Checkout/Payment/SalesChannel/CachedPaymentMethodRoute.php
+++ b/src/Core/Checkout/Payment/SalesChannel/CachedPaymentMethodRoute.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
+++ b/src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionRedemptionUpdater.php
@@ -17,7 +17,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 /**
  * @internal
  */
-#[Package('core')]
+#[Package('checkout')]
 class PromotionRedemptionUpdater implements EventSubscriberInterface
 {
     /**

--- a/src/Core/Checkout/Shipping/SalesChannel/CachedShippingMethodRoute.php
+++ b/src/Core/Checkout/Shipping/SalesChannel/CachedShippingMethodRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -92,7 +93,7 @@ class CachedShippingMethodRoute extends AbstractShippingMethodRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Checkout/Shipping/SalesChannel/CachedShippingMethodRoute.php
+++ b/src/Core/Checkout/Shipping/SalesChannel/CachedShippingMethodRoute.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/Content/Category/SalesChannel/CachedCategoryRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CachedCategoryRoute.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Profiling\Profiler;

--- a/src/Core/Content/Category/SalesChannel/CachedCategoryRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CachedCategoryRoute.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Profiling\Profiler;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -90,7 +91,7 @@ class CachedCategoryRoute extends AbstractCategoryRoute
             return null;
         }
 
-        return self::buildName($navigationId) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($navigationId) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Content/Category/SalesChannel/CachedNavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CachedNavigationRoute.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Profiling\Profiler;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
@@ -149,7 +150,7 @@ class CachedNavigationRoute extends AbstractNavigationRoute
             return null;
         }
 
-        return self::buildName($active) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($active) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Content/Category/SalesChannel/CachedNavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CachedNavigationRoute.php
@@ -10,7 +10,6 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/Content/Flow/DataAbstractionLayer/FieldSerializer/FlowTemplateConfigFieldSerializer.php
+++ b/src/Core/Content/Flow/DataAbstractionLayer/FieldSerializer/FlowTemplateConfigFieldSerializer.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Validation\Constraint\Uuid;
 use Symfony\Component\Validator\Constraints\Collection;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -57,7 +58,7 @@ class FlowTemplateConfigFieldSerializer extends JsonFieldSerializer
             'trueCase' => 0,
         ], $item), $sequences);
 
-        yield $field->getStorageName() => JsonFieldSerializer::encodeJson($value);
+        yield $field->getStorageName() => Json::encode($value);
     }
 
     protected function getConstraints(Field $field): array

--- a/src/Core/Content/Flow/Dispatching/AbstractFlowLoader.php
+++ b/src/Core/Content/Flow/Dispatching/AbstractFlowLoader.php
@@ -10,7 +10,5 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('business-ops')]
 abstract class AbstractFlowLoader
 {
-    abstract public function getDecorated(): AbstractFlowLoader;
-
     abstract public function load(): array;
 }

--- a/src/Core/Content/Flow/Dispatching/Action/FlowAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/FlowAction.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Content\Flow\Dispatching\Action;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @internal
- */
 #[Package('business-ops')]
 abstract class FlowAction
 {

--- a/src/Core/Content/Flow/Dispatching/CachedFlowLoader.php
+++ b/src/Core/Content/Flow/Dispatching/CachedFlowLoader.php
@@ -36,11 +36,6 @@ class CachedFlowLoader extends AbstractFlowLoader implements EventSubscriberInte
         ];
     }
 
-    public function getDecorated(): AbstractFlowLoader
-    {
-        return $this->decorated;
-    }
-
     public function load(): array
     {
         if (!empty($this->flows)) {
@@ -50,7 +45,7 @@ class CachedFlowLoader extends AbstractFlowLoader implements EventSubscriberInte
         $value = $this->cache->get(self::KEY, function (ItemInterface $item) {
             $item->tag([self::KEY]);
 
-            return CacheValueCompressor::compress($this->getDecorated()->load());
+            return CacheValueCompressor::compress($this->decorated->load());
         });
 
         return $this->flows = CacheValueCompressor::uncompress($value);

--- a/src/Core/Content/Flow/Dispatching/FlowLoader.php
+++ b/src/Core/Content/Flow/Dispatching/FlowLoader.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Connection;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 
 /**
  * @internal not intended for decoration or replacement
@@ -18,11 +17,6 @@ class FlowLoader extends AbstractFlowLoader
         private readonly Connection $connection,
         private readonly LoggerInterface $logger
     ) {
-    }
-
-    public function getDecorated(): AbstractFlowLoader
-    {
-        throw new DecorationPatternException(self::class);
     }
 
     public function load(): array

--- a/src/Core/Content/Flow/Dispatching/StorableFlow.php
+++ b/src/Core/Content/Flow/Dispatching/StorableFlow.php
@@ -7,19 +7,21 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
+ * @final
  */
 #[Package('business-ops')]
 class StorableFlow
 {
-    protected ?FlowState $state = null;
+    private ?FlowState $state = null;
 
     /**
      * @var array<string, mixed>
      */
-    protected array $config = [];
+    private array $config = [];
 
     /**
+     * @internal
+     *
      * @param array<string, mixed> $store
      * @param array<string, mixed> $data
      */

--- a/src/Core/Content/LandingPage/SalesChannel/CachedLandingPageRoute.php
+++ b/src/Core/Content/LandingPage/SalesChannel/CachedLandingPageRoute.php
@@ -11,7 +11,6 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;

--- a/src/Core/Content/LandingPage/SalesChannel/CachedLandingPageRoute.php
+++ b/src/Core/Content/LandingPage/SalesChannel/CachedLandingPageRoute.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -86,7 +87,7 @@ class CachedLandingPageRoute extends AbstractLandingPageRoute
             return null;
         }
 
-        return self::buildName($landingPageId) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($landingPageId) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
@@ -7,7 +7,6 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPriceContainer;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Uuid\Uuid;

--- a/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/CheapestPriceUpdater.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 #[Package('core')]
@@ -69,7 +70,7 @@ class CheapestPriceUpdater
             );
 
             foreach ($container->getVariantIds() as $variantId) {
-                $accessor = JsonFieldSerializer::encodeJson($this->buildAccessor($container, $variantId));
+                $accessor = Json::encode($this->buildAccessor($container, $variantId));
 
                 if (($existingAccessors[Uuid::fromHexToBytes($variantId)] ?? null) === $accessor) {
                     continue;

--- a/src/Core/Content/Product/SalesChannel/CrossSelling/CachedProductCrossSellingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/CrossSelling/CachedProductCrossSellingRoute.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/Content/Product/SalesChannel/CrossSelling/CachedProductCrossSellingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/CrossSelling/CachedProductCrossSellingRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -88,7 +89,7 @@ class CachedProductCrossSellingRoute extends AbstractProductCrossSellingRoute
             return null;
         }
 
-        return self::buildName($productId) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($productId) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Detail/CachedProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/CachedProductDetailRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -88,7 +89,7 @@ class CachedProductDetailRoute extends AbstractProductDetailRoute
             return null;
         }
 
-        return self::buildName($productId) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($productId) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Detail/CachedProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/CachedProductDetailRoute.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/Content/Product/SalesChannel/Listing/CachedProductListingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/CachedProductListingRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -88,7 +89,7 @@ class CachedProductListingRoute extends AbstractProductListingRoute
             return null;
         }
 
-        return self::buildName($categoryId) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($categoryId) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Listing/CachedProductListingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/CachedProductListingRoute.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/Content/Product/SalesChannel/Review/CachedProductReviewRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Review/CachedProductReviewRoute.php
@@ -9,7 +9,6 @@ use Shopware\Core\Framework\Adapter\Cache\CacheStateSubscriber;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/Content/Product/SalesChannel/Review/CachedProductReviewRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Review/CachedProductReviewRoute.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
@@ -89,7 +90,7 @@ class CachedProductReviewRoute extends AbstractProductReviewRoute
         $event = new ProductDetailRouteCacheKeyEvent($parts, $request, $context, $criteria);
         $this->dispatcher->dispatch($event);
 
-        return self::buildName($productId) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($productId) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Search/CachedProductSearchRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Search/CachedProductSearchRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -84,7 +85,7 @@ class CachedProductSearchRoute extends AbstractProductSearchRoute
             return null;
         }
 
-        return self::NAME . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::NAME . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Search/CachedProductSearchRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Search/CachedProductSearchRoute.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/Content/Product/SalesChannel/Suggest/CachedProductSuggestRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Suggest/CachedProductSuggestRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -85,7 +86,7 @@ class CachedProductSuggestRoute extends AbstractProductSuggestRoute
             return null;
         }
 
-        return self::NAME . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::NAME . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Suggest/CachedProductSuggestRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Suggest/CachedProductSuggestRoute.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/Content/Sitemap/SalesChannel/CachedSitemapRoute.php
+++ b/src/Core/Content/Sitemap/SalesChannel/CachedSitemapRoute.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\Request;
@@ -93,7 +94,7 @@ class CachedSitemapRoute extends AbstractSitemapRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/Content/Sitemap/SalesChannel/CachedSitemapRoute.php
+++ b/src/Core/Content/Sitemap/SalesChannel/CachedSitemapRoute.php
@@ -8,7 +8,6 @@ use Shopware\Core\Content\Sitemap\Service\SitemapExporterInterface;
 use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;

--- a/src/Core/Framework/App/AppEntity.php
+++ b/src/Core/Framework/App/AppEntity.php
@@ -20,9 +20,6 @@ use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetColl
 use Shopware\Core\System\Integration\IntegrationEntity;
 use Shopware\Core\System\TaxProvider\TaxProviderCollection;
 
-/**
- * @internal
- */
 #[Package('core')]
 class AppEntity extends Entity
 {

--- a/src/Core/Framework/App/FlowAction/FlowAction.php
+++ b/src/Core/Framework/App/FlowAction/FlowAction.php
@@ -7,9 +7,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SystemConfig\Exception\XmlParsingException;
 use Symfony\Component\Config\Util\XmlUtils;
 
-/**
- * @internal
- */
 #[Package('core')]
 class FlowAction
 {

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CustomFieldsSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/CustomFieldsSerializer.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteCommandExtractor;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\CustomField\CustomFieldService;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
@@ -68,7 +69,7 @@ class CustomFieldsSerializer extends JsonFieldSerializer
             return;
         }
 
-        yield $field->getStorageName() => parent::encodeJson($encoded);
+        yield $field->getStorageName() => Json::encode($encoded);
     }
 
     public function decode(Field $field, mixed $value): array|object|null

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/JsonFieldSerializer.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\Unexpected
 use Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\WriteFieldException;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
 
@@ -26,7 +27,7 @@ use Symfony\Component\Validator\Constraints\Type;
 class JsonFieldSerializer extends AbstractFieldSerializer
 {
     /**
-     * mariadbs `JSON_VALID` function does not allow escaped unicode.
+     * @deprecated tag:v6.6.0 - Will be removed, use \Shopware\Core\Framework\Util\Json::encode instead
      */
     public static function encodeJson(mixed $value, int $options = \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR | \JSON_INVALID_UTF8_IGNORE): string
     {
@@ -52,7 +53,7 @@ class JsonFieldSerializer extends AbstractFieldSerializer
         }
 
         if ($value !== null) {
-            $value = self::encodeJson($value);
+            $value = Json::encode($value);
         }
 
         yield $field->getStorageName() => $value;
@@ -80,7 +81,7 @@ class JsonFieldSerializer extends AbstractFieldSerializer
                 continue;
             }
             $value = $embedded instanceof JsonField
-                ? self::encodeJson($raw[$key])
+                ? Json::encode($raw[$key])
                 : $raw[$key];
 
             $embedded->compile($this->definitionRegistry);

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/ListFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/ListFieldSerializer.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\WriteFieldException;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Symfony\Component\Validator\Constraints\Type;
 
 /**
@@ -41,7 +42,7 @@ class ListFieldSerializer extends AbstractFieldSerializer
 
             $this->validateTypes($field, $value, $parameters);
 
-            $value = JsonFieldSerializer::encodeJson($value);
+            $value = Json::encode($value);
         }
 
         yield $field->getStorageName() => $value;

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceFieldSerializer.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Validation\Constraint\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use Symfony\Component\Validator\Constraints\Collection;
@@ -96,7 +97,7 @@ class PriceFieldSerializer extends AbstractFieldSerializer
         }
 
         if ($value !== null) {
-            $value = JsonFieldSerializer::encodeJson($value);
+            $value = Json::encode($value);
         }
 
         yield $field->getStorageName() => $value;

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
@@ -18,8 +18,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 /**
  * @final
  *
- * @internal
- *
  * @phpstan-import-type Offset from IterableQuery
  */
 #[AsMessageHandler]
@@ -46,6 +44,9 @@ class EntityIndexerRegistry
     ) {
     }
 
+    /**
+     * @internal
+     */
     public function __invoke(EntityIndexingMessage|IterateEntityIndexerMessage $message): void
     {
         if ($message instanceof EntityIndexingMessage) {

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexingMessage.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexingMessage.php
@@ -21,9 +21,6 @@ class EntityIndexingMessage implements AsyncMessageInterface
      */
     private array $skip = [];
 
-    /**
-     * @internal
-     */
     public function __construct(
         protected $data,
         protected $offset = null,

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\StateAwareTrait;
 use Shopware\Core\Framework\Struct\Struct;
+use Shopware\Core\Framework\Util\Json;
 
 /**
  * @final
@@ -140,7 +141,7 @@ class Criteria extends Struct implements \Stringable
     {
         $parsed = (new CriteriaArrayConverter(new AggregationParser()))->convert($this);
 
-        return JsonFieldSerializer::encodeJson($parsed);
+        return Json::encode($parsed);
     }
 
     /**

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer\Search;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Aggregation;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\Filter;

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/EntityScoreQueryBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/EntityScoreQueryBuilder.php
@@ -20,7 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
+ * @final
  */
 #[Package('core')]
 class EntityScoreQueryBuilder

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -26,7 +26,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -46,6 +46,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Lock\LockFactory;
@@ -498,8 +499,8 @@ class VersionManager
                         'id' => $id,
                         'version_commit_id' => $commitId,
                         'entity_name' => $entityName,
-                        'entity_id' => JsonFieldSerializer::encodeJson($primary),
-                        'payload' => JsonFieldSerializer::encodeJson($payload),
+                        'entity_id' => Json::encode($primary),
+                        'payload' => Json::encode($payload),
                         'user_id' => $userId,
                         'action' => $isClone ? 'clone' : $item->getOperation(),
                         'created_at' => $date,
@@ -818,7 +819,7 @@ class VersionManager
 
                 $new[] = [
                     'entityId' => $id,
-                    'payload' => JsonFieldSerializer::encodeJson($payload),
+                    'payload' => Json::encode($payload),
                     'userId' => $data->getUserId(),
                     'integrationId' => $data->getIntegrationId(),
                     'entityName' => $data->getEntityName(),
@@ -857,7 +858,7 @@ class VersionManager
                 ];
 
                 // deduplicate to prevent deletion errors
-                $entityKey = md5(JsonFieldSerializer::encodeJson($entity));
+                $entityKey = md5(Json::encode($entity));
                 if (isset($handled[$entityKey])) {
                     continue;
                 }

--- a/src/Core/Framework/Demodata/DemodataContext.php
+++ b/src/Core/Framework/Demodata/DemodataContext.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * @internal
+ * @final
  */
 #[Package('core')]
 class DemodataContext

--- a/src/Core/Framework/Demodata/DemodataGeneratorInterface.php
+++ b/src/Core/Framework/Demodata/DemodataGeneratorInterface.php
@@ -4,9 +4,6 @@ namespace Shopware\Core\Framework\Demodata;
 
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @internal
- */
 #[Package('core')]
 interface DemodataGeneratorInterface
 {

--- a/src/Core/Framework/Demodata/DemodataRequest.php
+++ b/src/Core/Framework/Demodata/DemodataRequest.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Demodata;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
+ * @final
  */
 #[Package('core')]
 class DemodataRequest

--- a/src/Core/Framework/Demodata/DemodataService.php
+++ b/src/Core/Framework/Demodata/DemodataService.php
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * @internal
+ * @final
  */
 #[Package('core')]
 class DemodataService

--- a/src/Core/Framework/Demodata/Event/DemodataRequestCreatedEvent.php
+++ b/src/Core/Framework/Demodata/Event/DemodataRequestCreatedEvent.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * @internal
+ * @final
  */
 #[Package('core')]
 class DemodataRequestCreatedEvent extends Event

--- a/src/Core/Framework/Increment/IncrementGatewayRegistry.php
+++ b/src/Core/Framework/Increment/IncrementGatewayRegistry.php
@@ -6,7 +6,7 @@ use Shopware\Core\Framework\Increment\Exception\IncrementGatewayNotFoundExceptio
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal - Used internally for Increment pattern
+ * @final
  */
 #[Package('core')]
 class IncrementGatewayRegistry

--- a/src/Core/Framework/Test/DataAbstractionLayer/FieldSerializer/JsonFieldSerializerTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/FieldSerializer/JsonFieldSerializerTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayer
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\JsonDefinition;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 
 /**
@@ -63,18 +64,18 @@ class JsonFieldSerializerTest extends TestCase
     public static function encodeProvider(): array
     {
         return [
-            [new JsonField('data', 'data'), ['foo' => 'bar'], JsonFieldSerializer::encodeJson(['foo' => 'bar'])],
-            [new JsonField('data', 'data'), ['foo' => 1], JsonFieldSerializer::encodeJson(['foo' => 1])],
-            [new JsonField('data', 'data'), ['foo' => 5.3], JsonFieldSerializer::encodeJson(['foo' => 5.3])],
-            [new JsonField('data', 'data'), ['foo' => ['bar' => 'baz']], JsonFieldSerializer::encodeJson(['foo' => ['bar' => 'baz']])],
+            [new JsonField('data', 'data'), ['foo' => 'bar'], Json::encode(['foo' => 'bar'])],
+            [new JsonField('data', 'data'), ['foo' => 1], Json::encode(['foo' => 1])],
+            [new JsonField('data', 'data'), ['foo' => 5.3], Json::encode(['foo' => 5.3])],
+            [new JsonField('data', 'data'), ['foo' => ['bar' => 'baz']], Json::encode(['foo' => ['bar' => 'baz']])],
 
             [new JsonField('data', 'data'), null, null],
-            [new JsonField('data', 'data', [], []), null, JsonFieldSerializer::encodeJson([])],
+            [new JsonField('data', 'data', [], []), null, Json::encode([])],
 
-            [new JsonField('data', 'data', [], ['foo' => 'bar']), null, JsonFieldSerializer::encodeJson(['foo' => 'bar'])],
-            [new JsonField('data', 'data', [], ['foo' => 1]), null, JsonFieldSerializer::encodeJson(['foo' => 1])],
-            [new JsonField('data', 'data', [], ['foo' => 5.3]), null, JsonFieldSerializer::encodeJson(['foo' => 5.3])],
-            [new JsonField('data', 'data', [], ['foo' => ['bar' => 'baz']]), null, JsonFieldSerializer::encodeJson(['foo' => ['bar' => 'baz']])],
+            [new JsonField('data', 'data', [], ['foo' => 'bar']), null, Json::encode(['foo' => 'bar'])],
+            [new JsonField('data', 'data', [], ['foo' => 1]), null, Json::encode(['foo' => 1])],
+            [new JsonField('data', 'data', [], ['foo' => 5.3]), null, Json::encode(['foo' => 5.3])],
+            [new JsonField('data', 'data', [], ['foo' => ['bar' => 'baz']]), null, Json::encode(['foo' => ['bar' => 'baz']])],
         ];
     }
 
@@ -94,11 +95,11 @@ class JsonFieldSerializerTest extends TestCase
     public static function decodeProvider(): array
     {
         return [
-            [new JsonField('data', 'data'), JsonFieldSerializer::encodeJson(['foo' => 'bar']), ['foo' => 'bar']],
+            [new JsonField('data', 'data'), Json::encode(['foo' => 'bar']), ['foo' => 'bar']],
 
-            [new JsonField('data', 'data'), JsonFieldSerializer::encodeJson(['foo' => 1]), ['foo' => 1]],
-            [new JsonField('data', 'data'), JsonFieldSerializer::encodeJson(['foo' => 5.3]), ['foo' => 5.3]],
-            [new JsonField('data', 'data'), JsonFieldSerializer::encodeJson(['foo' => ['bar' => 'baz']]), ['foo' => ['bar' => 'baz']]],
+            [new JsonField('data', 'data'), Json::encode(['foo' => 1]), ['foo' => 1]],
+            [new JsonField('data', 'data'), Json::encode(['foo' => 5.3]), ['foo' => 5.3]],
+            [new JsonField('data', 'data'), Json::encode(['foo' => ['bar' => 'baz']]), ['foo' => ['bar' => 'baz']]],
 
             [new JsonField('data', 'data'), null, null],
             [new JsonField('data', 'data', [], []), null, []],
@@ -166,7 +167,7 @@ class JsonFieldSerializerTest extends TestCase
 
     public function testIgnoresInvalidUtf8Characters(): void
     {
-        $result = $this->serializer::encodeJson("something\x82 another");
+        $result = Json::encode("something\x82 another");
 
         static::assertEquals('"something another"', $result);
     }

--- a/src/Core/Framework/Test/DataAbstractionLayer/FieldSerializer/ListFieldSerializerTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/FieldSerializer/ListFieldSerializerTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Framework\Test\DataAbstractionLayer\FieldSerializer;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\ListFieldSerializer;
 use Shopware\Core\Framework\Util\Json;
 use Symfony\Component\Validator\Validator\ValidatorInterface;

--- a/src/Core/Framework/Test/DataAbstractionLayer/FieldSerializer/ListFieldSerializerTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/FieldSerializer/ListFieldSerializerTest.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ListField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\ListFieldSerializer;
+use Shopware\Core\Framework\Util\Json;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
@@ -36,11 +37,11 @@ class ListFieldSerializerTest extends TestCase
     public static function decodeProvider(): array
     {
         return [
-            [new ListField('data', 'data'), JsonFieldSerializer::encodeJson(['foo' => 'bar']), ['bar']],
-            [new ListField('data', 'data'), JsonFieldSerializer::encodeJson([0 => 'bar', 1 => 'foo']), ['bar', 'foo']],
-            [new ListField('data', 'data'), JsonFieldSerializer::encodeJson(['foo' => 1]), [1]],
-            [new ListField('data', 'data'), JsonFieldSerializer::encodeJson(['foo' => 5.3]), [5.3]],
-            [new ListField('data', 'data'), JsonFieldSerializer::encodeJson(['foo' => ['bar' => 'baz']]), [['bar' => 'baz']]],
+            [new ListField('data', 'data'), Json::encode(['foo' => 'bar']), ['bar']],
+            [new ListField('data', 'data'), Json::encode([0 => 'bar', 1 => 'foo']), ['bar', 'foo']],
+            [new ListField('data', 'data'), Json::encode(['foo' => 1]), [1]],
+            [new ListField('data', 'data'), Json::encode(['foo' => 5.3]), [5.3]],
+            [new ListField('data', 'data'), Json::encode(['foo' => ['bar' => 'baz']]), [['bar' => 'baz']]],
             [new ListField('data', 'data'), null, null],
         ];
     }

--- a/src/Core/Framework/Util/Json.php
+++ b/src/Core/Framework/Util/Json.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Shopware\Core\Framework\Util;
+
+/**
+ * @final
+ */
+class Json
+{
+    /**
+     * Mariadbs `JSON_VALID` function does not allow escaped unicode.
+     */
+    public static function encode(mixed $value, int $options = \JSON_UNESCAPED_UNICODE | \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR | \JSON_INVALID_UTF8_IGNORE): string
+    {
+        return (string) json_encode($value, $options);
+    }
+}

--- a/src/Core/Framework/Util/Json.php
+++ b/src/Core/Framework/Util/Json.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Shopware\Core\Framework\Util;
 

--- a/src/Core/System/Country/SalesChannel/CachedCountryRoute.php
+++ b/src/Core/System/Country/SalesChannel/CachedCountryRoute.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\System\Country\SalesChannel;
 use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/System/Country/SalesChannel/CachedCountryRoute.php
+++ b/src/Core/System/Country/SalesChannel/CachedCountryRoute.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\Country\Event\CountryRouteCacheKeyEvent;
 use Shopware\Core\System\Country\Event\CountryRouteCacheTagsEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -90,7 +91,7 @@ class CachedCountryRoute extends AbstractCountryRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/System/Country/SalesChannel/CachedCountryStateRoute.php
+++ b/src/Core/System/Country/SalesChannel/CachedCountryStateRoute.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\System\Country\SalesChannel;
 use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/System/Country/SalesChannel/CachedCountryStateRoute.php
+++ b/src/Core/System/Country/SalesChannel/CachedCountryStateRoute.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\Country\Event\CountryStateRouteCacheKeyEvent;
 use Shopware\Core\System\Country\Event\CountryStateRouteCacheTagsEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -90,7 +91,7 @@ class CachedCountryStateRoute extends AbstractCountryStateRoute
             return null;
         }
 
-        return self::buildName($countryId) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($countryId) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/System/Currency/SalesChannel/CachedCurrencyRoute.php
+++ b/src/Core/System/Currency/SalesChannel/CachedCurrencyRoute.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\System\Currency\SalesChannel;
 use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/System/Currency/SalesChannel/CachedCurrencyRoute.php
+++ b/src/Core/System/Currency/SalesChannel/CachedCurrencyRoute.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\Currency\Event\CurrencyRouteCacheKeyEvent;
 use Shopware\Core\System\Currency\Event\CurrencyRouteCacheTagsEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -89,7 +90,7 @@ class CachedCurrencyRoute extends AbstractCurrencyRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5((string) JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . md5((string) Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/System/Language/SalesChannel/CachedLanguageRoute.php
+++ b/src/Core/System/Language/SalesChannel/CachedLanguageRoute.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\Language\Event\LanguageRouteCacheKeyEvent;
 use Shopware\Core\System\Language\Event\LanguageRouteCacheTagsEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -89,7 +90,7 @@ class CachedLanguageRoute extends AbstractLanguageRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5(JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . md5(Json::encode($event->getParts()));
     }
 
     /**

--- a/src/Core/System/Language/SalesChannel/CachedLanguageRoute.php
+++ b/src/Core/System/Language/SalesChannel/CachedLanguageRoute.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\System\Language\SalesChannel;
 use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/System/Salutation/SalesChannel/CachedSalutationRoute.php
+++ b/src/Core/System/Salutation/SalesChannel/CachedSalutationRoute.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\System\Salutation\SalesChannel;
 use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
-use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Json;

--- a/src/Core/System/Salutation/SalesChannel/CachedSalutationRoute.php
+++ b/src/Core/System/Salutation/SalesChannel/CachedSalutationRoute.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Shopware\Core\System\Salutation\Event\SalutationRouteCacheKeyEvent;
@@ -90,7 +91,7 @@ class CachedSalutationRoute extends AbstractSalutationRoute
             return null;
         }
 
-        return self::buildName() . '-' . md5((string) JsonFieldSerializer::encodeJson($event->getParts()));
+        return self::buildName() . '-' . md5((string) Json::encode($event->getParts()));
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Some of the classes changed in the pull request are now already used by developers to extend the system. However, the classes are marked with @internal which can lead to confusion. Furthermore, classes marked with @internal are not covered by the BC Checker tool. However, since it is Public API, these classes should not be excluded.

If you know of any other classes, feel free to add them as a comment or suggestion and I will add them.