### PR TITLE
Fix translator trans locale fallback if locale parameter not set

### DIFF
--- a/changelog/_unreleased/2023-07-29-fix-translator-trans-locale-fallback-if-locale-parameter-not-set.md
+++ b/changelog/_unreleased/2023-07-29-fix-translator-trans-locale-fallback-if-locale-parameter-not-set.md
@@ -1,0 +1,12 @@
+---
+title: Fix translator trans locale fallback if locale parameter not set
+issue: NEXT-00000
+author: Florian Kasper
+author_email: fk@bitsandlikes.de
+author_github: flkasper
+---
+
+# Core
+
+* Sets the initial locale of `Shopware\Core\Framework\Adapter\Translation\Translator` in the constructor to shopware default language locale using `Shopware\Core\Framework\Adapter\Translation\Translator::getFallbackLocale`.
+* Use current locale of `Shopware\Core\Framework\Adapter\Translation\Translator` as fallback if no locale is set as parameter when using `Shopware\Core\Framework\Adapter\Translation\Translator::trans`.

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -70,6 +70,7 @@ class Translator extends AbstractTranslator
         private readonly SnippetService $snippetService,
         private readonly bool $fineGrainedCache
     ) {
+        $this->setLocale($this->getFallbackLocale());
     }
 
     public static function buildName(string $id): string
@@ -156,8 +157,9 @@ class Translator extends AbstractTranslator
                 $this->traces[$trace]['shopware.translator'] = true;
             }
         }
+        $locale ??= $this->getLocale();
 
-        return $this->formatter->format($this->getCatalogue($locale)->get($id, $domain), $locale ?? $this->getFallbackLocale(), $parameters);
+        return $this->formatter->format($this->getCatalogue($locale)->get($id, $domain), $locale, $parameters);
     }
 
     /**

--- a/tests/integration/php/Core/Framework/Translation/TranslatorTest.php
+++ b/tests/integration/php/Core/Framework/Translation/TranslatorTest.php
@@ -253,6 +253,12 @@ class TranslatorTest extends TestCase
             $request,
             $this->getContainer()->get(RequestStack::class)->pop()
         );
+
+        $this->translator->setLocale('de-DE');
+        static::assertEquals(
+            $snippets[1]['value'],
+            $this->translator->trans('new.unit.test.key')
+        );
     }
 
     public function testDeleteSnippet(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

If the locale parameter in `Shopware\Core\Framework\Adapter\Translation\Translator::trans` is not set, snippets will not be translated/output correctly.
Without the locale parameter, the correct catalog is not used.


### 2. What does this change do, exactly?

- Sets the initial locale of `Shopware\Core\Framework\Adapter\Translation\Translator` in the constructor to shopware default language locale using `Shopware\Core\Framework\Adapter\Translation\Translator::getFallbackLocale`.
- Use current locale of `Shopware\Core\Framework\Adapter\Translation\Translator` as fallback if no locale is set as parameter when using `Shopware\Core\Framework\Adapter\Translation\Translator::trans`.

### 3. Describe each step to reproduce the issue or behaviour.

Use the function `Shopware\Core\Framework\Adapter\Translation\Translator::trans` in a command or service, e.g. `$translator->trans('general.homeLink')` 

Expected output: `Home`
Current output: `general.homeLink`

### 4. Please link to the relevant issues (if any).

-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ba90ed</samp>

This pull request fixes a bug in the `Translator` class that prevented translations from working properly without a locale parameter. It also adds a changelog entry and a test case for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ba90ed</samp>

*  Add a changelog entry for the fix ([link](https://github.com/shopware/platform/pull/3241/files?diff=unified&w=0#diff-2f86d08cd5f85646ceced6a2aa1ecf0856671cc8fd30d1ac8d0127d779026573R1-R12))
*  Set the initial locale of the translator to the shopware default language locale in the constructor ([link](https://github.com/shopware/platform/pull/3241/files?diff=unified&w=0#diff-4dcf5c3effda23eb35225683ee6d0c613dfe27f4058983a5aebf3392a3300d2fR73))
