### PR TITLE
fix: avoid removing plugin assets on admin build

### DIFF
--- a/src/Administration/Resources/app/administration/webpack.config.js
+++ b/src/Administration/Resources/app/administration/webpack.config.js
@@ -493,7 +493,12 @@ const baseConfig = ({ pluginPath, pluginFilepath }) => ({
          *
          * See `Options and Defaults` for information
          */
-        new CleanWebpackPlugin(),
+        new CleanWebpackPlugin({
+            cleanOnceBeforeBuildPatterns: [
+                '!**/*',
+                'administration',
+            ]
+        }),
     ],
 });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, the CleanWebpackPlugin removes all files within all plugin public folders during the administration build if the plugin has an administration entry point script. Even plugins in the vendor folder.

Thanks to @dneustadt who pointed out the correct code changes.

### 2. What does this change do, exactly?
Ensure that only the administration folder within the public directory is removed.

### 3. Describe each step to reproduce the issue or behaviour.
Place some files in the MyPlugin/src/Resource/public directory.
Then run bin/build-administration.sh

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af348ca</samp>

Fixed a bug that prevented the administration app from loading by adjusting the `CleanWebpackPlugin` plugin. The plugin now only cleans the `administration` folder instead of the entire output directory.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af348ca</samp>

*  Configure `CleanWebpackPlugin` to only clean `administration` folder ([link](https://github.com/shopware/platform/pull/3089/files?diff=unified&w=0#diff-495341c5724904c9afc2b8d581fab247a0eece8db8bbc18659bc2a49f9ef196cL496-R501))
