### PR TITLE
Allow empty string for equals filter via api

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/QueryStringParser.php
@@ -39,7 +39,7 @@ class QueryStringParser
                     throw new InvalidFilterQueryException('Parameter "field" for equals filter is missing.', $path . '/field');
                 }
 
-                if (!\array_key_exists('value', $query) || $query['value'] === '') {
+                if (!\array_key_exists('value', $query)) {
                     throw new InvalidFilterQueryException('Parameter "value" for equals filter is missing.', $path . '/value');
                 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When using the DAL from within Shopware, an EqualsFilter with an empty string works fine. When using the DAL via the REST-API, it will throw an exception. This is inconsistent and annoying.

### 2. What does this change do, exactly?
Now the check for empty string is removed, so the exception will not be triggered anymore if an EqualsFilter with an empty string is given.

### 3. Describe each step to reproduce the issue or behaviour.

```http
POST /api/search/order HTTP/1.1
Host: localhost
Accept: application/json
Content-Type: application/json

{
    "filter": [
        {
            "type": "equals",
            "field": "deliveries.trackingCodes",
            "value": ""
        }
    ]
}
```

```json
{
    "errors": [
        {
            "status": "400",
            "code": "FRAMEWORK__INVALID_FILTER_QUERY",
            "title": "Bad Request",
            "detail": "Parameter \u0022value\u0022 for equals filter is missing.",
            "source": {
                "pointer": "\/filter\/0\/value"
            },
            "meta": {
                "parameters": {
                    "message": "Parameter \u0022value\u0022 for equals filter is missing."
                }
            }
        }
    ]
}
```

### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1898e57</samp>

Fixed a bug in the `equals` filter of the query string parser that prevented using empty strings as values. Simplified the exception condition in `QueryStringParser.php`.