### PR TITLE
Add order tax status footnote

### DIFF
--- a/changelog/_unreleased/2022-10-21-add-order-tax-state-footnote-in-customer-order-history.md
+++ b/changelog/_unreleased/2022-10-21-add-order-tax-state-footnote-in-customer-order-history.md
@@ -1,0 +1,10 @@
+---
+title: Add order tax state footnote in customer's order history
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Added overridable variable `showVatNotice` to `@Storefront/storefront/layout/footer/footer.html.twig` to show or hide the VAT notice. It is still shown by default
+* Added override for block `base_footer_inner` to `@Storefront/storefront/page/account/order-history/index.html.twig` and pass `showVatNotice` as false to hide the global VAT notice on order history pages
+* Added VAT section to order history item matching the order VAT state. It is wrapped by block `page_account_order_item_detail_table_footnote` after `page_account_order_item_detail_table_labels_summary` in `@Storefront/storefront/page/account/order-history/order-detail.html.twig`

--- a/src/Storefront/Resources/app/storefront/src/scss/page/account/_order-detail.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/account/_order-detail.scss
@@ -19,7 +19,8 @@
 }
 
 .order-detail-content-header,
-.order-item-detail-footer {
+.order-item-detail-footer,
+.order-item-detail-footnote {
     padding-left: $order-grid-gutter-width / 2;
     padding-right: $order-grid-gutter-width / 2;
 }

--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -1,3 +1,7 @@
+{% if showVatNotice is not defined %}
+    {% set showVatNotice = true %}
+{% endif %}
+
 {% block layout_footer_inner_container %}
     <div class="container">
 
@@ -203,21 +207,23 @@
             {% endblock %}
 
             {% block layout_footer_vat %}
-                <div class="footer-vat">
-                    {% if context.taxState == "gross" %}
-                        <p>
-                            {{ "footer.includeVatText"|trans({
-                                '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.shippingPaymentInfoPage') })
-                            })|raw }}
-                        </p>
-                    {% else %}
-                        <p>
-                            {{ "footer.excludeVatText"|trans({
-                                '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.shippingPaymentInfoPage') })
-                            })|raw }}
-                        </p>
-                    {% endif %}
-                </div>
+                {% if showVatNotice %}
+                    <div class="footer-vat">
+                        {% if context.taxState == "gross" %}
+                            <p>
+                                {{ "footer.includeVatText"|trans({
+                                    '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.shippingPaymentInfoPage') })
+                                })|raw }}
+                            </p>
+                        {% else %}
+                            <p>
+                                {{ "footer.excludeVatText"|trans({
+                                    '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.shippingPaymentInfoPage') })
+                                })|raw }}
+                            </p>
+                        {% endif %}
+                    </div>
+                {% endif %}
             {% endblock %}
 
             {% block layout_footer_copyright %}

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/index.html.twig
@@ -69,3 +69,9 @@
         </div>
     {% endblock %}
 {% endblock %}
+
+{% block base_footer_inner %}
+    {% sw_include '@Storefront/storefront/layout/footer/footer.html.twig' with {
+        showVatNotice: false
+    } %}
+{% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
@@ -200,6 +200,20 @@
                                 </div>
                             </div>
                         {% endblock %}
+
+                        {% block page_account_order_item_detail_table_footnote %}
+                            <div class="order-item-detail-footnote">
+                                {% if context.taxState == "gross" %}
+                                    {{ "footer.includeVatText"|trans({
+                                        '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.shippingPaymentInfoPage') })
+                                    })|raw }}
+                                {% else %}
+                                    {{ "footer.excludeVatText"|trans({
+                                        '%url%': path('frontend.cms.page',{ id: config('core.basicInformation.shippingPaymentInfoPage') })
+                                    })|raw }}
+                                {% endif %}
+                            </div>
+                        {% endblock %}
                     </div>
                 {% endblock %}
             </div>


### PR DESCRIPTION
### 0. Follow-up

This is a follow up as a rebase for 6.5 from this earlier pull request.

https://github.com/shopware/platform/pull/2796

### 1. Why is this change necessary?

The hint in the footer about the prices, that are footnoted in the order history can be wrong, when different tax stated orders compared to the context tax state are displayed in the same order history.

### 2. What does this change do, exactly?

Add comparisons about the tax state and the tax status.

In the screenshot you can see a slightly modified order history page of a customer. I removed all parts that are not necessary to understand the issue.

1. We have a general footer claiming I am buying inclusive or exclusive VAT. This is taken from the context.taxState and applied to every price display
2. The first (bottom) order was taken with a different taxState than the second order (top) by changing the customer group
3. So my order history claims now, that the first order has a different taxStatus, than the context and therefore needs a different footnote about it.
4. To distinguish then I use a double asterisk **
5. This directly displayed under the order for simplicity of the solution

![image](https://user-images.githubusercontent.com/1133593/197138919-999fc9fa-c25c-4f83-991a-ff898090980f.png)


### 3. Describe each step to reproduce the issue or behaviour.

1. Register
6. Be in customer group for b2c
7. Buy
8. Get moved to different customer group for b2b
9. Buy
10. Open order history in admin
11. See different label in line item price column that displays the tax status
12. Open order history in storefront
13. See only an asterisk telling me the tax state of the context, not of the order
14. ![6xp4ye](https://user-images.githubusercontent.com/1133593/197081764-2fde1346-91da-481b-9040-a5d43926b05f.gif)


### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
