### PR TITLE
Fix jquery asset path in UPGRADE-6.5.md

### DIFF
--- a/UPGRADE-6.5.md
+++ b/UPGRADE-6.5.md
@@ -1097,7 +1097,7 @@ This is the recommended method for all apps/themes which don't have control over
 * This block is not deprecated and can be used in the long term beyond the next major version of shopware.
 * Don't** use the `{{ parent() }}` call. This prevents multiple usages of jQuery. Even if multiple other plugins/apps use this method, the jQuery script will only be added once.
 * Please use jQuery version `3.5.1` (slim minified) to avoid compatibility issues between different plugins/apps.
-* If you don't want to use a CDN for jQuery, [download jQuery from the official website](https://releases.jquery.com/jquery/) (jQuery Core 3.5.1 - slim minified) and add it to `MyExtension/src/Resources/app/storefront/src/assets/jquery-3.5.1.slim.min.js`
+* If you don't want to use a CDN for jQuery, [download jQuery from the official website](https://releases.jquery.com/jquery/) (jQuery Core 3.5.1 - slim minified) and add it to `MyExtension/src/Resources/public/assets/jquery-3.5.1.slim.min.js`
 * After executing `bin/console asset:install`, you can reference the file using the `assset()` function. See also: https://developer.shopware.com/docs/guides/plugins/plugins/storefront/add-custom-assets
 
 ```html


### PR DESCRIPTION
Fix jquery asset path

### 1. Why is this change necessary?
Otherwise it does not work 🤷‍♂️

### 2. What does this change do, exactly?
Fix the instruction how to re-add jquery via plugin asset.

### 3. Describe each step to reproduce the issue or behaviour.
- Put the jquery file at the mentioned path.
- Execute `bin/console assets:install`
- Look into `bundles/myextension/assets/` for the jquery file
- ![No asset here](https://media.tenor.com/nEP6ovplEd8AAAAi/so-really.gif)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca748a0</samp>

Updated the path to the jQuery file in the plugin migration guide. This reflects the new directory structure in Shopware 6.5 that removes the `app` directory.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca748a0</samp>

* Change the path to the jQuery file in the plugin extension to use the `public` directory instead of the `app` directory ([link](https://github.com/shopware/platform/pull/3192/files?diff=unified&w=0#diff-a3dc7b1dedf6c20afb757b753352e9ac3d87e2a63c54f8af85347657798d1f64L1100-R1100)). This is required to comply with the new directory structure in Shopware 6.5, as explained in the `UPGRADE-6.5.md` file.
