### PR TITLE
Remove cascade-delete on OrderTransaction to not affect OrderTransact…

### DIFF
--- a/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionDefinition.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionDefinition.php
@@ -72,7 +72,7 @@ class OrderTransactionDefinition extends EntityDefinition
             (new CustomFields())->addFlags(new ApiAware()),
             new ManyToOneAssociationField('order', 'order_id', OrderDefinition::class, 'id', false),
             (new ManyToOneAssociationField('paymentMethod', 'payment_method_id', PaymentMethodDefinition::class, 'id', false))->addFlags(new ApiAware()),
-            (new OneToManyAssociationField('captures', OrderTransactionCaptureDefinition::class, 'order_transaction_id'))->addFlags(new ApiAware(), new CascadeDelete()),
+            (new OneToManyAssociationField('captures', OrderTransactionCaptureDefinition::class, 'order_transaction_id'))->addFlags(new ApiAware()),
         ]);
     }
 }


### PR DESCRIPTION
This is one of the solutions to address issue #3195

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Without the change the issue reported in #3195 occurs. In short, when the system process the merge on versioned `OrderTransaction` entity, then it affects related `OrderTransactionCapture` entities and deletes all of them if there are any linked to `OrderTransaction` (because `OrderTransactionCapture` is not versioned)

### 2. What does this change do, exactly?

The change removes the `CascadeDelete` flag for `captures` relation in `OrderTransaction`. The cascade delete will only happen using SQL table definition, while the version merge will not cause the removal of `OrderTransactionCapture` entities.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create an Order with OrderTransaction
2. Create an `OrderTransactionCapture` (currently, only via API, POST: `/api/order-transaction-capture`) linked to `OrderTransaction` from pt.1 above
3. Confirm the entity entry is visible in the database (`order_transaction_capture` table)
4. Edit and save the order created in pt.1 to trigger the version created + merge process (can be by adding a tracking code)
5. Check for the entity entry (as in pt.3) - there is no entity in the database anymore

### 4. Please link to the relevant issues (if any).

#3195

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ad324d</samp>

Removed `CascadeDelete` flag from `captures` field in `OrderTransactionDefinition.php` to prevent unwanted deletion of order transaction captures.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ad324d</samp>

* Remove the `CascadeDelete` flag from the `captures` association field in the `OrderTransactionDefinition` class ([link](https://github.com/shopware/platform/pull/3196/files?diff=unified&w=0#diff-ffd513a077dbe54b9349b77a701f894a105276d2ead0528544842cd2eb7359c4L75-R75)). This prevents the deletion of the order transaction captures when the order transaction is deleted, as they are needed for accounting and reporting purposes. 
