### PR TITLE
Allow null query on listfield

### DIFF
--- a/changelog/_unreleased/2023-06-19-allow-query-on-null-for-listfields.md
+++ b/changelog/_unreleased/2023-06-19-allow-query-on-null-for-listfields.md
@@ -1,0 +1,9 @@
+---
+title: Allow to query/filter on null on fields of type ListField
+issue: 
+author: Kurt Inge Smådal
+author_email: kurt@flowretail.no
+author_github: @kurtinge
+---
+# Core
+* Allow to filter on 'null' for fields of type ListField

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
@@ -237,6 +237,7 @@ class SqlQueryParser
         if ($field instanceof ListField) {
             if ($query->getValue() === null) {
                 $result->addWhere($select . ' IS NULL');
+
                 return $result;
             }
             $result->addWhere('JSON_CONTAINS(' . $select . ', JSON_ARRAY(:' . $key . '))');

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
@@ -235,6 +235,10 @@ class SqlQueryParser
         $result = new ParseResult();
 
         if ($field instanceof ListField) {
+            if ($query->getValue() === null) {
+                $result->addWhere($select . ' IS NULL');
+                return $result;
+            }
             $result->addWhere('JSON_CONTAINS(' . $select . ', JSON_ARRAY(:' . $key . '))');
             $result->addParameter($key, $query->getValue());
 

--- a/tests/integration/php/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
+++ b/tests/integration/php/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Search\Parser;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser
+ */
+class SqlQueryParserTest extends TestCase
+{
+
+    use IntegrationTestBehaviour;
+
+    private EntityRepository $repository;
+
+    private Context $context;
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->context = Context::createDefaultContext();
+        $this->repository = $this->getContainer()->get('product.repository');
+        $this->connection = $this->getContainer()->get(Connection::class);
+    }
+
+
+    public function testParseEqualsFilterForListFieldsWithNullValues(): void
+    {
+        $method = ReflectionHelper::getMethod(SqlQueryParser::class, 'parseEqualsFilter');
+        $queryHelper = new EntityDefinitionQueryHelper();
+        $parser = new SqlQueryParser($queryHelper, $this->connection);
+        $definition = $this->repository->getDefinition();
+
+        $filter = new EqualsFilter('categoryIds', null);
+        $expectedResult = new ParseResult();
+        $expectedResult->addWhere('`product`.`category_ids` IS NULL');
+
+        $parseResult = $method->invoke($parser, $filter, $definition, $definition->getEntityName(), $this->context, false);
+
+        $this->assertEquals($expectedResult, $parseResult);
+    }
+
+    public function testParseEqualsFilterForListFields(): void
+    {
+        $method = ReflectionHelper::getMethod(SqlQueryParser::class, 'parseEqualsFilter');
+
+        $queryHelper = new EntityDefinitionQueryHelper();
+        $parser = new SqlQueryParser($queryHelper, $this->connection);
+        $definition = $this->repository->getDefinition();
+
+        $filter = new EqualsFilter('categoryIds', "testvalue123");
+        $parseResult = $method->invoke($parser, $filter, $definition, $definition->getEntityName(), $this->context, false);
+
+        $this->assertCount(1, $parseResult->getParameters());
+
+        $paramKey = array_keys($parseResult->getParameters())[0];
+        $expectedResult = new ParseResult();
+        $expectedResult->addWhere('JSON_CONTAINS(`product`.`category_ids`, JSON_ARRAY(:'. $paramKey . '))');
+        $expectedResult->addParameter($paramKey, 'testvalue123');
+
+
+        $this->assertEquals($expectedResult, $parseResult);
+    }
+
+}

--- a/tests/integration/php/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
+++ b/tests/integration/php/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
@@ -1,8 +1,6 @@
-<?php
+<?php declare(strict_types=1);
 
-declare(strict_types=1);
-
-namespace Shopware\Core\Framework\DataAbstractionLayer\Search\Parser;
+namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Search\Parser;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
@@ -10,6 +8,8 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\ParseResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
 
@@ -67,6 +67,7 @@ class SqlQueryParserTest extends TestCase
         $definition = $this->repository->getDefinition();
 
         $filter = new EqualsFilter('categoryIds', 'testvalue123');
+        /** @var ParseResult $parseResult */
         $parseResult = $method->invoke(
             $parser,
             $filter,
@@ -76,9 +77,11 @@ class SqlQueryParserTest extends TestCase
             false
         );
 
-        static::assertCount(1, $parseResult->getParameters());
+        $parseResultParameterKeys = array_keys($parseResult->getParameters());
 
-        $paramKey = array_keys($parseResult->getParameters())[0];
+        static::assertCount(1, $parseResultParameterKeys);
+
+        $paramKey = (string)$parseResultParameterKeys[0];
         $expectedResult = new ParseResult();
         $expectedResult->addWhere('JSON_CONTAINS(`product`.`category_ids`, JSON_ARRAY(:' . $paramKey . '))');
         $expectedResult->addParameter($paramKey, 'testvalue123');

--- a/tests/integration/php/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
+++ b/tests/integration/php/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Search\Parser;
@@ -19,12 +20,12 @@ use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
  */
 class SqlQueryParserTest extends TestCase
 {
-
     use IntegrationTestBehaviour;
 
     private EntityRepository $repository;
 
     private Context $context;
+
     private Connection $connection;
 
     protected function setUp(): void
@@ -33,7 +34,6 @@ class SqlQueryParserTest extends TestCase
         $this->repository = $this->getContainer()->get('product.repository');
         $this->connection = $this->getContainer()->get(Connection::class);
     }
-
 
     public function testParseEqualsFilterForListFieldsWithNullValues(): void
     {
@@ -46,9 +46,16 @@ class SqlQueryParserTest extends TestCase
         $expectedResult = new ParseResult();
         $expectedResult->addWhere('`product`.`category_ids` IS NULL');
 
-        $parseResult = $method->invoke($parser, $filter, $definition, $definition->getEntityName(), $this->context, false);
+        $parseResult = $method->invoke(
+            $parser,
+            $filter,
+            $definition,
+            $definition->getEntityName(),
+            $this->context,
+            false
+        );
 
-        $this->assertEquals($expectedResult, $parseResult);
+        static::assertEquals($expectedResult, $parseResult);
     }
 
     public function testParseEqualsFilterForListFields(): void
@@ -59,18 +66,23 @@ class SqlQueryParserTest extends TestCase
         $parser = new SqlQueryParser($queryHelper, $this->connection);
         $definition = $this->repository->getDefinition();
 
-        $filter = new EqualsFilter('categoryIds', "testvalue123");
-        $parseResult = $method->invoke($parser, $filter, $definition, $definition->getEntityName(), $this->context, false);
+        $filter = new EqualsFilter('categoryIds', 'testvalue123');
+        $parseResult = $method->invoke(
+            $parser,
+            $filter,
+            $definition,
+            $definition->getEntityName(),
+            $this->context,
+            false
+        );
 
-        $this->assertCount(1, $parseResult->getParameters());
+        static::assertCount(1, $parseResult->getParameters());
 
         $paramKey = array_keys($parseResult->getParameters())[0];
         $expectedResult = new ParseResult();
-        $expectedResult->addWhere('JSON_CONTAINS(`product`.`category_ids`, JSON_ARRAY(:'. $paramKey . '))');
+        $expectedResult->addWhere('JSON_CONTAINS(`product`.`category_ids`, JSON_ARRAY(:' . $paramKey . '))');
         $expectedResult->addParameter($paramKey, 'testvalue123');
 
-
-        $this->assertEquals($expectedResult, $parseResult);
+        static::assertEquals($expectedResult, $parseResult);
     }
-
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Right now it is not possible to filter on fields that are of type ListField and is empty. 
I.E it is not possible to add a filter to /api/search/products with this filter: 
```JSON
    "filter": [
        {
            "type": "equals",
            "field": "categoryIds",
            "value": null
        }
    ]
```

This filter will right now create a SQL WHERE-clause that looks like this
```SQL
WHERE  ((JSON_CONTAINS(`product`.`category_ids`, JSON_ARRAY(null))))
```

### 2. What does this change do, exactly?

This change check if the query/filter value is null if the field type is of and ListField instance, and add `field IS NULL` as the SQL query instead of `JSON_CONTAINS(field, JSON_ARRAY(null))`  

### 3. Describe each step to reproduce the issue or behaviour.

Try to do a query to `/api/search/product` with the payload 
```JSON
{
    "filter": [
        {
            "type": "equals",
            "field": "categoryIds",
            "value": null
        }
    ]
}
```

This should give a list of all products that is not placed inside any category, instead you get an empty list.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58e333e</samp>

This pull request introduces a new feature that allows to query/filter on null values for fields of type `ListField`. It updates the `SqlQueryParser` class and adds a changelog entry for the feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 58e333e</samp>

*  Add a changelog entry for the new feature of querying on null values for ListField fields ([link](https://github.com/shopware/platform/pull/3180/files?diff=unified&w=0#diff-8e0200258afef39894994e22afdac1d14eaca2e92b653da9dc918000b8f29a75R1-R9))
*  Update the `parseEqualsFilter` function in the `SqlQueryParser` class to handle null query values ([link](https://github.com/shopware/platform/pull/3180/files?diff=unified&w=0#diff-19045c4b95674b377c88b4ddf0e613509a0b7c164376184d3a1a0d3e7e6e102fR238-R241))
