### PR TITLE
fix: custom field rule with multi select

### DIFF
--- a/changelog/_unreleased/2023-08-30-fix-custom-field-rule-with-multi-select.md
+++ b/changelog/_unreleased/2023-08-30-fix-custom-field-rule-with-multi-select.md
@@ -1,0 +1,14 @@
+---
+title: Fix custom field rule with multi select
+issue: NEXT-23252
+author: Jan Emig
+author_email: j.emig@one-dot.de
+author_github: @Xnaff
+---
+# Core
+* Changed type declaration of `$renderedFieldValue` in `Shopware\Core\Checkout\Customer\Rule\CustomerCustomFieldRule` to also use `array` as type for multi select fields 
+* Changed type declaration of `$renderedFieldValue` in `Shopware\Core\Content\Flow\Rule\OrderCustomFieldRule` to also use `array` as type for multi select fields 
+* Changed type declaration of `$renderedFieldValue` in `Shopware\Core\Framework\Rule\CustomFieldRule` to also use `array` as type for multi select fields 
+* Changed method `match` in `Shopware\Core\Framework\Rule\CustomFieldRule` to fix the validation of multi select fields 
+* Added method `isArray` in `Shopware\Core\Framework\Rule\CustomFieldRule` to validate if the field value is an array from a multi select field 
+* Added method `arrayMatch` in `Shopware\Core\Framework\Rule\CustomFieldRule` to validate the field value against the rule value if the field value is an array from a multi select field 

--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -19,7 +19,7 @@ class LineItemCustomFieldRule extends Rule
     final public const RULE_NAME = 'cartLineItemCustomField';
 
     /**
-     * @var string|int|float|bool|null
+     * @var array|string|int|float|bool|null
      */
     protected $renderedFieldValue;
 
@@ -161,10 +161,10 @@ class LineItemCustomFieldRule extends Rule
     }
 
     /**
-     * @param string|int|float|bool|null $renderedFieldValue
+     * @param array|string|int|float|bool|null $renderedFieldValue
      * @param array<string, mixed> $renderedField
      *
-     * @return string|int|float|bool|null
+     * @return array|string|int|float|bool|null
      */
     private function getExpectedValue($renderedFieldValue, array $renderedField)
     {

--- a/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
@@ -14,7 +14,7 @@ class CustomerCustomFieldRule extends Rule
 {
     final public const RULE_NAME = 'customerCustomField';
 
-    protected string|int|bool|null|float $renderedFieldValue = null;
+    protected array|string|int|bool|null|float $renderedFieldValue = null;
 
     /**
      * @param array<string, string> $renderedField

--- a/src/Core/Content/Flow/Rule/OrderCustomFieldRule.php
+++ b/src/Core/Content/Flow/Rule/OrderCustomFieldRule.php
@@ -13,7 +13,7 @@ class OrderCustomFieldRule extends FlowRule
 {
     final public const RULE_NAME = 'orderCustomField';
 
-    protected string|int|bool|null|float $renderedFieldValue = null;
+    protected array|string|int|bool|null|float $renderedFieldValue = null;
 
     /**
      * @param array<string, string> $renderedField

--- a/src/Core/Framework/App/Manifest/Xml/CustomFieldTypes/MultiEntitySelectField.php
+++ b/src/Core/Framework/App/Manifest/Xml/CustomFieldTypes/MultiEntitySelectField.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('core')]
 class MultiEntitySelectField extends SingleEntitySelectField
 {
-    protected const COMPONENT_NAME = 'sw-entity-multi-id-select';
+    public const COMPONENT_NAME = 'sw-entity-multi-id-select';
 
     public static function fromXml(\DOMElement $element): CustomFieldType
     {

--- a/src/Core/Framework/App/Manifest/Xml/CustomFieldTypes/MultiSelectField.php
+++ b/src/Core/Framework/App/Manifest/Xml/CustomFieldTypes/MultiSelectField.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('core')]
 class MultiSelectField extends SingleSelectField
 {
-    protected const COMPONENT_NAME = 'sw-multi-select';
+    public const COMPONENT_NAME = 'sw-multi-select';
 
     public static function fromXml(\DOMElement $element): CustomFieldType
     {

--- a/src/Core/Framework/Rule/CustomFieldRule.php
+++ b/src/Core/Framework/Rule/CustomFieldRule.php
@@ -51,8 +51,12 @@ class CustomFieldRule
      * @param array<string, string> $renderedField
      * @param array<string, mixed> $customFields
      */
-    public static function match(array $renderedField, array|string|int|bool|null|float $renderedFieldValue, string $operator, array $customFields): bool
-    {
+    public static function match(
+        array $renderedField,
+        array|string|int|bool|null|float $renderedFieldValue,
+        string $operator,
+        array $customFields
+    ): bool {
         $actual = self::getValue($customFields, $renderedField);
         $expected = self::getExpectedValue($renderedFieldValue, $renderedField);
 
@@ -65,11 +69,11 @@ class CustomFieldRule
         }
 
         if (self::isFloat($renderedField)) {
-            return self::floatMatch($operator, (float) $actual, (float) $expected);
+            return self::floatMatch($operator, (float)$actual, (float)$expected);
         }
 
         if (self::isArray($renderedField)) {
-            return self::arrayMatch($operator, (array) $actual, (array) $expected);
+            return self::arrayMatch($operator, (array)$actual, (array)$expected);
         }
 
         return match ($operator) {
@@ -99,8 +103,8 @@ class CustomFieldRule
     private static function arrayMatch(string $operator, array $actual, array $expected): bool
     {
         return match ($operator) {
-            Rule::OPERATOR_NEQ => count(array_intersect($actual, $expected)) === 0,
-            Rule::OPERATOR_EQ => count(array_intersect($actual, $expected)) > 0,
+            Rule::OPERATOR_NEQ => \count(array_intersect($actual, $expected)) === 0,
+            Rule::OPERATOR_EQ => \count(array_intersect($actual, $expected)) > 0,
             default => throw new UnsupportedOperatorException($operator, self::class),
         };
     }
@@ -145,8 +149,10 @@ class CustomFieldRule
     /**
      * @param array<string, string> $renderedField
      */
-    private static function getExpectedValue(array|float|bool|int|string|null $renderedFieldValue, array $renderedField): array|float|bool|int|string|null
-    {
+    private static function getExpectedValue(
+        array|float|bool|int|string|null $renderedFieldValue,
+        array $renderedField
+    ): array|float|bool|int|string|null {
         if (self::isSwitchOrBoolField($renderedField) && \is_string($renderedFieldValue)) {
             return filter_var($renderedFieldValue, \FILTER_VALIDATE_BOOLEAN);
         }
@@ -183,7 +189,7 @@ class CustomFieldRule
             return false;
         }
 
-        if (!array_key_exists('componentName', $renderedField['config'])) {
+        if (!\array_key_exists('componentName', $renderedField['config'])) {
             return false;
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Rules with custom fields of type multi select resulted in an 500 server error because arrays, are not allowed in the type declaration.

### 2. What does this change do, exactly?
Validate the rule of custom fields with the type multi select

### 3. Describe each step to reproduce the issue or behaviour.
- Create a custom field of the type multi select for a customer
- Create a price rule wich uses this custom field
- Assign some value to a customer from the multi select custom field
- Log in as the customer

### 4. Please link to the relevant issues (if any).
[Issue: NEXT-23252](https://issues.shopware.com/issues/NEXT-23252)


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2233a5a</samp>

This pull request adds support for multi select fields in custom field rules, which allows creating more flexible conditions based on custom field values. It modifies the type declarations and logic of several rule classes to handle array values, and makes the component names of multi select field types public. It also adds a changelog entry for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2233a5a</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-d34b25a1d86441f4bd848da262837cc8246eb9d1f0fecfc8101c4ba4e0026658R1-R14))
  *  Modifying the type declarations of the `$renderedFieldValue` property and parameter in the `LineItemCustomFieldRule`, `CustomerCustomFieldRule` and `OrderCustomFieldRule` classes ([link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0L22-R22), [link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0L164-R167), [link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-807fcd493a01a0273756a10a4399c8970e4c83341f07468dadb5aa7c84a29357L17-R17), [link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-0a176a7edcad360b421a0607b9fcbace6a12808b8b991e56d19b9453891d3870L16-R16))
  *  Modifying the type declarations of the `$renderedFieldValue` parameter and the `getValue` method call in the `match` method of the `CustomFieldRule` class ([link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL52-R54))
  *  Adding a conditional statement to the `match` method of the `CustomFieldRule` class to use the `arrayMatch` method for array values ([link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fR71-R74))
  *  Adding the `arrayMatch` method to the `CustomFieldRule` class to compare array values with different operators using the `array_intersect` function ([link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fR99-R107))
  *  Modifying the return type of the `getValue` method and the type and return type of the `getExpectedValue` method of the `CustomFieldRule` class to allow array values ([link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL117-R132), [link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL133-R148))
  *  Adding the `isArray` method to the `CustomFieldRule` class to check if the rendered field is an array from a multi select field by checking the field type and the component name ([link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fR176-R199))
*  Make the `COMPONENT_NAME` constants of the `MultiEntitySelectField` and `MultiSelectField` classes public so that they can be used by the `CustomFieldRule` class ([link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-c990076bd957d0bb099a4632736887d0a98c9934a0391c6648c6a5cc4fafd2a0L13-R13), [link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-0fa50f8275064f19ac5f81f1f7f5fa6537307c901db6d2d8c6413143c4c6ee47L13-R13))
*  Add the use statements for the `MultiEntitySelectField` and `MultiSelectField` classes to the `CustomFieldRule` class ([link](https://github.com/shopware/platform/pull/3285/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fR5-R6))
