### PR TITLE
Track affiliate and campaign codes when only one is set during registration

### DIFF
--- a/changelog/_unreleased/2023-05-26-registration-affiliate-code-tracking.md
+++ b/changelog/_unreleased/2023-05-26-registration-affiliate-code-tracking.md
@@ -1,0 +1,9 @@
+---
+title: Registration affiliate code tracking
+issue: -
+author: Sander Meij
+author_email: sander@millerdigital.nl
+author_github: SanderMD
+---
+# Storefront
+* Changed `prepareAffiliateTracking` in `src/Storefront/Controller/RegisterController` to add the affiliate code or campaign code when only one of them is set

--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -276,10 +276,15 @@ class RegisterController extends StorefrontController
     private function prepareAffiliateTracking(RequestDataBag $data, SessionInterface $session): DataBag
     {
         $affiliateCode = $session->get(AffiliateTrackingListener::AFFILIATE_CODE_KEY);
-        $campaignCode = $session->get(AffiliateTrackingListener::CAMPAIGN_CODE_KEY);
-        if ($affiliateCode !== null && $campaignCode !== null) {
+        if ($affiliateCode !== null) {
             $data->add([
                 AffiliateTrackingListener::AFFILIATE_CODE_KEY => $affiliateCode,
+            ]);
+        }
+
+        $campaignCode = $session->get(AffiliateTrackingListener::CAMPAIGN_CODE_KEY);
+        if ($campaignCode !== null) {
+            $data->add([
                 AffiliateTrackingListener::CAMPAIGN_CODE_KEY => $campaignCode,
             ]);
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently you need to add both an affiliate code and a campaign code to the url for the tracking to work, instead of just one of them

### 2. What does this change do, exactly?
It checks if the affiliate code and campaign code are set in the session separately and adds them separately.

### 3. Describe each step to reproduce the issue or behaviour.

1. Open your shop with ?affiliateCode=test added to the url
2. Register with account
3.  The affiliate code isn't added to the account

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6e9c47b</samp>

Refactored `prepareAffiliateTracking` function in `RegisterController.php` to simplify the data object creation and avoid unnecessary array elements. This improves the affiliate tracking feature in the Shopware platform.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6e9c47b</samp>

* Refactor `prepareAffiliateTracking` function to separate affiliate code and campaign code logic ([link](https://github.com/shopware/platform/pull/3088/files?diff=unified&w=0#diff-c896227b68bf76ed398b89b38a6f82916183a7f595ebe2e6438fdf6eaa716d76L279-R287))
* Update the unit test for `prepareAffiliateTracking` in `src/Storefront/Test/Controller/RegisterControllerTest.php` ([link](https://github.com/shopware/platform/pull/3088/files?diff=unified&w=0#diff-c896227b68bf76ed398b89b38a6f82916183a7f595ebe2e6438fdf6eaa716d76L279-R287))
