### PR TITLE
fix: change argument type to UrlGeneratorInterface in BCStrategy to allow decorations

### DIFF
--- a/changelog/_unreleased/2023-10-03-change-type-of-urlgenerator.md
+++ b/changelog/_unreleased/2023-10-03-change-type-of-urlgenerator.md
@@ -1,0 +1,12 @@
+---
+title: Change type to UrlGeneratorInterface in BCStrategy
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Changed argument type of `UrlGenerator` to `UrlGeneratorInterface` in `Shopware\Core\Content\Media\Path\Domain\Strategy\BCStrategy`
+

--- a/src/Core/Content/Media/Core/Strategy/BCStrategy.php
+++ b/src/Core/Content/Media/Core/Strategy/BCStrategy.php
@@ -7,7 +7,7 @@ use Shopware\Core\Content\Media\Core\Application\AbstractMediaPathStrategy;
 use Shopware\Core\Content\Media\Core\Params\MediaLocationStruct;
 use Shopware\Core\Content\Media\Core\Params\ThumbnailLocationStruct;
 use Shopware\Core\Content\Media\MediaEntity;
-use Shopware\Core\Content\Media\Pathname\UrlGenerator;
+use Shopware\Core\Content\Media\Pathname\UrlGeneratorInterface;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -28,7 +28,7 @@ class BCStrategy extends AbstractMediaPathStrategy
     public function __construct(
         private readonly EntityRepository $mediaRepository,
         private readonly EntityRepository $thumbnailRepository,
-        private readonly UrlGenerator $generator
+        private readonly UrlGeneratorInterface $generator
     ) {
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The BCStrategy does not allow decorated UrlGenerator:
Shopware\Core\Content\Media\Core\Strategy\BCStrategy::__construct(): Argument #3 ($generator) must be of type Shopware\Core\Content\Media\Pathname\UrlGenerator, Frosh\ThumbnailProcessor\Service\UrlGeneratorDecorator given

### 2. What does this change do, exactly?
See above

### 3. Describe each step to reproduce the issue or behaviour.
Add decorator

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8263696</samp>

This pull request introduces a new interface for generating media URLs and refactors the `BCStrategy` class to use it. This improves the code quality and allows for more flexibility and testability. The change is documented in the changelog file `2023-10-03-change-type-of-urlgenerator.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8263696</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3337/files?diff=unified&w=0#diff-78b73e2b09bcf715119493417cf6eddb8db77ed0e303985d0a1ec6ea49ce0fc9R1-R12))
*  Replace the UrlGenerator class with the UrlGeneratorInterface in the BCStrategy class ([link](https://github.com/shopware/platform/pull/3337/files?diff=unified&w=0#diff-161b0eed861ac6a1e58b71008c8ce67725a364098f73e38fb150474f41a64edaL10-R10), [link](https://github.com/shopware/platform/pull/3337/files?diff=unified&w=0#diff-161b0eed861ac6a1e58b71008c8ce67725a364098f73e38fb150474f41a64edaL31-R31))
