### PR TITLE
Use referencefield for relation instead of hardcoded field

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/EntityTranslationDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityTranslationDefinition.php
@@ -62,7 +62,7 @@ abstract class EntityTranslationDefinition extends EntityDefinition
         $baseFields = [
             (new FkField($referenceField, $propertyBaseName, $translatedDefinition->getEntityName(), 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
             (new FkField('language_id', 'languageId', LanguageDefinition::ENTITY_NAME, 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
-            new ManyToOneAssociationField($propertyBaseName, $entityName . '_id', $translatedDefinition->getEntityName(), 'id', false),
+            new ManyToOneAssociationField($propertyBaseName, referenceField, $translatedDefinition->getEntityName(), 'id', false),
             new ManyToOneAssociationField('language', 'language_id', LanguageDefinition::ENTITY_NAME, 'id', false),
         ];
 

--- a/src/Core/Framework/DataAbstractionLayer/EntityTranslationDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityTranslationDefinition.php
@@ -53,14 +53,14 @@ abstract class EntityTranslationDefinition extends EntityDefinition
     protected function getBaseFields(): array
     {
         $translatedDefinition = $this->getParentDefinition();
-        $entityName = $translatedDefinition->getEntityName();
+        $referenceField = $translatedDefinition->getTranslationField()->getReferenceField();
 
-        $propertyBaseName = explode('_', $entityName);
+        $propertyBaseName = explode('_', $referenceField);
         $propertyBaseName = array_map('ucfirst', $propertyBaseName);
         $propertyBaseName = lcfirst(implode('', $propertyBaseName));
 
         $baseFields = [
-            (new FkField($entityName . '_id', $propertyBaseName . 'Id', $translatedDefinition->getEntityName(), 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
+            (new FkField($referenceField, $propertyBaseName, $translatedDefinition->getEntityName(), 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
             (new FkField('language_id', 'languageId', LanguageDefinition::ENTITY_NAME, 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
             new ManyToOneAssociationField($propertyBaseName, $entityName . '_id', $translatedDefinition->getEntityName(), 'id', false),
             new ManyToOneAssociationField('language', 'language_id', LanguageDefinition::ENTITY_NAME, 'id', false),

--- a/src/Core/Framework/DataAbstractionLayer/EntityTranslationDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityTranslationDefinition.php
@@ -62,7 +62,7 @@ abstract class EntityTranslationDefinition extends EntityDefinition
         $baseFields = [
             (new FkField($referenceField, $propertyBaseName, $translatedDefinition->getEntityName(), 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
             (new FkField('language_id', 'languageId', LanguageDefinition::ENTITY_NAME, 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
-            new ManyToOneAssociationField($propertyBaseName, referenceField, $translatedDefinition->getEntityName(), 'id', false),
+            new ManyToOneAssociationField($propertyBaseName, $referenceField, $translatedDefinition->getEntityName(), 'id', false),
             new ManyToOneAssociationField('language', 'language_id', LanguageDefinition::ENTITY_NAME, 'id', false),
         ];
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
One can define a field but the value isn't used.

### 2. What does this change do, exactly?
use the configured value

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58785b1</samp>

Refactored translation system to use reference fields instead of entity names for translation fields. Modified `EntityTranslationDefinition::getBaseFields` to support this change.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 58785b1</samp>

*  Refactor translation system to use reference fields instead of entity names ([link](https://github.com/shopware/platform/pull/3067/files?diff=unified&w=0#diff-1bb8a32b23fddce9fe829cb91c24825d4d72997b5d29b3e19131a904e9a8594cL56-R63))
