### PR TITLE
Fixes #2933 Add CacheResponseGenerateHash and CacheResponseSystemStates events

### DIFF
--- a/changelog/_unreleased/2023-10-02-add-events-to-cacheresponsesubscriber.md
+++ b/changelog/_unreleased/2023-10-02-add-events-to-cacheresponsesubscriber.md
@@ -1,0 +1,12 @@
+---
+title: Add events to CacheResponseSubscriber
+issue: /
+author: Rune Laenen
+author_email: rune@laenen.me
+author_github: runelaenen
+---
+# Storefront
+* Added `CacheResponseGenerateHashEvent` class
+* Added `CacheResponseSystemStatesEvent` class
+* Dispatches `CacheResponseGenerateHashEvent` in `buildCacheHash`
+* Dispatches `CacheResponseSystemStatesEvent` in `getSystemStates`

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -463,6 +463,7 @@
 
         <service id="Shopware\Storefront\Framework\Cache\CacheResponseSubscriber">
             <argument type="service" id="Shopware\Core\Checkout\Cart\SalesChannel\CartService"/>
+            <argument type="service" id="event_dispatcher"/>
             <argument>%shopware.http.cache.default_ttl%</argument>
             <argument>%shopware.http.cache.enabled%</argument>
             <argument type="service" id="Shopware\Storefront\Framework\Routing\MaintenanceModeResolver"/>

--- a/src/Storefront/Framework/Cache/Event/CacheResponseGenerateHashEvent.php
+++ b/src/Storefront/Framework/Cache/Event/CacheResponseGenerateHashEvent.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\Cache\Event;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('storefront')]
+class CacheResponseGenerateHashEvent extends Event
+{
+    public function __construct(
+        private readonly SalesChannelContext $salesChannelContext,
+        private array $parts
+    ) {
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getParts(): array
+    {
+        return $this->parts;
+    }
+
+    public function setParts(array $parts): void
+    {
+        $this->parts = $parts;
+    }
+
+    public function addPart(string $part): self
+    {
+        $this->parts[] = $part;
+
+        return $this;
+    }
+}

--- a/src/Storefront/Framework/Cache/Event/CacheResponseSystemStatesEvent.php
+++ b/src/Storefront/Framework/Cache/Event/CacheResponseSystemStatesEvent.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\Cache\Event;
+
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('storefront')]
+class CacheResponseSystemStatesEvent extends Event
+{
+    public function __construct(
+        private readonly SalesChannelContext $salesChannelContext,
+        private readonly Request $request,
+        private readonly Cart $cart,
+        private array $states
+    ) {
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getCart(): Cart
+    {
+        return $this->cart;
+    }
+
+    public function getStates(): array
+    {
+        return array_keys($this->states);
+    }
+
+    public function setState(string $key, bool $match): void
+    {
+        if ($match) {
+            $this->states[$key] = true;
+
+            return;
+        }
+
+        unset($this->states[$key]);
+    }
+}

--- a/tests/unit/Storefront/Framework/Cache/CacheResponseSubscriberTest.php
+++ b/tests/unit/Storefront/Framework/Cache/CacheResponseSubscriberTest.php
@@ -61,6 +61,7 @@ class CacheResponseSubscriberTest extends TestCase
     {
         $subscriber = new CacheResponseSubscriber(
             $this->createMock(CartService::class),
+            new EventDispatcher(),
             100,
             false,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -95,6 +96,7 @@ class CacheResponseSubscriberTest extends TestCase
     {
         $subscriber = new CacheResponseSubscriber(
             $this->createMock(CartService::class),
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -124,6 +126,7 @@ class CacheResponseSubscriberTest extends TestCase
     {
         $subscriber = new CacheResponseSubscriber(
             $this->createMock(CartService::class),
+            new EventDispatcher(),
             100,
             false,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -153,6 +156,7 @@ class CacheResponseSubscriberTest extends TestCase
     {
         $subscriber = new CacheResponseSubscriber(
             $this->createMock(CartService::class),
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -188,6 +192,7 @@ class CacheResponseSubscriberTest extends TestCase
 
         $subscriber = new CacheResponseSubscriber(
             $service,
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -270,6 +275,7 @@ class CacheResponseSubscriberTest extends TestCase
 
         $subscriber = new CacheResponseSubscriber(
             $cartService,
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver($requestStack, new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -354,6 +360,7 @@ class CacheResponseSubscriberTest extends TestCase
 
         $subscriber = new CacheResponseSubscriber(
             $this->createMock(CartService::class),
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -424,6 +431,7 @@ class CacheResponseSubscriberTest extends TestCase
     {
         $subscriber = new CacheResponseSubscriber(
             $this->createMock(CartService::class),
+            new EventDispatcher(),
             1,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -446,6 +454,7 @@ class CacheResponseSubscriberTest extends TestCase
     {
         $subscriber = new CacheResponseSubscriber(
             $this->createMock(CartService::class),
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -489,6 +498,7 @@ class CacheResponseSubscriberTest extends TestCase
     {
         $subscriber = new CacheResponseSubscriber(
             $this->createMock(CartService::class),
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -523,6 +533,7 @@ class CacheResponseSubscriberTest extends TestCase
     {
         $subscriber = new CacheResponseSubscriber(
             $this->createMock(CartService::class),
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -567,6 +578,7 @@ class CacheResponseSubscriberTest extends TestCase
 
         $subscriber = new CacheResponseSubscriber(
             $cartService,
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -603,6 +615,7 @@ class CacheResponseSubscriberTest extends TestCase
     {
         $subscriber = new CacheResponseSubscriber(
             $this->createMock(CartService::class),
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),
@@ -689,6 +702,7 @@ class CacheResponseSubscriberTest extends TestCase
     ): void {
         $subscriber = new CacheResponseSubscriber(
             $this->createStub(CartService::class),
+            new EventDispatcher(),
             100,
             true,
             new MaintenanceModeResolver(new RequestStack(), new CoreMaintenanceModeResolver(new EventDispatcher())),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently it is quity hacky (override the set cookie on the response event) to add extra 'layers' to the context cookie. Adding events will make it possible for a plugin to hook into the cache key generation easily. This is needed for example when a plugin uses some custom code to alter the storefront for certain customers.

### 2. What does this change do, exactly?
Adds 2 events in `CacheResponseSubscriber`
- buildCacheHash
- getSystemStates

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/platform/issues/2933

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5502b34</samp>

This pull request introduces two new events, `CacheResponseGenerateHashEvent` and `CacheResponseSystemStatesEvent`, to the `CacheResponseSubscriber` class, allowing plugins to customize the cache hash and the system states used for cache invalidation. It also updates the tests, the changelog and the service configuration to reflect the changes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5502b34</samp>

*  Add custom events to the `CacheResponseSubscriber` class to allow modifying the cache hash and system states ([link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-30cf3befcc1c9ace1d219cfb5a67c609e134b5e2b1040818bdf899ac8f3d8c4dR466), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-a0ca0535f0a9d8e2af2e4cfc33cddc5f3482a83fa0bea713dad4b0f5cb2d5b2dR13-R14), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-a0ca0535f0a9d8e2af2e4cfc33cddc5f3482a83fa0bea713dad4b0f5cb2d5b2dR24), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-a0ca0535f0a9d8e2af2e4cfc33cddc5f3482a83fa0bea713dad4b0f5cb2d5b2dR49), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-a0ca0535f0a9d8e2af2e4cfc33cddc5f3482a83fa0bea713dad4b0f5cb2d5b2dL222-R226), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-a0ca0535f0a9d8e2af2e4cfc33cddc5f3482a83fa0bea713dad4b0f5cb2d5b2dL228-R237), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-a0ca0535f0a9d8e2af2e4cfc33cddc5f3482a83fa0bea713dad4b0f5cb2d5b2dL277-R289))
   * Define the `CacheResponseGenerateHashEvent` class for the cache hash event ([link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-3db570d87310de457c88b81969937b9f4b2f7c0ca7ec90fe70aeca3a0e393b44R1-R39))
   * Define the `CacheResponseSystemStatesEvent` class for the system states event ([link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-ea75fa50acf25b5d6ff33060efe86745a55d26421e97b404959817f61ad90783R1-R52))
* Add the `event_dispatcher` service as a dependency to the `CacheResponseSubscriber` service in the XML configuration file ([link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-30cf3befcc1c9ace1d219cfb5a67c609e134b5e2b1040818bdf899ac8f3d8c4dR466))
* Add the `EventDispatcher` as an argument to the `CacheResponseSubscriber` constructor in the unit test methods ([link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR64), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR99), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR129), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR159), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR195), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR278), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR363), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR434), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR457), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR501), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR536), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR581), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR618), [link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-e5c9e7994545d15bd8caa9c1269e0250ca24c55c67e083777c9a1355b3428bcfR705))
* Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3336/files?diff=unified&w=0#diff-5d1771efd61696af4a75602e95f96239d51f963a396f09fbb1a31ad63fb4b47bR1-R12))
