### PR TITLE
Fix ElasticSearch date formatting to support millis that are not 0

### DIFF
--- a/src/Elasticsearch/Product/CustomFieldUpdater.php
+++ b/src/Elasticsearch/Product/CustomFieldUpdater.php
@@ -87,7 +87,7 @@ class CustomFieldUpdater implements EventSubscriberInterface
             ],
             CustomFieldTypes::DATETIME => [
                 'type' => 'date',
-                'format' => 'yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis',
+                'format' => 'yyyy-MM-dd HH:mm:ss.SSS||strict_date_optional_time||epoch_millis',
                 'ignore_malformed' => true,
             ],
             CustomFieldTypes::PRICE, CustomFieldTypes::JSON => [

--- a/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
+++ b/src/Elasticsearch/Product/ElasticsearchProductDefinition.php
@@ -126,12 +126,12 @@ class ElasticsearchProductDefinition extends AbstractElasticsearchDefinition
                 'ratingAverage' => self::FLOAT_FIELD,
                 'releaseDate' => [
                     'type' => 'date',
-                    'format' => 'yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis',
+                    'format' => 'yyyy-MM-dd HH:mm:ss.SSS||strict_date_optional_time||epoch_millis',
                     'ignore_malformed' => true,
                 ],
                 'createdAt' => [
                     'type' => 'date',
-                    'format' => 'yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis',
+                    'format' => 'yyyy-MM-dd HH:mm:ss.SSS||strict_date_optional_time||epoch_millis',
                     'ignore_malformed' => true,
                 ],
                 'sales' => self::INT_FIELD,

--- a/src/Elasticsearch/Product/EsProductDefinition.php
+++ b/src/Elasticsearch/Product/EsProductDefinition.php
@@ -151,12 +151,12 @@ class EsProductDefinition extends AbstractElasticsearchDefinition
             'ratingAverage' => self::FLOAT_FIELD,
             'releaseDate' => [
                 'type' => 'date',
-                'format' => 'yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis',
+                'format' => 'yyyy-MM-dd HH:mm:ss.SSS||strict_date_optional_time||epoch_millis',
                 'ignore_malformed' => true,
             ],
             'createdAt' => [
                 'type' => 'date',
-                'format' => 'yyyy-MM-dd HH:mm:ss.000||strict_date_optional_time||epoch_millis',
+                'format' => 'yyyy-MM-dd HH:mm:ss.SSS||strict_date_optional_time||epoch_millis',
                 'ignore_malformed' => true,
             ],
             'sales' => self::INT_FIELD,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When creating a dynamic product group where you filter by for example releaseDate using elasticsearch it will throw a "parse_exception" error due to the formatting.

### 2. What does this change do, exactly?
It changes the accepted formatting from elasticsearch from "yyyy-MM-dd HH:mm:ss.000" to "yyyy-MM-dd HH:mm:ss.SSS" where SSS is the placeholder for milliseconds

### 3. Describe each step to reproduce the issue or behaviour.

1. Update a Product via the Shopware API and set for example releaseDate to an ISO 8601 date (2020-05-12T13:13:42.817684Z for example). It is important that the date has milliseconds (happens with Carbon often for example) because the formatter will not error if it is exactly 000 (this is what the shopware frontend will do)
2. Create a dynamic product group filtering by releaseDate last 30 days for example
3. Open the Category for this dynamic product group and you will see mentined error

### 4. Please link to the relevant issues (if any).
I didnt see any related issues

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c75a7c</samp>

Fix date format for custom fields and product fields in Elasticsearch mapping. Replace `.000` with `.SSS` in the date format for the custom field type `DATETIME` and the product fields `releaseDate` and `createdAt` in the files `CustomFieldUpdater.php`, `ElasticsearchProductDefinition.php`, and `EsProductDefinition.php`. This resolves the issue https://issues.shopware.com/issues/NEXT-16385.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4c75a7c</samp>

*  Fix date format for custom fields of type `DATETIME` in Elasticsearch mapping ([link](https://github.com/shopware/platform/pull/3258/files?diff=unified&w=0#diff-2faf35360da227fcddb7de169e5ba9b6c7105a4cc8b1537b00e0294066a6a6dbL90-R90))
*  Fix date format for `releaseDate` and `createdAt` fields in Elasticsearch mapping for product entity ([link](https://github.com/shopware/platform/pull/3258/files?diff=unified&w=0#diff-f6f34de531f2162f715742f8936dce9c7f524232455d9b352f1cf3e284a76d0eL129-R134), [link](https://github.com/shopware/platform/pull/3258/files?diff=unified&w=0#diff-403b1b487d40f85ff018e8777ecdc00856c3d42fa3fcca63e04496fda3383079L154-R159))
*  Apply the same fix to the deprecated `EsProductDefinition` class for backward compatibility ([link](https://github.com/shopware/platform/pull/3258/files?diff=unified&w=0#diff-403b1b487d40f85ff018e8777ecdc00856c3d42fa3fcca63e04496fda3383079L154-R159))
