### PR TITLE
[NEXT-28233] Fix cascade deletion on custom primary key association

### DIFF
--- a/changelog/_unreleased/2023-06-07-fix-cascade-deletion-of-single-custom-primary-key-association.md
+++ b/changelog/_unreleased/2023-06-07-fix-cascade-deletion-of-single-custom-primary-key-association.md
@@ -1,0 +1,9 @@
+---
+title: Fix cascade deletion of single custom primary key Association
+issue: NEXT-28233
+author: Dominik Wißler
+author_email: wissla1993@aol.com
+author_github: Dominik Wißler
+---
+# Core
+* Changed method `fetchAssociation()` in `\Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityForeignKeyResolver` to skip flattening of single primary key arrays, if their `storageName` is not `'id'`.

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityForeignKeyResolver.php
@@ -241,12 +241,14 @@ class EntityForeignKeyResolver
             return [];
         }
 
-        // create flat list for single primary key entities
+        // create flat list for single primary key entities, if it is 'id'
         if ($primaryKeys->count() === 1) {
             /** @var Field $pk */
             $pk = $primaryKeys->first();
             $property = $pk->getPropertyName();
-            $affected = array_column($affected, $property);
+            if ($property === 'id') {
+                $affected = array_column($affected, $property);
+            }
         }
 
         // prevent circular reference for many to many


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The deletion of an Entity fails, if there is an Association that has only one Field with the PrimaryKey Flag and a `storageName` that is not '`id'`.

### 2. What does this change do, exactly?
It skips the flattening of single primary key arrays, if their `storageName` is not `'id'`. It ensures, that this `storageName` is an existing key in later array iteration.

### 3. Describe each step to reproduce the issue or behavior.
See [NEXT-28233](https://issues.shopware.com/issues/NEXT-28233).

### 4. Please link to the relevant issues (if any).
* [NEXT-28233](https://issues.shopware.com/issues/NEXT-28233)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 24feb98</samp>

Fix a bug in entity foreign key resolver when the primary key field is not `id`. Add a condition to `EntityForeignKeyResolver.php` to handle different types or formats of primary key and foreign key fields.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 24feb98</samp>

* Fix a bug where the entity foreign key resolver would create an empty list of affected entities if the primary key field is not 'id' and has a different type or format than the foreign key field ([link](https://github.com/shopware/platform/pull/3098/files?diff=unified&w=0#diff-d8cec99d252c25d8e2122aeb578ba052e8d9755969629e5ede0116c76f2a0d4eL244-R251))
