### PR TITLE
next-29203 - Fix cms page with custom css class

### DIFF
--- a/changelog/_unreleased/2023-07-13-fix-cms-page-css-class.md
+++ b/changelog/_unreleased/2023-07-13-fix-cms-page-css-class.md
@@ -1,0 +1,9 @@
+---
+title: Fix cms page won't add custom css classes.
+issue: NEXT-29203
+author: Mario Schierhoff
+author_email: DerKaito99@gmail.com
+author_github: @derkaito
+---
+# Storefront
+* fix `storefront/page/content/index.html.twig` to get cssClass from cmsPage variable instead of global page.landingPage.

--- a/src/Storefront/Resources/views/storefront/page/content/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/index.html.twig
@@ -14,8 +14,8 @@
             {% endblock %}
 
             {% block cms_content %}
-                {% set cmsPageClasses = ('cms-page ' ~ page.landingPage.cmsPage.cssClass|striptags)|trim %}
                 {% set cmsPage = page.landingPage ? page.landingPage.cmsPage : page.cmsPage %}
+                {% set cmsPageClasses = ('cms-page ' ~ cmsPage.cssClass|striptags)|trim %}
                 {% set landingPage = page.landingPage ? page.landingPage : {} %}
                 <div class="{{ cmsPageClasses }}">
                     {% block page_content_blocks %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently custom css classes added to an cms page won't show up in the document. 

### 2. What does this change do, exactly?

This change use the difined `cmsPage` variable. That are filled with `page.landingPage` or `page.cmsPage` instead of only reading the `page.landingPage`

### 3. Describe each step to reproduce the issue or behaviour.

* add custom css class to an shopping experiences
* load the page in a browser
* look for the .cms-page element the added css class is not set 

### 4. Please link to the relevant issues (if any).

[NEXT-29203](https://issues.shopware.com/issues/NEXT-29203)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4cacff</samp>

This pull request fixes a bug that prevented custom css classes from being applied to cms pages. It modifies the `index.html.twig` template to use the correct variable and adds a changelog entry for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f4cacff</samp>

* Fix cms page css class issue ([link](https://github.com/shopware/platform/pull/3215/files?diff=unified&w=0#diff-aa2cfda5020c2abeb50c861f66c864fe3aa9f136dfdb01cb8938570b92d9449dR1-R9), [link](https://github.com/shopware/platform/pull/3215/files?diff=unified&w=0#diff-d186c1054c970a718d87db6d564f9a2a976e15c15ea2f279417263e82e58239bL17-R18))
  - Add changelog entry in `changelog/_unreleased/2023-07-13-fix-cms-page-css-class.md` ([link](https://github.com/shopware/platform/pull/3215/files?diff=unified&w=0#diff-aa2cfda5020c2abeb50c861f66c864fe3aa9f136dfdb01cb8938570b92d9449dR1-R9))
  - Use `cmsPage` variable instead of `page.landingPage` to access `cssClass` property in `src/Storefront/Resources/views/storefront/page/content/index.html.twig` ([link](https://github.com/shopware/platform/pull/3215/files?diff=unified&w=0#diff-d186c1054c970a718d87db6d564f9a2a976e15c15ea2f279417263e82e58239bL17-R18))
