### PR TITLE
perf: Remove not needed complexity of local cache hash

### DIFF
--- a/changelog/_unreleased/2023-07-02-remove-not-needed-cache-hash-creation-for-cache-in-the-currencyformatter.md
+++ b/changelog/_unreleased/2023-07-02-remove-not-needed-cache-hash-creation-for-cache-in-the-currencyformatter.md
@@ -1,0 +1,9 @@
+---
+title: Remove not needed cache hash creation for cache in the CurrencyFormatter
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Removed not needed cache hash creation in the `Shopware\Core\System\Currency\CurrencyFormatter` for performance

--- a/changelog/_unreleased/2023-07-02-remove-not-needed-cache-hash-creation-for-cache-in-the-currencyformatter.md
+++ b/changelog/_unreleased/2023-07-02-remove-not-needed-cache-hash-creation-for-cache-in-the-currencyformatter.md
@@ -1,5 +1,5 @@
 ---
-title: Remove not needed cache hash creation for cache in the CurrencyFormatter
+title: Remove not needed cache hash creation for cache in the CurrencyFormatter and add cache reset
 issue: NEXT-0000
 author: Max
 author_email: max@swk-web.com
@@ -7,3 +7,4 @@ author_github: @aragon999
 ---
 # Core
 * Removed not needed cache hash creation in the `Shopware\Core\System\Currency\CurrencyFormatter` for performance
+* Added `reset` method to the `Shopware\Core\System\Currency\CurrencyFormatter` to reset the internal `NumberFormatter` cache on `kernel.reset`

--- a/src/Core/System/Currency/CurrencyFormatter.php
+++ b/src/Core/System/Currency/CurrencyFormatter.php
@@ -7,9 +7,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaI
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\Exception\LanguageNotFoundException;
 use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
+use Symfony\Contracts\Service\ResetInterface;
 
 #[Package('inventory')]
-class CurrencyFormatter
+class CurrencyFormatter implements ResetInterface
 {
     /**
      * @var \NumberFormatter[]
@@ -37,6 +38,11 @@ class CurrencyFormatter
         $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $decimals);
 
         return (string) $formatter->formatCurrency($price, $currency);
+    }
+
+    public function reset(): void
+    {
+        $this->formatter = [];
     }
 
     private function getFormatter(string $locale): \NumberFormatter

--- a/src/Core/System/Currency/CurrencyFormatter.php
+++ b/src/Core/System/Currency/CurrencyFormatter.php
@@ -31,21 +31,20 @@ class CurrencyFormatter
     {
         $decimals ??= $context->getRounding()->getDecimals();
 
-        $locale = $this->languageLocaleProvider->getLocaleForLanguageId($languageId);
-        $formatter = $this->getFormatter($locale, \NumberFormatter::CURRENCY);
+        $formatter = $this->getFormatter(
+            $this->languageLocaleProvider->getLocaleForLanguageId($languageId)
+        );
         $formatter->setAttribute(\NumberFormatter::FRACTION_DIGITS, $decimals);
 
         return (string) $formatter->formatCurrency($price, $currency);
     }
 
-    private function getFormatter(string $locale, int $format): \NumberFormatter
+    private function getFormatter(string $locale): \NumberFormatter
     {
-        $hash = md5(json_encode([$locale, $format], \JSON_THROW_ON_ERROR));
-
-        if (isset($this->formatter[$hash])) {
-            return $this->formatter[$hash];
+        if (isset($this->formatter[$locale])) {
+            return $this->formatter[$locale];
         }
 
-        return $this->formatter[$hash] = new \NumberFormatter($locale, $format);
+        return $this->formatter[$locale] = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
     }
 }

--- a/src/Core/System/DependencyInjection/currency.xml
+++ b/src/Core/System/DependencyInjection/currency.xml
@@ -35,6 +35,8 @@
 
         <service id="Shopware\Core\System\Currency\CurrencyFormatter" public="true">
             <argument type="service" id="Shopware\Core\System\Locale\LanguageLocaleCodeProvider"/>
+
+            <tag name="kernel.reset" method="reset"/>
         </service>
 
         <service id="Shopware\Core\System\Currency\SalesChannel\CurrencyRoute" public="true">


### PR DESCRIPTION
### 1. Why is this change necessary?
Performance.

### 2. What does this change do, exactly?
Remove unneeded cache hash creation, which consists of two function calls, `json_encode` and `md5`.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f586dd</samp>

This pull request improves the performance and readability of the `CurrencyFormatter` class by simplifying its cache logic and removing unnecessary arguments. It also adds a changelog entry for the change in `changelog/_unreleased/2023-07-02-remove-not-needed-cache-hash-creation-for-cache-in-the-currencyformatter.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f586dd</samp>

*  Simplify currency formatting by using locale and default format ([link](https://github.com/shopware/platform/pull/3199/files?diff=unified&w=0#diff-468417e4f65eb6c324bbc70a7b9d70216c247938b87940c92fc1198e70184b06L34-R36), [link](https://github.com/shopware/platform/pull/3199/files?diff=unified&w=0#diff-468417e4f65eb6c324bbc70a7b9d70216c247938b87940c92fc1198e70184b06L41-R48))
*  Remove unnecessary hash creation and caching logic for formatter ([link](https://github.com/shopware/platform/pull/3199/files?diff=unified&w=0#diff-468417e4f65eb6c324bbc70a7b9d70216c247938b87940c92fc1198e70184b06L41-R48))
