### PR TITLE
fix: ElasticSearch visibilities mapping definition

### DIFF
--- a/changelog/_unreleased/2023-05-17-fix-elasticsearch-visibility-mapping-definition.md
+++ b/changelog/_unreleased/2023-05-17-fix-elasticsearch-visibility-mapping-definition.md
@@ -1,0 +1,9 @@
+---
+title: Fix ElasticSearch visibility mapping definition
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Elasticsearch
+* Changed ElasticSearch mapping `visibilities.id` to `visibilities.salesChannelId` to match the indexed documents

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -157,7 +157,7 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 'visibilities' => [
                     'type' => 'nested',
                     'properties' => [
-                        'id' => self::KEYWORD_FIELD,
+                        'salesChannelId' => self::KEYWORD_FIELD,
                         'visibility' => self::INT_FIELD,
                         '_count' => self::INT_FIELD,
                     ],

--- a/tests/unit/php/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
+++ b/tests/unit/php/Elasticsearch/Product/ElasticsearchProductDefinitionTest.php
@@ -213,7 +213,7 @@ class ElasticsearchProductDefinitionTest extends TestCase
                 'visibilities' => [
                     'type' => 'nested',
                     'properties' => [
-                        'id' => [
+                        'salesChannelId' => [
                             'type' => 'keyword',
                             'normalizer' => 'sw_lowercase_normalizer',
                         ],


### PR DESCRIPTION
### 1. Why is this change necessary?
There currently is no error, but there is a mismatch between the indexed document and the mapping definition. It should have no effect, as the `salesChannelId` should be automatically a keyword field, when omitted in the mapping definition.

### 2. What does this change do, exactly?
Fix the mismatch.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2507023</samp>

This pull request fixes a bug in the ElasticSearch mapping definition for product visibilities, by renaming a field to match the indexed documents. This change affects the file `src/Elasticsearch/Product/ElasticsearchProductDefinition.php` and adds a changelog entry in `changelog/_unreleased/2023-05-17-fix-elasticsearch-visibility-mapping-definition.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2507023</samp>

* Fix ElasticSearch visibility mapping definition for product entity ([link](https://github.com/shopware/platform/pull/3079/files?diff=unified&w=0#diff-f6f34de531f2162f715742f8936dce9c7f524232455d9b352f1cf3e284a76d0eL160-R160), [link](https://github.com/shopware/platform/pull/3079/files?diff=unified&w=0#diff-6dc503c847babe0e1606e34c4ec6f42caf336b46c0b5271e1579d3d79ef4d29cR1-R9))
