### PR TITLE
Provide correct locale for translation MessageFormatter

### DIFF
--- a/changelog/_unreleased/2023-07-25-fix-translation-message-formatter-locale.md
+++ b/changelog/_unreleased/2023-07-25-fix-translation-message-formatter-locale.md
@@ -1,0 +1,9 @@
+---
+title: Fix translation MessageFormatter locale
+issue: NEXT-00000
+author: Dumka.pro
+author_email: hello@dumka.pro
+author_github: @dumka-pro
+---
+# Core
+* Provide correct locale for translation message formatting: using shopware locale to format translation messages correctly. Get correct position for locale pluralization rules.

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -15,6 +15,7 @@ use Shopware\Core\System\Locale\LanguageLocaleCodeProvider;
 use Shopware\Core\System\Snippet\SnippetService;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\CacheWarmer\WarmableInterface;
+use Symfony\Component\Intl\Locale;
 use Symfony\Component\Translation\Formatter\MessageFormatterInterface;
 use Symfony\Component\Translation\MessageCatalogueInterface;
 use Symfony\Component\Translation\Translator as SymfonyTranslator;
@@ -157,7 +158,9 @@ class Translator extends AbstractTranslator
             }
         }
 
-        return $this->formatter->format($this->getCatalogue($locale)->get($id, $domain), $locale ?? $this->getFallbackLocale(), $parameters);
+        $catalogue = $this->getCatalogue($locale);
+
+        return $this->formatter->format($catalogue->get($id, $domain), Locale::getFallback($catalogue->getLocale()), $parameters);
     }
 
     /**

--- a/src/Core/Framework/Test/Adapter/Translation/TranslatorPluralRulesTest.php
+++ b/src/Core/Framework/Test/Adapter/Translation/TranslatorPluralRulesTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Adapter\Translation;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * @internal
+ */
+class TranslatorPluralRulesTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function getTranslator(): TranslatorInterface
+    {
+        return $this->getContainer()->get('translator');
+    }
+
+    /**
+     * @dataProvider getChooseTests
+     */
+    public function testPluralRules($expected, $id, $number, $locale = null)
+    {
+        $this->assertEquals($expected, $this->getTranslator()->trans($id, ['%count%' => $number], null, $locale));
+    }
+
+    public static function getChooseTests()
+    {
+        return [
+            // Test English plural rules
+            ['There are 0 apples', 'There is one apple|There are %count% apples', 0, 'en-GB'],
+            ['There is one apple', 'There is one apple|There are %count% apples', 1, 'en-GB'],
+            ['There are 2 apples', 'There is one apple|There are %count% apples', 2, 'en-GB'],
+            ['There are 21 apples', 'There is one apple|There are %count% apples', 21, 'en-GB'],
+
+            ['There are 0 apples', 'There is one apple|There are %count% apples', 0, 'en_GB'],
+            ['There is one apple', 'There is one apple|There are %count% apples', 1, 'en_GB'],
+            ['There are 2 apples', 'There is one apple|There are %count% apples', 2, 'en_GB'],
+            ['There are 21 apples', 'There is one apple|There are %count% apples', 21, 'en_GB'],
+
+            // Test Ukrainian plural rules
+            ['0 яблук', '%count% яблуко|%count% яблука|%count% яблук', 0, 'uk-UA'],
+            ['1 яблуко', '%count% яблуко|%count% яблука|%count% яблук', 1, 'uk-UA'],
+            ['2 яблука', '%count% яблуко|%count% яблука|%count% яблук', 2, 'uk-UA'],
+            ['5 яблук', '%count% яблуко|%count% яблука|%count% яблук', 5, 'uk-UA'],
+            ['21 яблуко', '%count% яблуко|%count% яблука|%count% яблук', 21, 'uk-UA'],
+
+            ['0 яблук', '%count% яблуко|%count% яблука|%count% яблук', 0, 'uk_UA'],
+            ['1 яблуко', '%count% яблуко|%count% яблука|%count% яблук', 1, 'uk_UA'],
+            ['2 яблука', '%count% яблуко|%count% яблука|%count% яблук', 2, 'uk_UA'],
+            ['5 яблук', '%count% яблуко|%count% яблука|%count% яблук', 5, 'uk_UA'],
+            ['21 яблуко', '%count% яблуко|%count% яблука|%count% яблук', 21, 'uk_UA'],
+        ];
+    }
+}

--- a/tests/integration/php/Core/Framework/Adapter/Translation/TranslatorPluralRulesTest.php
+++ b/tests/integration/php/Core/Framework/Adapter/Translation/TranslatorPluralRulesTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Core\Framework\Test\Adapter\Translation;
+namespace Shopware\Tests\Integration\Core\Framework\Adapter\Translation;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -8,6 +8,8 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
  * @internal
+ *
+ * @covers \Shopware\Core\Framework\Adapter\Translation\Translator
  */
 class TranslatorPluralRulesTest extends TestCase
 {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If locale is not passed as argument directly to `Translator::trans()` method, fallback locale is always sent to `MessageFormatter::format()` method. Therefor, locale pluralization rules cannot be applied.

We want to use shopware locale instead to format translation messages correctly.

Lets say we have some translation string:

`"shop.cart.title" => "%count% продукт в кошику|%count% продукти в кошику|%count% продуктів в кошику"`

For example, for uk_UA locale, expected behavior is:
- `{{ "shop.cart.title"|trans({"%count%": 1}) }}` - 1 продукт в кошику
- `{{ "shop.cart.title"|trans({"%count%": 2 }}` - 2 продукти в кошику
- `{{ "shop.cart.title"|trans({"%count%": 5}) }}` - 5 продуктів в кошику
- `{{ "shop.cart.title"|trans({"%count%": 21}) }}` - 21 продукт в кошику


### 2. What does this change do, exactly?
- If locale is not passed as argument directly to `Translator::trans()` method, use MessageCatalogue::getLocale() method instead to retrieve shopware locale or use fallback one.

- `Symfony\Contracts\Translation\TranslatorTrait::getPluralizationRule()` method requires 2-digits or "underscore"-splited locale format to get correct position. Using `Symfony\Component\Intl\Locale::getFallback()` to convert locale format.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a new Shopware 6.5 project (with the production template).
2. Define translation strings with plural forms. `"shop.cart.title" => "%count% продукт в кошику|%count% продукти в кошику|%count% продуктів в кошику"`.
3. Use translation strings in template. `{{ "shop.cart.title"|trans({"%count%": 21}) }}`

### 4. Please link to the relevant issues (if any).
- https://issues.shopware.com/issues/NEXT-15840

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2023-07-25-fix-translation-message-format-locale.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b95287</samp>

This pull request fixes the translation and formatting of messages in the `Translator` class, by using the `Locale` component to handle different languages and regions. It also updates the changelog with a new entry for this fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b95287</samp>

*  Add a changelog entry for the fix ([link](https://github.com/shopware/platform/pull/3234/files?diff=unified&w=0#diff-46d0357f00ba234d4393ba92bd7ca4b82fa609ecc750d404a30886b36a0d7394R1-R9))
*  Import the Locale component from Symfony ([link](https://github.com/shopware/platform/pull/3234/files?diff=unified&w=0#diff-4dcf5c3effda23eb35225683ee6d0c613dfe27f4058983a5aebf3392a3300d2fR18))
*  Use the Locale::getFallback method to get the correct locale for the message formatter ([link](https://github.com/shopware/platform/pull/3234/files?diff=unified&w=0#diff-4dcf5c3effda23eb35225683ee6d0c613dfe27f4058983a5aebf3392a3300d2fL160-R163))
