### PR TITLE
refactor: Remove AFTER statement for order_line_item table

### DIFF
--- a/changelog/_unreleased/2023-10-04-remove-after-statement-from-order_line_item-migration.md
+++ b/changelog/_unreleased/2023-10-04-remove-after-statement-from-order_line_item-migration.md
@@ -1,0 +1,9 @@
+---
+title: Remove AFTER statement from order_line_item migration
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Remove AFTER statement from order_line_item migration to improve the performance for MySQL

--- a/src/Core/Migration/V6_4/Migration1659257496OrderLineItemDownload.php
+++ b/src/Core/Migration/V6_4/Migration1659257496OrderLineItemDownload.php
@@ -26,7 +26,7 @@ class Migration1659257496OrderLineItemDownload extends MigrationStep
         if (!EntityDefinitionQueryHelper::columnExists($connection, 'order_line_item', 'states')) {
             $connection->executeStatement('
                 ALTER TABLE `order_line_item`
-                ADD COLUMN `states` JSON NULL AFTER `promotion_id`,
+                ADD COLUMN `states` JSON NULL,
                 ADD CONSTRAINT `json.order_line_item.states` CHECK (JSON_VALID(`states`))
             ');
             $connection->executeStatement('


### PR DESCRIPTION
### 1. Why is this change necessary?
The migration takes quite some time with MySQL when one has a lot of entries in the `order_line_items` table, when using MySQL. For us we patched the migration, but it may be advantageous to also have integrated it in the new versions of Shopware. In the best case it should also be backported to the 6.4 branch.

### 2. What does this change do, exactly?
Remove an `AFTER` statement from a query which takes a lot of time:
https://shopwaretherightway.com/docs/plugin/database/#expensive-migrations

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ca6a59</samp>

This pull request removes the AFTER statement from the migration that adds a `states` column to the `order_line_item` table, to improve MySQL performance. It also adds a changelog entry for this change.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9ca6a59</samp>

*  Add a changelog entry for removing the AFTER statement from the order_line_item migration ([link](https://github.com/shopware/platform/pull/3342/files?diff=unified&w=0#diff-a5582bf46aecce9b670844e10f5acc3bb987254a359df2355c1c4ffec9728706R1-R9))
*  Remove the AFTER statement from the SQL query that adds the states column to the order_line_item table in `src/Core/Migration/V6_4/Migration1659257496OrderLineItemDownload.php` ([link](https://github.com/shopware/platform/pull/3342/files?diff=unified&w=0#diff-3f5c51a0fe2d0f04323f97e31431620f41544e9c29388567348b95ce40e0752cL29-R29))
