### PR TITLE
NEXT-00000 - Do not punish customers search by GTIN/EAN by preventing placeholder search of numeric tokens

### DIFF
--- a/changelog/_unreleased/2023-10-23-do-not-create-prefix-infix-placeholders-for-numbers.md
+++ b/changelog/_unreleased/2023-10-23-do-not-create-prefix-infix-placeholders-for-numbers.md
@@ -1,0 +1,8 @@
+---
+title: Expect numeric search terms to be more precise apply less typo correction
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed `\Shopware\Core\Content\Product\SearchKeyword\ProductSearchTermInterpreter::slop` to skip typo correction slop generation for numeric search tokens

--- a/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
+++ b/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
@@ -118,9 +118,18 @@ class ProductSearchTermInterpreter implements ProductSearchTermInterpreterInterf
             $slopSize = mb_strlen($token) > 4 ? 2 : 1;
             $length = mb_strlen($token);
 
+            // is too short
             if (mb_strlen($token) <= 2) {
                 $slops['normal'][] = $token . '%';
                 $slops['reversed'][] = $token . '%';
+                $tokenSlops[$token] = $slops;
+
+                continue;
+            }
+
+            // looks like a number
+            if (\preg_match('/\d/', $token) === 1) {
+                $slops['normal'][] = $token . '%';
                 $tokenSlops[$token] = $slops;
 
                 continue;

--- a/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
+++ b/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
@@ -58,9 +58,18 @@ class ProductSearchTermInterpreterTest extends TestCase
 
         $keywords = array_map(fn (SearchTerm $term) => $term->getTerm(), $matches->getTerms());
 
-        sort($expected);
-        sort($keywords);
-        static::assertEquals($expected, $keywords);
+        static::assertEqualsCanonicalizing($expected, $keywords);
+    }
+
+    public function testNumericInputIsNotMatchingWithInfixPlaceholders(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $matches = $this->interpreter->interpret('1000', $context);
+
+        $keywords = array_map(fn (SearchTerm $term) => $term->getTerm(), $matches->getTerms());
+
+        static::assertNotContains('10100', $keywords);
     }
 
     /**
@@ -76,9 +85,7 @@ class ProductSearchTermInterpreterTest extends TestCase
 
         $keywords = array_map(fn (SearchTerm $term) => $term->getTerm(), $matches->getTerms());
 
-        sort($expected);
-        sort($keywords);
-        static::assertEquals($expected, $keywords);
+        static::assertEqualsCanonicalizing($expected, $keywords);
     }
 
     /**
@@ -94,10 +101,7 @@ class ProductSearchTermInterpreterTest extends TestCase
 
         static::assertEquals(\count($expected), \count($tokenTerms));
         foreach ($tokenTerms as $index => $tokenTerm) {
-            sort($expected[$index]);
-            sort($tokenTerm);
-
-            static::assertEquals($expected[$index], $tokenTerm);
+            static::assertEqualsCanonicalizing($expected[$index], $tokenTerm);
         }
     }
 
@@ -165,7 +169,7 @@ class ProductSearchTermInterpreterTest extends TestCase
             ],
             [
                 '1000',
-                ['100', '10000', '10001', '10002', '10007'],
+                ['10000', '10001', '10002', '10007'],
             ],
             'test it uses only first 8 keywords' => [
                 '10',
@@ -194,7 +198,7 @@ class ProductSearchTermInterpreterTest extends TestCase
             ],
             [
                 '1000',
-                ['100', '10000', '10001', '10002', '10007'],
+                ['10000', '10001', '10002', '10007'],
             ],
             [
                 '1',
@@ -229,7 +233,7 @@ class ProductSearchTermInterpreterTest extends TestCase
                 'Büronetz 1000',
                 [
                     ['büronetzwerk'],
-                    ['100', '10000', '10001', '10002', '10007'],
+                    ['10000', '10001', '10002', '10007'],
                 ],
             ],
             [
@@ -270,7 +274,7 @@ class ProductSearchTermInterpreterTest extends TestCase
                 '³²¼¼³¬½{¬]Büronetz³²¼¼³¬½{¬] ³²¼¼³¬½{¬]1000³²¼¼³¬½{¬]',
                 [
                     ['büronetzwerk'],
-                    ['100', '10000', '10001', '10002', '10007'],
+                    ['10000', '10001', '10002', '10007'],
                 ],
             ],
             [
@@ -285,14 +289,14 @@ class ProductSearchTermInterpreterTest extends TestCase
                 '(๑★ .̫ ★๑)Büronet（★￣∀￣★） (̂ ˃̥̥̥ ˑ̫ ˂̥̥̥ )̂1000(*＾v＾*)',
                 [
                     ['büronetzwerk'],
-                    ['100', '10000', '10001', '10002', '10007'],
+                    ['10000', '10001', '10002', '10007'],
                 ],
             ],
             [
                 '‰€€Büronet¥Æ ‡‡1000††',
                 [
                     ['büronetzwerk'],
-                    ['100', '10000', '10001', '10002', '10007'],
+                    ['10000', '10001', '10002', '10007'],
                 ],
             ],
         ];
@@ -402,6 +406,7 @@ class ProductSearchTermInterpreterTest extends TestCase
             'netzwerkspieler',
             'schwarzweiß',
             'netzwerkprotokolle',
+            '10100',
             '10000',
             '10001',
             '10002',


### PR DESCRIPTION
### 1. Why is this change necessary?

Numeric searches are very often related to either measurements (amount, sizes and dimensions, …) or are part of a  pattern (EAN sets, ISO certification codes, product number cycle, model names from e.g. graphic cards). In all mentioned cases when you search for these you are very likely to have the correct search term:

* You do not predict EAN numbers, so you have it from a label
* Product numbers are predictable but not related to the content behind it, so you have it from a label or an invoice
* Model names are predictable (e.g. computer components from CPU or GPUs), so you likely know what model you expect to find
* When you are looking for certain measurement, you have them at hand from a measurement (pressure, measure tape, scale). This could be an issue now as this could allow for variation, but this should be handled by range inputs instead, nothing for a search (opinion!)
* When you have a brand name, the number is very likely to be decoration and a  (opinion!)

In any case you would eventually still have a typo, you should not find a total mismatch because then you are baited, that you got it right. Or maybe the product is not available in the store and now you got baited.

This does not improve search for terms, that are named number but not containing numeric digits.

To say it with the words of @jkrzefski 

> Do not punish the people, that have the right info for a good search

To say it with my thoughts on how this must have been planned

<img width="498" alt="image" src="https://github.com/shopware/shopware/assets/1133593/1fc1f06a-e3a9-485c-8845-b6465e6d0487">

### 2. What does this change do, exactly?

Prevent numeric search tokens to generate prefix or inplace placeholders to be used to scan the search keyword dictionary.

The dictionary search for "10000 meter" searches with these placeholders before my changes:

```
10000 => 
    1000%
    1_000%
    1__000%
    100%
    1_00%
    1__00%
    1000%
    100_0%
    100__0%
    100%
    100_%
    100__%
meter => 
    mter%
    m_ter%
    m__ter%
    mer%
    m_er%
    m__er%
    metr%
    met_r%
    met__r%
    met%
    met_%
    met__%
```

after my changes

```
10000 => 
    10000%
meter => 
    mter%
    m_ter%
    m__ter%
    mer%
    m_er%
    m__er%
    metr%
    met_r%
    met__r%
    met%
    met_%
    met__%
```

### 3. Describe each step to reproduce the issue or behaviour.

1. Have product numbers (MPN, GTIN, product.productNumber)
2. Search for product numbers
3. Get baited by search by number into products I am not looking for
4. Bailing the store because it cannot find what I am looking for

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcbe871</samp>

This pull request improves the product search functionality by refining the fuzzy query generation and adding more tests. It modifies the `ProductSearchTermInterpreter` class to skip numeric tokens when applying `slop`, and the `ProductSearchTermInterpreterTest` class to cover this case and simplify some assertions. It also adds a changelog entry for the change.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcbe871</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0aa49408dbd8a8f6a9ae27279a5acc4173f1bdce5f56120b5c849f41825746b1R1-R8))
*  Skip typo correction slop generation for numeric search tokens in the `slop` function of the `ProductSearchTermInterpreter` class ([link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-93cfe04f788b8260c084ae323f16917f27a5a24b63422e1b3ffc614b9eb621f0R121), [link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-93cfe04f788b8260c084ae323f16917f27a5a24b63422e1b3ffc614b9eb621f0R130-R137))
*  Simplify the assertions and ignore the order of the keywords in the `testMatching` and `testMatchingTokenTerms` functions of the `ProductSearchTermInterpreterTest` class ([link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0b1cad6000c2b5b2cf9d5bb7b82c7c6ea30fc38d0c4e4194443649bd578e8574L61-R74), [link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0b1cad6000c2b5b2cf9d5bb7b82c7c6ea30fc38d0c4e4194443649bd578e8574L97-R104))
*  Add a new test function to verify that numeric search terms do not match with infix placeholders in the `ProductSearchTermInterpreterTest` class ([link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0b1cad6000c2b5b2cf9d5bb7b82c7c6ea30fc38d0c4e4194443649bd578e8574L79-R88))
*  Remove the `100` keyword from the expected results of the data providers in the `ProductSearchTermInterpreterTest` class, as it is no longer generated as a slop for the `1000` search term ([link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0b1cad6000c2b5b2cf9d5bb7b82c7c6ea30fc38d0c4e4194443649bd578e8574L168-R172), [link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0b1cad6000c2b5b2cf9d5bb7b82c7c6ea30fc38d0c4e4194443649bd578e8574L197-R201), [link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0b1cad6000c2b5b2cf9d5bb7b82c7c6ea30fc38d0c4e4194443649bd578e8574L232-R236), [link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0b1cad6000c2b5b2cf9d5bb7b82c7c6ea30fc38d0c4e4194443649bd578e8574L273-R277), [link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0b1cad6000c2b5b2cf9d5bb7b82c7c6ea30fc38d0c4e4194443649bd578e8574L288-R292), [link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0b1cad6000c2b5b2cf9d5bb7b82c7c6ea30fc38d0c4e4194443649bd578e8574L295-R299))
*  Add a new keyword `10100` to the `setupKeywords` function in the `ProductSearchTermInterpreterTest` class, to be used as a test case for the numeric search term matching ([link](https://github.com/shopware/shopware/pull/3384/files?diff=unified&w=0#diff-0b1cad6000c2b5b2cf9d5bb7b82c7c6ea30fc38d0c4e4194443649bd578e8574R409))
