### PR TITLE
reset from & to dates so that time is really ignored

### DIFF
--- a/changelog/release-6-5-3-3/2023-07-28.md
+++ b/changelog/release-6-5-3-3/2023-07-28.md
@@ -1,0 +1,9 @@
+---
+title:              reset from & to dates so that time is really ignored       # Required
+issue:              NEXT-29662                              # Required
+author:             Tommy Quissens                          # Optional for shopware employees, Required for external developers
+author_email:       tommy.quissens@meteor.be                   # Optional for shopware employees, Required for external developers
+author_github:      @quisse                                 # Optional
+---
+# Core
+* reset from & to dates so that time is really ignored

--- a/src/Core/Framework/Rule/DateRangeRule.php
+++ b/src/Core/Framework/Rule/DateRangeRule.php
@@ -58,15 +58,23 @@ class DateRangeRule extends Rule
             throw new \LogicException('fromDate or toDate cannot be a string at this point.');
         }
         $toDate = $this->toDate;
+        $fromDate = $this->fromDate;
         $now = $scope->getCurrentTime();
+
+        if (!$this->useTime && $fromDate) {
+            $fromDate = (new \DateTime())
+                ->setTimestamp($fromDate->getTimestamp())
+                ->setTime(0, 0);
+        }
 
         if (!$this->useTime && $toDate) {
             $toDate = (new \DateTime())
                 ->setTimestamp($toDate->getTimestamp())
-                ->add(new \DateInterval('P1D'));
+                ->add(new \DateInterval('P1D'))
+                ->setTime(0, 0);
         }
 
-        if ($this->fromDate && $this->fromDate > $now) {
+        if ($fromDate && $fromDate > $now) {
             return false;
         }
 

--- a/src/Core/Framework/Test/Rule/DateRangeRuleTest.php
+++ b/src/Core/Framework/Test/Rule/DateRangeRuleTest.php
@@ -221,6 +221,27 @@ class DateRangeRuleTest extends TestCase
                 '2021-01-02 00:00:00 UTC',
                 false,
             ],
+            [
+                '2021-01-01 11:00:00 UTC',
+                '2021-01-02 10:00:00 UTC',
+                false,
+                '2021-01-01 10:00:00 UTC',
+                true,
+            ],
+            [
+                '2021-01-01 11:00:00 UTC',
+                '2021-01-02 10:00:00 UTC',
+                false,
+                '2021-01-02 10:00:00 UTC',
+                true,
+            ],
+            [
+                '2021-01-01 11:00:00 UTC',
+                '2021-01-02 10:00:00 UTC',
+                false,
+                '2021-01-03 10:00:00 UTC',
+                false,
+            ],
 
             // from and to set, useTime = true
             [
@@ -336,7 +357,7 @@ class DateRangeRuleTest extends TestCase
                 '2021-01-02 00:00:00 +02:00',
                 false,
                 '2021-01-01 21:59:59 UTC',
-                false,
+                true,
             ],
             // with useTime = true
             [


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When someone adds a rule via the api with a timestamp != `00:00:00.00000` , timestamps **are** taken in account even when `useTime` is off.

### 2. What does this change do, exactly?
Reset so that the end is actually the end.

### 3. Describe each step to reproduce the issue or behaviour.
Add a rule via the api with a timestamp != `00:00:00.00000` & test the rule in timing, see unit test.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-29662

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63979dc</samp>

This pull request improves the testing and functionality of the `DateRangeRule` class. It adds more test cases to `DateRangeRuleTest.php` and fixes a typo. It also adjusts the date range comparison logic in `DateRangeRule.php` to handle the case when the `useTime` property is false.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63979dc</samp>

* Adjust the date range comparison to handle the case when `useTime` is false ([link](https://github.com/shopware/platform/pull/3239/files?diff=unified&w=0#diff-c43984cff65cb72f6bd166b1892fe080a694959caf9dc8b6f4ed28bc57401013L61-R77))
* Add new test cases to cover the scenarios when `useTime` is false and the current time is equal to or within one day of the `fromDate` or `toDate` properties ([link](https://github.com/shopware/platform/pull/3239/files?diff=unified&w=0#diff-0ac0d4cc933b0bd2c7be6966135e81315c3cf3b60c8134232379a92ff044ccefR224-R244))
* Fix a typo in the expected result for a test case when `useTime` is false and the current time is one second before the `toDate` property ([link](https://github.com/shopware/platform/pull/3239/files?diff=unified&w=0#diff-0ac0d4cc933b0bd2c7be6966135e81315c3cf3b60c8134232379a92ff044ccefL339-R360))
