### PR TITLE
#3025 - Support active flag and maintenace mode in store api routes..

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,6 +20,8 @@
 /bin/pre-commit export-ignore
 /bin/pre-push export-ignore
 /config-schema.json export-ignore
+/config/routes/test export-ignore
+/config/services_test.xml export-ignore
 /*.md export-ignore
 /devenv.* export-ignore
 /docker-compose.yml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,12 @@ phpstan.neon
 
 config/jwt/
 config/packages/
+config/routes*
+!config/routes/
+config/routes/*
+!config/routes/test/
 config/services*
+!/config/services_test.xml
 
 custom
 !/custom/scripts/boot

--- a/changelog/_unreleased/2023-09-14-support-active-flag-and-maintenace-mode-in-store-api-routes..md
+++ b/changelog/_unreleased/2023-09-14-support-active-flag-and-maintenace-mode-in-store-api-routes..md
@@ -1,0 +1,15 @@
+---
+title: Support active flag and maintenace mode in store api routes.
+issue: NEXT-00000
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed method `validateRequest` in `Shopware\Core\Framework\Api\EventListener\Authentication\SalesChannelAuthenticationListener` class to support active flag and maintenance mode.
+* Added `Shopware\Core\Framework\Routing\MaintenanceModeResolver` to abstract maintenance related checks that can be used in both Storefront and store API routes.
+* Changed `Shopware\Storefront\Framework\Routing\MaintenanceModeResolver` to use `Shopware\Core\Framework\Routing\MaintenanceModeResolver` where applicable.
+* Changed `Shopware\Storefront\Framework\Routing\MaintenanceModeResolver` to use use `main` request to retrieve the attribute `SalesChannelRequest::ATTRIBUTE_SALES_CHANNEL_MAINTENANCE` as was already the case for `SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST` and `SalesChannelRequest::ATTRIBUTE_SALES_CHANNEL_MAINTENANCE_IP_WHITLELIST`. 
+* Added `Shopware\Core\Framework\Routing\Event\MaintenanceModeRequestEvent` event in order to determine if a user is allowed to access the page during maintenance mode, e.g. by providing a centrailized list of IPs.
+* Deprecated constant `ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE` of `Shopware\Core\SalesChannelRequest`. Use constant `ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE` of `Shopware\Core\PlatformRequest` instead.
+* Added constant `ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE` to `Shopware\Core\PlatformRequest`.

--- a/config/routes/test/core_framework.xml
+++ b/config/routes/test/core_framework.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<routes xmlns="http://symfony.com/schema/routing"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://symfony.com/schema/routing
+        https://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <import resource="../../../tests/integration/Core/Framework/Api/EventListener/FixturesPhp/*TestRoute.php" type="attribute" />
+</routes>

--- a/config/services_test.xml
+++ b/config/services_test.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="Shopware\Tests\Integration\Core\Framework\Api\EventListener\FixturesPhp\SalesChannelAuthenticationListenerTestRoute">
+            <tag name="controller.service_arguments"/>
+        </service>
+    </services>
+</container>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12723,11 +12723,6 @@ parameters:
 			path: src/Storefront/Framework/Media/Validator/StorefrontMediaDocumentValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Framework\\\\Routing\\\\MaintenanceModeResolver\\:\\:getMaintenanceWhitelist\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Storefront/Framework/Routing/MaintenanceModeResolver.php
-
-		-
 			message: "#^Method Shopware\\\\Storefront\\\\Framework\\\\Routing\\\\Router\\:\\:generate\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Storefront/Framework/Routing/Router.php

--- a/src/Core/Framework/Api/ApiException.php
+++ b/src/Core/Framework/Api/ApiException.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Exception\DefinitionNotFoundExc
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\MissingReverseAssociation;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\Exception\SalesChannelMaintenanceException;
 use Shopware\Core\Framework\Routing\Exception\SalesChannelNotFoundException;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
@@ -169,6 +170,11 @@ class ApiException extends HttpException
     public static function salesChannelNotFound(): ShopwareHttpException
     {
         return new SalesChannelNotFoundException();
+    }
+
+    public static function salesChannelMaintenanceException(): ShopwareHttpException
+    {
+        return new SalesChannelMaintenanceException();
     }
 
     public static function deleteLiveVersion(): ShopwareHttpException

--- a/src/Core/Framework/Api/EventListener/Authentication/SalesChannelAuthenticationListener.php
+++ b/src/Core/Framework/Api/EventListener/Authentication/SalesChannelAuthenticationListener.php
@@ -3,16 +3,20 @@
 namespace Shopware\Core\Framework\Api\EventListener\Authentication;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Types;
 use Shopware\Core\Framework\Api\ApiException;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\KernelListenerPriorities;
+use Shopware\Core\Framework\Routing\MaintenanceModeResolver;
 use Shopware\Core\Framework\Routing\RouteScopeCheckTrait;
 use Shopware\Core\Framework\Routing\RouteScopeRegistry;
 use Shopware\Core\Framework\Routing\StoreApiRouteScope;
+use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -29,7 +33,8 @@ class SalesChannelAuthenticationListener implements EventSubscriberInterface
      */
     public function __construct(
         private readonly Connection $connection,
-        private readonly RouteScopeRegistry $routeScopeRegistry
+        private readonly RouteScopeRegistry $routeScopeRegistry,
+        private readonly MaintenanceModeResolver $maintenanceModeResolver
     ) {
     }
 
@@ -39,7 +44,10 @@ class SalesChannelAuthenticationListener implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::CONTROLLER => ['validateRequest', KernelListenerPriorities::KERNEL_CONTROLLER_EVENT_PRIORITY_AUTH_VALIDATE],
+            KernelEvents::CONTROLLER => [
+                'validateRequest',
+                KernelListenerPriorities::KERNEL_CONTROLLER_EVENT_PRIORITY_AUTH_VALIDATE,
+            ],
         ];
     }
 
@@ -57,7 +65,10 @@ class SalesChannelAuthenticationListener implements EventSubscriberInterface
 
         $accessKey = $request->headers->get(PlatformRequest::HEADER_ACCESS_KEY);
         if (!$accessKey) {
-            throw ApiException::unauthorized('header', sprintf('Header "%s" is required.', PlatformRequest::HEADER_ACCESS_KEY));
+            throw ApiException::unauthorized(
+                'header',
+                sprintf('Header "%s" is required.', PlatformRequest::HEADER_ACCESS_KEY)
+            );
         }
 
         $origin = AccessKeyHelper::getOrigin($accessKey);
@@ -65,9 +76,11 @@ class SalesChannelAuthenticationListener implements EventSubscriberInterface
             throw ApiException::salesChannelNotFound();
         }
 
-        $salesChannelId = $this->getSalesChannelId($accessKey);
+        $salesChannelData = $this->getSalesChannelData($accessKey);
 
-        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, $salesChannelId);
+        $this->handleMaintenanceMode($request, $salesChannelData);
+
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, $salesChannelData['id']);
     }
 
     protected function getScopeRegistry(): RouteScopeRegistry
@@ -75,21 +88,63 @@ class SalesChannelAuthenticationListener implements EventSubscriberInterface
         return $this->routeScopeRegistry;
     }
 
-    private function getSalesChannelId(string $accessKey): string
+    /**
+     * @return array<string, mixed>
+     */
+    private function getSalesChannelData(string $accessKey): array
     {
         $builder = $this->connection->createQueryBuilder();
 
-        $salesChannelId = $builder->select(['sales_channel.id'])
+        $salesChannelData = $builder->select(
+            'sales_channel.id AS id',
+            'sales_channel.maintenance AS maintenance',
+            'sales_channel.maintenance_ip_whitelist as maintenanceIpWhitelist'
+        )
             ->from('sales_channel')
             ->where('sales_channel.access_key = :accessKey')
+            ->andWhere('sales_channel.active = :active')
             ->setParameter('accessKey', $accessKey)
+            ->setParameter('active', true, Types::BOOLEAN)
             ->executeQuery()
-            ->fetchOne();
+            ->fetchAssociative();
 
-        if (!$salesChannelId) {
+        if (!\is_array($salesChannelData)) {
             throw ApiException::salesChannelNotFound();
         }
 
-        return Uuid::fromBytesToHex($salesChannelId);
+        $id = $salesChannelData['id'] ?? null;
+
+        if ($id === null || $id === '') {
+            throw ApiException::salesChannelNotFound();
+        }
+
+        $salesChannelData['id'] = Uuid::fromBytesToHex($id);
+
+        return $salesChannelData;
+    }
+
+    /**
+     * @param array<string, mixed> $salesChannelData
+     */
+    private function handleMaintenanceMode(Request $request, array $salesChannelData): void
+    {
+        $maintenance = (bool) ($salesChannelData['maintenance'] ?? false);
+
+        if (!$maintenance) {
+            return;
+        }
+
+        if ($request->attributes->getBoolean(PlatformRequest::ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE)) {
+            return;
+        }
+
+        /** @var string[] $allowedIps */
+        $allowedIps = Json::decodeArray((string) ($salesChannelData['maintenanceIpWhitelist'] ?? ''));
+
+        if ($this->maintenanceModeResolver->isClientAllowed($request, $allowedIps)) {
+            return;
+        }
+
+        throw ApiException::salesChannelMaintenanceException();
     }
 }

--- a/src/Core/Framework/DependencyInjection/api.xml
+++ b/src/Core/Framework/DependencyInjection/api.xml
@@ -276,6 +276,7 @@
             <tag name="kernel.event_subscriber"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="Shopware\Core\Framework\Routing\RouteScopeRegistry"/>
+            <argument type="service" id="Shopware\Core\Framework\Routing\MaintenanceModeResolver"/>
         </service>
 
         <service id="Shopware\Core\Framework\Api\EventListener\Authentication\ApiAuthenticationListener">

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -216,6 +216,10 @@ base-uri 'self';
             <argument type="service" id="event_dispatcher"/>
         </service>
 
+        <service id="Shopware\Core\Framework\Routing\MaintenanceModeResolver">
+            <argument type="service" id="event_dispatcher"/>
+        </service>
+
         <!-- Custom Entity -->
         <service id="Shopware\Core\System\CustomEntity\Xml\Config\CustomEntityEnrichmentService">
             <argument type="service" id="Shopware\Core\System\CustomEntity\Xml\Config\AdminUi\AdminUiXmlSchemaValidator"/>

--- a/src/Core/Framework/Routing/Event/MaintenanceModeRequestEvent.php
+++ b/src/Core/Framework/Routing/Event/MaintenanceModeRequestEvent.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Routing\Event;
+
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('core')]
+class MaintenanceModeRequestEvent extends Event
+{
+    /**
+     * @param string[] $allowedIps
+     *
+     * @internal
+     */
+    public function __construct(
+        private readonly Request $request,
+        private readonly array $allowedIps,
+        private bool $isClientAllowed
+    ) {
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function isClientAllowed(): bool
+    {
+        return $this->isClientAllowed;
+    }
+
+    public function disallowClient(): void
+    {
+        $this->isClientAllowed = false;
+    }
+
+    public function allowClient(): void
+    {
+        $this->isClientAllowed = true;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedIps(): array
+    {
+        return $this->allowedIps;
+    }
+}

--- a/src/Core/Framework/Routing/Exception/SalesChannelMaintenanceException.php
+++ b/src/Core/Framework/Routing/Exception/SalesChannelMaintenanceException.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Routing\Exception;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\ShopwareHttpException;
+use Symfony\Component\HttpFoundation\Response;
+
+#[Package('core')]
+class SalesChannelMaintenanceException extends ShopwareHttpException
+{
+    public function __construct()
+    {
+        parent::__construct('Sales channel is in maintenance.');
+    }
+
+    public function getErrorCode(): string
+    {
+        return 'FRAMEWORK__ROUTING_SALES_CHANNEL_MAINTENANCE';
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_SERVICE_UNAVAILABLE;
+    }
+}

--- a/src/Core/Framework/Routing/MaintenanceModeResolver.php
+++ b/src/Core/Framework/Routing/MaintenanceModeResolver.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Routing;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\Event\MaintenanceModeRequestEvent;
+use Symfony\Component\HttpFoundation\IpUtils;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class MaintenanceModeResolver
+{
+    public function __construct(private readonly EventDispatcherInterface $eventDispatcher)
+    {
+    }
+
+    /**
+     * @param string[] $allowedIps
+     */
+    public function isClientAllowed(Request $request, array $allowedIps): bool
+    {
+        $isAllowed = IpUtils::checkIp(
+            (string) $request->getClientIp(),
+            $allowedIps
+        );
+
+        $event = new MaintenanceModeRequestEvent($request, $allowedIps, $isAllowed);
+
+        $this->eventDispatcher->dispatch($event);
+
+        return $event->isClientAllowed();
+    }
+}

--- a/src/Core/Framework/Util/Json.php
+++ b/src/Core/Framework/Util/Json.php
@@ -14,4 +14,25 @@ final class Json
     {
         return (string) json_encode($value, $options);
     }
+
+    /**
+     * @throws \JsonException
+     * @throws \UnexpectedValueException
+     *
+     * @return array<int, mixed>
+     */
+    public static function decodeArray(string $value): array
+    {
+        if ($value === '') {
+            return [];
+        }
+
+        $result = json_decode($value, true, flags: \JSON_THROW_ON_ERROR);
+
+        if (\is_array($result) && \array_is_list($result)) {
+            return $result;
+        }
+
+        throw new \UnexpectedValueException('Provided JSON is not a string.');
+    }
 }

--- a/src/Core/PlatformRequest.php
+++ b/src/Core/PlatformRequest.php
@@ -65,6 +65,7 @@ final class PlatformRequest
     public const ATTRIBUTE_CONTEXT_TOKEN_REQUIRED = '_contextTokenRequired';
     public const ATTRIBUTE_LOGIN_REQUIRED = '_loginRequired';
     public const ATTRIBUTE_LOGIN_REQUIRED_ALLOW_GUEST = '_loginRequiredAllowGuest';
+    public const ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE = 'allow_maintenance';
 
     /**
      * CSP

--- a/src/Core/SalesChannelRequest.php
+++ b/src/Core/SalesChannelRequest.php
@@ -9,7 +9,10 @@ final class SalesChannelRequest
 {
     public const ATTRIBUTE_IS_SALES_CHANNEL_REQUEST = '_is_sales_channel';
 
-    public const ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE = 'allow_maintenance';
+    /**
+     * @deprecated tag:v6.6.0 - Moved to PlatformRequest.
+     */
+    public const ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE = PlatformRequest::ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE;
 
     public const ATTRIBUTE_THEME_ID = 'theme-id';
     public const ATTRIBUTE_THEME_NAME = 'theme-name';

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -84,6 +84,7 @@
 
         <service id="Shopware\Storefront\Framework\Routing\MaintenanceModeResolver">
             <argument type="service" id="request_stack"/>
+            <argument type="service" id="Shopware\Core\Framework\Routing\MaintenanceModeResolver"/>
         </service>
 
         <service id="Shopware\Storefront\Framework\Routing\StorefrontRouteScope">

--- a/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
+++ b/src/Storefront/Framework/Routing/MaintenanceModeResolver.php
@@ -3,8 +3,10 @@
 namespace Shopware\Storefront\Framework\Routing;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\MaintenanceModeResolver as CoreMaintenanceModeResolver;
+use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
-use Symfony\Component\HttpFoundation\IpUtils;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -17,11 +19,17 @@ class MaintenanceModeResolver
     protected $requestStack;
 
     /**
+     * @var CoreMaintenanceModeResolver
+     */
+    protected $maintenanceModeResolver;
+
+    /**
      * @internal
      */
-    public function __construct(RequestStack $requestStack)
+    public function __construct(RequestStack $requestStack, CoreMaintenanceModeResolver $maintenanceModeResolver)
     {
         $this->requestStack = $requestStack;
+        $this->maintenanceModeResolver = $maintenanceModeResolver;
     }
 
     /**
@@ -31,8 +39,8 @@ class MaintenanceModeResolver
      */
     public function shouldRedirect(Request $request): bool
     {
-        return $this->isSalesChannelRequest($this->requestStack->getMainRequest())
-            && !$this->isMaintenancePageRequest($request)
+        return $this->isSalesChannelRequest()
+            && !$request->attributes->getBoolean(PlatformRequest::ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE)
             && !$this->isXmlHttpRequest($request)
             && !$this->isErrorControllerRequest($request)
             && $this->isMaintenanceRequest($request);
@@ -52,7 +60,7 @@ class MaintenanceModeResolver
 
     public function shouldBeCached(Request $request): bool
     {
-        return !$this->isMaintenanceModeActive($request) || !$this->isClientAllowed($request);
+        return !$this->isMaintenanceModeActive() || !$this->isClientAllowed($request);
     }
 
     /**
@@ -61,25 +69,14 @@ class MaintenanceModeResolver
      */
     public function isMaintenanceRequest(Request $request): bool
     {
-        return $this->isMaintenanceModeActive($request) && !$this->isClientAllowed($request);
+        return $this->isMaintenanceModeActive() && !$this->isClientAllowed($request);
     }
 
-    private function isSalesChannelRequest(?Request $master): bool
+    private function isSalesChannelRequest(): bool
     {
-        if (!$master) {
-            return false;
-        }
+        $main = $this->requestStack->getMainRequest();
 
-        return (bool) $master->attributes->get(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST);
-    }
-
-    private function isMaintenancePageRequest(Request $request): bool
-    {
-        if ($request->attributes->getBoolean(SalesChannelRequest::ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE)) {
-            return true;
-        }
-
-        return false;
+        return (bool) $main?->attributes->get(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST);
     }
 
     private function isXmlHttpRequest(Request $request): bool
@@ -93,35 +90,21 @@ class MaintenanceModeResolver
             && $request->attributes->get('_controller') === 'error_controller';
     }
 
-    private function isMaintenanceModeActive(?Request $master): bool
+    private function isMaintenanceModeActive(): bool
     {
-        if (!$master) {
-            return false;
-        }
+        $main = $this->requestStack->getMainRequest();
 
-        return (bool) $master->attributes->get(SalesChannelRequest::ATTRIBUTE_SALES_CHANNEL_MAINTENANCE);
+        return (bool) $main?->attributes->get(SalesChannelRequest::ATTRIBUTE_SALES_CHANNEL_MAINTENANCE);
     }
 
     private function isClientAllowed(Request $request): bool
     {
-        return IpUtils::checkIp(
-            (string) $request->getClientIp(),
-            $this->getMaintenanceWhitelist($this->requestStack->getMainRequest())
-        );
-    }
+        $main = $this->requestStack->getMainRequest();
+        $whitelist = $main?->attributes->get(SalesChannelRequest::ATTRIBUTE_SALES_CHANNEL_MAINTENANCE_IP_WHITLELIST) ?? '';
 
-    private function getMaintenanceWhitelist(?Request $master): array
-    {
-        if (!$master) {
-            return [];
-        }
+        /** @var string[] $allowedIps */
+        $allowedIps = Json::decodeArray((string) $whitelist);
 
-        $whitelist = $master->attributes->get(SalesChannelRequest::ATTRIBUTE_SALES_CHANNEL_MAINTENANCE_IP_WHITLELIST);
-
-        if (!$whitelist) {
-            return [];
-        }
-
-        return json_decode((string) $whitelist, true, 512, \JSON_THROW_ON_ERROR) ?? [];
+        return $this->maintenanceModeResolver->isClientAllowed($request, $allowedIps);
     }
 }

--- a/tests/integration/Core/Framework/Api/EventListener/FixturesPhp/SalesChannelAuthenticationListenerTestRoute.php
+++ b/tests/integration/Core/Framework/Api/EventListener/FixturesPhp/SalesChannelAuthenticationListenerTestRoute.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Api\EventListener\FixturesPhp;
+
+use Shopware\Core\Framework\Routing\StoreApiRouteScope;
+use Shopware\Core\PlatformRequest;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @internal
+ */
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]])]
+class SalesChannelAuthenticationListenerTestRoute
+{
+    #[
+        Route(
+            path: '/store-api/test/sales-channel-authentication-listener/default',
+            name: 'store-api.test.authentication_listener.default',
+            methods: [Request::METHOD_GET]
+        )
+    ]
+    public function defaultAction(): JsonResponse
+    {
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    #[
+        Route(
+            path: '/store-api/test/sales-channel-authentication-listener/maintenance-allowed',
+            name: 'store-api.test.authentication_listener.maintenance_allowed',
+            defaults: [PlatformRequest::ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE => true],
+            methods: [Request::METHOD_GET]
+        )
+    ]
+    public function maintenanceAllowed(): JsonResponse
+    {
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    #[
+        Route(
+            path: '/store-api/test/sales-channel-authentication-listener/maintenance-disallowed',
+            name: 'store-api.test.authentication_listener.maintenance_disallowed',
+            defaults: [PlatformRequest::ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE => false],
+            methods: [Request::METHOD_GET]
+        )
+    ]
+    public function maintenanceDisallowed(): JsonResponse
+    {
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+
+    #[
+        Route(
+            path: '/store-api/test/sales-channel-authentication-listener/no-auth-required',
+            name: 'store-api.test.authentication_listener.no_auth_required',
+            defaults: ['auth_required' => false],
+            methods: [Request::METHOD_GET]
+        )
+    ]
+    public function noAuthRequiredAction(): JsonResponse
+    {
+        return new JsonResponse(null, Response::HTTP_NO_CONTENT);
+    }
+}

--- a/tests/integration/Core/Framework/Api/EventListener/SalesChannelAuthenticationListenerTest.php
+++ b/tests/integration/Core/Framework/Api/EventListener/SalesChannelAuthenticationListenerTest.php
@@ -1,0 +1,177 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\Api\EventListener;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\ApiException;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Framework\Api\EventListener\Authentication\SalesChannelAuthenticationListener
+ * @covers \Shopware\Storefront\Framework\Routing\MaintenanceModeResolver
+ */
+class SalesChannelAuthenticationListenerTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use SalesChannelApiTestBehaviour;
+
+    private const MAINTENANCE_ALLOWED_IPS = ['192.168.0.2', '192.168.0.1', '192.168.0.3'];
+
+    public function testInactiveSalesChannel(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => false]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/default');
+
+        $this->assertExceptionResponse(
+            $browser,
+            Response::HTTP_PRECONDITION_FAILED,
+            ApiException::salesChannelNotFound()->getErrorCode()
+        );
+    }
+
+    public function testActiveSalesChannel(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => true]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/default');
+
+        $this->assertResponseSuccess($browser);
+    }
+
+    public function testMaintenanceSalesChannel(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => true, 'maintenance' => true]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/default');
+
+        $this->assertExceptionResponse(
+            $browser,
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            ApiException::salesChannelMaintenanceException()->getErrorCode()
+        );
+    }
+
+    public function testInactiveAndMaintenanceSalesChannel(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => false, 'maintenance' => true]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/default');
+
+        $this->assertExceptionResponse(
+            $browser,
+            Response::HTTP_PRECONDITION_FAILED,
+            ApiException::salesChannelNotFound()->getErrorCode()
+        );
+    }
+
+    public function testMaintenanceSalesChannelAndClientInAllowedIps(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => true, 'maintenance' => true, 'maintenanceIpWhitelist' => self::MAINTENANCE_ALLOWED_IPS]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/default', server: ['REMOTE_ADDR' => '192.168.0.1']);
+
+        $this->assertResponseSuccess($browser);
+    }
+
+    public function testMaintenanceSalesChannelAndClientNotInAllowedIps(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => true, 'maintenance' => true, 'maintenanceIpWhitelist' => self::MAINTENANCE_ALLOWED_IPS]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/default', server: ['REMOTE_ADDR' => '192.168.0.4']);
+
+        $this->assertExceptionResponse(
+            $browser,
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            ApiException::salesChannelMaintenanceException()->getErrorCode()
+        );
+    }
+
+    public function testMaintenanceSalesChannelWithMaintenanceAllowedRoute(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => true, 'maintenance' => true]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/maintenance-allowed');
+
+        $this->assertResponseSuccess($browser);
+    }
+
+    public function testMaintenanceSalesChannelWithMaintenanceDisallowedRoute(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => true, 'maintenance' => true]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/maintenance-disallowed');
+
+        $this->assertExceptionResponse(
+            $browser,
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            ApiException::salesChannelMaintenanceException()->getErrorCode()
+        );
+    }
+
+    public function testMaintenanceSalesChannelWithMaintenanceDisallowedRouteAndClientNotInAllowedIps(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => true, 'maintenance' => true, 'maintenanceIpWhitelist' => self::MAINTENANCE_ALLOWED_IPS]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/maintenance-disallowed', server: ['REMOTE_ADDR' => '192.168.0.1']);
+
+        $this->assertResponseSuccess($browser);
+    }
+
+    public function testMaintenanceSalesChannelWithMaintenanceDisallowedRouteAndClientInAllowedIps(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => true, 'maintenance' => true, 'maintenanceIpWhitelist' => self::MAINTENANCE_ALLOWED_IPS]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/maintenance-disallowed', server: ['REMOTE_ADDR' => '192.168.0.4']);
+
+        $this->assertExceptionResponse(
+            $browser,
+            Response::HTTP_SERVICE_UNAVAILABLE,
+            ApiException::salesChannelMaintenanceException()->getErrorCode()
+        );
+    }
+
+    public function testRouteWithoutAuthRequiredIgnoresActiveFlag(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => false]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/no-auth-required');
+
+        $this->assertResponseSuccess($browser);
+    }
+
+    public function testRouteWithoutAuthRequiredIgnoreMaintenanceModeFlag(): void
+    {
+        $browser = $this->createSalesChannelBrowser(salesChannelOverrides: ['active' => true, 'maintenance' => true]);
+        $browser->request(Request::METHOD_GET, '/store-api/test/sales-channel-authentication-listener/no-auth-required');
+
+        $this->assertResponseSuccess($browser);
+    }
+
+    private function assertExceptionResponse(KernelBrowser $browser, int $statusCode, string $errorCode): void
+    {
+        $response = $browser->getResponse();
+        static::assertInstanceOf(JsonResponse::class, $response);
+        static::assertSame($statusCode, $response->getStatusCode(), (string) $response->getContent());
+
+        $content = $response->getContent();
+        static::assertIsString($content);
+
+        $data = json_decode($content, true, flags: \JSON_THROW_ON_ERROR);
+        static::assertIsArray($data);
+        static::assertArrayHasKey('errors', $data);
+        static::assertCount(1, $data['errors'] ?? []);
+
+        $error = $data['errors'][0];
+
+        static::assertSame((string) $statusCode, $error['status']);
+        static::assertSame($errorCode, $error['code']);
+    }
+
+    private function assertResponseSuccess(KernelBrowser $browser): void
+    {
+        $response = $browser->getResponse();
+        static::assertInstanceOf(JsonResponse::class, $response);
+        static::assertSame(Response::HTTP_NO_CONTENT, $response->getStatusCode());
+
+        $content = $response->getContent();
+        static::assertIsString($content);
+        static::assertSame('', $content);
+    }
+}

--- a/tests/unit/Core/Framework/Routing/MaintenanceModeResolverTest.php
+++ b/tests/unit/Core/Framework/Routing/MaintenanceModeResolverTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Routing;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Routing\Event\MaintenanceModeRequestEvent;
+use Shopware\Core\Framework\Routing\MaintenanceModeResolver;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Framework\Routing\MaintenanceModeResolver
+ */
+class MaintenanceModeResolverTest extends TestCase
+{
+    public function testIsClientAllowedTriggersEventAndReturnsFalseForDisallowedClient(): void
+    {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $eventDispatcher->expects(static::once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(MaintenanceModeRequestEvent::class));
+
+        $resolver = new MaintenanceModeResolver($eventDispatcher);
+        static::assertFalse($resolver->isClientAllowed(new Request(server: ['REMOTE_ADDR' => '192.168.0.4']), []));
+    }
+
+    public function testIsClientAllowedTriggersEventAndReturnsTrueForAllowedClient(): void
+    {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $eventDispatcher->expects(static::once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(MaintenanceModeRequestEvent::class));
+
+        $resolver = new MaintenanceModeResolver($eventDispatcher);
+        static::assertTrue($resolver->isClientAllowed(new Request(server: ['REMOTE_ADDR' => '192.168.0.4']), ['192.168.0.4']));
+    }
+
+    public function testClientIsAllowedButEventDisallowsIt(): void
+    {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $eventDispatcher->expects(static::once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(MaintenanceModeRequestEvent::class))
+            ->willReturnCallback(function (MaintenanceModeRequestEvent $event) {
+                static::assertTrue($event->isClientAllowed());
+                $event->disallowClient();
+
+                return $event;
+            });
+
+        $resolver = new MaintenanceModeResolver($eventDispatcher);
+        static::assertFalse($resolver->isClientAllowed(new Request(server: ['REMOTE_ADDR' => '192.168.0.4']), ['192.168.0.4']));
+    }
+
+    public function testClientIsDisallowedButEventAllowsIt(): void
+    {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $eventDispatcher->expects(static::once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(MaintenanceModeRequestEvent::class))
+            ->willReturnCallback(function (MaintenanceModeRequestEvent $event) {
+                static::assertFalse($event->isClientAllowed());
+                $event->allowClient();
+
+                return $event;
+            });
+
+        $resolver = new MaintenanceModeResolver($eventDispatcher);
+        static::assertTrue($resolver->isClientAllowed(new Request(server: ['REMOTE_ADDR' => '192.168.0.4']), []));
+    }
+}

--- a/tests/unit/Core/Framework/Util/JsonTest.php
+++ b/tests/unit/Core/Framework/Util/JsonTest.php
@@ -1,0 +1,85 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Util;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Util\Json;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Framework\Util\Json
+ */
+class JsonTest extends TestCase
+{
+    public function testDecodeArrayReturnsEmptyArrayOnEmptyString(): void
+    {
+        static::assertSame([], Json::decodeArray(''));
+    }
+
+    public function testDecodeArrayThrowsJsonExceptionOnInvalidJsonString(): void
+    {
+        static::expectException(\JsonException::class);
+        Json::decodeArray('["abc", "foo"');
+    }
+
+    public function testDecodeArrayThrowsUnexcpectedValueExceptionOnDecodedObject(): void
+    {
+        static::expectException(\UnexpectedValueException::class);
+        Json::decodeArray('{"abc": "foo"}');
+    }
+
+    public function testDecodeArrayThrowsUnexcpectedValueExceptionOnDecodedObjectWithNumericNonSequentialIndices(): void
+    {
+        static::expectException(\UnexpectedValueException::class);
+        Json::decodeArray('{"0": "abc", "2": "foo"}');
+    }
+
+    public function testDecodeArrayDecodesObjectWithSequentialNumericIndicesAsArray(): void
+    {
+        static::assertSame(['abc', 'foo'], Json::decodeArray('{"0": "abc", "1": "foo"}'));
+    }
+
+    public function testDecodeArrayThrowsUnexcpectedValueExceptionOnDecodedString(): void
+    {
+        static::expectException(\UnexpectedValueException::class);
+        Json::decodeArray('"abc"');
+    }
+
+    public function testDecodeArrayThrowsUnexcpectedValueExceptionOnDecodedInt(): void
+    {
+        static::expectException(\UnexpectedValueException::class);
+        Json::decodeArray('123');
+    }
+
+    public function testDecodeArrayThrowsUnexcpectedValueExceptionOnDecodedFloat(): void
+    {
+        static::expectException(\UnexpectedValueException::class);
+        Json::decodeArray('12.01');
+    }
+
+    public function testDecodeArrayThrowsUnexcpectedValueExceptionOnDecodedBoolean(): void
+    {
+        static::expectException(\UnexpectedValueException::class);
+        Json::decodeArray('false');
+    }
+
+    public function testDecodeArrayThrowsUnexcpectedValueExceptionOnDecodedNull(): void
+    {
+        static::expectException(\UnexpectedValueException::class);
+        Json::decodeArray('null');
+    }
+
+    public function testDecodeArrayCorrectlyDecodesArray(): void
+    {
+        static::assertSame(['abc', 'foo'], Json::decodeArray('["abc", "foo"]'));
+    }
+
+    public function testDecodeArrayWithObjectsAsArrayListWithAssociativeArrays(): void
+    {
+        static::assertSame(
+            [['name' => 'abc'], ['name' => 'foo']],
+            Json::decodeArray('[{"name": "abc"}, {"name": "foo"}]')
+        );
+    }
+}

--- a/tests/unit/Storefront/Framework/Cache/CacheResponseSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Cache/CacheResponseSubscriberTest.php
@@ -10,12 +10,14 @@ use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Test\Cart\Common\Generator;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Event\BeforeSendResponseEvent;
+use Shopware\Core\Framework\Routing\MaintenanceModeResolver as CoreMaintenanceModeResolver;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Framework\Cache\CacheResponseSubscriber;
 use Shopware\Storefront\Framework\Routing\MaintenanceModeResolver;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -61,7 +63,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createMock(CartService::class),
             100,
             false,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -95,7 +97,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createMock(CartService::class),
             100,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -124,7 +126,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createMock(CartService::class),
             100,
             false,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -153,7 +155,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createMock(CartService::class),
             100,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -188,7 +190,7 @@ class CacheResponseSubscriberTest extends TestCase
             $service,
             100,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -270,7 +272,7 @@ class CacheResponseSubscriberTest extends TestCase
             $cartService,
             100,
             true,
-            new MaintenanceModeResolver($requestStack),
+            new MaintenanceModeResolver($requestStack, new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -354,7 +356,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createMock(CartService::class),
             100,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             $reverseProxyEnabled,
             null,
             null
@@ -424,7 +426,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createMock(CartService::class),
             1,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -446,7 +448,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createMock(CartService::class),
             100,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -489,7 +491,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createMock(CartService::class),
             100,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -523,7 +525,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createMock(CartService::class),
             100,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -567,7 +569,7 @@ class CacheResponseSubscriberTest extends TestCase
             $cartService,
             100,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null
@@ -603,7 +605,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createMock(CartService::class),
             100,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             '5',
             '6'
@@ -689,7 +691,7 @@ class CacheResponseSubscriberTest extends TestCase
             $this->createStub(CartService::class),
             100,
             true,
-            new MaintenanceModeResolver(new RequestStack()),
+            new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
             false,
             null,
             null

--- a/tests/unit/Storefront/Framework/Routing/MaintenanceModeResolverTest.php
+++ b/tests/unit/Storefront/Framework/Routing/MaintenanceModeResolverTest.php
@@ -3,8 +3,10 @@
 namespace Shopware\Tests\Unit\Storefront\Framework\Routing;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Routing\MaintenanceModeResolver as CoreMaintenanceModeResolver;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Storefront\Framework\Routing\MaintenanceModeResolver;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -17,7 +19,7 @@ class MaintenanceModeResolverTest extends TestCase
 {
     public function testShouldInstantiate(): void
     {
-        static::assertInstanceOf(MaintenanceModeResolver::class, new MaintenanceModeResolver($this->getRequestStack()));
+        static::assertInstanceOf(MaintenanceModeResolver::class, new MaintenanceModeResolver($this->getRequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())));
     }
 
     /**
@@ -36,7 +38,7 @@ class MaintenanceModeResolverTest extends TestCase
          * we need to be able to set the master-request's config here, since
          * the resolver reads the whitelist from it.
          */
-        $resolver = new MaintenanceModeResolver($this->getRequestStack($request));
+        $resolver = new MaintenanceModeResolver($this->getRequestStack($request), new CoreMaintenanceModeResolver(new EventDispatcher()));
 
         if ($shouldRedirect) {
             static::assertTrue(
@@ -59,7 +61,7 @@ class MaintenanceModeResolverTest extends TestCase
      */
     public function testShouldRedirectToShop(Request $request, bool $shouldRedirect): void
     {
-        $resolver = new MaintenanceModeResolver($this->getRequestStack($request));
+        $resolver = new MaintenanceModeResolver($this->getRequestStack($request), new CoreMaintenanceModeResolver(new EventDispatcher()));
 
         if ($shouldRedirect) {
             static::assertFalse(
@@ -83,7 +85,7 @@ class MaintenanceModeResolverTest extends TestCase
     public function testIsMaintenanceRequest(Request $request, bool $expected): void
     {
         static::assertEquals(
-            (new MaintenanceModeResolver($this->getRequestStack($request)))->isMaintenanceRequest($request),
+            (new MaintenanceModeResolver($this->getRequestStack($request), new CoreMaintenanceModeResolver(new EventDispatcher())))->isMaintenanceRequest($request),
             $expected
         );
     }
@@ -217,12 +219,12 @@ class MaintenanceModeResolverTest extends TestCase
         ];
     }
 
-    private function getRequestStack(?Request $master = null): RequestStack
+    private function getRequestStack(?Request $main = null): RequestStack
     {
         $requestStack = new RequestStack();
 
-        if ($master instanceof Request) {
-            $requestStack->push($master);
+        if ($main instanceof Request) {
+            $requestStack->push($main);
         }
 
         return $requestStack;


### PR DESCRIPTION
### 1. Why is this change necessary?

See issues #3025 and changelog.

### 2. What does this change do, exactly?

See issues #3025 and changelog.

### 3. Describe each step to reproduce the issue or behaviour.

See issues #3025 and changelog.

### 4. Please link to the relevant issues (if any).

#3025

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e3403c3</samp>

This pull request adds support for the active flag and the maintenance mode of the sales channels in the Store API routes. It introduces new events, exceptions and classes to handle the maintenance mode logic and to dispatch custom events for extensibility. It also refactors some existing classes and adds unit tests and changelog entries.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e3403c3</samp>

*  Add support for active flag and maintenance mode in Store API routes ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-1b94bfe175c8664e242ceeefea193219c114da4cccfe6a4886249e0ae3236645R1-R14))
*  Add a new SalesChannelMaintenanceException class that extends ShopwareHttpException ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-26e4fa9828a1e4eb36b5dd7bfa88fe9528e41659c716fdaf898b5330a3c2f1c0R1-R26))
*  Add a new ApiException static method to create a SalesChannelMaintenanceException instance ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-6b731528acc9f8b1f752535382b26a4d258ee7e55561f4c02fb1597e649ea77cR173-R177))
*  Add a new MaintenanceModeResolver class that encapsulates the logic for checking the maintenance mode and dispatching the related events ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-c3f573af2b04166987e7dfcb900ba1b38b973a21397b8446683e5557fe0fc299R1-R66))
*  Add a new IsMaintenanceActiveEvent class that represents an event that is dispatched to determine if the maintenance mode is active for a given request ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e75d952c322c25c1a3daf42003a198a18596168a33f364f236740cba0e506daeR1-R30))
*  Add a new IsMaintenanceAllowedRequestEvent class that represents an event that is dispatched to determine if a given request is allowed to access the sales channel in maintenance mode ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-79bfc9e7ba7a6f774756a4a39bc9345504a36c929794e59a8cf1e168391a03b5R1-R30))
*  Add a new MaintenanceAllowedClientEvent class that represents an event that is dispatched to determine if a given client is allowed to access the sales channel in maintenance mode based on the IP whitelist ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-f086079449f802e2db28c46c8719c2717bc833e023ba1b924973dd67d5b81198R1-R36))
*  Add the MaintenanceModeResolver as a dependency to the SalesChannelAuthenticationListener constructor ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e8f0f5fe457e6cb5676fc5e8a07a3f529ea9d8e7c4966c66618fd2f262c67121L32-R36), [link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-756e7ff306bf2376c4506427ce8eae6dc49df25ad76c9c80e6f5887efb4faaf1R279), [link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-30cf3befcc1c9ace1d219cfb5a67c609e134b5e2b1040818bdf899ac8f3d8c4dR87))
*  Rename the getSalesChannelId method to getSalesChannelData and change its return type to array in the SalesChannelAuthenticationListener class ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e8f0f5fe457e6cb5676fc5e8a07a3f529ea9d8e7c4966c66618fd2f262c67121L68-R82))
*  Add a check for the active flag of the sales channel and throw an exception if it is false in the getSalesChannelData method ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e8f0f5fe457e6cb5676fc5e8a07a3f529ea9d8e7c4966c66618fd2f262c67121L68-R82))
*  Add a new method handleMaintenanceMode to the SalesChannelAuthenticationListener class that checks if the maintenance mode is active and if the request or the client is allowed to access the sales channel ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e8f0f5fe457e6cb5676fc5e8a07a3f529ea9d8e7c4966c66618fd2f262c67121L78-R133))
*  Change the validateRequest method to use the handleMaintenanceMode method and the getSalesChannelData method in the SalesChannelAuthenticationListener class ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e8f0f5fe457e6cb5676fc5e8a07a3f529ea9d8e7c4966c66618fd2f262c67121L78-R133))
*  Add a new constant ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE to the PlatformRequest class that represents the request attribute that indicates if a request is allowed to access the sales channel in maintenance mode ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-95318cda9ed866a2b13dba48eeadd72d3b45a2d32d4a7a90ddfd130b9c211a34R68))
*  Deprecate the constant ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE of the SalesChannelRequest class and replace it with the constant ATTRIBUTE_IS_ALLOWED_IN_MAINTENANCE of the PlatformRequest class ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e2c422d2b3ca9dd235c9d6cdf1901139c32260ed268b82f57f0aeaefae29a211L12-R15))
*  Change the isMaintenanceModeActive method and the isClientAllowed method of the Storefront MaintenanceModeResolver class to use the CoreMaintenanceModeResolver and the main request from the request stack ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-61b80ffda29ace5aaf64bc04fe0224ad746d154de81a2ba25d2987d7a36b7489L96-R106))
*  Replace the isMaintenancePageRequest method call with the isMaintenanceAllowedRequest method call of the CoreMaintenanceModeResolver in the shouldRedirect method of the Storefront MaintenanceModeResolver class ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-61b80ffda29ace5aaf64bc04fe0224ad746d154de81a2ba25d2987d7a36b7489L35-R41))
*  Remove the isMaintenancePageRequest method and the getMaintenanceWhitelist method from the Storefront MaintenanceModeResolver class as they are no longer needed ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-61b80ffda29ace5aaf64bc04fe0224ad746d154de81a2ba25d2987d7a36b7489L76-L84), [link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-61b80ffda29ace5aaf64bc04fe0224ad746d154de81a2ba25d2987d7a36b7489L96-R106))
*  Add some use statements for the Types class and the Request class to the SalesChannelAuthenticationListener class file ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e8f0f5fe457e6cb5676fc5e8a07a3f529ea9d8e7c4966c66618fd2f262c67121L6-R11), [link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e8f0f5fe457e6cb5676fc5e8a07a3f529ea9d8e7c4966c66618fd2f262c67121R18))
*  Reformat the return array of the getSubscribedEvents method and the throw statement of the validateRequest method to use multiple lines for readability in the SalesChannelAuthenticationListener class file ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e8f0f5fe457e6cb5676fc5e8a07a3f529ea9d8e7c4966c66618fd2f262c67121L42-R49), [link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e8f0f5fe457e6cb5676fc5e8a07a3f529ea9d8e7c4966c66618fd2f262c67121L60-R70))
*  Add a new service definition for the CoreMaintenanceModeResolver class in the services.xml file ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-10c09911ceffac9304ed9f5095b5d830b04cf77112b9cbfa79296b8f3b37b53aR221-R224))
*  Add a new routes_test.xml file that imports the SalesChannelAuthenticationListenerTestRoute class as a route resource ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-e587da4ac34e01d55738eeaeddfdb3924da0e9edcf0faabb1c4d7216b8da7c12R1-R8))
*  Add a new services_test.xml file that defines the SalesChannelAuthenticationListenerTestRoute class as a service with the controller.service_arguments tag ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-9b9db02ff5232abe7e0d0d14285db5d489da6367413f65251922f23e23f545c8R1-R10))
*  Add a new SalesChannelAuthenticationListenerTestRoute class that defines some test routes for the SalesChannelAuthenticationListenerTest class with different maintenance mode attributes ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-52fc77bb477727e8e53e96461d0722616037617b78cdabcbe08651f3e48658f7R1-R55))
*  Add a new SalesChannelAuthenticationListenerTest class that contains unit tests for the SalesChannelAuthenticationListener class using different scenarios of sales channel activation, maintenance mode and IP whitelist ([link](https://github.com/shopware/platform/pull/3300/files?diff=unified&w=0#diff-88ebdd5ba56aa112a214023d42ae541f4b4472dde2fa1c94de49d937bcc87081R1-R156))
