### PR TITLE
NEXT-00000 - Add easier way to admin to only reindex some indices without inversion of selection

### DIFF
--- a/changelog/_unreleased/2023-10-02-easier-admin-way-to-only-reindex-indices-without-selection-inversion.md
+++ b/changelog/_unreleased/2023-10-02-easier-admin-way-to-only-reindex-indices-without-selection-inversion.md
@@ -1,0 +1,16 @@
+---
+title: Add easier way to admin to only reindex some indices without inversion of selection
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added `\Shopware\Core\Framework\DataAbstractionLayer\Indexing\MessageQueue\FullEntityIndexerMessage`, that will be handled as `dal:refresh:index`
+* Changed `api.action.cache.index` route to dispatch `\Shopware\Core\Framework\DataAbstractionLayer\Indexing\MessageQueue\FullEntityIndexerMessage` instead of `\Shopware\Core\Framework\DataAbstractionLayer\Indexing\MessageQueue\IterateEntityIndexerMessage`
+___
+# API
+* Added body parameter `only` to `api/_action/index` to reduce complexity when using `skip` instead
+* Changed `api/_action/index` to dispatch a single message instead of a message per indexer
+___
+# Administration
+* Added mode selection in `sw-settings-cache-index` to either skip indices like before or only run selected indexers and updaters

--- a/src/Administration/Resources/app/administration/src/core/service/api/cache.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/cache.api.service.js
@@ -13,9 +13,9 @@ class CacheApiService {
         return this.httpClient.get('/_action/cache_info', { headers });
     }
 
-    index(skip = []) {
+    index(skip = [], only = []) {
         const headers = this.getHeaders();
-        return this.httpClient.post('/_action/index', { skip }, { headers });
+        return this.httpClient.post('/_action/index', { skip, only }, { headers });
     }
 
     clear() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
@@ -36,7 +36,8 @@ export default {
                 clearAndWarmUpCache: false,
                 updateIndexes: false,
             },
-            skip: [],
+            indexingMethod: 'skip',
+            indexerSelection: [],
             indexers: {
                 'category.indexer': [
                     'category.child-count',
@@ -203,7 +204,37 @@ export default {
 
         updateIndexes() {
             this.processes.updateIndexes = true;
-            this.cacheApiService.index(this.skip).then(() => {
+
+            let skip = [];
+            let only = [];
+
+            if (this.indexingMethod === 'skip') {
+                skip = this.indexerSelection;
+            } else {
+                // eslint-disable-next-line no-restricted-syntax
+                for (const [indexerName, updaters] of Object.entries(this.indexers)) {
+                    if (this.indexerSelection.indexOf(indexerName) > -1) {
+                        only.push(indexerName);
+                    }
+
+                    const selectedUpdaters = [];
+
+                    // eslint-disable-next-line no-restricted-syntax
+                    for (const updater of updaters) {
+                        if (this.indexerSelection.indexOf(updater) > -1) {
+                            selectedUpdaters.push(updater);
+                        }
+                    }
+
+                    if (selectedUpdaters.length > 0) {
+                        only.push(indexerName);
+                    }
+
+                    only.push(...selectedUpdaters);
+                }
+            }
+
+            this.cacheApiService.index(skip, only).then(() => {
                 this.decreaseWorkerPoll();
                 this.createNotificationInfo({
                     message: this.$tc('sw-settings-cache.notifications.index.started'),
@@ -216,18 +247,33 @@ export default {
             });
         },
 
-        changeSkip(selected, name) {
+        changeSelection(selected, name) {
             if (selected) {
-                this.skip.push(name);
+                this.indexerSelection.push(name);
 
                 return;
             }
 
-            const index = this.skip.indexOf(name);
+            const index = this.indexerSelection.indexOf(name);
 
             if (index > -1) {
-                this.skip.splice(index, 1);
+                this.indexerSelection.splice(index, 1);
             }
+        },
+
+        flipIndexers() {
+            const leafs = [];
+
+            // eslint-disable-next-line no-restricted-syntax
+            for (const [indexerName, updaters] of Object.entries(this.indexers)) {
+                if (updaters.length > 0) {
+                    leafs.push(...updaters);
+                } else {
+                    leafs.push(indexerName);
+                }
+            }
+
+            this.indexerSelection = leafs.filter(entry => this.indexerSelection.indexOf(entry) === -1);
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
@@ -196,113 +196,127 @@
 
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_settings_cache_content_indexes_row %}
-                <sw-card-section>
-                    <sw-container
-                        align="center"
-                        columns="1fr auto"
-                        gap="20px"
-                    >
-                        <div>
-
-                            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                            {% block sw_settings_cache_content_indexes_row_heading %}
-                            <p class="sw-settings-cache__card-section-heading">
-                                {{ $tc('sw-settings-cache.section.indexesHeadline') }}
-                            </p>
-                            {% endblock %}
-
-                            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                            {% block sw_settings_cache_content_indexes_row_text %}
-                            <p>{{ $tc('sw-settings-cache.section.indexesText') }}</p>
-                            {% endblock %}
-                        </div>
+                <sw-card-section class="sw-settings-cache__card-indexes">
+                    <sw-container>
+                        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                        {% block sw_settings_cache_content_indexes_row_heading %}
+                        <p class="sw-settings-cache__card-section-heading">
+                            {{ $tc('sw-settings-cache.section.indexesHeadline') }}
+                        </p>
+                        {% endblock %}
 
                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                        {% block sw_settings_cache_content_indexes_row_button %}
-                        <sw-button-process
-                            variant="ghost"
-                            :is-loading="processes.updateIndexes"
-                            :process-success="processSuccess.updateIndexes"
-                            {% if VUE3 %}
-                            @update:process-success="resetButtons"
-                            {% else %}
-                            @process-finish="resetButtons"
-                            {% endif %}
-                            @click="updateIndexes"
-                        >
-                            {{ $tc('sw-settings-cache.section.indexesButton') }}
-                        </sw-button-process>
+                        {% block sw_settings_cache_content_indexes_row_text %}
+                        <p>{{ $tc('sw-settings-cache.section.indexesText') }}</p>
                         {% endblock %}
                     </sw-container>
-                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                    {% block sw_settings_cache_content_indexes_row_skip_select %}
-                    <sw-select-base
-                        class="sw-settings-cache__indexers-select"
-                        :disabled="processes.updateIndexes"
+                    <sw-container
+                        columns="1fr 2fr min-content"
+                        gap="10px"
+                        justify="end"
+                        align="end"
                     >
-                        <template #sw-select-selection>
-                            <sw-label
-                                v-for="(selection, index) in skip"
-                                :key="index"
-                                @dismiss="changeSkip(false, selection)"
-                            >
-                                {{ selection }}
-                            </sw-label>
-                            <sw-label
-                                ghost
-                                class="sw-settings-cache__indexers-placeholder"
-                            >
-                                {{ $tc('sw-settings-cache.section.indexesSkipSelectPlaceholder') }}
-                            </sw-label>
-                        </template>
-                        <template #results-list>
-                            <sw-select-result-list :options="[indexers]">
-                                <template #result-item="{ item, index }">
-                                    <ul
-                                        class="sw-settings-cache__indexers-list"
-                                        @click.stop
-                                    >
-                                        <li
-                                            v-for="(updaters, indexer) in item"
-                                            :key="indexer"
+                        <sw-select-field
+                            class="sw-settings-cache__skip-indexers-select"
+                            v-model="indexingMethod"
+                            :label="$tc('sw-settings-cache.section.indexingModeLabel')"
+                            :disabled="processes.updateIndexes"
+                        >
+                            <option value="skip">
+                                {{ $tc('sw-settings-cache.section.indexingModeOptionSkipLabel') }}
+                            </option>
+                            <option value="only">
+                                {{ $tc('sw-settings-cache.section.indexingModeOptionOnlyLabel') }}
+                            </option>
+                        </sw-select-field>
+                        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                        {% block sw_settings_cache_content_indexes_row_skip_select %}
+                        <sw-select-base
+                            class="sw-settings-cache__indexers-select"
+                            :label="indexingMethod === 'skip' ? $tc('sw-settings-cache.section.indexesSkipSelectLabel') : $tc('sw-settings-cache.section.indexesOnlySelectLabel')"
+                            :disabled="processes.updateIndexes"
+                        >
+                            <template #sw-select-selection>
+                                <sw-label
+                                    v-for="(selection, index) in indexerSelection"
+                                    :key="index"
+                                    @dismiss="changeSelection(false, selection)"
+                                >
+                                    {{ selection }}
+                                </sw-label>
+                                <sw-label
+                                    ghost
+                                    class="sw-settings-cache__indexers-placeholder"
+                                >
+                                    {{ indexingMethod === 'skip' ? $tc('sw-settings-cache.section.indexesSkipSelectPlaceholder') : $tc('sw-settings-cache.section.indexesOnlySelectPlaceholder') }}
+                                </sw-label>
+                            </template>
+                            <template #results-list>
+                                <sw-select-result-list :options="[indexers]">
+                                    <template #result-item="{ item, index }">
+                                        <ul
+                                            class="sw-settings-cache__indexers-list"
+                                            @click.stop
                                         >
-                                            <sw-checkbox-field
-                                                class="sw-settings-cache__indexers-entry"
-                                                :value="skip.includes(indexer)"
-                                                :label="indexer"
-                                                size="small"
-                                                {% if VUE3 %}
-                                                @update:value="changeSkip($event, indexer)"
-                                                {% else %}
-                                                @change="changeSkip($event, indexer)"
-                                                {% endif %}
-                                            />
-                                            <ul>
-                                                <li
-                                                    v-for="(updater, index) in updaters"
-                                                    :key="index"
-                                                >
-                                                    <sw-checkbox-field
-                                                        class="sw-settings-cache__indexers-entry"
-                                                        :value="skip.includes(updater) || skip.includes(indexer)"
-                                                        :label="updater"
-                                                        size="small"
-                                                        :disabled="skip.includes(indexer)"
-                                                        @click.prevent
-                                                        {% if VUE3 %}
-                                                        @update:value="changeSkip($event, updater)"
-                                                        {% else %}
-                                                        @change="changeSkip($event, updater)"
-                                                        {% endif %}
-                                                    />
-                                                </li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </template>
-                            </sw-select-result-list>
-                        </template>
-                    </sw-select-base>
+                                            <li
+                                                v-for="(updaters, indexer) in item"
+                                                :key="indexer"
+                                            >
+                                                <sw-checkbox-field
+                                                    class="sw-settings-cache__indexers-entry"
+                                                    :value="indexerSelection.includes(indexer)"
+                                                    :label="indexer"
+                                                    size="small"
+                                                    {% if VUE3 %}
+                                                    @update:value="changeSelection($event, indexer)"
+                                                    {% else %}
+                                                    @change="changeSelection($event, indexer)"
+                                                    {% endif %}
+                                                />
+                                                <ul>
+                                                    <li
+                                                        v-for="(updater, index) in updaters"
+                                                        :key="index"
+                                                    >
+                                                        <sw-checkbox-field
+                                                            class="sw-settings-cache__indexers-entry"
+                                                            :value="indexerSelection.includes(updater) || indexerSelection.includes(indexer)"
+                                                            :label="updater"
+                                                            size="small"
+                                                            :disabled="indexerSelection.includes(indexer)"
+                                                            @click.prevent
+                                                            {% if VUE3 %}
+                                                            @update:value="changeSelection($event, updater)"
+                                                            {% else %}
+                                                            @change="changeSelection($event, updater)"
+                                                            {% endif %}
+                                                        />
+                                                    </li>
+                                                </ul>
+                                            </li>
+                                        </ul>
+                                    </template>
+                                </sw-select-result-list>
+                            </template>
+                        </sw-select-base>
+                        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                        {% block sw_settings_cache_content_indexes_row_button %}
+                            <sw-button-process
+                                class="sw-button--large"
+                                variant="ghost"
+                                :is-loading="processes.updateIndexes"
+                                :process-success="processSuccess.updateIndexes"
+                                {% if VUE3 %}
+                                    @update:process-success="resetButtons"
+                                {% else %}
+                                    @process-finish="resetButtons"
+                                {% endif %}
+                                @click="updateIndexes"
+                            >
+                                Update
+                            </sw-button-process>
+                        {% endblock %}
+                    </sw-container>
                     {% endblock %}
                 </sw-card-section>
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.scss
@@ -5,6 +5,12 @@
         padding-top: 0;
     }
 
+    .sw-settings-cache__card-indexes {
+        .sw-container + .sw-container {
+            margin-top: 30px;
+        }
+    }
+
     &__indexers-entry {
         padding: 4px 8px;
         border-radius: $border-radius-default;
@@ -61,12 +67,18 @@
 
 .sw-settings-cache__indexers-select {
     &.sw-field {
-        margin: 8px 0 0;
+        margin: 0;
     }
 
     &.sw-select {
         .sw-select__selection {
             padding-top: 8px;
         }
+    }
+}
+
+.sw-settings-cache__skip-indexers-select {
+    &.sw-field {
+        margin-bottom: 0;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/snippet/de-DE.json
@@ -22,7 +22,13 @@
       "indexesHeadline": "Indizes",
       "indexesText": "Es werden alle Indizes asynchron aktualisiert. Der Fortschritt kann in den Mitteilungen eingesehen werden. Dies betrifft unter anderem die Produkt- und Kategorieindizes oder auch die SEO-URLs.",
       "indexesButton": "Indizes aktualisieren",
-      "indexesSkipSelectPlaceholder": "Indexer und/oder Updater überspringen"
+      "indexingModeLabel": "Methode",
+      "indexingModeOptionSkipLabel": "Alle aktualisieren außer Auswahl",
+      "indexingModeOptionOnlyLabel": "Nur Auswahl aktualisieren",
+      "indexesSkipSelectLabel": "Indexer und/oder Updater zum Überspringen",
+      "indexesOnlySelectLabel": "Indexer und/oder Updater",
+      "indexesSkipSelectPlaceholder": "Indexer und/oder Updater auswählen zum Überspringen",
+      "indexesOnlySelectPlaceholder": "Indexer und/oder Updater auswählen"
     },
     "notifications": {
       "clearCache": {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/snippet/en-GB.json
@@ -22,7 +22,13 @@
       "indexesHeadline": "Indexes",
       "indexesText": "All indexes are updated asynchronously. Keep track of the progress by monitoring the notifications.",
       "indexesButton": "Update indexes",
-      "indexesSkipSelectPlaceholder": "Skip indexers and/or updaters"
+      "indexingModeLabel": "Method",
+      "indexingModeOptionSkipLabel": "Update all, but skip selected",
+      "indexingModeOptionOnlyLabel": "Only update selected",
+      "indexesSkipSelectLabel": "Indexers and/or updaters to skip",
+      "indexesOnlySelectLabel": "Indexers and/or updaters",
+      "indexesSkipSelectPlaceholder": "Select indexers and/or updaters to skip",
+      "indexesOnlySelectPlaceholder": "Select indexers and/or updaters"
     },
     "notifications": {
       "clearCache": {

--- a/src/Core/Framework/Api/Controller/CacheController.php
+++ b/src/Core/Framework/Api/Controller/CacheController.php
@@ -48,12 +48,12 @@ class CacheController extends AbstractController
         $data = $dataBag->all();
 
         $skip = !empty($data['skip']) && \is_array($data['skip']) ? $data['skip'] : [];
-        $mapped = [];
-        foreach ($skip as $value) {
-            $mapped[] = (string) $value;
-        }
+        $only = !empty($data['only']) && \is_array($data['only']) ? $data['only'] : [];
 
-        $this->indexerRegistry->sendIndexingMessage([], $mapped);
+        $skip = \array_map('strval', $skip);
+        $only = \array_map('strval', $only);
+
+        $this->indexerRegistry->sendFullIndexingMessage($skip, $only);
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Indexing;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\MessageQueue\FullEntityIndexerMessage;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\MessageQueue\IterateEntityIndexerMessage;
 use Shopware\Core\Framework\Event\ProgressAdvancedEvent;
 use Shopware\Core\Framework\Event\ProgressFinishedEvent;
@@ -44,8 +45,14 @@ class EntityIndexerRegistry
     /**
      * @internal
      */
-    public function __invoke(EntityIndexingMessage|IterateEntityIndexerMessage $message): void
+    public function __invoke(EntityIndexingMessage|IterateEntityIndexerMessage|FullEntityIndexerMessage $message): void
     {
+        if ($message instanceof FullEntityIndexerMessage) {
+            $this->index(true, $message->getSkip(), $message->getOnly());
+
+            return;
+        }
+
         if ($message instanceof EntityIndexingMessage) {
             $indexer = $this->getIndexer($message->getIndexer());
 
@@ -185,6 +192,15 @@ class EntityIndexerRegistry
 
             $this->messageBus->dispatch(new IterateEntityIndexerMessage($name, null, $skip));
         }
+    }
+
+    /**
+     * @param list<string> $skip
+     * @param list<string> $only
+     */
+    public function sendFullIndexingMessage(array $skip = [], array $only = []): void
+    {
+        $this->messageBus->dispatch(new FullEntityIndexerMessage($skip, $only));
     }
 
     public function has(string $name): bool

--- a/src/Core/Framework/DataAbstractionLayer/Indexing/MessageQueue/FullEntityIndexerMessage.php
+++ b/src/Core/Framework/DataAbstractionLayer/Indexing/MessageQueue/FullEntityIndexerMessage.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Indexing\MessageQueue;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\MessageQueue\AsyncMessageInterface;
+
+#[Package('core')]
+class FullEntityIndexerMessage implements AsyncMessageInterface
+{
+    /**
+     * @internal
+     *
+     * @param list<string> $skip
+     * @param list<string> $only
+     */
+    public function __construct(
+        protected array $skip = [],
+        protected array $only = []
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSkip(): array
+    {
+        return $this->skip;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getOnly(): array
+    {
+        return $this->only;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

People, that cannot run `dal:refresh:index --only` hate to just click ALL the indexers to skip. Wouldn't it be nice to just click on those, that you want to run? To break the UI less I chose to just make it an invert button as this seems to be quite helpful for various cases without breaking any other click paths, that already exist.

I tried to approach a different way for my case with the SEO URL indexing, but as 
https://github.com/shopware/platform/blob/76213c438600c54fd05750d899a8c2eaceb8d6b9/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js#L38-L86
is basically the source of truth for the indexers in the admin, I cannot easily reuse it elsewhere.

Before (mouse-only):
![hacktoberfest-4-before](https://github.com/shopware/platform/assets/1133593/7287439c-b828-47c2-90e8-43a9384aa84d)

After ("go to settings" key bind):
![hacktoberfest-4](https://github.com/shopware/platform/assets/1133593/bdbdc34b-df45-4676-988b-2358bdfaeab4)
![hacktoberfest-4-after](https://github.com/shopware/platform/assets/1133593/c92b0eca-da46-4d6b-a3cf-85d82082f205)

### 2. What does this change do, exactly?

Add a button to invert the selection.

### 3. Describe each step to reproduce the issue or behaviour.

1. Change SEO URL template
2. Go to Settings > System > Caches & indices
3. Select all checkboxes but `category.seo-url`, `product.seo-url` and `landing_page.seo-url` to generate new SEO URLs and run indexers :/
4. Only be able to make 26.36 in a mouse only speedrun to reindex URLs

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9d14c8f</samp>

This pull request adds a new feature to the cache settings page in the administration module. It allows the user to invert the selection of indexers and updaters that should be skipped when clearing the cache. It also improves the layout and styling of the page and adds the corresponding translations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9d14c8f</samp>

*  Add a new feature to allow users to invert the selection of indexers and updaters on the admin indices updating page ([link](https://github.com/shopware/platform/pull/3335/files?diff=unified&w=0#diff-363831e2dab9d94d851b5d78125abff6d4ccf5754bce318b1fe1169a8190f9d0R1-R8))
   * Create a new method `flipIndexers` on the `sw-settings-cache-index` component that toggles the `skip` property of each indexer or updater based on the current selection ([link](https://github.com/shopware/platform/pull/3335/files?diff=unified&w=0#diff-85e258a2e7f1508efbe8dc33463d7f3c1e4bd5729b435aba3896cc0ac267f99cR227-R241))
   * Add a new button element to the `sw-settings-cache-index` template that calls the `flipIndexers` method on click and uses a new translation key for the label ([link](https://github.com/shopware/platform/pull/3335/files?diff=unified&w=0#diff-c8d6bdc0fa3c2d0ff7c72ff3b0ff05833bff26b792709c759426d787240e1457L197-R218))
   * Adjust the layout and styling of the `sw-settings-cache-index` template and add new classes for the buttons container and the indexes section ([link](https://github.com/shopware/platform/pull/3335/files?diff=unified&w=0#diff-c8d6bdc0fa3c2d0ff7c72ff3b0ff05833bff26b792709c759426d787240e1457L197-R218), [link](https://github.com/shopware/platform/pull/3335/files?diff=unified&w=0#diff-c8d6bdc0fa3c2d0ff7c72ff3b0ff05833bff26b792709c759426d787240e1457L234-R235), [link](https://github.com/shopware/platform/pull/3335/files?diff=unified&w=0#diff-7080eb292be39fa7f96df26a9e80f2ea9ff1b6155214acc09b95ca16e94bb77cR8-R21))
   * Add new translation keys and values for the German and English locales of the button label ([link](https://github.com/shopware/platform/pull/3335/files?diff=unified&w=0#diff-9d7cc3bdeea4dfb8cd8b09e8feb4eec84bd5ca0ed6ffd017c9999cff2f2ad615R25), [link](https://github.com/shopware/platform/pull/3335/files?diff=unified&w=0#diff-968e6d67bc0cd623da851afa5ee15204c8ce03f1c5d550e5f8aa47ce440ade26R25))
