### PR TITLE
feat: Change operator for shopware update to accept current version check in method `updateApiCheck` of UpdateController

### DIFF
--- a/changelog/_unreleased/2023-06-10-correct-version-compare-for-shopware.md
+++ b/changelog/_unreleased/2023-06-10-correct-version-compare-for-shopware.md
@@ -1,0 +1,13 @@
+---
+title: Correct version compare for shopware
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Change operator for shopware update to accept current version check in method `updateApiCheck` of UpdateController
+
+

--- a/src/Core/Framework/Update/Api/UpdateController.php
+++ b/src/Core/Framework/Update/Api/UpdateController.php
@@ -58,7 +58,7 @@ class UpdateController extends AbstractController
 
         $updates = $this->apiClient->checkForUpdates();
 
-        if (version_compare($this->shopwareVersion, $updates->version, '>')) {
+        if (version_compare($this->shopwareVersion, $updates->version, '>=')) {
             return new JsonResponse();
         }
 

--- a/tests/unit/php/Core/Framework/Update/Api/UpdateControllerTest.php
+++ b/tests/unit/php/Core/Framework/Update/Api/UpdateControllerTest.php
@@ -31,15 +31,20 @@ class UpdateControllerTest extends TestCase
 {
     public function testCheckForUpdatesNoUpdate(): void
     {
+        $apiClient = $this->createMock(ApiClient::class);
+        $apiClient
+            ->method('checkForUpdates')
+            ->willReturn(new Version(['version' => '6.5.1.0', 'date' => '2020-01-01']));
+
         $updateController = new UpdateController(
-            $this->createMock(ApiClient::class),
+            $apiClient,
             $this->createMock(WriteableCheck::class),
             $this->createMock(LicenseCheck::class),
             $this->createMock(ExtensionCompatibility::class),
             $this->createMock(EventDispatcherInterface::class),
             $this->createMock(SystemConfigService::class),
             $this->createMock(AbstractExtensionLifecycle::class),
-            '6.1.0'
+            '6.5.1.0'
         );
 
         $response = $updateController->updateApiCheck();
@@ -74,6 +79,33 @@ class UpdateControllerTest extends TestCase
 
         static::assertJson((string) $content);
         static::assertSame('{"extensions":[],"title":"","body":"","date":"2020-01-01T00:00:00.000+00:00","version":"6.5.0.0","fixedVulnerabilities":[]}', $content);
+    }
+
+    public function testCheckForUpdatesNoUpdateWithDisabledUpdateCheckByEnv(): void
+    {
+        $apiClient = $this->createMock(ApiClient::class);
+        $apiClient
+            ->method('checkForUpdates')
+            ->willReturn(new Version(['version' => '6.5.0.0', 'date' => '2020-01-01']));
+
+        $updateController = new UpdateController(
+            $apiClient,
+            $this->createMock(WriteableCheck::class),
+            $this->createMock(LicenseCheck::class),
+            $this->createMock(ExtensionCompatibility::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(SystemConfigService::class),
+            $this->createMock(AbstractExtensionLifecycle::class),
+            '6.1.0.0',
+            true
+        );
+
+        $response = $updateController->updateApiCheck();
+
+        $content = $response->getContent();
+
+        static::assertJson((string) $content);
+        static::assertSame('{}', $content);
     }
 
     public function testCheckForRequirements(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
The current operator expects the installed version always to be never than the latest released shopware: 6.5.1.1 cannot be higher than 6.5.1.1, therefore the message for available version is always printed.

![image](https://github.com/shopware/platform/assets/135993/0343cda7-b3c0-457e-8226-b08228e38314)


### 2. What does this change do, exactly?
Correct the operator to allow the current installed version.

### 3. Describe each step to reproduce the issue or behaviour.
Activate auto_update in config
Install current shopware and login into admin

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b67030</samp>

This pull request fixes a bug in the update check logic that would always show an update available even if the current version was the latest. It changes the operator for the version compare in `UpdateController.php` and adds a changelog entry for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b67030</samp>

*  Fix version compare operator for update check ([link](https://github.com/shopware/platform/pull/3109/files?diff=unified&w=0#diff-cb5a9088ec098cdb30b27147a56856044669cd1dd1525380042baf3d629543fcL61-R61), [link](https://github.com/shopware/platform/pull/3109/files?diff=unified&w=0#diff-282a772484e4c07e4797a3c243614c6442d14969b70bb26e76870be5d46a21eaR1-R13))
