### PR TITLE
Update 2022-11-07-deprecate-app-manifest-version-1.0.md

### DIFF
--- a/changelog/release-6-4-18-0/2022-11-07-deprecate-app-manifest-version-1.0.md
+++ b/changelog/release-6-4-18-0/2022-11-07-deprecate-app-manifest-version-1.0.md
@@ -24,4 +24,4 @@ With the upcoming major release we are going to release a new XML-schema for Sho
     Make sure to remove the attribute `openNewTab` from your `action-button` elements in your `manifest.xml` and use ActionButtonResponses as described in our [documentation](https://developer.shopware.com/docs/guides/plugins/apps/administration/add-custom-action-button) instead.
 3. Deprecation of `manifest-1.0.xsd`
 
-    Update the `xsi:noNamespaceSchemaLocation` attribute of your `manifest` root element. to `https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/Framework/App/Manifest/Schema/manifest-1.0.xsd`
+    Update the `xsi:noNamespaceSchemaLocation` attribute of your `manifest` root element. to `https://raw.githubusercontent.com/shopware/platform/trunk/src/Core/Framework/App/Manifest/Schema/manifest-2.0.xsd`


### PR DESCRIPTION
Is it possible that the link is not correct? When you try to access it, you only get a 404 page. I guess it should actually contain the link ...manifest-2.0.xsd.

Many greetings
Jonas