### PR TITLE
Resolve API request UUIDs via placeholders

### DIFF
--- a/src/Core/Framework/Api/EventListener/UuidReplacerSystaxListener.php
+++ b/src/Core/Framework/Api/EventListener/UuidReplacerSystaxListener.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Api\EventListener;
+
+use Psr\Container\ContainerInterface;
+use ReflectionClass;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\KernelListenerPriorities;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class UuidReplacerSystaxListener implements EventSubscriberInterface
+{
+    private const REPLACER_PATTER = <<<'REGEX'
+/(?<replace>\[%(?<entity>.+)\((?<query>.+)\)%\])/
+REGEX;
+
+    public function __construct(
+        #[Autowire(service: 'service_container')]
+        private ContainerInterface $container
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::CONTROLLER => [
+                'onRequest',
+                KernelListenerPriorities::KERNEL_CONTROLLER_EVENT_CONTEXT_RESOLVE_POST
+            ],
+        ];
+    }
+
+    public function onRequest(ControllerEvent $controllerEvent): void
+    {
+        $request = $controllerEvent->getRequest();
+        $content = $request->getContent();
+        $context = $request->attributes->get('sw-context');
+        $count = preg_match_all(self::REPLACER_PATTER, $content, $matches);
+
+        if ($count > 0) {
+            $replaces = $matches['replace'];
+            $entities = $matches['entity'];
+            $queries = $matches['query'];
+            foreach ($entities as $index => $entity) {
+                $repository = $this->container->get(sprintf('%s.repository', $entity));
+                if (!$repository instanceof EntityRepository) {
+                    throw new BadRequestHttpException(sprintf('Api resolver could not resolve entity "%s"', $entity));
+                }
+
+                $queryJson = '{' . str_replace('\'', '"', $queries[$index]) . '}';
+                $queryData = json_decode($queryJson, false, 512, JSON_THROW_ON_ERROR);
+                $filters = [];
+                foreach ($queryData as $field => $value) {
+                    $filters[] = new EqualsFilter($field, $value);
+                }
+                $criteria = (new Criteria())->addFilter(new AndFilter($filters));
+                $results = $repository->search($criteria, $context);
+
+                if ($results->count() === 0) {
+                    throw new BadRequestHttpException(sprintf('Could not find result for "%s"', $queryJson));
+                }
+                if ($results->count() > 1) {
+                    throw new BadRequestHttpException(sprintf('Result was not unique for "%s"', $queryJson));
+                }
+
+                $id = $results->first()->getId();
+                $replace = $replaces[$index];
+                $content = str_replace($replace, $id, $content);
+            }
+
+            $reflectionClass = new ReflectionClass($request);
+            $reflectionProperty = $reflectionClass->getProperty('content');
+            $reflectionProperty->setAccessible(true);
+            $reflectionProperty->setValue($request, $content);
+        }
+    }
+}


### PR DESCRIPTION
It's in the middle of the night and I got an idea, probably it's stupid, but I want to let you decide. The code is just my poc.

### 1. Why is this change necessary?
Adding e.g. products via Shopware API is hard, because we have to fetch all currency, tax, etc. UUIDs first.


### 2. What does this change do, exactly?
It checks all request for a certain placeholder pattern. This pattern contains information with which UUID the placeholder should be replaced. This way, a product can be created like this:

```json
[
  {
    "action": "upsert",
    "entity": "product",
    "payload": [
        {
            "name": "test name",
            "description": "test description",
            "productNumber": "test-123",
            "taxId": "[%tax('taxRate':19)%]",
            "price": [
                {
                    "currencyId": "[%currency('isoCode':'EUR')%]",
                    "gross": "2",
                    "net": "1",
                    "linked": false
                }
            ],
            "stock": 10
        }
    ]
  }
]
```

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 669a652</samp>

Added a new event listener `UuidReplacerSystaxListener` that allows using placeholders for entity UUIDs in the API request content. The class replaces the placeholders with the actual UUIDs based on the entity name and query expression.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 669a652</samp>

*  Add a new event listener class `UuidReplacerSystaxListener` to replace placeholders in the request content with UUIDs of matching entities ([link](https://github.com/shopware/platform/pull/3283/files?diff=unified&w=0#diff-28f4c5b7262938ee827777379f3a65e8e76b1a703eadb312c260f92ce36a19fcR1-R91))
