### PR TITLE
Fix custom icon in templates with restricted variables

### DIFF
--- a/changelog/_unreleased/2023-09-16-fix-custom-icon-in-templates-with-restricted-variables.md
+++ b/changelog/_unreleased/2023-09-16-fix-custom-icon-in-templates-with-restricted-variables.md
@@ -1,0 +1,13 @@
+---
+title: Fix custom icon in templates with restricted variables
+issue: NEXT-0000
+author: Stefan Poensgen
+author_email: mail@stefanpoensgen.de
+author_github: @stefanpoensgen
+---
+# Storefront
+* Add themeIconConfig to breadcrumb.html.twig inclusion in src/Storefront/Resources/views/storefront/base.html.twig
+* Add themeIconConfig to breadcrumb.html.twig inclusion in src/Storefront/Resources/views/storefront/page/content/index.html.twig
+* Add themeIconConfig to breadcrumb.html.twig inclusion in src/Storefront/Resources/views/storefront/page/content/product-detail.html.twig
+* Add themeIconConfig to cookie-configuration-group.html.twig inclusion in src/Storefront/Resources/views/storefront/layout/cookie/cookie-configuration.html.twig
+* Add themeIconConfig to flyout.html.twig inclusion in src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -74,6 +74,7 @@
                                 {% block base_breadcrumb %}
                                     {% sw_include '@Storefront/storefront/layout/breadcrumb.html.twig' with {
                                         context: context,
+                                        themeIconConfig: themeIconConfig,
                                         category: page.product.seoCategory
                                     } only %}
                                 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/cookie/cookie-configuration.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/cookie/cookie-configuration.html.twig
@@ -29,6 +29,7 @@
         <div class="offcanvas-cookie-list">
             {% for cookieGroup in cookieGroups %}
                 {% sw_include '@Storefront/storefront/layout/cookie/cookie-configuration-group.html.twig' with {
+                    themeIconConfig: themeIconConfig,
                     cookieGroup: cookieGroup
                 } only %}
             {% endfor %}

--- a/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
@@ -80,7 +80,12 @@
                                              data-flyout-menu-id="{{ treeItem.category.id }}">
                                             <div class="container">
                                                 {% block layout_main_navigation_menu_flyout_include %}
-                                                    {% sw_include '@Storefront/storefront/layout/navigation/flyout.html.twig' with {navigationTree: treeItem, level: level+1, page: page} only %}
+                                                    {% sw_include '@Storefront/storefront/layout/navigation/flyout.html.twig' with {
+                                                        themeIconConfig: themeIconConfig,
+                                                        navigationTree: treeItem,
+                                                        level: level+1,
+                                                        page: page
+                                                    } only %}
                                                 {% endblock %}
                                             </div>
                                         </div>

--- a/src/Storefront/Resources/views/storefront/page/content/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/index.html.twig
@@ -8,6 +8,7 @@
                 <div class="breadcrumb cms-breadcrumb container">
                     {% sw_include '@Storefront/storefront/layout/breadcrumb.html.twig' with {
                         context: context,
+                        themeIconConfig: themeIconConfig,
                         category: page.header.navigation.active
                     } only %}
                 </div>

--- a/src/Storefront/Resources/views/storefront/page/content/product-detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/product-detail.html.twig
@@ -11,6 +11,7 @@
                 <div class="breadcrumb cms-breadcrumb container">
                     {% sw_include '@Storefront/storefront/layout/breadcrumb.html.twig' with {
                         context: context,
+                        themeIconConfig: themeIconConfig,
                         category: page.product.seoCategory
                     } only %}
                 </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
The present system lacks the functionality to incorporate custom icons in some template files due to the absence of the "themeIconConfig" in the template.

### 2. What does this change do, exactly?
This modification introduces the missing "themeIconConfig" variable to the templates.

### 3. Describe each step to reproduce the issue or behaviour.
1. Override the "layout_breadcrumb_placeholder" block from breadcrumb.html.twig
2. Attempt to integrate a custom icon pack

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 15a4f42</samp>

This pull request fixes a bug that prevented custom icons from being displayed in the breadcrumb, cookie consent and flyout navigation components of the storefront. It does so by passing the `themeIconConfig` variable to the relevant template inclusions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 15a4f42</samp>

*  Add a changelog entry for the fix ([link](https://github.com/shopware/platform/pull/3318/files?diff=unified&w=0#diff-81ba45ae2726a35d8faca6318a650153db59b06ecfbef5095a977800e8984072R1-R13))
*  Pass the `themeIconConfig` variable to the `breadcrumb.html.twig` inclusion in various templates, to enable custom icons for the breadcrumb ([link](https://github.com/shopware/platform/pull/3318/files?diff=unified&w=0#diff-cb2569bee6fa9c51e42b68dcfb4e9099be533ac92ae0cce367b0e3b3cb45eb36R77), [link](https://github.com/shopware/platform/pull/3318/files?diff=unified&w=0#diff-d186c1054c970a718d87db6d564f9a2a976e15c15ea2f279417263e82e58239bR11), [link](https://github.com/shopware/platform/pull/3318/files?diff=unified&w=0#diff-c5137a916d56ec5cc51d43738ede9b9cece1788c8aef170dd858112790e5c897R14))
*  Pass the `themeIconConfig` variable to the `flyout.html.twig` inclusion in the `navigation.html.twig` template, to enable custom icons for the flyout submenus ([link](https://github.com/shopware/platform/pull/3318/files?diff=unified&w=0#diff-4a50c615605fa83efe7b880751fbb85ea814acf704632c4e33fb95273f4b782aL83-R88))
*  Pass the `themeIconConfig` variable to the `cookie-configuration-group.html.twig` inclusion in the `cookie-configuration.html.twig` template, to enable custom icons for the cookie groups ([link](https://github.com/shopware/platform/pull/3318/files?diff=unified&w=0#diff-6ecd9907e609c36b313129b575da43eaa458e81b3f83e5de018837b0085c1a5aR32))
