### PR TITLE
Update CleanupCartTaskHandler to use database index

### DIFF
--- a/adr/2023-05-09-optimise-cart-cleanup.md
+++ b/adr/2023-05-09-optimise-cart-cleanup.md
@@ -1,0 +1,37 @@
+---
+title: Optimize cart cleanup
+date: 2023-05-09
+area: core
+tags: [performance]
+---
+
+## Context
+
+The existing SQL snippet to delete the outdated cart entries doesn't use any database indix to narrow down entries that can be deleted. 
+On high traffic shops this leads to SQL query times larger than 30 seconds to find and remove these database entries.
+
+Running 
+```
+EXPLAIN DELETE FROM cart
+WHERE (updated_at IS NULL AND created_at <= '2023-02-01')
+   OR (updated_at IS NOT NULL AND updated_at <= '2023-02-01') LIMIT 1000;
+```
+shows that the original sql query doesn't use an index (`possible_keys` = `NULL`)
+
+## Decision
+
+Reorder the query parameters so that the relevant cart entries can be narrowed down by an indexed field.
+
+Testing the new SQL snippet by running 
+```
+EXPLAIN DELETE FROM cart
+        WHERE created_at <= '2023-02-01'
+          AND (updated_at IS NULL OR updated_at <= '2023-02-01') LIMIT 1000;
+```
+shows that the new query uses an index (`possible_keys` = `idx.cart.created_at`).
+
+
+## Consequences
+
+The logic stays the same but the amount of time needed to find the record drops 
+dramatically, so the change results in a better performance during cart cleanup.

--- a/changelog/_unreleased/2023-05-09-use-indices-for-cart-cleanup.md
+++ b/changelog/_unreleased/2023-05-09-use-indices-for-cart-cleanup.md
@@ -1,0 +1,8 @@
+---
+title: use-indices-for-cart-cleanup
+issue: NEXT-23615
+author: Robert Lang
+author_github: @RobertLang
+___
+# Core
+* Changed CleanupCartTaskHandler SQL to properly use `idx.cart.created_at` to select cart entries to be deleted.

--- a/src/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandler.php
+++ b/src/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandler.php
@@ -36,8 +36,8 @@ final class CleanupCartTaskHandler extends ScheduledTaskHandler
             $result = $this->connection->executeStatement(
                 <<<'SQL'
                 DELETE FROM cart
-                    WHERE (updated_at IS NULL AND created_at <= :timestamp)
-                        OR (updated_at IS NOT NULL AND updated_at <= :timestamp) LIMIT 1000;
+                    WHERE created_at <= :timestamp
+                        AND (updated_at IS NULL OR updated_at <= :timestamp) LIMIT 1000;
             SQL,
                 ['timestamp' => $time->format(Defaults::STORAGE_DATE_TIME_FORMAT)]
             );


### PR DESCRIPTION
Updated cart cleanup sql script to utilize database indices (created_at) during deletion. 

### 1. Why is this change necessary?

The existing SQL snippet to delete the outdated cart entries doesn't use any database indices to narrow down entries that can be deleted. On high traffic shops this leads to SQL query times larger than 30 seconds to find and remove these database entries.

### 2. What does this change do, exactly?

This change reorders the sql query arguments so that the index `idx.cart.created_at` can be used during data selection.

### 3. Describe each step to reproduce the issue or behaviour.

Try to run the cart cleanup command on a cart table with over 65k cart entries and check the query time. In our case the query took over 30 seconds to delete 1000 outdated cart entries. After the optimization the same delete routine completes in under a second.

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0d8e53</samp>

This pull request improves the performance of the cart cleanup SQL query by reordering the query parameters and documents the decision and consequences in a new ADR file. The affected files are `adr/2023-05-09-optimise-cart-cleanup.md` and `src/Core/Checkout/Cart/Cleanup/CleanupCartTaskHandler.php`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0d8e53</samp>

*  Add a new ADR document to explain the optimization decision for the cart cleanup query ([link](https://github.com/shopware/platform/pull/3069/files?diff=unified&w=0#diff-87fbdaa30c3299c3c5c7d7481306796935f23ebb08d1abf7d4473d92f8b9eca3R1-R37))
*  Reorder the query parameters in the `CleanupCartTaskHandler` class to use the indexed `created_at` field first and the `updated_at` field second ([link](https://github.com/shopware/platform/pull/3069/files?diff=unified&w=0#diff-716d2f2c063411fd8774c1acda668771892be05401e1b52cdc876c2a66497646L39-R40))
