### PR TITLE
Add update interval for sitemap documentation

### DIFF
--- a/src/Core/System/Resources/config/sitemap.xml
+++ b/src/Core/System/Resources/config/sitemap.xml
@@ -39,14 +39,14 @@
             <helpText>
                 Manually: refresh via console command: php bin/console sitemap:generate.
 
-                Scheduled: refresh via scheduled tasks.
+                Scheduled: refresh via scheduled tasks (every 24 hours).
 
                 Live: Refresh in intervals defined above, if Administration is opened.
             </helpText>
             <helpText lang="de-DE">
                 Manuell: Aktualisierung über Konsolenbefehl php bin/console sitemap:generate.
 
-                Geplant: Aktualisierung über geplante Tasks.
+                Geplant: Aktualisierung über geplante Tasks (alle 24 Stunden).
 
                 Live: Aktualisierung in regelmäßigen Intervallen (definiere oben)- wenn Admin geöffnet.
             </helpText>


### PR DESCRIPTION
### 1. Why is this change necessary?

The information how often the sitemap is generated, is hard to find.
Especially on new shops, no sitemap might exist, which is confusing.

Remark: We maybe also should add this to https://docs.shopware.com/en/shopware-6-en/settings/sitemap

### 2. What does this change do, exactly?

Add's the information

### 3. Describe each step to reproduce the issue or behaviour.

Open the sitemap config, check the help text

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec27bfe</samp>

Improved the documentation of the sitemap refresh mode in `sitemap.xml`. Clarified the frequency of the sitemap tasks for the `scheduled` option.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec27bfe</samp>

*  Update the comment for the scheduled option of the sitemap refresh mode to specify that the tasks run every 24 hours in both English and German ([link](https://github.com/shopware/platform/pull/3321/files?diff=unified&w=0#diff-2455977665f954d986de5d1eb9cded42de17aea1f431279ebb4c3b2b5e127057L42-R42), [link](https://github.com/shopware/platform/pull/3321/files?diff=unified&w=0#diff-2455977665f954d986de5d1eb9cded42de17aea1f431279ebb4c3b2b5e127057L49-R49)). This change affects the `src/Core/System/Resources/config/sitemap.xml` file and provides more clarity for the user and aligns with the documentation.
