### PR TITLE
Fix sw-datepicker for mounting on initial page load

### DIFF
--- a/changelog/_unreleased/2023-08-14-fix-sw-datepicker-to-load-refs-correctly-on-first-page-load.md
+++ b/changelog/_unreleased/2023-08-14-fix-sw-datepicker-to-load-refs-correctly-on-first-page-load.md
@@ -1,0 +1,8 @@
+---
+title: Fix datepicker to correctly load Vue refs on initial page loads
+author: Maximilian Rüsch
+author_email: maximilian.ruesch@pickware.de
+author_github: maximilianruesch
+---
+# Administration
+* Changed `sw-datepicker` to prevent component crashes if the component is on the initially visited page.

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/form/sw-datepicker/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/form/sw-datepicker/index.js
@@ -112,6 +112,9 @@ export default {
     },
 
     computed: {
+        /**
+         * @deprecated tag:v6.6.0 - Will be removed, use `this.$refs.flatpickrInput` instead.
+         */
         flatpickrInputRef() {
             return this.$refs.flatpickrInput;
         },
@@ -403,7 +406,7 @@ export default {
             });
 
             // Init flatpickr only if it is not already loaded.
-            this.flatpickrInstance = new Flatpickr(this.flatpickrInputRef, mergedConfig);
+            this.flatpickrInstance = new Flatpickr(this.$refs.flatpickrInput, mergedConfig);
             this.flatpickrInstance.config.onOpen.push(() => {
                 this.isDatepickerOpen = true;
             });

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/form/sw-datepicker/sw-datepicker.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/form/sw-datepicker/sw-datepicker.html.twig
@@ -10,7 +10,7 @@
     @sw-contextual-field-suffix-clicked="openDatepicker"
     @inheritance-restore="$emit('inheritance-restore', $event)"
     @inheritance-remove="$emit('inheritance-remove', $event)"
-    @hook:mounted="createFlatpickrInstance"
+    @base-field-mounted="createFlatpickrInstance"
     v-on="additionalEventListeners"
 >
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-base-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/field-base/sw-base-field/index.js
@@ -141,4 +141,8 @@ Component.register('sw-base-field', {
             return !!this.label || !!this.$slots.label || !!this.$scopedSlots?.label?.();
         },
     },
+
+    mounted() {
+        this.$emit('base-field-mounted');
+    },
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

Loading a page with a `sw-datepicker` on it as the first page (/ reloading the admin on that page) will lead to the `sw-datepicker` being empty and uninitialized (as seen in Image [0]). Interacting with it does not work. Opening the dev-tools shows multiple errors related to the initialization of the underlying `flatpickr` instance on the HTML `input` element (as seen in image [1]). The fact that multiple errors (and not a single one) occur is likely connected to the `sw-datepicker` being async, but this is not further investigated there.

Note that on all pictures related to the errors provided, you have the following information:
- A log that the `@hook:mounted` of the component was called (see the template of `sw-datepicker`
- A log of the state of the computed property and the `$refs` pointer to the HTML `input` object
- The error in the further handling trying to create the `flatpickr` instance

### 2. What does this change do, exactly?

1. This change removes an indirection between the `$ref` with which the HTML `input` element is referenced and the creation of the `flatpickr` instance, as it is[ incompatible with Vue computed properties](https://v2.vuejs.org/v2/guide/components-edge-cases.html#Accessing-Child-Component-Instances-amp-Child-Elements) (`$refs` are not reactive). Effect of this change is seen in image [2].
2. This change introduces a safeguard that gracefully prevents a `flatpickr` instance from being created if the required `$ref` is not yet set. Effect of this change (together with 1.) is seen in [3].

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a page with an unconditional `sw-datepicker` on it
2. Visit this page in the admin
3. Open dev-tools
4. Reload the admin

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7694bb8</samp>

This pull request fixes a bug in the `sw-datepicker` component that prevented it from working on the first page load. It also updates the changelog with the relevant information.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7694bb8</samp>

* Add a changelog entry for the fix of the datepicker component ([link](https://github.com/shopware/platform/pull/3267/files?diff=unified&w=0#diff-b86876f2a9e572415c739ab946d18fa535c65dca0a27375128e2cf6ce16b003bR1-R8))
* Remove the computed property `flatpickrInputRef` from the datepicker component, as it caused errors if the input ref was not yet available ([link](https://github.com/shopware/platform/pull/3267/files?diff=unified&w=0#diff-f9d8bc3c885eda1c9eec09603aed06db08ee10a71c2af095df3579e0a2f9fdc4L115-L118))
* Check if the input ref is available before initializing the flatpickr instance in the `initFlatpickr` method, to prevent the component from crashing on the first page load ([link](https://github.com/shopware/platform/pull/3267/files?diff=unified&w=0#diff-f9d8bc3c885eda1c9eec09603aed06db08ee10a71c2af095df3579e0a2f9fdc4R387-R390))
* Use the input ref directly instead of the computed property in the `updateFlatpickr` and `destroyFlatpickr` methods, to simplify the code and avoid the dependency ([link](https://github.com/shopware/platform/pull/3267/files?diff=unified&w=0#diff-f9d8bc3c885eda1c9eec09603aed06db08ee10a71c2af095df3579e0a2f9fdc4L406-R406))

Image [0]:
![image_0](https://github.com/shopware/platform/assets/78490564/e9d4b134-0c0b-48d6-b682-64a3f75e39ec)

Image [1]:
![image](https://github.com/shopware/platform/assets/78490564/c5f19b79-0be6-4bd2-b578-482b70c5effa)

Image [2]:
![image](https://github.com/shopware/platform/assets/78490564/f18c79f4-133e-469f-b2e0-4c66d573f1c8)

Image [3]:
![image](https://github.com/shopware/platform/assets/78490564/e92d8ca6-652b-420f-a64b-d6c18f7fb5bf)

