### PR TITLE
#2383 - Use correct languages to update product search keywords.

### DIFF
--- a/changelog/_unreleased/2023-09-01-use-correct-languages-to-update-product-search-keywords.md
+++ b/changelog/_unreleased/2023-09-01-use-correct-languages-to-update-product-search-keywords.md
@@ -1,0 +1,9 @@
+---
+title: Use correct languages to update product search keywords.
+issue: NEXT-00000
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed method `update` in `Shopware\Core\Content\Product\DataAbstractionLayer\SearchKeywordUpdater` class to use the association betwenn language and sales channels to determine if a language is in use.

--- a/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
@@ -64,7 +64,7 @@ class SearchKeywordUpdater implements ResetInterface
         }
 
         $criteria = new Criteria();
-        $criteria->addFilter(new NandFilter([new EqualsFilter('salesChannelDomains.id', null)]));
+        $criteria->addFilter(new NandFilter([new EqualsFilter('salesChannels.id', null)]));
         $languages = $this->languageRepository->search($criteria, Context::createDefaultContext())->getEntities();
 
         $languages = $this->sortLanguages($languages);

--- a/src/Core/Content/Test/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
+++ b/src/Core/Content/Test/Product/DataAbstractionLayer/SearchKeywordUpdaterTest.php
@@ -15,7 +15,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\Test\TestDefaults;
 
 /**
  * @internal
@@ -26,6 +25,8 @@ class SearchKeywordUpdaterTest extends TestCase
 
     private EntityRepository $productRepository;
 
+    private EntityRepository $salesChannelLanguageRepository;
+
     private EntityRepository $searchKeywordRepository;
 
     private Connection $connection;
@@ -33,22 +34,9 @@ class SearchKeywordUpdaterTest extends TestCase
     protected function setUp(): void
     {
         $this->productRepository = $this->getContainer()->get('product.repository');
+        $this->salesChannelLanguageRepository = $this->getContainer()->get('sales_channel_language.repository');
         $this->searchKeywordRepository = $this->getContainer()->get('product_search_keyword.repository');
         $this->connection = $this->getContainer()->get(Connection::class);
-
-        $this->getContainer()->get('language.repository')->upsert([
-            [
-                'id' => $this->getDeDeLanguageId(),
-                'salesChannelDomains' => [
-                    [
-                        'salesChannelId' => TestDefaults::SALES_CHANNEL,
-                        'currencyId' => Defaults::CURRENCY,
-                        'snippetSetId' => $this->getSnippetSetIdForLocale('de-DE'),
-                        'url' => $_SERVER['APP_URL'] . '/de',
-                    ],
-                ],
-            ],
-        ], Context::createDefaultContext());
     }
 
     /**
@@ -67,6 +55,39 @@ class SearchKeywordUpdaterTest extends TestCase
         $expectedDictionary = array_merge($germanKeywords, $additionalDictionaries);
         sort($expectedDictionary);
         $this->assertDictionary($this->getDeDeLanguageId(), $expectedDictionary);
+    }
+
+    /**
+     * @param array<mixed> $productData
+     * @param string[] $englishKeywords
+     * @param string[] $germanKeywords
+     * @param string[] $additionalDictionaries
+     *
+     * @dataProvider productKeywordProvider
+     */
+    public function testItUpdatesKeywordsForAvailableLanguagesOnly(array $productData, IdsCollection $ids, array $englishKeywords, array $germanKeywords, array $additionalDictionaries = []): void
+    {
+        $context = Context::createDefaultContext();
+
+        $criteria = new Criteria();
+
+        // Delete sales channel de-DE language associations to ensure only default language is used to create keywords.
+        $criteria->addFilter(new EqualsFilter('languageId', $this->getDeDeLanguageId()));
+
+        /** @var list<array<string, string>> $salesChannalLanguageIds */
+        $salesChannalLanguageIds = $this->salesChannelLanguageRepository->searchIds($criteria, $context)->getIds();
+        $this->salesChannelLanguageRepository->delete($salesChannalLanguageIds, $context);
+
+        $this->productRepository->create([$productData], Context::createDefaultContext());
+
+        $this->assertKeywords($ids->get('1000'), Defaults::LANGUAGE_SYSTEM, $englishKeywords);
+
+        $expectedDictionary = array_merge($englishKeywords, $additionalDictionaries);
+        sort($expectedDictionary);
+        $this->assertDictionary(Defaults::LANGUAGE_SYSTEM, $expectedDictionary);
+
+        $this->assertLanguageHasNoKeywords($this->getDeDeLanguageId());
+        $this->assertLanguageHasNoDictionary($this->getDeDeLanguageId());
     }
 
     public function testCustomFields(): void
@@ -267,6 +288,21 @@ class SearchKeywordUpdaterTest extends TestCase
         static::assertEquals($expectedKeywords, $keywords);
     }
 
+    private function assertLanguageHasNoKeywords(string $languageId): void
+    {
+        $keywords = $this->connection->fetchFirstColumn(
+            'SELECT `keyword`
+            FROM `product_search_keyword`
+            WHERE language_id = :languageId
+            ORDER BY `keyword` ASC',
+            [
+                'languageId' => Uuid::fromHexToBytes($languageId),
+            ]
+        );
+
+        static::assertCount(0, $keywords);
+    }
+
     private function assertDictionary(string $languageId, array $expectedKeywords): void
     {
         $dictionary = $this->connection->fetchFirstColumn(
@@ -280,6 +316,21 @@ class SearchKeywordUpdaterTest extends TestCase
         );
 
         static::assertEquals($expectedKeywords, $dictionary);
+    }
+
+    private function assertLanguageHasNoDictionary(string $languageId): void
+    {
+        $dictionary = $this->connection->fetchFirstColumn(
+            'SELECT `keyword`
+            FROM `product_keyword_dictionary`
+            WHERE language_id = :languageId
+            ORDER BY `keyword` ASC',
+            [
+                'languageId' => Uuid::fromHexToBytes($languageId),
+            ]
+        );
+
+        static::assertCount(0, $dictionary);
     }
 
     private function getLocaleIdByIsoCode(string $iso): string


### PR DESCRIPTION
### 1. Why is this change necessary?

To fix #2383

### 2. What does this change do, exactly?

See changelog file.

### 3. Describe each step to reproduce the issue or behaviour.

See issue.

### 4. Please link to the relevant issues (if any).

#2383

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2b8cda0</samp>

This pull request fixes a bug in the `SearchKeywordUpdater` class that caused product search keywords to be updated with incorrect languages. It changes the filter criterion for selecting the languages that are in use by the sales channels and adjusts the changelog and the test data accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2b8cda0</samp>

*  Add a changelog entry for the feature ([link](https://github.com/shopware/platform/pull/3293/files?diff=unified&w=0#diff-4b79eb33922a385687294ea407a7c087a59ca2cdf520e2701b2b0ddd2f975ff2R1-R9))
*  Change the filter criterion for selecting languages in the `SearchKeywordUpdater` class to use sales channels instead of sales channel domains ([link](https://github.com/shopware/platform/pull/3293/files?diff=unified&w=0#diff-484ebf24bb5a4ec5d0c56d5af8712e6f7aa4f580a63e898f0b318257527751f2L67-R67))
*  Adjust the test data for the `SearchKeywordUpdaterTest` class to provide sales channels for the languages ([link](https://github.com/shopware/platform/pull/3293/files?diff=unified&w=0#diff-f4a6ca2f50a19eb2e0452b4d01f0151ee6d45c95c5ebcdbd448804d5f5df673eL42-R44))
*  Verify that the search keywords are updated correctly for the products in different languages and sales channels ([link](https://github.com/shopware/platform/pull/3293/files?diff=unified&w=0#diff-f4a6ca2f50a19eb2e0452b4d01f0151ee6d45c95c5ebcdbd448804d5f5df673eL42-R44))

**Info**
tests currently fail in trunk as well. Added additional test because this way we specifically test that a language that was indexed is not anymore if it is removed from the corresponding relation.