### PR TITLE
Provide recipient option `default` in flow mail send modal if trigger implements `MailAware`

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-mail-send-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-mail-send-modal/index.js
@@ -65,6 +65,15 @@ export default {
             ];
         },
 
+        recipientMailStruct() {
+            return [
+                {
+                    value: 'default',
+                    label: this.$tc('sw-flow.modals.mail.labelMailStruct'),
+                },
+            ];
+        },
+
         recipientAdmin() {
             return [
                 {
@@ -105,6 +114,10 @@ export default {
             return ['CustomerAware', 'UserAware', 'OrderAware', 'CustomerGroupAware'];
         },
 
+        mailAware() {
+            return ['MailAware'];
+        },
+
         recipientOptions() {
             const allowedAwareOrigin = this.triggerEvent.aware ?? [];
             const allowAwareConverted = [];
@@ -142,6 +155,16 @@ export default {
             if (hasEntityAware) {
                 return [
                     ...this.recipientCustomer,
+                    ...this.recipientAdmin,
+                    ...this.recipientCustom,
+                ];
+            }
+
+            const hasMailAware = allowAwareConverted.some(allowedAware => this.mailAware.includes(allowedAware));
+
+            if (hasMailAware) {
+                return [
+                    ...this.recipientMailStruct,
                     ...this.recipientAdmin,
                     ...this.recipientCustom,
                 ];

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/de-DE.json
@@ -241,6 +241,7 @@
         "buttonAddMailTemplate": "E-Mail-Template hinzufügen",
         "labelDefault": "Standard",
         "labelCustomer": "Kunde",
+        "labelMailStruct": "Automatisch",
         "labelAdmin": "Administrator",
         "labelCustom": "Anderer Empfänger",
         "labelContactFormMail": "Anfragesteller",

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/en-GB.json
@@ -241,6 +241,7 @@
         "buttonAddMailTemplate": "Add email template",
         "labelDefault": "Default",
         "labelCustomer": "Customer",
+        "labelMailStruct": "Automatic",
         "labelAdmin": "Admin",
         "labelCustom": "Custom recipient",
         "labelContactFormMail": "Inquirer",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

See [3260](https://github.com/shopware/platform/issues/3260)

### 2. What does this change do, exactly?

This change makes it possible to configure an 'Automatic' email recipient in a send mail flow action if the flow trigger implements `MailAware`.

### 3. Describe each step to reproduce the issue or behaviour.

See [3260](https://github.com/shopware/platform/issues/3260)

### 4. Please link to the relevant issues (if any).

See [3260](https://github.com/shopware/platform/issues/3260)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 369c675</samp>

Added a new feature to the flow module that allows users to choose the mail structure for mail aware entities in the mail send modal. Added the corresponding snippets for the German and English translations. Refactored some code for readability.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 369c675</samp>

*  Add `recipientMailStruct` computed property to return mail structure option for mail send modal ([link](https://github.com/shopware/platform/pull/3261/files?diff=unified&w=0#diff-44642660d6e8c75eea1dead363d11c0b7011a733be9e65bc01b806d9a5e8c07bR68-R76))
*  Add `mailAware` computed property to return mail aware entities for mail send modal ([link](https://github.com/shopware/platform/pull/3261/files?diff=unified&w=0#diff-44642660d6e8c75eea1dead363d11c0b7011a733be9e65bc01b806d9a5e8c07bR117-R120))
*  Modify `recipientOptions` computed property to conditionally include mail structure option based on mail aware entities ([link](https://github.com/shopware/platform/pull/3261/files?diff=unified&w=0#diff-44642660d6e8c75eea1dead363d11c0b7011a733be9e65bc01b806d9a5e8c07bR163-R172))
*  Add snippet for mail structure option label to German and English translation files ([link](https://github.com/shopware/platform/pull/3261/files?diff=unified&w=0#diff-9c6aa1c7adeb73b7549f8b772686874e5e9135378e376a6c12d284c5bb189689R244), [link](https://github.com/shopware/platform/pull/3261/files?diff=unified&w=0#diff-cd85183509c27c812abafd565ba3593d4d90b9c0ae2fd791d3d6644576a6beddR244))
*  Reformat code to remove spaces inside curly braces for consistency and readability ([link](https://github.com/shopware/platform/pull/3261/files?diff=unified&w=0#diff-44642660d6e8c75eea1dead363d11c0b7011a733be9e65bc01b806d9a5e8c07bL1-R7), [link](https://github.com/shopware/platform/pull/3261/files?diff=unified&w=0#diff-44642660d6e8c75eea1dead363d11c0b7011a733be9e65bc01b806d9a5e8c07bL407-R431), [link](https://github.com/shopware/platform/pull/3261/files?diff=unified&w=0#diff-44642660d6e8c75eea1dead363d11c0b7011a733be9e65bc01b806d9a5e8c07bL415-R438), [link](https://github.com/shopware/platform/pull/3261/files?diff=unified&w=0#diff-44642660d6e8c75eea1dead363d11c0b7011a733be9e65bc01b806d9a5e8c07bL502-R525))
