### PR TITLE
NEXT-00000 - individual promotion redeemer

### DIFF
--- a/changelog/_unreleased/2023-10-21-fix-promotion-used-logic.md
+++ b/changelog/_unreleased/2023-10-21-fix-promotion-used-logic.md
@@ -1,0 +1,11 @@
+---
+title:              Fix promotion individual code redeemer if first assigned promotion is not instance of PromotionIndividualCodeEntity
+issue:              NEXT-00000
+author:             Wolfgang Kreminger
+author_email:       r4pt0s@protonmail.com
+author_github:      @r4pt0s
+---
+
+# Core
+
+-   Replaced `return` with `continue` in `src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php`

--- a/src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
+++ b/src/Core/Checkout/Promotion/Subscriber/PromotionIndividualCodeRedeemer.php
@@ -62,9 +62,10 @@ class PromotionIndividualCodeRedeemer implements EventSubscriberInterface
             }
 
             // if we did not use an individual code we might have
-            // just used a global one or anything else, so just quit in this case.
+            // just used a global one or anything else, so just continue in this case
+            // and go on with the next promotion if any are left in the collection
             if (!($individualCode instanceof PromotionIndividualCodeEntity)) {
-                return;
+                continue;
             }
 
             /** @var OrderCustomerEntity $customer */


### PR DESCRIPTION
Fix promotion individual code redeemer

### 1. Why is this change necessary?
Currently, individual promotion codes do not get marked as redeemed if other promotions get applied to the same cart as well.

### 2. What does this change do, exactly?
Instead of returning entirely, the loop continues until all line items are checked and no individual promotion code got found.

### 3. Describe each step to reproduce the issue or behaviour.
See issue #3385 

### 4. Please link to the relevant issues (if any).
#3385 and #3242 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d7654d</samp>

This pull request fixes a bug in the redemption of individual code promotions and adds support and tests for this feature. It changes the `PromotionRedemptionUpdater` and the `PromotionIndividualCodeRedeemer` classes and their test files, and updates the changelog accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0d7654d</samp>

*  Add a new changelog entry for the fix ([link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-d81c0b4d79d6f873109133ea74a060fa40280d8aaffd1ff498439e25eab4be5bR1-R11))
*  Fix the logic of the `PromotionIndividualCodeRedeemer` subscriber to process all promotions in the collection ([link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-e9b6d158353c513a2e67fe02d8ff6a3a086af263ae16b868ee14dae306902216L65-R68))
*  Format the opening PHP tag and the declare statement according to the PSR-12 coding standard in `PromotionRedemptionUpdaterTest.php` ([link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caL1-R4))
*  Add a new use statement for the `PromotionIndividualCodeRedeemer` class in `PromotionRedemptionUpdaterTest.php` ([link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caR18))
*  Add a new test case for the `PromotionIndividualCodeRedeemer` subscriber to check that the individual code is assigned to the customer who used it in the order ([link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caR148-R198))
*  Use the new helper method `createIndividualCodePayload` to create the expected payload for the individual code entity in the new test case ([link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caR255-R263))
*  Modify the helper method `createPromotionsAndOrder` to create a new individual code promotion and an individual code entity, and to set the customer id for the order ([link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caL143-R219))
*  Modify the helper method `createOrder` to add a new line item data for the individual code promotion, and to set the code and the promotionCodeType fields accordingly ([link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caL228-R321), [link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caR329-R344))
*  Modify the helper method `assertUpdatedCounts` to increase the expected number of promotions and line items, and to add a new assertion for the individual code promotion ([link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caL154-R226), [link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caL161-R233), [link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caR241-R246))
*  Modify the test case for the `PromotionRedemptionUpdater` to include the new individual code promotion id in the update method ([link](https://github.com/shopware/shopware/pull/3387/files?diff=unified&w=0#diff-54c19cb4f436fd83bcf1732dbff8f85c6bff1ef0507b6dc4715886c33b7c08caL59-R69))
