### PR TITLE
NEXT-30650 - Fix custom field rules

### DIFF
--- a/changelog/_unreleased/2023-10-26-cannot-create-rule-for-customer-custom-fields.md
+++ b/changelog/_unreleased/2023-10-26-cannot-create-rule-for-customer-custom-fields.md
@@ -1,0 +1,11 @@
+---
+title: fix custom field rules
+issue: NEXT-30650
+author: Nicolas Schäfer
+author_email: schaefer@studio1.de
+author_github: Nico-Schaefer-2111
+---
+# Core
+* Add selectedField property to CustomerCustomFieldRule
+* Add selectedFieldSet property to OrderCustomFieldRule
+* Adjust getContraints method of LineItemCustomFieldRule

--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Cart\Rule;
 
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\CustomFieldRule;
 use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Rule\RuleComparison;
@@ -66,25 +67,7 @@ class LineItemCustomFieldRule extends Rule
      */
     public function getConstraints(): array
     {
-        return [
-            'renderedField' => [new NotBlank()],
-            'selectedField' => [new NotBlank()],
-            'selectedFieldSet' => [new NotBlank()],
-            'renderedFieldValue' => $this->getRenderedFieldValueConstraints(),
-            'operator' => [
-                new NotBlank(),
-                new Choice(
-                    [
-                        self::OPERATOR_NEQ,
-                        self::OPERATOR_GTE,
-                        self::OPERATOR_LTE,
-                        self::OPERATOR_EQ,
-                        self::OPERATOR_GT,
-                        self::OPERATOR_LT,
-                    ]
-                ),
-            ],
-        ];
+        return CustomFieldRule::getConstraints($this->renderedField);
     }
 
     /**

--- a/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerCustomFieldRule.php
@@ -16,6 +16,10 @@ class CustomerCustomFieldRule extends Rule
 
     protected string|int|bool|null|float $renderedFieldValue = null;
 
+    protected ?string $selectedField = null;
+
+    protected ?string $selectedFieldSet = null;
+
     /**
      * @param array<string, string> $renderedField
      *

--- a/src/Core/Content/Flow/Rule/OrderCustomFieldRule.php
+++ b/src/Core/Content/Flow/Rule/OrderCustomFieldRule.php
@@ -15,6 +15,10 @@ class OrderCustomFieldRule extends FlowRule
 
     protected string|int|bool|null|float $renderedFieldValue = null;
 
+    protected ?string $selectedField = null;
+
+    protected ?string $selectedFieldSet = null;
+
     /**
      * @param array<string, string> $renderedField
      *


### PR DESCRIPTION
- add missing properties to custom field rules

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Custom field rules are not working. See more in the issue ticket [NEXT-30650](https://issues.shopware.com/issues/NEXT-30650)

### 2. What does this change do, exactly?

- Adding missing properties to OrderCustomFieldRule and CustomerCustomFieldRule
- Adjusts the method "getConstraints" of the LineItemCustomFieldRule class so it is analog to the other customFieldRules


### 3. Describe each step to reproduce the issue or behaviour.

1. open the backend > settings > rule builder
2. create new rule
3. select a "customer with custom field" condition
4. try to save the new rule

### 4. Please link to the relevant issues (if any).

[NEXT-30650](https://issues.shopware.com/issues/NEXT-30650)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89f110d</samp>

This pull request refactors and extends the custom field rules for line items, customers, and orders. It adds `selectedField` and `selectedFieldSet` properties to the `CustomerCustomFieldRule` and `OrderCustomFieldRule` classes, and reuses the `CustomFieldRule` class for the `LineItemCustomFieldRule` class. This improves the specificity and flexibility of the custom field rules.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89f110d</samp>

*  Add a changelog file for the pull request ([link](https://github.com/shopware/shopware/pull/3393/files?diff=unified&w=0#diff-f7a25d0f836c36a529372dda9ab9f26cfe7a1e72aea23ae87f7f45e5a85e8788R1-R11))
*  Use the CustomFieldRule class to simplify and unify the validation logic for custom field rules ([link](https://github.com/shopware/shopware/pull/3393/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0R7), [link](https://github.com/shopware/shopware/pull/3393/files?diff=unified&w=0#diff-5a52b9e180dedde7277a16a8b777ed06297370bc3260a7985357e77ffeae75b0L69-R70))
*  Add selectedField and selectedFieldSet properties to the CustomerCustomFieldRule and OrderCustomFieldRule classes to allow more specific and flexible matching of custom fields ([link](https://github.com/shopware/shopware/pull/3393/files?diff=unified&w=0#diff-807fcd493a01a0273756a10a4399c8970e4c83341f07468dadb5aa7c84a29357R19-R22), [link](https://github.com/shopware/shopware/pull/3393/files?diff=unified&w=0#diff-0a176a7edcad360b421a0607b9fcbace6a12808b8b991e56d19b9453891d3870R18-R21))
