### PR TITLE
Nested query version_id field check

### DIFF
--- a/changelog/_unreleased/2023-09-27-nested-query-version-id-check.md
+++ b/changelog/_unreleased/2023-09-27-nested-query-version-id-check.md
@@ -1,5 +1,4 @@
 ---
- title: Add order by position on rule payload update
  title: Check nested query for version id field
  author: Fabian Boensch
  author_github: @En0Ma1259

--- a/changelog/_unreleased/2023-09-27-nested-query-version-id-check.md
+++ b/changelog/_unreleased/2023-09-27-nested-query-version-id-check.md
@@ -1,0 +1,8 @@
+---
+ title: Add order by position on rule payload update
+ title: Check nested query for version id field
+ author: Fabian Boensch
+ author_github: @En0Ma1259
+ ---
+ # Core
+ * Checks if enity_version_id field exists

--- a/changelog/_unreleased/2023-09-29-cms-navigation-http-cache.md
+++ b/changelog/_unreleased/2023-09-29-cms-navigation-http-cache.md
@@ -1,7 +1,0 @@
----
- title: Added Http Cache to Route
- author: Fabian Boensch
- author_github: @En0Ma1259
- ---
- # Storefront
- * Added _httpCache Flag to cms navigation route

--- a/changelog/_unreleased/2023-09-29-cms-navigation-http-cache.md
+++ b/changelog/_unreleased/2023-09-29-cms-navigation-http-cache.md
@@ -1,0 +1,7 @@
+---
+ title: Added Http Cache to Route
+ author: Fabian Boensch
+ author_github: @En0Ma1259
+ ---
+ # Storefront
+ * Added _httpCache Flag to cms navigation route

--- a/src/Core/Content/Test/Product/Repository/ProductRepositoryTest.php
+++ b/src/Core/Content/Test/Product/Repository/ProductRepositoryTest.php
@@ -3339,9 +3339,9 @@ class ProductRepositoryTest extends TestCase
         $this->repository->create([$data], $this->context);
 
         $criteria = new Criteria();
-        $criteria->addFilter(new NotFilter(NotFilter::CONNECTION_OR), [
+        $criteria->addFilter(new NotFilter(NotFilter::CONNECTION_OR, [
             new PrefixFilter('seoUrls.pathInfo', '/detail/')
-        ]);
+        ]));
 
         $ids = $this->repository->searchIds($criteria, $this->context);
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
@@ -141,7 +141,7 @@ class CriteriaPartResolver
             $alias = $definition->getEntityName() . '.' . $field->getPropertyName();
 
             $query->addSelect(self::accessor($alias, $field->getReferenceField()) . ' as id');
-            if ($definition->isVersionAware() && $reference->getField($definition->getEntityName() . '_version_id')) {
+            if ($definition->isVersionAware() && $reference->getFields()->getByStorageName($definition->getEntityName() . '_version_id')) {
                 $query->addSelect(self::accessor($alias, $definition->getEntityName() . '_version_id'));
             }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
@@ -141,7 +141,7 @@ class CriteriaPartResolver
             $alias = $definition->getEntityName() . '.' . $field->getPropertyName();
 
             $query->addSelect(self::accessor($alias, $field->getReferenceField()) . ' as id');
-            if ($definition->isVersionAware()) {
+            if ($definition->isVersionAware() && $reference->getField($definition->getEntityName() . '_version_id')) {
                 $query->addSelect(self::accessor($alias, $definition->getEntityName() . '_version_id'));
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
A (e.g. category, product) search with a not-Filter will create a subquery (nested query) for an association field.
```JSON
/api/search/category
/api/search/product
{
    "filter": [
        {
            "type": "not",
            "operator": "or",
            "queries": [
                {
                    "type": "prefix",
                    "field": "seoUrls.seoPathInfo",
                    "value": "my-seo-prefix"
                }
            ]
        }
    ]
}
```
This search request will create a SQL similar as this
```SQL
SELECT `category`.`id`, `category`.`auto_increment`
FROM `category`
         LEFT JOIN (SELECT `category.seoUrls`.`foreign_key` as id, `category.seoUrls`.`category_version_id`
                    FROM `seo_url` `category.seoUrls`
                    WHERE (`category.seoUrls`.`seo_path_info` LIKE
                           :param_58248c1de1844034b782da4ff4f19911)) `category.seoUrls_1`
                   ON `category`.`id` = `category.seoUrls_1`.`id`
WHERE (`category`.`version_id` = :version)
  AND ((NOT (`category.seoUrls_1`.id IS NOT NULL)))
```
`seo_url` has non `category_version_id` field. The search result will return `An exception occurred while executing a query: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'category.seoUrls.category_version_id' in 'field list'`

`category_version_id` is not used in `ON` anyway

### 2. What does this change do, exactly?
If the parent is version aware, but the association has non version_id field `addSelect` will not be called

### 3. Describe each step to reproduce the issue or behavior.
See example in 1.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at affe6d3</samp>

This pull request fixes a bug that caused an SQL error when updating rule payloads with nested queries that did not have the entity_version_id field. It adds a condition to the `createNestedQuery` function in `CriteriaPartResolver.php` and a changelog file to document the change.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at affe6d3</samp>

*  Add order by position on rule payload update and check nested query for version id field ([link](https://github.com/shopware/platform/pull/3327/files?diff=unified&w=0#diff-73435e2b33914ac402ef5e4dea5657c96c8483db4a3e8d31e93cbe8d8437d5ecR1-R8))
   * Modify createNestedQuery function to select entity_version_id field only if reference field definition has it ([link](https://github.com/shopware/platform/pull/3327/files?diff=unified&w=0#diff-2ebf7b96699134114de6133aa9ce2e213107e0f4d64806d7d0dd7a765d328840L144-R144))
