### PR TITLE
feat: Allow to limit the sales channel for which the theme is compiled

### DIFF
--- a/changelog/_unreleased/2023-08-16-allow-to-restrict-theme-compile-to-themes-and-sales-channels.md
+++ b/changelog/_unreleased/2023-08-16-allow-to-restrict-theme-compile-to-themes-and-sales-channels.md
@@ -1,0 +1,10 @@
+---
+title: Allow to restrict theme:compile to themes and sales channels
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Added flags `--only` and `--skip` to the `theme:compile` command to skip or include the theme compilation for specific sales channel ids
+* Added flags `--only-themes` and `--skip-themes` to the `theme:compile` command to skip or include the theme compilation for specific theme ids

--- a/src/Storefront/Theme/Command/ThemeCompileCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCompileCommand.php
@@ -36,7 +36,12 @@ class ThemeCompileCommand extends Command
     {
         $this
             ->addOption('keep-assets', 'k', InputOption::VALUE_NONE, 'Keep current assets, do not delete them')
-            ->addOption('active-only', 'a', InputOption::VALUE_NONE, 'Compile themes only for active  sales channels');
+            ->addOption('active-only', 'a', InputOption::VALUE_NONE, 'Compile themes only for active sales channels')
+            ->addOption('only', 'o', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Compile themes only for given sales channels ids')
+            ->addOption('skip', 's', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Skip compiling themes for given sales channels ids')
+            ->addOption('only-themes', 'O', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Compile themes only for given sales channels ids')
+            ->addOption('skip-themes', 'S', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Skip compiling themes for given sales channels ids')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -45,7 +50,38 @@ class ThemeCompileCommand extends Command
         $context = Context::createDefaultContext();
         $this->io->writeln('Start theme compilation');
 
+        $onlySalesChannel = ((array) $input->getOption('only')) ?: null;
+        $skipSalesChannel = ((array) $input->getOption('skip')) ?: null;
+        if ($onlySalesChannel !== null && $skipSalesChannel !== null
+            && \count(array_intersect($onlySalesChannel, $skipSalesChannel)) > 0) {
+            $this->io->error('The sales channel includes and skips contain contradicting entries:' . implode(
+                ', ',
+                array_intersect($onlySalesChannel, $skipSalesChannel)
+            ));
+
+            return self::FAILURE;
+        }
+
+        $onlyThemes = ((array) $input->getOption('only-themes')) ?: null;
+        $skipThemes = ((array) $input->getOption('skip-themes')) ?: null;
+        if ($onlyThemes !== null && $skipThemes !== null
+            && \count(array_intersect($onlyThemes, $skipThemes)) > 0) {
+            $this->io->error('The theme includes and skips contain contradicting entries:' . implode(
+                ', ',
+                array_intersect($onlyThemes, $skipThemes)
+            ));
+
+            return self::FAILURE;
+        }
+
         foreach ($this->themeProvider->load($context, $input->getOption('active-only')) as $salesChannelId => $themeId) {
+            if ($onlySalesChannel !== null && !\in_array($salesChannelId, $onlySalesChannel, true)
+                || $skipSalesChannel !== null && \in_array($salesChannelId, $skipSalesChannel, true)
+                || $onlyThemes !== null && !\in_array($themeId, $onlyThemes, true)
+                || $skipThemes !== null && \in_array($themeId, $skipThemes, true)) {
+                continue;
+            }
+
             $this->io->block(\sprintf('Compiling theme for sales channel for : %s', $salesChannelId));
 
             $start = microtime(true);

--- a/tests/unit/Storefront/Theme/Command/ThemeCompileCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeCompileCommandTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Storefront\Theme\Command;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Storefront\Theme\Command\ThemeCompileCommand;
 use Shopware\Storefront\Theme\ConfigLoader\AbstractAvailableThemeProvider;
 use Shopware\Storefront\Theme\ThemeService;
@@ -59,6 +60,228 @@ class ThemeCompileCommandTest extends TestCase
 
         $commandTester->execute(['--active-only' => $activeOnly]);
         $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testItPassesSkipSalesChannelFlagCorrectly(): void
+    {
+        $salesChannelIdSkip1 = 'sales-channel-id1';
+        $salesChannelIdSkip2 = 'sales-channel-id2';
+        $salesChannelIdIncluded1 = 'sales-channel-id3';
+        $salesChannelIdIncluded2 = 'sales-channel-id4';
+        $themeId = 'theme-id';
+
+        $themeProvider = static::createMock(AbstractAvailableThemeProvider::class);
+        $themeProvider->expects(static::once())
+            ->method('load')
+            ->with(static::anything(), false)
+            ->willReturn([
+                $salesChannelIdSkip1 => $themeId,
+                $salesChannelIdSkip2 => $themeId,
+                $salesChannelIdIncluded1 => $themeId,
+                $salesChannelIdIncluded2 => $themeId,
+            ]);
+
+        $themeService = static::createMock(ThemeService::class);
+        $themeService->expects(static::exactly(2))
+            ->method('compileTheme')
+            ->willReturnCallback(
+                function (
+                    string $actualSalesChannelId,
+                    string $actualThemeId
+                ) use (
+                    $themeId,
+                    $salesChannelIdIncluded1,
+                    $salesChannelIdIncluded2
+                ): void {
+                    static::assertSame($themeId, $actualThemeId);
+                    static::assertContains(
+                        $actualSalesChannelId,
+                        [$salesChannelIdIncluded1, $salesChannelIdIncluded2]
+                    );
+                }
+            );
+
+        $commandTester = new CommandTester(new ThemeCompileCommand($themeService, $themeProvider));
+
+        $commandTester->execute(['--skip' => [$salesChannelIdSkip1, $salesChannelIdSkip2]]);
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testItPassesOnlySalesChannelFlagCorrectly(): void
+    {
+        $salesChannelIdSkip1 = 'sales-channel-id1';
+        $salesChannelIdSkip2 = 'sales-channel-id2';
+        $salesChannelIdIncluded1 = 'sales-channel-id3';
+        $salesChannelIdIncluded2 = 'sales-channel-id4';
+        $themeId = 'theme-id';
+
+        $themeProvider = static::createMock(AbstractAvailableThemeProvider::class);
+        $themeProvider->expects(static::once())
+            ->method('load')
+            ->with(static::anything(), false)
+            ->willReturn([
+                $salesChannelIdSkip1 => $themeId,
+                $salesChannelIdSkip2 => $themeId,
+                $salesChannelIdIncluded1 => $themeId,
+                $salesChannelIdIncluded2 => $themeId,
+            ]);
+
+        $themeService = static::createMock(ThemeService::class);
+        $themeService->expects(static::exactly(2))
+            ->method('compileTheme')
+            ->willReturnCallback(
+                function (
+                    string $actualSalesChannelId,
+                    string $actualThemeId
+                ) use (
+                    $themeId,
+                    $salesChannelIdIncluded1,
+                    $salesChannelIdIncluded2
+                ): void {
+                    static::assertSame($themeId, $actualThemeId);
+                    static::assertContains(
+                        $actualSalesChannelId,
+                        [$salesChannelIdIncluded1, $salesChannelIdIncluded2]
+                    );
+                }
+            );
+
+        $commandTester = new CommandTester(new ThemeCompileCommand($themeService, $themeProvider));
+
+        $commandTester->execute(['--only' => [$salesChannelIdIncluded1, $salesChannelIdIncluded2]]);
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testItPassesSkipThemeFlagCorrectly(): void
+    {
+        $salesChannelIdSkip1 = 'sales-channel-id1';
+        $salesChannelIdSkip2 = 'sales-channel-id2';
+        $salesChannelIdIncluded1 = 'sales-channel-id3';
+        $salesChannelIdIncluded2 = 'sales-channel-id4';
+        $themeIdSkip = 'theme-id-skip';
+        $themeIdIncluded = 'theme-id-included';
+
+        $themeProvider = static::createMock(AbstractAvailableThemeProvider::class);
+        $themeProvider->expects(static::once())
+            ->method('load')
+            ->with(static::anything(), false)
+            ->willReturn([
+                $salesChannelIdSkip1 => $themeIdSkip,
+                $salesChannelIdSkip2 => $themeIdSkip,
+                $salesChannelIdIncluded1 => $themeIdIncluded,
+                $salesChannelIdIncluded2 => $themeIdIncluded,
+            ]);
+
+        $themeService = static::createMock(ThemeService::class);
+        $themeService->expects(static::exactly(2))
+            ->method('compileTheme')
+            ->willReturnCallback(
+                function (
+                    string $actualSalesChannelId,
+                    string $actualThemeId
+                ) use (
+                    $themeIdIncluded,
+                    $salesChannelIdIncluded1,
+                    $salesChannelIdIncluded2
+                ): void {
+                    static::assertSame($themeIdIncluded, $actualThemeId);
+                    static::assertContains(
+                        $actualSalesChannelId,
+                        [$salesChannelIdIncluded1, $salesChannelIdIncluded2]
+                    );
+                }
+            );
+
+        $commandTester = new CommandTester(new ThemeCompileCommand($themeService, $themeProvider));
+
+        $commandTester->execute(['--skip-themes' => [$themeIdSkip]]);
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testItPassesOnlyThemeFlagCorrectly(): void
+    {
+        $salesChannelIdSkip1 = 'sales-channel-id1';
+        $salesChannelIdSkip2 = 'sales-channel-id2';
+        $salesChannelIdIncluded1 = 'sales-channel-id3';
+        $salesChannelIdIncluded2 = 'sales-channel-id4';
+        $themeIdSkip = 'theme-id-skip';
+        $themeIdIncluded = 'theme-id-included';
+
+        $themeProvider = static::createMock(AbstractAvailableThemeProvider::class);
+        $themeProvider->expects(static::once())
+            ->method('load')
+            ->with(static::anything(), false)
+            ->willReturn([
+                $salesChannelIdSkip1 => $themeIdSkip,
+                $salesChannelIdSkip2 => $themeIdSkip,
+                $salesChannelIdIncluded1 => $themeIdIncluded,
+                $salesChannelIdIncluded2 => $themeIdIncluded,
+            ]);
+
+        $themeService = static::createMock(ThemeService::class);
+        $themeService->expects(static::exactly(2))
+            ->method('compileTheme')
+            ->willReturnCallback(
+                function (
+                    string $actualSalesChannelId,
+                    string $actualThemeId
+                ) use (
+                    $themeIdIncluded,
+                    $salesChannelIdIncluded1,
+                    $salesChannelIdIncluded2
+                ): void {
+                    static::assertSame($themeIdIncluded, $actualThemeId);
+                    static::assertContains(
+                        $actualSalesChannelId,
+                        [$salesChannelIdIncluded1, $salesChannelIdIncluded2]
+                    );
+                }
+            );
+
+        $commandTester = new CommandTester(new ThemeCompileCommand($themeService, $themeProvider));
+
+        $commandTester->execute(['--only-themes' => [$themeIdIncluded]]);
+        $commandTester->assertCommandIsSuccessful();
+    }
+
+    public function testItFailsWithContradictingSalesChannelArgs(): void
+    {
+        $themeProvider = static::createMock(AbstractAvailableThemeProvider::class);
+        $themeProvider->expects(static::never())
+            ->method('load');
+
+        $themeService = static::createMock(ThemeService::class);
+        $themeService->expects(static::never())
+            ->method('compileTheme');
+
+        $commandTester = new CommandTester(new ThemeCompileCommand($themeService, $themeProvider));
+
+        $salesChannelId = Uuid::randomHex();
+        $commandTester->execute([
+            '--only' => [$salesChannelId],
+            '--skip' => [$salesChannelId],
+        ]);
+        static::assertSame(1, $commandTester->getStatusCode());
+    }
+
+    public function testItFailsWithContradictingThemeArgs(): void
+    {
+        $themeProvider = static::createMock(AbstractAvailableThemeProvider::class);
+        $themeProvider->expects(static::never())
+            ->method('load');
+
+        $themeService = static::createMock(ThemeService::class);
+        $themeService->expects(static::never())
+            ->method('compileTheme');
+
+        $commandTester = new CommandTester(new ThemeCompileCommand($themeService, $themeProvider));
+
+        $themeId = Uuid::randomHex();
+        $commandTester->execute([
+            '--only-themes' => [$themeId],
+            '--skip-themes' => [$themeId],
+        ]);
+        static::assertSame(1, $commandTester->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently one needs to compile the themes always for at least all active sales channels. This PR adds four options to the `theme:compile` command to restrict the theme compilation.

### 2. What does this change do, exactly?
Add the flags `--only`, `--skip`, `--only-themes` and `--skip-themes` to the `theme:compile` command, to either restrict by sales channel ids or by theme ids (or both).

Not sure if `--only` and `--skip` are should have a more specific name, i.e. `--only-sale-channels=<id1>,<id2>`, but I think it is shorter to only have to type `--only` :-)

Also the command only fails if the arguments contain contradicting ids, but maybe it should also fail if two arguments are passed.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a668ba</samp>

This pull request enhances the `theme:compile` command to allow users to specify which themes and sales channels they want to compile. It also adds a changelog entry and unit tests for the new features. The purpose of these changes is to improve the performance and usability of the theme compilation process.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7a668ba</samp>

*  Add new flags to `theme:compile` command to restrict theme compilation to specific themes and sales channels ([link](https://github.com/shopware/platform/pull/3274/files?diff=unified&w=0#diff-a71123cace1520076733857aaa4013415f142e8289e1f5ad85343c9ed096b35aL39-R44), [link](https://github.com/shopware/platform/pull/3274/files?diff=unified&w=0#diff-5e3445a696fdbc3139f96d10405ba24d7b731f3f52e0fe21c8b15a4649d28474R1-R10))
*  Modify `execute` method of `theme:compile` command to use the new flags to filter the themes and print messages for each sales channel ([link](https://github.com/shopware/platform/pull/3274/files?diff=unified&w=0#diff-a71123cace1520076733857aaa4013415f142e8289e1f5ad85343c9ed096b35aL48-R83))
*  Add unit tests for `theme:compile` command to verify the new flags and the theme filtering logic ([link](https://github.com/shopware/platform/pull/3274/files?diff=unified&w=0#diff-3b6a057f8de02bfec8c19237cc7ca238689339d66d05c8782176981ce9eecc5cR64-R197))
