### PR TITLE
NEXT-29496

### DIFF
--- a/changelog/_unreleased/2023-09-07-improve-filtering-with-dynamic-product-groups.md
+++ b/changelog/_unreleased/2023-09-07-improve-filtering-with-dynamic-product-groups.md
@@ -1,0 +1,9 @@
+---
+title: Improve filtering with dynamic product groups
+issue: NEXT-29496
+author: Bastiaan de Vogel
+author_email: bdevogel@msn.com
+author_github: bforbird
+---
+# Core
+* Changed `parseTermsAggregation` to return proper aggregations in `src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php`.

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
@@ -344,6 +344,15 @@ class EntityAggregator implements EntityAggregatorInterface
         if ($aggregation->getAggregation()) {
             $this->extendQuery($aggregation->getAggregation(), $query, $definition, $context);
         }
+
+        // First create the results of this entity, then create the aggregation with those results, so you get proper filters.
+        $whereQuery = clone $query;
+        $whereQuery->resetQueryPart('select');
+        $whereQuery->resetQueryPart('groupBy');
+        $whereQuery->select($countAccessor);
+
+        $query->resetQueryPart('where');
+        $query->where("$countAccessor IN ($whereQuery)");
     }
 
     private function parseAvgAggregation(


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When showing a dynamic product group in a PLP, filters based on the same properties as where the dynamic product group is based on, are empty.

### 2. What does this change do, exactly?
This change will result in proper filters shown on listing pages based on dynamic product groups.

### 3. Describe each step to reproduce the issue or behaviour.
* Create products with different properties.
* Create a dynamic product group based on properties.
* Create a product listing page based on that dynamic product group.
* See if you can filter on the same properties of those where the dynamic product group is based on.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-29496

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 048f6d3</samp>

This pull request introduces a feature that allows filtering products by dynamic product groups, based on the criteria defined in the administration. It also changes the `EntityAggregator` class to improve the performance and accuracy of the aggregation query.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 048f6d3</samp>

*  Add a changelog entry for the feature ([link](https://github.com/shopware/platform/pull/3301/files?diff=unified&w=0#diff-c8cc365205d65cb38ff7ed7701bbb68fc50b359dd1aababac0c3804f8c590400R1-R9))
*  Refactor the `parseTermsAggregation` method to use the entity query results for the aggregation query ([link](https://github.com/shopware/platform/pull/3301/files?diff=unified&w=0#diff-b22066b678708ac91f92e8e9447d0ed8491326be101b4f0ddaea2281160b975cR347-R355))
