### PR TITLE
NEXT-31655 - Fix OrderEntity::$language to support null

### DIFF
--- a/changelog/_unreleased/2023-06-16-order-get-language-can-be-null.md
+++ b/changelog/_unreleased/2023-06-16-order-get-language-can-be-null.md
@@ -1,0 +1,10 @@
+---
+title: Allow usage of language property on OrderEntity when not loading the language association
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed return type of `\Shopware\Core\Checkout\Order::getLanguage()` to also allow null
+* Changed parameter type of `\Shopware\Core\Checkout\Order::setLanguage()` to also allow null
+* Changed PHPdoc type of `\Shopware\Core\Checkout\Order::$language` to also allow null

--- a/src/Core/Checkout/Order/OrderEntity.php
+++ b/src/Core/Checkout/Order/OrderEntity.php
@@ -120,7 +120,8 @@ class OrderEntity extends Entity
     protected $languageId;
 
     /**
-     * @var LanguageEntity
+     * @deprecated tag:v6.6.0 - Native type hint will be added
+     * @var LanguageEntity|null
      */
     protected $language;
 
@@ -371,12 +372,12 @@ class OrderEntity extends Entity
         $this->languageId = $languageId;
     }
 
-    public function getLanguage(): LanguageEntity
+    public function getLanguage(): ?LanguageEntity
     {
         return $this->language;
     }
 
-    public function setLanguage(LanguageEntity $language): void
+    public function setLanguage(?LanguageEntity $language): void
     {
         $this->language = $language;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

You cannot check an instance of `OrderEntity` whether the language association has been loaded because in that case the field `OrderEntity::$language` would not be `instanceof LanguageEntity`. Therefore you cannot simply access the result of `getLanguage()` because you have to wrap it with a try-catch.

### 2. What does this change do, exactly?

Allow null results as this is what we have, when the language association is not requested. And it is not requested by default.

### 3. Describe each step to reproduce the issue or behaviour.

Will die with a php Error.

```php
/** @var $orderRepository EntityRepository */
/** @var $context Context */
$orderRepository->search(new Criteria(), $context)->first()?->getLanguage();
```

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8c75c7</samp>

This pull request fixes a bug in the `OrderEntity` class that caused errors when accessing orders without a language association. It updates the type annotations and methods of the `language` property and adds a changelog entry for the core module.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d8c75c7</samp>

* Allow null values for the language property and methods of the `OrderEntity` class ([link](https://github.com/shopware/platform/pull/3188/files?diff=unified&w=0#diff-aeb3f3dbd458a463f11ae71810d6e7bb3fd515b813f479eb17532c4b99ad4627L123-R123), [link](https://github.com/shopware/platform/pull/3188/files?diff=unified&w=0#diff-aeb3f3dbd458a463f11ae71810d6e7bb3fd515b813f479eb17532c4b99ad4627L372-R377))
* Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3188/files?diff=unified&w=0#diff-cdb67c664244aae096ebe549ed9ff89fbbf42101992312c363f15b41953be5a6R1-R10))
