### PR TITLE
Remove objects from storefront exceptions messages

### DIFF
--- a/changelog/_unreleased/2023-08-08-remove-objects-from-storefront-exceptions.md
+++ b/changelog/_unreleased/2023-08-08-remove-objects-from-storefront-exceptions.md
@@ -1,0 +1,9 @@
+---
+title: Remove objects from the storefront exception messages
+flag: V6_5_0_0
+author: Ruslan Belziuk
+author_email: ruslan@dumka.pro
+author_github: @ruslanbelziuk
+---
+# Storefront
+* Prevent the context object from ruining the debug process with a very long JSON string

--- a/src/Storefront/Controller/Exception/StorefrontException.php
+++ b/src/Storefront/Controller/Exception/StorefrontException.php
@@ -18,6 +18,14 @@ class StorefrontException extends HttpException
      */
     public static function cannotRenderView(string $view, string $message, array $parameters): self
     {
+        /**
+         * The parameters array often contains large objects (like the page context). Passing them into the exception
+         * message may overflow further regex functions. Therefore we filter out all objects.
+         */
+        $parameters = array_filter($parameters, static function ($param) {
+            return !\is_object($param);
+        });
+
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::CAN_NOT_RENDER_VIEW,

--- a/tests/unit/Storefront/Controller/Exception/StorefrontExceptionTest.php
+++ b/tests/unit/Storefront/Controller/Exception/StorefrontExceptionTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Unit\Storefront\Controller\Exception;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
 use Shopware\Storefront\Controller\Exception\StorefrontException;
 
 /**
@@ -14,7 +15,12 @@ class StorefrontExceptionTest extends TestCase
 {
     public function testCannotRenderView(): void
     {
-        $res = StorefrontException::cannotRenderView('test.html.twig', 'Error message', ['param' => 'Param']);
+        $parameters = [
+            'param' => 'Param',
+            'context' => Context::createDefaultContext(),
+        ];
+
+        $res = StorefrontException::cannotRenderView('test.html.twig', 'Error message', $parameters);
 
         static::assertEquals(500, $res->getStatusCode());
         static::assertEquals('STOREFRONT__CAN_NOT_RENDER_VIEW', $res->getErrorCode());


### PR DESCRIPTION
### 1. Why is this change necessary?
When an exception happens within a Twig template, Shopware creates a wrapping exception, that also includes all the parameters that were passed to the template in a JSON format.

Since the list of parameters includes a Context object, the resulting JSON turns up extremely long. In fact, it's too long for a further Symfony regex function to process the string. It results into the `Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer::formatFileFromText()` method returning `null` instead of a `string` and it causes a brand new exception, that prevents the developer from seeing the original one. Example:
<img width="1326" alt="image" src="https://github.com/shopware/platform/assets/1923175/933f41a8-a6aa-4028-87c6-1559dff3a6b9">


### 2. What does this change do, exactly?
It filters out all the objects from the exception message.


### 3. Describe each step to reproduce the issue or behaviour.

1. Switch `APP_ENV` to `debug`
2. Include a non-existing template in your `index.html.twig`:
```{% sw_include 'non-existing.html.twig' %}```
3. You will see an exception: `Symfony\Component\ErrorHandler\ErrorRenderer\HtmlErrorRenderer::formatFileFromText(): Return value must be of type string, null returned`, instead of the exception regarding a missing template file.


### 4. Please link to the relevant issues (if any).
I haven't found any.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] ~I have written or adjusted the documentation according to my changes~
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3d1ba96</samp>

This pull request fixes a bug that caused the storefront to crash when trying to render a non-existing template. It adds a filter to the `cannotRenderView` function in `StorefrontException.php` and updates the corresponding unit test in `StorefrontExceptionTest.php`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3d1ba96</samp>

*  Add a filter to the `cannotRenderView` function in the `StorefrontException` class to prevent large objects from being passed into the exception message ([link](https://github.com/shopware/platform/pull/3256/files?diff=unified&w=0#diff-fb55936411acf81481a993266d31520942066b6a3783fb3fe3ae3613e4c30419R21-R28))
*  Update the unit test for the `cannotRenderView` function in the `StorefrontExceptionTest` class to include a `context` parameter that would be filtered out by the function ([link](https://github.com/shopware/platform/pull/3256/files?diff=unified&w=0#diff-c9714cf9964a0bae24ba7a6cf1e25b42e2994444c1920141d70a142bc7541841R6), [link](https://github.com/shopware/platform/pull/3256/files?diff=unified&w=0#diff-c9714cf9964a0bae24ba7a6cf1e25b42e2994444c1920141d70a142bc7541841L17-R24))
