### PR TITLE
Use displayed SEO URL template value for validation hints

### DIFF
--- a/changelog/_unreleased/2023-10-01-use-displayed-seo-url-template-value-for-validation-hints.md
+++ b/changelog/_unreleased/2023-10-01-use-displayed-seo-url-template-value-for-validation-hints.md
@@ -1,0 +1,8 @@
+---
+title: Use displayed SEO URL template value for validation hints
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Changed `sw-seo-url-template-card` to use the displayed value for the empty check and the related warning

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url-template-card/sw-seo-url-template-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-seo/component/sw-seo-url-template-card/sw-seo-url-template-card.html.twig
@@ -85,7 +85,7 @@
                                     name="regular-exclamation-triangle"
                                 />
                                 <sw-icon
-                                    v-else-if="!seoUrlTemplate.template"
+                                    v-else-if="!props.currentValue"
                                     v-tooltip="$tc('sw-seo-url-template-card.general.textUrlPreviewEmptyTemplate', 1, {
                                         entity: $tc(`global.entities.${seoUrlTemplate.entityName}`, 0)
                                     })"


### PR DESCRIPTION
### 1. Why is this change necessary?

Users, that do not know how inherited values technically work, can be confused about a warning, that inherited values are taken empty.

Before:
![hacktoberfest-3-wrong](https://github.com/shopware/platform/assets/1133593/9ef1b97d-dc28-4234-a194-88057cbbeb3b)

After:
![hacktoberfest-3-right](https://github.com/shopware/platform/assets/1133593/3ef7de51-1ca2-475e-8a6e-617fc954f71e)

### 2. What does this change do, exactly?

Use a different value for an empty check.

### 3. Describe each step to reproduce the issue or behaviour.

1. Go to SEO URL settings
2. Change sales channel selection to a specific sales channel
3. See a warning icon with a tooltip about the displayed value would be empty
![image](https://github.com/shopware/platform/assets/1133593/4de03f85-7343-4060-8dfd-577db44009f9)

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 189f317</samp>

This pull request fixes a bug in the `sw-seo-url-template-card` component that showed a misleading warning when the SEO URL template contained only placeholders. It also adds a changelog entry for this change.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 189f317</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3334/files?diff=unified&w=0#diff-cb42e465333765614e4fda0a8aecd02faeedb3db6dde1d85b87b97513f4a3588R1-R8))
*  Use the displayed value of the SEO URL template for validation hints instead of the original value ([link](https://github.com/shopware/platform/pull/3334/files?diff=unified&w=0#diff-cad350204cdd0282e8add04d2b3f7c0ff9ea234c950fe253d155a315ceb65334L88-R88))
