### PR TITLE
Moved closing div in correct twig block

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
@@ -54,32 +54,32 @@
                                 {% block component_line_item_quantity_select %}
                                     {% block component_line_item_quantity_select_input %}
                                         <div class="input-group line-item-quantity-group quantity-selector-group" data-quantity-selector="true">
-                                                <button
-                                                    {% if isDigital %}disabled="disabled"{% endif %}
-                                                    type="button"
-                                                    class="btn btn-outline-light btn-minus js-btn-minus"
-                                                >
-                                                        {% sw_icon 'minus' style {'size': 'xs'}  %}
-                                                </button>
-                                                <input
-                                                    {% if isDigital %}disabled="disabled"{% endif %}
-                                                    type="number"
-                                                    name="quantity"
-                                                    class="form-control js-quantity-selector quantity-selector-group-input quantity-input-{{ lineItem.id }} {% if displayMode === 'offcanvas' %} js-offcanvas-cart-change-quantity-number{% endif %}"
-                                                    min="{{ quantityInformation.minPurchase }}"
-                                                    max="{{ maxQuantity }}"
-                                                    step="{{ quantityInformation.purchaseSteps }}"
-                                                    value="{{ lineItem.quantity }}"
-                                                />
-                                                <button
-                                                    {% if isDigital %}disabled="disabled"{% endif %}
-                                                    type="button"
-                                                    class="btn btn-outline-light btn-plus js-btn-plus"
-                                                >
-                                                        {% sw_icon 'plus' style {'size': 'xs'} %}
-                                                </button>
-                                        {% endblock %}
-                                    </div>
+                                            <button
+                                                {% if isDigital %}disabled="disabled"{% endif %}
+                                                type="button"
+                                                class="btn btn-outline-light btn-minus js-btn-minus"
+                                            >
+                                                {% sw_icon 'minus' style {'size': 'xs'}  %}
+                                            </button>
+                                            <input
+                                                {% if isDigital %}disabled="disabled"{% endif %}
+                                                type="number"
+                                                name="quantity"
+                                                class="form-control js-quantity-selector quantity-selector-group-input quantity-input-{{ lineItem.id }} {% if displayMode === 'offcanvas' %} js-offcanvas-cart-change-quantity-number{% endif %}"
+                                                min="{{ quantityInformation.minPurchase }}"
+                                                max="{{ maxQuantity }}"
+                                                step="{{ quantityInformation.purchaseSteps }}"
+                                                value="{{ lineItem.quantity }}"
+                                            />
+                                            <button
+                                                {% if isDigital %}disabled="disabled"{% endif %}
+                                                type="button"
+                                                class="btn btn-outline-light btn-plus js-btn-plus"
+                                            >
+                                                {% sw_icon 'plus' style {'size': 'xs'} %}
+                                            </button>
+                                        </div>
+                                    {% endblock %}
                                 {% endblock %}
                             </form>
                         {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Closing div isnt in correct block

### 2. What does this change do, exactly?
Moved closing div in the correct twig block `component_line_item_quantity_select_input`

Hope this dont need a changelog file. 😊

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd40cb5</samp>

Fixed indentation of a closing tag in a Twig template. This change affects the `quantity.html.twig` file, which renders the quantity input for line items in the storefront.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fd40cb5</samp>

*  Fixed the indentation of the `</div>` tag for the `component_line_item_quantity_select_input` block ([link](https://github.com/shopware/platform/pull/3050/files?diff=unified&w=0#diff-3d1ddeacb1494fa2923a28e91d7bb421d9e3699896d93a5e7a09b6eab770d244L57-R82))
