### PR TITLE
NEXT-25239 - Fix many to one versioned references

### DIFF
--- a/changelog/_unreleased/2023-04-27-fix-versioned-many-to-one-references.md
+++ b/changelog/_unreleased/2023-04-27-fix-versioned-many-to-one-references.md
@@ -1,0 +1,9 @@
+---
+title: Fix versioned many to one references
+issue: NEXT-25239
+author: Maximilian Ruesch
+author_email: maximilian.ruesch@pickware.de
+author_github: maximilianruesch
+---
+# Core
+* Changed the ManyToOneAssociationFieldResolver to build versioned many to one references correctly from unversioned entities.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19301,3 +19301,8 @@ parameters:
 			message: "#^Parameter \\#2 \\$entities of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\AggregationResult\\\\Metric\\\\EntityResult constructor expects Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityCollection\\<Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\>, Shopware\\\\Core\\\\Content\\\\Property\\\\PropertyGroupCollection given\\.$#"
 			count: 1
 			path: src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
+
+		-
+			message: "#^Method Shopware\\\\Tests\\\\Integration\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\FieldResolver\\\\ManyToOneAssociationFieldResolverTest\\:\\:getBaseConfig\\(\\) should return Shopware\\\\Core\\\\Checkout\\\\Document\\\\Aggregate\\\\DocumentBaseConfig\\\\DocumentBaseConfigEntity\\|null but returns Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\|null\\.$#"
+			count: 1
+			path: tests/integration/php/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
@@ -119,7 +119,6 @@ export default {
             criteria.addSorting(Criteria.sort('createdAt', 'DESC'));
             criteria.addAssociation('documentType');
             criteria.addFilter(Criteria.equals('order.id', this.order.id));
-            criteria.addFilter(Criteria.equals('order.versionId', this.order.versionId));
 
             if (!this.term) {
                 return criteria;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-select-document-type-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-select-document-type-modal/index.js
@@ -70,7 +70,6 @@ export default {
         documentCriteria() {
             const criteria = new Criteria(1, 100);
             criteria.addFilter(Criteria.equals('order.id', this.order.id));
-            criteria.addFilter(Criteria.equals('order.versionId', this.order.versionId));
             criteria.addFilter(Criteria.equals('documentType.technicalName', 'invoice'));
 
             return criteria;

--- a/tests/integration/php/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
+++ b/tests/integration/php/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
@@ -1,0 +1,249 @@
+<?php
+/*
+ * Copyright (c) Pickware GmbH. All rights reserved.
+ * This file is part of software that is released under a proprietary license.
+ * You must not copy, modify, distribute, make publicly available, or execute
+ * its contents or parts thereof without express permission by the copyright
+ * holder, unless otherwise permitted by law.
+ */
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Dbal\FieldResolver;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeDefinition;
+use Shopware\Core\Checkout\Document\DocumentDefinition;
+use Shopware\Core\Checkout\Document\DocumentEntity;
+use Shopware\Core\Checkout\Order\OrderDefinition;
+use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Checkout\Test\Document\DocumentTrait;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldResolver\FieldResolverContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldResolver\ManyToOneAssociationFieldResolver;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+class ManyToOneAssociationFieldResolverTest extends TestCase
+{
+    use DocumentTrait;
+    use KernelTestBehaviour;
+
+    protected ManyToOneAssociationFieldResolver $resolver;
+
+    protected QueryBuilder $queryBuilder;
+
+    protected DefinitionInstanceRegistry $definitionInstanceRegistry;
+
+    protected EntityRepository $orderRepository;
+
+    protected EntityRepository $documentRepository;
+
+    protected Connection $connection;
+
+    protected SalesChannelContext $salesChannelContext;
+
+    protected Context $context;
+
+    protected function setUp(): void
+    {
+        $this->resolver = $this->getContainer()->get(ManyToOneAssociationFieldResolver::class);
+        $this->queryBuilder = new QueryBuilder($this->getContainer()->get(Connection::class));
+        $this->definitionInstanceRegistry = $this->getContainer()->get(DefinitionInstanceRegistry::class);
+        $this->orderRepository = $this->getContainer()->get('order.repository');
+        $this->documentRepository = $this->getContainer()->get('document.repository');
+        $this->connection = $this->getContainer()->get(Connection::class);
+        $this->context = Context::createDefaultContext();
+        $this->salesChannelContext = $this->getContainer()->get(SalesChannelContextFactory::class)->create(
+            Uuid::randomHex(),
+            TestDefaults::SALES_CHANNEL,
+            [SalesChannelContextService::CUSTOMER_ID => $this->createCustomer()]
+        );
+    }
+
+    public function testVersionConstraintWithVersionedReferenceToVersionedEntity(): void
+    {
+        // Document itself is not versioned, but has a versioned reference on the versioned order
+        $documentDefinition = $this->definitionInstanceRegistry->get(DocumentDefinition::class);
+        $orderDefinition = $this->definitionInstanceRegistry->get(OrderDefinition::class);
+        $documentAssociationField = $documentDefinition->getField('order');
+
+        static::assertNotNull($documentAssociationField);
+        $resolverContext = new FieldResolverContext(
+            '',
+            'document',
+            $documentAssociationField,
+            $documentDefinition,
+            $orderDefinition,
+            $this->queryBuilder,
+            $this->context,
+            null,
+        );
+
+        $this->resolver->join($resolverContext);
+
+        static::assertSame([
+            '`document`' => [
+                [
+                    'joinType' => 'left',
+                    'joinTable' => '`order`',
+                    'joinAlias' => '`document.order`',
+                    'joinCondition' => '`document`.`order_id` = `document.order`.`id` AND `document`.`order_version_id` = `document.order`.`version_id`',
+                ],
+            ],
+        ], $this->queryBuilder->getQueryPart('join'));
+    }
+
+    public function testVersionConstraintWithReferenceToNonVersionedEntity(): void
+    {
+        // Document and document type are not versioned, thus also document cannot have a versioned reference to its type
+        $documentDefinition = $this->definitionInstanceRegistry->get(DocumentDefinition::class);
+        $documentTypeDefinition = $this->definitionInstanceRegistry->get(DocumentTypeDefinition::class);
+        $documentAssociationField = $documentDefinition->getField('documentType');
+
+        static::assertNotNull($documentAssociationField);
+        $resolverContext = new FieldResolverContext(
+            '',
+            'document',
+            $documentAssociationField,
+            $documentDefinition,
+            $documentTypeDefinition,
+            $this->queryBuilder,
+            $this->context,
+            null,
+        );
+
+        $this->resolver->join($resolverContext);
+
+        static::assertSame([
+            '`document`' => [
+                [
+                    'joinType' => 'left',
+                    'joinTable' => '`document_type`',
+                    'joinAlias' => '`document.documentType`',
+                    'joinCondition' => '`document`.`document_type_id` = `document.documentType`.`id`',
+                ],
+            ],
+        ], $this->queryBuilder->getQueryPart('join'));
+    }
+
+    public function testVersionConstraintWithReferenceToSelf(): void
+    {
+        // Document and document type are not versioned, thus also document cannot have a versioned reference to its type
+        $documentDefinition = $this->definitionInstanceRegistry->get(DocumentDefinition::class);
+        $documentTypeDefinition = $this->definitionInstanceRegistry->get(DocumentDefinition::class);
+        $documentAssociationField = $documentDefinition->getField('referencedDocument');
+
+        static::assertNotNull($documentAssociationField);
+        $resolverContext = new FieldResolverContext(
+            '',
+            'document',
+            $documentAssociationField,
+            $documentDefinition,
+            $documentTypeDefinition,
+            $this->queryBuilder,
+            $this->context,
+            null,
+        );
+
+        $this->resolver->join($resolverContext);
+
+        static::assertSame([
+            '`document`' => [
+                [
+                    'joinType' => 'left',
+                    'joinTable' => '`document`',
+                    'joinAlias' => '`document.referencedDocument`',
+                    'joinCondition' => '`document`.`referenced_document_id` = `document.referencedDocument`.`id`',
+                ],
+            ],
+        ], $this->queryBuilder->getQueryPart('join'));
+    }
+
+    public function testVersionConstraintWithOneToOneVersionedReferenceFromVersionedEntity(): void
+    {
+        // Document itself is not versioned, but has a versioned reference on the versioned order
+        $orderDefinition = $this->definitionInstanceRegistry->get(OrderDefinition::class);
+        $orderCustomerDefinition = $this->definitionInstanceRegistry->get(DocumentDefinition::class);
+        $orderAssociationField = $orderDefinition->getField('orderCustomer');
+
+        static::assertNotNull($orderAssociationField);
+        $resolverContext = new FieldResolverContext(
+            '',
+            'order',
+            $orderAssociationField,
+            $orderDefinition,
+            $orderCustomerDefinition,
+            $this->queryBuilder,
+            $this->context,
+            null,
+        );
+
+        $this->resolver->join($resolverContext);
+
+        static::assertSame([
+            '`order`' => [
+                [
+                    'joinType' => 'left',
+                    'joinTable' => '`order_customer`',
+                    'joinAlias' => '`order.orderCustomer`',
+                    'joinCondition' => '`order`.`id` = `order.orderCustomer`.`order_id` AND `order`.`version_id` = `order.orderCustomer`.`order_version_id`',
+                ],
+            ],
+        ], $this->queryBuilder->getQueryPart('join'));
+    }
+
+    public function testCorrectOrderVersionOverAssociationOverRepositorySearch(): void
+    {
+        // 1. Create a new order and extract order number
+        $cart = $this->generateDemoCart(2);
+        $orderId = $this->persistCart($cart);
+        /** @var OrderEntity $order */
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $this->context)->first();
+
+        // 2. Generate a document attached to the order
+        $this->createDocument('invoice', $orderId, [], $this->context);
+
+        // 3. Set created order version to be lexicographically smaller than the live version
+        $this->connection->executeStatement(
+            'UPDATE `order`
+            SET `version_id` = :newVersionId
+            WHERE `version_id` != :liveVersionId AND `id` = :orderId',
+            [
+                'newVersionId' => hex2bin('00000000000000000000000000000000'),
+                'liveVersionId' => hex2bin(Defaults::LIVE_VERSION),
+                'orderId' => hex2bin($orderId),
+            ],
+        );
+
+        // 4. Search for the document over the order number of its attached order
+        $documents = $this->documentRepository->search(
+            (new Criteria())
+                ->addFilter(new EqualsFilter('order.orderNumber', $order->getOrderNumber()))
+                ->addAssociation('order')
+                ->setTotalCountMode(Criteria::TOTAL_COUNT_MODE_EXACT),
+            $this->context,
+        );
+
+        static::assertCount(1, $documents);
+        static::assertEquals(1, $documents->getTotal());
+        /** @var DocumentEntity $document */
+        $document = $documents->first();
+        static::assertNotNull($document->getOrder());
+        static::assertEquals('00000000000000000000000000000000', $document->getOrder()->getVersionId());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

As described in the linked issue, versioned references (e.g. from document to order over the `id` and `version_id` of said order) from unversioned entities (e.g. document) are not respected properly and result in undefined / unreasoned behaviour. This results in wrong total calculations and possibly wrongfully returned associations.

### 2. What does this change do, exactly?

This change fixes the `ManyToOneAssociationFieldResolver` to respect versioned references from unversioned entities through adding respective checks and constructing additions for the join condition. It also adds some useful comments to understand the methods, removes false ones and renames methods for better understanding and consistency.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create an order
2. Generate a document for that order
3. In the Database, check if the order version number created for the document is lexicographically smaller than the live version, if it is, change it (in the `order` table so FK kick in) so it is bigger
4. With an API client of your choice, log in and prepare a search for the document via the `/api/search/document` endpoint.
5. In the request for 3., specify a filter on `order.orderNumber` for the respective order of that document and request the `order` in the associations. Additionally, request exact counting of the entities (total-count-mode: 1).
6. Dispatch the request
6.1 The results will include an order in the live version (which is wrong as the document references another version, the live version is just lexicographically the first one)
6.2 The results will include a wrong total (2 instead of 1)
7. Add an additional filter for `order.versionId` for the specific version of the document
8. Dispatch the request again
8.1 The results will still include an order in the live version
8.2 The results will now have a correct total count (due to filters being respected in the ID fetch for the document)

As can be seen, both 6.* and 8.1 leave unsatisfying results. This PR will fix all problems from 6.*, which also resolves 8.1 as we not even need an additional filter.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-25239

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80317b1</samp>

This pull request fixes a bug in the `ManyToOneAssociationFieldResolver` class that caused incorrect joins and queries for versioned many to one associations. It also adds documentation, formatting and tests for the updated class. The affected files are `ManyToOneAssociationFieldResolver.php`, `ManyToOneAssociationFieldResolverTest.php` and `2023-04-27-fix-versioned-many-to-one-references.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80317b1</samp>

*  Add a changelog entry for the fix of versioned many-to-one references ([link](https://github.com/shopware/platform/pull/3065/files?diff=unified&w=0#diff-36f0e8375ea5d580eeea06b478b7a90ae141e922ef16cb1ebbc4a8cc90fe85b3R1-R9))
*  Modify the join method of the `ManyToOneAssociationFieldResolver` class to use the new `buildVersionWhere` method instead of the `buildWhere` method ([link](https://github.com/shopware/platform/pull/3065/files?diff=unified&w=0#diff-a2ec283863b69be2cabbcda70bbf8da63ba6df687adfcffbc0cd95510d7aa81bL79-R80))
*  Remove the internal annotation from the `buildWhere` method, as it is no longer overwritten by the parent class ([link](https://github.com/shopware/platform/pull/3065/files?diff=unified&w=0#diff-a2ec283863b69be2cabbcda70bbf8da63ba6df687adfcffbc0cd95510d7aa81bL86-L88))
*  Replace the `buildWhere` method with the new `buildVersionWhere` method, which handles different scenarios of version-aware and non-version-aware entities and fields ([link](https://github.com/shopware/platform/pull/3065/files?diff=unified&w=0#diff-a2ec283863b69be2cabbcda70bbf8da63ba6df687adfcffbc0cd95510d7aa81bL127-R167))
*  Add a docblock comment to the `buildVersionWhere` method ([link](https://github.com/shopware/platform/pull/3065/files?diff=unified&w=0#diff-a2ec283863b69be2cabbcda70bbf8da63ba6df687adfcffbc0cd95510d7aa81bL127-R167))
*  Add a trailing comma to the `from` method call in the `createSubVersionQuery` method, to comply with the coding standards ([link](https://github.com/shopware/platform/pull/3065/files?diff=unified&w=0#diff-a2ec283863b69be2cabbcda70bbf8da63ba6df687adfcffbc0cd95510d7aa81bL153-R179))
*  Add a docblock comment to the `joinVersion` method, which joins the correct version of the referenced entity based on the available fields ([link](https://github.com/shopware/platform/pull/3065/files?diff=unified&w=0#diff-a2ec283863b69be2cabbcda70bbf8da63ba6df687adfcffbc0cd95510d7aa81bR198-R206))
*  Add a trailing comma to the `str_replace` method call in the `joinVersion` method, to comply with the coding standards ([link](https://github.com/shopware/platform/pull/3065/files?diff=unified&w=0#diff-a2ec283863b69be2cabbcda70bbf8da63ba6df687adfcffbc0cd95510d7aa81bL190-R226))
*  Add a new test class for the `ManyToOneAssociationFieldResolver` class, to verify the functionality of the versioning logic ([link](https://github.com/shopware/platform/pull/3065/files?diff=unified&w=0#diff-5db42b6f5e5dbb75b19778cf2090d7b3ad3b89311278bffdca41c469b4120c9eR1-R206))
*  Include the necessary use statements, properties, setup method and test cases in the test class ([link](https://github.com/shopware/platform/pull/3065/files?diff=unified&w=0#diff-5db42b6f5e5dbb75b19778cf2090d7b3ad3b89311278bffdca41c469b4120c9eR1-R206))
