### PR TITLE
Skip package build if environment variable isset

### DIFF
--- a/src/Administration/Resources/app/administration/webpack.config.js
+++ b/src/Administration/Resources/app/administration/webpack.config.js
@@ -122,7 +122,7 @@ const pluginEntries = (() => {
     const pluginDefinition = JSON.parse(fs.readFileSync(pluginFile, 'utf8'));
 
     return Object.entries(pluginDefinition)
-        .filter(([name, definition]) => !!definition.administration && !!definition.administration.entryFilePath)
+        .filter(([name, definition]) => !!definition.administration && !!definition.administration.entryFilePath && !process.env.hasOwnProperty('SKIP_' + definition.technicalName.toUpperCase().replace(/-/g, '_')))
         .map(([name, definition]) => {
             console.log(chalk.green(`# Plugin "${name}": Injected successfully`));
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Based on the merged [pull request](https://github.com/shopware/webpack-plugin-injector/pull/4) it would be nice to skip the package build within the adminstration build process.

### 2. What does this change do, exactly?

This pull request adds a condition to filter the plugins. Is a matching environment variable isset the plugin will not rebuild.

### 3. Describe each step to reproduce the issue or behaviour.

-/-

### 4. Please link to the relevant issues (if any).

-/-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77ebd0b</samp>

This change enables skipping plugins in the administration webpack build by using environment variables. It modifies the `pluginEntries` function in `webpack.config.js` to filter out plugins with `SKIP_` prefixes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77ebd0b</samp>

*  Add a condition to skip loading plugins with `SKIP_` prefix in the environment variables ([link](https://github.com/shopware/platform/pull/3028/files?diff=unified&w=0#diff-495341c5724904c9afc2b8d581fab247a0eece8db8bbc18659bc2a49f9ef196cL125-R125))
