### PR TITLE
Allow importing medias with encoded urls

### DIFF
--- a/changelog/_unreleased/2023-06-08-allow-import-of-encoded-url.md
+++ b/changelog/_unreleased/2023-06-08-allow-import-of-encoded-url.md
@@ -1,0 +1,27 @@
+---
+title: Allow uploading of url encoded media
+issue:
+author: Michael Köck
+author_email: mkoeck@elektroshopkoeck.com
+author_github: mkoeck
+---
+# Core
+*  Changed deserialize method of src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php to urldecode the filename before saving it to the destination key of the cacheMediaFiles
+___
+# API
+*  
+___
+# Administration
+*  
+___
+# Storefront
+*  
+___
+# Upgrade Information
+## MediaSerializer
+### deserialize
+The deserialize method of src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php was changed such that the filename will be urldecoded before saving it to the cacheMediaFiles.
+Previously, encoded url raised an error during validateFileNameDoesNotContainForbiddenCharacter when importing them, because they contained % signs. 
+On the other hand, not encoding urls raised an "Invalid media url" exception.
+
+This change allows importing medias with filenames that contain special characters by supplying an encoded url in the import file.

--- a/changelog/_unreleased/2023-06-08-allow-import-of-encoded-url.md
+++ b/changelog/_unreleased/2023-06-08-allow-import-of-encoded-url.md
@@ -8,15 +8,6 @@ author_github: mkoeck
 # Core
 *  Changed deserialize method of src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php to urldecode the filename before saving it to the destination key of the cacheMediaFiles
 ___
-# API
-*  
-___
-# Administration
-*  
-___
-# Storefront
-*  
-___
 # Upgrade Information
 ## MediaSerializer
 ### deserialize

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
@@ -99,7 +99,7 @@ class MediaSerializer extends AbstractMediaSerializer implements ResetInterface
 
             $this->cacheMediaFiles[(string) $deserialized['id']] = [
                 'media' => $media,
-                'destination' => $pathInfo['filename'],
+                'destination' => urldecode($pathInfo['filename']),
             ];
         }
 

--- a/src/Core/Content/Test/ImportExport/ImportExportTest.php
+++ b/src/Core/Content/Test/ImportExport/ImportExportTest.php
@@ -154,12 +154,12 @@ class ImportExportTest extends AbstractImportExportTestCase
 
         static::assertNotNull($product);
     }
-    
+
     public function testMediaWithEncodedUrl(): void
     {
         $fixturesPath = __DIR__ . '/fixtures/media_encoded_url.csv';
         $progress = $this->import(Context::createDefaultContext(), MediaDefinition::ENTITY_NAME, $fixturesPath, 'media_encoded_url.csv', null, false, true);
-    
+
         static::assertTrue($progress->isFinished());
         static::assertImportExportSucceeded($progress, $this->getInvalidLogContent($progress->getInvalidRecordsLogId()));
     }

--- a/src/Core/Content/Test/ImportExport/ImportExportTest.php
+++ b/src/Core/Content/Test/ImportExport/ImportExportTest.php
@@ -35,6 +35,7 @@ use Shopware\Core\Content\ImportExport\Service\FileService;
 use Shopware\Core\Content\ImportExport\Service\ImportExportService;
 use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Content\ImportExport\Struct\Progress;
+use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientDefinition;
 use Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute;
 use Shopware\Core\Content\Product\Aggregate\ProductConfiguratorSetting\ProductConfiguratorSettingCollection;
@@ -50,7 +51,6 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityC
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
-use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;

--- a/src/Core/Content/Test/ImportExport/ImportExportTest.php
+++ b/src/Core/Content/Test/ImportExport/ImportExportTest.php
@@ -50,6 +50,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityC
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionDefinition;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -152,6 +153,15 @@ class ImportExportTest extends AbstractImportExportTestCase
         $product = $this->productRepository->search($criteria, Context::createDefaultContext())->first();
 
         static::assertNotNull($product);
+    }
+    
+    public function testMediaWithEncodedUrl(): void
+    {
+        $fixturesPath = __DIR__ . '/fixtures/media_encoded_url.csv';
+        $progress = $this->import(Context::createDefaultContext(), MediaDefinition::ENTITY_NAME, $fixturesPath, 'media_encoded_url.csv', null, false, true);
+    
+        static::assertTrue($progress->isFinished());
+        static::assertImportExportSucceeded($progress, $this->getInvalidLogContent($progress->getInvalidRecordsLogId()));
     }
 
     public function testCategory(): void

--- a/src/Core/Content/Test/ImportExport/fixtures/media_encoded_url.csv
+++ b/src/Core/Content/Test/ImportExport/fixtures/media_encoded_url.csv
@@ -1,0 +1,2 @@
+url
+https://media3.bsh-group.com/Product_Shots/19071749_SI_CEJ_Backblech_HZ631070_HEZ631070_Ma%C3%9Fe_def.png


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

First pull request (ever!). Apologies in advance if I made an error somewhere.

### 1. Why is this change necessary?
Currently it is impossible to import medias via url that contain special characters such as ß. 

Encoding the url leads to "Provided filename is not permitted: Filename must not contain %"
Not encoding the url leads to "Invalid media url"

Therefore it is impossible to upload from such urls. Given, that sometimes the user will not have access to the filename, it might not be possible to avoid using special characters.

### 2. What does this change do, exactly?
Before adding the media to the cache, the filename will be url_decoded. After the filename has been url decoded validateFileNameDoesNotContainForbiddenCharacter which looks among others for % does not fail anymore (except if the filename still contains forbidden characters after decoding)

### 3. Describe each step to reproduce the issue or behaviour.
Use the import tool with a csv file that contains an url with ß, or the encoded version %C3%9F

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76153dc</samp>

This pull request adds a feature to allow importing media with encoded urls in the ImportExport module. It also adds a test case and a changelog entry for the feature, and fixes the MediaSerializer class to handle encoded filenames.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 76153dc</samp>

*  Add a changelog entry for the feature that allows importing of encoded media urls ([link](https://github.com/shopware/platform/pull/3062/files?diff=unified&w=0#diff-2df7421e12ebc680317034a64771efd8d43ecbce361c13341033414d2137958aR1-R27))
*  Modify the MediaSerializer class to urldecode the filename before saving it to the cacheMediaFiles array ([link](https://github.com/shopware/platform/pull/3062/files?diff=unified&w=0#diff-fa1bb00353c0374d9b3288831a0f9e2736a23e103795b40f20f264790989c277L102-R102))
*  Create a fixture file with a media url that contains an encoded character ([link](https://github.com/shopware/platform/pull/3062/files?diff=unified&w=0#diff-6e055576d0f1f4118edeaab2d164725de023577d8a9c6e0a74fbd5f163b93689R1-R2))
*  Import the MediaDefinition class and add a test case for the feature using the fixture file ([link](https://github.com/shopware/platform/pull/3062/files?diff=unified&w=0#diff-63929f6ad9a2d200bfccff409ab50a187e050fd61445f3d345f462bae64f29e1R53), [link](https://github.com/shopware/platform/pull/3062/files?diff=unified&w=0#diff-63929f6ad9a2d200bfccff409ab50a187e050fd61445f3d345f462bae64f29e1R157-R165))
