### PR TITLE
fix: Allow ajax modal attributes in HTML sanitizer

### DIFF
--- a/changelog/_unreleased/2023-06-11-allow-ajax-modal-attributes-in-html-sanitizer.md
+++ b/changelog/_unreleased/2023-06-11-allow-ajax-modal-attributes-in-html-sanitizer.md
@@ -1,0 +1,9 @@
+---
+title: Allow ajax modal attributes in HTML sanitizer
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed HTML sanitizer config to allow ajax modal attributes `data-ajax-modal` and `data-url` in snippets, the product description and app templates

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -223,6 +223,12 @@ shopware:
             - name: media
               tags: ["img"]
               attributes: ["src", "alt"]
+            - name: modal
+              tags: ["a"]
+              attributes: ["data-ajax-modal", "data-url"]
+              custom_attributes:
+                  - tags: ["a"]
+                    attributes: ["data-ajax-modal", "data-url"]
             - name: script
               tags: ["script"]
               options:
@@ -241,11 +247,11 @@ shopware:
 
         fields:
             - name: product_translation.description
-              sets: ["basic", "media"]
+              sets: ["basic", "media", "modal"]
             - name: app_cms_block.template
-              sets: ["basic", "media", "tidy"]
+              sets: ["basic", "media", "tidy", "modal"]
             - name: snippet.value
-              sets: ["basic", "media", "bootstrap"]
+              sets: ["basic", "media", "bootstrap", "modal"]
 
     logger:
         file_rotation_count: 14

--- a/tests/integration/php/Framework/Util/HtmlSanitizerTest.php
+++ b/tests/integration/php/Framework/Util/HtmlSanitizerTest.php
@@ -179,4 +179,13 @@ class HtmlSanitizerTest extends TestCase
 
         static::assertSame('<a target="_blank" href="#" rel="noreferrer noopener">Test</a>', $filteredString);
     }
+
+    public function testAllowedModalAttributes(): void
+    {
+        foreach (['product_translation.description', 'app_cms_block.template', 'snippet.value'] as $field) {
+            $filteredString = $this->sanitizer->sanitize('<a data-ajax-modal="true" data-url="https://shopware.com" href="https://shopware.com">Test</a>', null, false, $field);
+
+            static::assertSame('<a data-ajax-modal="true" data-url="https://shopware.com" href="https://shopware.com">Test</a>', $filteredString);
+        }
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the AJAX modal attributes `data-ajax-modal` and `data-url` are filtered by the HTML sanitizer. Which is problematic, when one wants to [edit a snippet which contains such attributes](https://github.com/shopware/platform/blob/trunk/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json#L29), as after saving the modal functionality does not work anymore.

### 2. What does this change do, exactly?
Allow these attributes in the default Shopware configuration. Furthermore I additionally allowed them in the app block templates and product description, as one might want to use the modal functionality there as well.

### 3. Describe each step to reproduce the issue or behaviour.
Save for example the snippet `privacyNoticeText`.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-26073

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 76f9452</samp>

This pull request adds a new feature to the HTML sanitizer that enables ajax modal windows in some fields. It introduces a new `modal` tag in `shopware.yaml` and updates the changelog accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 76f9452</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3110/files?diff=unified&w=0#diff-2d889d3bee418731f5f5d3e6963d762f0dfa6bf4b1438c904039b42a59925144R1-R9))
*  Configure the HTML sanitizer to allow the `modal` tag and its attributes ([link](https://github.com/shopware/platform/pull/3110/files?diff=unified&w=0#diff-e0d53f5ab2b7f5d42fc04e96e051e0c60c80e77a63fcb806ea4b83b13163912eR223-R228))
*  Apply the `modal` set to the fields that use the HTML sanitizer ([link](https://github.com/shopware/platform/pull/3110/files?diff=unified&w=0#diff-e0d53f5ab2b7f5d42fc04e96e051e0c60c80e77a63fcb806ea4b83b13163912eL241-R251))
