### PR TITLE
NEXT-00000 - add active from to tax rule

### DIFF
--- a/changelog/_unreleased/2023-07-13-add-active-from-to-tax-rule.md
+++ b/changelog/_unreleased/2023-07-13-add-active-from-to-tax-rule.md
@@ -1,0 +1,21 @@
+---
+title: Add active from to tax rule
+issue: NEXT-00000
+---
+# Core
+
+* The biggest change is in `src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php` file.
+  First, I check which rule has the highest (lowest) position. If there are 2 records with the same position, then the date is checked and the newer one is selected.
+* Add active_from datetime column in tax_rule table `src/Core/Migration/V6_5/Migration1688927492AddTaxActiveFromField.php`
+* Add function `filterByTypePosition` in `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php`
+* Add function `highestTypePosition` in `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php`
+* Add function `latestActivationDate` in `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php`
+* Add activeFrom in TaxRule definition `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleDefinition.php`
+* Add activeFrom in TaxRule entity `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php`
+* Add `AbstractTaxRuleTypeFilter` implementing `TaxRuleTypeFilterInterface`, because all filters has activeFrom matching
+* Add activeFrom matching in filers: `EntireCountryRuleTypeFilter`, `IndividualStatesRuleTypeFilter`, `ZipCodeRangeRuleTypeFilter`, `ZipCodeRuleTypeFilter`
+
+# Administration
+* Add field to add activeFrom date time `src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-rule-modal/sw-settings-tax-rule-modal.html.twig`
+* Add activeFrom to data grid `src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/index.js`
+* Display activeFrom in tax rules list `src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/index.js`

--- a/changelog/_unreleased/2023-07-13-add-active-from-to-tax-rule.md
+++ b/changelog/_unreleased/2023-07-13-add-active-from-to-tax-rule.md
@@ -3,19 +3,20 @@ title: Add active from to tax rule
 issue: NEXT-00000
 ---
 # Core
-
-* The biggest change is in `src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php` file.
+* Changed in `src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php` file.
   First, I check which rule has the highest (lowest) position. If there are 2 records with the same position, then the date is checked and the newer one is selected.
-* Add active_from datetime column in tax_rule table `src/Core/Migration/V6_5/Migration1688927492AddTaxActiveFromField.php`
-* Add function `filterByTypePosition` in `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php`
-* Add function `highestTypePosition` in `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php`
-* Add function `latestActivationDate` in `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php`
-* Add activeFrom in TaxRule definition `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleDefinition.php`
-* Add activeFrom in TaxRule entity `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php`
-* Add `AbstractTaxRuleTypeFilter` implementing `TaxRuleTypeFilterInterface`, because all filters has activeFrom matching
-* Add activeFrom matching in filers: `EntireCountryRuleTypeFilter`, `IndividualStatesRuleTypeFilter`, `ZipCodeRangeRuleTypeFilter`, `ZipCodeRuleTypeFilter`
+* Added active_from datetime column in tax_rule table `src/Core/Migration/V6_5/Migration1688927492AddTaxActiveFromField.php`
+* Added function `filterByTypePosition` in `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php`
+* Added function `highestTypePosition` in `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php`
+* Added function `latestActivationDate` in `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php`
+* Added activeFrom in TaxRule definition `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleDefinition.php`
+* Added activeFrom in TaxRule entity `src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php`
+* Added `AbstractTaxRuleTypeFilter` implementing `TaxRuleTypeFilterInterface`, because all filters has activeFrom matching
+* Added activeFrom matching in filers: `EntireCountryRuleTypeFilter`, `IndividualStatesRuleTypeFilter`, `ZipCodeRangeRuleTypeFilter`, `ZipCodeRuleTypeFilter`
+
+___
 
 # Administration
-* Add field to add activeFrom date time `src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-rule-modal/sw-settings-tax-rule-modal.html.twig`
-* Add activeFrom to data grid `src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/index.js`
-* Display activeFrom in tax rules list `src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/index.js`
+* Added field to add activeFrom date time `src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-rule-modal/sw-settings-tax-rule-modal.html.twig`
+* Added activeFrom to data grid `src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/index.js`
+* Added activeFrom in tax rules list `src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-base/sw-category-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-base/sw-category-detail-base.html.twig
@@ -42,11 +42,14 @@
         {% block sw_category_detail_information_tags %}
         <sw-entity-tag-select
             v-if="category && !isLoading"
-            {% if VUE3 %}
+            {% if VUE3 %
+}
             v-model:entityCollection="category.tags"
-            {% else %}
+            {% else %
+}
             v-model="category.tags"
-            {% endif %}
+            {% endif %
+}
             class="sw-category-detail-base__tags"
             :label="$tc('sw-category.base.general.labelCategoryTags')"
             :placeholder="$tc('sw-category.base.general.labelCategoryTagsPlaceholder')"

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-base/sw-category-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-base/sw-category-detail-base.html.twig
@@ -42,14 +42,11 @@
         {% block sw_category_detail_information_tags %}
         <sw-entity-tag-select
             v-if="category && !isLoading"
-            {% if VUE3 %
-}
+            {% if VUE3 %}
             v-model:entityCollection="category.tags"
-            {% else %
-}
+            {% else %}
             v-model="category.tags"
-            {% endif %
-}
+            {% endif %}
             class="sw-category-detail-base__tags"
             :label="$tc('sw-category.base.general.labelCategoryTags')"
             :placeholder="$tc('sw-category.base.general.labelCategoryTagsPlaceholder')"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-rule-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-rule-modal/index.js
@@ -61,7 +61,7 @@ export default {
             return criteria;
         },
 
-        ...mapPropertyErrors('taxRule', ['taxRuleTypeId', 'countryId', 'taxRate']),
+        ...mapPropertyErrors('taxRule', ['taxRuleTypeId', 'countryId', 'taxRate', 'activeFrom']),
     },
 
     created() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-rule-modal/sw-settings-tax-rule-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-rule-modal/sw-settings-tax-rule-modal.html.twig
@@ -72,6 +72,16 @@
             </template>
         </sw-number-field>
         {% endblock %}
+
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_settings_tax_rule_modal_tax_active_from %}
+            <sw-datepicker
+                v-model="taxRule.activeFrom"
+                date-type="datetime"
+                :error="taxRuleActiveFromError"
+                :label="$tc('sw-settings-tax.taxRuleCard.labelActiveFrom')"
+            />
+        {% endblock %}
     </sw-container>
     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-rule-modal/sw-settings-tax-rule-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-rule-modal/sw-settings-tax-rule-modal.spec.js
@@ -20,6 +20,7 @@ async function createWrapper() {
             'sw-container': true,
             'sw-entity-single-select': true,
             'sw-number-field': true,
+            'sw-datepicker': true,
         },
         provide: {
             shortcutService: {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/index.js
@@ -97,6 +97,10 @@ export default {
                 dataIndex: 'type.typeName',
                 label: 'sw-settings-tax.taxRuleCard.labelAppliesOn',
             }, {
+                property: 'activeFrom',
+                dataIndex: 'activeFrom',
+                label: 'sw-settings-tax.taxRuleCard.labelActiveFrom',
+            }, {
                 property: 'taxRate',
                 dataIndex: 'taxRate',
                 label: 'sw-settings-tax.taxRuleCard.labelTaxRate',

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/sw-tax-rule-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-tax-rule-card/sw-tax-rule-card.html.twig
@@ -104,6 +104,19 @@
                 {% endblock %}
 
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                {% block sw_settings_tax_rule_grid_column_tax_rule_active_from %}
+                    <template #column-activeFrom="{ item }">
+                        {{ item.activeFrom | date({
+                            hour: '2-digit',
+                            minute: '2-digit',
+                            day: '2-digit',
+                            month: '2-digit',
+                            year: 'numeric'
+                        }) }}
+                    </template>
+                {% endblock %}
+
+                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_settings_tax_list_grid_columns_actions %}
                 <template #actions="{ item }">
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/snippet/de-DE.json
@@ -78,7 +78,8 @@
       "cardTitleAvailability": "Verfügbarkeit",
       "labelPriority": "Priorität",
       "labelActive": "Aktiv",
-      "placeholderAvailabilityRule": "Verfügbarkeitsregel auswählen ..."
+      "placeholderAvailabilityRule": "Verfügbarkeitsregel auswählen ...",
+      "labelActiveFrom": "Aktiv von"
     }
   },
   "sw-privileges": {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/snippet/de-DE.json
@@ -68,7 +68,8 @@
       "emptyStateDescription": "Füge Steuerraten für verschiedene Länder hinzu.",
       "createStateDescription": "Speichere zuerst den Steuersatz, um weitere Länder hinzufügen zu können.",
       "textDeleteConfirm": "Bist Du Dir sicher, dass Du das Land \"{name}\" löschen möchtest?",
-      "placeholderStates": "Staaten hinzufügen"
+      "placeholderStates": "Staaten hinzufügen",
+      "labelActiveFrom": "Aktiv von"
     },
     "taxProviderDetail": {
       "textHeadline": "Steueranbieter",
@@ -78,8 +79,7 @@
       "cardTitleAvailability": "Verfügbarkeit",
       "labelPriority": "Priorität",
       "labelActive": "Aktiv",
-      "placeholderAvailabilityRule": "Verfügbarkeitsregel auswählen ...",
-      "labelActiveFrom": "Aktiv von"
+      "placeholderAvailabilityRule": "Verfügbarkeitsregel auswählen ..."
     }
   },
   "sw-privileges": {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/snippet/en-GB.json
@@ -68,7 +68,8 @@
       "emptyStateDescription": "Add individual tax rates for different countries.",
       "createStateDescription": "Save this tax rate first, then add more countries.",
       "textDeleteConfirm": "Are you sure you want to delete this country: \"{name}\"?",
-      "placeholderStates": "Add states..."
+      "placeholderStates": "Add states...",
+      "labelActiveFrom": "Active from"
     },
     "taxProviderDetail": {
       "textHeadline": "Tax provider",

--- a/src/Core/Migration/V6_5/Migration1688927492AddTaxActiveFromField.php
+++ b/src/Core/Migration/V6_5/Migration1688927492AddTaxActiveFromField.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_5;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1688927492AddTaxActiveFromField extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1688927492;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('ALTER TABLE `tax_rule` ADD `active_from` DATETIME(3) NULL AFTER `data`;');
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextFactory.php
@@ -152,10 +152,19 @@ class SalesChannelContextFactory extends AbstractSalesChannelContextFactory
 
                 return false;
             });
-            $taxRules->sortByTypePosition();
-            $taxRule = $taxRules->first();
 
             $matchingRules = new TaxRuleCollection();
+            $taxRule = $taxRules->highestTypePosition();
+
+            if (!$taxRule) {
+                $tax->setRules($matchingRules);
+
+                continue;
+            }
+
+            $taxRules = $taxRules->filterByTypePosition($taxRule->getType()->getPosition());
+            $taxRule = $taxRules->latestActivationDate();
+
             if ($taxRule) {
                 $matchingRules->add($taxRule);
             }

--- a/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php
+++ b/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleCollection.php
@@ -16,6 +16,21 @@ class TaxRuleCollection extends EntityCollection
         $this->sort(fn (TaxRuleEntity $entityA, TaxRuleEntity $entityB) => $entityA->getType()->getPosition() <=> $entityB->getType()->getPosition());
     }
 
+    public function filterByTypePosition(int $position): TaxRuleCollection
+    {
+        return $this->filter(fn (TaxRuleEntity $taxRule) => $taxRule->getType()->getPosition() === $position);
+    }
+
+    public function highestTypePosition(): ?TaxRuleEntity
+    {
+        return $this->reduce(fn (?TaxRuleEntity $result, TaxRuleEntity $item) => $result === null || $item->getType()->getPosition() < $result->getType()->getPosition() ? $item : $result);
+    }
+
+    public function latestActivationDate(): ?TaxRuleEntity
+    {
+        return $this->reduce(fn (?TaxRuleEntity $result, TaxRuleEntity $item) => $result === null || $item->getActiveFrom() > $result->getActiveFrom() ? $item : $result);
+    }
+
     public function getApiAlias(): string
     {
         return 'tax_rule_collection';

--- a/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleDefinition.php
+++ b/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleDefinition.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\System\Tax\Aggregate\TaxRule;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
@@ -62,6 +63,7 @@ class TaxRuleDefinition extends EntityDefinition
                 new StringField('toZipCode', 'toZipCode'),
             ]),
             (new FkField('tax_id', 'taxId', TaxDefinition::class))->addFlags(new Required()),
+            new DateTimeField('active_from', 'activeFrom'),
             new ManyToOneAssociationField('type', 'tax_rule_type_id', TaxRuleTypeDefinition::class, 'id', $autoload),
             new ManyToOneAssociationField('country', 'country_id', CountryDefinition::class, 'id'),
             new ManyToOneAssociationField('tax', 'tax_id', TaxDefinition::class, 'id'),

--- a/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
+++ b/src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
@@ -54,6 +54,11 @@ class TaxRuleEntity extends Entity
      */
     protected $data;
 
+    /**
+     * @var \DateTimeInterface|null
+     */
+    protected $activeFrom;
+
     public function getTaxId(): string
     {
         return $this->taxId;
@@ -135,5 +140,15 @@ class TaxRuleEntity extends Entity
     public function setData(?array $data): void
     {
         $this->data = $data;
+    }
+
+    public function getActiveFrom(): ?\DateTimeInterface
+    {
+        return $this->activeFrom;
+    }
+
+    public function setActiveFrom(?\DateTimeInterface $activeFrom): void
+    {
+        $this->activeFrom = $activeFrom;
     }
 }

--- a/src/Core/System/Tax/TaxRuleType/AbstractTaxRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/AbstractTaxRuleTypeFilter.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\System\Tax\TaxRuleType;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
+
+#[Package('customer-order')]
+abstract class AbstractTaxRuleTypeFilter implements TaxRuleTypeFilterInterface
+{
+    protected function isTaxActive(TaxRuleEntity $taxRuleEntity): bool
+    {
+        return $taxRuleEntity->getActiveFrom() < (new \DateTime())->setTimezone(new \DateTimeZone('UTC'));
+    }
+}

--- a/src/Core/System/Tax/TaxRuleType/EntireCountryRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/EntireCountryRuleTypeFilter.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
 
 #[Package('customer-order')]
-class EntireCountryRuleTypeFilter implements TaxRuleTypeFilterInterface
+class EntireCountryRuleTypeFilter extends AbstractTaxRuleTypeFilter
 {
     final public const TECHNICAL_NAME = 'entire_country';
 
@@ -18,6 +18,10 @@ class EntireCountryRuleTypeFilter implements TaxRuleTypeFilterInterface
             || !$this->metPreconditions($taxRuleEntity, $shippingLocation)
         ) {
             return false;
+        }
+
+        if ($taxRuleEntity->getActiveFrom() !== null) {
+            return $this->isTaxActive($taxRuleEntity);
         }
 
         return true;

--- a/src/Core/System/Tax/TaxRuleType/IndividualStatesRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/IndividualStatesRuleTypeFilter.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
 
 #[Package('customer-order')]
-class IndividualStatesRuleTypeFilter implements TaxRuleTypeFilterInterface
+class IndividualStatesRuleTypeFilter extends AbstractTaxRuleTypeFilter
 {
     final public const TECHNICAL_NAME = 'individual_states';
 
@@ -25,6 +25,10 @@ class IndividualStatesRuleTypeFilter implements TaxRuleTypeFilterInterface
 
         if (!\in_array($stateId, $states, true)) {
             return false;
+        }
+
+        if ($taxRuleEntity->getActiveFrom() !== null) {
+            return $this->isTaxActive($taxRuleEntity);
         }
 
         return true;

--- a/src/Core/System/Tax/TaxRuleType/ZipCodeRangeRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/ZipCodeRangeRuleTypeFilter.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
 
 #[Package('customer-order')]
-class ZipCodeRangeRuleTypeFilter implements TaxRuleTypeFilterInterface
+class ZipCodeRangeRuleTypeFilter extends AbstractTaxRuleTypeFilter
 {
     final public const TECHNICAL_NAME = 'zip_code_range';
 
@@ -27,6 +27,10 @@ class ZipCodeRangeRuleTypeFilter implements TaxRuleTypeFilterInterface
 
         if ($fromZipCode === null || $toZipCode === null || $zipCode < $fromZipCode || $zipCode > $toZipCode) {
             return false;
+        }
+
+        if ($taxRuleEntity->getActiveFrom() !== null) {
+            return $this->isTaxActive($taxRuleEntity);
         }
 
         return true;

--- a/src/Core/System/Tax/TaxRuleType/ZipCodeRuleTypeFilter.php
+++ b/src/Core/System/Tax/TaxRuleType/ZipCodeRuleTypeFilter.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
 
 #[Package('customer-order')]
-class ZipCodeRuleTypeFilter implements TaxRuleTypeFilterInterface
+class ZipCodeRuleTypeFilter extends AbstractTaxRuleTypeFilter
 {
     final public const TECHNICAL_NAME = 'zip_code';
 
@@ -26,6 +26,10 @@ class ZipCodeRuleTypeFilter implements TaxRuleTypeFilterInterface
 
         if ($shippingZipCode !== $zipCode) {
             return false;
+        }
+
+        if ($taxRuleEntity->getActiveFrom() !== null) {
+            return $this->isTaxActive($taxRuleEntity);
         }
 
         return true;

--- a/src/Core/System/Test/SalesChannel/Context/SalesChannelContextTest.php
+++ b/src/Core/System/Test/SalesChannel/Context/SalesChannelContextTest.php
@@ -69,6 +69,19 @@ class SalesChannelContextTest extends TestCase
                     'id' => Uuid::randomHex(),
                     'countryId' => $shippingCountryId,
                     'taxRate' => 10,
+                    'activeFrom' => (new \DateTime())->modify('-3 days'),
+                    'taxRuleTypeId' => $this->taxRuleTypes->getByTechnicalName(EntireCountryRuleTypeFilter::TECHNICAL_NAME)->getId(),
+                ], [
+                    'id' => Uuid::randomHex(),
+                    'countryId' => $shippingCountryId,
+                    'taxRate' => 9,
+                    'activeFrom' => (new \DateTime())->modify('-2 days'),
+                    'taxRuleTypeId' => $this->taxRuleTypes->getByTechnicalName(EntireCountryRuleTypeFilter::TECHNICAL_NAME)->getId(),
+                ], [
+                    'id' => Uuid::randomHex(),
+                    'countryId' => $shippingCountryId,
+                    'taxRate' => 8,
+                    'activeFrom' => (new \DateTime())->modify('+3 days'),
                     'taxRuleTypeId' => $this->taxRuleTypes->getByTechnicalName(EntireCountryRuleTypeFilter::TECHNICAL_NAME)->getId(),
                 ],
             ],
@@ -77,7 +90,7 @@ class SalesChannelContextTest extends TestCase
         $taxRuleCollection = $salesChannelContext->buildTaxRules($taxData['id']);
 
         static::assertCount(1, $taxRuleCollection);
-        static::assertSame(10.0, $taxRuleCollection->first()->getTaxRate());
+        static::assertSame(9.0, $taxRuleCollection->first()->getTaxRate());
         static::assertSame(100.0, $taxRuleCollection->first()->getPercentage());
     }
 
@@ -179,6 +192,7 @@ class SalesChannelContextTest extends TestCase
                     'id' => Uuid::randomHex(),
                     'countryId' => $shippingCountryId,
                     'taxRate' => 9,
+                    'activeFrom' => (new \DateTime())->modify('-2 days'),
                     'taxRuleTypeId' => $this->taxRuleTypes->getByTechnicalName(IndividualStatesRuleTypeFilter::TECHNICAL_NAME)->getId(),
                     'data' => [
                         'states' => [$countryStateId],
@@ -188,6 +202,7 @@ class SalesChannelContextTest extends TestCase
                     'id' => Uuid::randomHex(),
                     'countryId' => $shippingCountryId,
                     'taxRate' => 8,
+                    'activeFrom' => (new \DateTime())->modify('-3 days'),
                     'taxRuleTypeId' => $this->taxRuleTypes->getByTechnicalName(ZipCodeRangeRuleTypeFilter::TECHNICAL_NAME)->getId(),
                     'data' => [
                         'fromZipCode' => '12000',

--- a/tests/migration/Core/V6_5/Migration1688927492AddTaxActiveFromFieldTest.php
+++ b/tests/migration/Core/V6_5/Migration1688927492AddTaxActiveFromFieldTest.php
@@ -66,9 +66,9 @@ class Migration1688927492AddTaxActiveFromFieldTest extends TestCase
         $this->taxRepository->create([$taxData], $context);
         /** @var TaxRuleEntity $taxRule */
         $taxRule = $this->taxRuleRepository->search(new Criteria([$taxRuleId]), $context)->first();
-        static::assertInstanceOf(\DateTime::class, $taxRule->getActiveFrom());
 
         // THEN
+        static::assertInstanceOf(\DateTimeInterface::class, $taxRule->getActiveFrom());
         static::assertEquals($activeFrom->getTimestamp(), $taxRule->getActiveFrom()->getTimestamp());
     }
 

--- a/tests/migration/Core/V6_5/Migration1688927492AddTaxActiveFromFieldTest.php
+++ b/tests/migration/Core/V6_5/Migration1688927492AddTaxActiveFromFieldTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_5;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Tax\Aggregate\TaxRule\TaxRuleEntity;
+use Shopware\Core\System\Tax\Aggregate\TaxRuleType\TaxRuleTypeCollection;
+use Shopware\Core\System\Tax\Aggregate\TaxRuleType\TaxRuleTypeEntity;
+use Shopware\Core\System\Tax\TaxRuleType\EntireCountryRuleTypeFilter;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Migration\V6_5\Migration1688927492AddTaxActiveFromField
+ */
+class Migration1688927492AddTaxActiveFromFieldTest extends TestCase
+{
+    use DatabaseTransactionBehaviour;
+    use KernelTestBehaviour;
+
+    private EntityRepository $taxRepository;
+
+    private EntityRepository $taxRuleRepository;
+
+    private TaxRuleTypeCollection $taxRuleTypes;
+
+    protected function setUp(): void
+    {
+        $this->taxRuleTypes = $this->loadTaxRuleTypes();
+        $this->taxRepository = $this->getContainer()->get('tax.repository');
+        $this->taxRuleRepository = $this->getContainer()->get('tax_rule.repository');
+    }
+
+    public function testTaxRuleAfterMigration(): void
+    {
+        // GIVEN
+        $taxId = Uuid::randomHex();
+        $taxRuleId = Uuid::randomHex();
+        $activeFrom = new \DateTime();
+        $context = Context::createDefaultContext();
+        static::assertInstanceOf(TaxRuleTypeEntity::class, $this->taxRuleTypes->getByTechnicalName(EntireCountryRuleTypeFilter::TECHNICAL_NAME));
+        $taxData = [
+            'id' => $taxId,
+            'name' => 'test',
+            'taxRate' => 7.125,
+            'rules' => [
+                [
+                    'id' => $taxRuleId,
+                    'taxRate' => 10,
+                    'activeFrom' => $activeFrom,
+                    'country' => [
+                        'name' => 'test',
+                    ],
+                    'taxRuleTypeId' => $this->taxRuleTypes->getByTechnicalName(EntireCountryRuleTypeFilter::TECHNICAL_NAME)->getId(),
+                ],
+            ],
+        ];
+
+        // THEN
+        $this->taxRepository->create([$taxData], $context);
+        /** @var TaxRuleEntity $taxRule */
+        $taxRule = $this->taxRuleRepository->search(new Criteria([$taxRuleId]), $context)->first();
+        static::assertInstanceOf(\DateTime::class, $taxRule->getActiveFrom());
+
+        // THEN
+        static::assertEquals($activeFrom->getTimestamp(), $taxRule->getActiveFrom()->getTimestamp());
+    }
+
+    private function loadTaxRuleTypes(): TaxRuleTypeCollection
+    {
+        /** @var TaxRuleTypeCollection $collection */
+        $collection = $this->getContainer()->get('tax_rule_type.repository')->search(new Criteria(), Context::createDefaultContext())->getEntities();
+
+        return $collection;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

We currently have no way to manage the tax activity date. We cannot schedule a specific day for tax implementation. Sometimes the tax rate changes. In addition, such a date will allow us to "recalculate" the tax backwards (if a tax change was introduced and we did not know about it). This change is useful for large stores selling in multiple countries, so they need more tax management.

### 2. What does this change do, exactly?

My change adds a new date time field to the tax rule. We can set the date of its activation. It is stored in UTC format. The admin can set this date in the panel when creating a tax rule. In SalesChannelContext, the latest tax activity date is always selected from all the rules that meet the criteria.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 256b18a</samp>

This pull request adds a new feature to the tax system that allows defining tax rules that are only valid from a certain date onwards. It introduces a new `activeFrom` property to the `TaxRuleEntity` and `TaxRuleDefinition` classes, and a new `active_from` column to the `tax_rule` table. It also modifies the tax rule matching logic in the `SalesChannelContextFactory` and the tax rule type filters to check the activation date of the tax rules. Additionally, it updates the administration UI and the unit tests to support the new feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 256b18a</samp>

*  Add the `activeFrom` property to the `TaxRuleEntity` class and the `tax_rule` table to store the activation date of each tax rule ([link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-2ae7f19f238e89bf16fad51ac02b3722c0848fd38e1521ba8656e2e758e6ef3cR6),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-2ae7f19f238e89bf16fad51ac02b3722c0848fd38e1521ba8656e2e758e6ef3cR66),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-eb4d19eb50cd71decc5d2bed7761000878e7150dcd8f7807827660e9075b96e4R57-R61),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-eb4d19eb50cd71decc5d2bed7761000878e7150dcd8f7807827660e9075b96e4R144-R153),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-2a0604e327822be0674f91b72768fa1435f05b0c3f279262551e8d8cb5881e01R1-R28),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-b29cfac1b9c35d784dd7efbf3b5c7631cf865c61031694fae8eb41d02ba0dfefR1-R82))
*  Add the `isTaxActive` method to the `AbstractTaxRuleTypeFilter` class to check if a tax rule is active based on the current date and the `activeFrom` property ([link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-b5ae77baa27247904d0965be10a433d2d71e1c610465960129beb686da33794bR19-R33),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-b4bd1e51f09a46ed83232b0ad4645c7ee48b3cb6b6425b6ae774e51b89e02251R1-R17))
*  Modify the `match` methods of the `EntireCountryRuleTypeFilter`, `IndividualStatesRuleTypeFilter`, `ZipCodeRangeRuleTypeFilter`, and `ZipCodeRuleTypeFilter` classes to use the `isTaxActive` method if the `activeFrom` property is not null ([link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-1b2db26d9e65fdcd7dcac5dcfa8ba556b1f175d3735ef8a4cf04c65a068bc9ffL11-R11),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-1b2db26d9e65fdcd7dcac5dcfa8ba556b1f175d3735ef8a4cf04c65a068bc9ffR23-R26),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-32db726c08f416d8010e1cfd120097d15acb27994ba617cda189d12da08d9556L11-R11),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-32db726c08f416d8010e1cfd120097d15acb27994ba617cda189d12da08d9556R30-R33),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-cb0a161d4525d7f27bf6e800d7d81028de425bfc260072b7102efe13250f9284L11-R11),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-cb0a161d4525d7f27bf6e800d7d81028de425bfc260072b7102efe13250f9284R32-R35),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-b7a7830823aacf568e664026fc09b88ddcb354582a70603df417f4b7f24e045dL11-R11),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-b7a7830823aacf568e664026fc09b88ddcb354582a70603df417f4b7f24e045dR31-R34))
*  Modify the `getTaxRules` method of the `SalesChannelContextFactory` class to filter the tax rules by the highest type position and the latest activation date ([link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-d9909deceaf8a3de1970aac9bfebd418097905939bd2dc6bc9d52a3315c25b09L155-R167))
*  Modify the `testGetTaxRuleCollectionCustomerShippingCountry` and `testGetTaxRuleCollectionCustomerShippingTypeZipCodeRangeOverridesIndividualStates` methods of the `SalesChannelContextTest` class to create and assert tax rules with different `activeFrom` dates ([link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-ef556f549f29c81e6d0e37aa8922c1e114407e48e6a25bbf0d12fad5e719ed44L72-R85),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-ef556f549f29c81e6d0e37aa8922c1e114407e48e6a25bbf0d12fad5e719ed44L80-R93),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-ef556f549f29c81e6d0e37aa8922c1e114407e48e6a25bbf0d12fad5e719ed44R195),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-ef556f549f29c81e6d0e37aa8922c1e114407e48e6a25bbf0d12fad5e719ed44R205))
*  Add the `sw-datepicker` component to the `sw-settings-tax-rule-modal` template and the `sw-settings-tax-rule-modal` unit test to allow the user to select a date and time for the `activeFrom` property ([link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-bc9bbaf290e624eb53ebfe107d6dc65c8ab83b1f995c8d9496495259730be2b8R75-R84),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-d3bd54a50c7798049cd619724bae090cbdb546ef39e292c79c14c2e23a7916eaR23))
*  Add the `activeFrom` property to the list of mapped errors and columns for the `sw-settings-tax-rule-modal` and `sw-tax-rule-card` components to display validation errors and activation dates for the tax rules ([link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-71ae65257264edc36f2ab416e9cb4b67167fff0e409184f4a31b602dc7c0488cL64-R64),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-38479b5d15ad4c4c1b3b6d233e9f27569580c9e2766c59009e04931bb58c3da8R100-R103))
*  Add the `sw_settings_tax_rule_grid_column_tax_rule_active_from` block to the `sw-tax-rule-card` template to format the `activeFrom` property as a date string in the grid column ([link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-7853c4690bd50f42ec6222507dadfeec547e60a2244e70b839ac4cb58b356e2aR107-R119))
*  Add the `labelActiveFrom` snippet to the `de-DE.json` and `en-GB.json` files for the `sw-settings-tax` module to provide the German and English translations for the label of the `activeFrom` property ([link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-694a0ca2de5869e2ea3cbb90c0b1783e7be2c533e3234405e5d9e2edcb6a0fc9L81-R82),[link](https://github.com/shopware/platform/pull/3214/files?diff=unified&w=0#diff-ab119f53a6bc297becf801346baa113113d420c812457193944d29b9581462d9L71-R72))
