### PR TITLE
NEXT-22108: fixed sub folder navigation

### DIFF
--- a/changelog/_unreleased/2023-08-11-fix-media-move-navigation.md
+++ b/changelog/_unreleased/2023-08-11-fix-media-move-navigation.md
@@ -1,0 +1,6 @@
+---
+title: Media cannot be moved higher than the parent folder
+issue: NEXT-22108
+---
+# Administration
+* Changed the method `updateParentFolder` in `src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-move/index.js`

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-move/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-move/index.js
@@ -127,7 +127,7 @@ export default {
                 const criteria = new Criteria(1, 1)
                     .addFilter(Criteria.equals('id', child.parentId))
                     .addAssociation('children');
-                const items = await this.mediaFolderRepository.search(criteria, Context.api);$
+                const items = await this.mediaFolderRepository.search(criteria, Context.api);
                 if (items.length === 1) {
                     this.parentFolder = items[0];
                 } else {

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-move/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-move/index.js
@@ -1,7 +1,7 @@
 import template from './sw-media-modal-move.html.twig';
 import './sw-media-modal-move.scss';
 
-const { Mixin, Context } = Shopware;
+const { Mixin, Context, Data: { Criteria } } = Shopware;
 
 /**
  * @status ready
@@ -124,7 +124,15 @@ export default {
             } else if (child.parentId === null) {
                 this.parentFolder = { id: null, name: this.rootFolderName };
             } else {
-                this.parentFolder = await this.mediaFolderRepository.get(child.parentId, Context.api);
+                const criteria = new Criteria(1, 1)
+                    .addFilter(Criteria.equals('id', child.parentId))
+                    .addAssociation('children');
+                const items = await this.mediaFolderRepository.search(criteria, Context.api);$
+                if (items.length === 1) {
+                    this.parentFolder = items[0];
+                } else {
+                    this.parentFolder = null;
+                }
             }
         },
 


### PR DESCRIPTION
### 1. Why is this change necessary?

the navigation in the media move modal is broken.

### 2. What does this change do, exactly?

added "children" association to the criteria for the parent folder.

### 3. Describe each step to reproduce the issue or behaviour.

1. create at least two subfolder
2. add an image
2. try to move the file up

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-22108

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a89299c</samp>

This pull request fixes a bug that could cause media folders to be moved to invalid locations in the administration. It improves the query logic in `sw-media-modal-move` and adds a changelog entry for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a89299c</samp>

*  Add changelog entry for fixing media move navigation ([link](https://github.com/shopware/platform/pull/3259/files?diff=unified&w=0#diff-1d9f80a15ef424fb3b0a5f855e03c7b72aea4c88cc8c514f08566c986d58da74R1-R6))
*  Import `Criteria` class to create media folder query filter ([link](https://github.com/shopware/platform/pull/3259/files?diff=unified&w=0#diff-bc50a6135f4647b329d35d831c602e254c5af94fade9edba7196b68b8523a0c4L4-R4))
*  Update `updateParentFolder` method to fetch parent folder with children association and prevent invalid moves ([link](https://github.com/shopware/platform/pull/3259/files?diff=unified&w=0#diff-bc50a6135f4647b329d35d831c602e254c5af94fade9edba7196b68b8523a0c4L127-R135))
