### PR TITLE
NEXT-00000 - Fix export tempfile closed before copying data

### DIFF
--- a/changelog/_unreleased/2023-08-31-fix-export-tempfile-closed-before-copying-data.md
+++ b/changelog/_unreleased/2023-08-31-fix-export-tempfile-closed-before-copying-data.md
@@ -1,0 +1,9 @@
+---
+title: Fix export temporary file closed before copying data
+issue:
+author: Cuong Huynh
+author_email: cuong.huynh@pluszwei.io
+author_github: cuonghuynh
+---
+# Administration
+* Fixed the export to work with Google Bucket adapter

--- a/changelog/_unreleased/2023-08-31-fix-export-tempfile-closed-before-copying-data.md
+++ b/changelog/_unreleased/2023-08-31-fix-export-tempfile-closed-before-copying-data.md
@@ -1,6 +1,6 @@
 ---
 title: Fix export temporary file closed before copying data
-issue:
+issue: NEXT-30327
 author: Cuong Huynh
 author_email: cuong.huynh@pluszwei.io
 author_github: cuonghuynh

--- a/changelog/_unreleased/2023-08-31-fix-export-tempfile-closed-before-copying-data.md
+++ b/changelog/_unreleased/2023-08-31-fix-export-tempfile-closed-before-copying-data.md
@@ -5,5 +5,5 @@ author: Cuong Huynh
 author_email: cuong.huynh@pluszwei.io
 author_github: cuonghuynh
 ---
-# Administration
-* Fixed the export to work with Google Bucket adapter
+# Core
+* Changed the export `\Shopware\Core\Content\ImportExport\Processing\Writer\AbstractFileWriter::flush` to work with Google Bucket adapter

--- a/src/Core/Content/ImportExport/Processing/Writer/AbstractFileWriter.php
+++ b/src/Core/Content/ImportExport/Processing/Writer/AbstractFileWriter.php
@@ -34,6 +34,10 @@ abstract class AbstractFileWriter extends AbstractWriter
     {
         rewind($this->buffer);
 
+        if (!is_resource($this->tempFile)) {
+            $this->initTempFile();
+        }
+
         $bytesCopied = stream_copy_to_stream($this->buffer, $this->tempFile);
         if ($bytesCopied === false) {
             throw new \RuntimeException(sprintf('Could not copy stream to %s', $this->tempPath));

--- a/src/Core/Content/ImportExport/Processing/Writer/AbstractFileWriter.php
+++ b/src/Core/Content/ImportExport/Processing/Writer/AbstractFileWriter.php
@@ -34,7 +34,7 @@ abstract class AbstractFileWriter extends AbstractWriter
     {
         rewind($this->buffer);
 
-        if (!is_resource($this->tempFile)) {
+        if (!\is_resource($this->tempFile)) {
             $this->initTempFile();
         }
 

--- a/src/Core/Content/ImportExport/Processing/Writer/AbstractFileWriter.php
+++ b/src/Core/Content/ImportExport/Processing/Writer/AbstractFileWriter.php
@@ -35,7 +35,7 @@ abstract class AbstractFileWriter extends AbstractWriter
         rewind($this->buffer);
 
         if (!\is_resource($this->tempFile)) {
-            $this->initTempFile();
+            $this->tempFile = fopen($this->tempPath, 'a+b');
         }
 
         $bytesCopied = stream_copy_to_stream($this->buffer, $this->tempFile);


### PR DESCRIPTION
### 1. Why is this change necessary?
For using the Google Bucket adapter, the temporary file will be closed after uploading the content finish, and the export call writer finish function, the temp file alrady closed therefore it through the error.

### 2. What does this change do, exactly?
Ensure the temporary file is still open before flushing the content.

### 3. Describe each step to reproduce the issue or behaviour.
1. Config filesystem private to use Google Bucket adapter
2. Go to Admin Import/Export -> Select Export tab ->  Select a profile then run Export
3. The export log display status is always "processing"
4. Check `dead_message` table, we will see the Export message in there

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/3282 or https://github.com/shopware/platform/issues/1747

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e46119a</samp>

Fix export error by initializing file handle before writing data. This change affects the `AbstractFileWriter` class and its subclasses.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e46119a</samp>

* Initialize the temporary file handle before writing data to avoid errors ([link](https://github.com/shopware/platform/pull/3288/files?diff=unified&w=0#diff-b5daa581eee0a887bb9955715e372226a895921dbedadad1a5afdecc39e22d6eR37-R40))
