### PR TITLE
NEXT-00000 - Make databag consistently convert arrays to databags

### DIFF
--- a/changelog/_unreleased/2023-06-13-ensure-databags-convert-parameters-consistently.md
+++ b/changelog/_unreleased/2023-06-13-ensure-databags-convert-parameters-consistently.md
@@ -1,0 +1,9 @@
+---
+title: Ensure databags convert parameters consistently
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed `\Shopware\Core\Framework\Validation\DataBag\DataBag::set` and `\Shopware\Core\Framework\Validation\DataBag\DataBag::add` to convert arrays to `\Shopware\Core\Framework\Validation\DataBag\DataBag` like the constructor
+* Added `\Shopware\Core\Framework\Validation\DataBag\DataBag::__clone` to deep clone

--- a/tests/unit/Core/Framework/Validation/DataBag/DataBagTest.php
+++ b/tests/unit/Core/Framework/Validation/DataBag/DataBagTest.php
@@ -45,6 +45,53 @@ class DataBagTest extends TestCase
         static::assertEquals(['a' => 'b'], $bag->all('4'));
     }
 
+    public function testAddSetConvertsToDataBag(): void
+    {
+        $bag = new DataBag();
+
+        // test setting databag stays a databag, but converts to array
+        $bag->set('1', new DataBag(['a' => 'b']));
+
+        static::assertInstanceOf(DataBag::class, $bag->get('1'));
+        static::assertSame(['a' => 'b'], $bag->get('1')->all());
+
+        // test setting array becomes a databag, but converts to array
+        $bag->set('2', ['a' => 'b']);
+
+        static::assertInstanceOf(DataBag::class, $bag->get('2'));
+        static::assertSame(['a' => 'b'], $bag->get('2')->all());
+
+        // test adding databag parameter stays a databag, but converts to array
+        $bag->add([
+            '3' => new DataBag(['a' => 'b']),
+        ]);
+
+        static::assertInstanceOf(DataBag::class, $bag->get('3'));
+        static::assertSame(['a' => 'b'], $bag->get('3')->all());
+
+        // test adding array parameters becomes a databag, but converts to array
+        $bag->add([
+            '4' => ['a' => 'b'],
+        ]);
+
+        static::assertInstanceOf(DataBag::class, $bag->get('4'));
+        static::assertSame(['a' => 'b'], $bag->get('4')->all());
+    }
+
+    public function testEnsureCloningIsDeep(): void
+    {
+        $bag = new DataBag();
+        $innerBag = new DataBag();
+
+        $bag->set('key', $innerBag);
+
+        static::assertSame($innerBag, $bag->get('key'));
+
+        $clone = clone $bag;
+
+        static::assertNotSame($innerBag, $clone->get('key'));
+    }
+
     public function testAllWorksOnlyOnArrays(): void
     {
         $bag = new DataBag([


### PR DESCRIPTION
### 1. Why is this change necessary?

I was never sure when I had a sub databag and when I get an array. Super weird. And when I clone it I still have the original sub databags. So not a good clone

### 2. What does this change do, exactly?

Override set and add to behave like the __construct and add a __clone implementation to deep clone inner databags.

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c090963</samp>

This pull request improves the `DataBag` class to handle arrays of parameters more consistently and efficiently, and to support deep cloning. It also adds unit tests and a changelog entry for the changes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c090963</samp>

*  Add changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3114/files?diff=unified&w=0#diff-7ada08f1eb89482ad6b97616cb18de001151bc651450dea73983e1904d95c13cR1-R9))
*  Refactor `DataBag` constructor to use a private method for converting arrays to `DataBag` instances ([link](https://github.com/shopware/platform/pull/3114/files?diff=unified&w=0#diff-1d748732ae02a8c8636bcb55bbb7f4d447602ddde93fa242461679204ae9e7dfL17-R17))
*  Override `add` and `set` methods of `DataBag` to also convert arrays to `DataBag` instances ([link](https://github.com/shopware/platform/pull/3114/files?diff=unified&w=0#diff-1d748732ae02a8c8636bcb55bbb7f4d447602ddde93fa242461679204ae9e7dfR46-R66))
*  Implement `__clone` method of `DataBag` to perform a deep clone of the instance and its nested `DataBag` values ([link](https://github.com/shopware/platform/pull/3114/files?diff=unified&w=0#diff-1d748732ae02a8c8636bcb55bbb7f4d447602ddde93fa242461679204ae9e7dfR46-R66))
*  Extract the logic of converting arrays to `DataBag` instances into a private method `wrapArrayParameters` ([link](https://github.com/shopware/platform/pull/3114/files?diff=unified&w=0#diff-1d748732ae02a8c8636bcb55bbb7f4d447602ddde93fa242461679204ae9e7dfR79-R89))
*  Add unit tests for the `add`, `set`, and `__clone` methods of `DataBag` in `DataBagTest` ([link](https://github.com/shopware/platform/pull/3114/files?diff=unified&w=0#diff-247d64b0917d0fed0e7c36edcc890606fa76db6bc02857e05567d76b7cd60c49R48-R94))
