### PR TITLE
added `\IteratorAggregate` to the `Shopware\Core\Framework\Struct\ArrayStruct` to allow iteration through the values

### DIFF
--- a/changelog/_unreleased/2023-04-19-make-an-array-struct-iterable.md
+++ b/changelog/_unreleased/2023-04-19-make-an-array-struct-iterable.md
@@ -1,0 +1,12 @@
+---
+title: Make an array struct iterable and countable
+issue: 
+author: Dominik Mank
+author_email: d.mank@web-fabric.de
+author_github: dominikmank
+---
+
+# Core
+
+* added `\IteratorAggregate` and `\Countable` to the `Shopware\Core\Framework\Struct\ArrayStruct` to allow iteration through the values and counting the values
+* added test cases for the `Shopware\Core\Framework\Struct\ArrayStruct`

--- a/src/Core/Framework/Struct/ArrayStruct.php
+++ b/src/Core/Framework/Struct/ArrayStruct.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Struct;
 
 use Shopware\Core\Framework\Log\Package;
+use Traversable;
 
 /**
  * @template-covariant TKey
@@ -11,7 +12,7 @@ use Shopware\Core\Framework\Log\Package;
  * @implements \ArrayAccess<string|int, mixed>
  */
 #[Package('core')]
-class ArrayStruct extends Struct implements \ArrayAccess
+class ArrayStruct extends Struct implements \ArrayAccess, \IteratorAggregate, \Countable
 {
     /**
      * @param array<string|int, mixed> $data
@@ -100,5 +101,15 @@ class ArrayStruct extends Struct implements \ArrayAccess
     public function getVars(): array
     {
         return $this->data;
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new \ArrayIterator($this->data);
+    }
+
+    public function count(): int
+    {
+        return count($this->data);
     }
 }

--- a/tests/unit/php/Core/Framework/Struct/ArrayStructTest.php
+++ b/tests/unit/php/Core/Framework/Struct/ArrayStructTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Shopware\Tests\Unit\Core\Framework\Struct;
+
+use Shopware\Core\Framework\Struct\ArrayStruct;
+use PHPUnit\Framework\TestCase;
+
+class ArrayStructTest extends TestCase
+{
+    /**
+     * @dataProvider hasDataProvider
+     */
+    public function testHas(array $dataSet, mixed $searchFor, bool $expectFound): void
+    {
+        $arrayStruct = new ArrayStruct($dataSet);
+        static::assertSame($expectFound, $arrayStruct->has($searchFor));
+    }
+
+    /**
+     * @dataProvider hasDataProvider
+     */
+    public function testOffsetExists(array $dataSet, mixed $searchFor, bool $expectFound): void
+    {
+        $arrayStruct = new ArrayStruct($dataSet);
+        static::assertSame($expectFound, $arrayStruct->offsetExists($searchFor));
+    }
+
+    public function testOffsetGet(): void
+    {
+        $dataSet = ['a' => 'a', 'b' => ['b']];
+        $arrayStruct = new ArrayStruct($dataSet);
+        foreach ($dataSet as $offset => $value) {
+            static::assertSame($arrayStruct->offsetGet($offset), $value);
+        }
+    }
+
+    public function testOffsetSet(): void
+    {
+        $arrayStruct = new ArrayStruct([]);
+        static::assertCount(0, $arrayStruct->all());
+
+        $arrayStruct->offsetSet('new_value', 'some_value');
+
+        static::assertCount(1, $arrayStruct->all(), 'the count should increment by 1');
+        static::assertSame('some_value', $arrayStruct->get('new_value'));
+    }
+
+    public function testOffsetUnset(): void
+    {
+        $arrayStruct = new ArrayStruct(['a' => 'value']);
+        static::assertCount(1, $arrayStruct->all());
+
+        $arrayStruct->offsetUnset('a');
+
+        static::assertCount(0, $arrayStruct->all(), 'the count should decrement by 1');
+    }
+
+    public function testGet(): void
+    {
+        $dataSet = ['a' => 'a', 'b' => ['b']];
+        $arrayStruct = new ArrayStruct($dataSet);
+        foreach ($dataSet as $offset => $value) {
+            static::assertSame($arrayStruct->get($offset), $value);
+        }
+    }
+
+    public function testSet(): void
+    {
+        $arrayStruct = new ArrayStruct([]);
+        static::assertCount(0, $arrayStruct->all());
+
+        $arrayStruct->set('new_value', 'some_value');
+
+        static::assertCount(1, $arrayStruct->all(), 'the count should increment by 1');
+        static::assertSame('some_value', $arrayStruct->get('new_value'));
+    }
+
+    public function testAssign(): void
+    {
+        $arrayStruct = new ArrayStruct(['a' => 'value', 'b' => ['array_value']]);
+
+        static::assertSame('value', $arrayStruct->get('a'));
+        static::assertSame(['array_value'], $arrayStruct->get('b'));
+
+        $arrayStruct->assign(['a' => 'new_value', 'b' => null]);
+
+        static::assertSame('new_value', $arrayStruct->get('a'));
+        static::assertNull($arrayStruct->get('b'));
+    }
+
+    public function testJsonSerialize(): void
+    {
+        $arrayStruct = new ArrayStruct(['test' => 'value', 'date' => (new \DateTimeImmutable('2023-04-19 00:00:00'))]);
+
+        $serializedStruct = $arrayStruct->jsonSerialize();
+        static::assertArrayHasKey('test', $serializedStruct);
+        static::assertArrayHasKey('date', $serializedStruct);
+        static::assertSame('value', $serializedStruct['test']);
+        static::assertSame('2023-04-19T00:00:00.000+00:00', $serializedStruct['date']);
+    }
+
+    public function testGetApiAlias(): void
+    {
+        $struct = new ArrayStruct();
+        static::assertSame('array_struct', $struct->getApiAlias());
+
+        $otherStruct = new ArrayStruct([], 'anAlias');
+        static::assertSame('anAlias', $otherStruct->getApiAlias());
+    }
+
+    public function testGetVars(): void
+    {
+        $dataSet = ['a' => 'a', 'b' => 'b'];
+        $arrayStruct = new ArrayStruct($dataSet);
+        static::assertSame($dataSet, $arrayStruct->getVars());
+    }
+
+    public function testGetIterator(): void
+    {
+        $arrayStruct = new ArrayStruct();
+        static::assertInstanceOf(\ArrayIterator::class, $arrayStruct->getIterator());
+    }
+
+    public function testCount(): void
+    {
+        $arrayStruct = new ArrayStruct();
+        static::assertCount(0, $arrayStruct);
+
+        $arrayStruct->set('test', 'value');
+        static::assertCount(1, $arrayStruct);
+    }
+
+    public function hasDataProvider(): \Generator
+    {
+        $defaultDataSet = [
+            'a' => 'value',
+            'b' => ['array_value'],
+            94 => 44,
+            'null_value' => null,
+        ];
+
+        yield 'found a' => [$defaultDataSet, 'a', true];
+        yield 'found numeric 94' => [$defaultDataSet, 94, true];
+        yield 'value 94 as string' => [$defaultDataSet, '94', true];
+        yield 'key not existing' => [$defaultDataSet, 'not_existing', false];
+        yield 'null value' => [$defaultDataSet, 'null_value', true];
+    }
+
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
To have the possibility, to iterate through the array struct data


### 2. What does this change do, exactly?
It adds the IteratorAggregate to the ArrayStruct to allow iteration through the values. Also the tests for the class are added.
Also Countable was added to allow the count on the values.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3465b4a</samp>

This pull request adds the ability to iterate over the values of an `ArrayStruct` object using `foreach` and other functions. It implements the `IteratorAggregate` interface, adds a changelog entry, and provides unit tests for the `ArrayStruct` class.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3465b4a</samp>

*  Implement the `IteratorAggregate` interface for the `ArrayStruct` class to make it iterable ([link](https://github.com/shopware/platform/pull/3046/files?diff=unified&w=0#diff-f21dd8cab48e2967baac4b0d4fb97e6107099f658733615947db47490e31b511R6),[link](https://github.com/shopware/platform/pull/3046/files?diff=unified&w=0#diff-f21dd8cab48e2967baac4b0d4fb97e6107099f658733615947db47490e31b511L14-R15),[link](https://github.com/shopware/platform/pull/3046/files?diff=unified&w=0#diff-f21dd8cab48e2967baac4b0d4fb97e6107099f658733615947db47490e31b511R105-R109))
  * Add the `Traversable` interface to the use statements ([link](https://github.com/shopware/platform/pull/3046/files?diff=unified&w=0#diff-f21dd8cab48e2967baac4b0d4fb97e6107099f658733615947db47490e31b511R6))
  * Declare that the class implements the `IteratorAggregate` interface ([link](https://github.com/shopware/platform/pull/3046/files?diff=unified&w=0#diff-f21dd8cab48e2967baac4b0d4fb97e6107099f658733615947db47490e31b511L14-R15))
  * Define the `getIterator` method that returns a new `ArrayIterator` with the internal data array ([link](https://github.com/shopware/platform/pull/3046/files?diff=unified&w=0#diff-f21dd8cab48e2967baac4b0d4fb97e6107099f658733615947db47490e31b511R105-R109))
* Add a new unit test file for the `ArrayStruct` class in `tests/unit/php/Core/Framework/Struct/ArrayStructTest.php` ([link](https://github.com/shopware/platform/pull/3046/files?diff=unified&w=0#diff-0ce3e270fa18d8afda019e1e38db6752fb150a57ac47071cadbecd03258fbf92R1-R140))
* Add a markdown file to the changelog directory with the title, issue, author, and core changes of the pull request ([link](https://github.com/shopware/platform/pull/3046/files?diff=unified&w=0#diff-f898028d6a7bbcb8b24ca736a8d8506d308a7016b5e926bae5b38ab22c58c786R1-R12))
  * Follow the template for unreleased changes and use the issue number `NEXT-12345` ([link](https://github.com/shopware/platform/pull/3046/files?diff=unified&w=0#diff-f898028d6a7bbcb8b24ca736a8d8506d308a7016b5e926bae5b38ab22c58c786R1-R12))
