### PR TITLE
NEXT-31423 - Prevent sorting of original data

### DIFF
--- a/changelog/_unreleased/2023-10-12-fix-unsubscribe-name
+++ b/changelog/_unreleased/2023-10-12-fix-unsubscribe-name
@@ -1,6 +1,6 @@
 ---
 title: Fix unsubscribe name
-issue: NEXT-29662
+issue: NEXT-00000
 author: Tommy Quissens
 author_email: tommy.quissens@meteor.be
 author_github: @quisse

--- a/changelog/_unreleased/2023-10-12-fix-unsubscribe-name
+++ b/changelog/_unreleased/2023-10-12-fix-unsubscribe-name
@@ -1,0 +1,9 @@
+---
+title: Fix unsubscribe name
+issue: NEXT-29662
+author: Tommy Quissens
+author_email: tommy.quissens@meteor.be
+author_github: @quisse
+---
+# Storefront
+* The javascript `sort()` function sorts it's array, which prevent unsubscribing of events to an element since the name at key `0` is sorted.

--- a/changelog/_unreleased/2023-10-12-fix-unsubscribe-name
+++ b/changelog/_unreleased/2023-10-12-fix-unsubscribe-name
@@ -1,6 +1,6 @@
 ---
 title: Fix unsubscribe name
-issue: NEXT-00000
+issue: NEXT-31423
 author: Tommy Quissens
 author_email: tommy.quissens@meteor.be
 author_github: @quisse

--- a/src/Storefront/Resources/app/storefront/src/helper/emitter.helper.js
+++ b/src/Storefront/Resources/app/storefront/src/helper/emitter.helper.js
@@ -100,7 +100,7 @@ export default class NativeEventEmitter {
     unsubscribe(eventName) {
         const splitEventName = eventName.split('.');
         this.listeners = this.listeners.reduce((accumulator, listener) => {
-            const foundEvent = listener.splitEventName.sort().toString() === splitEventName.sort().toString();
+            const foundEvent = [...listener.splitEventName].sort().toString() === splitEventName.sort().toString();
 
             if (foundEvent) {
                 this.el.removeEventListener(listener.splitEventName[0], listener.cb);

--- a/src/Storefront/Resources/app/storefront/test/helper/emitter.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/emitter.helper.test.js
@@ -116,6 +116,12 @@ describe('NativeEventEmitter tests', () => {
             expect(emitter.listeners.length).toBe(2);
             emitter.unsubscribe(`${eventName}.test`);
             expect(emitter.listeners.length).toBe(1);
+
+            // sort will order uppercase characters before lowercase
+            // this tests if the sort isn't changing the splitEventName
+            expect(emitter.listeners.length).toBe(2);
+            emitter.unsubscribe(`${eventName}.Test`);
+            expect(emitter.listeners.length).toBe(1);
         });
     });
 

--- a/src/Storefront/Resources/app/storefront/test/helper/emitter.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/emitter.helper.test.js
@@ -106,15 +106,15 @@ describe('NativeEventEmitter tests', () => {
             const noop = jest.mock();
             const eventName = 'foo';
 
-            emitter.subscribe(`${eventName}.test`, (event) => {
+            // sort will order uppercase characters before lowercase
+            // this tests if the sort isn't changing the splitEventName
+            emitter.subscribe(`${eventName}.Test`, (event) => {
                 expect(event.type).toBe(eventName);
                 done();
             });
             emitter.subscribe(eventName, noop);
             emitter.publish(eventName);
 
-            // sort will order uppercase characters before lowercase
-            // this tests if the sort isn't changing the splitEventName
             expect(emitter.listeners.length).toBe(2);
             emitter.unsubscribe(`${eventName}.Test`);
             expect(emitter.listeners.length).toBe(1);

--- a/src/Storefront/Resources/app/storefront/test/helper/emitter.helper.test.js
+++ b/src/Storefront/Resources/app/storefront/test/helper/emitter.helper.test.js
@@ -113,10 +113,6 @@ describe('NativeEventEmitter tests', () => {
             emitter.subscribe(eventName, noop);
             emitter.publish(eventName);
 
-            expect(emitter.listeners.length).toBe(2);
-            emitter.unsubscribe(`${eventName}.test`);
-            expect(emitter.listeners.length).toBe(1);
-
             // sort will order uppercase characters before lowercase
             // this tests if the sort isn't changing the splitEventName
             expect(emitter.listeners.length).toBe(2);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The javascript `sort()` function sorts it's array, which prevent unsubscribing of events to an element since the name at key `0` is sorted.

### 2. What does this change do, exactly?
Make sure the source doesn't get sorted.

### 3. Describe each step to reproduce the issue or behaviour.
Try to unsubscribe an event

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc81220</samp>

This pull request fixes a bug in the `Emitter` class that prevented unsubscribing from event listeners with mixed case names. It also adds a test case to ensure the bug is resolved and prevent regressions.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc81220</samp>

* Fix a bug in the `unsubscribe` method of the `Emitter` class that caused incorrect removal of event listeners ([link](https://github.com/shopware/shopware/pull/3360/files?diff=unified&w=0#diff-2cd4efab8283de2d6c67b55ccf9a32a3c06abdba8249a543b68daf6a3f19f4c9L103-R103))
* Add a test case to verify the bug fix in the `unsubscribe` method of the `Emitter` class ([link](https://github.com/shopware/shopware/pull/3360/files?diff=unified&w=0#diff-53c74f19afa0e58c872f9f73f317cc4ba94c1c748191a754c6c7c216e4d1d0ccR119-R124))
