### PR TITLE
Feature - add active from to tax rule

### DIFF
--- a/src/Core/Migration/V6_5/Migration1688927492AddTaxActiveFromField.php
+++ b/src/Core/Migration/V6_5/Migration1688927492AddTaxActiveFromField.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_5;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1688927492AddTaxActiveFromField extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1688927492;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('ALTER TABLE `tax_rule` ADD `active_from` DATETIME(3) NULL AFTER `data`;');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/System/SalesChannel/SalesChannelContext.php
+++ b/src/Core/System/SalesChannel/SalesChannelContext.php
@@ -152,13 +152,12 @@ class SalesChannelContext extends Struct
             throw new TaxNotFoundException($taxId);
         }
 
-        if ($tax->getRules()->first() !== null) {
-            // NEXT-21735 - This is covered randomly
-            // @codeCoverageIgnoreStart
+        $newestTaxRule = $tax->getRules()->newestTaxRule();
+
+        if ($newestTaxRule !== null) {
             return new TaxRuleCollection([
-                new TaxRule($tax->getRules()->first()->getTaxRate(), 100),
+                new TaxRule($newestTaxRule->getTaxRate(), 100),
             ]);
-            // @codeCoverageIgnoreEnd
         }
 
         return new TaxRuleCollection([

--- a/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php
+++ b/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php
@@ -16,6 +16,11 @@ class TaxRuleCollection extends EntityCollection
         $this->sort(fn (TaxRuleEntity $entityA, TaxRuleEntity $entityB) => $entityA->getType()->getPosition() <=> $entityB->getType()->getPosition());
     }
 
+    public function newestTaxRule(): ?TaxRuleEntity
+    {
+        return $this->reduce(fn ($result, $item) => $result === null || $item->getActiveFrom() > $result->getActiveFrom() ? $item : $result);
+    }
+
     public function getApiAlias(): string
     {
         return 'tax_rule_collection';

--- a/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleDefinition.php
+++ b/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleDefinition.php
@@ -3,7 +3,9 @@
 namespace Shopware\Core\System\Tax\Aggregate\TaxRule;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
@@ -62,6 +64,7 @@ class TaxRuleDefinition extends EntityDefinition
                 new StringField('toZipCode', 'toZipCode'),
             ]),
             (new FkField('tax_id', 'taxId', TaxDefinition::class))->addFlags(new Required()),
+            (new DateTimeField('active_from', 'activeFrom'))->addFlags(new ApiAware()),
             new ManyToOneAssociationField('type', 'tax_rule_type_id', TaxRuleTypeDefinition::class, 'id', $autoload),
             new ManyToOneAssociationField('country', 'country_id', CountryDefinition::class, 'id'),
             new ManyToOneAssociationField('tax', 'tax_id', TaxDefinition::class, 'id'),

--- a/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
+++ b/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
@@ -54,6 +54,11 @@ class TaxRuleEntity extends Entity
      */
     protected $data;
 
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $activeFrom;
+
     public function getTaxId(): string
     {
         return $this->taxId;
@@ -135,5 +140,15 @@ class TaxRuleEntity extends Entity
     public function setData(?array $data): void
     {
         $this->data = $data;
+    }
+
+    public function getActiveFrom(): ?\DateTimeInterface
+    {
+        return $this->activeFrom;
+    }
+
+    public function setActiveFrom(?\DateTimeInterface $activeFrom): void
+    {
+        $this->activeFrom = $activeFrom;
     }
 }

--- a/src/Core/System/Tax/TaxRuleType/AbstractTaxRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/AbstractTaxRuleTypeFilter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\System\Tax\TaxRuleType;
+
+use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
+
+abstract class AbstractTaxRuleTypeFilter implements TaxRuleTypeFilterInterface
+{
+    protected function isTaxActive(TaxRuleEntity $taxRuleEntity): bool
+    {
+        return $taxRuleEntity->getActiveFrom() > (new \DateTime())->setTimezone(new \DateTimeZone('UTC'));
+    }
+}

--- a/src/Core/System/Tax/TaxRuleType/EntireCountryRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/EntireCountryRuleTypeFilter.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
 
 #[Package('customer-order')]
-class EntireCountryRuleTypeFilter implements TaxRuleTypeFilterInterface
+class EntireCountryRuleTypeFilter extends AbstractTaxRuleTypeFilter
 {
     final public const TECHNICAL_NAME = 'entire_country';
 
@@ -18,6 +18,10 @@ class EntireCountryRuleTypeFilter implements TaxRuleTypeFilterInterface
             || !$this->metPreconditions($taxRuleEntity, $shippingLocation)
         ) {
             return false;
+        }
+
+        if($taxRuleEntity->getActiveFrom() !== null ) {
+            return $this->isTaxActive($taxRuleEntity);
         }
 
         return true;

--- a/src/Core/System/Tax/TaxRuleType/IndividualStatesRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/IndividualStatesRuleTypeFilter.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
 
 #[Package('customer-order')]
-class IndividualStatesRuleTypeFilter implements TaxRuleTypeFilterInterface
+class IndividualStatesRuleTypeFilter extends AbstractTaxRuleTypeFilter
 {
     final public const TECHNICAL_NAME = 'individual_states';
 
@@ -25,6 +25,10 @@ class IndividualStatesRuleTypeFilter implements TaxRuleTypeFilterInterface
 
         if (!\in_array($stateId, $states, true)) {
             return false;
+        }
+
+        if($taxRuleEntity->getActiveFrom() !== null ) {
+            return $this->isTaxActive($taxRuleEntity);
         }
 
         return true;

--- a/src/Core/System/Tax/TaxRuleType/ZipCodeRangeRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/ZipCodeRangeRuleTypeFilter.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
 
 #[Package('customer-order')]
-class ZipCodeRangeRuleTypeFilter implements TaxRuleTypeFilterInterface
+class ZipCodeRangeRuleTypeFilter extends AbstractTaxRuleTypeFilter
 {
     final public const TECHNICAL_NAME = 'zip_code_range';
 
@@ -27,6 +27,10 @@ class ZipCodeRangeRuleTypeFilter implements TaxRuleTypeFilterInterface
 
         if ($fromZipCode === null || $toZipCode === null || $zipCode < $fromZipCode || $zipCode > $toZipCode) {
             return false;
+        }
+
+        if($taxRuleEntity->getActiveFrom() !== null ) {
+            return $this->isTaxActive($taxRuleEntity);
         }
 
         return true;

--- a/src/Core/System/Tax/TaxRuleType/ZipCodeRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/ZipCodeRuleTypeFilter.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
 
 #[Package('customer-order')]
-class ZipCodeRuleTypeFilter implements TaxRuleTypeFilterInterface
+class ZipCodeRuleTypeFilter extends AbstractTaxRuleTypeFilter
 {
     final public const TECHNICAL_NAME = 'zip_code';
 
@@ -26,6 +26,10 @@ class ZipCodeRuleTypeFilter implements TaxRuleTypeFilterInterface
 
         if ($shippingZipCode !== $zipCode) {
             return false;
+        }
+
+        if($taxRuleEntity->getActiveFrom() !== null ) {
+            return $this->isTaxActive($taxRuleEntity);
         }
 
         return true;


### PR DESCRIPTION
### 1. Why is this change necessary?

We currently have no way to manage the tax activity date. We cannot schedule a specific day for tax implementation. Sometimes the tax rate changes. In addition, such a date will allow us to "recalculate" the tax backwards (if a tax change was introduced and we did not know about it). This change is useful for large stores selling in multiple countries, so they need more tax management.

### 2. What does this change do, exactly?

My change adds a new date time field to the tax rule. We can set the date of its activation. It is stored in UTC format. The admin can set this date in the panel when creating a tax rule. In SalesChannelContext, the latest tax activity date is always selected from all the rules that meet the criteria.

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 30a08e3</samp>

This pull request adds a new feature to the `tax_rule` entity and its related classes, which allows specifying a date from which a tax rule becomes active. This feature improves the tax calculation logic and enables more flexible tax configuration. The pull request also adds a new migration class, a new method to the `TaxRuleCollection` class, and a new abstract class for tax rule type filters. It also updates the existing tax rule type filter classes and the `SalesChannelContext` class to use the new feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 30a08e3</samp>

*  Add a new `active_from` field to the `tax_rule` table and entity to indicate when a tax rule becomes active ([link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-2a0604e327822be0674f91b72768fa1435f05b0c3f279262551e8d8cb5881e01R1-R23), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-2ae7f19f238e89bf16fad51ac02b3722c0848fd38e1521ba8656e2e758e6ef3cL6-R8), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-2ae7f19f238e89bf16fad51ac02b3722c0848fd38e1521ba8656e2e758e6ef3cR67), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-eb4d19eb50cd71decc5d2bed7761000878e7150dcd8f7807827660e9075b96e4R57-R61), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-eb4d19eb50cd71decc5d2bed7761000878e7150dcd8f7807827660e9075b96e4R144-R153))
*  Add a new abstract class `AbstractTaxRuleTypeFilter` that provides a common method `isTaxActive` to check the validity of a tax rule based on the `active_from` field ([link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-b4bd1e51f09a46ed83232b0ad4645c7ee48b3cb6b6425b6ae774e51b89e02251R1-R15))
*  Modify the existing tax rule type filter classes (`EntireCountryRuleTypeFilter`, `IndividualStatesRuleTypeFilter`, `ZipCodeRangeRuleTypeFilter`, `ZipCodeRuleTypeFilter`) to extend the abstract class and use the `isTaxActive` method in their `match` methods ([link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-1b2db26d9e65fdcd7dcac5dcfa8ba556b1f175d3735ef8a4cf04c65a068bc9ffL11-R11), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-1b2db26d9e65fdcd7dcac5dcfa8ba556b1f175d3735ef8a4cf04c65a068bc9ffR23-R26), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-32db726c08f416d8010e1cfd120097d15acb27994ba617cda189d12da08d9556L11-R11), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-32db726c08f416d8010e1cfd120097d15acb27994ba617cda189d12da08d9556R30-R33), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-cb0a161d4525d7f27bf6e800d7d81028de425bfc260072b7102efe13250f9284L11-R11), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-cb0a161d4525d7f27bf6e800d7d81028de425bfc260072b7102efe13250f9284R32-R35), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-b7a7830823aacf568e664026fc09b88ddcb354582a70603df417f4b7f24e045dL11-R11), [link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-b7a7830823aacf568e664026fc09b88ddcb354582a70603df417f4b7f24e045dR31-R34))
*  Modify the `buildTaxRules` method in the `SalesChannelContext` class to use the `newestTaxRule` method of the `TaxRuleCollection` class instead of the first tax rule of a tax entity ([link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-065408d9c1f3d25bc250a96e8147cd7c935afe2e77bf92b2ce9c5a7dcedb746cL155-R160))
*  Add a new method `newestTaxRule` to the `TaxRuleCollection` class that returns the tax rule with the latest `active_from` value or null if the collection is empty ([link](https://github.com/shopware/platform/pull/3209/files?diff=unified&w=0#diff-b5ae77baa27247904d0965be10a433d2d71e1c610465960129beb686da33794bR19-R23))
