### PR TITLE
feature: allow seo url to either have trailing slash or not

### DIFF
--- a/changelog/_unreleased/2023-04-17-allow-trailing-slash-in-seo-url.md
+++ b/changelog/_unreleased/2023-04-17-allow-trailing-slash-in-seo-url.md
@@ -1,0 +1,9 @@
+---
+title:          allow-trailing-slash-in-seo-url
+issue:          null
+author:         Jan Emig
+author_email:   j.emig@one-dot.de
+author_github:  Xnaff
+---
+# Core
+* Changed method `resolve()` in `src/Core/Content/Seo/SeoResolver.php` to allow trailing slashes or no slashes in SEO URLs

--- a/src/Core/Content/Seo/SeoResolver.php
+++ b/src/Core/Content/Seo/SeoResolver.php
@@ -31,20 +31,21 @@ class SeoResolver extends AbstractSeoResolver
      */
     public function resolve(string $languageId, string $salesChannelId, string $pathInfo): array
     {
-        $seoPathInfo = ltrim($pathInfo, '/');
+        $seoPathInfo = trim($pathInfo, '/');
 
         $query = (new QueryBuilder($this->connection))
             ->select('id', 'path_info pathInfo', 'is_canonical isCanonical')
             ->from('seo_url')
             ->where('language_id = :language_id')
             ->andWhere('(sales_channel_id = :sales_channel_id OR sales_channel_id IS NULL)')
-            ->andWhere('seo_path_info = :seoPath')
+            ->andWhere('(seo_path_info = :seoPath OR seo_path_info = :seoPathWithSlash)')
             ->orderBy('seo_path_info')
             ->addOrderBy('sales_channel_id IS NULL') // sales_channel_specific comes first
             ->setMaxResults(1)
             ->setParameter('language_id', Uuid::fromHexToBytes($languageId))
             ->setParameter('sales_channel_id', Uuid::fromHexToBytes($salesChannelId))
-            ->setParameter('seoPath', $seoPathInfo);
+            ->setParameter('seoPath', $seoPathInfo)
+            ->setParameter('seoPathWithSlash', $seoPathInfo . '/');
 
         $query->setTitle('seo-url::resolve');
 

--- a/src/Core/Framework/Test/Seo/SeoResolverTest.php
+++ b/src/Core/Framework/Test/Seo/SeoResolverTest.php
@@ -104,6 +104,16 @@ class SeoResolverTest extends TestCase
         static::assertEquals(0, $resolved['isCanonical']);
         static::assertArrayHasKey('canonicalPathInfo', $resolved);
         static::assertEquals('/awesome-product-v2', $resolved['canonicalPathInfo']);
+        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'detail/1234/');
+        static::assertEquals('/detail/1234', $resolved['pathInfo']);
+        static::assertEquals(0, $resolved['isCanonical']);
+        static::assertArrayHasKey('canonicalPathInfo', $resolved);
+        static::assertEquals('/awesome-product-v2', $resolved['canonicalPathInfo']);
+        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/detail/1234/');
+        static::assertEquals('/detail/1234', $resolved['pathInfo']);
+        static::assertEquals(0, $resolved['isCanonical']);
+        static::assertArrayHasKey('canonicalPathInfo', $resolved);
+        static::assertEquals('/awesome-product-v2', $resolved['canonicalPathInfo']);
 
         // old canonical
         $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'awesome-product');
@@ -116,12 +126,28 @@ class SeoResolverTest extends TestCase
         static::assertEquals(0, $resolved['isCanonical']);
         static::assertArrayHasKey('canonicalPathInfo', $resolved);
         static::assertEquals('/awesome-product-v2', $resolved['canonicalPathInfo']);
+        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'awesome-product/');
+        static::assertEquals('/detail/1234', $resolved['pathInfo']);
+        static::assertEquals(0, $resolved['isCanonical']);
+        static::assertArrayHasKey('canonicalPathInfo', $resolved);
+        static::assertEquals('/awesome-product-v2', $resolved['canonicalPathInfo']);
+        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/awesome-product/');
+        static::assertEquals('/detail/1234', $resolved['pathInfo']);
+        static::assertEquals(0, $resolved['isCanonical']);
+        static::assertArrayHasKey('canonicalPathInfo', $resolved);
+        static::assertEquals('/awesome-product-v2', $resolved['canonicalPathInfo']);
 
         // canonical
         $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'awesome-product-v2');
         static::assertEquals('/detail/1234', $resolved['pathInfo']);
         static::assertEquals(1, $resolved['isCanonical']);
         $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/awesome-product-v2');
+        static::assertEquals('/detail/1234', $resolved['pathInfo']);
+        static::assertEquals(1, $resolved['isCanonical']);
+        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, 'awesome-product-v2/');
+        static::assertEquals('/detail/1234', $resolved['pathInfo']);
+        static::assertEquals(1, $resolved['isCanonical']);
+        $resolved = $this->seoResolver->resolve($context->getLanguageId(), $salesChannelId, '/awesome-product-v2/');
         static::assertEquals('/detail/1234', $resolved['pathInfo']);
         static::assertEquals(1, $resolved['isCanonical']);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
A lot of our customers get their products removed from google shopping, because google shopping can't reach the provided URL from the export file. I know we can implement this with server settings, but for some reason the customer has different urls in the database, sometimes with trailing slash sometimes without. A regeneration of the seo urls would solve that, but when the customer decides to change the seo template again, then this needs to be done again and will take some time until we find out that the customer changed the template again. For us the best solution is to handle this with shopware and currently we decorate this class. I write this pull request because it would be nice to have it in the shopware core.


### 2. What does this change do, exactly?
Search for the seo url in the database with and without a trailing slash, since only one version exists.

### 3. Describe each step to reproduce the issue or behaviour.
Add a slash or remove a slash in the url of a product or category. One version will result in a 404

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91898b6</samp>

Fixes a bug in `SeoResolver` that could affect SEO URLs for some routes. It improves the comparison logic between the request `pathInfo` and the database `seo_path_info`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91898b6</samp>

*  Trim leading and trailing slashes from `pathInfo` to match `seo_path_info` column ([link](https://github.com/shopware/platform/pull/3040/files?diff=unified&w=0#diff-c1983566d1f828b895f34c857a818993170cb7ec44c19927324c56bfc4d327b5L34-R34))
*  Add condition to query to handle `pathInfo` and `seo_path_info` with or without trailing slash ([link](https://github.com/shopware/platform/pull/3040/files?diff=unified&w=0#diff-c1983566d1f828b895f34c857a818993170cb7ec44c19927324c56bfc4d327b5L41-R41), [link](https://github.com/shopware/platform/pull/3040/files?diff=unified&w=0#diff-c1983566d1f828b895f34c857a818993170cb7ec44c19927324c56bfc4d327b5L47-R48))
*  Pass `pathInfo` with slash as new parameter to query ([link](https://github.com/shopware/platform/pull/3040/files?diff=unified&w=0#diff-c1983566d1f828b895f34c857a818993170cb7ec44c19927324c56bfc4d327b5L47-R48))
