### PR TITLE
feat: implement product-stream custom field entity select

### DIFF
--- a/changelog/_unreleased/2023-03-24-implement-custom-field-entity-select-for-dynamic-product-groups.md
+++ b/changelog/_unreleased/2023-03-24-implement-custom-field-entity-select-for-dynamic-product-groups.md
@@ -1,0 +1,9 @@
+---
+title: Implement Custom Field entity select for dynamic product groups
+issue: -
+author: Rafael Kraut
+author_email: 14234815+RafaelKr@users.noreply.github.com
+author_github: RafaelKr
+___
+# Administration
+* Update dynamic product group condition component `module/sw-product-stream/component/sw-product-stream-value` to show a `sw-entity-single-select` or `sw-entity-multi-id-select` for custom fields of type `'entity'`. Previously this rendered a text field where you had to insert an UUID. 

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/index.js
@@ -334,6 +334,16 @@ export default {
             return criteria;
         },
 
+        customFieldCriteria() {
+            const criteria = new Criteria(1, 25);
+
+            if (typeof this.searchTerm === 'string' && this.searchTerm.length > 0) {
+                criteria.addQuery(Criteria.contains('name', this.searchTerm), 500);
+            }
+
+            return criteria;
+        },
+
         visibilitiesLabelCallback() {
             return (item) => {
                 if (!item) {
@@ -468,6 +478,16 @@ export default {
             }
 
             return Object.values(category.breadcrumb).join(' / ');
+        },
+
+        isCustomField(fieldName) {
+            const strippedFieldName = fieldName.replace(/customFields\./, '');
+
+            return Object.keys(this.productCustomFields).includes(strippedFieldName);
+        },
+
+        getCustomFieldEntityName(fieldName) {
+            return fieldName.replace(/customFields\./, '');
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.html.twig
@@ -59,7 +59,74 @@
         </sw-arrow-field>
         {% endblock %}
 
-        <template v-if="fieldType === 'uuid'">
+        <template v-if="isCustomField(fieldName) && fieldType === 'entity'">
+            {% block sw_product_stream_value_entity_single_value_custom_field %}
+            <sw-entity-single-select
+                v-if="!isMultiSelectValue"
+                v-model="actualCondition.value"
+                size="medium"
+                :entity="getCustomFieldEntityName(fieldName)"
+                :criteria="customFieldCriteria"
+                :context="context"
+                :disabled="disabled"
+                show-clearable-button
+                @select-collapsed="onSelectCollapsed"
+                @search-term-change="setSearchTerm"
+            >
+                <template #selection-label-property="{ item }">
+                    <slot
+                        name="selection-label-property"
+                        v-bind="{ item }"
+                    >
+                        {{ item.translated?.name || item.name }}
+                    </slot>
+                </template>
+
+                <template #result-description-property="{ item }">
+                    <slot
+                        name="result-description-property"
+                        v-bind="{ item }"
+                    >
+                        {{ item.translated?.name || item.name }}
+                    </slot>
+                </template>
+            </sw-entity-single-select>
+            {% endblock %}
+
+            {% block sw_product_stream_value_entity_multi_value_custom_field %}
+            <sw-entity-multi-id-select
+                v-else-if="isMultiSelectValue"
+                v-model="multiValue"
+                size="medium"
+                :repository="repositoryFactory.create(getCustomFieldEntityName(fieldName))"
+                :criteria="customFieldCriteria"
+                :context="context"
+                :disabled="disabled"
+                @select-collapsed="onSelectCollapsed"
+                @search-term-change="setSearchTerm"
+            >
+                <template #selection-label-property="{ item }">
+                    <slot
+                        name="selection-label-property"
+                        v-bind="{ item }"
+                    >
+                        {{ item.translated?.name || item.name }}
+                    </slot>
+                </template>
+
+                <template #result-label-property="{ item, searchTerm, highlightSearchTerm }">
+                    <slot
+                        name="result-label-property"
+                        v-bind="{ item, searchTerm, highlightSearchTerm }"
+                    >
+                        {{ item.translated?.name || item.name }}
+                    </slot>
+                </template>
+            </sw-entity-multi-id-select>
+            {% endblock %}
+        </template>
+
+        <template v-else-if="fieldType === 'uuid'">
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_product_stream_value_entity_single_value %}
             <sw-entity-single-select


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We created a custom field with type entity on products. Currently when creating a new dynamic product stream you can select the custom field, but you need to enter the UUID value.


### 2. What does this change do, exactly?
This change implements the usage of `sw-entity-single-select`/`sw-entity-multi-id-select` fields in these cases, so we get a nice filterable dropdown.

> **Disclaimer:** This patches an urgent need of a customer of us. This PR could be used as is, but this only patches the UX for `CustomFieldTypes::ENTITY`.
> Many other CustomFieldTypes also require a similar patch **which I won't provide**. A clean solution would be to move the condition rendering for custom fields into an own component. Also the filter type should update when using specific custom field types, e.g. `date`.



### 3. Describe each step to reproduce the issue or behaviour.
1. Create a custom field:
  - type: `Shopware\Core\System\CustomField\CustomFieldTypes::ENTITY` (`'entity'`).
  - config:
  ```php
[
    'entity' => 'product', // or another entity with a name and some entries
    'componentName' => 'sw-entity-single-select',
    'customFieldType' => 'select',
    'customFieldPosition' => 10,
    'label' => [
        'en-GB' => 'Entity-Test',
        'de-DE' => 'Entity-Test',
    ],
],
```
2. Go to any product and assign a value to the `Entity Test` custom field. You need to know the UUID of that value for step 5.
3. Create a new dynamic product group
4. Select `Entity-Test` => `equals` or `equalsAny`
5. Now you need to enter the UUID of the entity we selected in step 2 to make the product show up in the preview.

With the change applied we now have a dropdown field where we can select the entity/entities instead of entering plain UUID(s).

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e765a3</samp>

This pull request adds support for custom fields of type `'entity'` as dynamic product group conditions in the administration module. It updates the `sw-product-stream-value` component and its template to fetch and display the custom field values using select components. It also adds a changelog entry for this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e765a3</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3024/files?diff=unified&w=0#diff-b0cf8a5f02587c735e54ce2271a497454381a026d32ddca65e4f4b0c7a406792R1-R9))
*  Implement custom field criteria for fetching entity-type custom fields from the API ([link](https://github.com/shopware/platform/pull/3024/files?diff=unified&w=0#diff-a9fac98f4fd5928eee3c97128d82fc43261c6637a4014c53df551adaa93d6a30R337-R346))
*  Add helper methods for identifying and extracting custom field names from condition field names ([link](https://github.com/shopware/platform/pull/3024/files?diff=unified&w=0#diff-a9fac98f4fd5928eee3c97128d82fc43261c6637a4014c53df551adaa93d6a30R482-R491))
*  Replace text field with entity select components for custom field values in the template ([link](https://github.com/shopware/platform/pull/3024/files?diff=unified&w=0#diff-8927a86f5baabdce811576a519a8c9ac52355b8b3a4e2db7e044087036d77d70L62-R129))
