### PR TITLE
Pagination http cache

### DIFF
--- a/changelog/_unreleased/2022-09-29-cms-navigation-http-cache.md
+++ b/changelog/_unreleased/2022-09-29-cms-navigation-http-cache.md
@@ -1,0 +1,7 @@
+---
+ title: Added Http Cache to Route
+ author: Fabian Boensch
+ author_github: @En0Ma1259
+ ---
+ # Storefront
+ * Added _httpCache Flag to cms navigation route

--- a/src/Storefront/Controller/CmsController.php
+++ b/src/Storefront/Controller/CmsController.php
@@ -63,7 +63,7 @@ class CmsController extends StorefrontController
     /**
      * Navigation id is required to load the slot config for the navigation
      */
-    #[Route(path: '/widgets/cms/navigation/{navigationId}', name: 'frontend.cms.navigation.page', defaults: ['navigationId' => null, 'XmlHttpRequest' => true], methods: ['GET', 'POST'])]
+    #[Route(path: '/widgets/cms/navigation/{navigationId}', name: 'frontend.cms.navigation.page', defaults: ['navigationId' => null, 'XmlHttpRequest' => true, '_httpCache' => true], methods: ['GET', 'POST'])]
     public function category(?string $navigationId, Request $request, SalesChannelContext $salesChannelContext): Response
     {
         if (!$navigationId) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Add CMS navigation call to the HTTP cache. Will result in a faster response.

Couldn't see why this route should not be cachable. Cache tag `product-listing-route-$categoryId` will be added, so CacheInvalidationSubscriber will invalidate this route on changes.

### 2. What does this change do, exactly?
Adds `_httpCache => true` to `frontend.cms.navigation.page` route.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c828f43</samp>

The pull request adds a Http Cache flag to the `category` route of the `CmsController` class. This allows the cms navigation feature to be cached and improve performance. The change is documented in a changelog file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c828f43</samp>

*  Add a Http Cache flag to the cms navigation route ([link](https://github.com/shopware/platform/pull/3331/files?diff=unified&w=0#diff-0b98dc8ac85528a58135d5696ee97ae39aded423839722f8688a3d101ea75609R1-R7), [link](https://github.com/shopware/platform/pull/3331/files?diff=unified&w=0#diff-e8a1e30d48ea04df2f3d4eaa2b720fe0a3d7e42ee5144dc6e555bd2b1db35bc4L66-R66))
   - Create a changelog file `changelog/_unreleased/2022-09-29-cms-navigation-http-cache.md` with metadata and a summary of the pull request ([link](https://github.com/shopware/platform/pull/3331/files?diff=unified&w=0#diff-0b98dc8ac85528a58135d5696ee97ae39aded423839722f8688a3d101ea75609R1-R7))
   - Modify the `src/Storefront/Controller/CmsController.php` file to add a `_httpCache` default parameter with a value of true to the Route annotation of the category method ([link](https://github.com/shopware/platform/pull/3331/files?diff=unified&w=0#diff-e8a1e30d48ea04df2f3d4eaa2b720fe0a3d7e42ee5144dc6e555bd2b1db35bc4L66-R66))
