### PR TITLE
Disable the Opcode cache in the web installer

### DIFF
--- a/src/WebInstaller/stub.php
+++ b/src/WebInstaller/stub.php
@@ -7,6 +7,7 @@ ignore_user_abort(true);
 if (function_exists('ini_set')) {
     @ini_set('display_errors', '1');
     @ini_set('display_startup_errors', '1');
+    @ini_set('opcache.enable', '0');
     @ini_set('opcache.enable_cli', '0');
     @ini_set('max_execution_time', '300');
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Installing on a shared hosting with enabled opcache results in an error 
`Fatal error: Uncaught Error: Failed opening required 'phar:///var/www/customer/htdocs/public/sw.php/index.php' (include_path='.:/opt/php-8.2/lib/php') in /var/www/customer/htdocs/public/sw.php:61 Stack trace: #0 /var/www/customer/htdocs/public/sw.php(61): Phar::webPhar(NULL, 'index.php', NULL, Array, 'rewrites') #1 {main} thrown in /var/www/customer/htdocs/public/sw.php on line 61`


### 2. What does this change do, exactly?
It disables the opcache during the webinstall

### 3. Describe each step to reproduce the issue or behaviour.
This behaviour occurs on some shared hosting setups with enabled opcache. See See: https://github.com/contao/contao-manager/issues/347#issuecomment-434752134

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 69b7bad</samp>

Disable opcache for `stub.php` file to fix extraction bug. This file is a self-extracting archive that contains the Shopware installer and needs to modify itself.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 69b7bad</samp>

* Disable opcache extension for stub.php file to prevent extraction issues ([link](https://github.com/shopware/platform/pull/3071/files?diff=unified&w=0#diff-49d37f0f6ae926ee09587f63ab5aca9a03a4fc8bf7fc2894a845139ba0371dcfR10))
