### PR TITLE
Use ArrayEntity for EXTENSION_INDEXER_SKIP

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Event\ProgressAdvancedEvent;
 use Shopware\Core\Framework\Event\ProgressFinishedEvent;
 use Shopware\Core\Framework\Event\ProgressStartedEvent;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Struct\ArrayEntity;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -143,7 +143,7 @@ class EntityIndexerRegistry
         if (!$context->hasExtension(self::EXTENSION_INDEXER_SKIP)) {
             return;
         }
-        /** @var ArrayStruct<string, mixed> $skip */
+        /** @var ArrayEntity<string, mixed> $skip */
         $skip = $context->getExtension(self::EXTENSION_INDEXER_SKIP);
 
         $message->addSkip(...$skip->get('skips'));

--- a/tests/integration/php/Core/Content/Product/DataAbstractionLayer/StatesUpdaterTest.php
+++ b/tests/integration/php/Core/Content/Product/DataAbstractionLayer/StatesUpdaterTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -87,7 +87,7 @@ class StatesUpdaterTest extends TestCase
         ];
 
         $context = Context::createDefaultContext();
-        $context->addExtension(EntityIndexerRegistry::EXTENSION_INDEXER_SKIP, new ArrayStruct(['skips' => [ProductIndexer::STATES_UPDATER]]));
+        $context->addExtension(EntityIndexerRegistry::EXTENSION_INDEXER_SKIP, new ArrayEntity([ProductIndexer::STATES_UPDATER]));
 
         $this->productRepository->create($products, $context);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

It confuses developers, when you typehint it ArrayStruct but put in an ArrayEntity. Maybe we should just make the `::all()` covered by an interface.

### 2. What does this change do, exactly?

It changes typehints and usage in tests. Why the test does not fail? I don't know but I spotted it in there.

### 3. Describe each step to reproduce the issue or behaviour.

1. See usage of the extension
2. See used typehint Array**STRUCT**
3. Start to use instanceof check on that Array**STRUCT**
4. Code is not executed
5. Realize the extension is of a different type Array**ENTITY**
6. 
<img width="540" alt="Florentin Will is not amused" src="https://user-images.githubusercontent.com/1133593/229806737-aa6389d9-01e6-4a49-9d03-571e11a589e3.png">

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8fc38f1</samp>

This pull request refactors the product indexer and the data abstraction layer by replacing the `ArrayStruct` class with the `ArrayEntity` class. This change affects the `EntityIndexerRegistry` class and the `StatesUpdaterTest` class.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8fc38f1</samp>

*  Rename `ArrayStruct` class to `ArrayEntity` to avoid confusion with `Struct` class ([link](https://github.com/shopware/platform/pull/3035/files?diff=unified&w=0#diff-384e38f7598d4f43e5f6b66f6d741bc9205b92af2939382f17129368429b75fbL12-R12), [link](https://github.com/shopware/platform/pull/3035/files?diff=unified&w=0#diff-384e38f7598d4f43e5f6b66f6d741bc9205b92af2939382f17129368429b75fbL146-R146), [link](https://github.com/shopware/platform/pull/3035/files?diff=unified&w=0#diff-9acd800f81605eeff90bd233bf8fba06eed74f8caa276250f445deedb23b297bL17-R17), [link](https://github.com/shopware/platform/pull/3035/files?diff=unified&w=0#diff-9acd800f81605eeff90bd233bf8fba06eed74f8caa276250f445deedb23b297bL90-R90))
