### PR TITLE
fix(administration): promotion v2 date-picker prop usage so time-pickers are displayed again

### DIFF
--- a/changelog/_unreleased/2023-08-01-fix-promotion-datepicker-prop-usage.md
+++ b/changelog/_unreleased/2023-08-01-fix-promotion-datepicker-prop-usage.md
@@ -1,0 +1,9 @@
+---
+title: Fix sw-promotion-v2 detail via datepicker usage so timepickers are displayed again.
+issue: NEXT-?
+author: AubreyHewes
+author_email: AubreyHewes@users.noreply.github.com
+author_github: @AubreyHewes
+---
+# Administration
+* Fix sw-promotion-v2 detail via datepicker usage so timepickers are displayed again.

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/sw-promotion-v2-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/view/sw-promotion-v2-detail-base/sw-promotion-v2-detail-base.html.twig
@@ -48,7 +48,7 @@
             <sw-datepicker
                 v-model="promotion.validFrom"
                 class="sw-promotion-v2-detail-base__field-valid-from"
-                date-type="datetime-local"
+                date-type="datetime"
                 :label="$tc('sw-promotion-v2.detail.base.general.validFromLabel')"
                 :placeholder-text="$tc('sw-promotion-v2.detail.base.general.validFromPlaceholder')"
                 :disabled="!acl.can('promotion.editor')"
@@ -60,7 +60,7 @@
             <sw-datepicker
                 v-model="promotion.validUntil"
                 class="sw-promotion-v2-detail-base__field-valid-until"
-                date-type="datetime-local"
+                date-type="datetime"
                 :label="$tc('sw-promotion-v2.detail.base.general.validUntilLabel')"
                 :placeholder-text="$tc('sw-promotion-v2.detail.base.general.validUntilPlaceholder')"
                 :disabled="!acl.can('promotion.editor')"


### PR DESCRIPTION
### 1. Why is this change necessary?

Fixes the date-pickers to display time-pickers in the promotion v2 detail/create screens.

### 2. What does this change do, exactly?

Uses the correct prop value for the date-picker `dateType` so the time-pickers are displayed again.
 (as currently used `datetime-local` was removed in v6.5)

### 3. Describe each step to reproduce the issue or behaviour.

Open the promotion detail/create - the date-pickers do not have time-pickers as `datetime-local` was deprecated in 6.4 and removed in 6.5.

### 4. Please link to the relevant issues (if any).
#3238

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a66888</samp>

This pull request fixes the datepicker components in the promotion detail view, so that they show the correct time format according to the `date-type` prop. It also adds a changelog entry for the fix in `changelog/_unreleased/2023-08-01-fix-promotion-datepicker-prop-usage.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a66888</samp>

*  Fix the `date-type` prop of the `sw-datepicker` component in the promotion detail view ([link](https://github.com/shopware/platform/pull/3243/files?diff=unified&w=0#diff-cf3b5b4e58bb1a2870eb369713b08e41ceab5c8804b8db64acc51224062c28cfL51-R51),[link](https://github.com/shopware/platform/pull/3243/files?diff=unified&w=0#diff-cf3b5b4e58bb1a2870eb369713b08e41ceab5c8804b8db64acc51224062c28cfL63-R63))
* Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3243/files?diff=unified&w=0#diff-246aa965524269a907b5d13e688fc47f13f6f979032435acd94299be6285e1dcR1-R9))
