### PR TITLE
feat: Add endpoints to change or delete multiple line items at once

### DIFF
--- a/changelog/_unreleased/2023-07-12-add-storefront-controller-endpoints-to-change-or-delete-multiple-line-items-at-once.md
+++ b/changelog/_unreleased/2023-07-12-add-storefront-controller-endpoints-to-change-or-delete-multiple-line-items-at-once.md
@@ -1,0 +1,13 @@
+---
+title: Add storefront controller endpoints to change or delete multiple line items at once
+issue: NEXT-00000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added method `Core\Checkout\Cart\SalesChannel\CartService::update` to update multiple line items at once
+* Added method `Core\Checkout\Cart\SalesChannel\CartService::removeItems` to remove multiple line items at once
+___
+# Storefront
+* Added controller endpoints `/checkout/line-item/delete` (`frontend.checkout.line-items.delete`) and `/checkout/line-item/update` (`frontend.checkout.line-items.update`) to remove or update multiple line items at once

--- a/src/Core/Checkout/Cart/SalesChannel/CartService.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartService.php
@@ -107,7 +107,7 @@ class CartService implements ResetInterface
     }
 
     /**
-     * @param array<string, mixed>[] $items
+     * @param array<string|int, mixed>[] $items
      *
      * @throws CartException
      */

--- a/src/Core/Checkout/Cart/SalesChannel/CartService.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartService.php
@@ -17,6 +17,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Service\ResetInterface;
 
+/**
+ * @deprecated tag:v6.6.0 - reason:becomes-final - Should not be extended and is only intended as cache
+ */
 #[Package('checkout')]
 class CartService implements ResetInterface
 {
@@ -95,13 +98,23 @@ class CartService implements ResetInterface
      */
     public function changeQuantity(Cart $cart, string $identifier, int $quantity, SalesChannelContext $context): Cart
     {
-        $request = new Request();
-        $request->request->set('items', [
+        return $this->update($cart, [
             [
                 'id' => $identifier,
                 'quantity' => $quantity,
             ],
-        ]);
+        ], $context);
+    }
+
+    /**
+     * @param array<string, mixed>[] $items
+     *
+     * @throws CartException
+     */
+    public function update(Cart $cart, array $items, SalesChannelContext $context): Cart
+    {
+        $request = new Request();
+        $request->request->set('items', $items);
 
         $cart = $this->itemUpdateRoute->change($request, $cart, $context)->getCart();
 
@@ -113,8 +126,18 @@ class CartService implements ResetInterface
      */
     public function remove(Cart $cart, string $identifier, SalesChannelContext $context): Cart
     {
+        return $this->removeItems($cart, [$identifier], $context);
+    }
+
+    /**
+     * @param string[] $ids
+     *
+     * @throws CartException
+     */
+    public function removeItems(Cart $cart, array $ids, SalesChannelContext $context): Cart
+    {
         $request = new Request();
-        $request->request->set('ids', [$identifier]);
+        $request->request->set('ids', $ids);
 
         $cart = $this->itemRemoveRoute->remove($request, $cart, $context)->getCart();
 

--- a/tests/unit/php/Core/Checkout/Cart/SalesChannel/CartServiceTest.php
+++ b/tests/unit/php/Core/Checkout/Cart/SalesChannel/CartServiceTest.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\SalesChannel;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\AbstractCartPersister;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartCalculator;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartDeleteRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemAddRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemRemoveRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartItemUpdateRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartLoadRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\AbstractCartOrderRoute;
+use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Checkout\Cart\SalesChannel\CartService
+ */
+class CartServiceTest extends TestCase
+{
+    private AbstractCartDeleteRoute&MockObject $cartDeleteRoute;
+
+    private AbstractCartItemUpdateRoute&MockObject $cartItemUpdateRoute;
+
+    private AbstractCartItemRemoveRoute&MockObject $cartItemRemoveRoute;
+
+    private CartService $cartService;
+
+    protected function setUp(): void
+    {
+        $this->cartDeleteRoute = $this->createMock(AbstractCartDeleteRoute::class);
+        $this->cartItemUpdateRoute = $this->createMock(AbstractCartItemUpdateRoute::class);
+        $this->cartItemRemoveRoute = $this->createMock(AbstractCartItemRemoveRoute::class);
+
+        $this->cartService = new CartService(
+            $this->createMock(AbstractCartPersister::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(CartCalculator::class),
+            $this->createMock(AbstractCartLoadRoute::class),
+            $this->cartDeleteRoute,
+            $this->createMock(AbstractCartItemAddRoute::class),
+            $this->cartItemUpdateRoute,
+            $this->cartItemRemoveRoute,
+            $this->createMock(AbstractCartOrderRoute::class),
+        );
+    }
+
+    /**
+     * @dataProvider providerCartServiceRoutes
+     */
+    public function testRouteCalled(
+        string $routeName,
+        string $routeMethodName,
+        array $routeMethodArgumentsValidator,
+        string $cartServiceMethod,
+        array $cartServiceMethodArgs,
+    ): void {
+        $this->{$routeName}->expects(static::once())
+            ->method($routeMethodName)
+            ->with(...$routeMethodArgumentsValidator);
+
+        $this->cartService->{$cartServiceMethod}(...$cartServiceMethodArgs);
+    }
+
+    public function providerCartServiceRoutes()
+    {
+        $context = $this->createMock(SalesChannelContext::class);
+        yield 'testDeleteCartCallsDeleteRoute' => ['cartDeleteRoute', 'delete', [$context], 'deleteCart', [$context]];
+
+        $cart = new Cart(Uuid::randomHex());
+
+        $id1 = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+        $ids = [$id1, $id2];
+
+        yield 'testRemoveItemsCallsRemoveRoute' => ['cartItemRemoveRoute', 'remove', [
+            static::callback(function (Request $actualRequest) use ($ids) {
+                static::assertEquals($ids, $actualRequest->request->all('ids'));
+
+                return true;
+            }),
+            $cart,
+            $context,
+        ], 'removeItems', [$cart, $ids, $context]];
+
+        yield 'testRemoveCallsRemoveRoute' => ['cartItemRemoveRoute', 'remove', [
+            static::callback(function (Request $actualRequest) use ($id1) {
+                static::assertEquals([$id1], $actualRequest->request->all('ids'));
+
+                return true;
+            }),
+            $cart,
+            $context,
+        ], 'remove', [$cart, $id1, $context]];
+
+        yield 'testChangeQuantityCallsItemUpdateRoute' => ['cartItemUpdateRoute', 'change', [
+            static::callback(function (Request $actualRequest) use ($id1) {
+                $items = $actualRequest->request->all('items');
+                static::assertIsArray($items);
+                static::assertCount(1, $items);
+                static::assertEquals($id1, $items[0]['id']);
+                static::assertEquals(5, $items[0]['quantity']);
+
+                return true;
+            }),
+            $cart,
+            $context,
+        ], 'changeQuantity', [$cart, $id1, 5, $context]];
+
+        $items = [
+            [
+                'id' => $id1,
+                'quantity' => 123,
+            ],
+            [
+                'id' => $id2,
+                'quantity' => 234,
+            ],
+        ];
+
+        yield 'testUpdateMethodCallsUpdateRoute' => ['cartItemUpdateRoute', 'change', [
+            static::callback(function (Request $actualRequest) use ($items) {
+                static::assertEquals($items, $actualRequest->request->all('items'));
+
+                return true;
+            }),
+            $cart,
+            $context,
+        ], 'update', [$cart, $items, $context]];
+    }
+}

--- a/tests/unit/php/Storefront/Controller/CartLineItemControllerTest.php
+++ b/tests/unit/php/Storefront/Controller/CartLineItemControllerTest.php
@@ -180,4 +180,167 @@ class CartLineItemControllerTest extends TestCase
         $this->expectExceptionObject($exception);
         $this->controller->addLineItems($cart, new RequestDataBag($request->request->all()), $request, $context);
     }
+
+    public function testDeleteLineItems(): void
+    {
+        $id1 = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+        $ids = [$id1, $id2];
+
+        $request = new Request([], ['ids' => $ids]);
+        $cart = new Cart(Uuid::randomHex());
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $this->cartService->expects(static::once())
+            ->method('removeItems')
+            ->with($cart, $ids, $context)
+            ->willReturn($cart);
+
+        $stack = $this->createMock(RequestStack::class);
+        $stack->method('getSession')->willReturn(new Session(new MockArraySessionStorage()));
+        $this->container->method('get')
+            ->willReturnCallback(function ($id) use ($stack) {
+                if ($id === 'translator') {
+                    return $this->createMock(TranslatorInterface::class);
+                }
+
+                if ($id === 'request_stack') {
+                    return $stack;
+                }
+
+                return null;
+            });
+
+        $this->controller->deleteLineItems($cart, $request, $context);
+    }
+
+    public function testDeleteLineItemsMissingIdsParameter(): void
+    {
+        $request = new Request();
+        $cart = new Cart(Uuid::randomHex());
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $this->cartService->expects(static::never())->method('remove');
+
+        $stack = $this->createMock(RequestStack::class);
+        $session = new Session(new MockArraySessionStorage());
+        $stack->method('getSession')->willReturn($session);
+        $this->container->method('get')
+            ->willReturnCallback(function ($id) use ($stack) {
+                if ($id === 'translator') {
+                    return $this->createMock(TranslatorInterface::class);
+                }
+
+                if ($id === 'request_stack') {
+                    return $stack;
+                }
+
+                return null;
+            });
+
+        $this->controller->deleteLineItems($cart, $request, $context);
+
+        static::assertArrayHasKey('danger', $session->getFlashBag()->peekAll());
+    }
+
+    public function testDeleteLineItemsWrongParameter(): void
+    {
+        $request = new Request();
+        $cart = new Cart(Uuid::randomHex());
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $this->cartService->expects(static::never())->method('remove');
+
+        $stack = $this->createMock(RequestStack::class);
+        $session = new Session(new MockArraySessionStorage());
+        $stack->method('getSession')->willReturn($session);
+        $this->container->method('get')
+            ->willReturnCallback(function ($id) use ($stack) {
+                if ($id === 'translator') {
+                    return $this->createMock(TranslatorInterface::class);
+                }
+
+                if ($id === 'request_stack') {
+                    return $stack;
+                }
+
+                return null;
+            });
+
+        $this->controller->deleteLineItems($cart, $request, $context);
+
+        static::assertArrayHasKey('danger', $session->getFlashBag()->peekAll());
+    }
+
+    public function testUpdateLineItems(): void
+    {
+        $id1 = Uuid::randomHex();
+        $id2 = Uuid::randomHex();
+        $lineItems = [
+            [
+                'id' => $id1,
+                'quantity' => 5,
+                'stackable' => false,
+            ],
+            [
+                'id' => $id2,
+                'removable' => false,
+            ],
+        ];
+
+        $request = new Request([], ['lineItems' => $lineItems]);
+        $cart = new Cart(Uuid::randomHex());
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $this->cartService->expects(static::once())
+            ->method('update')
+            ->with($cart, $lineItems, $context)
+            ->willReturn($cart);
+
+        $stack = $this->createMock(RequestStack::class);
+        $stack->method('getSession')->willReturn(new Session(new MockArraySessionStorage()));
+        $this->container->method('get')
+            ->willReturnCallback(function ($id) use ($stack) {
+                if ($id === 'translator') {
+                    return $this->createMock(TranslatorInterface::class);
+                }
+
+                if ($id === 'request_stack') {
+                    return $stack;
+                }
+
+                return null;
+            });
+
+        $this->controller->updateLineItems($cart, new RequestDataBag($request->request->all()), $request, $context);
+    }
+
+    public function testDeleteLineItemsMissingParameter(): void
+    {
+        $request = new Request();
+        $cart = new Cart(Uuid::randomHex());
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $this->cartService->expects(static::never())->method('update');
+
+        $stack = $this->createMock(RequestStack::class);
+        $session = new Session(new MockArraySessionStorage());
+        $stack->method('getSession')->willReturn($session);
+        $this->container->method('get')
+            ->willReturnCallback(function ($id) use ($stack) {
+                if ($id === 'translator') {
+                    return $this->createMock(TranslatorInterface::class);
+                }
+
+                if ($id === 'request_stack') {
+                    return $stack;
+                }
+
+                return null;
+            });
+
+        $this->controller->updateLineItems($cart, new RequestDataBag($request->request->all()), $request, $context);
+
+        static::assertArrayHasKey('danger', $session->getFlashBag()->peekAll());
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is quite cumbersome to update or remove several line items at once. Before Shopware 6.5 it was possible to use the store API directly to perform such a task, but this has been removed with 6.5. The result is that now in order to perform the task the storefront controller routes have to be called multiple times.

I am not sure if this is the correct approach. Or how else this might be solved. Maybe this is also related to: https://github.com/shopware/platform/discussions/3145 as with such a feature one could write an custom endpoint performing this task.

Therefore I create this PR as draft, and if it will be accepted in some way, I will add tests and so on.

### 2. What does this change do, exactly?
Add new endpoints to change or delete multiple line items at once.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 839a465</samp>

The code adds new functionality to the storefront for deleting and updating cart items using dedicated routes. It also updates the `CartLineItemController` and its service definition to use these routes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 839a465</samp>

*  Add routes for removing and updating cart items in the storefront ([link](https://github.com/shopware/platform/pull/3173/files?diff=unified&w=0#diff-7015f2cd7a2263b52a154f50856f91d09beb81fd2e9ba201caec676a317448dfR11-R12), [link](https://github.com/shopware/platform/pull/3173/files?diff=unified&w=0#diff-7015f2cd7a2263b52a154f50856f91d09beb81fd2e9ba201caec676a317448dfL46-R50), [link](https://github.com/shopware/platform/pull/3173/files?diff=unified&w=0#diff-7015f2cd7a2263b52a154f50856f91d09beb81fd2e9ba201caec676a317448dfR76-R93), [link](https://github.com/shopware/platform/pull/3173/files?diff=unified&w=0#diff-7015f2cd7a2263b52a154f50856f91d09beb81fd2e9ba201caec676a317448dfR165-R182), [link](https://github.com/shopware/platform/pull/3173/files?diff=unified&w=0#diff-1d14bb223ffc956e7791a6931aab00f35c820f961c832b72ddc0b84ef5c2b9f0R105-R106))
  * Import `AbstractCartItemRemoveRoute` and `AbstractCartItemUpdateRoute` classes from `Shopware\Core\Checkout\Cart\SalesChannel` namespace ([link](https://github.com/shopware/platform/pull/3173/files?diff=unified&w=0#diff-7015f2cd7a2263b52a154f50856f91d09beb81fd2e9ba201caec676a317448dfR11-R12))
  * Inject `cartItemRemoveRoute` and `cartItemUpdateRoute` instances as constructor parameters and assign them to private properties in `CartLineItemController` ([link](https://github.com/shopware/platform/pull/3173/files?diff=unified&w=0#diff-7015f2cd7a2263b52a154f50856f91d09beb81fd2e9ba201caec676a317448dfL46-R50))
  * Define `deleteLineItems` method with `POST` or `DELETE` methods and `/checkout/line-item/delete` path in `CartLineItemController` ([link](https://github.com/shopware/platform/pull/3173/files?diff=unified&w=0#diff-7015f2cd7a2263b52a154f50856f91d09beb81fd2e9ba201caec676a317448dfR76-R93))
  * Define `updateLineItems` method with `POST` or `DELETE` methods and `/checkout/line-item/update` path in `CartLineItemController` ([link](https://github.com/shopware/platform/pull/3173/files?diff=unified&w=0#diff-7015f2cd7a2263b52a154f50856f91d09beb81fd2e9ba201caec676a317448dfR165-R182))
  * Add references to `CartItemRemoveRoute` and `CartItemUpdateRoute` services as arguments to `CartLineItemController` service definition in `controller.xml` file ([link](https://github.com/shopware/platform/pull/3173/files?diff=unified&w=0#diff-1d14bb223ffc956e7791a6931aab00f35c820f961c832b72ddc0b84ef5c2b9f0R105-R106))
