### PR TITLE
NEXT-23252 - Customer Custom Field Rule evaluates wrong on multiple-selection custom fields

### DIFF
--- a/changelog/_unreleased/2023-10-17-customer-custom-field-rule-evaluates-wrong-on-multiple-selection-custom-fields.md
+++ b/changelog/_unreleased/2023-10-17-customer-custom-field-rule-evaluates-wrong-on-multiple-selection-custom-fields.md
@@ -1,0 +1,19 @@
+---
+title: Customer Custom Field Rule evaluates wrong on multiple-selection custom fields
+issue: NEXT-23252
+author: Jan Emig
+author_email: j.emig@one-dot.de
+author_github: @Xnaff
+---
+# Core
+* Changed method `match` in `Shopware\Core\Framework\Rule\CustomFieldRule` to fix the validation of multi select fields
+* Changed method `isFloat` in `Shopware\Core\Framework\Rule\CustomFieldRule` to public function to be able to use it in `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to prevent duplicate code
+* Changed method `getExpectedValue` in `Shopware\Core\Framework\Rule\CustomFieldRule` to public function to be able to use it in `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to prevent duplicate code
+* Changed method `getValue` in `Shopware\Core\Framework\Rule\CustomFieldRule` to public function to be able to use it in `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to prevent duplicate code
+* Changed method `floatMatch` in `Shopware\Core\Framework\Rule\CustomFieldRule` to public function to be able to use it in `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to prevent duplicate code
+* Changed method `getConstraints` in `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to use same public function from `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to prevent duplicate code
+* Removed method `getRenderedFieldValueConstraints` in `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to use same public function from `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to prevent duplicate code
+* Removed method `getValue` in `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to use same public function from `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to prevent duplicate code
+* Removed method `getExpectedValue` in `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to use same public function from `Shopware\Core\Checkout\Cart\Rule\LineItemCustomFieldRule` to prevent duplicate code
+* Added method `isArray` in `Shopware\Core\Framework\Rule\CustomFieldRule` to validate if the field value is an array from a multi select field
+* Added method `arrayMatch` in `Shopware\Core\Framework\Rule\CustomFieldRule` to validate the field value against the rule value if the field value is an array from a multi select field

--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -4,14 +4,12 @@ namespace Shopware\Core\Checkout\Cart\Rule;
 
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\CustomFieldRule;
 use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Rule\RuleComparison;
 use Shopware\Core\Framework\Rule\RuleScope;
-use Shopware\Core\System\CustomField\CustomFieldTypes;
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Constraints\Choice;
-use Symfony\Component\Validator\Constraints\NotBlank;
 
 #[Package('services-settings')]
 class LineItemCustomFieldRule extends Rule
@@ -22,10 +20,6 @@ class LineItemCustomFieldRule extends Rule
      * @var array<string>|string|int|float|bool|null
      */
     protected $renderedFieldValue;
-
-    protected ?string $selectedField = null;
-
-    protected ?string $selectedFieldSet = null;
 
     /**
      * @param array<string, mixed> $renderedField
@@ -66,25 +60,7 @@ class LineItemCustomFieldRule extends Rule
      */
     public function getConstraints(): array
     {
-        return [
-            'renderedField' => [new NotBlank()],
-            'selectedField' => [new NotBlank()],
-            'selectedFieldSet' => [new NotBlank()],
-            'renderedFieldValue' => $this->getRenderedFieldValueConstraints(),
-            'operator' => [
-                new NotBlank(),
-                new Choice(
-                    [
-                        self::OPERATOR_NEQ,
-                        self::OPERATOR_GTE,
-                        self::OPERATOR_LTE,
-                        self::OPERATOR_EQ,
-                        self::OPERATOR_GT,
-                        self::OPERATOR_LT,
-                    ]
-                ),
-            ],
-        ];
+        return CustomFieldRule::getConstraints($this->renderedField);
     }
 
     /**
@@ -97,8 +73,8 @@ class LineItemCustomFieldRule extends Rule
             return RuleComparison::isNegativeOperator($this->operator);
         }
 
-        $actual = $this->getValue($customFields, $this->renderedField);
-        $expected = $this->getExpectedValue($this->renderedFieldValue, $this->renderedField);
+        $actual = CustomFieldRule::getValue($customFields, $this->renderedField);
+        $expected = CustomFieldRule::getExpectedValue($this->renderedFieldValue, $this->renderedField);
 
         if ($actual === null) {
             if ($this->operator === self::OPERATOR_NEQ) {
@@ -106,6 +82,14 @@ class LineItemCustomFieldRule extends Rule
             }
 
             return false;
+        }
+
+        if (CustomFieldRule::isFloat($this->renderedField)) {
+            return CustomFieldRule::floatMatch($this->operator, (float) $actual, (float) $expected);
+        }
+
+        if (CustomFieldRule::isArray($this->renderedField)) {
+            return CustomFieldRule::arrayMatch($this->operator, (array) $actual, (array) $expected);
         }
 
         return match ($this->operator) {
@@ -117,61 +101,5 @@ class LineItemCustomFieldRule extends Rule
             self::OPERATOR_LT => $actual < $expected,
             default => throw new UnsupportedOperatorException($this->operator, self::class),
         };
-    }
-
-    /**
-     * @return Constraint[]
-     */
-    private function getRenderedFieldValueConstraints(): array
-    {
-        $constraints = [];
-
-        if (!\array_key_exists('type', $this->renderedField)) {
-            return [new NotBlank()];
-        }
-
-        if ($this->renderedField['type'] !== CustomFieldTypes::BOOL) {
-            $constraints[] = new NotBlank();
-        }
-
-        return $constraints;
-    }
-
-    /**
-     * @param array<string, mixed> $customFields
-     * @param array<string, mixed> $renderedField
-     *
-     * @return string|int|float|bool|null
-     */
-    private function getValue(array $customFields, array $renderedField): mixed
-    {
-        if (\in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH], true)) {
-            if (!empty($customFields) && \array_key_exists($this->renderedField['name'], $customFields)) {
-                return $customFields[$renderedField['name']];
-            }
-
-            return false;
-        }
-
-        if (!empty($customFields) && \array_key_exists($this->renderedField['name'], $customFields)) {
-            return $customFields[$renderedField['name']];
-        }
-
-        return null;
-    }
-
-    /**
-     * @param array<string>|string|int|float|bool|null $renderedFieldValue
-     * @param array<string, mixed> $renderedField
-     *
-     * @return array<string>|string|int|float|bool|null
-     */
-    private function getExpectedValue($renderedFieldValue, array $renderedField)
-    {
-        if (\in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH], true)) {
-            return (bool) ($renderedFieldValue ?? false); // those fields are initialized with null in the rule builder
-        }
-
-        return $renderedFieldValue;
     }
 }

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerCustomFieldRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerCustomFieldRuleTest.php
@@ -198,16 +198,31 @@ class CustomerCustomFieldRuleTest extends TestCase
         static::assertFalse($this->rule->match($this->scope));
     }
 
+    public function testMultiSelectCustomField(): void
+    {
+        $this->setupRule([1, 2], 'select', ['componentName' => 'sw-multi-select']);
+        $this->setCustomerCustomFields([self::CUSTOM_FIELD_NAME => [1]]);
+        static::assertTrue($this->rule->match($this->scope));
+    }
+
+    public function testMultiSelectCustomFieldInvalid(): void
+    {
+        $this->setupRule([1, 2], 'select', ['componentName' => 'sw-multi-select']);
+        $this->setCustomerCustomFields([self::CUSTOM_FIELD_NAME => [3]]);
+        static::assertFalse($this->rule->match($this->scope));
+    }
+
     /**
      * @dataProvider customFieldCheckoutScopeProvider
      */
     public function testCustomFieldCheckoutScope(
-        bool|string|null $customFieldValue,
+        array|bool|string|null $customFieldValue,
         string $type,
-        bool|string|null $customFieldValueInCustomer,
-        bool $result
+        array|bool|string|null $customFieldValueInCustomer,
+        bool $result,
+        array $config = []
     ): void {
-        $this->setupRule($customFieldValue, $type);
+        $this->setupRule($customFieldValue, $type, $config);
         $this->setCustomerCustomFields([self::CUSTOM_FIELD_NAME => $customFieldValueInCustomer]);
         static::assertSame($result, $this->rule->match($this->scope));
     }
@@ -223,6 +238,8 @@ class CustomerCustomFieldRuleTest extends TestCase
             'testBooleanCustomFieldInvalid' => [false, 'bool', true, false],
             'testStringCustomField' => ['my_test_value', 'string', 'my_test_value', true],
             'testStringCustomFieldInvalid' => ['my_test_value', 'string', 'my_invalid_value', false],
+            'testMultiSelectCustomField' => [[1, 2], 'select', [1], true, ['componentName' => 'sw-multi-select']],
+            'testMultiSelectCustomFieldInvalid' => [[1, 2], 'select', [3], false, ['componentName' => 'sw-multi-select']],
         ];
     }
 
@@ -263,7 +280,7 @@ class CustomerCustomFieldRuleTest extends TestCase
         $this->customer->method('getCustomFields')->willReturn($customFields);
     }
 
-    private function setupRule(bool|string|null $customFieldValue, string $type): void
+    private function setupRule(array|bool|string|null $customFieldValue, string $type, array $config = []): void
     {
         $this->rule->assign(
             [
@@ -271,6 +288,7 @@ class CustomerCustomFieldRuleTest extends TestCase
                 'renderedField' => [
                     'type' => $type,
                     'name' => self::CUSTOM_FIELD_NAME,
+                    'config' => $config,
                 ],
                 'renderedFieldValue' => $customFieldValue,
             ]

--- a/tests/unit/Core/Framework/Rule/CustomFieldRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/CustomFieldRuleTest.php
@@ -47,11 +47,13 @@ class CustomFieldRuleTest extends TestCase
         array|bool|string|null|int $renderedFieldValue,
         string $type,
         string $operator,
-        bool $isMatching
+        bool $isMatching,
+        array $config = []
     ): void {
         $renderedField = [
             'type' => $type,
             'name' => self::CUSTOM_FIELD_NAME,
+            'config' => $config
         ];
 
         static::assertEquals(CustomFieldRule::match($renderedField, $renderedFieldValue, $operator, $customFields), $isMatching);
@@ -294,13 +296,62 @@ class CustomFieldRuleTest extends TestCase
                 '=',
                 false,
             ],
-            'custom field ["option_1", "option_2"] value / rendered field value ["option_1", "option_2"]/ select type/ EQ operator / matching' => [
+            'custom field "[option_1, option_2]" value / rendered field multi select value "[option_1]"/ select type/ EQ operator / matching' => [
                 [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+                ['option_1'],
+                'select',
+                '=',
+                true,
+                ['componentName' => 'sw-multi-select']
+            ],
+            'custom field "[option_2, option_3]" value / rendered field multi select value "[option_1, option_2]"/ select type/ EQ operator / matching' => [
+                [self::CUSTOM_FIELD_NAME => ['option_2', 'option_3']],
                 ['option_1', 'option_2'],
                 'select',
                 '=',
                 true,
+                ['componentName' => 'sw-multi-select']
             ],
+            'custom field "[option_1, option_2]" value / rendered field multi select value "[option_3]"/ select type/ EQ operator / matching' => [
+                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+                ['option_3'],
+                'select',
+                '=',
+                false,
+                ['componentName' => 'sw-multi-select']
+            ],
+            'custom field "[option_1, option_2]" value / rendered field multi select value "[option_3, option_4]"/ select type/ EQ operator / not matching' => [
+                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+                ['option_3', 'option_4'],
+                'select',
+                '=',
+                false,
+                ['componentName' => 'sw-multi-select']
+            ],
+            'custom field "[option_1, option_2]" value / rendered field multi select value "[option_1]"/ select type/ NEQ operator / not matching' => [
+                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+                ['option_1'],
+                'select',
+                '!=',
+                false,
+                ['componentName' => 'sw-multi-select']
+            ],
+            'custom field "[option_1, option_2]" value / rendered field multi select value "[option_3]"/ select type/ NEQ operator / matching' => [
+                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+                ['option_3'],
+                'select',
+                '!=',
+                true,
+                ['componentName' => 'sw-multi-select']
+            ],
+            'custom field ["option_1", "option_2"] / rendered field multi select value null/ select type/ EQ operator / not matching' => [
+                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+                null,
+                'select',
+                '=',
+                false,
+                ['componentName' => 'sw-multi-select']
+            ]
         ];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Rules with custom fields of type multi select resulted in an 500 server error because arrays, are not allowed in the type declaration.

### 2. What does this change do, exactly?

Validate the rule of custom fields with the type multi select

### 3. Describe each step to reproduce the issue or behaviour.

- Create a custom field of the type multi select for a customer
- Create a price rule wich uses this custom field
- Assign some value to a customer from the multi select custom field
- Log in as the customer

### 4. Please link to the relevant issues (if any).

[NEXT-23252](https://issues.shopware.com/issues/NEXT-23252)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c1907a</samp>

This pull request fixes and improves the custom field rule logic for multi select fields. It refactors the `LineItemCustomFieldRule` class to use the common `CustomFieldRule` class, and adds support for validating array custom fields in both classes. It also updates the type declarations and constants for the related classes and fields. It adds and modifies unit tests to cover the new functionality and scenarios. It updates the changelog entry with the relevant information.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c1907a</samp>

*  Add changelog entry for fixing custom field rule with multi select fields ([link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-e84e2eb387d440b5cdaf106e74d32ce857a88ad59b70e70e53330a2db3e61f44R1-R21))
*  Refactor `LineItemCustomFieldRule` class to use methods from `CustomFieldRule` class and handle multi select fields ([link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0L7-R12), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0L22-R23), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0L69-R63), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0L100-R77), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0R87-R94), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0L121-L176))
*  Update type declaration of `renderedFieldValue` property in `CustomerCustomFieldRule` and `OrderCustomFieldRule` classes to support multi select fields ([link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-807fcd493a01a0273756a10a4399c8970e4c83341f07468dadb5aa7c84a29357L17-R17), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-0a176a7edcad360b421a0607b9fcbace6a12808b8b991e56d19b9453891d3870L16-R16))
*  Make `COMPONENT_NAME` constants public in `MultiEntitySelectField` and `MultiSelectField` classes for multi select fields check ([link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-c990076bd957d0bb099a4632736887d0a98c9934a0391c6648c6a5cc4fafd2a0L13-R13), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-0fa50f8275064f19ac5f81f1f7f5fa6537307c901db6d2d8c6413143c4c6ee47L13-R13))
*  Update `CustomFieldRule` class to handle multi select fields and make some methods public for reuse ([link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fR5-R6), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL52-R54), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fR71-R74), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL80-R86), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fR99-R107), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL117-R132), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL133-R148), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-7ac06dd25df7f86504bdf27a8542d323862056e2d63670f295d1ddbef1d3314fL157-R203))
*  Add test cases for `LineItemCustomFieldRule` and `CustomerCustomFieldRule` with multi select fields and different values ([link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-0b6128a7095eb48e0bd2323328ef56200e65dd9f7c55aba2352f6aab40f88b30R133-R146), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-0b6128a7095eb48e0bd2323328ef56200e65dd9f7c55aba2352f6aab40f88b30R204-R205), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-0b6128a7095eb48e0bd2323328ef56200e65dd9f7c55aba2352f6aab40f88b30L202-R220), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-0b6128a7095eb48e0bd2323328ef56200e65dd9f7c55aba2352f6aab40f88b30R228), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-c31eda51da70c15289156bbb2fd62d0c9c7ad1b52dacb665b96b6620facc7a2dL201-R225), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-c31eda51da70c15289156bbb2fd62d0c9c7ad1b52dacb665b96b6620facc7a2dR241-R242), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-c31eda51da70c15289156bbb2fd62d0c9c7ad1b52dacb665b96b6620facc7a2dL266-R283), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-c31eda51da70c15289156bbb2fd62d0c9c7ad1b52dacb665b96b6620facc7a2dR291))
*  Update `CustomFieldRuleTest` to include test cases with multi select fields and different operators and values ([link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-3a9e026ace506934dab7fdd56fb1550cee2ee92dfaa109a2143c5f14c5fe1260L46-R55), [link](https://github.com/shopware/shopware/pull/3373/files?diff=unified&w=0#diff-3a9e026ace506934dab7fdd56fb1550cee2ee92dfaa109a2143c5f14c5fe1260R291-R338))
