### PR TITLE
Remove whitespace from DomSelector

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/address-editor/address-editor.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/address-editor/address-editor.plugin.js
@@ -186,7 +186,7 @@ export default class AddressEditorPlugin extends Plugin {
 
                         const invalidFields = DomAccess.querySelectorAll(
                             modal,
-                            `${FormAjaxSubmitInstance.options.replaceSelectors[0]} .is-invalid`,
+                            `${FormAjaxSubmitInstance.options.replaceSelectors[0]}.is-invalid`,
                             false
                         );
 


### PR DESCRIPTION
### 1. Why is this change necessary?
To re-enable selection of invalid fields

```js
var a = ['.abcdefg'];
window.console.log(`${a[0]}.test`)
=> '.abcdefg.test'

var a = ['.abcdefg'];
window.console.log(`${a[0]} .test`)
=> '.abcdefg .test'
```


### 2. What does this change do, exactly?
Removes the whitespace from the selector introduced in `553591e`

### 3. Describe each step to reproduce the issue or behaviour.
///

### 4. Please link to the relevant issues (if any).
///

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70e5d46</samp>

Fixed a selector bug in the `address-editor` plugin that prevented customers from editing their addresses in a modal. Updated the file `address-editor.plugin.js` with the correct query.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70e5d46</samp>

* Fix invalid field selector in address editor plugin ([link](https://github.com/shopware/platform/pull/3221/files?diff=unified&w=0#diff-9d7fdc9e673d34c4d3f483b904e363663fae74d66283d745c96b64d181b89f20L189-R189))
