### PR TITLE
Use the new v7 uuid format when creating uuids

### DIFF
--- a/changelog/_unreleased/2023-05-23-use-uuidv7-when-creating-new-uuids.md
+++ b/changelog/_unreleased/2023-05-23-use-uuidv7-when-creating-new-uuids.md
@@ -1,0 +1,10 @@
+---
+title: use uuidv7 when creating new uuids
+issue: NONE
+author: Jochen Manz
+author_email: j.manz@kellerkinder.de
+author_github: jochenmanz
+---
+# Core
+* Replaces the uuid v4 generation with Ramsey/Uuid v7 implementation to use the v6 time-based UUID bit layout
+```

--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,7 @@
         "psr/http-factory": "~1.0.1",
         "psr/http-message": "^1.1 || ^2.0",
         "psr/log": "~3.0.0",
+        "ramsey/uuid": "^4.7",
         "scssphp/scssphp": "v1.11.0",
         "setasign/fpdi": "~2.3.7",
         "shopware/conflicts": "*",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Using the v7 uuid format gives a small performance improvement for every insert into the database.

Generating 10000 products via: APP_ENV=prod bin/console framework:demodata --products=1000 

original code:
87.402081012726 
138.91876411438 

vs:

new v7 code:
78.274962186813
121.2949090004

### 2. What does this change do, exactly?
Uses Ramsey/Uuid to generate a time-based uuid

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f52c59d</samp>

This pull request replaces the core Uuid class with a new library that generates uuid v7 values. This affects the `src/Core/Framework/Uuid/Uuid.php` file, the `composer.json` file and the changelog file `changelog/_unreleased/2023-05-23-use-uuidv7-when-creating-new-uuids.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f52c59d</samp>

* Replace core functionality of generating uuids with ramsey/uuid library that uses uuid v7 format ([link](https://github.com/shopware/platform/pull/3086/files?diff=unified&w=0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R92), [link](https://github.com/shopware/platform/pull/3086/files?diff=unified&w=0#diff-7321a101e8662b754f92c7d6eca9d09ba57a867d2b8440af19caf7ba215203f5R5-R7), [link](https://github.com/shopware/platform/pull/3086/files?diff=unified&w=0#diff-7321a101e8662b754f92c7d6eca9d09ba57a867d2b8440af19caf7ba215203f5L19-R42))
  * Add dependency of ramsey/uuid to `composer.json` ([link](https://github.com/shopware/platform/pull/3086/files?diff=unified&w=0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R92))
  * Import classes from ramsey/uuid in `Uuid.php` ([link](https://github.com/shopware/platform/pull/3086/files?diff=unified&w=0#diff-7321a101e8662b754f92c7d6eca9d09ba57a867d2b8440af19caf7ba215203f5R5-R7))
  * Use UnixTimeGenerator and BinaryUtils to create and modify 16-byte strings in randomHex and randomBytes methods of `Uuid.php` ([link](https://github.com/shopware/platform/pull/3086/files?diff=unified&w=0#diff-7321a101e8662b754f92c7d6eca9d09ba57a867d2b8440af19caf7ba215203f5L19-R42))
* Add changelog entry for the pull request in `_unreleased` directory ([link](https://github.com/shopware/platform/pull/3086/files?diff=unified&w=0#diff-b8f7b2bed5e153cafcc1f23eb5cf8d330423e31e89ddc054e2eda578a443e407R1-R10))
