### PR TITLE
Fix snipet file collection and snippet service performance

### DIFF
--- a/src/Core/System/Snippet/Files/SnippetFileCollection.php
+++ b/src/Core/System/Snippet/Files/SnippetFileCollection.php
@@ -12,6 +12,8 @@ use Shopware\Core\System\Snippet\Exception\InvalidSnippetFileException;
 #[Package('system-settings')]
 class SnippetFileCollection extends Collection
 {
+    private ?array $mapping = null;
+
     /**
      * @param AbstractSnippetFile $snippetFile
      */
@@ -110,13 +112,14 @@ class SnippetFileCollection extends Collection
 
     public function hasFileForPath(string $filePath): bool
     {
-        $filePath = realpath($filePath);
+        if ($this->mapping === null) {
+            $this->mapping = [];
+            foreach ($this->elements as $element) {
+                $this->mapping[realpath($element->getPath())] = true;
+            }
+        }
 
-        $filesWithMatchingPath = $this->filter(
-            static fn (AbstractSnippetFile $file): bool => realpath($file->getPath()) === $filePath
-        );
-
-        return $filesWithMatchingPath->count() > 0;
+        return isset($this->mapping[realpath($filePath)]);
     }
 
     protected function getExpectedClass(): ?string

--- a/src/Core/System/Snippet/SnippetService.php
+++ b/src/Core/System/Snippet/SnippetService.php
@@ -109,7 +109,7 @@ class SnippetService
 
         $snippets = [];
 
-        $snippetFileCollection = clone $this->snippetFileCollection;
+        $snippetFileCollection = $this->snippetFileCollection;
 
         $usingThemes = $this->getUsedThemes($salesChannelId);
         $unusedThemes = $this->getUnusedThemes($usingThemes);


### PR DESCRIPTION
## SnippetService

The clone of the collection is unnecessary due to two facts:
1) Class variable is injected from the container, it is immutable for multiple requests, no need to clone it
2) It is filtered aftwards

## SnippetCollection

In projects with multiple plugins, this function is called nearly 100 times. The internal collection contains round about 50 items. So it is looping over 50 items 100 times which creates a load (locally) of 50ms. After this change it is reduced (locally) to 0.05 ms with the same result 

Here a trace of a project:

![image](https://github.com/shopware/platform/assets/1035358/d424481d-5804-442e-868e-7a05e093e51b)

![image](https://github.com/shopware/platform/assets/1035358/512c82e0-6c5e-498e-ac04-51a8116a5c13)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 210dc41</samp>

Optimized the loading of snippets from files by using a mapping property in `SnippetFileCollection` and removing an unnecessary cloning operation in `SnippetService`. This reduces the memory and time consumption of the snippet system.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 210dc41</samp>

* Optimize the `hasFileForPath` method in the `SnippetFileCollection` class by using a private `$mapping` property to cache the file paths and their existence in the collection ([link](https://github.com/shopware/platform/pull/3264/files?diff=unified&w=0#diff-7b3c72f5f3bc8f1ff57f9a03a076bf850dd32830f3edf68eaed975b591c80badR15-R16),[link](https://github.com/shopware/platform/pull/3264/files?diff=unified&w=0#diff-7b3c72f5f3bc8f1ff57f9a03a076bf850dd32830f3edf68eaed975b591c80badL113-R122))
* Remove the unnecessary cloning of the `$snippetFileCollection` property in the `getStorefrontSnippets` method in the `SnippetService` class to reduce memory usage and execution time ([link](https://github.com/shopware/platform/pull/3264/files?diff=unified&w=0#diff-b5281fb7db32cdc0b7eeb50147ba0dbe5ef9b1a1f5ca4d915f4b0858b7fb41d6L112-R112))
