### PR TITLE
prevent cache warmup messages for default headless channel

### DIFF
--- a/src/Storefront/Framework/Cache/CacheWarmer/CacheWarmer.php
+++ b/src/Storefront/Framework/Cache/CacheWarmer/CacheWarmer.php
@@ -2,10 +2,12 @@
 
 namespace Shopware\Storefront\Framework\Cache\CacheWarmer;
 
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Cache\CacheIdLoader;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -31,6 +33,9 @@ class CacheWarmer
         $cacheId ??= $this->cacheIdLoader->load();
 
         $criteria = new Criteria();
+        $criteria->addFilter(
+            new EqualsFilter('salesChannel.typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT),
+        );
         $domains = $this->salesChannelDomainRepository->search($criteria, Context::createDefaultContext())->getEntities();
 
         $this->cacheIdLoader->write($cacheId);


### PR DESCRIPTION
### 1. Why is this change necessary?

To omit faulty cache warmup messages in the queue.

### 2. What does this change do, exactly?

It omits the default headless sales channel domain `default.headless0` from creating cache warmup messages.

### 3. Describe each step to reproduce the issue or behaviour.

Call `bin/console http:cache:warm:up` and you will get faulty messages for the domain `http://localhost/default.headless0`.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9bbeee</samp>

This change fixes a cache warming bug for the storefront by skipping the headless sales channel. It modifies the `CacheWarmer.php` file to add a filter to the cache warming query.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9bbeee</samp>

*  Exclude headless sales channel from cache warming ([link](https://github.com/shopware/platform/pull/3252/files?diff=unified&w=0#diff-a811b61884b78b4810cf56c0ac43047398ace045f113aff79f5dfdfdd366a2c8R9-R11), [link](https://github.com/shopware/platform/pull/3252/files?diff=unified&w=0#diff-a811b61884b78b4810cf56c0ac43047398ace045f113aff79f5dfdfdd366a2c8R37-R41))
   * Import classes from DataAbstractionLayer namespace to create filters ([link](https://github.com/shopware/platform/pull/3252/files?diff=unified&w=0#diff-a811b61884b78b4810cf56c0ac43047398ace045f113aff79f5dfdfdd366a2c8R9-R11))
   * Add filter to criteria object to exclude sales channel with url 'default.headless0' ([link](https://github.com/shopware/platform/pull/3252/files?diff=unified&w=0#diff-a811b61884b78b4810cf56c0ac43047398ace045f113aff79f5dfdfdd366a2c8R37-R41))
