### PR TITLE
NEXT-31086 - Skip creation of category links in SeoUrlGenerator (Revert NEXT-10719)

### DIFF
--- a/changelog/_unreleased/2023-10-13-fix-seo-url-criteria-for-category.md
+++ b/changelog/_unreleased/2023-10-13-fix-seo-url-criteria-for-category.md
@@ -1,0 +1,9 @@
+---
+title: fix seo url criteria for category
+issue: NEXT-0000
+author: Jeff Böhm
+author_email: 3028277+jeboehm@users.noreply.github.com
+author_github: jeboehm
+---
+# Storefront
+* Changed `Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute::prepareCriteria()` to filter categories of type `CategoryDefinition::TYPE_FOLDER` and type `CategoryDefinition::TYPE_LINK`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11411,6 +11411,11 @@ parameters:
 			path: tests/unit/Storefront/Framework/Routing/StorefrontResponseTest.php
 
 		-
+			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Shopware\\\\\\\\Core\\\\\\\\Framework\\\\\\\\DataAbstractionLayer\\\\\\\\Search\\\\\\\\Filter\\\\\\\\EqualsFilter' and Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Filter\\\\EqualsFilter will always evaluate to true\\.$#"
+			count: 1
+			path: tests/unit/php/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
+
+		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array will always evaluate to true\\.$#"
 			count: 1
 			path: tests/unit/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRouteTest.php

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
@@ -43,14 +43,13 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
 
     public function prepareCriteria(Criteria $criteria, SalesChannelEntity $salesChannel): void
     {
-        $criteria->addFilter(new NotFilter(MultiFilter::CONNECTION_OR, [
-            new EqualsFilter('type', CategoryDefinition::TYPE_FOLDER),
-            new EqualsFilter('linkType', CategoryDefinition::LINK_TYPE_EXTERNAL),
-        ]));
-
-        $criteria->addFilter(
+        $criteria->addFilter(new MultiFilter(MultiFilter::CONNECTION_AND, [
             new EqualsFilter('active', true),
-        );
+            new NotFilter(NotFilter::CONNECTION_OR, [
+                new EqualsFilter('type', CategoryDefinition::TYPE_FOLDER),
+                new EqualsFilter('type', CategoryDefinition::TYPE_LINK),
+            ]),
+        ]));
     }
 
     public function getMapping(Entity $category, ?SalesChannelEntity $salesChannel): SeoUrlMapping

--- a/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
+++ b/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
@@ -34,29 +34,34 @@ class NavigationPageSeoUrlRouteTest extends TestCase
         $navigationPageSeoUrlRoute->prepareCriteria($criteria, $salesChannel);
 
         $filters = $criteria->getFilters();
-        static::assertCount(2, $filters);
+        /** @var MultiFilter $multiFilter */
+        $multiFilter = $filters[0];
+        static::assertInstanceOf(MultiFilter::class, $multiFilter);
+        static::assertEquals('AND', $multiFilter->getOperator());
+        $multiFilterQueries = $multiFilter->getQueries();
 
-        $notFilter = $filters[0];
+        static::assertCount(2, $multiFilterQueries);
+        static::assertInstanceOf(EqualsFilter::class, $multiFilterQueries[0]);
+        $this->assertEqualsFilter(
+            $multiFilterQueries[0],
+            'active',
+            true
+        );
+
+        $notFilter = $multiFilterQueries[1];
         static::assertInstanceOf(NotFilter::class, $notFilter);
-
-        static::assertEquals(MultiFilter::CONNECTION_OR, $notFilter->getOperator());
+        static::assertEquals('OR', $notFilter->getOperator());
 
         $notFilterQueries = $notFilter->getQueries();
         static::assertCount(2, $notFilterQueries);
+    }
 
-        $equalsFilter = $notFilterQueries[0];
-        static::assertInstanceOf(EqualsFilter::class, $equalsFilter);
-        static::assertEquals('type', $equalsFilter->getField());
-        static::assertEquals(CategoryDefinition::TYPE_FOLDER, $equalsFilter->getValue());
-
-        $equalsFilter2 = $notFilterQueries[1];
-        static::assertInstanceOf(EqualsFilter::class, $equalsFilter2);
-        static::assertEquals('linkType', $equalsFilter2->getField());
-        static::assertEquals(CategoryDefinition::LINK_TYPE_EXTERNAL, $equalsFilter2->getValue());
-
-        $equalsFilterActive = $filters[1];
-        static::assertInstanceOf(EqualsFilter::class, $equalsFilterActive);
-        static::assertEquals('active', $equalsFilterActive->getField());
-        static::assertTrue($equalsFilterActive->getValue());
+    private function assertEqualsFilter(
+        EqualsFilter $equalsFilter,
+        string $field,
+        string|bool $value
+    ): void {
+        static::assertEquals($field, $equalsFilter->getField());
+        static::assertEquals($value, $equalsFilter->getValue());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
This basically reverts commit https://github.com/shopware/shopware/commit/5806fcf096284db38a9e8061e43ace4c5169ee21.
The change that is reverted here aimed to exclude categories that are marked as external link.
External links were already excluded before the commit. So it actually didn't change the behavior for external links but at this time it included internal links that can lead to missing seo_url entries, as explained below.
Internal links are resolved to the linked entity in \Shopware\Core\Content\Category\Service\CategoryUrlGenerator::generate anyway.

### 2. What does this change do, exactly?
Restore previous behavior.
- External links are still ignored
- Internal links are ignored as before

### 3. Describe each step to reproduce the issue or behaviour.
When you build the same navigation tree twice, for example
- Headernavigation -> MyFolderA (Folder) -> MyPageA (page)
- Footernavigation -> MyFolderA (Folder) -> MyPageA (link, internal to MyPageA)

the unique index on seo_path will replace the actual seo_url for the true category page. The header navigation won't use the seo_url for MyPageA. The footer navigation won't have a seo_url for the link either.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/commit/5806fcf096284db38a9e8061e43ace4c5169ee21

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
