### PR TITLE
Transform payload in line item controller

### DIFF
--- a/changelog/_unreleased/2023-06-19-product-payload-for-storefront-controller.md
+++ b/changelog/_unreleased/2023-06-19-product-payload-for-storefront-controller.md
@@ -1,6 +1,6 @@
 ---
 title: Product payload for storefront controller 
-issue:
+issue: NEXT-28698
 author: Alexander Schmidt
 author_email: support@kiplingi.de
 author_github: @kiplingi

--- a/changelog/_unreleased/2023-06-19-product-payload-for-storefront-controller.md
+++ b/changelog/_unreleased/2023-06-19-product-payload-for-storefront-controller.md
@@ -1,0 +1,11 @@
+---
+title: Product payload for storefront controller 
+issue:
+author: Alexander Schmidt
+author_email: support@kiplingi.de
+author_github: @kiplingi
+---
+
+# Storefront
+
+Extends the line item controller with the possibility to add a product payload to the line item.

--- a/src/Core/Content/Product/Exception/ProductLineItemPayloadException.php
+++ b/src/Core/Content/Product/Exception/ProductLineItemPayloadException.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Exception;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Package('inventory')]
+class ProductLineItemPayloadException extends ShopwareHttpException
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'The payload of the product line item could not be processed.'
+        );
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'CONTENT__INVALID_PAYLOAD';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_NOT_FOUND;
+    }
+}

--- a/src/Storefront/Controller/CartLineItemController.php
+++ b/src/Storefront/Controller/CartLineItemController.php
@@ -276,6 +276,9 @@ class CartLineItemController extends StorefrontController
      */
     private function getLineItemArray(RequestDataBag $lineItemData): array
     {
+        if ($lineItemData->has('payload')) {
+            $lineItemData->set('payload', json_decode($lineItemData->getString('payload'), true));
+        }
         $lineItemArray = $lineItemData->all();
         $lineItemArray['quantity'] = $lineItemData->getInt('quantity', 1);
         $lineItemArray['stackable'] = $lineItemData->getBoolean('stackable', true);

--- a/src/Storefront/Controller/CartLineItemController.php
+++ b/src/Storefront/Controller/CartLineItemController.php
@@ -11,6 +11,7 @@ use Shopware\Core\Checkout\Cart\LineItemFactoryRegistry;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionCartAddedInformationError;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionItemBuilder;
+use Shopware\Core\Content\Product\Exception\ProductLineItemPayloadException;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\SalesChannel\AbstractProductListRoute;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -252,7 +253,7 @@ class CartLineItemController extends StorefrontController
                 if (!$this->traceErrors($cart)) {
                     $this->addFlash(self::SUCCESS, $this->trans('checkout.addToCartSuccess', ['%count%' => $count]));
                 }
-            } catch (ProductNotFoundException) {
+            } catch (ProductNotFoundException|ProductLineItemPayloadException) {
                 $this->addFlash(self::DANGER, $this->trans('error.addToCartError'));
             }
 
@@ -277,7 +278,13 @@ class CartLineItemController extends StorefrontController
     private function getLineItemArray(RequestDataBag $lineItemData): array
     {
         if ($lineItemData->has('payload')) {
-            $lineItemData->set('payload', json_decode($lineItemData->getString('payload'), true, 512, \JSON_THROW_ON_ERROR));
+            $payload = $lineItemData->get('payload');
+
+            if (mb_strlen($payload, '8bit') > (1024 * 256)) {
+                throw new ProductLineItemPayloadException();
+            }
+
+            $lineItemData->set('payload', json_decode($payload, true, 512, \JSON_THROW_ON_ERROR));
         }
         $lineItemArray = $lineItemData->all();
         $lineItemArray['quantity'] = $lineItemData->getInt('quantity', 1);

--- a/src/Storefront/Controller/CartLineItemController.php
+++ b/src/Storefront/Controller/CartLineItemController.php
@@ -277,7 +277,7 @@ class CartLineItemController extends StorefrontController
     private function getLineItemArray(RequestDataBag $lineItemData): array
     {
         if ($lineItemData->has('payload')) {
-            $lineItemData->set('payload', json_decode($lineItemData->getString('payload'), true));
+            $lineItemData->set('payload', json_decode($lineItemData->getString('payload'), true, 512, \JSON_THROW_ON_ERROR));
         }
         $lineItemArray = $lineItemData->all();
         $lineItemArray['quantity'] = $lineItemData->getInt('quantity', 1);


### PR DESCRIPTION
### 1. Why is this change necessary?
It is not possible to add products with payload from the storefront to the cart in the app system.

### 2. What does this change do, exactly?
It parses a json string to add as payload to a line item.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1578079</samp>

This pull request adds a feature to store product payload data in the line item of the cart. It updates the `CartLineItemController` to handle the payload parameter and adds a changelog entry for the feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1578079</samp>

*  Add a product payload to the line item in the storefront controller ([link](https://github.com/shopware/platform/pull/3179/files?diff=unified&w=0#diff-416d8fd0cde75fcda18f48859d408633bae092b2616ff2569e311aaffc939182R1-R11), [link](https://github.com/shopware/platform/pull/3179/files?diff=unified&w=0#diff-7015f2cd7a2263b52a154f50856f91d09beb81fd2e9ba201caec676a317448dfR279-R281))
