### PR TITLE
Fix asset service using google cloud

### DIFF
--- a/changelog/_unreleased/2023-03-30-fix-asset-service-google-cloud.md
+++ b/changelog/_unreleased/2023-03-30-fix-asset-service-google-cloud.md
@@ -1,0 +1,10 @@
+---
+title: Fix AssetService using Google Cloud
+issue:
+flag:
+author: Pascal Josephy
+author_email: pascal.josephy@jkweb.ch
+author_github: pascaljosephy
+---
+# Core
+*  Changed `Shopware\Core\Framework\Plugin\Util\AssetService`

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -142,7 +142,12 @@ class AssetService
             // @codeCoverageIgnoreEnd
 
             $this->filesystem->writeStream($targetDir . '/' . $file->getRelativePathname(), $fs);
-            fclose($fs);
+
+            // The Google Cloud Storage filesystem closes the stream even though it should not. To prevent a fatal
+            // error, we therefore need to check whether the stream has been closed yet.
+            if (\is_resource($fs)) {
+               fclose($fs);
+            }
         }
     }
 


### PR DESCRIPTION

## 1. Why is this change necessary?

When using Google Cloud, files are closed resulting in an error. Since PHP 8.0 it is an error, not just a warning.
 
## 2. What does this change do, exactly?

Add a check `is_resource` similar as in other places (eg. `Shopware\Core\Content\ImportExport`)