### PR TITLE
bugfix: prevent urls duplications in redis tags

### DIFF
--- a/changelog/_unreleased/2023-10-05-prevent-url-duplication-in-redis-tags.md
+++ b/changelog/_unreleased/2023-10-05-prevent-url-duplication-in-redis-tags.md
@@ -1,0 +1,12 @@
+---
+title: Change type to UrlGeneratorInterface in BCStrategy
+issue: NEXT-0000
+author: bodzix
+author_email: bj@bodzix.pl
+author_github: bodzix
+---
+
+# Storefront
+
+* Removing all occurrences of a given url before adding a new url to the tag in `Shopware\Storefront\Framework\Cache\ReverseProxy\ReverseProxyCache`
+

--- a/src/Storefront/Framework/Cache/ReverseProxy/RedisReverseProxyGateway.php
+++ b/src/Storefront/Framework/Cache/ReverseProxy/RedisReverseProxyGateway.php
@@ -57,6 +57,8 @@ LUA;
     public function tag(array $tags, string $url, Response $response): void
     {
         foreach ($tags as $tag) {
+            // To avoid duplicates of the same url inside one tag
+            $this->redis->lRem($tag, $url, 1);
             $this->redis->lPush($tag, $url); // @phpstan-ignore-line - because multiple redis implementations phpstan doesn't like this
         }
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When a shop has a lot of products, RedisStorage begins to encounter significant problems with duplicated entries in tags. For example, when both Product A and Product B are visible on the homepage, the tagging mechanism adds the URL '/' for each product to the same tag, resulting in duplication.

Another crucial reason why this is important is that Varnish does not work when a user is logged in or the cart is not empty. However, tagging still functions, leading to the addition of new duplicated URLs to the list. After a few hours, the Redis storage exceeds its memory limit.

### 2. What does this change do, exactly?
The solution is simple: Remove duplicates from the tag before adding a new one. This approach costs less than checking if the URL already exists on the list in Redis.

### 3. Describe each step to reproduce the issue or behaviour.
1. Preprare Shopware setup with Reverse HTTP Cache with Redis
2. Observe redis call with MONITOR e.g `redis-cli MONITOR  | grep -E "REM|PUSH"`
3. Open homepage and add something to the cart
4. Refresh the page a few times; you will notice many LPUSH operations adding "/" to the same tags, causing duplicates.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95e0e50</samp>

This pull request fixes a bug in the `RedisReverseProxyGateway` class that could cause url duplication in redis tags. This improves the cache invalidation logic and performance for the `Storefront` change type.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 95e0e50</samp>

*  Prevent url duplication in redis tags for cache invalidation ([link](https://github.com/shopware/platform/pull/3346/files?diff=unified&w=0#diff-ffe74acbfa50fcf4eb5827eb947c07bc2eb439277939152d3a84442dd71eb4c5R1-R12))
   * Modify `tag` method in `RedisReverseProxyGateway` class ([link](https://github.com/shopware/platform/pull/3346/files?diff=unified&w=0#diff-4ff3427ecddaf987313bda6e474a58f7af03c401771f9f75b62e6fb73a47d35bR60-R61))
