### PR TITLE
NEXT-21783 - Fix admin grid headline action resize on click

### DIFF
--- a/changelog/_unreleased/2023-10-01-fix-admin-grid-headline-actions-resize.md
+++ b/changelog/_unreleased/2023-10-01-fix-admin-grid-headline-actions-resize.md
@@ -1,0 +1,9 @@
+---
+title: Fix admin grid headline actions resizing on using context menus
+issue: NEXT-30845
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Changed CSS-selectors like `:not(.sw-data-grid__cell--actions)` for icon coloring and sizing on to also contain `:not(.sw-data-grid__cell--header)` so context buttons in `sw-customer-list`, `sw-order-list`, `sw-product-list`, `sw-promotion-v2-list`, `sw-property-list`, `sw-settings-country-list`, `sw-settings-shipping-list` and `sw-settings-tax-list` do not resize in their active state

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.scss
@@ -366,8 +366,8 @@
             justify-content: center;
         }
 
-        .sw-button:not(:last-child) {
-            margin-right: 5px;
+        .sw-button + .sw-button {
+            margin-left: 5px;
         }
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/page/sw-customer-list/sw-customer-list.scss
@@ -10,7 +10,7 @@ $sw-customer-list-color-success: $color-emerald-500;
         position: absolute;
     }
 
-    .sw-data-grid__cell:not(.sw-data-grid__cell--actions) {
+    .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
             color: $sw-customer-list-color-error;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.scss
@@ -10,7 +10,7 @@ $sw-order-list-color-success: $color-emerald-500;
         position: absolute;
     }
 
-    .sw-data-grid__cell:not(.sw-data-grid__cell--actions) {
+    .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
             color: $sw-order-list-color-error;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.scss
@@ -10,7 +10,7 @@ $sw-product-list-color-success: $color-emerald-500;
         position: absolute;
     }
 
-    .sw-data-grid__cell:not(.sw-data-grid__cell--actions) {
+    .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .sw-data-grid__cell-content {
             .is--inactive {
                 width: 16px;

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/page/sw-promotion-v2-list/sw-promotion-v2-list.scss
@@ -4,7 +4,7 @@ $sw-promotion-list-color-error: $color-crimson-500;
 $sw-promotion-list-color-success: $color-emerald-500;
 
 .sw-promotion-v2-list {
-    .sw-data-grid__cell:not(.sw-data-grid__cell--actions) {
+    .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
             color: $sw-promotion-list-color-error;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/sw-property-list.scss
@@ -4,7 +4,7 @@ $sw-property-list-color-error: $color-crimson-500;
 $sw-property-list-color-success: $color-emerald-500;
 
 .sw-property-list {
-    .sw-data-grid__cell:not(.sw-data-grid__cell--actions) {
+    .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
             color: $sw-property-list-color-error;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/page/sw-settings-country-list/sw-settings-country-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/page/sw-settings-country-list/sw-settings-country-list.scss
@@ -4,7 +4,7 @@ $sw-country-list-color-error: $color-crimson-500;
 $sw-country-list-color-success: $color-emerald-500;
 
 .sw-settings-country-list {
-    .sw-data-grid__cell:not(.sw-data-grid__cell--actions) {
+    .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
             color: $sw-country-list-color-error;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-list/sw-settings-shipping-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-list/sw-settings-shipping-list.scss
@@ -4,7 +4,7 @@ $sw-settings-shipping-list-color-error: $color-crimson-500;
 $sw-settings-shipping-list-color-success: $color-emerald-500;
 
 .sw-settings-shipping-list {
-    .sw-data-grid__cell:not(.sw-data-grid__cell--actions) {
+    .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--inactive {
             color: $sw-settings-shipping-list-color-error;
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-list/sw-settings-tax-list.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-list/sw-settings-tax-list.scss
@@ -3,7 +3,7 @@
 $sw-settings-tax-list-color-success: $color-emerald-500;
 
 .sw-settings-tax-list {
-    .sw-data-grid__cell:not(.sw-data-grid__cell--actions) {
+    .sw-data-grid__cell:not(.sw-data-grid__cell--header) {
         .is--active {
             color: $sw-settings-tax-list-color-success;
         }


### PR DESCRIPTION
### 1. Why is this change necessary?

Before:

<img width="200" alt="image" src="https://github.com/shopware/platform/assets/1133593/a183e359-64ad-4e6a-a0f0-ae3712dbf583">
<img width="316" alt="image" src="https://github.com/shopware/platform/assets/1133593/0d018239-8e13-4c40-9a8d-9871fbb0a06b">

After:

<img width="217" alt="image" src="https://github.com/shopware/platform/assets/1133593/b605b913-bae0-47a3-ad90-b7eb34dba6df">
<img width="316" alt="image" src="https://github.com/shopware/platform/assets/1133593/7c52f39e-8de1-4119-b3d6-3bbaf50d24c4">

In the second image have a look at the context menu arrow pointing towards the button. It moves around:

![hacktoberfest-1-case1](https://github.com/shopware/platform/assets/1133593/538eb9bf-1d28-4237-8d38-e959fd75eb62)
![hacktoberfest-1-case2](https://github.com/shopware/platform/assets/1133593/bfbf2eca-03a2-4fa8-aad5-38ac11bc7f02)

### 2. What does this change do, exactly?

Change a bunch of CSS selectors to ignore code, that looks like it wants to change icons to not affect these.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use the administration

### 4. Please link to the relevant issues (if any).

I hooked into [NEXT-21783](https://issues.shopware.com/issues/NEXT-21783) as it seems that someone already had to fix it.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e63161c</samp>

This pull request fixes a visual bug in the admin grid header that caused the buttons to have inconsistent margins and colors when resized or clicked. It updates the CSS rules for the margin between buttons and the color of inactive cells in several data grid components, such as `sw-customer-list`, `sw-order-list`, `sw-product-list`, and others. It also adds a changelog entry for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e63161c</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3332/files?diff=unified&w=0#diff-6aedd0822f75ff84fdad5fbe25cae5094dd9412402f9712fef1eaa753ed7f542R1-R9))
*  Fix the margin between buttons in the data grid header to be consistent regardless of the number of buttons ([link](https://github.com/shopware/platform/pull/3332/files?diff=unified&w=0#diff-31b6a39a6338cacea36388ecea5ac13baecd21d2561fa8f29c493818f6710ebeL369-R370))
*  Prevent the context buttons in the header cells of various list pages from changing color when clicked by excluding them from the inactive cell color rule ([link](https://github.com/shopware/platform/pull/3332/files?diff=unified&w=0#diff-54a21ea29e66fa8680a70a2a0647cf910ad61d440be94b7760afd70834fca2ccL13-R13), [link](https://github.com/shopware/platform/pull/3332/files?diff=unified&w=0#diff-bb5b0a572f8faa59447ea6a6fc8a8febe937dbaebc76b55f22ddae0e6276e7d5L13-R13), [link](https://github.com/shopware/platform/pull/3332/files?diff=unified&w=0#diff-294884426c95f872e4bf5a2a92ffa94db5f8d1ea728c2301e94ae50e048466dfL13-R13), [link](https://github.com/shopware/platform/pull/3332/files?diff=unified&w=0#diff-476062ec0a0d34aa4b297748072ea646f5f84e8f1397ea63ec5d96f7b9a1d6feL7-R7), [link](https://github.com/shopware/platform/pull/3332/files?diff=unified&w=0#diff-4e27a030210cca92226fcb2b7639bc90dfcecb154a376acebf5a1c1d6f820d37L7-R7), [link](https://github.com/shopware/platform/pull/3332/files?diff=unified&w=0#diff-e357f5fdbac368c69d6f9bd52119caf835084f9f40a05ec2c8d1e3424982bb0cL7-R7), [link](https://github.com/shopware/platform/pull/3332/files?diff=unified&w=0#diff-15fdb6ed33f45cefb082e3dfc29b21b347e90ea6de3a742687f48a0c166218d6L7-R7), [link](https://github.com/shopware/platform/pull/3332/files?diff=unified&w=0#diff-85ab2eff4b91e162107c70ab4f199e42db8b7f91f111cb6521271af08f52ed87L6-R6))


[NEXT-21783]: https://shopware.atlassian.net/browse/NEXT-21783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ