### PR TITLE
Pass default shopware locale to Translation MessageFormatter

### DIFF
--- a/adr/2023-07-25-fix-translation-message-format-locale.md
+++ b/adr/2023-07-25-fix-translation-message-format-locale.md
@@ -1,0 +1,31 @@
+---
+title: Default handling for non specified salutations
+date: 2023-06-28
+area: core
+tags: [adr, salutation]
+---
+
+## Context
+
+If locale is not passed as argument directly to `Translator::trans()` method, fallback locale is always sent to `MessageFormatter::format()` method. Therefor, locale pluralization rules cannot be applied.
+
+We want to use shopware locale instead to format translation messages correctly.
+
+Lets say we have some translation string:
+
+`"shop.cart.title" => "%count% продукт в кошику|%count% продукти в кошику|%count% продуктів в кошику"`
+
+For example, for uk_UA locale, expected behavior is:
+- `{{ "shop.cart.title"|trans({"%count%": 1}) }}` - 1 продукт в кошику
+- `{{ "shop.cart.title"|trans({"%count%": 2 }}` - 2 продукти в кошику
+- `{{ "shop.cart.title"|trans({"%count%": 5}) }}` - 5 продуктів в кошику
+- `{{ "shop.cart.title"|trans({"%count%": 21}) }}` - 21 продукт в кошику
+
+## Decision
+- If locale is not passed as argument directly to `Translator::trans()` method, use MessageCatalogue::getLocale() method instead to retrieve shopware locale or use fallback one.
+
+- `Symfony\Contracts\Translation\TranslatorTrait::getPluralizationRule()` method requires 2-digits or "underscore"-splited locale format to get correct position. Using `Symfony\Component\Intl\Locale::getFallback()` to convert locale format.
+## Consequences
+As a result of this decision, the following consequences will occur:
+
+* Correct translation message formatting: using shopware locale to format translation messages correctly. Get correct position for locale pluralization rules.

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -15,6 +15,7 @@ use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 use Shopware\Core\System\Snippet\SnippetService;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
+use Symfony\Component\Intl\Locale;
 use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\Translator as SymfonyTranslator;
@@ -157,7 +158,9 @@ class Translator extends AbstractTranslator
             }
         }
 
-        return $this->formatter->format($this->getCatalogue($locale)->get($id, $domain), $locale ?? $this->getFallbackLocale(), $parameters);
+        $catalogue = $this->getCatalogue($locale);
+
+        return $this->formatter->format($catalogue->get($id, $domain), Locale::getFallback($catalogue->getLocale()), $parameters);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If locale is not passed as argument directly to `Translator::trans()` method, fallback locale is always sent to `MessageFormatter::format()` method. Therefor, locale pluralization rules cannot be applied.

We want to use shopware locale instead to format translation messages correctly.

Lets say we have some translation string:

`"shop.cart.title" => "%count% продукт в кошику|%count% продукти в кошику|%count% продуктів в кошику"`

For example, for uk_UA locale, expected behavior is:
- `{{ "shop.cart.title"|trans({"%count%": 1}) }}` - 1 продукт в кошику
- `{{ "shop.cart.title"|trans({"%count%": 2 }}` - 2 продукти в кошику
- `{{ "shop.cart.title"|trans({"%count%": 5}) }}` - 5 продуктів в кошику
- `{{ "shop.cart.title"|trans({"%count%": 21}) }}` - 21 продукт в кошику


### 2. What does this change do, exactly?
- If locale is not passed as argument directly to `Translator::trans()` method, use MessageCatalogue::getLocale() method instead to retrieve shopware locale or use fallback one.

- `Symfony\Contracts\Translation\TranslatorTrait::getPluralizationRule()` method requires 2-digits or "underscore"-splited locale format to get correct position. Using `Symfony\Component\Intl\Locale::getFallback()` to convert locale format.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a new Shopware 6.5 project (with the production template).
2. Define translation strings with plural forms. `"shop.cart.title" => "%count% продукт в кошику|%count% продукти в кошику|%count% продуктів в кошику"`.
3. Use translation strings in template. `{{ "shop.cart.title"|trans({"%count%": 21}) }}`

### 4. Please link to the relevant issues (if any).
- https://issues.shopware.com/issues/NEXT-15840

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2023-07-25-fix-translation-message-format-locale.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 795f8f6</samp>

This pull request fixes a bug in the translation system that caused incorrect pluralization of some messages. It also documents the rationale and implications of the fix in a new ADR file `adr/2023-07-25-fix-translation-message-format-locale.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 795f8f6</samp>

*  Add a new ADR document to explain the decision and consequences of fixing the translation message format locale issue (`adr/2023-07-25-fix-translation-message-format-locale.md`)
*  Import the Locale class from the Symfony\Component\Intl namespace to manipulate locale identifiers and get fallback locales (`src/Core/Framework/Adapter/Translation/Translator.php`, [link](https://github.com/shopware/platform/pull/3233/files?diff=unified&w=0#diff-4dcf5c3effda23eb35225683ee6d0c613dfe27f4058983a5aebf3392a3300d2fR18))
