### PR TITLE
Fix for distorted Thumbnails

### DIFF
--- a/changelog/_unreleased/2023-08-04-Fix-for-distorted-Thumbnails.md
+++ b/changelog/_unreleased/2023-08-04-Fix-for-distorted-Thumbnails.md
@@ -1,0 +1,9 @@
+---
+title:              Fix for distorted Thumbnails
+issue:              NEXT-30672
+author:             Kevin Hansen
+author_email:       kevin.hansen@banemo.de
+---
+# Core
+*  Fixed incorrect condition that skipped thumbnail size calculation 
+*  Fixed thumbnail size calculation to take unequal aspect ratios into account

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -345,7 +345,7 @@ class ThumbnailService
         MediaThumbnailSizeEntity $preferredThumbnailSize,
         MediaFolderConfigurationEntity $config
     ): array {
-        if (!$config->getKeepAspectRatio() || $preferredThumbnailSize->getWidth() !== $preferredThumbnailSize->getHeight()) {
+        if (!$config->getKeepAspectRatio()) {
             $calculatedWidth = $preferredThumbnailSize->getWidth();
             $calculatedHeight = $preferredThumbnailSize->getHeight();
 
@@ -361,10 +361,10 @@ class ThumbnailService
         }
 
         if ($imageSize['width'] >= $imageSize['height']) {
-            $aspectRatio = $imageSize['height'] / $imageSize['width'];
-
+            $factor = $preferredThumbnailSize->getWidth() / $imageSize['width'];
+            
             $calculatedWidth = $preferredThumbnailSize->getWidth();
-            $calculatedHeight = (int) ceil($preferredThumbnailSize->getHeight() * $aspectRatio);
+            $calculatedHeight = (int) ceil($imageSize['height'] * $factor);
 
             $useOriginalSizeInThumbnails = $imageSize['width'] < $calculatedWidth || $imageSize['height'] < $calculatedHeight;
 
@@ -377,9 +377,9 @@ class ThumbnailService
             ];
         }
 
-        $aspectRatio = $imageSize['width'] / $imageSize['height'];
+        $factor = $preferredThumbnailSize->getHeight() / $imageSize['height'];
 
-        $calculatedWidth = (int) ceil($preferredThumbnailSize->getWidth() * $aspectRatio);
+        $calculatedWidth = (int) ceil($imageSize['width'] * $factor);
         $calculatedHeight = $preferredThumbnailSize->getHeight();
 
         $useOriginalSizeInThumbnails = $imageSize['width'] < $calculatedWidth || $imageSize['height'] < $calculatedHeight;


### PR DESCRIPTION
### 1. Why is this change necessary?
Thumbnails are distorted if the config for thumbnail width and height isn't equal

### 2. What does this change do, exactly?
To check whether the KeepAspectRatio config is set **or** the configured width and height is different doesn't make sense.
Currently every Thumbnail that has a different width and height config is distorted.
You only have to check, if the KeepAspectRatio config is set and then calculate the correct thumbnail size based on a factor and not the aspect ratio.

Here is a small table that represents the new calculation:

Image width | Image height | Factor | Thumbnail width | Thumbnail height | New width | New height
-- | -- | -- | -- | -- | -- | --
2000 | 1000 | 0,4 | 800 | 600 | 800 | 400
2000 | 1000 | 0,3 | 600 | 800 | 600 | 300
2000 | 1000 | 0,4 | 800 | 800 | 800 | 400
1000 | 2000 | 0,3 | 800 | 600 | 300 | 600
1000 | 2000 | 0,4 | 600 | 800 | 400 | 800
1000 | 2000 | 0,4 | 800 | 800 | 400 | 800

### 3. Describe each step to reproduce the issue or behaviour.
Create a new Thumbnail config width deviating width and height -> upload images.