### PR TITLE
Provide nested line item modal for container items

### DIFF
--- a/changelog/_unreleased/2023-09-16-allow-nested-line-item-modal-for-container-items.md
+++ b/changelog/_unreleased/2023-09-16-allow-nested-line-item-modal-for-container-items.md
@@ -1,0 +1,10 @@
+---
+title: Provide nested line item modal for container items
+issue: NEXT-0000
+author: Stefan Poensgen
+author_email: mail@stefanpoensgen.de
+author_github: @stefanpoensgen
+---
+# Administration
+* Add line item type `container` in src/Administration/Resources/app/administration/src/module/sw-order/order.types.ts
+* Check for line item type `container` in src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
@@ -328,6 +328,10 @@ export default {
             return item.type === this.lineItemTypes.PROMOTION;
         },
 
+        isContainerItem(item) {
+            return item.type === this.lineItemTypes.CONTAINER;
+        },
+
         getMinItemPrice(id) {
             if (this.isCreditItem(id)) {
                 return null;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
@@ -138,7 +138,7 @@
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_order_line_items_grid_grid_columns_label_link %}
             <div
-                v-else-if="!isInlineEdit && isProductItem(item)"
+                v-else-if="!isInlineEdit && (isProductItem(item) || isContainerItem(item))"
                 class="sw-order-line-items-grid__item-product"
             >
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/order.types.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/order.types.ts
@@ -14,6 +14,7 @@ enum LineItemType {
     CREDIT = 'credit',
     CUSTOM = 'custom',
     PROMOTION = 'promotion',
+    CONTAINER = 'container',
 }
 
 enum PriceType {


### PR DESCRIPTION
### 1. Why is this change necessary?
With the introduction of the container line item in version 6.5, a framework was set for enabling custom integrations. However, there's an existing gap: for orders containing a container line item, there is currently no functionality allowing users to view the child items within the order detail view.

### 2. What does this change do, exactly?
Introduced the new line item container in the order.types.ts.
Updated the sw-order-line-items-grid component logic to provide the nested line item modal.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create an order with a container line item.
2. Navigate to the order detail view.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 66eec88</samp>

This pull request adds support for container line items in orders, which can group other line items together. It introduces a new `container` type for line items, and modifies the `sw-order-line-items-grid` component to allow opening a nested line item modal for container items.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 66eec88</samp>

*  Add a new line item type `container` that can hold other line items ([link](https://github.com/shopware/platform/pull/3319/files?diff=unified&w=0#diff-0c21f60ae23fd6fc26dc83c55b295baafc822bc3f6b8a2214b1f1b1f0bc07680R17), [link](https://github.com/shopware/platform/pull/3319/files?diff=unified&w=0#diff-c9b277ac5d074f2198df1edefcc940ef866efb7594165c0dbb0c27319f079d15R331-R334))
*  Enable opening a nested line item modal for container items in the order line items grid ([link](https://github.com/shopware/platform/pull/3319/files?diff=unified&w=0#diff-9d25e736ef89bfb929f155b7dbfd78fa55004921e75e9a0b0c611f47528c1b91L141-R141), [link](https://github.com/shopware/platform/pull/3319/files?diff=unified&w=0#diff-ea7dc5a5fb5b1f5f30a89d0eb8f2c75a5da68fd617e164f3203fb903e2686fddR1-R10))
*  Adjust the label of line items to be a link if they are product or container items ([link](https://github.com/shopware/platform/pull/3319/files?diff=unified&w=0#diff-9d25e736ef89bfb929f155b7dbfd78fa55004921e75e9a0b0c611f47528c1b91L141-R141))
