### PR TITLE
refactor: Deprecate CartEvents

### DIFF
--- a/changelog/_unreleased/2023-10-04-deprecated-shopware-core-checkout-cart-cartevents.md
+++ b/changelog/_unreleased/2023-10-04-deprecated-shopware-core-checkout-cart-cartevents.md
@@ -1,0 +1,9 @@
+---
+title: Deprecated Shopware\Core\Checkout\Cart\CartEvents
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Deprecated Shopware\Core\Checkout\Cart\CartEvents and Shopware\Core\Checkout\Cart\CartEvents::CHECKOUT_ORDER_PLACED use Shopware\Core\Framework\Event\BusinessEvents::CHECKOUT_ORDER_PLACED

--- a/src/Core/Checkout/Cart/CartEvents.php
+++ b/src/Core/Checkout/Cart/CartEvents.php
@@ -2,13 +2,19 @@
 
 namespace Shopware\Core\Checkout\Cart;
 
+use Shopware\Core\Framework\Event\BusinessEvents;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.6.0 - will be removed without replacement
+ */
 #[Package('checkout')]
 class CartEvents
 {
     /**
+     * @deprecated tag:v6.6.0 - use `Shopware\Core\Framework\Event\BusinessEvents::CHECKOUT_ORDER_PLACED` instead
+     *
      * @Event("Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent")
      */
-    final public const CHECKOUT_ORDER_PLACED = 'checkout.order.placed';
+    final public const CHECKOUT_ORDER_PLACED = BusinessEvents::CHECKOUT_ORDER_PLACED;
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
It is confusing to have the same constants at several places.

### 2. What does this change do, exactly?
Unify the constants and use the one which are more commonly used (in my opinion). Also the class which contains the event is not really needed anymore afterwards.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 75cf1ef</samp>

This pull request deprecates the `CartEvents` class and the `CHECKOUT_ORDER_PLACED` constant in the `Shopware\Core\Checkout\Cart` namespace and replaces them with the new `BusinessEvents::CHECKOUT_ORDER_PLACED` constant in the `Shopware\Core\Framework\Event` namespace. This is part of a refactoring of the event system to use business events instead of cart events.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 75cf1ef</samp>

*  Deprecate `CartEvents` class and `CHECKOUT_ORDER_PLACED` constant ([link](https://github.com/shopware/platform/pull/3343/files?diff=unified&w=0#diff-c7b04e33eff7629de6a13e950eddfddfe3d361f57fb0f23dee52c85e125de61bL5-R19), )
* Add changelog entry for deprecation ([link](https://github.com/shopware/platform/pull/3343/files?diff=unified&w=0#diff-b294c62890810ad8f81490af7101dc74c2c72a8f79e45198d3a9f06e853e4141R1-R9))
