### PR TITLE
Add custom field editor for units, that already have custom field storage

### DIFF
--- a/changelog/_unreleased/2023-06-14-add-custom-field-set-renderer-to-units.md
+++ b/changelog/_unreleased/2023-06-14-add-custom-field-set-renderer-to-units.md
@@ -1,0 +1,9 @@
+---
+title: Add editor for custom fields on units
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Added usage of `sw-custom-field-set-renderer` to `sw-settings-units-detail` page to edit custom fields on units
+* Added entity `unit` to `customFieldDataProviderService` to allow admin users to create custom field sets for units

--- a/src/Administration/Resources/app/administration/src/app/service/custom-field.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/custom-field.service.js
@@ -121,6 +121,7 @@ export default function createCustomFieldService() {
         'salutation',
         'shipping_method',
         'tax',
+        'unit',
     ];
 
     return {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-units/page/sw-settings-units-detail/index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-units/page/sw-settings-units-detail/index.html.twig
@@ -41,6 +41,11 @@
                     :error="unitShortCodeError"
                     required
                 />
+                <sw-custom-field-set-renderer
+                    :entity="unit"
+                    :sets="customFieldSets"
+                    :disabled="!acl.can('unit.editor')"
+                />
             </sw-card>
 
             <sw-skeleton v-else />


### PR DESCRIPTION
### 1. Why is this change necessary?

You can use custom fields on units as the database can use this, but you cannot display its values in the admin. This might be due to the reason, that you cannot create custom field sets for them. Maybe we just do both now.

### 2. Please link to the relevant issues (if any).

https://github.com/shopware/platform/pull/3116

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa5dc0a</samp>

This pull request adds the ability to edit custom fields for units in the administration. It modifies the `sw-settings-units-detail` component and page to fetch and render the custom field sets for the unit entity. It also updates the `customFieldDataProviderService` to include the `unit` entity as an option for custom fields.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aa5dc0a</samp>

*  Add an editor for custom fields on units ([link](https://github.com/shopware/platform/pull/3117/files?diff=unified&w=0#diff-e2ac3edbc77af81b0ab4dcdbe44011a5cac40318d9d99fc044d922b0d0e720b0R1-R9))
   * Register the `unit` entity for custom fields in the `customFieldDataProviderService` ([link](https://github.com/shopware/platform/pull/3117/files?diff=unified&w=0#diff-06dc3bda64c728a8cf72cd238aa54ae8e7ea8f1cbc64c11af13184deff6ea9c2R124))
   * Add the `sw-custom-field-set-renderer` component to the `sw-settings-units-detail` page ([link](https://github.com/shopware/platform/pull/3117/files?diff=unified&w=0#diff-7e3d7838e2a91e8f12aeca3d8000890336b8e413e0171efa4dea437373f0f5a7R44-R48))
      * Import the `Criteria` class from the `admin-extension-sdk` package ([link](https://github.com/shopware/platform/pull/3117/files?diff=unified&w=0#diff-3b773a6b14e04b2c7012ea544398a040a7154fb4cd2d2001989c35836d0f9746R5))
      * Add a data property `customFieldSets` to store the custom field sets for the unit entity ([link](https://github.com/shopware/platform/pull/3117/files?diff=unified&w=0#diff-3b773a6b14e04b2c7012ea544398a040a7154fb4cd2d2001989c35836d0f9746R21-R26))
      * Add computed properties `customFieldSetRepository` and `customFieldSetCriteria` to handle the CRUD operations and filtering for the `custom_field_set` entity ([link](https://github.com/shopware/platform/pull/3117/files?diff=unified&w=0#diff-3b773a6b14e04b2c7012ea544398a040a7154fb4cd2d2001989c35836d0f9746R43-R53))
      * Modify the `created` lifecycle hook to fetch the custom field sets for the unit entity and load or create the unit entity afterwards ([link](https://github.com/shopware/platform/pull/3117/files?diff=unified&w=0#diff-3b773a6b14e04b2c7012ea544398a040a7154fb4cd2d2001989c35836d0f9746L64-R93))
   * Disable the component if the user does not have the `unit.editor` permission ([link](https://github.com/shopware/platform/pull/3117/files?diff=unified&w=0#diff-7e3d7838e2a91e8f12aeca3d8000890336b8e413e0171efa4dea437373f0f5a7R44-R48))
