### PR TITLE
Add entity index to state machine history

### DIFF
--- a/changelog/_unreleased/2023-09-11-add-entity-index-to-state-machine-history.md
+++ b/changelog/_unreleased/2023-09-11-add-entity-index-to-state-machine-history.md
@@ -1,0 +1,9 @@
+---
+title: Add entity index to state machine history
+issue: 
+author: Maximilian Rüsch
+author_email: maximilian.ruesch@pickware.de
+author_github: maximilianruesch
+---
+# Core
+* Adds a migration to add an index to the `state_machine_history` table to improve performance of state history searches.

--- a/src/Core/Migration/V6_5/Migration1694426018AddEntityIndexToStateMachineHistory.php
+++ b/src/Core/Migration/V6_5/Migration1694426018AddEntityIndexToStateMachineHistory.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_5;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1694426018AddEntityIndexToStateMachineHistory extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1694426018;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $indexes = $connection->executeQuery('
+            SELECT INDEX_NAME FROM information_schema.STATISTICS
+                WHERE table_schema = :database
+                  AND table_name = \'state_machine_history\'
+                  AND (COLUMN_NAME = \'referenced_id\'
+                    OR COLUMN_NAME = \'referenced_version_id\');
+        ', ['database' => $connection->getDatabase()])->fetchFirstColumn();
+
+        if (!\in_array('idx.state_machine_history.referenced_entity', $indexes, true)) {
+            $connection->executeStatement('
+                CREATE INDEX `idx.state_machine_history.referenced_entity`
+                    ON `state_machine_history` (`referenced_id`, `referenced_version_id`);
+            ');
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/tests/migration/Core/V6_5/Migration1694426018AddEntityIndexToStateMachineHistoryTest.php
+++ b/tests/migration/Core/V6_5/Migration1694426018AddEntityIndexToStateMachineHistoryTest.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_5;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_5\Migration1694426018AddEntityIndexToStateMachineHistory;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Migration\V6_5\Migration1694426018AddEntityIndexToStateMachineHistory
+ */
+class Migration1694426018AddEntityIndexToStateMachineHistoryTest extends TestCase
+{
+    private Connection $connection;
+
+    private Migration1694426018AddEntityIndexToStateMachineHistory $migration;
+
+    protected function setUp(): void
+    {
+        $this->migration = new Migration1694426018AddEntityIndexToStateMachineHistory();
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertEquals('1694426018', $this->migration->getCreationTimestamp());
+    }
+
+    public function testUpdate(): void
+    {
+        $this->migration->update($this->connection);
+
+        static::assertStringContainsString(
+            '`idx.state_machine_history.referenced_entity` (`referenced_id`,`referenced_version_id`)',
+            $this->getSchema(),
+        );
+    }
+
+    public function testUpdateTwice(): void
+    {
+        $this->migration->update($this->connection);
+
+        static::assertStringContainsString(
+            '`idx.state_machine_history.referenced_entity` (`referenced_id`,`referenced_version_id`)',
+            $this->getSchema(),
+        );
+
+        $expected = $this->getSchema();
+
+        $this->migration->update($this->connection);
+        static::assertSame($expected, $this->getSchema());
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    private function getSchema(): string
+    {
+        $schema = $this->connection->fetchAssociative(sprintf('SHOW CREATE TABLE `%s`', 'state_machine_history'));
+        static::assertNotFalse($schema);
+        static::assertIsString($schema['Create Table']);
+
+        return $schema['Create Table'];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

With https://github.com/shopware/platform/commit/36ebe7b2f082facea86d6ed34c79380686a8cbad, the performance of searching through state machine history entries was vastly improved by storing the entity id and version_id in separate columns.

Searching through these columns however is still slow compared to what could be achieved by simply adding an index over these columns.

### 2. What does this change do, exactly?

It adds the index described above.

### 3. Describe each step to reproduce the issue or behaviour.

Search through the state machine history with a simple DAL query and a huge amount of orders (≥ 5.000.000 History Entries).

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 97a38fc</samp>

This pull request adds two indexes to the `state_machine_history` table to improve the query performance for the state history of an entity. It also adds a changelog entry and a test class for the migration.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 97a38fc</samp>

*  Add indexes to `state_machine_history` table to improve query performance ([link](https://github.com/shopware/platform/pull/3307/files?diff=unified&w=0#diff-cd183a61fdf405657d1770b39556a2460cdb790b14b35efbd2824fb86374bd8aR1-R48))
   * Create a migration class that adds two indexes, one for `referenced_id` and one for `referenced_version_id` columns ([link](https://github.com/shopware/platform/pull/3307/files?diff=unified&w=0#diff-cd183a61fdf405657d1770b39556a2460cdb790b14b35efbd2824fb86374bd8aR1-R48))
   * Write a test class that checks the creation timestamp and the update logic of the migration class ([link](https://github.com/shopware/platform/pull/3307/files?diff=unified&w=0#diff-8fde4f8974c18c3d39322ad291b93dac7487777ba3246acc09ebd75924be3e59R1-R76))
      * Use `KernelLifecycleManager` to get a database connection and assert that the indexes are created and not duplicated ([link](https://github.com/shopware/platform/pull/3307/files?diff=unified&w=0#diff-8fde4f8974c18c3d39322ad291b93dac7487777ba3246acc09ebd75924be3e59R1-R76))
* Update the changelog with a summary of the feature ([link](https://github.com/shopware/platform/pull/3307/files?diff=unified&w=0#diff-bf53a07516656edbd875714eae5baf32f0cd75871aae1375d79a635cf4968031R1-R9))
   * Write a changelog entry that describes the title, issue, author and summary of the feature ([link](https://github.com/shopware/platform/pull/3307/files?diff=unified&w=0#diff-bf53a07516656edbd875714eae5baf32f0cd75871aae1375d79a635cf4968031R1-R9))
