### PR TITLE
NEXT-00000 - Trigger console events when running console commands as sub commands

### DIFF
--- a/changelog/_unreleased/2023-10-20-trigger-command-events-when-run-by-code.md
+++ b/changelog/_unreleased/2023-10-20-trigger-command-events-when-run-by-code.md
@@ -1,0 +1,8 @@
+---
+title: Trigger Symfony command events, when commands are run by code
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed sub command invocation within `system:install`, `system:setup` and `system:update:finish` from direct command service usage to running through Symfony application to trigger Symfony command events

--- a/src/Core/Maintenance/System/Command/SystemInstallCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemInstallCommand.php
@@ -179,22 +179,43 @@ class SystemInstallCommand extends Command
     private function runCommands(array $commands, OutputInterface $output): int
     {
         $application = $this->getApplication();
+
         if ($application === null) {
             throw new \RuntimeException('No application initialised');
         }
 
+        $wasCatchingExceptions = $application->areExceptionsCaught();
+        $wasAutoExiting = $application->isAutoExitEnabled();
+        $application->setCatchExceptions(false);
+        $application->setAutoExit(false);
+
+        try {
+            return $this->runCommandByApplication($application, $commands, $output);
+        } finally {
+            $application->setCatchExceptions($wasCatchingExceptions);
+            $application->setAutoExit($wasAutoExiting);
+        }
+    }
+
+    /**
+     * @param array<int, array<string, string|bool|null>> $commands
+     */
+    private function runCommandByApplication(Application $application, array $commands, OutputInterface $output): int
+    {
         foreach ($commands as $parameters) {
             // remove params with null value
             $parameters = array_filter($parameters);
 
             $output->writeln('');
 
-            $command = $application->find((string) $parameters['command']);
+            $commandName = (string) $parameters['command'];
             $allowedToFail = $parameters['allowedToFail'] ?? false;
             unset($parameters['command'], $parameters['allowedToFail']);
+            \array_unshift($parameters, $commandName);
 
             try {
-                $returnCode = $command->run(new ArrayInput($parameters, $command->getDefinition()), $output);
+                $returnCode = $application->run(new ArrayInput($parameters), $output);
+
                 if ($returnCode !== 0 && !$allowedToFail) {
                     return $returnCode;
                 }

--- a/src/Core/Maintenance/System/Command/SystemUpdateFinishCommand.php
+++ b/src/Core/Maintenance/System/Command/SystemUpdateFinishCommand.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
 use Shopware\Core\Framework\Update\Event\UpdatePreFinishEvent;
 use Shopware\Core\Kernel;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -111,13 +112,10 @@ class SystemUpdateFinishCommand extends Command
         }
         $command = $application->find('database:migrate');
 
-        $arguments = [
+        return $this->runCommand($application, $command, [
             'identifier' => 'core',
             '--all' => true,
-        ];
-        $arrayInput = new ArrayInput($arguments, $command->getDefinition());
-
-        return $command->run($arrayInput, $output);
+        ], $output);
     }
 
     private function installAssets(OutputInterface $output): int
@@ -128,7 +126,7 @@ class SystemUpdateFinishCommand extends Command
         }
         $command = $application->find('assets:install');
 
-        return $command->run(new ArrayInput([], $command->getDefinition()), $output);
+        return $this->runCommand($application, $command, [], $output);
     }
 
     private function rebootKernelWithoutPlugins(): ContainerInterface
@@ -140,5 +138,23 @@ class SystemUpdateFinishCommand extends Command
         $kernel->reboot(null, new StaticKernelPluginLoader($classLoad));
 
         return $kernel->getContainer();
+    }
+
+    private function runCommand(Application $application,  Command $command, array $arguments, OutputInterface $output): int
+    {
+        \array_unshift($arguments, $command->getName());
+
+        $arrayInput = new ArrayInput($arguments, $command->getDefinition());
+        $wasCatchingExceptions = $application->areExceptionsCaught();
+        $wasAutoExiting = $application->isAutoExitEnabled();
+        $application->setCatchExceptions(false);
+        $application->setAutoExit(false);
+
+        try {
+            return $application->run($arrayInput, $output);
+        } finally {
+            $application->setCatchExceptions($wasCatchingExceptions);
+            $application->setAutoExit($wasAutoExiting);
+        }
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Event subscribers onto Symfony console events like terminate are not called, when maintenance commands execute these as subcommands. This is due to the fact, that commands do not dispatch the events themselves but the Symfony application instead.

If you now have subscribers on these events for monitoring or added behaviour they are just not triggered as expected.

### 2. What does this change do, exactly?

Change calls from `Command->run` to `Application->run`

### 3. Describe each step to reproduce the issue or behaviour.

* Subscribe to `\Symfony\Component\Console\ConsoleEvents::TERMINATE`
* Start new action on certain command like `assets:install`
* Run CI/CD command `system:update:finish` and new additional action is not run

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d72c5d0</samp>

This pull request enhances the system maintenance commands by using the Symfony application to run sub commands and trigger command events. This affects the `SystemInstallCommand`, `SystemUpdateFinishCommand`, and `SystemSetupCommand` classes in the `src/Core/Maintenance/System/Command` directory. It also adds a changelog entry for the changes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d72c5d0</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-13d06360af062299fc0c8ba4565844d6dd054f0597e0c1a91af960b390b6f54dR1-R8))
*  Use the Symfony application to run sub commands in the system install, setup, and update finish commands, triggering the command events ([link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-33423ef9f7d06c4b6ba7ae8b4e43c31058371fbd22177926e1c932954f23e0d9L182-R204), [link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-33423ef9f7d06c4b6ba7ae8b4e43c31058371fbd22177926e1c932954f23e0d9L192-R218), [link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-9f7713763c6351c7430b4f0eacc68fc8dbc61af210379cd500ca24560c0aade4L288-R307), [link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-a8ed67eee015f1347697f3aab750e977a144afff346c68af8a46870a3b29a78eL114-R118), [link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-a8ed67eee015f1347697f3aab750e977a144afff346c68af8a46870a3b29a78eL131-R129), [link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-a8ed67eee015f1347697f3aab750e977a144afff346c68af8a46870a3b29a78eR142-R159))
*  Add a missing use statement for the `Application` class in `SystemUpdateFinishCommand.php` ([link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-a8ed67eee015f1347697f3aab750e977a144afff346c68af8a46870a3b29a78eR16))
*  Simplify the code for running sub commands by adding a helper method `runCommand` in `SystemUpdateFinishCommand.php` ([link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-a8ed67eee015f1347697f3aab750e977a144afff346c68af8a46870a3b29a78eL114-R118), [link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-a8ed67eee015f1347697f3aab750e977a144afff346c68af8a46870a3b29a78eL131-R129), [link](https://github.com/shopware/shopware/pull/3379/files?diff=unified&w=0#diff-a8ed67eee015f1347697f3aab750e977a144afff346c68af8a46870a3b29a78eR142-R159))
