### PR TITLE
NEXT-00000 - Allow elasticsearch to be better drop in for normal search

### DIFF
--- a/changelog/_unreleased/2023-10-20-allow-tokenizer-overrides-when-using-elasticsearch.md
+++ b/changelog/_unreleased/2023-10-20-allow-tokenizer-overrides-when-using-elasticsearch.md
@@ -1,0 +1,8 @@
+---
+title: Allow tokenizer decorators wihth elasticsearch package
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Elasticsearch
+* Changed dependency of `\Shopware\Elasticsearch\Product\ProductSearchQueryBuilder` from `\Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer` to `\Shopware\Core\Framework\DataAbstractionLayer\Search\Term\TokenizerInterface` to allow tokenizer decorators work when adding elasticsearch bundle

--- a/src/Elasticsearch/Product/ProductSearchQueryBuilder.php
+++ b/src/Elasticsearch/Product/ProductSearchQueryBuilder.php
@@ -16,7 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Filter\AbstractTokenFilter;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\TokenizerInterface;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -41,7 +41,7 @@ class ProductSearchQueryBuilder extends AbstractProductSearchQueryBuilder
         private readonly EntityDefinitionQueryHelper $helper,
         private readonly EntityDefinition $productDefinition,
         private readonly AbstractTokenFilter $tokenFilter,
-        private readonly Tokenizer $tokenizer,
+        private readonly TokenizerInterface $tokenizer,
         private readonly ElasticsearchHelper $elasticsearchHelper
     ) {
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Decorate `\Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer` by implementing the `\Shopware\Core\Framework\DataAbstractionLayer\Search\Term\TokenizerInterface` differently to improve token detection.

### 2. What does this change do, exactly?

Change internal argument type to the interface to allow decorators.

### 3. Describe each step to reproduce the issue or behaviour.

* Decorate tokenizer using the interface
* Be still sad about the default search
* Throw opensearch onto it
* Container does not compile anymore

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1aa6369</samp>

This pull request introduces a new interface for the `Tokenizer` component of the Elasticsearch product search query builder, allowing developers to override or customize the default behavior. It also updates the changelog with a corresponding entry.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1aa6369</samp>

*  Introduce `TokenizerInterface` to allow customizing the tokenizer behavior when using Elasticsearch ([link](https://github.com/shopware/shopware/pull/3381/files?diff=unified&w=0#diff-85b966af36ae41cde60a36e9d4c12d6c9f82836c987d0b4cc48b98961f7e555eR1-R8))
* Replace the use of the concrete `Tokenizer` class with the `TokenizerInterface` interface in the `ProductSearchQueryBuilder` class ([link](https://github.com/shopware/shopware/pull/3381/files?diff=unified&w=0#diff-29b62b9b6212ddfa677c491cf24a804c962ce772ec6428b90b2468fe00a87f44L19-R19))
* Update the constructor of the `ProductSearchQueryBuilder` class to accept a `TokenizerInterface` instance instead of a `Tokenizer` instance ([link](https://github.com/shopware/shopware/pull/3381/files?diff=unified&w=0#diff-29b62b9b6212ddfa677c491cf24a804c962ce772ec6428b90b2468fe00a87f44L44-R44))
