### PR TITLE
Fix: Using designer in Category sends us back to the wrong page

### DIFF
--- a/changelog/_unreleased/2023-09-28-fix-cms-back.md
+++ b/changelog/_unreleased/2023-09-28-fix-cms-back.md
@@ -1,0 +1,9 @@
+---
+title: Fix: Using designer in category send us back to the wrong page. 
+issue: NEXT-30765
+author: amenk
+author_github: amenk
+--- 
+# Administration
+* Changed: When using the designer in a category and closing the view, we are now sent back to the category, not the template list.
+

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -1158,5 +1158,13 @@ export default {
         onChangeDontRemindCheckbox() {
             this.cmsMissingElementDontRemind = !this.cmsMissingElementDontRemind;
         },
+
+        back() {
+            if (window.history.length > 2) {
+                this.$router.back();
+            } else {
+                this.$router.push({name: 'sw.cms.index'});
+            }
+        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
@@ -31,12 +31,12 @@
                     <div class="sw-cms-detail__page-info">
                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                         {% block sw_cms_detail_toolbar_back_button %}
-                        <router-link
-                            :to="{ name: 'sw.cms.index' }"
+                        <a
+                            @click="back()"
                             class="sw-cms-detail__back-btn"
                         >
                             <sw-icon name="regular-times" />
-                        </router-link>
+                        </a>
                         {% endblock %}
 
                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->


### PR DESCRIPTION
### 1. Why is this change necessary?

Admin user experience is bad, when editing shopping experience templates from a category and closing the view to go back.

### 2. What does this change do, exactly?

* We use the history to go back to the correct position (where we came from)
* If the history is not filled sufficiently, we still go back to sw.cms.index

### 3. Describe each step to reproduce the issue or behaviour.

![step 1](https://github.com/shopware/platform/assets/1087128/bac9017a-b55f-4437-bde6-62c57a353c2b)
![step 2](https://github.com/shopware/platform/assets/1087128/1681d8c0-a58a-4188-b331-839d8a3caa30)
![step 3](https://github.com/shopware/platform/assets/1087128/865454c4-3a26-4e7d-9fbc-2d4d400d1b64)

1. In Category -> Layout -> Edit in Designer
2. Click X Button on the top left

What we would expect: Navigates Back to Category
What it does: Navigates to CMS Index

### 4. Please link to the relevant issues (if any).

Remark: The same issue happens, when we edit a product from the category. I would like to have some feedback to the approach and we could fix it there as well.

We even could create a mixin <router-back>


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86a0eb4</samp>

This pull request improves the back navigation in the CMS detail page by adding a `back` method to the `sw-cms-detail` component and using it in the template. ~This change is part of a refactoring of the CMS module to use the new UI library.~

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 86a0eb4</samp>

*  Add a `back` method to the `sw-cms-detail` component that navigates to the previous page or the CMS index page depending on the window history length ([link](https://github.com/shopware/platform/pull/3322/files?diff=unified&w=0#diff-e69ada56fc80af214ca57951d97c540905be9e95913865f405dc8cebb5bb6ccdR1161-R1168))
* Replace the `router-link` element with a regular `a` element that calls the `back` method on click in the `sw-cms-detail.html.twig` template ([link](https://github.com/shopware/platform/pull/3322/files?diff=unified&w=0#diff-9aac886c05248df0c784f3ffb15c77df10f3290e2cc995671b77d9298ad2d843L34-R39))


