### PR TITLE
feat: forward wishlist instead of removing history in WishlistLocalStoragePlugin

### DIFF
--- a/changelog/_unreleased/2023-10-03-forward-wishlist-instead-of-removing-history-in-wishlist-plugin.md
+++ b/changelog/_unreleased/2023-10-03-forward-wishlist-instead-of-removing-history-in-wishlist-plugin.md
@@ -1,0 +1,11 @@
+---
+title: forward wishlist instead of removing history in WishlistLocalStoragePlugin
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Storefront
+* Changed WishlistLocalStoragePlugin to forward instead of replacing history in wishlist plugin to support using browsers history back button
+

--- a/src/Storefront/Resources/app/storefront/src/plugin/wishlist/local-wishlist.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/wishlist/local-wishlist.plugin.js
@@ -23,7 +23,7 @@ export default class WishlistLocalStoragePlugin extends BaseWishlistStoragePlugi
 
     add(productId, router) {
         if (window.useDefaultCookieConsent && !CookieStorageHelper.getItem(this.cookieEnabledName)) {
-            window.location.replace(router.afterLoginPath);
+            window.location.href = router.afterLoginPath;
 
             return;
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
It hurts UX to not do so :-)

### 2. What does this change do, exactly?
Changed `location.replace` to `location.href` in WishlistLocalStoragePlugin

### 3. Describe each step to reproduce the issue or behaviour.
#### Requirements
- do not allow wishlists cookie
- be not loggedin
#### Steps
- try adding product to wishlist (being forwarded to login)
- you don't want to login, so use history back in browser
- being somewhere, but not at the product
- leave shop annoyed
- perform tableflip

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ea4082</samp>

This pull request fixes a bug in the wishlist plugin that removed the browser history when redirecting to the login page. It changes the `local-wishlist.plugin.js` file to use `window.location.href` instead of `window.location.replace` and adds a changelog entry for the change.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9ea4082</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/platform/pull/3338/files?diff=unified&w=0#diff-0847cc918aa6def682baa1cab12adb27e6ddc60b5ff114dc9b8049e005634655R1-R11))
*  Change the `add` method of the `WishlistLocalStoragePlugin` to forward the current URL as a parameter to the login page instead of replacing the browser history ([link](https://github.com/shopware/platform/pull/3338/files?diff=unified&w=0#diff-d4343bc757cfaa3f0d078aa2489ad46a395a31fed5e5e85f0a8e685ec6fa2c61L26-R26))
