### PR TITLE
NEXT-25187 - Allow HTML on property_group_option.name

### DIFF
--- a/changelog/_unreleased/2023-06-15-html-in-property-group-option-name.md
+++ b/changelog/_unreleased/2023-06-15-html-in-property-group-option-name.md
@@ -1,0 +1,15 @@
+---
+title: Allow HTML on property_group_option.name
+issue: NEXT-25187
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added `new AllowHtml()` flag to the `name` of entity `property_group_option` in `Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionDefinition.php` and `Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationDefinition.php`
+___
+# Administration
+* Changed rendering of `property_group_option.translated.name` from `innerText` to embedded and sanitized HTML in `sw-product-properties`, `sw-product-restriction-selection.html.twig`, `sw-product-variants-configurator-prices.html.twig`, `sw-product-variants-delivery-media.html.twig` and `sw-property-list.html.twig`
+___
+# Storefront
+* Changed rendering of `property_group_option.translated.name` from Twig auto-escape to sanitized HTML in `@Storefront/storefront/component/buy-widget/configurator.html.twig`, `@Storefront/storefront/component/product/properties.html.twig`, `@Storefront/storefront/page/product-detail/configurator.html.twig`, `@Storefront/storefront/page/product-detail/configurator/select.html.twig`, `@Storefront/storefront/page/product-detail/properties.html.twig`

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/sw-product-properties.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-properties/sw-product-properties.html.twig
@@ -131,7 +131,9 @@
                                     :dismissable="acl.can('product.deleter')"
                                     @dismiss="onDeletePropertyValue(option)"
                                 >
-                                    {{ option.translated.name }}
+                                    <template
+                                        v-html="$sanitize(option.translated.name)"
+                                    ></template>
                                 </sw-label>
                             </div>
                             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-restriction-selection/sw-product-restriction-selection.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-restriction-selection/sw-product-restriction-selection.html.twig
@@ -56,14 +56,12 @@
 
                 <template
                     #selection-label-property="{ item }"
-                >
-                    {{ item.option.translated.name }}
-                </template>
+                    v-html="$sanitize(item.option.translated.name)"
+                />
                 <template
                     #result-label-property="{ item }"
-                >
-                    {{ item.option.translated.name }}
-                </template>
+                    v-html="$sanitize(item.option.translated.name)"
+                />
             </sw-multi-select>
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/sw-product-variants-configurator-prices.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-prices/sw-product-variants-configurator-prices.html.twig
@@ -68,9 +68,8 @@
                     {% block sw_product_variants_configurator_prices_column_name %}
                     <template
                         #column-name="{ item, isInlineEdit, compact }"
-                    >
-                        {{ item.option.translated.name }}
-                    </template>
+                        v-html="$sanitize(item.option.translated.name)"
+                    />
                     {% endblock %}
 
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-delivery/sw-product-variants-delivery-media/sw-product-variants-delivery-media.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-delivery/sw-product-variants-delivery-media/sw-product-variants-delivery-media.html.twig
@@ -47,9 +47,8 @@
             {% block sw_product_variants_delivery_media_data_grid_column_name %}
             <template
                 #column-name="{ item, isInlineEdit, compact }"
-            >
-                {{ item.option.translated.name }}
-            </template>
+                v-html="$sanitize(item.option.translated.name)"
+            />
             {% endblock %}
 
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.html.twig
@@ -114,7 +114,8 @@
                         v-for="(option, index) in item.options.slice(0, 4)"
                         :key="option.id"
                     >
-                        {{ (index > 0) ? `, ${option.translated.name}` : option.translated.name }}
+                        <template v-if="index > 0">, </template>
+                        <template v-html="$sanitize(option.translated.name)"/>
                     </span>
                     <span v-if="item.options.length >= 5">
                         , ...

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionDefinition.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Property\Aggregate\PropertyGroupOptionTranslation\Prop
 use Shopware\Core\Content\Property\PropertyGroupDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
@@ -68,7 +69,7 @@ class PropertyGroupOptionDefinition extends EntityDefinition
         return new FieldCollection([
             (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
             (new FkField('property_group_id', 'groupId', PropertyGroupDefinition::class))->addFlags(new ApiAware(), new Required()),
-            (new TranslatedField('name'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
+            (new TranslatedField('name'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING), new AllowHtml()),
             (new TranslatedField('position'))->addFlags(new ApiAware()),
             (new StringField('color_hex_code', 'colorHexCode'))->addFlags(new ApiAware()),
             (new FkField('media_id', 'mediaId', MediaDefinition::class))->addFlags(new ApiAware()),

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationDefinition.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOptionTranslation/PropertyGroupOptionTranslationDefinition.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Property\Aggregate\PropertyGroupOptionTranslatio
 use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOptionDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
@@ -50,7 +51,7 @@ class PropertyGroupOptionTranslationDefinition extends EntityTranslationDefiniti
     protected function defineFields(): FieldCollection
     {
         return new FieldCollection([
-            (new StringField('name', 'name'))->addFlags(new ApiAware(), new Required()),
+            (new StringField('name', 'name'))->addFlags(new ApiAware(), new Required(), new AllowHtml()),
             (new IntField('position', 'position'))->addFlags(new ApiAware()),
             (new CustomFields())->addFlags(new ApiAware()),
         ]);

--- a/src/Core/Framework/Test/DataAbstractionLayer/Search/NaturalSortingTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Search/NaturalSortingTest.php
@@ -106,6 +106,10 @@ class NaturalSortingTest extends TestCase
                 ['1', '10', '1.0', '1.1', '1.3', '1.5', '2.22222'], // natural sorting
                 ['1', '1.0', '1.1', '1.3', '1.5', '10', '2.22222'], // none natural
             ],
+            [
+                ['fancy', '<b>fancy</b>'], // natural sorting
+                ['<b>fancy</b>', 'fancy'], // none natural
+            ],
         ];
     }
 }

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/configurator.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/configurator.html.twig
@@ -83,7 +83,7 @@
                                                                     {% if displayType == 'color' and option.colorHexCode %}
                                                                         style="background-color: {{ option.colorHexCode }}"
                                                                     {% endif %}
-                                                                       title="{{ option.translated.name }}"
+                                                                       title="{{ option.translated.name|striptags|e('html_attr') }}"
                                                                        for="{{ optionIdentifier }}">
 
                                                                     {% if displayType == 'media' and media %}
@@ -95,8 +95,8 @@
                                                                                 },
                                                                                 attributes: {
                                                                                     class: 'product-detail-configurator-option-image',
-                                                                                    alt: option.translated.name,
-                                                                                    title: option.translated.name
+                                                                                    alt: option.translated.name|striptags|e('html_attr'),
+                                                                                    title: option.translated.name|striptags|e('html_attr')
                                                                                 }
                                                                             } %}
                                                                         {% endblock %}
@@ -104,7 +104,7 @@
                                                                         (displayType == 'media' and not media) or
                                                                         (displayType == 'color' and not option.colorHexCode) %}
                                                                         {% block buy_widget_configurator_option_radio_label_text %}
-                                                                            {{ option.translated.name }}
+                                                                            {{ option.translated.name|sw_sanitize }}
                                                                         {% endblock %}
                                                                     {% endif %}
                                                                 </label>

--- a/src/Storefront/Resources/views/storefront/component/product/properties.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/properties.html.twig
@@ -19,7 +19,7 @@
                                                 {% apply spaceless %}
                                                     {% for option in group.options %}
                                                         {% set i = ( i | default(0) ) + 1 %}
-                                                        <span>{% if i > 1 %}, {% endif %}{{ option.translated.name|e }}</span>
+                                                        <span>{% if i > 1 %}, {% endif %}{{ option.translated.name|sw_sanitize }}</span>
                                                     {% endfor %}
                                                 {% endapply %}
                                             </td>

--- a/src/Storefront/Resources/views/storefront/page/product-detail/configurator.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/configurator.html.twig
@@ -69,7 +69,7 @@
                                                                        {% if displayType == 'color' and option.colorHexCode %}
                                                                        style="background-color: {{ option.colorHexCode }}"
                                                                        {% endif %}
-                                                                       title="{{ option.translated.name }}"
+                                                                       title="{{ option.translated.name|striptags|e('html_attr') }}"
                                                                        for="{{ optionIdentifier }}">
 
                                                                     {% if displayType == 'media' and media %}
@@ -81,8 +81,8 @@
                                                                                 },
                                                                                 attributes: {
                                                                                     class: 'product-detail-configurator-option-image',
-                                                                                    alt: option.translated.name,
-                                                                                    title: option.translated.name
+                                                                                    alt: option.translated.name|striptags|e('html_attr'),
+                                                                                    title: option.translated.name|striptags|e('html_attr')
                                                                                 }
                                                                             } %}
                                                                         {% endblock %}
@@ -90,7 +90,7 @@
                                                                               (displayType == 'media' and not media) or
                                                                               (displayType == 'color' and not option.colorHexCode) %}
                                                                         {% block page_product_detail_configurator_option_radio_label_text %}
-                                                                            {{ option.translated.name }}
+                                                                            {{ option.translated.name|sw_sanitize }}
                                                                         {% endblock %}
                                                                     {% endif %}
                                                                 </label>

--- a/src/Storefront/Resources/views/storefront/page/product-detail/configurator/select.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/configurator/select.html.twig
@@ -22,7 +22,7 @@
 
                     {% block page_product_detail_configurator_select_option %}
                         <option value="{{ option.id }}"{% if selected %} selected="selected"{% endif %}>
-                            {{ option.translated.name }}
+                            {{ option.translated.name|sw_sanitize }}
                         </option>
                     {% endblock %}
                 {% endfor %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/properties.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/properties.html.twig
@@ -23,7 +23,7 @@
                                                 {% apply spaceless %}
                                                     {% for option in group.options %}
                                                         {% set i = ( i|default(0) ) + 1 %}
-                                                        <span>{% if i > 1 %}, {% endif %}{{ option.translated.name|e }}</span>
+                                                        <span>{% if i > 1 %}, {% endif %}{{ option.translated.name|sw_sanitize }}</span>
                                                     {% endfor %}
                                                 {% endapply %}
                                             </td>


### PR DESCRIPTION
### 1. Why is this change necessary?

Because as ["OG AllowHtml code owner"](https://github.com/shopware/platform/pull/400) I shall add HTML to everything, where someone needs it.

And it has been requested from the community :D (see part 4)

It should not break with existing data as HTML has been stripped. So there is nothing in there, that is bad.

### 2. What does this change do, exactly?

Add AllowHtml in `property_group_option_translation.name` and display it as HTML anywhere possible. This needs more testing though! That is also the reason why I did not write a changelog as I expect it to change on the long run.

### 3. Describe each step to reproduce the issue or behaviour.

Taken from the [ticket](https://issues.shopware.com/issues/NEXT-25187)

> When creating any kind of string field the field serializer will sanitize against html. This does not detect html correctly.
> Environment:
> DEV / PROD / HEADLESS
> Steps to reproduce:
> Using api or admin backend enter a value like this into any string field:
> `<test`
> Expected result:
> The field should be saved with the actual value
> Actual result:
> The field will be completely empty, triggering validation errors if required. One thing that is slightly more concerning is that a value of
>
> `< test>`
> will not be sanitized. This might lead to XSS in other scenarios (just a guess).

### 4. Please link to the relevant issues (if any).

NEXT-25187
https://issues.shopware.com/issues/NEXT-25187
https://github.com/shopware/platform/issues/2872

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a093624</samp>

The pull request adds a new feature to allow HTML formatting in the property group option names. It modifies the entity definition, the templates, and the test cases to handle HTML tags in the option names. It also applies different filters to prevent HTML injection or XSS attacks in some cases. The affected files are mainly in the `src` directory, under the `Core`, `Storefront`, and `Administration` modules.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a093624</samp>

*  Enable HTML formatting in property group option names by adding the `v-html` directive or the `raw` filter to the templates that render the option name in various components in the administration and storefront modules ([link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-a17c889c40d4e3727764ad2b910388c114e010c2e886e3e49a7f57466847538bL134-R136), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-c27c752102e2f33a4e330deda32ef5336caf4ee8f574b161cc2b1c806190dbccL60-R65), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-332a9262dfe90ee7155791e352f65b3bd910b49b9bbe0f4c73c30c4e4f1dfea6L70-R71), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-d8c3f2ce2844af81f13c51595989a7ea894029077443bcbcc6c14956b226b00bL49-R50), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-bdcd0e97609c4b9c32b9c47c7268bcc4e8048ea05d769490b63f47dd1f0f9404L119-R120), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-9a2127b1b1d5275219b5e700492bed19f678376e0bf36bb59455619359aa80caL102-R102), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-a7c20fdec8f80d3cd4470cffc8c814efd361df7e73665aecebea2c94fd82f341L21-R21), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-f57502e87747627991a83d96c7a77d1dfed6bea542d5b86d4d23d336cdf7fe4eL89-R89), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-0213865df1ab662ca8440707b93782d946ce9576261137c2abc600c10a840cc5L20-R20), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-7a3622a108695f4a1eab1c32de3eb4767b236d860a2671008b5053e6ffb5cd45L21-R21))
*  Add the `AllowHtml` flag to the translated name field of the property group option entity in the `PropertyGroupOptionDefinition.php` file to allow the field to accept and store HTML tags in the database ([link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-cdbbdc7cc25caf8fca2162edbf28268aef9b2b791606d8651381a1a2739940c8R14), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-cdbbdc7cc25caf8fca2162edbf28268aef9b2b791606d8651381a1a2739940c8L71-R72))
*  Add a new test case to the natural sorting test class in the `NaturalSortingTest.php` file to check if the natural sorting algorithm can handle HTML tags in the option names ([link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-22aa5fc6c3bbc0f7656adf44bbd16edf692d998ae6cc6ab1089273014c41faa4R110-R113))
*  Prevent HTML injection or XSS attacks from the option name in the title and alt attributes of the label and image elements by adding the `striptags` and `e('html_attr')` filters to the option name in the `configurator.html.twig` and `select.html.twig` files in the storefront module ([link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-9a2127b1b1d5275219b5e700492bed19f678376e0bf36bb59455619359aa80caL81-R81), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-9a2127b1b1d5275219b5e700492bed19f678376e0bf36bb59455619359aa80caL93-R94), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-f57502e87747627991a83d96c7a77d1dfed6bea542d5b86d4d23d336cdf7fe4eL68-R68), [link](https://github.com/shopware/platform/pull/3118/files?diff=unified&w=0#diff-f57502e87747627991a83d96c7a77d1dfed6bea542d5b86d4d23d336cdf7fe4eL80-R81))
