### PR TITLE
Avoid creating SEO URLs for headless sales channels.

### DIFF
--- a/changelog/_unreleased/2023-09-20-avoid-creating-seo-urls-for-headless-sales-channels.md
+++ b/changelog/_unreleased/2023-09-20-avoid-creating-seo-urls-for-headless-sales-channels.md
@@ -1,0 +1,13 @@
+---
+title: Avoid creating SEO URLs for headless sales channels.
+issue: NEXT-00000
+flag: v6.6.0.0
+author: Andreas Allacher
+author_email: andreas.allacher@massiveart.com
+author_github: @AndreasA
+---
+# Core
+* Changed method `createUrls` of `Shopware\Core\Checkout\Customer\Subscriber\CustomerGroupSubscriber` to only retrieve sales channels that are not of the `SALES_CHANNEL_TYPE_API` type for SEO URL generation.
+* Changed method `update` of `Shopware\Core\Content\Seo\SeoUrlUpdater` to only retrieve sales channels that are not of the `SALES_CHANNEL_TYPE_API` type for SEO URL generation.
+* Changed method `updateCanonicalUrl` of `Shopware\Core\Content\Seo\Api\SeoActionController` to silently ignore sales channels that are of the `SALES_CHANNEL_TYPE_API` type for SEO URL update.
+* Changed method `createCustomSeoUrls` of `Shopware\Core\Content\Seo\Api\SeoActionController` to silently ignore sales channels that are of the `SALES_CHANNEL_TYPE_API` type for SEO URL update.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13165,11 +13165,6 @@ parameters:
 			path: src/Storefront/Test/Framework/Seo/Api/SeoActionControllerTest.php
 
 		-
-			message: "#^Parameter \\#3 \\$message of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\) expects string, string\\|false given\\.$#"
-			count: 4
-			path: src/Storefront/Test/Framework/Seo/Api/SeoActionControllerTest.php
-
-		-
 			message: "#^Anonymous variable in a `\\$canonicalUrl\\-\\>\\.\\.\\.\\(\\)` method call can lead to false dead methods\\. Make sure the variable type is known$#"
 			count: 2
 			path: src/Storefront/Test/Framework/Seo/DataAbstractionLayer/Indexing/SeoUrlIndexerTest.php

--- a/src/Core/Content/Seo/Api/SeoActionController.php
+++ b/src/Core/Content/Seo/Api/SeoActionController.php
@@ -18,6 +18,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidator;
@@ -155,6 +156,12 @@ class SeoActionController extends AbstractController
             throw SeoException::salesChannelNotFound($salesChannelId);
         }
 
+        if ($salesChannel->getTypeId() === Defaults::SALES_CHANNEL_TYPE_API) {
+            if (Feature::isActive('v6.6.0.0')) {
+                return new Response('', Response::HTTP_NO_CONTENT);
+            }
+        }
+
         $this->seoUrlPersister->updateSeoUrls(
             $context,
             $seoUrlData['routeName'],
@@ -197,14 +204,22 @@ class SeoActionController extends AbstractController
         }
 
         foreach ($writeData as $salesChannelId => $writeRows) {
-            $salesChannelEntity = null;
-
             if ($salesChannelId === '') {
                 throw SeoException::salesChannelIdParameterIsMissing();
             }
 
             /** @var SalesChannelEntity $salesChannelEntity */
             $salesChannelEntity = $salesChannels->get($salesChannelId);
+
+            if ($salesChannelEntity === null) {
+                throw SeoException::salesChannelNotFound((string) $salesChannelId);
+            }
+
+            if ($salesChannelEntity->getTypeId() === Defaults::SALES_CHANNEL_TYPE_API) {
+                if (Feature::isActive('v6.6.0.0')) {
+                    continue;
+                }
+            }
 
             $this->seoUrlPersister->updateSeoUrls(
                 $context,

--- a/src/Core/Content/Test/Seo/SeoUrlUpdaterTest.php
+++ b/src/Core/Content/Test/Seo/SeoUrlUpdaterTest.php
@@ -12,6 +12,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestDataCollection;
@@ -35,7 +36,12 @@ class SeoUrlUpdaterTest extends TestCase
     /**
      * @var array<string, mixed>
      */
-    private array $salesChannel;
+    private array $storefrontSalesChannel;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $headlessSalesChannel;
 
     protected function setUp(): void
     {
@@ -48,8 +54,7 @@ class SeoUrlUpdaterTest extends TestCase
         $this->ids->set(self::PARENT, $this->getDeDeLanguageId());
         $this->ids->create(self::CHILD);
 
-        // Create storefront saleschannel for child language
-        $this->salesChannel = $this->createSalesChannel([
+        $salesChannelOverride = [
             // Create child language
             'language' => [
                 'id' => $this->ids->get(self::CHILD),
@@ -76,10 +81,21 @@ class SeoUrlUpdaterTest extends TestCase
                     'languageId' => $this->ids->get(self::CHILD),
                     'currencyId' => Defaults::CURRENCY,
                     'snippetSetId' => $this->getSnippetSetIdForLocale(self::PARENT),
-                    'url' => 'http://localhost',
                 ],
             ],
-        ]);
+        ];
+
+        // Create storefront saleschannel for child language
+        $storefrontSalesChannelOverride = $salesChannelOverride;
+        $storefrontSalesChannelOverride['typeId'] = Defaults::SALES_CHANNEL_TYPE_STOREFRONT;
+        $storefrontSalesChannelOverride['domains'][0]['url'] = 'http://localhost/storefront';
+        $this->storefrontSalesChannel = $this->createSalesChannel($storefrontSalesChannelOverride);
+
+        // Create headless sales channel.
+        $headlessSalesChannelOverride = $salesChannelOverride;
+        $headlessSalesChannelOverride['typeId'] = Defaults::SALES_CHANNEL_TYPE_API;
+        $headlessSalesChannelOverride['domains'][0]['url'] = 'http://localhost/headless';
+        $this->headlessSalesChannel = $this->createSalesChannel($headlessSalesChannelOverride);
     }
 
     /**
@@ -117,11 +133,11 @@ class SeoUrlUpdaterTest extends TestCase
             [$this->ids->get('p1')]
         );
 
-        // Search for created seo url
+        // Search for created seo url of storefront sales channel.
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('foreignKey', $this->ids->get('p1')));
         $criteria->addFilter(new EqualsFilter('routeName', TestProductSeoUrlRoute::ROUTE_NAME));
-        $criteria->addFilter(new EqualsFilter('salesChannelId', $this->salesChannel['id']));
+        $criteria->addFilter(new EqualsFilter('salesChannelId', $this->storefrontSalesChannel['id']));
         $seoUrl = $this->getContainer()->get('seo_url.repository')->search(
             $criteria,
             Context::createDefaultContext()
@@ -132,6 +148,23 @@ class SeoUrlUpdaterTest extends TestCase
 
         // Check if seo path matches the expected path
         static::assertStringStartsWith($pathInfo, $seoUrl->getSeoPathInfo());
+
+        // Verify URL of headless sales channel.
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('routeName', TestProductSeoUrlRoute::ROUTE_NAME));
+        $criteria->addFilter(new EqualsFilter('salesChannelId', $this->headlessSalesChannel['id']));
+        $seoUrl = $this->getContainer()->get('seo_url.repository')->search(
+            $criteria,
+            Context::createDefaultContext()
+        )->first();
+
+        if (Feature::isActive('v6.6.0.0')) {
+            // Check that no seo url was created.
+            static::assertNull($seoUrl);
+        } else {
+            // Check that seo url was created.
+            static::assertNotNull($seoUrl);
+        }
     }
 
     /**

--- a/src/Storefront/Test/Framework/Seo/SeoUrl/SeoUrlTest.php
+++ b/src/Storefront/Test/Framework/Seo/SeoUrl/SeoUrlTest.php
@@ -16,9 +16,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\QueueTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
@@ -33,6 +35,7 @@ class SeoUrlTest extends TestCase
 {
     use IntegrationTestBehaviour;
     use QueueTestBehaviour;
+    use SalesChannelApiTestBehaviour;
     use StorefrontSalesChannelTestHelper;
 
     private EntityRepository $productRepository;
@@ -134,7 +137,7 @@ class SeoUrlTest extends TestCase
         $salesChannelId = Uuid::randomHex();
         $salesChannelContext = $this->createStorefrontSalesChannelContext($salesChannelId, 'test');
 
-        $id = $this->createTestProduct();
+        $id = $this->createTestProduct(salesChannelId: $salesChannelId);
 
         $criteria = new Criteria([$id]);
         $criteria->addAssociation('seoUrls');
@@ -149,6 +152,32 @@ class SeoUrlTest extends TestCase
         $seoUrl = $seoUrls->first();
         static::assertInstanceOf(SeoUrlEntity::class, $seoUrl);
         static::assertEquals('foo-bar/P1234', $seoUrl->getSeoPathInfo());
+    }
+
+    public function testSearchProductForHeadlessSalesChannelHasCorrectUrl(): void
+    {
+        $salesChannelId = Uuid::randomHex();
+        $salesChannelContext = $this->createSalesChannelContext(
+            [
+                'id' => $salesChannelId,
+                'name' => 'test',
+                'typeId' => Defaults::SALES_CHANNEL_TYPE_API,
+            ]
+        );
+
+        $id = $this->createTestProduct(salesChannelId: $salesChannelId);
+
+        $criteria = new Criteria([$id]);
+        $criteria->addAssociation('seoUrls');
+
+        /** @var ProductEntity $product */
+        $product = $this->productRepository->search($criteria, $salesChannelContext->getContext())->first();
+
+        static::assertInstanceOf(SeoUrlCollection::class, $product->getSeoUrls());
+
+        /** @var SeoUrlCollection $seoUrls */
+        $seoUrls = $product->getSeoUrls();
+        static::assertCount(Feature::isActive('v6.6.0.0') ? 0 : 1, $seoUrls);
     }
 
     public function testSearchCategory(): void
@@ -596,7 +625,7 @@ class SeoUrlTest extends TestCase
         return $this->productRepository->upsert([$data], Context::createDefaultContext());
     }
 
-    private function createTestProduct(array $overrides = []): string
+    private function createTestProduct(array $overrides = [], string $salesChannelId = TestDefaults::SALES_CHANNEL): string
     {
         $id = Uuid::randomHex();
         $insert = [
@@ -619,7 +648,7 @@ class SeoUrlTest extends TestCase
             'stock' => 0,
             'visibilities' => [
                 [
-                    'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                    'salesChannelId' => $salesChannelId,
                     'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL,
                 ],
             ],


### PR DESCRIPTION
### 1. Why is this change necessary?

see #3250

### 2. What does this change do, exactly?

see #3250

### 3. Describe each step to reproduce the issue or behaviour.

see #3250

### 4. Please link to the relevant issues (if any).

#3250

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 589967b</samp>

This pull request fixes a bug that caused SEO URLs to be created and updated for headless sales channels, which are not supposed to have them. It does this by adding filters and conditions to the classes and methods that handle SEO URLs, such as `CustomerGroupSubscriber`, `SeoActionController`, and `SeoUrlUpdater`. It also adds and modifies some tests to verify the correct behavior of these classes and methods. Additionally, it adds a changelog file to document the changes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 589967b</samp>

*  Add a changelog file to document the pull request ([link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-2b7f11eea9395150754feafe9c6c105da6b35023f6e9221d218775c5352f6047R1-R12))
  *  Add a NandFilter to the criteria for fetching customer groups and sales channels in the CustomerGroupSubscriber and SeoUrlUpdater classes ([link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-407af697d68285f44253e7593084f0317f58d405ef2ee262fd47a0194b992fdfL122-R130), [link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-75d650a4598390969cb6c96e4188587db25a7ad66689d3791c06de0ea38565afL56-R64))
  *  Skip the headless sales channels in the loops over the registration sales channels and the sales channel IDs in the CustomerGroupSubscriber and SeoActionController classes ([link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-407af697d68285f44253e7593084f0317f58d405ef2ee262fd47a0194b992fdfL135-R141), [link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-f11af3c829092d28b75748b8a77d78c26a1cab16d6122d556f73894f110b1d7fR211-R218))
  *  Add a condition to the SQL query for loading the URL templates in the SeoUrlUpdater class to exclude the headless sales channels ([link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-75d650a4598390969cb6c96e4188587db25a7ad66689d3791c06de0ea38565afL93-R104))
  *  Return a no content response in the updateCanonicalUrl method in the SeoActionController class if the sales channel is headless ([link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-f11af3c829092d28b75748b8a77d78c26a1cab16d6122d556f73894f110b1d7fR158-R161))
  *  Add a test method to the CustomerGroupSubscriberTest class to check that no SEO URLs are created for headless sales channels ([link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-0e001acd2d7e03a17586465f0727cec2a6131d8b72971d54f7a837dbbaa1cd13R89-R109))
  *  Modify the testSeoLanguageInheritance method in the SeoUrlUpdaterTest class to use the storefront sales channel ID and verify that no SEO URL is created for the headless sales channel ([link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-a20316f872778a9ffd05a899bc19ee626575c1ff57ad32df7fc63d8817b42e96L120-R139), [link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-a20316f872778a9ffd05a899bc19ee626575c1ff57ad32df7fc63d8817b42e96R150-R161))
  *  Add a test method to the SeoActionControllerTest class to check that the updateCanonicalUrl method does nothing for the headless sales channel ([link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-fd4ff3c4859877dc4a46128a57db317c0428fa1a1bde7e07ed1187f545ca31e2R274-R310))
*  Add use statements and properties to the classes and test classes to use the NandFilter, Uuid, Defaults, and array_merge classes and functions and to store the storefront and headless sales channels ([link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-407af697d68285f44253e7593084f0317f58d405ef2ee262fd47a0194b992fdfR17), [link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-75d650a4598390969cb6c96e4188587db25a7ad66689d3791c06de0ea38565afL12-R15), [link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-a20316f872778a9ffd05a899bc19ee626575c1ff57ad32df7fc63d8817b42e96R19), [link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-a20316f872778a9ffd05a899bc19ee626575c1ff57ad32df7fc63d8817b42e96L38-R43), [link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-fd4ff3c4859877dc4a46128a57db317c0428fa1a1bde7e07ed1187f545ca31e2R15), [link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-fd4ff3c4859877dc4a46128a57db317c0428fa1a1bde7e07ed1187f545ca31e2R28))
*  Remove an unused variable declaration in the createCustomSeoUrls method in the SeoActionController class ([link](https://github.com/shopware/platform/pull/3311/files?diff=unified&w=0#diff-f11af3c829092d28b75748b8a77d78c26a1cab16d6122d556f73894f110b1d7fL200-L201))
