### PR TITLE
NEXT-28681 - Add third level menu entry support when no path is provided

### DIFF
--- a/changelog/_unreleased/2023-07-11-add-support-for-third-level-menu-entries-in-expanded-menu.md
+++ b/changelog/_unreleased/2023-07-11-add-support-for-third-level-menu-entries-in-expanded-menu.md
@@ -1,0 +1,11 @@
+---
+title: Add support for third level menu entries in expanded menu
+issue: NEXT-28681
+author: Cedric Engler
+author_email: cedric.engler@pickware.de
+author_github: @Ceddy610
+---
+# Administration
+* Added `currentExpandedMenuEntries` computed variable in `sw-admin-menu-item` component
+* Changed `onMenuItemClick` method in `sw-admin-menu` component to handle the `navigation-list-item__level-2` style property
+* Added the class property in `sw-admin-menu-item` template to handle the expanded sub menu items

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/index.js
@@ -91,6 +91,10 @@ Component.register('sw-admin-menu-item', {
             return false;
         },
 
+        expandedMenuEntries() {
+            return Shopware.State.get('adminMenu').expandedEntries;
+        },
+
         entryPath() {
             if (this.entry.path && this.hasAccessToRoute(this.entry.path)) {
                 return this.entry.path;

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/sw-admin-menu-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/sw-admin-menu-item.html.twig
@@ -162,6 +162,7 @@
             </li>
 
             <sw-admin-menu-item
+                :class="{ 'is--entry-expanded': expandedMenuEntries.includes(entry) }"
                 :key="getCustomKey(entry.id || entryPath)"
                 :entry="entry"
                 :border-color="borderColor"

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/sw-admin-menu-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/sw-admin-menu-item.spec.js
@@ -99,6 +99,7 @@ describe('src/app/component/structure/sw-admin-menu-item', () => {
     beforeEach(async () => {
         Shopware.State.get('settingsItems').settingsGroups.shop = [];
         Shopware.State.get('settingsItems').settingsGroups.system = [];
+        Shopware.State.get('adminMenu').expandedEntries = [];
     });
 
     it('should be a Vue.js component', async () => {
@@ -279,6 +280,55 @@ describe('src/app/component/structure/sw-admin-menu-item', () => {
 
         const navigationLink = wrapper.find('.sw-admin-menu__navigation-link');
         expect(navigationLink.element.tagName).toBe('SPAN');
+    });
+
+    it('should expand the sub menu entries when the parent is active', async () => {
+        const children = {
+            id: 'sw-product',
+            label: 'sw-product.general.mainMenuItemGeneral',
+            color: '#57D9A3',
+            path: 'sw.product.index',
+            icon: 'default-symbol-products',
+            parent: 'sw-catalogue',
+            position: 10,
+            level: 2,
+            moduleType: 'core',
+            children: [
+                {
+                    id: 'sw-review',
+                    label: 'sw-review.general.mainMenuItemList',
+                    color: '#57D9A3',
+                    path: 'sw.review.index',
+                    icon: 'default-symbol-products',
+                    parent: 'sw-catalogue',
+                    position: 20,
+                    level: 3,
+                    moduleType: 'core',
+                    children: [],
+                },
+            ],
+        };
+        Shopware.State.get('adminMenu').expandedEntries = [children];
+        const wrapper = await createWrapper({
+            privileges: [],
+            propsData: {
+                entry: {
+                    id: 'sw-catalogue',
+                    moduleType: 'core',
+                    label: 'global.sw-admin-menu.navigation.mainMenuItemCatalogue',
+                    color: '#57D9A3',
+                    icon: 'default-symbol-products',
+                    position: 20,
+                    level: 1,
+                    children: [children],
+                },
+            },
+        });
+
+        const subMenu = wrapper.find('.navigation-list-item__sw-product');
+        await wrapper.vm.$nextTick();
+
+        expect(subMenu.classes()).toContain('is--entry-expanded');
     });
 
     it('should show a link when the path goes to a route which needs a privilege which is set', async () => {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/index.js
@@ -424,6 +424,11 @@ The admin menu only supports up to three levels of nesting.`,
                 return;
             }
 
+            let parentEntry;
+            if (target.classList.contains('navigation-list-item__level-2')) {
+                parentEntry = entry.children.find((child) => target.classList.contains(child.id));
+            }
+
             const firstChild = target.firstChild;
             this.removeClassesFromElements(
                 Array.from(this.$el.querySelectorAll(
@@ -442,12 +447,19 @@ The admin menu only supports up to three levels of nesting.`,
             }
 
             if (isEntryExpanded) {
-                Shopware.State.commit('adminMenu/collapseMenuEntry', entry);
+                Shopware.State.commit(
+                    'adminMenu/collapseMenuEntry',
+                    parentEntry || entry,
+                );
 
                 firstChild.classList.remove('router-link-active');
-                firstChild.classList.remove('is--entry-expanded');
+                if (parentEntry) {
+                    target.classList.remove('is--entry-expanded');
+                } else {
+                    firstChild.classList.remove('is--entry-expanded');
+                }
             } else {
-                Shopware.State.commit('adminMenu/expandMenuEntry', entry);
+                Shopware.State.commit('adminMenu/expandMenuEntry', parentEntry || entry);
 
                 firstChild.classList.add('router-link-active');
                 target.classList.add('is--entry-expanded');
@@ -513,7 +525,10 @@ The admin menu only supports up to three levels of nesting.`,
                 return;
             }
 
-            target.classList.add('is--flyout-enabled');
+            if (!target.classList.contains('navigation-list-item__level-2')) {
+                target.classList.add('is--flyout-enabled');
+            }
+
             this.flyoutStyle = {
                 top: `${target.getBoundingClientRect().top - document.getElementById('app').getBoundingClientRect().top}px`,
             };

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.scss
@@ -56,8 +56,8 @@ $sw-admin-menu-active-text: $color-white;
 
     .collapsible-text {
         transition:
-            opacity $sw-admin-menu-transition,
-            transform $sw-admin-menu-transition;
+                opacity $sw-admin-menu-transition,
+                transform $sw-admin-menu-transition;
         transform: translateX(-50px);
         opacity: 0;
         display: inline-block;
@@ -569,8 +569,7 @@ $sw-admin-menu-active-text: $color-white;
         display: none;
     }
 
-    .navigation-list-item__level-2:hover,
-    .navigation-list-item__level-2.is--flyout-enabled {
+    .navigation-list-item__level-2:hover {
         & > .sw-admin-menu__navigation-link {
             background: $sw-admin-menu-background-hover;
 
@@ -578,6 +577,9 @@ $sw-admin-menu-active-text: $color-white;
                 color: $sw-admin-menu-active-text;
             }
         }
+    }
+
+    .navigation-list-item__level-2.is--flyout-enabled {
 
         .sw-admin-menu__sub-navigation-list {
             display: block;
@@ -596,6 +598,26 @@ $sw-admin-menu-active-text: $color-white;
 
             .sw-admin-menu__navigation-link {
                 padding: 12px 30px;
+            }
+        }
+    }
+
+    .navigation-list-item__level-2.is--entry-expanded {
+        .sw-admin-menu__sub-navigation-list {
+            top: 0;
+            left: 100%;
+            background: $sw-admin-menu-background;
+
+            .sw-admin-menu__navigation-list-item {
+                display: block;
+
+                &:hover {
+                    background: $sw-admin-menu-background-hover;
+                }
+            }
+
+            .navigation-list-item__level-3 .sw-admin-menu__navigation-link {
+                padding-left: 72px;
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
If you have third level menu entries under a second level menu entry, which does not have a path, the component does not render the menu entries as expected.

### 2. What does this change do, exactly?
This change adds some minor changes in the handling of third level entries in the `sw-admin-menu` and `sw-admin-menu-item` component, as well as some styling changes, so that the third level entries are rendered properly in the expanded menu.

### 3. Describe each step to reproduce the issue or behaviour.

- Create a new module with new menu entry, which doesn't have a path, and has a parent (e.g. `sw-extensions`)
- Add some new entries, with parent of the entry created above
- Expand the new menu entry

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-28681

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 058ba65</samp>

This pull request adds support for third-level menu entries in the expanded admin menu. It modifies the `sw-admin-menu-item` component and its test, style and template files to implement the sub menu expansion logic and appearance. It also updates the `sw-admin-menu` component and style file to handle the sub menu interactions and prevent flyout menu conflicts. It documents the change in the changelog folder.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 058ba65</samp>

*  Add support for third level menu entries in expanded menu mode ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-3515bff455efd9162a1c9972c8335e06d3d7877acd9772f5ee3d75d6568a5da6R1-R11))
*  Add a computed variable `expandedMenuEntries` to return the state of the expanded sub menu entries from the `adminMenu` module ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-015ac2f87423fa4f7eb85d442d5eca337d347831a368450da1c9cb261b5d834dR94-R97))
*  Bind the `is--entry-expanded` class to the sub menu items that are expanded according to the `expandedMenuEntries` variable ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-988190e7a0c3dcf58700b3e4ec3b4d677cf39eb53a982544349937a7336aecd5R165))
*  Add a conditional statement to assign the `parentEntry` variable to the sub menu entry that matches the target element's class if it is a second level menu item ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-cf9dbb62c9f46d3c38815d05cce120d06a63641c4c603cc9ca0738ac11c9e4ceR427-R431))
*  Use the `parentEntry` variable instead of the `entry` variable to commit the `expandMenuEntry` or `collapseMenuEntry` mutations to the `adminMenu` module ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-cf9dbb62c9f46d3c38815d05cce120d06a63641c4c603cc9ca0738ac11c9e4ceL445-R462))
*  Add or remove the `is--entry-expanded` class to the target element if it is a sub menu entry ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-cf9dbb62c9f46d3c38815d05cce120d06a63641c4c603cc9ca0738ac11c9e4ceL445-R462))
*  Prevent adding the `is--flyout-enabled` class to the target element if it is a second level menu item ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-cf9dbb62c9f46d3c38815d05cce120d06a63641c4c603cc9ca0738ac11c9e4ceL516-R531))
*  Remove the `.navigation-list-item__level-2.is--flyout-enabled` selector from the style file, as it is no longer needed ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-7a019751e212859eedf57f4b15153ce0e0d6072de7b0a21d55cede0817565b85L572-R572))
*  Add a new selector `.navigation-list-item__level-2.is--flyout-enabled` to the style file that sets the display property of the sub navigation list to block ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-7a019751e212859eedf57f4b15153ce0e0d6072de7b0a21d55cede0817565b85L581-R583))
*  Add a new selector `.navigation-list-item__level-2.is--entry-expanded` to the style file that styles the sub navigation list of the expanded sub menu entries ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-7a019751e212859eedf57f4b15153ce0e0d6072de7b0a21d55cede0817565b85R604-R623))
*  Fix the indentation of the `transition` property in the `.collapsible-text` class in the style file ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-7a019751e212859eedf57f4b15153ce0e0d6072de7b0a21d55cede0817565b85L59-R60))
*  Add a blank line at the end of the `sw-admin-menu` component file ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-cf9dbb62c9f46d3c38815d05cce120d06a63641c4c603cc9ca0738ac11c9e4ceL719-L718))
*  Initialize the `expandedEntries` state to an empty array in the component test file ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-4c423c7f3eb057a87afe2628cc4d005cfb3c07a5c9619ef39906d77e6ab3dd1aR102))
*  Add a test case to check if the sub menu entries are expanded when the parent entry is active and in the `expandedEntries` state ([link](https://github.com/shopware/platform/pull/3208/files?diff=unified&w=0#diff-4c423c7f3eb057a87afe2628cc4d005cfb3c07a5c9619ef39906d77e6ab3dd1aR285-R333))
