### PR TITLE
Fix: Make RequeueDeadMessagesService respect RecoverableExceptionInterface

### DIFF
--- a/changelog/_unreleased/2023-03-20-make-requeuing-dead-messages-respect-recoverable-exceptions.md
+++ b/changelog/_unreleased/2023-03-20-make-requeuing-dead-messages-respect-recoverable-exceptions.md
@@ -1,0 +1,9 @@
+---
+title:              Make requeuing dead messages respect recoverable exceptions
+issue:              NEXT-25825
+author:             Dominik Pretzsch
+author_email:       dominik.pretzsch@3m5.de
+author_github:      @blacksheep--
+---
+# Core
+*  Added check to make sure dead messages implementing RecoverableExceptionInterface won't be canceled after MAX_RETRIES failures in `src/Framework/MessageQueue/DeadMessage/RequeueDeadMessagesService.php`

--- a/src/Core/Framework/MessageQueue/DeadMessage/RequeueDeadMessagesService.php
+++ b/src/Core/Framework/MessageQueue/DeadMessage/RequeueDeadMessagesService.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\Message\RetryMessage;
+use Symfony\Component\Messenger\Exception\RecoverableExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /***

--- a/src/Core/Framework/MessageQueue/DeadMessage/RequeueDeadMessagesService.php
+++ b/src/Core/Framework/MessageQueue/DeadMessage/RequeueDeadMessagesService.php
@@ -67,7 +67,7 @@ class RequeueDeadMessagesService
                 continue;
             }
 
-            if ($message->getErrorCount() > self::MAX_RETRIES) {
+            if ($message->getErrorCount() > self::MAX_RETRIES && !is_subclass_of($message->getException(), RecoverableExceptionInterface::class)) {
                 $this->logger->warning(sprintf('Dropped the message %s after %d retries', $message->getOriginalMessageClass(), self::MAX_RETRIES), [
                     'exception' => $message->getException(),
                     'exceptionFile' => $message->getExceptionFile(),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The RequeueDeadMessagesService has a constant `self::MAX_RETRIES` value which is enforced for ALL errors. But this contradicts the purpose of throwing `RecoverableMessageHandlingException` because these kinds of messages should be retried forever. There are use-cases which rely on these kind of messages not being "silently" dropped after 3 retries.

The current implementation is ignoring the class of execption thrown which is in $message->getException()

### 2. What does this change do, exactly?
Added check to make sure dead messages implementing RecoverableExceptionInterface won't be canceled after MAX_RETRIES failures

### 3. Describe each step to reproduce the issue or behaviour.
1. Implement an AbstractMessageHandler
2. In the handle($message) method, throw an exception of type RecoverableMessageHandlingException (described [here](https://symfony.com/doc/current/messenger.html#forcing-retrying))

### 4. Please link to the relevant issues (if any).
[NEXT-25825](https://issues.shopware.com/issues/NEXT-25825)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
