### PR TITLE
[NEXT-26207] Support non-UUID FKFields

### DIFF
--- a/changelog/_unreleased/2023-04-18-fix-non-uuid-fk-fields-in-data-abstraction-layer.md
+++ b/changelog/_unreleased/2023-04-18-fix-non-uuid-fk-fields-in-data-abstraction-layer.md
@@ -1,0 +1,8 @@
+---
+title: Fix non-UUID FKFields in data abstraction layer
+issue: NEXT-26207
+author: Hannes Wernery
+author_email: hannes.wernery@pickware.de
+---
+# Core
+* Changed data abstraction layer to support non-UUID FKFields.

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityWriteGateway.php
@@ -33,6 +33,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\JsonUpdateCommand
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\PrimaryKeyBag;
@@ -90,7 +91,13 @@ class EntityWriteGateway implements EntityWriteGatewayInterface
 
         $wasChild = $this->wasChild($definition, $state);
 
-        return new EntityExistence($definition->getEntityName(), Uuid::fromBytesToHexList($primaryKey), $exists, $isChild, $wasChild, $state);
+        $decodedPrimaryKey = [];
+        foreach ($primaryKey as $fieldStorageName => $fieldValue) {
+            $field = $definition->getFields()->getByStorageName($fieldStorageName);
+            $decodedPrimaryKey[$fieldStorageName] = $field ? $field->getSerializer()->decode($field, $fieldValue) : $fieldValue;
+        }
+
+        return new EntityExistence($definition->getEntityName(), $decodedPrimaryKey, $exists, $isChild, $wasChild, $state);
     }
 
     /**
@@ -296,7 +303,19 @@ class EntityWriteGateway implements EntityWriteGatewayInterface
                     if ($id === null) {
                         continue 2;
                     }
-                    $newIds[] = Uuid::fromHexToBytes($id);
+                    $newIds[] = $field->getSerializer()->encode(
+                        $field,
+                        new EntityExistence(
+                            $definition->getEntityName(),
+                            [$field->getPropertyName() => $id],
+                            false,
+                            false,
+                            false,
+                            [],
+                        ),
+                        new KeyValuePair($field->getPropertyName(), $id, true),
+                        $parameters,
+                    )->current();
                 }
 
                 foreach ($newIds as $newId) {
@@ -331,7 +350,7 @@ class EntityWriteGateway implements EntityWriteGatewayInterface
             foreach ($result as $state) {
                 $values = [];
                 foreach ($pkFields as $storageKey => $field) {
-                    $values[$field->getPropertyName()] = Uuid::fromBytesToHex($state[$storageKey]);
+                    $values[$field->getPropertyName()] = $field->getSerializer()->decode($field, $state[$storageKey]);
                 }
                 if ($versionField) {
                     $values[$versionField->getPropertyName()] = $parameters->getContext()->getContext()->getVersionId();
@@ -640,9 +659,13 @@ class EntityWriteGateway implements EntityWriteGatewayInterface
             return $state;
         }
 
-        $hexPrimaryKey = Uuid::fromBytesToHexList($primaryKey);
+        $decodedPrimaryKey = [];
+        foreach ($primaryKey as $fieldName => $fieldValue) {
+            $field = $definition->getField($fieldName);
+            $decodedPrimaryKey[$fieldName] = $field ? $field->getSerializer()->decode($field, $fieldValue) : $fieldValue;
+        }
 
-        $currentState = $this->primaryKeyBag === null ? null : $this->primaryKeyBag->getExistenceState($definition, $hexPrimaryKey);
+        $currentState = $this->primaryKeyBag === null ? null : $this->primaryKeyBag->getExistenceState($definition, $decodedPrimaryKey);
         if ($currentState === null) {
             $currentState = $this->fetchFromDatabase($definition, $primaryKey);
         }

--- a/src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php
@@ -385,12 +385,12 @@ class EntityWriteResultFactory
             /** @var StorageAware&Field $field */
             $field = $fields->first();
 
-            return Uuid::fromBytesToHex($primaryKey[$field->getStorageName()]);
+            return $field->getSerializer()->decode($field, $primaryKey[$field->getStorageName()]);
         }
 
         /** @var StorageAware&Field $field */
         foreach ($fields as $field) {
-            $data[$field->getPropertyName()] = Uuid::fromBytesToHex($primaryKey[$field->getStorageName()]);
+            $data[$field->getPropertyName()] = $field->getSerializer()->decode($field, $primaryKey[$field->getStorageName()]);
         }
 
         return $data;
@@ -436,7 +436,7 @@ class EntityWriteResultFactory
 
             $key = $command->getPrimaryKey()[$primaryKey->getStorageName()];
 
-            $convertedPayload[$primaryKey->getPropertyName()] = Uuid::fromBytesToHex($key);
+            $convertedPayload[$primaryKey->getPropertyName()] = $primaryKey->getSerializer()->decode($primaryKey, $key);
         }
 
         return $convertedPayload;

--- a/src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\SetNullOnDeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\RestrictDeleteViolation;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Validation\RestrictDeleteViolationException;
 use Shopware\Core\Framework\Log\Package;
@@ -432,16 +433,33 @@ class EntityWriter implements EntityWriterInterface
 
         $skipped = [];
         foreach ($resolved as $primaryKey) {
+            /** @var array<string, string> $mappedBytes */
             $mappedBytes = [];
             /**
              * @var string $key
              * @var string $value
              */
             foreach ($primaryKey as $key => $value) {
-                /** @var StorageAware $field */
+                /**
+                 * Primary key fields are always storage aware.
+                 *
+                 * @var Field&StorageAware $field
+                 */
                 $field = $definition->getFields()->get($key);
 
-                $mappedBytes[$field->getStorageName()] = Uuid::fromHexToBytes($value);
+                $mappedBytes[$field->getStorageName()] = $field->getSerializer()->encode(
+                    $field,
+                    new EntityExistence(
+                        $definition->getEntityName(),
+                        [$key => $value],
+                        false,
+                        false,
+                        false,
+                        [],
+                    ),
+                    new KeyValuePair($key, $value, true),
+                    $parameters,
+                )->current();
             }
 
             $existence = $this->gateway->getExistence($definition, $mappedBytes, [], $commandQueue);

--- a/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/WriteCommandExtractor.php
@@ -32,7 +32,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\DataStack;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\WriteFieldException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\WriteConstraintViolationException;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -194,7 +193,11 @@ class WriteCommandExtractor
 
         /** @var Field&StorageAware $pkField */
         foreach ($definition->getPrimaryKeys() as $pkField) {
-            $parameters->getContext()->set($parameters->getDefinition()->getEntityName(), $pkField->getPropertyName(), Uuid::fromBytesToHex($pkData[$pkField->getStorageName()]));
+            $parameters->getContext()->set(
+                $parameters->getDefinition()->getEntityName(),
+                $pkField->getPropertyName(),
+                $pkField->getSerializer()->decode($pkField, $pkData[$pkField->getStorageName()]),
+            );
         }
 
         if ($definition instanceof MappingEntityDefinition) {

--- a/src/Core/Framework/Test/DataAbstractionLayer/Write/NonUuidFkField/NonUuidFkField.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Write/NonUuidFkField/NonUuidFkField.php
@@ -1,0 +1,25 @@
+<?php
+/*
+ * Copyright (c) Pickware GmbH. All rights reserved.
+ * This file is part of software that is released under a proprietary license.
+ * You must not copy, modify, distribute, make publicly available, or execute
+ * its contents or parts thereof without express permission by the copyright
+ * holder, unless otherwise permitted by law.
+ */
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Write\NonUuidFkField;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+
+/**
+ * @internal test class
+ */
+class NonUuidFkField extends FkField
+{
+    protected function getSerializerClass(): string
+    {
+        return NonUuidFkFieldSerializer::class;
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Write/NonUuidFkField/NonUuidFkFieldSerializer.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Write/NonUuidFkField/NonUuidFkFieldSerializer.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Copyright (c) Pickware GmbH. All rights reserved.
+ * This file is part of software that is released under a proprietary license.
+ * You must not copy, modify, distribute, make publicly available, or execute
+ * its contents or parts thereof without express permission by the copyright
+ * holder, unless otherwise permitted by law.
+ */
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Write\NonUuidFkField;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\FieldSerializerInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
+
+/**
+ * @internal test class
+ */
+class NonUuidFkFieldSerializer implements FieldSerializerInterface
+{
+    public function encode(Field $field, EntityExistence $existence, KeyValuePair $data, WriteParameterBag $parameters): \Generator
+    {
+        /** @var StorageAware $field */
+        yield $field->getStorageName() => $data->getValue();
+    }
+
+    public function decode(Field $field, mixed $value): mixed
+    {
+        return $value;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $data
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function normalize(Field $field, array $data, WriteParameterBag $parameters): array
+    {
+        return $data;
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Write/NonUuidFkField/TestEntityOneDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Write/NonUuidFkField/TestEntityOneDefinition.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Copyright (c) Pickware GmbH. All rights reserved.
+ * This file is part of software that is released under a proprietary license.
+ * You must not copy, modify, distribute, make publicly available, or execute
+ * its contents or parts thereof without express permission by the copyright
+ * holder, unless otherwise permitted by law.
+ */
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Write\NonUuidFkField;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+/**
+ * @internal test class
+ */
+class TestEntityOneDefinition extends EntityDefinition
+{
+    public function getEntityName(): string
+    {
+        return 'test_entity_one';
+    }
+
+    public function since(): ?string
+    {
+        return null;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new StringField('technical_name', 'technicalName'))->addFlags(new PrimaryKey(), new Required()),
+        ]);
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Write/NonUuidFkField/TestEntityTwoDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Write/NonUuidFkField/TestEntityTwoDefinition.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * Copyright (c) Pickware GmbH. All rights reserved.
+ * This file is part of software that is released under a proprietary license.
+ * You must not copy, modify, distribute, make publicly available, or execute
+ * its contents or parts thereof without express permission by the copyright
+ * holder, unless otherwise permitted by law.
+ */
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Write\NonUuidFkField;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+/**
+ * @internal test class
+ */
+class TestEntityTwoDefinition extends EntityDefinition
+{
+    public function getEntityName(): string
+    {
+        return 'test_entity_two';
+    }
+
+    public function since(): ?string
+    {
+        return null;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            (new NonUuidFkField('test_entity_one_technical_name', 'testEntityOneTechnicalName', TestEntityOneDefinition::class))->addFlags(new Required()),
+            new ManyToOneAssociationField('testEntityOne', 'test_entity_one_technical_name', TestEntityOneDefinition::class, 'technical_name'),
+        ]);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

In a vanilla Shopware you can assume all `FKField`s have UUID values. But when implementing a `FKField` that is _not_ a UUID (e.g. a technical name or any other string key), this assumption cause crashes. We had some of these issues in the past (SW 6.4) and fixed them together. Meaning, SW6.4 supports non-UUID FKs.

We now came accross the same problem in the current SW 6.5 RC.

When you use a `FKField` that is _not_ a UUID, the WriteCommandQueue assumes that you can always call `Uuid::fromBytesToHex` on a value of this field. The WriteCommandQueue now crashes any entity write attempts with a non-UUID `FKField`.

### 2. What does this change do, exactly?

The described problem can easily be fixed by using the `FKFields` **serializer** (`FieldSerializerInterface`). This will result in the use `Uuid::fromBytesToHex` for all basic `FKFields` but supports non-UUID `FKFields` with their own serializer as well.

### 3. Describe each step to reproduce the issue or behaviour.

Create a non-UUID `FKField` that extends Shopware's `FKField` that supports any string value with its own serializer (`FieldSerializerInterface`).
Create an entity that has such a custom `FKField` property.
Try to create and save such an entity with a `FKField` value. The write command will fail:

```
{status: "400", code: "FRAMEWORK__UUID_INVALID_LENGTH", title: "Bad Request",…}
code: "FRAMEWORK__UUID_INVALID_LENGTH"
detail: "UUID has a invalid length. 16 bytes expected, 22 given. Hexadecimal reprensentation: <NOT-PASTED-FOR-ISSUE>"
```

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-26207

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5179f9</samp>

Fix a bug in `WriteCommandQueue` that caused errors when using non-UUID foreign key fields. Update the changelog to document the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b5179f9</samp>

*  Add a changelog entry for the fix ([link](https://github.com/shopware/platform/pull/3043/files?diff=unified&w=0#diff-bf0045830408e728db3f03facc4d38ca388ce0d1e12c99f3a914e053034c4a3fR1-R8))
*  Fix the decoding of non-UUID FKFields in WriteCommandQueue by using the serializer of the FKField ([link](https://github.com/shopware/platform/pull/3043/files?diff=unified&w=0#diff-f90728edbb8d236e9d380554827740dc48f0c0650cd0f14d1d1169485627b47dL215-R215))
