### PR TITLE
Update UPGRADE-6.5.md

### DIFF
--- a/UPGRADE-6.5.md
+++ b/UPGRADE-6.5.md
@@ -68,6 +68,10 @@ This change allows importing medias with filenames that contain special characte
 
 # 6.5.2.0
 The `context` property is used instead of `contextData` property in `src/Core/Content/Media/Message/GenerateThumbnailsMessage` due to the `context` data is serialized in context source
+
+## Update to Symfony 6.3
+Shopware now uses Symfony version 6.3, please make sure your plugins are compatible.
+
 ## Introduce BeforeLoadStorableFlowDataEvent
 The event is dispatched before the flow storer restores the data, so you can customize the criteria before passing it to the entity repository
 


### PR DESCRIPTION
Shopware 6.5.2 uses Symfony 6.3. Would be a nice addition in the upgrade doc.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Would be nice to notify readers that Shopware uses Symfony 6.3 since Shopware 6.5.2.0. 

### 2. What does this change do, exactly?
Notify readers of Symfony 6.3 since Shopware 6.5.2.0

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8aad0f9</samp>

Update upgrade guide for Shopware 6.5 with Symfony 6.3 compatibility notes. This change helps developers to prepare their plugins for the new Symfony version.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8aad0f9</samp>

* Upgrade Shopware to use Symfony 6.3 and add a notice to the upgrade guide ([link](https://github.com/shopware/platform/pull/3210/files?diff=unified&w=0#diff-a3dc7b1dedf6c20afb757b753352e9ac3d87e2a63c54f8af85347657798d1f64R71-R74))
