### PR TITLE
NEXT-31615 - fix language mapping in SalesChannelValidator

### DIFF
--- a/changelog/_unreleased/2023-10-13-fix-sales_channel_language_validator.md
+++ b/changelog/_unreleased/2023-10-13-fix-sales_channel_language_validator.md
@@ -1,0 +1,9 @@
+---
+title: Fix salesChannel language validator
+issue: NEXT-19596
+author: Sascha Heilmeier
+author_email: sascha.heilmeier@netlogix.de
+author_github: @scarbous
+---
+# API
+* Fix the validation of the SalesChannel to avoid errors when updating the sales channels.

--- a/changelog/_unreleased/2023-10-13-fix-sales_channel_language_validator.md
+++ b/changelog/_unreleased/2023-10-13-fix-sales_channel_language_validator.md
@@ -6,4 +6,4 @@ author_email: sascha.heilmeier@netlogix.de
 author_github: @scarbous
 ---
 # API
-* Fix the validation of the SalesChannel to avoid errors when updating the sales channels.
+* Changed the validation of the SalesChannel to avoid errors when updating the sales channels.

--- a/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
+++ b/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
@@ -382,9 +382,12 @@ class SalesChannelValidator implements EventSubscriberInterface
             $mapping[$id]['current_default'] = $record['current_default'];
             $mapping[$id]['state'][] = $record['language_id'];
             $mapping[$id]['inserts'] = array_filter(
-                $mapping[$id]['inserts'],
-                fn ($value) => $value == $record['language_id']
+                $mapping[$id]['inserts'] ?? [],
+                fn ($value) => $value != $record['language_id']
             );
+            if(empty($mapping[$id]['inserts'])){
+                unset($mapping[$id]['inserts']);
+            }
         }
 
         return $mapping;

--- a/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
+++ b/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
@@ -381,6 +381,10 @@ class SalesChannelValidator implements EventSubscriberInterface
             $id = (string) $record['sales_channel_id'];
             $mapping[$id]['current_default'] = $record['current_default'];
             $mapping[$id]['state'][] = $record['language_id'];
+            $mapping[$id]['inserts'] = array_filter(
+                $mapping[$id]['inserts'],
+                fn ($value) => $value == $record['language_id']
+            );
         }
 
         return $mapping;

--- a/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
+++ b/src/Core/System/SalesChannel/Validation/SalesChannelValidator.php
@@ -383,9 +383,9 @@ class SalesChannelValidator implements EventSubscriberInterface
             $mapping[$id]['state'][] = $record['language_id'];
             $mapping[$id]['inserts'] = array_filter(
                 $mapping[$id]['inserts'] ?? [],
-                fn ($value) => $value != $record['language_id']
+                fn ($value) => $value !== $record['language_id']
             );
-            if(empty($mapping[$id]['inserts'])){
+            if (empty($mapping[$id]['inserts'])) {
                 unset($mapping[$id]['inserts']);
             }
         }

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -269,6 +269,20 @@ class SalesChannelValidatorTest extends TestCase
             [],
             [$id1, $id2],
         ];
+
+        yield 'Update default language id and multiple languages in same time' => [
+            [
+                [
+                    'id' => $id1,
+                    'languageId' => 'de-DE',
+                    'languages' => [
+                        [ 'id' => 'de-DE' ],
+                        [ 'id' => Defaults::LANGUAGE_SYSTEM ]],
+                ],
+            ],
+            [],
+            [$id1, $id2],
+        ];
     }
 
     public function testPreventDeletionOfDefaultLanguageId(): void

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -318,35 +318,6 @@ class SalesChannelValidatorTest extends TestCase
         static::assertCount(0, $result);
     }
 
-    public function testInsertSalesChannelLanguageWhichAlreadyExist(): void
-    {
-        $id = Uuid::randomHex();
-
-        $salesChannelData = $this
-            ->getSalesChannelData($id, Defaults::LANGUAGE_SYSTEM, [Defaults::LANGUAGE_SYSTEM]);
-
-        $context = Context::createDefaultContext();
-
-        $this->getSalesChannelRepository()
-            ->create([$salesChannelData], $context);
-
-        static::expectException(WriteException::class);
-        static::expectExceptionMessage(sprintf(
-            self::DUPLICATED_ENTRY_VALIDATION_MESSAGE,
-            Defaults::LANGUAGE_SYSTEM,
-            $id
-        ));
-
-        $this->getSalesChannelLanguageRepository()->create([[
-            'salesChannelId' => $id,
-            'languageId' => Defaults::LANGUAGE_SYSTEM,
-        ]], $context);
-
-        $this->getSalesChannelRepository()->delete([[
-            'id' => $id,
-        ]], Context::createDefaultContext());
-    }
-
     public function testOnlyStorefrontAndHeadlessSalesChannelsWillBeSupported(): void
     {
         $id = Uuid::randomHex();

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -276,8 +276,8 @@ class SalesChannelValidatorTest extends TestCase
                     'id' => $id1,
                     'languageId' => 'de-DE',
                     'languages' => [
-                         ['id' => 'de-DE'],
-                         ['id' => Defaults::LANGUAGE_SYSTEM]],
+                        ['id' => 'de-DE'],
+                        ['id' => Defaults::LANGUAGE_SYSTEM]],
                 ],
             ],
             [],

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -318,6 +318,35 @@ class SalesChannelValidatorTest extends TestCase
         static::assertCount(0, $result);
     }
 
+    public function testInsertSalesChannelLanguageWhichAlreadyExist(): void
+    {
+        $id = Uuid::randomHex();
+
+        $salesChannelData = $this
+            ->getSalesChannelData($id, Defaults::LANGUAGE_SYSTEM, [Defaults::LANGUAGE_SYSTEM]);
+
+        $context = Context::createDefaultContext();
+
+        $this->getSalesChannelRepository()
+            ->create([$salesChannelData], $context);
+
+        static::expectException(WriteException::class);
+        static::expectExceptionMessage(sprintf(
+            self::DUPLICATED_ENTRY_VALIDATION_MESSAGE,
+            Defaults::LANGUAGE_SYSTEM,
+            $id
+        ));
+
+        $this->getSalesChannelLanguageRepository()->create([[
+            'salesChannelId' => $id,
+            'languageId' => Defaults::LANGUAGE_SYSTEM,
+        ]], $context);
+
+        $this->getSalesChannelRepository()->delete([[
+            'id' => $id,
+        ]], Context::createDefaultContext());
+    }
+
     public function testOnlyStorefrontAndHeadlessSalesChannelsWillBeSupported(): void
     {
         $id = Uuid::randomHex();

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -277,7 +277,8 @@ class SalesChannelValidatorTest extends TestCase
                     'languageId' => 'de-DE',
                     'languages' => [
                         ['id' => 'de-DE'],
-                        ['id' => Defaults::LANGUAGE_SYSTEM]],
+                        ['id' => Defaults::LANGUAGE_SYSTEM],
+                    ],
                 ],
             ],
             [],
@@ -330,17 +331,17 @@ class SalesChannelValidatorTest extends TestCase
         $this->getSalesChannelRepository()
             ->create([$salesChannelData], $context);
 
-        static::expectException(WriteException::class);
-        static::expectExceptionMessage(sprintf(
-            self::DUPLICATED_ENTRY_VALIDATION_MESSAGE,
-            Defaults::LANGUAGE_SYSTEM,
-            $id
-        ));
+        $exception = null;
 
-        $this->getSalesChannelLanguageRepository()->create([[
-            'salesChannelId' => $id,
-            'languageId' => Defaults::LANGUAGE_SYSTEM,
-        ]], $context);
+        try {
+            $this->getSalesChannelLanguageRepository()->create([[
+                'salesChannelId' => $id,
+                'languageId' => Defaults::LANGUAGE_SYSTEM,
+            ]], $context);
+        } catch (\Exception $exception) {
+        }
+
+        static::assertNull($exception);
 
         $this->getSalesChannelRepository()->delete([[
             'id' => $id,

--- a/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
+++ b/tests/integration/Core/System/SalesChannel/Validation/SalesChannelValidatorTest.php
@@ -276,8 +276,8 @@ class SalesChannelValidatorTest extends TestCase
                     'id' => $id1,
                     'languageId' => 'de-DE',
                     'languages' => [
-                        [ 'id' => 'de-DE' ],
-                        [ 'id' => Defaults::LANGUAGE_SYSTEM ]],
+                         ['id' => 'de-DE'],
+                         ['id' => Defaults::LANGUAGE_SYSTEM]],
                 ],
             ],
             [],


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

it solves the problem described in NEXT-19596 - #3363

### 2. What does this change do, exactly?

When a SalesChannel get updated, it remove inserts which are already set.

### 3. Describe each step to reproduce the issue or behaviour.

The issue is described in #3363

### 4. Please link to the relevant issues (if any).

* #3363
* NEXT-19596

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 104a454</samp>

This pull request fixes a bug in the `SalesChannelValidator` that caused errors when updating sales channels with different languages. It also adds a changelog entry for the fix in `changelog/_unreleased/2023-10-13-fix-sales_channel_language_validator.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 104a454</samp>

*  Add a changelog entry for the fix ([link](https://github.com/shopware/shopware/pull/3365/files?diff=unified&w=0#diff-6eea13b51d904d7aa6213cc11eda24a0660d8b9d93ac0f2653e0d4b521a1a7e9R1-R9))
*  Filter out inserts that do not match the language id of the record in `SalesChannelValidator` ([link](https://github.com/shopware/shopware/pull/3365/files?diff=unified&w=0#diff-cb4d3f9cba3a63a3e144b7f69a303304f9d8020f1d5895d73b5c0563e6023840R384-R387))
