### PR TITLE
fix: Elasticsearch DateTime criteria parser

### DIFF
--- a/changelog/_unreleased/2023-06-03-fix-elasticsearch-datetime-criteria-parser.md
+++ b/changelog/_unreleased/2023-06-03-fix-elasticsearch-datetime-criteria-parser.md
@@ -1,0 +1,9 @@
+---
+title: Fix Elasticsearch DateTime criteria parser
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed DateTime format of the Elasticsearch query in the `Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser` to ignore milliseconds and fix them to `000`

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -813,8 +813,8 @@ class CriteriaParser
         if ($field instanceof DateTimeField) {
             return match (true) {
                 $value === null => null,
-                \is_array($value) => \array_map(fn ($value) => (new \DateTime($value))->format(Defaults::STORAGE_DATE_TIME_FORMAT), $value),
-                default => (new \DateTime($value))->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+                \is_array($value) => \array_map(fn ($value) => (new \DateTime($value))->format('Y-m-d H:i:s.000'), $value),
+                default => (new \DateTime($value))->format('Y-m-d H:i:s.000'),
             };
         }
 

--- a/tests/integration/php/Elasticsearch/Product/ElasticsearchProductTest.php
+++ b/tests/integration/php/Elasticsearch/Product/ElasticsearchProductTest.php
@@ -3241,6 +3241,13 @@ class ElasticsearchProductTest extends TestCase
 
         static::assertCount(1, $result->getIds());
 
+        // Test with non-zero ms
+        $criteria = new EsAwareCriteria();
+        $criteria->addFilter(new EqualsFilter('createdAt', '2019-01-01 10:11:00.123'));
+        $result = $this->createEntitySearcher()->search($this->productDefinition, $criteria, $this->context);
+
+        static::assertCount(1, $result->getIds());
+
         $criteria = new EsAwareCriteria();
         $criteria->addFilter(new EqualsFilter('releaseDate', '2019/01/01 10:11:00'));
         $result = $this->createEntitySearcher()->search($this->productDefinition, $criteria, $this->context);

--- a/tests/unit/php/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
+++ b/tests/unit/php/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
@@ -436,6 +436,18 @@ class CriteriaParserTest extends TestCase
                 ],
             ],
         ];
+
+        yield 'range filter: datetime' => [
+            new RangeFilter('createdAt', [RangeFilter::GTE => '2023-06-01', RangeFilter::LT => '2023-06-03 13:47:42.759']),
+            [
+                'range' => [
+                    'createdAt' => [
+                        'gte' => '2023-06-01 00:00:00.000',
+                        'lt' => '2023-06-03 13:47:42.000',
+                    ],
+                ],
+            ],
+        ];
     }
 
     public function getDefinition(): EntityDefinition


### PR DESCRIPTION
### 1. Why is this change necessary?
Without this change a category with an assigned product stream which for example has such a condition:
![image](https://github.com/shopware/platform/assets/6317761/f942ddc4-9ffd-456e-9276-62ba3d8400cb)
results in an error:
```
{"error":{"root_cause":[{"type":"parse_exception","reason":"failed to parse date field [2023-06-03 13:47:42.759] with format [yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis]: [failed to parse date field [2023-06-03 13:47:42.759] with format [yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis]]"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"sw_product_xxxx_xxx","node":"xxxx","reason":{"type":"parse_exception","reason":"failed to parse date field [2023-06-03 13:47:42.759] with format [yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis]: [failed to parse date field [2023-06-03 13:47:42.759] with format [yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis]]","caused_by":{"type":"illegal_argument_exception","reason":"failed to parse date field [2023-06-03 13:47:42.759] with format [yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis]","caused_by":{"type":"date_time_parse_exception","reason":"Failed to parse with all enclosed parsers"}}}}]},"status":400}
```
since the milliseconds are explicitly set for the `lt` range.

### 2. What does this change do, exactly?
Set the milliseconds to `000` such that it matches the format.

### 3. Describe each step to reproduce the issue or behaviour.
See above.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 75f9915</samp>

Fixed a bug in the Elasticsearch criteria parser that caused incorrect results when filtering or sorting by DateTime fields. Added a changelog entry for the fix in `changelog/_unreleased/2023-06-03-fix-elasticsearch-datetime-criteria-parser.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 75f9915</samp>

*  Fix Elasticsearch DateTime criteria parser to match MySQL format ([link](https://github.com/shopware/platform/pull/3095/files?diff=unified&w=0#diff-e7dbe359981348a46b3fe8895ad8db9355de28d5f2ace601e0f381ecf5f163dfL816-R817), [link](https://github.com/shopware/platform/pull/3095/files?diff=unified&w=0#diff-ef9bb8b5c26eedae3ba96d7e11e9142361c19cf728c2e20a6710f944ec0d0a28R1-R9))
