### PR TITLE
Change snippet from billing to shipping address

### DIFF
--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -365,7 +365,7 @@
     "summaryNetPrice": "Gesamtnettosumme",
     "summaryTax": "zzgl. %rate% % MwSt.",
     "proceedLink": "Zur Kasse",
-    "addressEqualText": "Entspricht der Rechnungsadresse",
+    "addressEqualText": "Entspricht der Lieferadresse",
     "billingAddressHeader": "Rechnungsadresse",
     "shippingAddressHeader": "Lieferadresse",
     "confirmHeader": "Bestellung abschließen",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -365,7 +365,7 @@
     "summaryNetPrice": "Net total",
     "summaryTax": "plus %rate%% VAT",
     "proceedLink": "Go to checkout",
-    "addressEqualText": "Same as billing address",
+    "addressEqualText": "Same as shipping address",
     "billingAddressHeader": "Billing address",
     "shippingAddressHeader": "Shipping address",
     "confirmHeader": "Complete order",


### PR DESCRIPTION
### 1. Why is this change necessary?

![MicrosoftTeams-image (9)](https://github.com/shopware/platform/assets/11394739/87153218-dd40-4075-a8dc-c36b8a5caf78)

### 2. What does this change do, exactly?

Change snippet from billing to shipping address.

### 3. Describe each step to reproduce the issue or behaviour.

1. Go to checkout.
2. Read.
3. Think.
4. Be confused.

### 4. Please link to the relevant issues (if any).

None (surprisingly)

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0155594</samp>

Fixed a label in the storefront snippets that was misleading about the address copying logic. Changed the `addressEqualText` value in `storefront.en-GB.json` to reflect that the billing address is copied from the shipping address.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0155594</samp>

*  Update the label for using the same address for billing and shipping to reflect the actual logic ([link](https://github.com/shopware/platform/pull/3093/files?diff=unified&w=0#diff-bc5ded833e624c41436413308429bfd584e4881cc2953d22bfff91d1ca65230dL368-R368))
*  Change the `addressEqualText` value in `storefront.en-GB.json` from "Use shipping address for billing" to "Use this address for billing as well" ([link](https://github.com/shopware/platform/pull/3093/files?diff=unified&w=0#diff-bc5ded833e624c41436413308429bfd584e4881cc2953d22bfff91d1ca65230dL368-R368))
