### PR TITLE
NEXT-36134 - make configurable protected and fixed the calculation of isCombinable

### DIFF
--- a/changelog/_unreleased/2023-09-13-make-configurable-protected-and-fixed-the-calculation-of-isCombinable.md
+++ b/changelog/_unreleased/2023-09-13-make-configurable-protected-and-fixed-the-calculation-of-isCombinable.md
@@ -1,0 +1,2 @@
+# Core
+* make configurable protected and fixed the calculation of `isCombinable` to the actual value

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductConfiguratorLoader.php
@@ -210,7 +210,7 @@ class ProductConfiguratorLoader
         $current[] = $option->getId();
 
         // available with all other current selected options
-        if ($combinations->hasCombination($current) && $combinations->isAvailable($current)) {
+        if ($combinations->hasCombination($current)) {
             return true;
         }
 

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionEntity.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionEntity.php
@@ -75,14 +75,14 @@ class PropertyGroupOptionEntity extends Entity
     protected $media;
 
     /**
-     * @internal
+     * @var bool|null
      */
-    private ?ProductConfiguratorSettingEntity $configuratorSetting = null;
+    protected $combinable = false;
 
     /**
      * @internal
      */
-    private bool $combinable = false;
+    private ?ProductConfiguratorSettingEntity $configuratorSetting = null;
 
     public function getGroupId(): string
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently, it is not possible to recognize via the API whether an option can be combined with the currently opened product or not. 

### 2. What does this change do, exactly?

It is additionally output configurable in the API. https://shopware.stoplight.io/docs/store-api/2eabfcc461800-property-group-option

### 3. Describe each step to reproduce the issue or behaviour.

1. create a product with 2 configuration options, e.g. color and size
2. create 2 sizes e.g. L, XL
3. create two colors e.g. blue, red
4. create one variant L + blue and one XL + red
6. open the variant L + blue in the API and look at configurator the value "configurable". There will be "false" for the size XL and for the color red.