### PR TITLE
Improve document number already exists check performance

### DIFF
--- a/changelog/_unreleased/2023-10-10-Improve-document-number-already-exists-check-performance.md
+++ b/changelog/_unreleased/2023-10-10-Improve-document-number-already-exists-check-performance.md
@@ -1,0 +1,11 @@
+---
+title: Improve document number already exists check performance
+issue:
+author: Benedikt Brunner
+author_email: benedikt.brunner@pickware.de
+author_github: Benedikt-Brunner
+---
+# Core
+*  Added document number column to `document` generated from config with an index and adjusted the `DocumentGenerator` to greatly increase performance of checking if a document number already exists.
+
+

--- a/src/Core/Checkout/Document/DocumentDefinition.php
+++ b/src/Core/Checkout/Document/DocumentDefinition.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Computed;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\SearchRanking;
@@ -64,6 +65,7 @@ class DocumentDefinition extends EntityDefinition
             (new BoolField('sent', 'sent'))->addFlags(new ApiAware()),
             (new BoolField('static', 'static'))->addFlags(new ApiAware()),
             (new StringField('deep_link_code', 'deepLinkCode'))->addFlags(new ApiAware(), new Required()),
+            (new StringField('document_number', 'documentNumber'))->addFlags(new ApiAware(), new Computed()),
             (new CustomFields())->addFlags(new ApiAware()),
 
             (new ManyToOneAssociationField('documentType', 'document_type_id', DocumentTypeDefinition::class, 'id'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),

--- a/src/Core/Checkout/Document/DocumentEntity.php
+++ b/src/Core/Checkout/Document/DocumentEntity.php
@@ -67,6 +67,11 @@ class DocumentEntity extends Entity
     protected $deepLinkCode;
 
     /**
+     * @var string|null
+     */
+    protected $documentNumber;
+
+    /**
      * @var DocumentTypeEntity|null
      */
     protected $documentType;
@@ -159,6 +164,16 @@ class DocumentEntity extends Entity
     public function setDeepLinkCode(string $deepLinkCode): void
     {
         $this->deepLinkCode = $deepLinkCode;
+    }
+
+    public function getDocumentNumber(): string|null
+    {
+        return $this->documentNumber;
+    }
+
+    public function setDocumentNumber(string|null $documentNumber): void
+    {
+        $this->documentNumber = $documentNumber;
     }
 
     public function getDocumentType(): ?DocumentTypeEntity

--- a/src/Core/Checkout/Document/Service/DocumentGenerator.php
+++ b/src/Core/Checkout/Document/Service/DocumentGenerator.php
@@ -260,7 +260,7 @@ class DocumentGenerator
     ): void {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('documentType.technicalName', $documentTypeName));
-        $criteria->addFilter(new EqualsFilter('config.documentNumber', $documentNumber));
+        $criteria->addFilter(new EqualsFilter('documentNumber', $documentNumber));
 
         if ($documentId !== null) {
             $criteria->addFilter(new NotFilter(

--- a/src/Core/Migration/V6_5/Migration1696945299AddGeneratedDocumentNumberColumn.php
+++ b/src/Core/Migration/V6_5/Migration1696945299AddGeneratedDocumentNumberColumn.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright (c) Pickware GmbH. All rights reserved.
+ * This file is part of software that is released under a proprietary license.
+ * You must not copy, modify, distribute, make publicly available, or execute
+ * its contents or parts thereof without express permission by the copyright
+ * holder, unless otherwise permitted by law.
+ */
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_5;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1696945299AddGeneratedDocumentNumberColumn extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1696945299;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $columns = $connection->executeQuery('
+            SELECT COLUMN_NAME, DATA_TYPE FROM information_schema.columns
+                WHERE table_schema = :database
+                  AND table_name = \'document\'
+                  AND COLUMN_NAME = \'document_number\';
+        ', ['database' => $connection->getDatabase()])->fetchAllAssociativeIndexed();
+
+        if (!\array_key_exists('document_number', $columns)) {
+            $connection->executeStatement('
+                ALTER TABLE `document`
+                ADD COLUMN `document_number` VARCHAR(255)
+                GENERATED ALWAYS AS (
+                    COALESCE(JSON_UNQUOTE(JSON_EXTRACT(`config`, \'$.documentNumber\')))
+                ) STORED;
+            ');
+        }
+        $indexes = $connection->executeQuery('
+            SELECT INDEX_NAME FROM information_schema.STATISTICS
+                WHERE table_schema = :database
+                  AND table_name = \'document\'
+                  AND COLUMN_NAME = \'document_number\'
+        ', ['database' => $connection->getDatabase()])->fetchFirstColumn();
+
+        if (!\in_array('idx.document.document_number', $indexes, true)) {
+            $connection->executeStatement('
+                CREATE INDEX `idx.document.document_number`
+                    ON `document` (`document_number`);
+            ');
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/tests/integration/Core/Framework/Api/fixtures/api-aware-fields.json
+++ b/tests/integration/Core/Framework/Api/fixtures/api-aware-fields.json
@@ -1167,6 +1167,7 @@
     "document.sent",
     "document.static",
     "document.deepLinkCode",
+    "document.documentNumber",
     "document.customFields",
     "document.documentType",
     "document.order",

--- a/tests/migration/Core/V6_5/Migration1696945299AddGeneratedDocumentNumberColumnTest.php
+++ b/tests/migration/Core/V6_5/Migration1696945299AddGeneratedDocumentNumberColumnTest.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Copyright (c) Pickware GmbH. All rights reserved.
+ * This file is part of software that is released under a proprietary license.
+ * You must not copy, modify, distribute, make publicly available, or execute
+ * its contents or parts thereof without express permission by the copyright
+ * holder, unless otherwise permitted by law.
+ */
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_5;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_5\Migration1696945299AddGeneratedDocumentNumberColumn;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Migration\V6_5\Migration1696945299AddGeneratedDocumentNumberColumn
+ */
+class Migration1696945299AddGeneratedDocumentNumberColumnTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private Connection $connection;
+
+    private Migration1696945299AddGeneratedDocumentNumberColumn $migration;
+
+    protected function setUp(): void
+    {
+        $this->migration = new Migration1696945299AddGeneratedDocumentNumberColumn();
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testGetCreationTimestamp(): void
+    {
+        static::assertEquals('1696945299', $this->migration->getCreationTimestamp());
+    }
+
+    public function testUpdate(): void
+    {
+        $this->migration->update($this->connection);
+
+        static::assertStringContainsString(
+            '`document_number` varchar(255)',
+            $this->getSchema(),
+        );
+
+        static::assertStringContainsString(
+            '`idx.document.document_number` (`document_number`)',
+            $this->getSchema(),
+        );
+    }
+
+    public function testUpdateTwice(): void
+    {
+        $this->migration->update($this->connection);
+
+        static::assertStringContainsString(
+            '`document_number` varchar(255)',
+            $this->getSchema(),
+        );
+
+        static::assertStringContainsString(
+            '`idx.document.document_number` (`document_number`)',
+            $this->getSchema(),
+        );
+
+        $expected = $this->getSchema();
+
+        $this->migration->update($this->connection);
+        static::assertSame($expected, $this->getSchema());
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    private function getSchema(): string
+    {
+        $schema = $this->connection->fetchAssociative(sprintf('SHOW CREATE TABLE `%s`', 'document'));
+        static::assertNotFalse($schema);
+        static::assertIsString($schema['Create Table']);
+
+        return $schema['Create Table'];
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The current check if there is already a document with the given document number in `DocumentGenerator` is to slow for large datasets.
Because the current query has to parse the document number from the `config` column it isn't efficient enough and creating a new document starts to slow down significantly around ~500K documents.


### 2. What does this change do, exactly?
It adds a migration to generate the `document_number` column and an index on that column, it also adjusts the querying process to take advantage of the added column and index.


### 3. Describe each step to reproduce the issue or behaviour.
1. Generate many orders with documents.
2. Create a new document and measure the time taken.

#### My data:
 * Time-baseline: 700-800ms (No orders/documents)
 * Time-before-fix: 3-4s (With orders/documents)
 * Time-after-fix: 700-800ms (With orders/documents)
 * ~5000 Orders
 * ~100 Documents/Order (~500K Documents)

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f91bac</samp>

This pull request adds a new `documentNumber` field to the `DocumentDefinition` and `DocumentEntity` classes, and uses it to improve the performance of the document number already exists check. It also provides a migration to add the field to the database, and updates the changelog, the API fixtures and the tests accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3f91bac</samp>

*  Add a new document number field to the document entity and definition, which is exposed to the API and computed from the config field ([link](https://github.com/shopware/shopware/pull/3374/files?diff=unified&w=0#diff-d99d66c210650264792358b2fd9c788b288ab58494e56b30a744c304565eb5ebR13), [link](https://github.com/shopware/shopware/pull/3374/files?diff=unified&w=0#diff-d99d66c210650264792358b2fd9c788b288ab58494e56b30a744c304565eb5ebR68), [link](https://github.com/shopware/shopware/pull/3374/files?diff=unified&w=0#diff-0d8b447bcd5ed646e987fd84cb864a9b0064b976273e5f55e07795bdaf3ae8f0R70-R74), [link](https://github.com/shopware/shopware/pull/3374/files?diff=unified&w=0#diff-0d8b447bcd5ed646e987fd84cb864a9b0064b976273e5f55e07795bdaf3ae8f0R169-R178), [link](https://github.com/shopware/shopware/pull/3374/files?diff=unified&w=0#diff-11396af0edef2ef5daaad90a4fbd7546b7e62c23f392e1de7bc65bb3e41e579dR1170))
*  Optimize the document number already exists check by using the new field instead of the config field for filtering the criteria ([link](https://github.com/shopware/shopware/pull/3374/files?diff=unified&w=0#diff-6bfd75e9d343b818ecd9cb65e9e2b868563ae1b7fe32f99acda787a8bb1d1b38L263-R263))
*  Create a migration that adds the document number column and index to the document table, with a generated expression from the config field, and checks for their existence before creating them ([link](https://github.com/shopware/shopware/pull/3374/files?diff=unified&w=0#diff-f2716b541a37571e634b4caa199275c17950949d161c0a7aa9375c4548bf7751R1-R65))
*  Add a changelog entry for the performance improvement of the document number check ([link](https://github.com/shopware/shopware/pull/3374/files?diff=unified&w=0#diff-1fb7f6812b23c51e76f84f78efefe7cc9a3db8ef66ace2a9c1977375d0a09a52R1-R11))
*  Add a test class that covers the migration and asserts the creation and idempotence of the column and index ([link](https://github.com/shopware/shopware/pull/3374/files?diff=unified&w=0#diff-66d7ec6e44ec46a9698d682b9b2fb7e943516bf21575d4d067ef543da49c32e2R1-R90))
