### PR TITLE
feat: add thumbnail sizes to media folder of manufacturers, specify suitable sizes for media folders of manufacturers and products

### DIFF
--- a/changelog/_unreleased/2023-06-24-add-thumbnail-sizes-to-product-manufacturers.md
+++ b/changelog/_unreleased/2023-06-24-add-thumbnail-sizes-to-product-manufacturers.md
@@ -1,0 +1,23 @@
+---
+title: add thumbnail sizes to product manufacturers
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Added three thumbnail sizes for media folder "Product Manufacturer Media": 200px, 360px and 1920px
+* Added one more thumbnail size for media folder "Product Media" to fit the listing in default theme: 280px
+
+___
+# Storefront
+
+* Added sizes attribute with 200px for thumbnail of manufacturer within block `element_manufacturer_logo_image` in `element/cms-element-manufacturer-logo.html.twig` 
+* Added thumbnail usage within block `page_product_detail_manufacturer_logo` in `page/product-detail/headline.html.twig`
+
+___
+# Upgrade Information
+
+* Update your thumbnails by running command: `media:generate-thumbnails`

--- a/src/Core/Migration/Traits/EnsureThumbnailSizesTrait.php
+++ b/src/Core/Migration/Traits/EnsureThumbnailSizesTrait.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\Traits;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[Package('core')]
+trait EnsureThumbnailSizesTrait
+{
+    /**
+     * @param list<array{width: int, height: int}> $thumbnailSizes
+     *
+     * @return string[]
+     */
+    final protected function ensureThumbnailSizes(array $thumbnailSizes, Connection $connection): array
+    {
+        /** @var list<array{id: string, width: string, height: string}> $allSizes */
+        $allSizes = $connection->fetchAllAssociative(
+            'SELECT `id`, `width`, `height` FROM `media_thumbnail_size`'
+        );
+
+        $insertStatement = $connection->prepare('
+                INSERT INTO `media_thumbnail_size` (`id`, `width`, `height`, created_at)
+                VALUES (:id, :width, :height, :createdAt)
+            ');
+
+        $sizes = [];
+        foreach ($thumbnailSizes as $thumbnailSize) {
+            $result = array_filter($allSizes, function ($var) use ($thumbnailSize) {
+                return (int) $var['width'] === $thumbnailSize['width'] && (int) $var['height'] === $thumbnailSize['height'];
+            });
+
+            if (\count($result) > 0) {
+                $sizes[] = reset($result)['id'];
+
+                continue;
+            }
+
+            $id = Uuid::randomBytes();
+            $insertStatement->executeStatement([
+                'id' => $id,
+                'width' => $thumbnailSize['width'],
+                'height' => $thumbnailSize['height'],
+                'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            ]);
+
+            $sizes[] = $id;
+        }
+
+        return $sizes;
+    }
+}

--- a/src/Core/Migration/V6_5/Migration1687462843ProductManufacturerMediaThumbnails.php
+++ b/src/Core/Migration/V6_5/Migration1687462843ProductManufacturerMediaThumbnails.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_5;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Migration\Traits\EnsureThumbnailSizesTrait;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1687462843ProductManufacturerMediaThumbnails extends MigrationStep
+{
+    use EnsureThumbnailSizesTrait;
+
+    public function getCreationTimestamp(): int
+    {
+        return 1687462843;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $thumbnailSizes = [
+            ['width' => 200, 'height' => 200],
+            ['width' => 360, 'height' => 360],
+            ['width' => 1920, 'height' => 1920],
+        ];
+
+        $thumbnailSizeIds = $this->ensureThumbnailSizes($thumbnailSizes, $connection);
+
+        $configurationId = $connection->fetchOne(
+            'SELECT media_folder_configuration_id FROM media_folder WHERE name = :name',
+            ['name' => 'Product Manufacturer Media']
+        );
+
+        if (!$configurationId) {
+            return;
+        }
+
+        $statement = $connection->prepare('
+                    REPLACE INTO `media_folder_configuration_media_thumbnail_size` (`media_folder_configuration_id`, `media_thumbnail_size_id`)
+                    VALUES (:folderConfigurationId, :thumbnailSizeId)
+                ');
+
+        foreach ($thumbnailSizeIds as $thumbnailSizeId) {
+            $statement->executeStatement([
+                'folderConfigurationId' => $configurationId,
+                'thumbnailSizeId' => $thumbnailSizeId,
+            ]);
+        }
+
+        $this->registerIndexer($connection, 'media_folder_configuration.indexer');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/Migration/V6_5/Migration1687463180ProductMediaThumbnails.php
+++ b/src/Core/Migration/V6_5/Migration1687463180ProductMediaThumbnails.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_5;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Migration\Traits\EnsureThumbnailSizesTrait;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1687463180ProductMediaThumbnails extends MigrationStep
+{
+    use EnsureThumbnailSizesTrait;
+
+    public function getCreationTimestamp(): int
+    {
+        return 1687463180;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $thumbnailSizes = [
+            ['width' => 280, 'height' => 280],
+        ];
+
+        $thumbnailSizeIds = $this->ensureThumbnailSizes($thumbnailSizes, $connection);
+
+        $configurationId = $connection->fetchOne(
+            'SELECT media_folder_configuration_id FROM media_folder WHERE name = :name',
+            ['name' => 'Product Media']
+        );
+
+        if (!$configurationId) {
+            return;
+        }
+
+        $statement = $connection->prepare('
+                    REPLACE INTO `media_folder_configuration_media_thumbnail_size` (`media_folder_configuration_id`, `media_thumbnail_size_id`)
+                    VALUES (:folderConfigurationId, :thumbnailSizeId)
+                ');
+
+        foreach ($thumbnailSizeIds as $thumbnailSizeId) {
+            $statement->executeStatement([
+                'folderConfigurationId' => $configurationId,
+                'thumbnailSizeId' => $thumbnailSizeId,
+            ]);
+        }
+
+        $this->registerIndexer($connection, 'media_folder_configuration.indexer');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-manufacturer-logo.html.twig
@@ -44,7 +44,10 @@
                                 {% endif %}
 
                                 {% sw_thumbnails 'cms-image-thumbnails' with {
-                                    media: manufacturer.media
+                                    media: manufacturer.media,
+                                    sizes: {
+                                        'default': '200px'
+                                    }
                                 } %}
                             {% endblock %}
                         </div>

--- a/src/Storefront/Resources/views/storefront/page/product-detail/headline.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/headline.html.twig
@@ -22,9 +22,18 @@
                            title="{{ page.product.manufacturer.translated.name }}">
                             {% if page.product.manufacturer.media %}
                                 {% block page_product_detail_manufacturer_logo %}
-                                    <img src="{{ page.product.manufacturer.media|sw_encode_media_url }}"
-                                         class="product-detail-manufacturer-logo"
-                                         alt="{{ page.product.manufacturer.translated.name }}"/>
+                                    {% set attributes = {
+                                        'class': 'product-detail-manufacturer-logo',
+                                        'alt': page.product.manufacturer.translated.name,
+                                        'title': page.product.manufacturer.translated.name
+                                    } %}
+
+                                    {% sw_thumbnails 'product-detail-manufacturer-image-thumbnails' with {
+                                        media: page.product.manufacturer.media,
+                                        sizes: {
+                                            'default': '200px'
+                                        }
+                                    } %}
                                 {% endblock %}
                             {% else %}
                                 {% block page_product_detail_manufacturer_text %}

--- a/tests/migration/Core/V6_5/Migration1687462843ProductManufacturerMediaThumbnailsTest.php
+++ b/tests/migration/Core/V6_5/Migration1687462843ProductManufacturerMediaThumbnailsTest.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_5;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\V6_5\Migration1687462843ProductManufacturerMediaThumbnails;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Migration\V6_5\Migration1687462843ProductManufacturerMediaThumbnails
+ */
+class Migration1687462843ProductManufacturerMediaThumbnailsTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testUpdate(): void
+    {
+        /** @var Connection $con */
+        $con = $this->getContainer()->get(Connection::class);
+
+        if (\count($this->thumbnailSizesIds($con)) > 1) {
+            $this->revertMigration($con);
+        }
+
+        // 1920px is already registered
+        static::assertCount(1, $this->thumbnailSizesIds($con));
+
+        $productManufacturerFolderConfigurationId = $this->getProductManufacturerFolderConfigurationId($con);
+
+        static::assertNotNull($productManufacturerFolderConfigurationId);
+
+        static::assertCount(0, $this->getConfiguredThumbnailSizeIds($con, $productManufacturerFolderConfigurationId));
+
+        $m = new Migration1687462843ProductManufacturerMediaThumbnails();
+        $m->update($con);
+
+        $thumbnailSizeIds = $this->thumbnailSizesIds($con);
+        static::assertCount(3, $thumbnailSizeIds);
+
+        $configuredThumbnailSizes = $this->getConfiguredThumbnailSizeIds($con, $productManufacturerFolderConfigurationId);
+        static::assertCount(3, $configuredThumbnailSizes);
+
+        static::assertEmpty(array_diff($thumbnailSizeIds, $configuredThumbnailSizes));
+
+        $m->update($con);
+    }
+
+    private function revertMigration(Connection $connection): void
+    {
+        $thumbnailSizes = [
+            ['width' => 200, 'height' => 200],
+            ['width' => 360, 'height' => 360],
+        ];
+
+        foreach ($thumbnailSizes as $thumbnailSize) {
+            $connection->delete(
+                'media_thumbnail_size',
+                ['width' => $thumbnailSize['width'], 'height' => $thumbnailSize['height']]
+            );
+        }
+
+        /*
+         * There is an existing entry fpr 1920px thumbnail, which we should not remove generally!
+         * We should just remove it from the specific mediaFolder
+         */
+        $id_1920px = $connection->fetchOne(
+            'SELECT `id` FROM `media_thumbnail_size` WHERE width = :width AND height = :height',
+            ['width' => 1920, 'height' => 1920]
+        );
+
+        $connection->delete(
+            'media_folder_configuration_media_thumbnail_size',
+            [
+                'media_folder_configuration_id' => $this->getProductManufacturerFolderConfigurationId($connection),
+                'media_thumbnail_size_id' => $id_1920px,
+            ]
+        );
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function thumbnailSizesIds(Connection $connection): array
+    {
+        $thumbnailSizes = [
+            ['width' => 200, 'height' => 200],
+            ['width' => 360, 'height' => 360],
+            ['width' => 1920, 'height' => 1920],
+        ];
+
+        $ids = [];
+
+        foreach ($thumbnailSizes as $thumbnailSize) {
+            $id = $connection->fetchOne(
+                'SELECT id FROM media_thumbnail_size WHERE width = :width AND height = :height',
+                ['width' => $thumbnailSize['width'], 'height' => $thumbnailSize['height']]
+            );
+
+            if (!empty($id)) {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
+    }
+
+    private function getProductManufacturerFolderConfigurationId(Connection $connection): ?string
+    {
+        $id = $connection->fetchOne(
+            'SELECT media_folder_configuration_id FROM media_folder WHERE name = :name',
+            ['name' => 'Product Manufacturer Media']
+        );
+
+        if (\is_string($id) && !empty($id)) {
+            return $id;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getConfiguredThumbnailSizeIds(Connection $connection, string $configurationId): array
+    {
+        return $connection->fetchFirstColumn('
+                    SELECT `media_thumbnail_size_id` FROM `media_folder_configuration_media_thumbnail_size` WHERE `media_folder_configuration_id`=:folderConfigurationId
+                ', [
+            'folderConfigurationId' => $configurationId,
+        ]);
+    }
+}

--- a/tests/migration/Core/V6_5/Migration1687463180ProductMediaThumbnailsTest.php
+++ b/tests/migration/Core/V6_5/Migration1687463180ProductMediaThumbnailsTest.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_5;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\V6_5\Migration1687463180ProductMediaThumbnails;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Migration\V6_5\Migration1687463180ProductMediaThumbnails
+ */
+class Migration1687463180ProductMediaThumbnailsTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testUpdate(): void
+    {
+        /** @var Connection $con */
+        $con = $this->getContainer()->get(Connection::class);
+
+        if (\count($this->thumbnailSizesIds($con)) > 0) {
+            $this->revertMigration($con);
+        }
+
+        static::assertCount(0, $this->thumbnailSizesIds($con));
+
+        $productManufacturerFolderConfigurationId = $this->getProductFolderConfigurationId($con);
+
+        static::assertNotNull($productManufacturerFolderConfigurationId);
+
+        $beforeConfiguredThumbnailSizeIds = $this->getConfiguredThumbnailSizeIds($con, $productManufacturerFolderConfigurationId);
+
+        $m = new Migration1687463180ProductMediaThumbnails();
+        $m->update($con);
+
+        $thumbnailSizeIds = $this->thumbnailSizesIds($con);
+        static::assertCount(1, $thumbnailSizeIds);
+
+        $configuredThumbnailSizes = $this->getConfiguredThumbnailSizeIds($con, $productManufacturerFolderConfigurationId);
+        static::assertCount(\count($beforeConfiguredThumbnailSizeIds) + 1, $configuredThumbnailSizes);
+
+        $m->update($con);
+    }
+
+    private function revertMigration(Connection $connection): void
+    {
+        $thumbnailSizes = [
+            ['width' => 280, 'height' => 280],
+        ];
+
+        foreach ($thumbnailSizes as $thumbnailSize) {
+            $connection->delete(
+                'media_thumbnail_size',
+                ['width' => $thumbnailSize['width'], 'height' => $thumbnailSize['height']]
+            );
+        }
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function thumbnailSizesIds(Connection $connection): array
+    {
+        $thumbnailSizes = [
+            ['width' => 280, 'height' => 280],
+        ];
+
+        $ids = [];
+        foreach ($thumbnailSizes as $thumbnailSize) {
+            $id = $connection->fetchOne(
+                'SELECT id FROM media_thumbnail_size WHERE width = :width AND height = :height',
+                ['width' => $thumbnailSize['width'], 'height' => $thumbnailSize['height']]
+            );
+
+            if (!empty($id)) {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
+    }
+
+    private function getProductFolderConfigurationId(Connection $connection): ?string
+    {
+        $id = $connection->fetchOne(
+            'SELECT media_folder_configuration_id FROM media_folder WHERE name = :name',
+            ['name' => 'Product Media']
+        );
+
+        if (\is_string($id) && !empty($id)) {
+            return $id;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getConfiguredThumbnailSizeIds(Connection $connection, string $configurationId): array
+    {
+        return $connection->fetchFirstColumn('
+                    SELECT `media_thumbnail_size_id` FROM `media_folder_configuration_media_thumbnail_size` WHERE `media_folder_configuration_id`=:folderConfigurationId
+                ', [
+            'folderConfigurationId' => $configurationId,
+        ]);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Manufacturer logos don't have any thumbnail size.
Product image in the listing is announced for 280px size, but there is none - the next one is 400px.

### 2. What does this change do, exactly?
- thumbnail sizes for manufacturers: 200px (used generally), 360px (used in minimal product view), 1920px (default)
- thumbnail size for products: 280px (used in listing)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0a04bc8</samp>

This pull request adds thumbnail support for manufacturer media in the core and storefront. It introduces two migration classes that create and assign thumbnail sizes for the product manufacturer media and product media folders. It also updates the templates for the cms-element-manufacturer-logo and the product-detail-headline to use the `sw_thumbnails` function with the appropriate sizes parameter to render the manufacturer logos with the optimal quality and performance.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0a04bc8</samp>

* Create and assign thumbnail sizes for product manufacturer media and product media folders ([link](https://github.com/shopware/platform/pull/3187/files?diff=unified&w=0#diff-bf967fe1e5d1cb0db8145886cbf27a6dd3af9ad1189e70cdd8583e09c9d2cac0R1-R87), [link](https://github.com/shopware/platform/pull/3187/files?diff=unified&w=0#diff-c8e562724593aa924ca953a6cec32feb55c0314a5fbc0bf23ad88314c24fdd82R1-R85))
* Use `sw_thumbnails` function to render manufacturer logos with thumbnails on the storefront ([link](https://github.com/shopware/platform/pull/3187/files?diff=unified&w=0#diff-445a145e196d70ff9b70f4243f94aaadb9c51a430351c485eddb9ebb9b7679b7L47-R50), [link](https://github.com/shopware/platform/pull/3187/files?diff=unified&w=0#diff-86c33dd97715f01b7b527a3af6b31b3fc2d59f84d4acfda431a7c194b665a4faL25-R36))
