### PR TITLE
NEXT-00000 - Use non arbitrary product search index info

### DIFF
--- a/changelog/_unreleased/2023-10-22-show-non-arbitrary-product-search-index-info.md
+++ b/changelog/_unreleased/2023-10-22-show-non-arbitrary-product-search-index-info.md
@@ -1,0 +1,8 @@
+---
+title: Use date aggregation to show product search index info
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Administration
+* Changed date display in `sw-settings-search-search-index` to a human readable time range using aggregations and `sw-time-ago`

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.html.twig
@@ -50,7 +50,12 @@
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_settings_search_search_index_lastest_build %}
     <span class="sw-settings-search__search-index-latest-build">
-        {{ $tc('sw-settings-search.generalTab.textLastedBuild') }} {{ latestBuild }}
+        <template v-if="latestIndex">
+            {{ $tc('sw-settings-search.generalTab.textLastedBuild') }} <sw-time-ago :date="latestIndex.firstDate"></sw-time-ago> &dash; <sw-time-ago :date="latestIndex.lastDate"></sw-time-ago>
+        </template>
+        <template v-else>
+            {{ $tc('sw-settings-search.generalTab.textSearchNotIndexedYet') }}
+        </template>
     </span>
     {% endblock %}
     {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

The product indexing info is not reliable. Currently it just requests the first indexing item. "First" means just sorted by id. When we have uuidv7 it should even be the first one to be indexed be the "Rebuild search index" step.

If you now rebuild search index and close the browser window you get the info of the current date time of the last indexing and still most of the products can't be found using the search because the search is not ready.

<img width="986" alt="image" src="https://github.com/shopware/shopware/assets/1133593/ebc3f5c1-76c7-4d5f-86fb-28fab7e30722">

### 2. What does this change do, exactly?

Use an aggregation of min and max createdAt instead of choosing the first indexing item's createdAt and using sw-time-ago for a human readable rendering

<img width="984" alt="image" src="https://github.com/shopware/shopware/assets/1133593/158b588f-4141-4269-beaa-a12aabb77490">

At least you now know you need a full indexing after you changed settings.

### 3. Describe each step to reproduce the issue or behaviour.

Abort indexing or just have a product update of the "first" product and immediately the info is a lie.

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db48881</samp>

This pull request enhances the search index component in the `sw-settings-search` module by using aggregations instead of sorting to get the latest product search keywords, and by showing a more informative and user-friendly time range of the last index build. It also updates the changelog and the template accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db48881</samp>

*  Add a changelog entry for the feature of showing non-arbitrary product search index info ([link](https://github.com/shopware/shopware/pull/3382/files?diff=unified&w=0#diff-e6929ddb8fdc104190f869ae48b8e4705251786b15159c14fe101b584d842064R1-R8))
*  Refactor the `sw-settings-search-search-index` component to use aggregations instead of sorting to get the first and last dates of the product search keywords ([link](https://github.com/shopware/shopware/pull/3382/files?diff=unified&w=0#diff-be0fc1cf6f4dcfaa83eb2dae1447f281aade76c49cdb21c9fdf9efcc79b47862L33-R33), [link](https://github.com/shopware/shopware/pull/3382/files?diff=unified&w=0#diff-be0fc1cf6f4dcfaa83eb2dae1447f281aade76c49cdb21c9fdf9efcc79b47862L54-R57), [link](https://github.com/shopware/shopware/pull/3382/files?diff=unified&w=0#diff-be0fc1cf6f4dcfaa83eb2dae1447f281aade76c49cdb21c9fdf9efcc79b47862L91-R86))
*  Adjust the template of the `sw_settings_search_search_index_lastest_build` block to display the time range of the latest index using the `sw-time-ago` component, or a fallback message if the index is empty ([link](https://github.com/shopware/shopware/pull/3382/files?diff=unified&w=0#diff-d2780cb530020eda160018126a9df252538befac1e59a49a20ed0550efea6f72L53-R58))
