### PR TITLE
NEXT-29560: Fix custom fields are not taken from translated value inside the cart

### DIFF
--- a/changelog/_unreleased/2023-07-27-fix-custom-fields-in-cart-line-item-payload-are-not-translated.md
+++ b/changelog/_unreleased/2023-07-27-fix-custom-fields-in-cart-line-item-payload-are-not-translated.md
@@ -1,0 +1,10 @@
+---
+title:              Custom fields in cart line item payload are not translated
+issue:              NEXT-29560
+flag:               
+author:             Christoph Pötz
+author_email:       christoph.poetz@acris.at
+author_github:      @acris-cp
+---
+# Core
+*  Function enrich inside core/Content/Product/Cart/ProductCartProcessor.php: Fix custom fields are not taken from translated value inside the cart

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -339,7 +339,7 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
 
         $payload = [
             'isCloseout' => $product->getIsCloseout(),
-            'customFields' => $product->getCustomFields(),
+            'customFields' => $product->getTranslation('customFields'),
             'createdAt' => $product->getCreatedAt() ? $product->getCreatedAt()->format(Defaults::STORAGE_DATE_TIME_FORMAT) : null,
             'releaseDate' => $product->getReleaseDate() ? $product->getReleaseDate()->format(Defaults::STORAGE_DATE_TIME_FORMAT) : null,
             'isNew' => $product->isNew(),


### PR DESCRIPTION
### 1. Why is this change necessary?
The custom fields which are stored at the line item payload are not taken from the translated value. This causes problems with different plugins / functionalities which makes use of custom fields inside the cart.

### 2. What does this change do, exactly?
The change fixes, that the custom fields which are save at the line item payload for products is taken from the translated value instead.

### 3. Describe each step to reproduce the issue or behaviour.
1. Make a new rule and use the Shopware default rule condition "Item with custom field".
2. Use the rule anywhere in the checkout process (e.g. as a availability rule of a shipping method).
3. Make a product and save the custom field which you assigned in the rule a above only for one language (e.g. English).
4. Now open the shop storefront in the German language.
5. Add the product to the cart and you see, the rule will not become value, because as described above in the payload value will never be the translated value of the custom fields.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-29560

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9229c7</samp>

This pull request fixes a bug where custom fields in the cart line item payload were not translated according to the selected language. It modifies the `enrich` function in `ProductCartProcessor.php` and adds a changelog entry for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c9229c7</samp>

* Fix custom fields in cart line item payload to use translated values ([link](https://github.com/shopware/platform/pull/3237/files?diff=unified&w=0#diff-f54047b4deaa6b142777e901802f77656d545e16466a31f94291e2b99f969a05L342-R342), [link](https://github.com/shopware/platform/pull/3237/files?diff=unified&w=0#diff-42c6763b73e86e9e9f33c63214bdbb1a5d240a0a6fccc1dff17ae9f8f0d8a501R1-R10))
