### PR TITLE
Add `contentPadding` prop for `sw-card` component

### DIFF
--- a/changelog/_unreleased/2023-03-21-add-contentpadding-prop-for-card-component.md
+++ b/changelog/_unreleased/2023-03-21-add-contentpadding-prop-for-card-component.md
@@ -1,0 +1,9 @@
+---
+title: Add `contentPadding` prop for `sw-card` component
+issue: -
+author: Vu Le
+author_email: vu.le@shapeandshift.dev
+author_github: crisalder2806
+---
+# Administration
+* Added `contentPadding` property in `src/app/component/base/sw-card/index.js` to add/remove content padding.

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-card/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-card/index.js
@@ -50,6 +50,11 @@ Component.register('sw-card', {
             required: false,
             default: false,
         },
+        contentPadding: {
+            type: Boolean,
+            // eslint-disable-next-line vue/no-boolean-default
+            default: true,
+        },
     },
 
     computed: {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-card/sw-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-card/sw-card.html.twig
@@ -75,7 +75,7 @@
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_card_content %}
-        <div class="sw-card__content">
+        <div class="sw-card__content" :class="{'no--padding': !contentPadding}">
             <div
                 v-if="!!$slots['context-actions'] || !!$scopedSlots['context-actions']"
                 class="sw-card__context-menu"

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-card/sw-card.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-card/sw-card.scss
@@ -155,6 +155,10 @@
         border-radius: $border-radius-lg;
         position: relative;
 
+        &.no--padding {
+            padding: 0;
+        }
+
         @media screen and (max-width: $content-width) {
             padding: 15px;
         }

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-card/sw-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-card/sw-card.spec.js
@@ -106,4 +106,28 @@ describe('src/app/component/base/sw-card', () => {
         await buttonScopedCard.trigger('click');
         expect(wrapper.find('.scoped-slot').exists()).toBeTruthy();
     });
+
+    it('should have content padding', async () => {
+        const options = {
+            propsData: {
+                positionIdentifier: 'test',
+                contentPadding: true,
+            }
+        };
+        const wrapper = await createWrapper(options);
+
+        expect(wrapper.find('.sw-card__content').classes('no--padding')).toBe(false);
+    });
+
+    it('should not have content padding', async () => {
+        const options = {
+            propsData: {
+                positionIdentifier: 'test',
+                contentPadding: false,
+            }
+        };
+        const wrapper = await createWrapper(options);
+
+        expect(wrapper.find('.sw-card__content').classes('no--padding')).toBe(true);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.html.twig
@@ -7,6 +7,7 @@
             position-identifier=""
             :title="componentSection.props.title"
             :subtitle="componentSection.props.subtitle"
+            :content-padding="componentSection.props?.contentPadding ?? true"
         >
             <sw-iframe-renderer
                 :src="componentSection.src"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This change adds the ability to add/remove padding of the `sw-card` component content which sometimes is not necessary/needed on the UI.

### 2. What does this change do, exactly?
Add `contentPadding` property to `sw-card` component to add/remove card content padding.


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
