### PR TITLE
update quantity.html.twig

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
@@ -78,8 +78,8 @@
                                                 >
                                                         {% sw_icon 'plus' style {'size': 'xs'} %}
                                                 </button>
+                                                   </div>
                                         {% endblock %}
-                                    </div>
                                 {% endblock %}
                             </form>
                         {% endblock %}


### PR DESCRIPTION
wrong hierarchy of closing tag div and endblock

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a4b40d</samp>

Fix missing HTML element in quantity input component. This resolves a layout issue in `src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig` reported in issue #21776.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a4b40d</samp>

* Fix missing closing `</div>` tag in quantity input component ([link](https://github.com/shopware/platform/pull/3052/files?diff=unified&w=0#diff-3d1ddeacb1494fa2923a28e91d7bb421d9e3699896d93a5e7a09b6eab770d244L81-R82))
