### PR TITLE
NEXT-00000 - Remove internal hint from PartialEntity to communicate the use of public API

### DIFF
--- a/changelog/_unreleased/2023-10-23-make-partial-entity-and-fields-public-api.md
+++ b/changelog/_unreleased/2023-10-23-make-partial-entity-and-fields-public-api.md
@@ -1,0 +1,8 @@
+---
+title: Make PartialEntity and Criteria fields public API
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Removed `internal` PHP docs from `\Shopware\Core\Framework\DataAbstractionLayer\PartialEntity`, `\Shopware\Core\Framework\DataAbstractionLayer\Event\PartialEntityLoadedEvent`, `\Shopware\Core\System\SalesChannel\Entity\PartialSalesChannelEntityLoadedEvent`, `\Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria::addFields` and `\Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria::getFields`

--- a/src/Core/Framework/DataAbstractionLayer/Event/PartialEntityLoadedEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/PartialEntityLoadedEvent.php
@@ -7,9 +7,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\Log\Package;
 
-/**
- * @internal
- */
 #[Package('core')]
 class PartialEntityLoadedEvent extends EntityLoadedEvent
 {

--- a/src/Core/Framework/DataAbstractionLayer/PartialEntity.php
+++ b/src/Core/Framework/DataAbstractionLayer/PartialEntity.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\DataAbstractionLayer;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 
-/**
- * @internal
- */
 #[Package('core')]
 class PartialEntity extends ArrayEntity
 {

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -603,8 +603,6 @@ class Criteria extends Struct implements \Stringable
 
     /**
      * @param string[] $fields
-     *
-     * @internal
      */
     public function addFields(array $fields): self
     {
@@ -615,8 +613,6 @@ class Criteria extends Struct implements \Stringable
 
     /**
      * @return string[]
-     *
-     * @internal
      */
     public function getFields(): array
     {

--- a/src/Core/System/SalesChannel/Entity/PartialSalesChannelEntityLoadedEvent.php
+++ b/src/Core/System/SalesChannel/Entity/PartialSalesChannelEntityLoadedEvent.php
@@ -7,9 +7,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
-/**
- * @internal
- */
 #[Package('buyers-experience')]
 class PartialSalesChannelEntityLoadedEvent extends SalesChannelEntityLoadedEvent
 {


### PR DESCRIPTION
### 1. Why is this change necessary?

You can already use fields and partial entities via REST API and as well there are events, that are meant to be subscribed by plugins. Therefore at least the events should not be internal. But the REST API makes it too weird. Why should the REST API fields be public API but internally, plugins shall not use it. That makes no sense to me. So let's just make it public API.

### 2. What does this change do, exactly?

Remove some PHP hints so the BC checks, BC promise from Shopware see this code differently. Static code analysis tools will not annoy plugin devs about it being internal.

### 3. Describe each step to reproduce the issue or behaviour.

1. Improve code performance by using Partial Entities instead of ProductEntity
2. Have more performant code with lots of DAL features
3. Fight phpstan, that you use "internal API"

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 51213c1</samp>

This pull request makes some methods and classes related to partial entities and fields public, allowing developers to use them for customizing search criteria and handling entity loading events. The affected classes are `Criteria`, `PartialEntity`, `PartialEntityLoadedEvent`, and `PartialSalesChannelEntityLoadedEvent`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 51213c1</samp>

*  Make `PartialEntity` and related classes and methods part of the public API ([link](https://github.com/shopware/shopware/pull/3383/files?diff=unified&w=0#diff-ed8eef324eed827de2ef4e2bdb0b3d869faca5cf9c233bc67c14dfbd7e3d669eR1-R8))
   * Remove `internal` PHP doc from `PartialEntityLoadedEvent` class ([link](https://github.com/shopware/shopware/pull/3383/files?diff=unified&w=0#diff-1c91010ccb88a2d5279fef32ffd0758e50ba9e47afe55b6a754982ed68ed9ee1L10-L12))
   * Remove `internal` PHP doc from `PartialEntity` class ([link](https://github.com/shopware/shopware/pull/3383/files?diff=unified&w=0#diff-c05c35c3b1899be11fb720405e53c22e1a680ee9d4d8fb3cdf7282ea868f5e12L8-L10))
   * Remove `internal` PHP doc from `setTitle` and `addFields` methods of `Criteria` class ([link](https://github.com/shopware/shopware/pull/3383/files?diff=unified&w=0#diff-f445f835c9e5ce980dcc51e4f0d9bc7fd0cd60de4549fa03310c2000433f7ca7L606-L607),[link](https://github.com/shopware/shopware/pull/3383/files?diff=unified&w=0#diff-f445f835c9e5ce980dcc51e4f0d9bc7fd0cd60de4549fa03310c2000433f7ca7L618-L619))
   * Remove `internal` PHP doc from `PartialSalesChannelEntityLoadedEvent` class ([link](https://github.com/shopware/shopware/pull/3383/files?diff=unified&w=0#diff-fa6063020f8bac82a5d0914d26938bb279fbe0c3371a484c2b9a43ecb25d7c22L10-L12))
