### PR TITLE
Allow TemplateFinderInterface in ExtendsTokenParser::__construct

### DIFF
--- a/src/Core/Framework/Adapter/Twig/TokenParser/ExtendsTokenParser.php
+++ b/src/Core/Framework/Adapter/Twig/TokenParser/ExtendsTokenParser.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Framework\Adapter\Twig\TokenParser;
 
-use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
+use Shopware\Core\Framework\Adapter\Twig\TemplateFinderInterface;
 use Shopware\Core\Framework\Log\Package;
 use Twig\Node\Node;
 use Twig\Parser;
@@ -17,7 +17,7 @@ final class ExtendsTokenParser extends AbstractTokenParser
      */
     protected $parser;
 
-    public function __construct(private readonly TemplateFinder $finder)
+    public function __construct(private readonly TemplateFinderInterface $finder)
     {
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
To be able to easily replace the implementation of the template finder.

### 2. What does this change do, exactly?
Change variable type from implementation class to its interface.

### 3. Describe each step to reproduce the issue or behaviour.
None

### 4. Please link to the relevant issues (if any).
None

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72cbeb2</samp>

Refactored `ExtendsTokenParser` to use an interface for finding templates. This makes the class more flexible and easier to test.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 72cbeb2</samp>

*  Replace `TemplateFinder` class with `TemplateFinderInterface` interface in `ExtendsTokenParser` class to follow dependency inversion principle and improve flexibility and testability ([link](https://github.com/shopware/platform/pull/3074/files?diff=unified&w=0#diff-2bff30f3504afcc30cc2cc369e3cc1dcf12d58cb7ff1bd03a5dd910f32869d3dL5-R5), [link](https://github.com/shopware/platform/pull/3074/files?diff=unified&w=0#diff-2bff30f3504afcc30cc2cc369e3cc1dcf12d58cb7ff1bd03a5dd910f32869d3dL20-R20),  )
