### PR TITLE
NEXT-25671 - Fixed setting of custom field number type

### DIFF
--- a/changelog/_unreleased/2023-10-13-fixed-setting-of-custom-field-number-type.md
+++ b/changelog/_unreleased/2023-10-13-fixed-setting-of-custom-field-number-type.md
@@ -1,0 +1,9 @@
+---
+title: Fixed setting of custom field number type
+issue: NEXT-25671
+author: Alexander Pankow
+author_email: alexander.pankow@blackpoint.de
+author_github: LiaraAlis
+---
+# Administration
+* Changed order of properties when merging custom field config in `sw-custom-field-detail` component.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-detail/index.js
@@ -199,8 +199,8 @@ export default {
             }
 
             this.currentCustomField.config = {
-                ...this.currentCustomField.config,
                 ...this.fieldTypes[customFieldType].config,
+                ...this.currentCustomField.config,
             };
         },
 


### PR DESCRIPTION
Fixed [NEXT-25671](https://issues.shopware.com/issues/NEXT-25671) by switching order of parameters when merging custom field config in `applyTypeConfiguration()`. This prevents overriding values set by user with default values.

Before building js and completing the tasks below, I want to discuss if this change can cause some unwanted side effects. I've tested multiple types and was not able to find any problems. With my change it was possible to create a custom field of type number with integer type. If that is okay, I can commit changes with the built js and created changelog file.

What do you think?

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


[NEXT-25671]: https://shopware.atlassian.net/browse/NEXT-25671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ