### PR TITLE
NEXT-31275 - use the product ids from the dispatched cross selling criteria context

### DIFF
--- a/changelog/_unreleased/2023-10-24-fix-cross-selling-use-criteria-ids-after-event-dispatch.md
+++ b/changelog/_unreleased/2023-10-24-fix-cross-selling-use-criteria-ids-after-event-dispatch.md
@@ -6,4 +6,4 @@ author_email: j.emig@one-dot.de
 author_github: @Xnaff
 ---
 # Core
-* Edit method `loadByIds` in `Shopware\Core\Content\Product\SalesChannel\CrossSelling\ProductCrossSellingRoute` to use the ids from the context after the event dispatch. 
+* Changed method `loadByIds` in `Shopware\Core\Content\Product\SalesChannel\CrossSelling\ProductCrossSellingRoute` to use the ids from the context after the event dispatch. 

--- a/changelog/_unreleased/2023-10-24-fix-cross-selling-use-criteria-ids-after-event-dispatch.md
+++ b/changelog/_unreleased/2023-10-24-fix-cross-selling-use-criteria-ids-after-event-dispatch.md
@@ -1,0 +1,9 @@
+---
+title: Fix custom field rule with multi select
+issue: NEXT-31275
+author: Jan Emig
+author_email: j.emig@one-dot.de
+author_github: @Xnaff
+---
+# Core
+* Edit method `loadByIds` in `Shopware\Core\Content\Product\SalesChannel\CrossSelling\ProductCrossSellingRoute` to use the ids from the context after the event dispatch. 

--- a/src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
@@ -172,6 +172,7 @@ class ProductCrossSellingRoute extends AbstractProductCrossSellingRoute
         /** @var ProductCollection $products */
         $products = $result->getEntities();
 
+        $ids = $criteria->getIds();
         $products->sortByIdArray($ids);
 
         $element->setProducts($products);

--- a/src/Core/Content/Test/Product/SalesChannel/CrossSelling/CrossSellingRouteTest.php
+++ b/src/Core/Content/Test/Product/SalesChannel/CrossSelling/CrossSellingRouteTest.php
@@ -5,17 +5,24 @@ namespace Shopware\Core\Content\Test\Product\SalesChannel\CrossSelling;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductCrossSelling\ProductCrossSellingDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
+use Shopware\Core\Content\Product\Events\ProductCrossSellingIdsCriteriaEvent;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\SalesChannel\AbstractProductCloseoutFilterFactory;
 use Shopware\Core\Content\Product\SalesChannel\CrossSelling\AbstractProductCrossSellingRoute;
 use Shopware\Core\Content\Product\SalesChannel\CrossSelling\ProductCrossSellingRoute;
+use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader;
+use Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\TaxAddToSalesChannelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -23,6 +30,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -440,6 +448,59 @@ class CrossSellingRouteTest extends TestCase
         }
     }
 
+    public function testCrossSellingEventSubscriberCriteriaIdChange(): void
+    {
+        $eventDispatcher = new EventDispatcher();
+        $productRepository = $this->getContainer()->get('product.repository');
+        $eventDispatcher->addListener(
+            ProductCrossSellingIdsCriteriaEvent::class,
+            static function (ProductCrossSellingIdsCriteriaEvent $event) use ($productRepository) {
+                $ids = array_values($event->getCrossSelling()->getAssignedProducts()->getProductIds());
+
+                $criteria = new Criteria();
+                $criteria->addFilter(new EqualsAnyFilter('parentId', $ids));
+                $crossSellingProducts = $productRepository->searchIds($criteria, $event->getContext())->getIds();
+                $event->getCriteria()->setIds($crossSellingProducts);
+            }
+        );
+
+        $route = new ProductCrossSellingRoute(
+            $this->getContainer()->get('product_cross_selling.repository'),
+            $eventDispatcher,
+            $this->createMock(ProductStreamBuilderInterface::class),
+            $this->getContainer()->get('sales_channel.product.repository'),
+            $this->createMock(SystemConfigService::class),
+            $this->createMock(ProductListingLoader::class),
+            $this->createMock(AbstractProductCloseoutFilterFactory::class)
+        );
+
+        $productId = Uuid::randomHex();
+
+        $productData = $this->getProductData($productId);
+        $productData['crossSellings'] = [[
+            'name' => 'Test Cross Selling',
+            'sortBy' => ProductCrossSellingDefinition::SORT_BY_PRICE,
+            'sortDirection' => FieldSorting::ASCENDING,
+            'active' => true,
+            'limit' => 3,
+            'type' => 'productList',
+            'assignedProducts' => $this->createAssignedProducts(true, false, true),
+        ]];
+
+        $this->salesChannelContext->getContext()->setConsiderInheritance(true);
+        $this->productRepository->create([$productData], $this->salesChannelContext->getContext());
+
+        $product = $this->productRepository->search(new Criteria([$productId]), $this->salesChannelContext->getContext())->get($productId);
+        static::assertInstanceOf(ProductEntity::class, $product);
+        $result = $route->load($product->getId(), new Request(), $this->salesChannelContext, new Criteria())->getResult();
+        static::assertEquals(1, $result->count());
+
+        $element = $result->first();
+        static::assertNotNull($element);
+        static::assertEquals(5, $element->getProducts()->count());
+        static::assertEquals(5, $element->getCrossSelling()->getAssignedProducts()?->count());
+    }
+
     private function createProductStream(bool $includesIsCloseoutProducts = false, bool $noStock = false): string
     {
         $id = Uuid::randomHex();
@@ -465,10 +526,10 @@ class CrossSellingRouteTest extends TestCase
     /**
      * @return list<array{productId: string, position: int}>
      */
-    private function createAssignedProducts(bool $includesIsCloseoutProducts = false, bool $noStock = false): array
+    private function createAssignedProducts(bool $includesIsCloseoutProducts = false, bool $noStock = false, bool $withChild = false): array
     {
         $assignedProducts = [];
-        $randomProductIds = array_column($this->createProducts($includesIsCloseoutProducts, $noStock), 'id');
+        $randomProductIds = array_column($this->createProducts($includesIsCloseoutProducts, $noStock, $withChild), 'id');
 
         foreach ($randomProductIds as $index => $productId) {
             $assignedProducts[] = [
@@ -483,7 +544,7 @@ class CrossSellingRouteTest extends TestCase
     /**
      * @return list<array<string, mixed>>
      */
-    private function createProducts(bool $isCloseout = false, bool $noStock = false): array
+    private function createProducts(bool $isCloseout = false, bool $noStock = false, bool $withChild = false): array
     {
         $manufacturerId = Uuid::randomHex();
         $taxId = Uuid::randomHex();
@@ -497,11 +558,11 @@ class CrossSellingRouteTest extends TestCase
                     $stock = $i > 0 ? 0 : 1;
                 }
 
-                $products[] = $this->getProductData(null, $manufacturerId, $taxId, $stock, $isCloseout);
+                $products[] = $this->getProductData(null, $manufacturerId, $taxId, $withChild, $stock, $isCloseout);
             }
         } else {
             for ($i = 0; $i < 5; ++$i) {
-                $products[] = $this->getProductData(null, $manufacturerId, $taxId);
+                $products[] = $this->getProductData(null, $manufacturerId, $taxId, $withChild);
             }
         }
 
@@ -514,7 +575,7 @@ class CrossSellingRouteTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private function getProductData(?string $id = null, ?string $manufacturerId = null, ?string $taxId = null, int $stock = 1, bool $isCloseout = false): array
+    private function getProductData(?string $id = null, ?string $manufacturerId = null, ?string $taxId = null, bool $withChild = false, int $stock = 1, bool $isCloseout = false): array
     {
         $price = random_int(0, 10);
 
@@ -531,6 +592,33 @@ class CrossSellingRouteTest extends TestCase
                 ['salesChannelId' => $this->salesChannelContext->getSalesChannel()->getId(), 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
             ],
         ];
+
+        if ($withChild) {
+            $optionId = Uuid::randomHex();
+            $product['configuratorSettings'] = [[
+                'option' => [
+                    'id' => $optionId,
+                    'name' => 'Option',
+                    'position' => 0,
+                    'group' => [
+                        'sortingType' => 'alphanumeric',
+                        'displayType' => 'text',
+                        'name' => 'test one group',
+                    ],
+                ],
+                'position' => 0,
+            ]];
+            $product['children'] = [[
+                'id' => Uuid::randomHex(),
+                'productNumber' => Uuid::randomHex(),
+                'stock' => 1,
+                'options' => [
+                    [
+                        'id' => $optionId,
+                    ],
+                ],
+            ]];
+        }
 
         $this->addTaxDataToSalesChannel($this->salesChannelContext, $product['tax']);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

If you subscribe to the ProductCrossSellingIdsCriteriaEvent and change the id's of the criteria, because for example you want do load the parent product or display the same color than the pdp product color selection, then you will get no result at all in the cross selling

### 2. What does this change do, exactly?

It uses the id's from the context after the event dispatch so the right id's get compared in the sortByIdArray method.

### 3. Describe each step to reproduce the issue or behaviour.

- Subscribe to the ProductCrossSellingIdsCriteriaEvent and change the search id's in the context.
- No products at all are shown

### 4. Please link to the relevant issues (if any).

[NEXT-31275](https://issues.shopware.com/issues/NEXT-31275)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c987001</samp>

This pull request fixes a bug in the cross selling feature, where the custom field rule with multi select was not applied correctly for cross selling products. It does so by using the ids from the `Criteria` object after the `ProductCrossSellingCriteriaEvent` is dispatched in `ProductCrossSellingRoute.php`. It also adds a changelog entry for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c987001</samp>

* Fix cross selling use criteria ids after event dispatch ([link](https://github.com/shopware/shopware/pull/3388/files?diff=unified&w=0#diff-1153d26ff6808cc586a3c9929416bba0b0f9fa7d411a7cff8ab7e4f612ed62f6R175), [link](https://github.com/shopware/shopware/pull/3388/files?diff=unified&w=0#diff-b73d617d88c504db6f8d907739b7ac1213200c09ea49e99df081bdebb3793d31R1-R9))
