### PR TITLE
feat: category content overwrite indicator

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.html.twig
@@ -37,6 +37,8 @@
             :style="sliderStyle"
         ></span>
         {% endblock %}
+
+        <slot name="additional" />
     </div>
     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.html.twig
@@ -38,7 +38,7 @@
         ></span>
         {% endblock %}
 
-        <slot name="additional" />
+        <slot name="additional"></slot>
     </div>
     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/index.js
@@ -349,7 +349,7 @@ Component.register('sw-text-editor', {
         value: {
             handler() {
                 if (this.$refs.textEditor && this.value !== this.$refs.textEditor.innerHTML) {
-                    this.$refs.textEditor.innerHTML = '';
+                    this.$refs.textEditor.innerHTML = this.value;
                     this.content = this.value;
                     this.isEmpty = this.emptyCheck(this.content);
                     this.placeholderVisible = this.isEmpty;

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
@@ -92,5 +92,12 @@ export default {
         closeLayoutModal() {
             this.showLayoutSelectionModal = false;
         },
+
+        hasCmsPageOverrides() {
+            return true;
+            // FIXME: How to determine if there are any overrides in this component?
+            // const overrides = this.category.getCmsPageOverrides();
+            // return (overrides !== null && overrides.length > 0);
+        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
@@ -96,7 +96,7 @@ export default {
 
         hasCmsPageOverrides() {
             let overrideCount = 0;
-            if (this.cmsPage.sections === null) {
+            if (this.cmsPage === null || this.cmsPage.sections === null) {
                 return false;
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
@@ -96,15 +96,25 @@ export default {
 
         hasCmsPageOverrides() {
             let overrideCount = 0;
+            if (this.cmsPage.sections === null) {
+                return false;
+            }
+
             this.cmsPage.sections.forEach((section) => {
-                section.blocks.forEach((block) => {
+                if (section.blocks === null) {
+                    return;
+                }
+                (section.blocks ?? []).forEach((block) => {
+                    if (block.slots === null) {
+                        return;
+                    }
                     block.slots.forEach((slot) => {
-                        if(!isEqual(slot.originalConfig, slot.config)) {
-                            overrideCount++;
+                        if (!isEqual(slot.originalConfig, slot.config)) {
+                            overrideCount += 1;
                         }
-                    })
-                })
-            })
+                    });
+                });
+            });
             return overrideCount > 0;
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash';
 import template from './sw-category-layout-card.html.twig';
 import './sw-category-layout-card.scss';
 
@@ -94,10 +95,17 @@ export default {
         },
 
         hasCmsPageOverrides() {
-            return true;
-            // FIXME: How to determine if there are any overrides in this component?
-            // const overrides = this.category.getCmsPageOverrides();
-            // return (overrides !== null && overrides.length > 0);
+            let overrideCount = 0;
+            this.cmsPage.sections.forEach((section) => {
+                section.blocks.forEach((block) => {
+                    block.slots.forEach((slot) => {
+                        if(!isEqual(slot.originalConfig, slot.config)) {
+                            overrideCount++;
+                        }
+                    })
+                })
+            })
+            return overrideCount > 0;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/index.js
@@ -96,16 +96,16 @@ export default {
 
         hasCmsPageOverrides() {
             let overrideCount = 0;
-            if (this.cmsPage === null || this.cmsPage.sections === null) {
+            if (!this.cmsPage || !this.cmsPage.sections) {
                 return false;
             }
 
             this.cmsPage.sections.forEach((section) => {
-                if (section.blocks === null) {
+                if (!section.blocks) {
                     return;
                 }
-                (section.blocks ?? []).forEach((block) => {
-                    if (block.slots === null) {
+                section.blocks.forEach((block) => {
+                    if (!block.slots) {
                         return;
                     }
                     block.slots.forEach((slot) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.html.twig
@@ -81,6 +81,12 @@
                     @click="openLayoutModal"
                 >
                     {{ cmsPage ? $tc('sw-category.base.cms.changeLayout') : $tc('sw-category.base.cms.changeLayoutEmpty') }}
+                    <sw-icon
+                        name="regular-lightbulb"
+                        size="16"
+                        color="#f39c12"
+                        v-tooltip="{ message: 'Content was customized on this category. Changing the layout will reset to the content from the new layout.'}"
+                    ></sw-icon>
                 </sw-button>
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.html.twig
@@ -82,12 +82,12 @@
                 >
                     {{ cmsPage ? $tc('sw-category.base.cms.changeLayout') : $tc('sw-category.base.cms.changeLayoutEmpty') }}
                     <sw-icon
+                        v-if="hasCmsPageOverrides()"
+                        v-tooltip="{ message: 'Content was customized on this category. Changing the layout will reset to the content from the new layout.'}"
                         name="regular-lightbulb"
                         size="16"
                         color="#f39c12"
-                        v-if="hasCmsPageOverrides()"
-                        v-tooltip="{ message: 'Content was customized on this category. Changing the layout will reset to the content from the new layout.'}"
-                    ></sw-icon>
+                    />
                 </sw-button>
                 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.html.twig
@@ -85,6 +85,7 @@
                         name="regular-lightbulb"
                         size="16"
                         color="#f39c12"
+                        v-if="hasCmsPageOverrides()"
                         v-tooltip="{ message: 'Content was customized on this category. Changing the layout will reset to the content from the new layout.'}"
                     ></sw-icon>
                 </sw-button>

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-layout-card/sw-category-layout-card.spec.js
@@ -143,6 +143,68 @@ describe('src/module/sw-category/component/sw-category-layout-card', () => {
         expect(resetLayoutButton.props('disabled')).toBe(true);
     });
 
+    it.skip('should have an override warning indicator at the button for resetting', async () => {
+        global.activeAclRoles = ['category.editor'];
+
+        const wrapper = await createWrapper();
+
+        await wrapper.setProps({
+            cmsPage: {
+                type: 'category',
+                sections: [
+                    {
+                        blocks: [
+                            {
+                                slots: [
+                                    {
+                                        originalConfig: { content: { source: 'static', value: '<h2>Template Box 1</h2>' }, verticalAlign: { source: 'static', value: 'flex-end' } },
+                                        config: { content: { source: 'static', value: '<h2>Template Box 1 custom</h2>' }, verticalAlign: { source: 'static', value: 'flex-end' } },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        await flushPromises();
+        const resetLayoutButtonIndicator = wrapper.find('.sw-category-detail-layout__layout-reset [data-testid="sw-icon__regular-lightbulb"]');
+
+        expect(resetLayoutButtonIndicator.exists()).toBeTruthy(); // FIXME: does not find it yet
+    });
+
+    it.skip('should have no override warning indicator at the button for resetting', async () => {
+        global.activeAclRoles = ['category.editor'];
+
+        const wrapper = await createWrapper();
+
+        await wrapper.setProps({
+            cmsPage: {
+                type: 'category',
+                sections: [
+                    {
+                        blocks: [
+                            {
+                                slots: [
+                                    {
+                                        originalConfig: { content: { source: 'static', value: '<h2>Template Box 1</h2>' }, verticalAlign: { source: 'static', value: 'flex-end' } },
+                                        config: { content: { source: 'static', value: '<h2>Template Box 1</h2>' }, verticalAlign: { source: 'static', value: 'flex-end' } },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+
+        await flushPromises();
+        const resetLayoutButtonIndicator = wrapper.find('.sw-category-detail-layout__layout-reset [data-testid="sw-icon__regular-lightbulb"]');
+
+        expect(resetLayoutButtonIndicator.exists()).toBeFalsy();
+    });
+
     it('should pass the category id and type to the sw.cms.create route', async () => {
         const wrapper = await createWrapper();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -409,6 +409,7 @@ export default {
                                     if (slot.config === null) {
                                         slot.config = {};
                                     }
+                                    slot.config.isOverwritten = true;
                                     merge(slot.config, cloneDeep(this.category.slotConfig[slot.id]));
                                 }
                             });
@@ -834,6 +835,9 @@ export default {
                             }
                             if (configField.type) {
                                 delete configField.type;
+                            }
+                            if (configField.hasOwnProperty('isOverwritten')) {
+                                delete configField.isOverwritten;
                             }
                         });
                     });

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/index.js
@@ -401,21 +401,19 @@ export default {
                     return null;
                 }
 
-                if (this.category.slotConfig !== null) {
-                    cmsPage.sections.forEach((section) => {
-                        section.blocks.forEach((block) => {
-                            block.slots.forEach((slot) => {
-                                if (this.category.slotConfig[slot.id]) {
-                                    if (slot.config === null) {
-                                        slot.config = {};
-                                    }
-                                    slot.config.isOverwritten = true;
-                                    merge(slot.config, cloneDeep(this.category.slotConfig[slot.id]));
-                                }
-                            });
+                cmsPage.sections.forEach((section) => {
+                    section.blocks.forEach((block) => {
+                        block.slots.forEach((slot) => {
+                            if (slot.config === null) {
+                                slot.config = {};
+                            }
+                            slot.originalConfig = cloneDeep(slot.config);
+                            if (this.category.slotConfig !== null && this.category.slotConfig[slot.id]) {
+                                merge(slot.config, cloneDeep(this.category.slotConfig[slot.id]));
+                            }
                         });
                     });
-                }
+                });
 
                 this.updateCmsPageDataMapping();
                 Shopware.State.commit('cmsPageState/setCurrentPage', cmsPage);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.js
@@ -1,6 +1,9 @@
+import { isEqual } from 'lodash';
 import template from './sw-cms-page-form.html.twig';
 import './sw-cms-page-form.scss';
 import CMS from '../../constant/sw-cms.constant';
+
+const { cloneDeep } = Shopware.Utils.object;
 
 /**
  * @private
@@ -125,6 +128,16 @@ export default {
             const isBlockDisplay = !(Object.values(block?.visibility).indexOf(true) > -1);
 
             return isSectionDisplay || isBlockDisplay;
+        },
+
+        getIsOverridden(slot) {
+            const result = !isEqual(slot.originalConfig, slot.config);
+            return result;
+        },
+
+        clearOverride(slot) {
+            slot.config = cloneDeep(slot.originalConfig);
+            // FIXME: in some cases, the texteditor is not updated, even the value changes
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.js
@@ -137,7 +137,6 @@ export default {
 
         clearOverride(slot) {
             slot.config = cloneDeep(slot.originalConfig);
-            // FIXME: in some cases, the texteditor is not updated, even the value changes
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
@@ -173,9 +173,9 @@
                                     @click="clearOverride(element)"
                                 >
                                     <sw-icon
+                                        v-tooltip="{ message: 'Reset to content from layout' }"
                                         name="regular-trash"
                                         small
-                                        v-tooltip="{ message: 'Reset to content from layout' }"
                                     />
                                 </sw-button>
                             </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
@@ -134,6 +134,14 @@
                     class="sw-cms-page-form__block-card"
                     :title="$tc(getBlockTitle(block))"
                 >
+                    <template #subtitle>
+                        <span class="sw-cms-page-form__block-overwrite-indicatior"
+                             v-for="slot in block.slots"
+                        >
+                            <sw-icon v-if="slot.config.isOverwritten" name="regular-tools-alt" color="#3498db" />
+                        </span>
+                    </template>
+
                     <template #header-right>
                         <div class="sw-cms-page-form__block-device-actions">
                             <sw-icon :name="getDeviceActive('mobile', section, block)" />
@@ -151,7 +159,6 @@
                         :key="blockIndex"
                         class="sw-cms-page-form__element-config"
                     >
-
                         <template v-if="displayNotification(section, block)">
                             <sw-alert variant="info">
                                 {{ $tc('sw-cms.blocks.blockDisableState') }}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
@@ -134,14 +134,6 @@
                     class="sw-cms-page-form__block-card"
                     :title="$tc(getBlockTitle(block))"
                 >
-                    <template #subtitle>
-                        <span class="sw-cms-page-form__block-overwrite-indicatior"
-                             v-for="slot in block.slots"
-                        >
-                            <sw-icon v-if="slot.config.isOverwritten" name="regular-tools-alt" color="#3498db" />
-                        </span>
-                    </template>
-
                     <template #header-right>
                         <div class="sw-cms-page-form__block-device-actions">
                             <sw-icon :name="getDeviceActive('mobile', section, block)" />
@@ -171,7 +163,22 @@
                             :is="cmsElements[element.type].configComponent"
                             :element="element"
                             @element-update="elementUpdate"
-                        />
+                        >
+                            <template #additional>
+                                <sw-button
+                                    v-if="element.config.isOverwritten"
+                                    size="small"
+                                    class="sw-cms-page-form__overwrite-reset"
+                                    square
+                                >
+                                    <sw-icon
+                                        name="regular-trash"
+                                        small
+                                        v-tooltip="{ message: 'Reset to content from layout' }"
+                                    />
+                                </sw-button>
+                            </template>
+                        </component>
                         {% endblock %}
                     </div>
                     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.html.twig
@@ -166,10 +166,11 @@
                         >
                             <template #additional>
                                 <sw-button
-                                    v-if="element.config.isOverwritten"
+                                    v-if="getIsOverridden(element)"
                                     size="small"
                                     class="sw-cms-page-form__overwrite-reset"
                                     square
+                                    @click="clearOverride(element)"
                                 >
                                     <sw-icon
                                         name="regular-trash"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.scss
@@ -169,4 +169,8 @@
         align-items: center;
         justify-content: flex-end;
     }
+
+    &__block-overwrite-indicatior {
+        display: flex;
+    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/sw-cms-page-form.scss
@@ -170,7 +170,10 @@
         justify-content: flex-end;
     }
 
-    &__block-overwrite-indicatior {
-        display: flex;
+    &__overwrite-reset {
+        height: 32px;
+        position: absolute; // FIXME: overlaps sometimes
+        right: 0;
+        top: 10px;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
@@ -17,7 +17,6 @@
             :title="$tc('sw-cms.elements.general.config.tab.content')"
             name="content"
             :active-tab="active"
-            warningTooltip="foo"
         >
             {{ $tc('sw-cms.elements.general.config.tab.content') }}
         </sw-tabs-item>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
@@ -5,6 +5,10 @@
     class="sw-cms-el-config-text__tabs"
     default-item="content"
 >
+    <template #additional>
+        <slot name="additional">
+        </slot>
+    </template>
 
     <template #default="{ active }">
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
@@ -13,6 +17,7 @@
             :title="$tc('sw-cms.elements.general.config.tab.content')"
             name="content"
             :active-tab="active"
+            warningTooltip="foo"
         >
             {{ $tc('sw-cms.elements.general.config.tab.content') }}
         </sw-tabs-item>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/__snapshots__/sw-settings-index.spec.js.snap
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/__snapshots__/sw-settings-index.spec.js.snap
@@ -57,6 +57,7 @@ exports[`module/sw-settings/page/sw-settings-index should render correctly 1`] =
           class="sw-tabs__slider"
           style="transform: translate(0, 0px) rotate(90deg); width: 0px;"
         />
+         
       </div>
        
       <!---->


### PR DESCRIPTION
Proof Of Concept for an Indicator to show which slots are currently overwritten

Todos:

- [x] Use a proper icon
- [x] Styling
- [x] Make it reactive: When editing text, indicate directly that the content was overwriten
- [x] Add a warning near the "Change layout" button which says something like "Overwrites apply, when you change the layout, they will be/might be reset"
- [ ] Tests?

### 1. Why is this change necessary?

It is not visible which content is from the layout (shopping experience)  and which is customized. Especially when reassigning layouts this is problematic.

### 2. What does this change do, exactly?

It shows one or more icons (currently dependent on the number of slots in a block which are customized icon) to indicate that those differ from the original page layout.

### 3. Describe each step to reproduce the issue or behaviour.

* Create a layout with multiple slots
* Assign to a category
* Overwrite the content in the category for some slots

### 4. Please link to the relevant issues (if any).

See https://feedback.shopware.com/forums/942607-shopware-6-product-feedback-ideas/suggestions/46032460-flag-whether-shopware-takes-content-from-shopping

Was also raised in this comment: https://github.com/shopware/shopware/pull/1024#issuecomment-647532278

The pull request #1024 tried to solve the sibling problem.

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


### Demo / Mockups

![image](https://github.com/shopware/shopware/assets/1087128/ca54362d-2ac1-44cb-b30c-4e2368072a66)
![image](https://github.com/shopware/shopware/assets/1087128/18e9adaf-2e11-42b7-ac63-b651c1c01639)

### Alternatives

We might also combine this with a reset-from-template option for each slot or block, so actually it would be a trash-can-button indicating that the content was customized.

Suggestions are welcome!

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 814dca2</samp>

This pull request adds a feature to the CMS page form component that shows an icon for each slot that has been customized by the user. It modifies the `sw-category-detail` and `sw-cms-page-form` modules and their corresponding templates and styles.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 814dca2</samp>

*  Add `isOverwritten` property to slot config object to indicate user customization ([link](https://github.com/shopware/shopware/pull/3369/files?diff=unified&w=0#diff-bb4c8d520c7fb8fb9a0faafedcfa4df4ac71ec1de9c4c6c829b4587aff095567R412))
*  Remove `isOverwritten` property from slot config object before saving ([link](https://github.com/shopware/shopware/pull/3369/files?diff=unified&w=0#diff-bb4c8d520c7fb8fb9a0faafedcfa4df4ac71ec1de9c4c6c829b4587aff095567R839-R841))
*  Render `regular-tools-alt` icon for each overwritten slot in `subtitle` slot of `sw-cms-page-form` component ([link](https://github.com/shopware/shopware/pull/3369/files?diff=unified&w=0#diff-c341fc6b3a9cca3c6e439a93a85a4690d7f81cc330b8cf9901c99edc0d3696edR137-R144))
*  Style icon with `sw-cms-page-form__block-overwrite-indicatior` class ([link](https://github.com/shopware/shopware/pull/3369/files?diff=unified&w=0#diff-1bb2697d7b8df444bac9c020ecc2edda2cf86ecdf119e62558ff2f4dfd1e344bR172-R175))
*  Remove empty line from `sw-cms-page-form` component template ([link](https://github.com/shopware/shopware/pull/3369/files?diff=unified&w=0#diff-c341fc6b3a9cca3c6e439a93a85a4690d7f81cc330b8cf9901c99edc0d3696edL154))
