### PR TITLE
Sort child line items by position

### DIFF
--- a/changelog/_unreleased/2023-09-16-sort-child-line-items-by-position.md
+++ b/changelog/_unreleased/2023-09-16-sort-child-line-items-by-position.md
@@ -1,0 +1,9 @@
+---
+title: Sort child line items by position
+issue: NEXT-0000
+author: Stefan Poensgen
+author_email: mail@stefanpoensgen.de
+author_github: @stefanpoensgen
+---
+# Administration
+* Sort child line items by position in src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -105,7 +105,7 @@ export default {
 
             criteria
                 .getAssociation('lineItems.children')
-                .addSorting(Criteria.naturalSorting('label'));
+                .addSorting(Criteria.sort('position', 'ASC'));
 
             criteria
                 .addAssociation('salesChannel');


### PR DESCRIPTION
### 1. Why is this change necessary?
The change is necessary to ensure consistency in sorting child line items, aligning them with the way normal line items are sorted.

### 2. What does this change do, exactly?
This change modifies the sorting criteria for child line items, making them sort by their 'position' in ascending order.

### 3. Describe each step to reproduce the issue or behaviour.
Navigate to the order details page in the admin.
View an order with multiple child line items.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 243871d</samp>

Added a feature to sort child line items by position in the order detail page. Modified the `lineItems.children` association in `sw-order-detail/index.js` and added a changelog entry.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 243871d</samp>

*  Add a feature to sort child line items by position in the order detail page ([link](https://github.com/shopware/platform/pull/3320/files?diff=unified&w=0#diff-5c1f5b82d103a492229e5c35f4d2db271e50b4ecf94683872eb46567d352901dR1-R9))
*  Change the sorting criteria for the lineItems.children association from naturalSorting by label to sort by position in ascending order in `index.js` ([link](https://github.com/shopware/platform/pull/3320/files?diff=unified&w=0#diff-0d0a5c7a38b83dbef4e50a36d243a38941a0306bc66f1469723518b82044224dL108-R108))
