### PR TITLE
fix html lang attribute

### DIFF
--- a/changelog/_unreleased/2023-05-10_fix-html-locale-attribute.md
+++ b/changelog/_unreleased/2023-05-10_fix-html-locale-attribute.md
@@ -1,0 +1,10 @@
+---
+title: Fix HTML locale attribute
+issue: -
+author: Silvio Kennecke
+author_email: development@silvio-kennecke.de
+author_github: @silviokennecke
+---
+# Storefront
+* Changed `HeaderPageletLoader::getLanguages` to load associated locale
+* Changed `base.html.twig` to use `activeLanguage.locale` instead of `activeLanguage.translationCode`

--- a/src/Storefront/Pagelet/Header/HeaderPageletLoader.php
+++ b/src/Storefront/Pagelet/Header/HeaderPageletLoader.php
@@ -109,6 +109,7 @@ class HeaderPageletLoader implements HeaderPageletLoaderInterface
 
         $criteria->addSorting(new FieldSorting('name', FieldSorting::ASCENDING));
         $criteria->addAssociation('productSearchConfig');
+        $criteria->addAssociation('locale');
         $apiRequest = new Request();
 
         $event = new LanguageRouteRequestEvent($request, $apiRequest, $context, $criteria);

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block base_html %}
-<html lang="{{ page.header.activeLanguage.translationCode.code }}"
+<html lang="{{ page.header.activeLanguage.locale.code }}"
       itemscope="itemscope"
       itemtype="https://schema.org/WebPage">
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
In case, you use inherited language, the html lang attribute is empty.

### 2. What does this change do, exactly?
* Changed `HeaderPageletLoader::getLanguages` to load associated locale
* Changed `base.html.twig` to use `activeLanguage.locale` instead of `activeLanguage.translationCode`. In case of inherited languages, the `translationCode` is null, whereas `locale` stores the inherited locale.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a language, that inherits another language.
2. Assign the language to your storefront.
3. Open the storefront in that language.
4. Check the `lang` attribute in the `html` tag.

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change <- I couldn't think of a useful test for this
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have read the contribution requirements and fulfil them.

copilot:summary

copilot:walkthrough
