### PR TITLE
fix: Do not use request locale to format the rich snippet product release date

### DIFF
--- a/changelog/_unreleased/2023-05-07-do-not-use-request-locale-to-format-the-rich-snippet-product-release-date.md
+++ b/changelog/_unreleased/2023-05-07-do-not-use-request-locale-to-format-the-rich-snippet-product-release-date.md
@@ -1,0 +1,10 @@
+---
+title: Do not use request locale to format the rich snippet product release date
+issue: NEXT-00000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed `format_date` call in the twig templates `views/storefront/page/product-detail/buy-widget.html.twig` and
+ `storefront/component/buy-widget/buy-widget.html.twig` to not consider the request locale, as there is an explicit format specified

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
@@ -53,7 +53,7 @@
 
             {% block buy_widget_rich_snippets_release_date %}
                 <meta itemprop="releaseDate"
-                      content="{{ product.releaseDate|format_date(pattern="Y-MM-dd", locale=app.request.locale) }}"/>
+                      content="{{ product.releaseDate|format_date(pattern='Y-MM-dd') }}"/>
             {% endblock %}
         {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
@@ -53,7 +53,7 @@
 
             {% block page_product_detail_rich_snippets_release_date %}
                 <meta itemprop="releaseDate"
-                      content="{{ page.product.releaseDate|format_date(pattern="Y-MM-dd", locale=app.request.locale) }}"/>
+                      content="{{ page.product.releaseDate|format_date(pattern='Y-MM-dd') }}"/>
             {% endblock %}
         {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Yesterday the shop of a customer had an error raised, that the locale could not be extracted: 
![image](https://user-images.githubusercontent.com/6317761/236689797-e82befdd-b998-40d4-b767-161a19228ac7.png)

### 2. What does this change do, exactly?
Remove the locale, as there is a fixed format specified.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e7b06f0</samp>

This pull request fixes the rich snippet product release date formatting in the `buy-widget.html.twig` template, by removing the unnecessary `locale` argument from the `format_date` filter. This ensures that the date is always in the ISO 8601 format, regardless of the request locale.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e7b06f0</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3064/files?diff=unified&w=0#diff-75530cccad5e33293ac54fc4e95a1ba4172f68bb26ce93d49ecbbb24dc6ec1cfR1-R10))
*  Remove the `locale` argument from the `format_date` filter in the `buy-widget.html.twig` template, to ensure the rich snippet product release date is formatted in ISO 8601 regardless of the request locale ([link](https://github.com/shopware/platform/pull/3064/files?diff=unified&w=0#diff-50b0e0bb0ac9975cd0f391dd36f0d506def2ffcd2c97158213b6c3138b1e4b8eL56-R56), [link](https://github.com/shopware/platform/pull/3064/files?diff=unified&w=0#diff-98ccbe0dbf0320878cc23eb11a8f34ad01bad4daa461fb9d5cb3fbff8584cba5L56-R56))
