### PR TITLE
Fix overridden promise $super calls in async component factory

### DIFF
--- a/changelog/_unreleased/2023-08-09-fix-overridden-super-calls-in-promise-chains-in-admin-components.md
+++ b/changelog/_unreleased/2023-08-09-fix-overridden-super-calls-in-promise-chains-in-admin-components.md
@@ -1,0 +1,9 @@
+---
+title: Fix overridden super calls in promise chains in admin components
+issue:
+author: Maximilian Rüsch
+author_email: maximilian.ruesch@pickware.de
+author_github: maximilianruesch
+---
+# Administration
+* Fixed the `async-component.factory.ts` to allow overrides of components that make `$super` calls inside promise chains.

--- a/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.spec.js
@@ -1399,7 +1399,7 @@ describe('core/factory/async-component.factory.ts', () => {
         });
     });
 
-    describe.only('should build the $super-call-stack when $super-call to an asynchronous method is inside an promise chain and the component providing the promise chain is overridden', () => {
+    describe('should build the $super-call-stack when $super-call to an asynchronous method is inside an promise chain and the component providing the promise chain is overridden', () => {
         createComponentMatrix({
             A: () => ({
                 methods: {

--- a/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.spec.js
@@ -1352,6 +1352,53 @@ describe('core/factory/async-component.factory.ts', () => {
         });
     });
 
+    describe('should build the $super-call-stack when $super-call is inside an promise chain and the component providing the promise chain is overridden', () => {
+        createComponentMatrix({
+            A: () => ({
+                methods: {
+                    fooBar() {
+                        return 'fooBar';
+                    },
+                },
+                template: '{% block content %}<div>This is a test template.</div>{% endblock %}',
+            }),
+            B: () => ({
+                methods: {
+                    fooBar() {
+                        const p = new Promise((resolve) => {
+                            resolve('Baz');
+                        });
+
+
+                        return p.then((value) => {
+                            const prev = this.$super('fooBar');
+
+                            return `${prev}${value}`;
+                        });
+                    },
+                },
+            }),
+            C: () => ({
+                methods: {
+                    fooBar() {
+                        return this.$super('fooBar').then((value) => `${value}Buz`);
+                    },
+                },
+            }),
+        }).forEach(({ testCase, components }) => {
+            it(`${testCase}`, async () => {
+                ComponentFactory.register('test-component', components.A());
+                ComponentFactory.override('test-component', components.B());
+                ComponentFactory.override('test-component', components.C());
+
+                const component = shallowMount(await ComponentFactory.build('test-component'));
+
+                expect(component.vm).toBeTruthy();
+                expect(await component.vm.fooBar()).toBe('fooBarBazBuz');
+            });
+        });
+    });
+
     describe('should extend an extended component and all three components get build before with usage of parent', () => {
         createComponentMatrix({
             A: () => ({

--- a/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.ts
+++ b/src/Administration/Resources/app/administration/src/core/factory/async-component.factory.ts
@@ -643,15 +643,8 @@ function addSuperBehaviour(inheritedFrom: string, superRegistry: SuperRegistry):
             this._virtualCallStack[name] = superFuncObject.parent;
 
             // @ts-expect-error
-            const result = superFuncObject.func.bind(this)(...args);
-
-            // reset the virtual call-stack
-            if (superFuncObject.parent) {
-                this._virtualCallStack[name] = this._inheritedFrom();
-            }
-
             // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            return result;
+            return superFuncObject.func.bind(this)(...args);
         },
         _initVirtualCallStack(name) {
             // if there is no virtualCallStack


### PR DESCRIPTION
### 1. Why is this change necessary?

Without the change, overriding a component which was already overridden was not entirely possible if the first override makes a `$super` call inside a promise chain. The second override itself worked, but calling `$super` from it to the overridden method in the first override caused an infinite loop as the virtual call stack was reset every iteration.

### 2. What does this change do, exactly?

Removes a virtual call stack reset that caused the problem described above. Also adds a test for the described case.

### 3. Describe each step to reproduce the issue or behaviour.

1. Register a regular component with any method
2. Register an override for the component that overrides this method and returns a promise chain which at some point calls `$super` to the regular component method.
3. Register another override for the component that also overrides the method and calls `$super` to the first override. This second `$super` call does not need to be inside a promise chain, but can be.
4. Profit

Or alternatively:
1. Execute the given new unit test without the change.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb2ee08</samp>

This pull request fixes a bug in the `async-component.factory.ts` that caused the `$super` calls inside promise chains to be overridden by the wrong component. It also adds a changelog entry and a unit test for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fb2ee08</samp>

* Fix overridden `$super` calls in promise chains in admin components ([link](https://github.com/shopware/platform/pull/3257/files?diff=unified&w=0#diff-5d7bf7ebdab6033da74de1bf7446bab0e466337f1cc35815712a21e008e68c4dR1-R9))
* Simplify the `_inheritedFrom` method in the `async-component.factory.ts` ([link](https://github.com/shopware/platform/pull/3257/files?diff=unified&w=0#diff-f454ec143c7039fa6a9d2fb4e120ba852c54eb63e97dc6b708bb9c50f6ea2465L646-R647))
* Add a unit test for the `async-component.factory.ts` ([link](https://github.com/shopware/platform/pull/3257/files?diff=unified&w=0#diff-0b38e57a0f3666e7cb12c77f16f2d9f95a0f0e4c94b6c084cf3007300565568eR1355-R1401))
