### PR TITLE
refactor: Simplify SeoUrlUpdater

### DIFF
--- a/changelog/_unreleased/2023-08-28-refactor-internals-of-seourlupdater.md
+++ b/changelog/_unreleased/2023-08-28-refactor-internals-of-seourlupdater.md
@@ -1,0 +1,9 @@
+---
+title: Refactor internals of SeoUrlUpdater
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Refactor and simplify internals of `Shopware\Core\Content\Seo\SeoUrlUpdater`


### PR DESCRIPTION
### 1. Why is this change necessary?
Recently I needed to debug the `SeoUrlUpdater` in combination with a plugin of ours. I found it quite hard to debug, in particular as the public API only allows to update a single `$routeName`, but internally there was also logic which allows to fetch multiple `routes` at once.

### 2. What does this change do, exactly?
Refactor (and in my opinion simplify) the `SeoUrlUpdater`.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3865c0</samp>

This pull request improves the performance and readability of the `SeoUrlUpdater` class, which handles the generation and update of SEO-friendly urls for different languages and sales channels. It simplifies the logic for loading and applying SEO url templates, and removes some unnecessary code. It also adds a changelog entry for this change.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e3865c0</samp>

*  Add a changelog entry for the refactoring of the `SeoUrlUpdater` class ([link](https://github.com/shopware/platform/pull/3284/files?diff=unified&w=0#diff-f9f87b93b6f1964d16b7747c59a8127b3a32ffc8b2a25b7f6bc9ab5fa4ebf8f4R1-R9))
*  Simplify and refactor the `update` method of the `SeoUrlUpdater` class to load the SEO url templates for a single route name and use the existing context ([link](https://github.com/shopware/platform/pull/3284/files?diff=unified&w=0#diff-75d650a4598390969cb6c96e4188587db25a7ad66689d3791c06de0ea38565afL41-R84))
*  Simplify and refactor the `loadUrlTemplate` method of the `SeoUrlUpdater` class to fetch the SEO url templates for a single route name and use a key-value fetch mode ([link](https://github.com/shopware/platform/pull/3284/files?diff=unified&w=0#diff-75d650a4598390969cb6c96e4188587db25a7ad66689d3791c06de0ea38565afL103-R121))
*  Simplify and refactor the `fetchLanguageChains` method of the `SeoUrlUpdater` class to accept a context and use the language repository ([link](https://github.com/shopware/platform/pull/3284/files?diff=unified&w=0#diff-75d650a4598390969cb6c96e4188587db25a7ad66689d3791c06de0ea38565afL151-R133))
*  Add type annotations for the constructor parameters of the `SeoUrlUpdater` class ([link](https://github.com/shopware/platform/pull/3284/files?diff=unified&w=0#diff-75d650a4598390969cb6c96e4188587db25a7ad66689d3791c06de0ea38565afR24-R26))
*  Update the import statement for the `LanguageEntity` class to use the `LanguageCollection` class instead ([link](https://github.com/shopware/platform/pull/3284/files?diff=unified&w=0#diff-75d650a4598390969cb6c96e4188587db25a7ad66689d3791c06de0ea38565afL14-R13))
*  Remove an unused import statement from the `SeoUrlUpdater` class ([link](https://github.com/shopware/platform/pull/3284/files?diff=unified&w=0#diff-75d650a4598390969cb6c96e4188587db25a7ad66689d3791c06de0ea38565afL5))
