### PR TITLE
Fix check for existence of export directory in ProductExportFileHandler

### DIFF
--- a/src/Core/Content/ProductExport/Service/ProductExportFileHandler.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportFileHandler.php
@@ -22,8 +22,6 @@ class ProductExportFileHandler implements ProductExportFileHandlerInterface
 
     public function getFilePath(ProductExportEntity $productExport, bool $partialGeneration = false): string
     {
-        $this->ensureDirectoryExists();
-
         $filePath = sprintf(
             '%s/%s',
             $this->exportDirectory,
@@ -96,12 +94,5 @@ class ProductExportFileHandler implements ProductExportFileHandlerInterface
         $expireTimestamp = $productExport->getGeneratedAt()->getTimestamp() + $productExport->getInterval();
 
         return (new \DateTime())->getTimestamp() > $expireTimestamp;
-    }
-
-    private function ensureDirectoryExists(): void
-    {
-        if (!$this->fileSystem->directoryExists($this->exportDirectory)) {
-            $this->fileSystem->createDirectory($this->exportDirectory);
-        }
     }
 }

--- a/src/Core/Content/ProductExport/Service/ProductExportFileHandler.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportFileHandler.php
@@ -100,7 +100,7 @@ class ProductExportFileHandler implements ProductExportFileHandlerInterface
 
     private function ensureDirectoryExists(): void
     {
-        if (!$this->fileSystem->fileExists($this->exportDirectory)) {
+        if (!$this->fileSystem->directoryExists($this->exportDirectory)) {
             $this->fileSystem->createDirectory($this->exportDirectory);
         }
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
For using the Google Bucket adapte and product export

### 2. What does this change do, exactly?
Fixes the problem with exceeded rate limit for object mutation operations on bucket directory object

### 3. Describe each step to reproduce the issue or behaviour.
Config filesystem private to use Google Bucket adapter
Have multiple consumer pods that are consuming message queue
Go to Admin Import/Export -> Select Export tab -> Select a profile then run Export

### 4. Please link to the relevant issues (if any).
[#3357](https://github.com/shopware/shopware/issues/3357)

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddddcb9</samp>

Fix product export directory creation and other issues. The pull request corrects a bug in the `ProductExportFileHandler` class that caused an error when the export directory was a file, and also addresses other problems with the product export feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ddddcb9</samp>

* Fix incorrect method call to check export directory existence ([link](https://github.com/shopware/shopware/pull/3358/files?diff=unified&w=0#diff-ce7b485f9fc07b2360e9d633e09f40540ca50af1b13f2598b75651ba0b1db8baL103-R103))
