### PR TITLE
feat: set correct date format when comparing dates of documents in default language

### DIFF
--- a/changelog/_unreleased/2023-07-02-change-date-format-in-test.md
+++ b/changelog/_unreleased/2023-07-02-change-date-format-in-test.md
@@ -1,0 +1,12 @@
+---
+title: Change date-format in test
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Changed the date format in InvoiceRendererTest to fit the default language also on single digit days
+

--- a/tests/integration/php/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
+++ b/tests/integration/php/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
@@ -163,7 +163,7 @@ class InvoiceRendererTest extends TestCase
                 );
 
                 static::assertStringContainsString(
-                    sprintf('Date %s', (new \DateTime())->format('d M Y')),
+                    sprintf('Date %s', (new \DateTime())->format('j M Y')),
                     $rendered->getHtml()
                 );
             },


### PR DESCRIPTION
### 1. Why is this change necessary?
see https://github.com/shopware/platform/actions/runs/5436050681/jobs/9885622091

### 2. What does this change do, exactly?
Correct the format.

### 3. Describe each step to reproduce the issue or behaviour.
run test on days with one digit.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbee338</samp>

This pull request fixes a test failure in the `InvoiceRendererTest` by changing the date format to match the English locale. It also adds a changelog entry for this change in `changelog/_unreleased/2023-07-02-change-date-format-in-test.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at dbee338</samp>

* Add a changelog entry for changing the date format in the invoice data provider test ([link](https://github.com/shopware/platform/pull/3198/files?diff=unified&w=0#diff-13d7306291badb5ed387d2d8efc1744e02f3cb52cd84d9e487ddeadbcdc735ccR1-R12))
* Adjust the date format in the invoice data provider test to use the day without leading zero (`InvoiceRendererTest.php`, [link](https://github.com/shopware/platform/pull/3198/files?diff=unified&w=0#diff-10b509a6ea4202dd36f4cc95244fecbb0e7b5986238fa1bd302b78c129a6fcdeL166-R166))
