### PR TITLE
NEXT-25798 Use configured minimum search term length for search

### DIFF
--- a/changelog/_unreleased/2023-03-15-use-min-search-term-length-in-search.md
+++ b/changelog/_unreleased/2023-03-15-use-min-search-term-length-in-search.md
@@ -1,0 +1,20 @@
+---
+title: Use configured minimum search term length for search
+issue: NEXT-25798
+author: Tobias Graml
+author_email: tobias.graml@nosto.com
+author_github: @TobiasGraml11
+---
+
+# Administration
+* Changed `min` value for `minSearchLength` to 0 at `src/module/sw-settings-search/component/sw-settings-search-search-behaviour/index.js`
+
+# Core
+* Added member variable and constructor parameter `productSearchConfigRepository` to the following files:
+  * `src/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php`
+  * `src/Core/Content/Product/SalesChannel/Suggest/ProductSuggestRoute.php`
+  * `src/Core/Content/Product/SearchKeyword/ProductSearchBuilder.php`
+  * `src/Elasticsearch/Product/ProductSearchBuilder.php`
+  * `src/Storefront/Controller/SearchController.php`
+  * `src/Storefront/Page/Search/SearchPageLoader.php`
+* Created `src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigHelper.php`

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/index.js
@@ -29,7 +29,7 @@ export default {
 
     data: () => {
         return {
-            min: 1,
+            min: 0,
             max: 20,
         };
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/sw-settings-search-search-behaviour.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/sw-settings-search-search-behaviour.spec.js
@@ -130,8 +130,8 @@ describe('module/sw-settings-search/component/sw-settings-search-search-behaviou
         expect(wrapper.vm.searchBehaviourConfigs.minSearchLength).toBe(20);
 
         // take the min value if the current value smaller than the min value.
-        await minSearchLengthElement.setValue(0);
+        await minSearchLengthElement.setValue(-1);
         await minSearchLengthElement.trigger('change');
-        expect(wrapper.vm.searchBehaviourConfigs.minSearchLength).toBe(1);
+        expect(wrapper.vm.searchBehaviourConfigs.minSearchLength).toBe(0);
     });
 });

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -237,6 +237,7 @@
         <service id="Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface"
                  class="Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilder">
             <argument type="service" id="Shopware\Core\Content\Product\SearchKeyword\ProductSearchTermInterpreter"/>
+            <argument type="service" id="product_search_config.repository"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\Cart\ProductLineItemFactory"/>
@@ -250,6 +251,7 @@
             <argument type="service" id="Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader"/>
+            <argument type="service" id="product_search_config.repository"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\SalesChannel\Suggest\CachedProductSuggestRoute" decorates="Shopware\Core\Content\Product\SalesChannel\Suggest\ProductSuggestRoute" decoration-priority="-1000" public="true">
@@ -265,6 +267,7 @@
             <argument type="service" id="Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader"/>
+            <argument type="service" id="product_search_config.repository"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\SalesChannel\Search\ResolvedCriteriaProductSearchRoute" decorates="Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute" decoration-priority="-2000" public="true">

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigHelper.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigHelper.php
@@ -6,11 +6,16 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
 
+#[Package('inventory')]
 class ProductSearchConfigHelper
 {
-    public static function isSearchTermMissing(EntityRepository $productSearchConfigRepository, Context $context, ?string $term = ''): bool
-    {
+    public static function isSearchTermMissing(
+        EntityRepository $productSearchConfigRepository,
+        Context $context,
+        ?string $term
+    ): bool {
         $criteria = new Criteria();
         $criteria->addFilter(
             new EqualsFilter('languageId', $context->getLanguageId())
@@ -18,6 +23,6 @@ class ProductSearchConfigHelper
 
         $minTermLength = $productSearchConfigRepository->search($criteria, $context)->first()->getMinSearchLength();
 
-        return \strlen($term) < $minTermLength;
+        return \strlen($term ?? '') < $minTermLength;
     }
 }

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigHelper.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigHelper.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Aggregate\ProductSearchConfig;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+
+class ProductSearchConfigHelper
+{
+    public static function isSearchTermMissing(EntityRepository $productSearchConfigRepository, Context $context, ?string $term = ''): bool
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(
+            new EqualsFilter('languageId', $context->getLanguageId())
+        );
+
+        $minTermLength = $productSearchConfigRepository->search($criteria, $context)->first()->getMinSearchLength();
+
+        return \strlen($term) < $minTermLength;
+    }
+}

--- a/src/Elasticsearch/Product/ProductSearchBuilder.php
+++ b/src/Elasticsearch/Product/ProductSearchBuilder.php
@@ -2,8 +2,10 @@
 
 namespace Shopware\Elasticsearch\Product;
 
+use Shopware\Core\Content\Product\Aggregate\ProductSearchConfig\ProductSearchConfigHelper;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
@@ -20,7 +22,8 @@ class ProductSearchBuilder implements ProductSearchBuilderInterface
     public function __construct(
         private readonly ProductSearchBuilderInterface $decorated,
         private readonly ElasticsearchHelper $helper,
-        private readonly ProductDefinition $productDefinition
+        private readonly ProductDefinition $productDefinition,
+        private readonly EntityRepository $productSearchConfigRepository
     ) {
     }
 
@@ -40,9 +43,13 @@ class ProductSearchBuilder implements ProductSearchBuilderInterface
             $term = (string) $search;
         }
 
-        $term = trim($term);
-
-        if (empty($term)) {
+        if (
+            ProductSearchConfigHelper::isSearchTermMissing(
+                $this->productSearchConfigRepository,
+                $context->getContext(),
+                trim($term)
+            )
+        ) {
             throw new MissingRequestParameterException('search');
         }
 

--- a/src/Elasticsearch/Resources/config/services.xml
+++ b/src/Elasticsearch/Resources/config/services.xml
@@ -148,6 +148,7 @@
             <argument type="service" id="Shopware\Elasticsearch\Product\ProductSearchBuilder.inner"/>
             <argument type="service" id="Shopware\Elasticsearch\Framework\ElasticsearchHelper"/>
             <argument type="service" id="Shopware\Core\Content\Product\ProductDefinition"/>
+            <argument type="service" id="product_search_config.repository"/>
         </service>
 
         <service id="Shopware\Elasticsearch\Framework\Indexing\CreateAliasTaskHandler" public="true">

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -299,6 +299,7 @@
             <argument type="service" id="Shopware\Storefront\Page\Search\SearchPageLoader"/>
             <argument type="service" id="Shopware\Storefront\Page\Suggest\SuggestPageLoader"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute"/>
+            <argument type="service" id="product_search_config.repository"/>
 
             <call method="setContainer">
                 <argument type="service" id="service_container"/>

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -258,6 +258,7 @@
             <argument type="service" id="Shopware\Storefront\Page\GenericPageLoader"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Search\ProductSearchRoute"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="product_search_config.repository"/>
         </service>
 
         <service id="Shopware\Storefront\Page\Product\ProductPageLoader">

--- a/src/Storefront/Page/Search/SearchPageLoader.php
+++ b/src/Storefront/Page/Search/SearchPageLoader.php
@@ -3,7 +3,9 @@
 namespace Shopware\Storefront\Page\Search;
 
 use Shopware\Core\Content\Category\Exception\CategoryNotFoundException;
+use Shopware\Core\Content\Product\Aggregate\ProductSearchConfig\ProductSearchConfigHelper;
 use Shopware\Core\Content\Product\SalesChannel\Search\AbstractProductSearchRoute;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
@@ -22,7 +24,8 @@ class SearchPageLoader
     public function __construct(
         private readonly GenericPageLoaderInterface $genericLoader,
         private readonly AbstractProductSearchRoute $productSearchRoute,
-        private readonly EventDispatcherInterface $eventDispatcher
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly EntityRepository $productSearchConfigRepository
     ) {
     }
 
@@ -40,7 +43,13 @@ class SearchPageLoader
             $page->getMetaInformation()->setRobots('noindex,follow');
         }
 
-        if (!$request->query->has('search')) {
+        if (
+            ProductSearchConfigHelper::isSearchTermMissing(
+                $this->productSearchConfigRepository,
+                $salesChannelContext->getContext(),
+                $request->query->get('search')
+            )
+        ) {
             throw new MissingRequestParameterException('search');
         }
 

--- a/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
@@ -1,5 +1,10 @@
+{% set minSearchLength = page.header.activeLanguage.productSearchConfig.minSearchLength is not null
+    ? page.header.activeLanguage.productSearchConfig.minSearchLength
+    : 3
+%}
+
 {% set searchWidgetOptions = {
-    searchWidgetMinChars: page.header.activeLanguage.productSearchConfig.minSearchLength ?: 3
+    searchWidgetMinChars: max(1, minSearchLength)
 } %}
 
 {% block layout_header_search %}

--- a/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
@@ -1,10 +1,7 @@
-{% set minSearchLength = page.header.activeLanguage.productSearchConfig.minSearchLength is not null
-    ? page.header.activeLanguage.productSearchConfig.minSearchLength
-    : 3
-%}
-
 {% set searchWidgetOptions = {
-    searchWidgetMinChars: max(1, minSearchLength)
+    searchWidgetMinChars: page.header.activeLanguage.productSearchConfig.minSearchLength is not null
+        ? page.header.activeLanguage.productSearchConfig.minSearchLength
+        : 3
 } %}
 
 {% block layout_header_search %}

--- a/tests/unit/php/Core/Content/Product/SalesChannel/Suggest/ProductSuggestRouteTest.php
+++ b/tests/unit/php/Core/Content/Product/SalesChannel/Suggest/ProductSuggestRouteTest.php
@@ -15,9 +15,11 @@ use Shopware\Core\Content\Product\SalesChannel\Suggest\ProductSuggestRouteRespon
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,6 +31,8 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ProductSuggestRouteTest extends TestCase
 {
+    use KernelTestBehaviour;
+
     private EventDispatcher $eventDispatcher;
 
     /**
@@ -41,11 +45,14 @@ class ProductSuggestRouteTest extends TestCase
      */
     private ProductListingLoader $listingLoader;
 
+    private EntityRepository $productSearchConfigRepository;
+
     protected function setUp(): void
     {
         $this->eventDispatcher = new EventDispatcher();
         $this->searchBuilder = $this->createMock(ProductSearchBuilderInterface::class);
         $this->listingLoader = $this->createMock(ProductListingLoader::class);
+        $this->productSearchConfigRepository = $this->getContainer()->get('product_search_config.repository');
     }
 
     public function testGetDecoratedShouldThrowException(): void
@@ -139,7 +146,8 @@ class ProductSuggestRouteTest extends TestCase
         return new ProductSuggestRoute(
             $this->searchBuilder,
             $this->eventDispatcher,
-            $this->listingLoader
+            $this->listingLoader,
+            $this->productSearchConfigRepository
         );
     }
 }

--- a/tests/unit/php/Elasticsearch/Product/ProductSearchBuilderTest.php
+++ b/tests/unit/php/Elasticsearch/Product/ProductSearchBuilderTest.php
@@ -5,8 +5,10 @@ namespace Shopware\Tests\Unit\Elasticsearch\Product;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Routing\Exception\MissingRequestParameterException;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Elasticsearch\Framework\ElasticsearchHelper;
 use Shopware\Elasticsearch\Product\ProductSearchBuilder;
@@ -19,6 +21,15 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ProductSearchBuilderTest extends TestCase
 {
+    use KernelTestBehaviour;
+
+    private EntityRepository $productSearchConfigRepository;
+
+    public function setUp(): void
+    {
+        $this->productSearchConfigRepository = $this->getContainer()->get('product_search_config.repository');
+    }
+
     /**
      * @dataProvider providerQueries
      *
@@ -43,7 +54,8 @@ class ProductSearchBuilderTest extends TestCase
         $searchBuilder = new ProductSearchBuilder(
             $mockProductSearchBuilder,
             $mockElasticsearchHelper,
-            $productDefinition
+            $productDefinition,
+            $this->productSearchConfigRepository
         );
 
         $searchBuilder->build($request, $criteria, $mockSalesChannelContext);
@@ -82,7 +94,8 @@ class ProductSearchBuilderTest extends TestCase
         $searchBuilder = new ProductSearchBuilder(
             $mockProductSearchBuilder,
             $mockElasticsearchHelper,
-            new ProductDefinition()
+            new ProductDefinition(),
+            $this->productSearchConfigRepository
         );
 
         $mockSalesChannelContext = $this->createMock(SalesChannelContext::class);
@@ -109,7 +122,8 @@ class ProductSearchBuilderTest extends TestCase
         $searchBuilder = new ProductSearchBuilder(
             $mockProductSearchBuilder,
             $mockElasticsearchHelper,
-            new ProductDefinition()
+            new ProductDefinition(),
+            $this->productSearchConfigRepository
         );
 
         $mockSalesChannelContext = $this->createMock(SalesChannelContext::class);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
1. It should be possible to set the minimum search term length to 0
2. It should be possible to use the configuration for the minimum search term length within the search

### 2. What does this change do, exactly?
1. Make it possible to configure 0 within the administration
2. Only throw `MissingRequestParameterException`, if the search term limit is not reached

### 3. Describe each step to reproduce the issue or behaviour.
Open `<shopUrl>/search?search=`

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-25798

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
