### PR TITLE
Fix error handling on document preview

### DIFF
--- a/changelog/_unreleased/2023-08-21-add-error-handling-on-document-preview.md
+++ b/changelog/_unreleased/2023-08-21-add-error-handling-on-document-preview.md
@@ -1,0 +1,10 @@
+---
+title: Add error handling on document preview
+issue: NEXT-30006
+author: Cedric Engler
+author_email: cedric.engler@pickware.de
+author_github: Ceddy610
+---
+# Administration
+* Changed the `getDocumentPreview` method on `Administration/Resources/app/administration/src/core/service/api/document.api.service.js` so that an error gets caught with the call of the listener
+* Changed the `onPreview` method on `Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js` so that the property `isLoadingPreview` is changed on `finally`

--- a/src/Administration/Resources/app/administration/src/core/service/api/document.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/document.api.service.js
@@ -96,7 +96,18 @@ class DocumentApiService extends ApiService {
                     responseType: 'blob',
                     headers: this.getBasicHeaders(),
                 },
-            );
+            )
+            .catch( async (error) => {
+                const errorObject = JSON.parse(await error.response.data.text());
+                if (errorObject.errors) {
+                    this.$listener(
+                        this.createDocumentEvent(
+                            'create-document-fail',
+                            errorObject.errors.pop(),
+                        ),
+                    );
+                }
+            });
     }
 
     getDocument(documentId, documentDeepLink, context, download = false) {

--- a/src/Administration/Resources/app/administration/src/core/service/api/document.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/document.api.service.spec.js
@@ -272,6 +272,39 @@ describe('documentService', () => {
         expect(didRequest).toBeTruthy();
     });
 
+    it('handles an error when getDocumentPreview is being called', async () => {
+        const { documentApiService, clientMock } = getDocumentApiService();
+
+        documentApiService.setListener(expectCreateDocumentFailed);
+
+        let didRequest = false;
+        const orderId = '4a4a687257644d52bf481b4c20e59213';
+        const orderDeepLink = 'DEEP_LINK';
+        const type = 'invoice';
+        const errorBody = {
+            errors: [
+                {
+                    detail: 'some-error-detail',
+                },
+            ],
+        };
+
+        clientMock.onGet(`/_action/order/${orderId}/${orderDeepLink}/document/${type}/preview`)
+            .reply(() => {
+                didRequest = true;
+
+                return [
+                    500,
+                    new Blob([JSON.stringify(errorBody)], {
+                        type: 'application/json',
+                    }),
+                ];
+            });
+
+        documentApiService.getDocumentPreview(orderId, orderDeepLink, type, {});
+        expect(didRequest).toBeTruthy();
+    });
+
     it('calls getDocument with correct endpoint', async () => {
         const { documentApiService, clientMock } = getDocumentApiService();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
@@ -431,9 +431,9 @@ export default {
                     link.remove();
                 }
 
-                this.isLoadingPreview = false;
-
                 return response;
+            }).finally(() => {
+                this.isLoadingPreview = false;
             });
         },
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
There is no error handling if the creation of the document preview fails in the adminstration.

### 2. What does this change do, exactly?
This change adds a `catch` to `getDocumentPreview`, so if the request fails, the listener should be called with the error details. Furthermore, the `isLoadingPreview` is changed in the `finally` case, so that the `isLoading` attribute of the preview button is changed, even if the request fails.

### 3. Describe each step to reproduce the issue or behaviour.

- Enforce an error during the creation of a document preview.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-30006

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e4567f</samp>

This pull request adds error handling on document preview requests in the order administration module. It catches and emits errors from the `DocumentApiService`, and updates the `OrderDocumentCard` component to show an error message and hide the loading indicator.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e4567f</samp>

*  Add error handling on document preview requests ([link](https://github.com/shopware/platform/pull/3277/files?diff=unified&w=0#diff-d68d373216574ef4ac75967ceaf497e2bc3dbd1775afc321fabee3506304cb4eR1-R10))
   * Modify `getDocumentPreview` method on `DocumentApiService` to catch and emit errors ([link](https://github.com/shopware/platform/pull/3277/files?diff=unified&w=0#diff-6974635b1c5be0169593ce5c18d0a98293f99d6ba9e0e665cf7082c32561277bL99-R110))
   * Add unit test for `getDocumentPreview` method to verify error emission ([link](https://github.com/shopware/platform/pull/3277/files?diff=unified&w=0#diff-8c8a1230b5226eeeb697d7c27f916ca50f95701a1e043221970251a1062276f5R275-R307))
   * Modify `onPreview` method on `OrderDocumentCard` component to hide loading indicator on error ([link](https://github.com/shopware/platform/pull/3277/files?diff=unified&w=0#diff-4f4ac0dac602f250291b1ae6396dc4af13882e01875c4f418a03aaf08c5bae3aL434-R436))
