### PR TITLE
Update de-DE.json

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/snippet/de-DE.json
@@ -336,7 +336,7 @@
         "description": "Wenn Du die Erweiterung deinstallierst, kannst Du sie nicht mehr verwenden.",
         "alert": "Bist Du sicher, dass Du die Erweiterung deinstallieren möchtest?",
         "buttonLabel": "Deinstallieren",
-        "labelRemovePluginData": "Alle App-Daten entgültig entfernen",
+        "labelRemovePluginData": "Alle App-Daten endgültig entfernen",
         "helpTextRemovePluginData": "Warnung: Alle Daten der App werden dauerhaft entfernt. Dieser Vorgang ist nicht umkehrbar."
       },
       "sw-extension-listing-card": {


### PR DESCRIPTION
Line 339 "labelRemovePluginData" had a little spelling mistake with "entgültig" > "endgültig".

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
There's a spelling mistake

### 2. What does this change do, exactly?
Fix the spelling mistake

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26c6a2e</samp>

Fixed a spelling error in the German translation of the extension uninstallation dialog. Changed `entgültig` to `endgültig` in `src/Administration/Resources/app/administration/src/module/sw-extension/snippet/de-DE.json`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26c6a2e</samp>

* Fix spelling of "endgültig" in German translation of extension uninstallation dialog ([link](https://github.com/shopware/platform/pull/3066/files?diff=unified&w=0#diff-3afe02e9b67757e2173f0098e5d4cb8487b718f5a6446d2497f3efe3f82a8385L339-R339))
