### PR TITLE
feat: correct class AbstractMediaUrlGenerator to namespace Shopware\Core\Content\Media\Core\Application\

### DIFF
--- a/changelog/_unreleased/2023-08-14-media-path-storage.md
+++ b/changelog/_unreleased/2023-08-14-media-path-storage.md
@@ -154,7 +154,7 @@ class ForwardCompatible
 ### Path strategies
 Beside the url generator change, we also had to change the media path strategy. The strategies are no longer working with a `MediaEntity`. They are now working with a `MediaFile` object. This object is a simple struct, which contains the path and the updated at timestamp. The path is the same as the one stored in the database. The updated at timestamp is the timestamp, when the path was generated. This is important for the cache invalidation. The `MediaFile` object is also used for the thumbnail generation. The thumbnail generation is now also working with a `MediaLocation` object instead.
 
-As foundation, we use `\Shopware\Core\Content\Media\Domain\Path\AbstractMediaPathStrategy` as base class and dependency injection service id:
+As foundation, we use `\Shopware\Core\Content\Media\Core\Application\AbstractMediaPathStrategy` as base class and dependency injection service id:
 
 ```php
 <?php

--- a/changelog/_unreleased/2023-10-06-correct-namespace-of-abstractmediaurlgenerator.md
+++ b/changelog/_unreleased/2023-10-06-correct-namespace-of-abstractmediaurlgenerator.md
@@ -1,0 +1,11 @@
+---
+title: Correct namespace of AbstractMediaUrlGenerator
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Changed namespace of `AbstractMediaUrlGenerator` from `Shopware\Core\Content\Media\Domain\Path` to `Shopware\Core\Content\Media\UrlGenerator\AbstractMediaUrlGenerator` in several places

--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -118,7 +118,7 @@
             <argument type="service" id="shopware.filesystem.private"/>
             <argument type="service" id="Shopware\Core\Content\Media\MediaService"/>
             <argument>%shopware.filesystem.private_local_download_strategy%</argument>
-            <argument type="service" id="Shopware\Core\Content\Media\Domain\Path\AbstractMediaUrlGenerator"/>
+            <argument type="service" id="Shopware\Core\Content\Media\Core\Application\AbstractMediaUrlGenerator"/>
         </service>
 
         <!-- Commands -->

--- a/src/Core/Content/DependencyInjection/media_path.xml
+++ b/src/Core/Content/DependencyInjection/media_path.xml
@@ -6,7 +6,7 @@
 
     <services>
         <service id="Shopware\Core\Content\Media\Core\Application\MediaUrlLoader">
-            <argument type="service" id="Shopware\Core\Content\Media\Domain\Path\AbstractMediaUrlGenerator"/>
+            <argument type="service" id="Shopware\Core\Content\Media\Core\Application\AbstractMediaUrlGenerator"/>
             <argument type="service" id="Shopware\Core\Content\Media\Pathname\UrlGeneratorInterface" />
 
             <!-- trigger "new" media path handling and url generation -->
@@ -63,7 +63,7 @@
             <tag name="shopware.path.strategy" />
         </service>
 
-        <service id="Shopware\Core\Content\Media\Domain\Path\AbstractMediaUrlGenerator" class="Shopware\Core\Content\Media\Infrastructure\Path\MediaUrlGenerator">
+        <service id="Shopware\Core\Content\Media\Core\Application\AbstractMediaUrlGenerator" class="Shopware\Core\Content\Media\Infrastructure\Path\MediaUrlGenerator">
             <argument type="service" id="shopware.filesystem.public"/>
         </service>
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The service registration is in the wrong class

### 2. What does this change do, exactly?
Use the correct namespace as file is announced: https://github.com/shopware/platform/blob/trunk/src/Core/Content/Media/Core/Application/AbstractMediaUrlGenerator.php#L3

### 3. Describe each step to reproduce the issue or behaviour.
get the service through container 💥 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c20a00c</samp>

The pull request fixes the namespaces of some media-related classes that were moved to a different layer, and updates the dependency injection and changelog files accordingly. This improves the consistency and correctness of the media URL generation and download functionality.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c20a00c</samp>

*  Corrected the namespace of the `AbstractMediaUrlGenerator` class and its subclasses from `Domain` to `Core\Application` ([link](https://github.com/shopware/platform/pull/3348/files?diff=unified&w=0#diff-0eb78c8858ce9a5fe9bcfe06e3fd138db253af7ee7a4dae9e6fe0c6d9135bf5fR1-R11), [link](https://github.com/shopware/platform/pull/3348/files?diff=unified&w=0#diff-a3ddbeb578f43b8fa8fe9951e2379f89d7c873fb7aa31c1cd7fb5c3f85aacf43L9-R9), [link](https://github.com/shopware/platform/pull/3348/files?diff=unified&w=0#diff-a3ddbeb578f43b8fa8fe9951e2379f89d7c873fb7aa31c1cd7fb5c3f85aacf43L66-R66), [link](https://github.com/shopware/platform/pull/3348/files?diff=unified&w=0#diff-c00a7475b5c48f48531ffb5ed144803f4fa59b41ea73d0566dc4c1f87ea2d23cL121-R121))
* Updated the changelog entry for the media path storage feature to use the new namespace of the `AbstractMediaPathStrategy` class ([link](https://github.com/shopware/platform/pull/3348/files?diff=unified&w=0#diff-c6b80b549a1aaabe7a83622627a4bdebc3a2cef40dc7ff436b780d01b46331d3L157-R157))
* Added a new changelog entry for the namespace correction of the `AbstractMediaUrlGenerator` class ([link](https://github.com/shopware/platform/pull/3348/files?diff=unified&w=0#diff-0eb78c8858ce9a5fe9bcfe06e3fd138db253af7ee7a4dae9e6fe0c6d9135bf5fR1-R11))
