### PR TITLE
[NEXT-26251] Add sales channel ID parameter and port handling to sales-channel:update:domain command.

### DIFF
--- a/changelog/_unreleased/2023-04-19-add-sales-channel-id-parameter-and-port-handling-to-sales-channel-update-domain-command.md
+++ b/changelog/_unreleased/2023-04-19-add-sales-channel-id-parameter-and-port-handling-to-sales-channel-update-domain-command.md
@@ -1,0 +1,12 @@
+---
+title: Add sales channel ID parameter and port handling to sales-channel:update:domain command
+issue: NEXT-26251
+author: Uwe Kleinmann
+author_email: u.kleinmann@kellerkinder.de
+author_github: kleinmann
+---
+
+# Core
+
+* Added `sales-channel-id` parameter to update domains of just one sales channel in `sales-channel:update:domain` command.
+* Added port handling in `sales-channel:update:domain` command

--- a/src/Core/Maintenance/Test/SalesChannel/Command/SalesChannelUpdateDomainCommandTest.php
+++ b/src/Core/Maintenance/Test/SalesChannel/Command/SalesChannelUpdateDomainCommandTest.php
@@ -6,10 +6,12 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Maintenance\SalesChannel\Command\SalesChannelUpdateDomainCommand;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -21,9 +23,19 @@ use Symfony\Component\Console\Tester\CommandTester;
 class SalesChannelUpdateDomainCommandTest extends TestCase
 {
     use IntegrationTestBehaviour;
+    use SalesChannelApiTestBehaviour;
 
     public function testUpdateDomainCommand(): void
     {
+        $this->createSalesChannel(['domains' => [
+            [
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+                'currencyId' => Defaults::CURRENCY,
+                'snippetSetId' => $this->getSnippetSetIdForLocale('en-GB'),
+                'url' => 'http://localhost',
+            ],
+        ]]);
+
         $commandTester = new CommandTester($this->getContainer()->get(SalesChannelUpdateDomainCommand::class));
         $commandTester->execute(['domain' => 'test.de']);
 
@@ -33,14 +45,19 @@ class SalesChannelUpdateDomainCommandTest extends TestCase
             "\"bin/console sales-channel:maintenance:disable\" returned errors:\n" . $commandTester->getDisplay()
         );
 
+        /** @var EntityRepository $domainRepo */
         $domainRepo = $this->getContainer()->get('sales_channel_domain.repository');
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('salesChannel.typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT));
 
-        /** @var SalesChannelDomainEntity $domain */
-        $domain = $domainRepo->search($criteria, Context::createDefaultContext())->first();
+        $domains = $domainRepo->search($criteria, Context::createDefaultContext());
+        /** @var SalesChannelDomainEntity $firstDomain */
+        $firstDomain = $domains->first();
+        /** @var SalesChannelDomainEntity $lastDomain */
+        $lastDomain = $domains->last();
 
-        static::assertSame('test.de', parse_url($domain->getUrl(), \PHP_URL_HOST));
+        static::assertSame('test.de', parse_url($firstDomain->getUrl(), \PHP_URL_HOST));
+        static::assertSame('test.de', parse_url($lastDomain->getUrl(), \PHP_URL_HOST));
     }
 
     public function testUpdateWithRandomPreviousDomain(): void
@@ -86,5 +103,61 @@ class SalesChannelUpdateDomainCommandTest extends TestCase
         $domain = $domainRepo->search($criteria, Context::createDefaultContext())->first();
 
         static::assertSame('test.de', parse_url($domain->getUrl(), \PHP_URL_HOST));
+    }
+
+    public function testUpdateWithSpecificSalesChannel(): void
+    {
+        /** @var EntityRepository $salesChannelRepository */
+        $salesChannelRepository = $this->getContainer()->get('sales_channel.repository');
+        $context = Context::createDefaultContext();
+
+        $secondSalesChannel = $this->createSalesChannel();
+
+        $storefrontCriteria = (new Criteria())->addFilter(new EqualsFilter('typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT));
+        $salesChannelId = $salesChannelRepository->searchIds($storefrontCriteria, $context)->firstId();
+
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelUpdateDomainCommand::class));
+        $commandTester->execute(['domain' => 'test.de', '--sales-channel-id' => $salesChannelId]);
+
+        static::assertEquals(
+            0,
+            $commandTester->getStatusCode(),
+            "\"bin/console sales-channel:maintenance:disable\" returned errors:\n" . $commandTester->getDisplay()
+        );
+
+        /** @var EntityRepository $domainRepo */
+        $domainRepo = $this->getContainer()->get('sales_channel_domain.repository');
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('salesChannel.typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT));
+        $domains = $domainRepo->search($criteria, Context::createDefaultContext());
+
+        /** @var SalesChannelDomainEntity $firstDomain */
+        $firstDomain = $domains->first();
+        /** @var SalesChannelDomainEntity $lastDomain */
+        $lastDomain = $domains->last();
+
+        static::assertSame('test.de', parse_url($firstDomain->getUrl(), \PHP_URL_HOST));
+        static::assertSame(parse_url($secondSalesChannel['domains'][0]['url'], \PHP_URL_HOST), parse_url($lastDomain->getUrl(), \PHP_URL_HOST));
+    }
+
+    public function testUpdateWithPortComponent(): void
+    {
+        $commandTester = new CommandTester($this->getContainer()->get(SalesChannelUpdateDomainCommand::class));
+        $commandTester->execute(['domain' => 'test.de:9999']);
+
+        static::assertEquals(
+            0,
+            $commandTester->getStatusCode(),
+            "\"bin/console sales-channel:maintenance:disable\" returned errors:\n" . $commandTester->getDisplay()
+        );
+
+        $domainRepo = $this->getContainer()->get('sales_channel_domain.repository');
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('salesChannel.typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT));
+
+        /** @var SalesChannelDomainEntity $domain */
+        $domain = $domainRepo->search($criteria, Context::createDefaultContext())->first();
+
+        static::assertSame('test.de', parse_url($domain->getUrl(), \PHP_URL_HOST));
+        static::assertSame(9999, parse_url($domain->getUrl(), \PHP_URL_PORT));
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
* `sales-channel:update:domain` currently updates either all domains or domains having a particular existing host. This is too limiting, as in some CI/deployment cases we want to update specific sales channels with different domains.

### 2. What does this change do, exactly?
* Add new parameter `sales-channel-id` to command to limit to a specific sales channel
* Handle ports in new domain correctly, otherwise they were kept as previously set, even if new domain does not have a port component.

### 3. Describe each step to reproduce the issue or behaviour.
* Run `sales-channel:update:domain`
* Be sad because all my precious sales channel domains were updated instead of just the one sales channel I was looking for

### 4. Please link to the relevant issues (if any).
* https://issues.shopware.com/issues/NEXT-26251

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 31a2f8a</samp>

This pull request improves the functionality and testing of the `SalesChannelUpdateDomainCommand` class, which allows updating the domain of a sales channel via the command line. It adds a new option to filter by sales channel ID and handles different domain formats, such as host, port and scheme. It also updates the corresponding test class and adds a changelog entry.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 31a2f8a</samp>

*  Add a new option to the `SalesChannelUpdateDomainCommand` class to allow specifying a sales channel ID as a parameter ([link](https://github.com/shopware/platform/pull/3044/files?diff=unified&w=0#diff-e63c9e81859f76d98bf5e57ec22a9e0a1621badaf19970993cb16fe19aedde2cR37),[link](https://github.com/shopware/platform/pull/3044/files?diff=unified&w=0#diff-e63c9e81859f76d98bf5e57ec22a9e0a1621badaf19970993cb16fe19aedde2cL41-R53))
*  Improve the logic of the `replaceDomain` method of the `SalesChannelUpdateDomainCommand` class to handle the port component of the new domain argument and use the appropriate component of the parse_url result ([link](https://github.com/shopware/platform/pull/3044/files?diff=unified&w=0#diff-e63c9e81859f76d98bf5e57ec22a9e0a1621badaf19970993cb16fe19aedde2cL74-R97))
*  Add a new changelog file to document the title, author and summary of the pull request ([link](https://github.com/shopware/platform/pull/3044/files?diff=unified&w=0#diff-4dd1fd787049bd68888daab02704ec212ef4f000d3cf9a4c2eb2035340e48aa5R1-R11))
*  Add tests for the new option and the port handling logic in the `SalesChannelUpdateDomainCommandTest` class, using the `SalesChannelApiTestBehaviour` trait and the `EntityRepository` class ([link](https://github.com/shopware/platform/pull/3044/files?diff=unified&w=0#diff-53b4d414d58f963dcae5bd195a81afa4574d1fbe85e346c3a167c1478bd67591L9-R14),[link](https://github.com/shopware/platform/pull/3044/files?diff=unified&w=0#diff-53b4d414d58f963dcae5bd195a81afa4574d1fbe85e346c3a167c1478bd67591L24-R38),[link](https://github.com/shopware/platform/pull/3044/files?diff=unified&w=0#diff-53b4d414d58f963dcae5bd195a81afa4574d1fbe85e346c3a167c1478bd67591L36-R60),[link](https://github.com/shopware/platform/pull/3044/files?diff=unified&w=0#diff-53b4d414d58f963dcae5bd195a81afa4574d1fbe85e346c3a167c1478bd67591R107-R162))
*  Add a new use statement for the `EqualsFilter` class in the `SalesChannelUpdateDomainCommand` class ([link](https://github.com/shopware/platform/pull/3044/files?diff=unified&w=0#diff-e63c9e81859f76d98bf5e57ec22a9e0a1621badaf19970993cb16fe19aedde2cR8))
