### PR TITLE
NEXT-00000 - Add post update message to system:update:finish output

### DIFF
--- a/changelog/_unreleased/2023-10-20-system-update-finish-message-on-cli.md
+++ b/changelog/_unreleased/2023-10-20-system-update-finish-message-on-cli.md
@@ -1,0 +1,8 @@
+---
+title: Show system update finish messages when running system:update:finish
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added console output for `system:update:finish`'s additional post update message data, that was just visible to the administration before 

--- a/src/Core/Maintenance/System/Command/SystemUpdateFinishCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemUpdateFinishCommand.php
@@ -95,6 +95,7 @@ class SystemUpdateFinishCommand extends Command
         $eventDispatcher = $this->container->get('event_dispatcher');
         $updateEvent = new UpdatePostFinishEvent($context, $oldVersion, $newVersion);
         $eventDispatcher->dispatch($updateEvent);
+        $output->writeln($updateEvent->getPostUpdateMessage());
 
         $this->installAssets($output);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When you subscribe to `\Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent` you will only see the message in the administration. But it would be already be helpful after running `system:update:finish` because there can be hints in it, why the admin might not be able to use. So you are locked out of the data, that is crucial for updating a system.

### 2. What does this change do, exactly?

Print after the data has been stored in the administration notifications.

### 3. Describe each step to reproduce the issue or behaviour.

* Subscribe `\Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent`
* Add data to it
* Expect it in the CI/CD logs

<img width="402" alt="Scene from pulp fiction where John Travolta is standing confused around in a room and looking around" src="https://github.com/shopware/shopware/assets/1133593/01c0e7e0-9b10-4d4c-878c-af5dcd604e79">

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca362f0</samp>

This pull request adds a feature to show the post update message data on the CLI when running the `system:update:finish` command. It also updates the changelog file with the corresponding entry.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca362f0</samp>

*  Add a changelog entry for the feature ([link](https://github.com/shopware/shopware/pull/3378/files?diff=unified&w=0#diff-2051e1137e41f7e967b55a1856077d67821e633f621addf5e6545afb3a90e658R1-R8))
*  Print the post update message data to the console output in the `SystemUpdateFinishCommand` class ([link](https://github.com/shopware/shopware/pull/3378/files?diff=unified&w=0#diff-a8ed67eee015f1347697f3aab750e977a144afff346c68af8a46870a3b29a78eR98))
