### PR TITLE
NEXT-26212 Fixed creating multiple empty Elasticsearch indices

### DIFF
--- a/changelog/_unreleased/2023-05-12-prevent-elasticsearch-indexer-from-creating-multiple-empty-indices.md
+++ b/changelog/_unreleased/2023-05-12-prevent-elasticsearch-indexer-from-creating-multiple-empty-indices.md
@@ -1,0 +1,9 @@
+---
+title: Prevent Elasticsearch indexer from creating multiple empty indices
+issue: NEXT-26212
+author: Tomasz Nowicki
+author_email: nowik18@gmail.com
+author_github: Tomasz18
+---
+# Core
+* Changed the `Shopware\Elasticsearch\Framework\Indexing\ElasticsearchIndexer::updateIds` function to fix indices creation for each function call when there are only sales channels without the default language

--- a/src/Core/Framework/Test/TestCaseBase/BasicTestDataBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/BasicTestDataBehaviour.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Language\LanguageEntity;
@@ -288,5 +289,18 @@ trait BasicTestDataBehaviour
         $connection = $this->getContainer()->get(Connection::class);
 
         return Uuid::fromBytesToHex($connection->fetchOne('SELECT id FROM currency WHERE iso_code = :iso', ['iso' => $iso]));
+    }
+
+    protected function getNonDefaultLanguageId(): ?string
+    {
+        /** @var EntityRepository $repository */
+        $repository = $this->getContainer()->get('language.repository');
+
+        $criteria = new Criteria();
+        $criteria->addFilter(
+            new NotFilter(NotFilter::CONNECTION_AND, [new EqualsFilter('id', Defaults::LANGUAGE_SYSTEM)])
+        );
+
+        return $repository->searchIds($criteria, Context::createDefaultContext())->firstId();
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
This change is necessary to avoid creating multiple empty, not used and not necessary Elasticsearch indices. There is check only for the default language before index is created and there may be a configuration where there is no sales channel with the default language.

### 2. What does this change do, exactly?
This change prevents creating empty indices by checking if index for each language already exists instead of checking only the default language.

### 3. Describe each step to reproduce the issue or behaviour.
1. Setup Shopware with only one sales channel and only one language different than default (English)
    - Languages: Deutsch
    - Default language: Deutsch
    - One domain:
        - Language: Deutsch
        - Snippet set: BASE de-DE
2. Add a product and assign it to a category
3. Configure Elasticsearch and ensure there are no indices created
4. Run command bin/console dal:refresh:index multiple times

### 4. Please link to the relevant issues (if any).
[NEXT-26212](https://issues.shopware.com/issues/NEXT-26212)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3083fab</samp>

This pull request improves the elasticsearch indexing process by allowing optional parameters for definitions and languages, and preventing the creation of multiple empty indices for non-default languages. It also adds new test cases and a changelog entry for this change.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3083fab</samp>

*  Add a changelog file for the pull request ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-3168410048fedd18a859c67c9009f07cb4259ee2903b1b45d46f993dae5a6043R1-R9))
*  Add a new optional parameter `$definitions` to the `init` function of the `ElasticsearchIndexer` class to limit the scope of the index creation and update ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-b3a1309b729eff5a91a31b2e8d7ba0c574a1c72930eb7db37ca6dfc621ea2284L206-R236), [link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-b3a1309b729eff5a91a31b2e8d7ba0c574a1c72930eb7db37ca6dfc621ea2284L212-R243), [link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-b3a1309b729eff5a91a31b2e8d7ba0c574a1c72930eb7db37ca6dfc621ea2284L222-R253))
*  Modify the `updateIds` function of the `ElasticsearchIndexer` class to filter the languages that do not have an index alias and call the `init` function with the definitions and languages parameters ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-b3a1309b729eff5a91a31b2e8d7ba0c574a1c72930eb7db37ca6dfc621ea2284L127-R136))
*  Add two new helper functions `indexExists` and `getElasticSearchDefinition` to the `ElasticsearchIndexer` class to check the index alias existence and get the Elasticsearch definition for a given entity definition ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-b3a1309b729eff5a91a31b2e8d7ba0c574a1c72930eb7db37ca6dfc621ea2284R147-R166))
*  Add a use statement for the `AbstractElasticsearchDefinition` class to the `ElasticsearchIndexer` file ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-b3a1309b729eff5a91a31b2e8d7ba0c574a1c72930eb7db37ca6dfc621ea2284R24))
*  Add a new test case `testUpdateSkipsGeneratingIndexIfExists` to the `ElasticsearchIndexerTest` class in the integration test directory to check that the Elasticsearch indexer does not create multiple empty indices for each updateIds call when there are only sales channels without the default language ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-5c21a20b163cdb17ee41fde8d4478081807ede67ce139b9847c3b0908f28cb38R130-R222))
*  Add several use statements to the `ElasticsearchIndexerTest` file in the integration test directory for the classes used in the new test case ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-5c21a20b163cdb17ee41fde8d4478081807ede67ce139b9847c3b0908f28cb38L6-R17), [link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-5c21a20b163cdb17ee41fde8d4478081807ede67ce139b9847c3b0908f28cb38R27))
*  Add a new test case `testUpdateDoesNotCreateIndexIfExists` to the `ElasticsearchIndexerTest` class in the unit test directory to check that the Elasticsearch indexer does not create an index if it already exists for a given definition and language ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-accb761039463230a5ade84214c9a71e7c699c4a2a312d7f87d48b0071ecc9b1R243-R285))
*  Add a use statement for the `LanguageDefinition` class to the `ElasticsearchIndexerTest` file in the unit test directory ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-accb761039463230a5ade84214c9a71e7c699c4a2a312d7f87d48b0071ecc9b1R22))
*  Add a new protected function `getNonDefaultLanguageId` to the `BasicTestDataBehaviour` class to return the first language id that is not the default language id ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-f5b38620c3b82a7750265ed4f7e7772540c8be0054cef9659d8b4087a5a9cb9aR293-R305))
*  Add a use statement for the `NotFilter` class to the `BasicTestDataBehaviour` file ([link](https://github.com/shopware/platform/pull/3072/files?diff=unified&w=0#diff-f5b38620c3b82a7750265ed4f7e7772540c8be0054cef9659d8b4087a5a9cb9aR14))
