### PR TITLE
Return error on preview with invalid SEO URL template

### DIFF
--- a/changelog/_unreleased/2023-10-01-return-error-on-preview-with-invalid-seo-url-template.md
+++ b/changelog/_unreleased/2023-10-01-return-error-on-preview-with-invalid-seo-url-template.md
@@ -1,0 +1,14 @@
+---
+title: Return error on preview with invalid SEO URL template
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added class `\Shopware\Core\Content\Seo\ConfiguredSeoUrlRoute` to allow passing `\Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface` with an altered configuration 
+___
+# API
+* Changed `/api/_action/seo-url-template/preview` to also return `FRAMEWORK__INVALID_SEO_TEMPLATE` 
+___
+# Administration
+* Changed SEO URL validation with Admin API changes to flag SEO URL templates with invalid property reference as invalid

--- a/src/Core/Content/Seo/Api/SeoActionController.php
+++ b/src/Core/Content/Seo/Api/SeoActionController.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Seo\Api;
 
 use Shopware\Core\Content\Seo\Exception\NoEntitiesForPreviewException;
+use Shopware\Core\Content\Seo\ConfiguredSeoUrlRoute;
 use Shopware\Core\Content\Seo\SeoException;
 use Shopware\Core\Content\Seo\SeoUrl\SeoUrlEntity;
 use Shopware\Core\Content\Seo\SeoUrlGenerator;
@@ -317,7 +318,7 @@ class SeoActionController extends AbstractController
             throw SeoException::salesChannelIdParameterIsMissing();
         }
 
-        $result = $this->seoUrlGenerator->generate($ids, $template, $seoUrlRoute, $context, $salesChannel);
+        $result = $this->seoUrlGenerator->generate($ids, $template, new ConfiguredSeoUrlRoute($seoUrlRoute, $config), $context, $salesChannel);
         if (\is_array($result)) {
             return $result;
         }

--- a/src/Core/Content/Seo/ConfiguredSeoUrlRoute.php
+++ b/src/Core/Content/Seo/ConfiguredSeoUrlRoute.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Content\Seo;
+
+use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlMapping;
+use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
+use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+
+#[Package('buyers-experience')]
+class ConfiguredSeoUrlRoute implements SeoUrlRouteInterface
+{
+    public function __construct(
+        private readonly SeoUrlRouteInterface $decorated,
+        private readonly SeoUrlRouteConfig $config
+    ) {
+    }
+
+    public function getConfig(): SeoUrlRouteConfig
+    {
+        return $this->config;
+    }
+
+    public function prepareCriteria(Criteria $criteria, SalesChannelEntity $salesChannel): void
+    {
+        $this->decorated->prepareCriteria($criteria, $salesChannel);
+    }
+
+    public function getMapping(Entity $entity, ?SalesChannelEntity $salesChannel): SeoUrlMapping
+    {
+        return $this->decorated->getMapping($entity, $salesChannel);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Before:
![hacktoberfest-2-wrong](https://github.com/shopware/platform/assets/1133593/40a8b644-c314-4863-962d-6d01e08b272c)

After:
![hacktoberfest-2-right](https://github.com/shopware/platform/assets/1133593/5da73304-bfe9-4fed-bd2c-a19a4e8cc757)

### 2. What does this change do, exactly?

Ensure that the following code has effect as the config is passed on
https://github.com/shopware/platform/blob/76213c438600c54fd05750d899a8c2eaceb8d6b9/src/Core/Content/Seo/Api/SeoActionController.php#L281
The line changes the value of an object, that is returned by a getter of a service. The getter functions like a factory to not make the service stateful. The object is not used to pass it it to the URL generation though changing that value would only impact the SEO URL generation so I assume once that should've had the effect I am fixing here. Later on the OG service is passed on a the getter for the config is called again and therefore the factory creates a new configuration object.

### 3. Describe each step to reproduce the issue or behaviour.

1. Write a SEO URL template and make a typo in a property reference
2. Get a check mark, that the template is valid
3. Do not understand, that no preview has given because there is an error in the template
4. Go to Settings > System > Caches & indices
5. Select all checkboxes but `category.seo-url`, `product.seo-url` and `landing_page.seo-url` to generate new SEO URLs and run indexers :/
6. Be confused, that there are only these weird technical URLs

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

---

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bc91d94</samp>

This pull request improves the API and the testing for SEO URL template actions. It adds a new class `ConfiguredSeoUrlRoute` to handle custom configuration and validation of SEO URL routes. It also returns an error on preview with an invalid SEO URL template and updates the changelog accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bc91d94</samp>

*  Add a new feature to return an error on preview with an invalid SEO URL template ([link](https://github.com/shopware/platform/pull/3333/files?diff=unified&w=0#diff-abd894879a83e8850e68eba5b92e4721ac3a569fa77fdd5d997330842332b90eR1-R14))
*  Import the new class `ConfiguredSeoUrlRoute` in the `SeoActionController` class ([link](https://github.com/shopware/platform/pull/3333/files?diff=unified&w=0#diff-f11af3c829092d28b75748b8a77d78c26a1cab16d6122d556f73894f110b1d7fR6))
*  Wrap the given `SeoUrlRouteInterface` with a `ConfiguredSeoUrlRoute` instance in the `getPreview` method of the `SeoActionController` class to validate the SEO URL template against the configuration ([link](https://github.com/shopware/platform/pull/3333/files?diff=unified&w=0#diff-f11af3c829092d28b75748b8a77d78c26a1cab16d6122d556f73894f110b1d7fL320-R321))
*  Create a new class `ConfiguredSeoUrlRoute` that implements the `SeoUrlRouteInterface` and decorates another `SeoUrlRouteInterface` with a custom configuration in the file `src/Core/Content/Seo/ConfiguredSeoUrlRoute.php` ([link](https://github.com/shopware/platform/pull/3333/files?diff=unified&w=0#diff-894618d88ed6bb01495267c15386da645059da01dafd0e195121427d6b414d5eR1-R38))
*  Rename the `testValidateInvalid` method to `testValidateInvalidTwigSyntax` in the `SeoActionControllerTest` class to clarify the test purpose ([link](https://github.com/shopware/platform/pull/3333/files?diff=unified&w=0#diff-fd4ff3c4859877dc4a46128a57db317c0428fa1a1bde7e07ed1187f545ca31e2L52-R52))
*  Add a new test method `testValidateInvalidDataUsage` to the `SeoActionControllerTest` class to test the validation of SEO URL templates with invalid data usage ([link](https://github.com/shopware/platform/pull/3333/files?diff=unified&w=0#diff-fd4ff3c4859877dc4a46128a57db317c0428fa1a1bde7e07ed1187f545ca31e2R68-R83))
*  Add a new test method `testPreviewWithBrokenTemplate` to the `SeoActionControllerTest` class to test the preview of SEO URL templates with invalid data usage ([link](https://github.com/shopware/platform/pull/3333/files?diff=unified&w=0#diff-fd4ff3c4859877dc4a46128a57db317c0428fa1a1bde7e07ed1187f545ca31e2R161-R181))
