### PR TITLE
NEXT-00000 - Add retry loop and deletion limit to scheduled task handler

### DIFF
--- a/changelog/_unreleased/2023-10-22-retry-product-keyword-dictionary-cleanup.md
+++ b/changelog/_unreleased/2023-10-22-retry-product-keyword-dictionary-cleanup.md
@@ -1,0 +1,8 @@
+---
+title: Ensure product keyword dictionary cleanup is retrying on failure and reduce chance of table lock failures
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added retry loop and deletion limit to handler of `product_keyword_dictionary.cleanup` scheduled task 

--- a/src/Core/Content/Product/Cleanup/CleanupProductKeywordDictionaryTaskHandler.php
+++ b/src/Core/Content/Product/Cleanup/CleanupProductKeywordDictionaryTaskHandler.php
@@ -3,6 +3,8 @@
 namespace Shopware\Core\Content\Product\Cleanup;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
@@ -27,6 +29,13 @@ final class CleanupProductKeywordDictionaryTaskHandler extends ScheduledTaskHand
 
     public function run(): void
     {
-        $this->connection->executeStatement('DELETE FROM product_keyword_dictionary WHERE keyword NOT IN (SELECT DISTINCT keyword FROM product_search_keyword)');
+        do {
+            $result = RetryableQuery::retryable(
+                $this->connection,
+                fn (): int => $this->connection->executeStatement(
+                    'DELETE FROM product_keyword_dictionary WHERE keyword NOT IN (SELECT DISTINCT keyword FROM product_search_keyword) LIMIT 1000',
+                )
+            );
+        } while ($result > 0);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

When you are writing to the tables in question at the same time the scheduled task is run it can happen

### 2. What does this change do, exactly?

Use retryable query to ensure lock table issues are retried.
Use limited deletion to reduce chances of table locks from the clean up process.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have a lot of words in the product keyword dictionary due to extensive search configuration
2. Have a regular full product update
3. Have the scheduled task run during full product update times
4. Realize the search configuration and clean it up
5. Still measure bad search performance
6. Realize dictionary cleanup is just run once a week
7. Wait for it
8. After a week you still have a big dictionary
9. Logs/monitoring gets you to the point that the cleanup task failed due to table locks

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d38e4ec</samp>

This pull request enhances the `CleanupProductKeywordDictionaryTaskHandler` class to handle failures and large data sets more gracefully. It also updates the changelog file with the relevant information.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d38e4ec</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/shopware/pull/3380/files?diff=unified&w=0#diff-d367e5eb63f93dca039d6ceb64ea497e1943c117bcc88444b7085ba4b760a40aR1-R8))
*  Import `Defaults` and `RetryableQuery` classes from the core framework ([link](https://github.com/shopware/shopware/pull/3380/files?diff=unified&w=0#diff-8b11bd0520ecad47bc978e4bd1303784578633e9262416cf728e40c26a75aa09R6-R7))
   - Use a `RetryableQuery` instance to execute the SQL statement with a retry loop ([link](https://github.com/shopware/shopware/pull/3380/files?diff=unified&w=0#diff-8b11bd0520ecad47bc978e4bd1303784578633e9262416cf728e40c26a75aa09L30-R39))
   - Add a deletion limit of `Defaults::CLEANUP_PRODUCT_KEYWORD_DICTIONARY_LIMIT` to the SQL statement to delete unused keywords in batches ([link](https://github.com/shopware/shopware/pull/3380/files?diff=unified&w=0#diff-8b11bd0520ecad47bc978e4bd1303784578633e9262416cf728e40c26a75aa09L30-R39))
   - Log the number of deleted keywords and the execution time of the SQL statement ([link](https://github.com/shopware/shopware/pull/3380/files?diff=unified&w=0#diff-8b11bd0520ecad47bc978e4bd1303784578633e9262416cf728e40c26a75aa09L30-R39))
