### PR TITLE
added missing "export STOREFRONT_ASSETS_PORT" on watch-storefront.sh

### DIFF
--- a/changelog/_unreleased/2023-08-30-missing-export-storefront_assets_port-on-watch-storefront-sh.md
+++ b/changelog/_unreleased/2023-08-30-missing-export-storefront_assets_port-on-watch-storefront-sh.md
@@ -1,0 +1,11 @@
+---
+title: Missing "export STOREFRONT_ASSETS_PORT" on watch-storefront.sh
+issue: NEXT-30280
+author: Matheus Gontijo
+author_email: matheus@matheusgontijo.com
+author_github: https://github.com/matheusgontijo
+---
+
+Missing "export STOREFRONT_ASSETS_PORT" on watch-storefront.sh
+
+It's used later on few places, like `Storefront/Resources/app/storefront/build/proxy-server-hot/index.js`, but because it was not exported, the value is "undefined".

--- a/src/WebInstaller/Resources/flex-config/bin/watch-storefront.sh
+++ b/src/WebInstaller/Resources/flex-config/bin/watch-storefront.sh
@@ -18,9 +18,10 @@ eval "$curenv"
 set +o allexport
 
 export APP_URL
-export PROXY_URL
-export STOREFRONT_PROXY_PORT
 export ESLINT_DISABLE
+export PROXY_URL
+export STOREFRONT_ASSETS_PORT
+export STOREFRONT_PROXY_PORT
 
 DATABASE_URL="" "${CWD}"/console feature:dump
 "${CWD}"/console theme:compile


### PR DESCRIPTION
Missing `export STOREFRONT_ASSETS_PORT` on `watch-storefront.sh`

It's used later on few places, like `Storefront/Resources/app/storefront/build/proxy-server-hot/index.js`, but because it was not exported, the value is `undefined`.