### PR TITLE
Ci/lint workflow

### DIFF
--- a/.github/workflows/01-php-lint.yml
+++ b/.github/workflows/01-php-lint.yml
@@ -10,6 +10,7 @@ on:
       - 'changelog/**/*.md'
       - 'src/**/snippet/**/*.json'
       - '**.php'
+      - '.github/workflows/01-php-lint.yml'
 
 jobs:
   build:

--- a/.github/workflows/01-php-lint.yml
+++ b/.github/workflows/01-php-lint.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check Code
         run: |
           composer run ecs -- --no-progress-bar
-          composer run phpstan -- --error-format=gitlab --no-progress | tee phpstan-report.json
+          composer run phpstan -- --error-format=github --no-progress | tee phpstan-report.json
           composer run lint:changelog
           composer run lint:snippets
           # TODO: Re-Enable BC-Check after 6.5 RC release

--- a/.github/workflows/01-php-lint.yml
+++ b/.github/workflows/01-php-lint.yml
@@ -37,7 +37,6 @@ jobs:
           composer run phpstan -- --error-format=github --no-progress | tee phpstan-report.json
           composer run lint:changelog
           composer run lint:snippets
-          # TODO: Re-Enable BC-Check after 6.5 RC release
-          # git remote add bc-checker-upstream https://github.com/shopware/platform.git
-          # git fetch bc-checker-upstream
-          # composer run bc-check
+          git remote add bc-checker-upstream https://github.com/shopware/platform.git
+          git fetch bc-checker-upstream
+          composer run bc-check

--- a/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
@@ -230,7 +230,7 @@ abstract class KernelPluginLoader extends Bundle
      *
      * @throws KernelPluginLoaderException
      *
-     * @return array<string>
+     * @return list<string>
      */
     private function mapPsrPaths(string $plugin, array $psr, string $projectDir, string $pluginRootPath): array
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
I noticed that the phpstan errors are not displayed in PRs. Furthermore the BC checker was disabled, and finally the lint workflow should probably also run if the workflow file has been changed.

### 2. What does this change do, exactly?
[Display](https://github.com/shopware/platform/pull/3111/commits/201fc49bbae989389d216cd37ff032beafbfe314) the phpstan errors using the Github formatter, run the BC checker in the php lint workflow and always run the phplint if the workflow file has been changed.

I hope it is okay that I created three different commits and not three different PRs. Feel free to squash :-)
If I should add a changelog please let me know, but since this is most probably not relevant for the end user, I omitted it.

Edit: I also fixed the incorrect return type, which was leading to the failed phpstan check, hope it is okay, to leave it in the same PR as well.

### 3. Describe each step to reproduce the issue or behaviour.
Create a PR.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 201fc49</samp>

Added a new GitHub workflow to lint PHP code and ensure backward compatibility. The workflow uses `phpstan` and `bc-check` tools and runs on every push and pull request to the `shopware/platform` repository.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 201fc49</samp>

* Add and enable PHP lint workflow for `.github/workflows/01-php-lint.yml` file ([link](https://github.com/shopware/platform/pull/3111/files?diff=unified&w=0#diff-2925453d69ce52ced4517c23301cc3f29e1e4f349b88d5cb73a391f636b7eec4R13))
* Switch to `github` error format and enable backward compatibility check for `phpstan` command in PHP lint workflow ([link](https://github.com/shopware/platform/pull/3111/files?diff=unified&w=0#diff-2925453d69ce52ced4517c23301cc3f29e1e4f349b88d5cb73a391f636b7eec4L37-R43))
