### PR TITLE
Adjust sync path json

### DIFF
--- a/changelog/_unreleased/2023-07-11-fix-sync-api-json.md
+++ b/changelog/_unreleased/2023-07-11-fix-sync-api-json.md
@@ -1,0 +1,9 @@
+---
+title: Remove info about single-transaction header
+issue: 
+author: Micha Hobert
+author_email: m.hobert@shopware.com
+author_github: Isengo1989
+---
+# Core
+* Removed info about the single transaction header and insert and update (sync api can only perform upsert and delete)

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sync.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sync.json
@@ -8,7 +8,7 @@
                     "Bulk Operations"
                 ],
                 "summary": "Bulk edit entities",
-                "description": "Starts a sync process for the list of provided actions. This can be inserts, upserts, updates and deletes on different entities. to an asynchronous process in the background. You can control the behaviour with the `single-operation` and `indexing-behavior` header.",
+                "description": "Starts a sync process for the list of provided actions. This can be upserts and deletes on different entities to an asynchronous process in the background. You can control the behaviour with the `indexing-behavior` header.",
                 "operationId": "sync",
                 "parameters": [
                     {
@@ -18,15 +18,6 @@
                         "schema": {
                             "type": "boolean",
                             "default": true
-                        }
-                    },
-                    {
-                        "name": "single-operation",
-                        "in": "header",
-                        "description": "Controls weather the data is written at once or in seperate transactions.\n    - `true`: Data will be written in a single transaction",
-                        "schema": {
-                            "type": "boolean",
-                            "default": false
                         }
                     },
                     {


### PR DESCRIPTION
### 1. Why is this change necessary?
Single transaction header was removed recently

### 2. What does this change do, exactly?
Remove that info in the sync.json and also remove **insert** and **update** since the sync API can only perform upsert and delete.

### 3. Describe each step to reproduce the issue or behaviour.
-


### 4. Please link to the relevant issues (if any).
-


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffa359c</samp>

This pull request fixes the Admin API schema for the `sync` endpoint, making it consistent with the actual implementation and documentation. It also adds a changelog entry for the fix in `changelog/_unreleased/2023-07-11-fix-sync-api-json.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ffa359c</samp>

* Update the sync endpoint in the Admin API schema to reflect the actual functionality and limitations of the sync API ([link](https://github.com/shopware/platform/pull/3211/files?diff=unified&w=0#diff-afd3d145035448113ea8ec4a9f8ddf0f61db677589ae93ba540dabbeb52a9c78L11-R11), [link](https://github.com/shopware/platform/pull/3211/files?diff=unified&w=0#diff-afd3d145035448113ea8ec4a9f8ddf0f61db677589ae93ba540dabbeb52a9c78L24-L32))
* Add a changelog entry for the sync API fix in `changelog/_unreleased/2023-07-11-fix-sync-api-json.md` ([link](https://github.com/shopware/platform/pull/3211/files?diff=unified&w=0#diff-9ee2b2bb59ac8c3406fa24c63e9de4abfc5dd69f4976a6a4077940deb7b33ee2R1-R9))
