### PR TITLE
Fix/rule with multi select

### DIFF
--- a/changelog/_unreleased/2023-08-30-fix-custom-field-rule-with-multi-select.md
+++ b/changelog/_unreleased/2023-08-30-fix-custom-field-rule-with-multi-select.md
@@ -1,0 +1,14 @@
+---
+title: Fix custom field rule with multi select
+issue: NEXT-23252
+author: Jan Emig
+author_email: j.emig@one-dot.de
+author_github: @Xnaff
+---
+# Core
+* Changed type declaration of `$renderedFieldValue` in `Shopware\Core\Checkout\Customer\Rule\CustomerCustomFieldRule` to also use `array` as type for multi select fields 
+* Changed type declaration of `$renderedFieldValue` in `Shopware\Core\Content\Flow\Rule\OrderCustomFieldRule` to also use `array` as type for multi select fields 
+* Changed type declaration of `$renderedFieldValue` in `Shopware\Core\Framework\Rule\CustomFieldRule` to also use `array` as type for multi select fields 
+* Changed method `match` in `Shopware\Core\Framework\Rule\CustomFieldRule` to fix the validation of multi select fields 
+* Added method `isArray` in `Shopware\Core\Framework\Rule\CustomFieldRule` to validate if the field value is an array from a multi select field 
+* Added method `arrayMatch` in `Shopware\Core\Framework\Rule\CustomFieldRule` to validate the field value against the rule value if the field value is an array from a multi select field 

--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Shopware\Core\Checkout\Cart\Rule;
 

--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -19,7 +19,7 @@ class LineItemCustomFieldRule extends Rule
     final public const RULE_NAME = 'cartLineItemCustomField';
 
     /**
-     * @var string|int|float|bool|null
+     * @var array|string|int|float|bool|null
      */
     protected $renderedFieldValue;
 
@@ -161,10 +161,10 @@ class LineItemCustomFieldRule extends Rule
     }
 
     /**
-     * @param string|int|float|bool|null $renderedFieldValue
+     * @param array|string|int|float|bool|null $renderedFieldValue
      * @param array<string, mixed> $renderedField
      *
-     * @return string|int|float|bool|null
+     * @return array|string|int|float|bool|null
      */
     private function getExpectedValue($renderedFieldValue, array $renderedField)
     {

--- a/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
@@ -14,7 +14,7 @@ class CustomerCustomFieldRule extends Rule
 {
     final public const RULE_NAME = 'customerCustomField';
 
-    protected string|int|bool|null|float $renderedFieldValue = null;
+    protected array|string|int|bool|null|float $renderedFieldValue = null;
 
     /**
      * @param array<string, string> $renderedField

--- a/src/Core/Content/Flow/Rule/OrderCustomFieldRule.php
+++ b/src/Core/Content/Flow/Rule/OrderCustomFieldRule.php
@@ -13,7 +13,7 @@ class OrderCustomFieldRule extends FlowRule
 {
     final public const RULE_NAME = 'orderCustomField';
 
-    protected string|int|bool|null|float $renderedFieldValue = null;
+    protected array|string|int|bool|null|float $renderedFieldValue = null;
 
     /**
      * @param array<string, string> $renderedField

--- a/src/Core/Framework/App/Manifest/Xml/CustomFieldTypes/MultiEntitySelectField.php
+++ b/src/Core/Framework/App/Manifest/Xml/CustomFieldTypes/MultiEntitySelectField.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('core')]
 class MultiEntitySelectField extends SingleEntitySelectField
 {
-    protected const COMPONENT_NAME = 'sw-entity-multi-id-select';
+    public const COMPONENT_NAME = 'sw-entity-multi-id-select';
 
     public static function fromXml(\DOMElement $element): CustomFieldType
     {

--- a/src/Core/Framework/App/Manifest/Xml/CustomFieldTypes/MultiSelectField.php
+++ b/src/Core/Framework/App/Manifest/Xml/CustomFieldTypes/MultiSelectField.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('core')]
 class MultiSelectField extends SingleSelectField
 {
-    protected const COMPONENT_NAME = 'sw-multi-select';
+    public const COMPONENT_NAME = 'sw-multi-select';
 
     public static function fromXml(\DOMElement $element): CustomFieldType
     {

--- a/src/Core/Framework/Rule/CustomFieldRule.php
+++ b/src/Core/Framework/Rule/CustomFieldRule.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Shopware\Core\Framework\Rule;
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Rules with custom fields of type multi select resulted in an 500 server error because arrays, are not allowed in the type declaration.

### 2. What does this change do, exactly?

Validate the rule of custom fields with the type multi select

### 3. Describe each step to reproduce the issue or behaviour.
- Create a custom field of the type multi select for a customer
- Create a price rule wich uses this custom field
- Assign some value to a customer from the multi select custom field
- Log in as the customer

### 4. Please link to the relevant issues (if any).
[Issue: NEXT-23252](https://issues.shopware.com/issues/NEXT-23252)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d86ea7e</samp>

This pull request fixes the custom field rule validation for multi select fields in different contexts. It adds new methods and tests to the `LineItemCustomFieldRule`, `CustomFieldRule`, `CustomerCustomFieldRule` and `OrderCustomFieldRule` classes, and modifies some type declarations and logic. It also changes the visibility of some constants in the `MultiEntitySelectField` and `MultiSelectField` classes, and updates the changelog file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d86ea7e</samp>

*  Add a new changelog file to document the fix for the custom field rule with multi select fields ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-d34b25a1d86441f4bd848da262837cc8246eb9d1f0fecfc8101c4ba4e0026658R1-R19))
*  Modify the type declaration of the renderedFieldValue property in the LineItemCustomFieldRule, CustomerCustomFieldRule and OrderCustomFieldRule classes to also include array as a possible type ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0L22-R25), [link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-807fcd493a01a0273756a10a4399c8970e4c83341f07468dadb5aa7c84a29357L17-R17), [link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-0a176a7edcad360b421a0607b9fcbace6a12808b8b991e56d19b9453891d3870L16-R16))
*  Import the MultiEntitySelectField and MultiSelectField classes from the App\Manifest\Xml\CustomFieldTypes namespace in the LineItemCustomFieldRule and CustomFieldRule classes ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0R6-R7), [link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fR5-R6))
*  Import the FloatComparator class from the Framework\Util namespace in the LineItemCustomFieldRule class ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0R13))
*  Add two if statements to the match method in the LineItemCustomFieldRule class to check if the rendered field is a float or an array and call the corresponding match methods accordingly ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0R114-R121))
*  Add two new private static methods to the LineItemCustomFieldRule class: floatMatch and arrayMatch. The floatMatch method compares the field value as a float with the rule value using the FloatComparator class and the operator. The arrayMatch method validates the field value against the rule value if the field value is an array from a multi select field using the array_intersect function and the operator ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0R133-R154))
*  Modify the type declaration of the renderedFieldValue parameter in the getExpectedValue method in the LineItemCustomFieldRule class to also include array as a possible type ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0L164-R200))
*  Add two new private static methods to the LineItemCustomFieldRule class: isFloat and isArray. The isFloat method checks if the rendered field is of type float. The isArray method checks if the rendered field is an array from a multi select field by looking at the type and the component name of the rendered field config ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0R210-R241))
*  Add an if statement to the match method in the CustomFieldRule class to check if the rendered field is an array and call the arrayMatch method accordingly ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL66-R78))
*  Add a new private static method to the CustomFieldRule class: arrayMatch. The arrayMatch method validates the field value against the rule value if the field value is an array from a multi select field using the array_intersect function and the operator ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fR103-R111))
*  Modify the type declaration of the return value of the getValue method in the CustomFieldRule class to also include array as a possible type ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL117-R136))
*  Modify the type declaration of the renderedFieldValue parameter and the return value of the getExpectedValue method in the CustomFieldRule class to also include array as a possible type ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL133-R155))
*  Add a new private static method to the CustomFieldRule class: isArray. The isArray method checks if the rendered field is an array from a multi select field by looking at the type and the component name of the rendered field config ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fR182-R205))
*  Modify the visibility of the COMPONENT_NAME constant in the MultiEntitySelectField and MultiSelectField classes from protected to public ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-c990076bd957d0bb099a4632736887d0a98c9934a0391c6648c6a5cc4fafd2a0L13-R13), [link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-0fa50f8275064f19ac5f81f1f7f5fa6537307c901db6d2d8c6413143c4c6ee47L13-R13))
*  Modify the type declaration of the customFieldValue and customFieldValueInLineItem parameters in the testCustomFieldCartScope method in the LineItemCustomFieldRuleTest class to also include array as a possible type ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-8b85e391b82db02eb2832f3274e5b245a078d09f28f237ebf185f4b25241c609L131-R149))
*  Add a new parameter to the testCustomFieldCartScope and testCustomFieldCartScopeNested methods in the LineItemCustomFieldRuleTest class: renderedFieldConfig. This parameter is an array that contains the configuration of the rendered field, such as the component name. This parameter is passed to the setupRule method to assign it to the rule object ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-8b85e391b82db02eb2832f3274e5b245a078d09f28f237ebf185f4b25241c609L141-R158), [link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-8b85e391b82db02eb2832f3274e5b245a078d09f28f237ebf185f4b25241c609L163-R181))
*  Add two new test methods to the LineItemCustomFieldRuleTest class: testSelectCustomField and testSelectCustomFieldInvalid. These methods test the validation of the rule with a multi select field and a matching or non-matching value. They use the setupRule method with a rendered field config that specifies the component name as sw-multi-select and the setCustomerCustomFields method to set the custom field value in the line item ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-8b85e391b82db02eb2832f3274e5b245a078d09f28f237ebf185f4b25241c609R193))
*  Add two new data sets to the customFieldCartScopeProvider method in the LineItemCustomFieldRuleTest class: testSelectCustomField and testSelectCustomFieldInvalid. These data sets provide the parameters for the testCustomFieldCartScope and testCustomFieldCartScopeNested methods to test the validation of the rule with a multi select field and a matching or non-matching value. They include the rendered field config that specifies the component name as sw-multi-select ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-8b85e391b82db02eb2832f3274e5b245a078d09f28f237ebf185f4b25241c609R205-R206))
*  Modify the type declaration of the customFieldValue parameter in the setupRule method in the LineItemCustomFieldRuleTest class to also include array as a possible type ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-8b85e391b82db02eb2832f3274e5b245a078d09f28f237ebf185f4b25241c609L200-R221))
*  Add a new parameter to the setupRule method in the LineItemCustomFieldRuleTest class: renderedFieldConfig. This parameter is an array that contains the configuration of the rendered field, such as the component name. This parameter is used to assign it to the rule object ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-8b85e391b82db02eb2832f3274e5b245a078d09f28f237ebf185f4b25241c609R229))
*  Modify the type declaration of the customFieldValue and customFieldValueInCustomer parameters in the testCustomFieldCheckoutScope method in the CustomerCustomFieldRuleTest class to also include array as a possible type ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-c31eda51da70c15289156bbb2fd62d0c9c7ad1b52dacb665b96b6620facc7a2dL201-R225))
*  Add two new data sets to the customFieldCheckoutScopeProvider method in the CustomerCustomFieldRuleTest class: testSelectCustomField and testSelectCustomFieldInvalid. These data sets provide the parameters for the testCustomFieldCheckoutScope method to test the validation of the rule with a multi select field and a matching or non-matching value. They include the rendered field config that specifies the component name as sw-multi-select ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-c31eda51da70c15289156bbb2fd62d0c9c7ad1b52dacb665b96b6620facc7a2dR241-R242))
*  Modify the type declaration of the customFieldValue parameter in the setupRule method in the CustomerCustomFieldRuleTest class to also include array as a possible type ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-c31eda51da70c15289156bbb2fd62d0c9c7ad1b52dacb665b96b6620facc7a2dL266-R283))
*  Add a new parameter to the setupRule method in the CustomerCustomFieldRuleTest class: renderedFieldConfig. This parameter is an array that contains the configuration of the rendered field, such as the component name. This parameter is used to assign it to the rule object ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-c31eda51da70c15289156bbb2fd62d0c9c7ad1b52dacb665b96b6620facc7a2dR291))
*  Modify the type declaration of the renderedFieldValue parameter in the testMatch method in the CustomFieldRuleTest class to also include array as a possible type. It also adds a new parameter to the testMatch method: renderedFieldConfig. This parameter is an array that contains the configuration of the rendered field, such as the component name. This parameter is used to create the renderedField array that is passed to the match method ([link](https://github.com/shopware/platform/pull/3323/files?diff=unified&w=0#diff-3a9e026ace506934dab7fdd56fb1550cee2ee92dfaa109a2143c5f14c5fe1260L46-R55))
