### PR TITLE
NEXT-29904 - Fix Change sorting of availability for best variant calculation

### DIFF
--- a/changelog/_unreleased/2023-10-10-bugfix-find-best-variant-set-available-sorting-to-desc.md
+++ b/changelog/_unreleased/2023-10-10-bugfix-find-best-variant-set-available-sorting-to-desc.md
@@ -1,0 +1,8 @@
+---
+title: Fix find best variant sorting
+issue: NEXT-XXX
+author: Alexander Kludt
+author_email: coding@aggrosoft.de
+---
+# Core
+* Changed `\Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute` to use ascending sorting on product.available field, makes sure to get an available variant as best variant

--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -142,7 +142,7 @@ class ProductDetailRoute extends AbstractProductDetailRoute
         $criteria = (new Criteria())
             ->addFilter(new EqualsFilter('product.parentId', $productId))
             ->addSorting(new FieldSorting('product.price'))
-            ->addSorting(new FieldSorting('product.available'))
+            ->addSorting(new FieldSorting('product.available', FieldSorting::DESCENDING))
             ->setLimit(1);
 
         $criteria->setTitle('product-detail-route::find-best-variant');

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/ProductDetailRouteTest.php
@@ -110,6 +110,7 @@ class ProductDetailRouteTest extends TestCase
         $productEntity = new SalesChannelProductEntity();
         $productEntity->setCmsPageId('4');
         $productEntity->setId($this->idsCollection->create('product1'));
+        $productEntity->setAvailable(true);
         $productEntity->setUniqueIdentifier('BestVariant');
 
         $idsSearchResult = new IdSearchResult(
@@ -139,6 +140,7 @@ class ProductDetailRouteTest extends TestCase
         static::assertInstanceOf(ProductDetailRouteResponse::class, $result);
         static::assertEquals(4, $result->getProduct()->getCmsPageId());
         static::assertEquals('BestVariant', $result->getProduct()->getUniqueIdentifier());
+        static::assertTrue($result->getProduct()->getAvailable());
     }
 
     public function testConfigHideCloseoutProductsWhenOutOfStockFiltersResults(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

On the storefront product detail page, the cheapest NOT AVAILABLE variant is preselected (and not the cheapest available), if there is no variant in the admin storefront presentation is defined.

### 2. What does this change do, exactly?

Change the sorting of availability from ASC to DESC for best variant calculation

### 3. Describe each step to reproduce the issue or behaviour.

- One product with variants and one not available variant (with cheapest price).
- Select "main product" in the storefront presentation and clear "main variant" selection
- open the product detail page in the storefront: The not available variant with the cheapest price is preselected.

### 4. Please link to the relevant issues (if any).

#2925 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d36dee1</samp>

This pull request fixes a bug that displayed unavailable product variants in the product detail route. It changes the `ProductDetailRoute` class, the `ProductDetailRouteTest` class, and adds a changelog entry.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d36dee1</samp>

*  Add a changelog entry for the bugfix ([link](https://github.com/shopware/shopware/pull/3352/files?diff=unified&w=0#diff-1a6417071f2a137ebad33bf609db6de9eb1f73b3eb108c5f6ccd22435a7fe250R1-R8))
*  Change the sorting criteria for finding the best variant of a product, by setting the `product.available` field to descending order in `ProductDetailRoute.php` ([link](https://github.com/shopware/shopware/pull/3352/files?diff=unified&w=0#diff-cb9fa9dfc8f95fb7c43a2fb8ff60c815b8793ebe857fafcc3820421b4841291eL145-R145))
*  Update the test case in `ProductDetailRouteTest.php` to simulate a product with an available variant and assert that the product returned by the route is also available ([link](https://github.com/shopware/shopware/pull/3352/files?diff=unified&w=0#diff-bf303ca4ae341d36ddc6ba68c4d605eed2e23486793827589017dac31f1ef2ecR113), [link](https://github.com/shopware/shopware/pull/3352/files?diff=unified&w=0#diff-bf303ca4ae341d36ddc6ba68c4d605eed2e23486793827589017dac31f1ef2ecR143))
