### PR TITLE
Fix support for Symfonys `trusted_*` kernel parameters

### DIFF
--- a/changelog/_unreleased/2023-07-14-trusted-kernel-parameters.md
+++ b/changelog/_unreleased/2023-07-14-trusted-kernel-parameters.md
@@ -1,0 +1,8 @@
+---
+title: Fix support for Symfonys `trusted_*` kernel parameters
+author: Christian Schiffler
+author_email: c.schiffler@cyberspectrum.de
+author_github: discordier
+---
+# Core
+* Changed `\Shopware\Core\Kernel::boot()` to support for Symfonys trusted_* kernel parameters that were previously ignored.

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -13,6 +13,7 @@ use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\HttpKernel\Kernel as HttpKernel;
@@ -164,6 +165,17 @@ class Kernel extends HttpKernel
 
         // init container
         $this->initializeContainer();
+
+        // Taken from \Symfony\Component\HttpKernel\Kernel::preBoot()
+        $container = $this->container;
+
+        if ($container->hasParameter('kernel.trusted_hosts') && $trustedHosts = $container->getParameter('kernel.trusted_hosts')) {
+            Request::setTrustedHosts($trustedHosts);
+        }
+
+        if ($container->hasParameter('kernel.trusted_proxies') && $container->hasParameter('kernel.trusted_headers') && $trustedProxies = $container->getParameter('kernel.trusted_proxies')) {
+            Request::setTrustedProxies(\is_array($trustedProxies) ? $trustedProxies : array_map('trim', explode(',', $trustedProxies)), $container->getParameter('kernel.trusted_headers'));
+        }
 
         foreach ($this->getBundles() as $bundle) {
             $bundle->setContainer($this->container);


### PR DESCRIPTION
The code for handling the kernel parameters `trusted_*` has been omitted in `\Shopware\Core\Kernel::boot()`.

This rendered the normal way of configuring these parameters in a Symfony application useless.

### 1. Why is this change necessary?

The method `\Shopware\Core\Kernel::boot()` [is missing](https://github.com/shopware/platform/blob/fb06e27d30b8f34953dff30dc556d44fc428e235/src/Core/Kernel.php#L168) the [handling of `trusted_*` parameters](https://github.com/symfony/symfony/blob/e15ccda3d5e05c152310127130d23239ee763de0/src/Symfony/Component/HttpKernel/Kernel.php#L759) that are implemented in the upstream Symfony kernel.

### 2. What does this change do, exactly?

This change implements handling of said parameters.

However, as upstream implements them in the private method `preBoot()`, I have implemented them in the calling method `boot()` instead.

### 3. Describe each step to reproduce the issue or behaviour.

Create a framework bundle configuration as mentioned in the official Symfony docs [here](https://symfony.com/doc/6.2/deployment/proxies.html#solution-settrustedproxies) and suggested in Shopware community by Moritz Naczenski [here](https://forum.shopware.com/t/shopware-6-mit-ssl-hinter-reverse-proxy/61571/2).

### 4. Please link to the relevant issues (if any).

Don't know of any issue.

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
  - I failed to locate any tests that are related to the kernel specifically - pointers welcome. 
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b4bd51e</samp>

This pull request improves the security and compatibility of the Shopware kernel with Symfony by setting the trusted proxies and headers from the configuration. It affects the file `src/Core/Kernel.php` and adds a changelog entry in `changelog/_unreleased/2023-07-14-trusted-kernel-parameters.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b4bd51e</samp>

*  Add a changelog entry for the fix ([link](https://github.com/shopware/platform/pull/3217/files?diff=unified&w=0#diff-0736b50ed25cfc62d2637a922d88e2de80a82a06472ae8d65844f76a5bde87e3R1-R8))
*  Import the `Request` class from Symfony in the `Kernel` class ([link](https://github.com/shopware/platform/pull/3217/files?diff=unified&w=0#diff-0f9fbc724c97e5f417094a9615b21a5aef470b2b2086c24ec21e4dc7cdfa5fe3R16))
*  Set the trusted hosts, proxies, and headers from the kernel parameters to the `Request` class in the `Kernel::boot` method ([link](https://github.com/shopware/platform/pull/3217/files?diff=unified&w=0#diff-0f9fbc724c97e5f417094a9615b21a5aef470b2b2086c24ec21e4dc7cdfa5fe3R169-R179))
