### PR TITLE
Fix bulk edit: when empty custom fields is passed, it wipes out ALL custom fields

### DIFF
--- a/changelog/_unreleased/2023-05-12-fix-bulk-edit-when-empty-custom-fields-is-passed-it-wipes-out-all-custom-fields.md
+++ b/changelog/_unreleased/2023-05-12-fix-bulk-edit-when-empty-custom-fields-is-passed-it-wipes-out-all-custom-fields.md
@@ -1,0 +1,9 @@
+---
+title: Fix bulk edit - when empty custom fields is passed, it wipes out ALL custom fields
+issue: NEXT-27562
+author: Matheus Gontijo
+author_email: matheus@matheusgontijo.com
+author_github: Matheus Gontijo
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.js` - Transform "undefined" values to "null", as "undefined" is not a valid JSON value.

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/service/handler/bulk-edit-product.handler.js
@@ -64,7 +64,9 @@ class BulkEditProductHandler extends BulkEditBaseHandler {
             return Promise.resolve({ data: [] });
         }
 
-        return this.syncService.sync(syncPayload, {}, {
+        const syncPayloadStringified = JSON.stringify(syncPayload, (k, v) => v === undefined ? null : v);
+
+        return this.syncService.sync(syncPayloadStringified, {}, {
             'single-operation': 1,
             'sw-language-id': Shopware.Context.api.languageId,
         });


### PR DESCRIPTION
Fix bulk edit: when empty custom fields is passed, it wipes out ALL custom fields

### 1. Why is this change necessary?
It fixes a bug found on product bulk edit.


### 2. What does this change do, exactly?
Transform "undefined" values to "null", as "undefined" is not a valid JSON value.


### 3. Describe each step to reproduce the issue or behaviour.

Let's say that we have 99 custom fields with the following values.

```
my_custom_field_01: "AAAA"
my_custom_field_02: "BBBB"
my_custom_field_03: "CCCC"

[...]

my_custom_field_98: "QAPOAPSFQWE"
my_custom_field_99: "WEROPUIEWPO"
```

Then admin user decides to bulk edit just a SINGLE custom field. Let's pick up the "my_custom_field_66".

- Admin user goes to admin
- Select few given products
- Go the the bulk edit section
- JUST SELECT ONE custom field to be edit, in our case "my_custom_field_66"
- Change "my_custom_field_66" to "Foo Bar"
- Save
- Cool. All the given products have "my_custom_field_66" as "Foo Bar", as expected

However, here comes the bug:

- Admin user goes to admin
- Select few given products
- Go the the bulk edit section
- JUST SELECT ONE custom field to be edit, in our case "my_custom_field_66"
- 👉👉 Very important, here goes the issue: change "my_custom_field_66" to empty value ""
- Save
- 🚨🚨 All products have the 99 custom fields wiped out! Incredible! All content for all 99 custom fields are gone. It's not just intefering on "my_custom_field_66", but wiping out all custom fields.

Reason: "undefined" is being passed on the request, however, JSON don't have "undefined", only "null". If we transform "undefined"'s into "null"'s the request is being processed normally.



### 4. Please link to the relevant issues (if any).
None.

### 5. Checklist

- [ X ] I have rebased my changes to remove merge conflicts
- [   ] I have written tests and verified that they fail without my change
- [  ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [  ] I have written or adjusted the documentation according to my changes
- [ X ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ X ] I have read the contribution requirements and fulfil them.
