### PR TITLE
Fix silencing flow errors inside a transaction

### DIFF
--- a/changelog/_unreleased/2023-10-30-fix-silencing-flow-errors-inside-transactions.md
+++ b/changelog/_unreleased/2023-10-30-fix-silencing-flow-errors-inside-transactions.md
@@ -1,0 +1,9 @@
+---
+title: Fix silencing flow errors inside transaction
+issue:
+author: Maximilian Rüsch
+author_email: maximilian.ruesch@pickware.de
+author_github: maximilianruesch
+---
+# Core
+* Changed the `SetOrderStateAction` such that any exceptions are rethrown if the action is executed inside a nested transaction that does not have save points enabled for transaction nesting.

--- a/tests/integration/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
+++ b/tests/integration/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Core\Content\Test\Flow;
+namespace Shopware\Tests\Integration\Core\Content\Flow\Dispatching\Action;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
@@ -16,6 +16,7 @@ use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PrePayment;
 use Shopware\Core\Content\Flow\Dispatching\Action\SetOrderStateAction;
 use Shopware\Core\Content\Flow\Dispatching\FlowFactory;
+use Shopware\Core\Content\Test\Flow\OrderActionTrait;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -26,6 +27,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestDataCollection;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader;
+use Shopware\Core\System\StateMachine\StateMachineException;
 use Shopware\Core\Test\TestDefaults;
 
 /**
@@ -75,7 +77,7 @@ class SetOrderStateActionTest extends TestCase
         $orderStateAfterAction = $this->getOrderState($orderId);
         static::assertSame($orderState, $orderStateAfterAction);
 
-        $orderDeliveryStateAfterAction = $this->getOderDeliveryState($orderId);
+        $orderDeliveryStateAfterAction = $this->getOrderDeliveryState($orderId);
         static::assertSame($orderDeliveryState, $orderDeliveryStateAfterAction);
 
         $orderTransactionStateAfterAction = $this->getOrderTransactionState($orderId);
@@ -96,152 +98,83 @@ class SetOrderStateActionTest extends TestCase
         $orderStateAfterAction = $this->getOrderState($orderId);
         static::assertNotSame($orderState, $orderStateAfterAction);
 
-        $orderDeliveryStateAfterAction = $this->getOderDeliveryState($orderId);
+        $orderDeliveryStateAfterAction = $this->getOrderDeliveryState($orderId);
         static::assertNotSame($orderDeliveryState, $orderDeliveryStateAfterAction);
 
         $orderTransactionStateAfterAction = $this->getOrderTransactionState($orderId);
         static::assertNotSame($orderTransactionState, $orderTransactionStateAfterAction);
     }
 
-    /**
-     * @param array<string, mixed> $config
-     * @param array<string, mixed> $expects
-     *
-     * @dataProvider statusProvider
-     */
-    public function testSetOrderStatus(array $config, array $expects): void
+    public function testThrowsWhenEntityNotFoundAndInsideATransactionWithoutSavepointNesting(): void
     {
+        // Because this test needs to change savepoint nesting we need to commit the current transaction, as we cannot
+        // change this property inside a running transaction.
+        $this->connection->commit();
+        $this->connection->setNestTransactionsWithSavepoints(false);
+        $this->connection->beginTransaction();
+
         $orderId = Uuid::randomHex();
         $context = Context::createDefaultContext();
 
-        $this->orderRepository->create($this->getOrderData($orderId, $context), $context);
+        $orderData = $this->getOrderData($orderId, $context);
+        $orderData[0]['deliveries'] = [];
+        $this->orderRepository->create($orderData, $context);
         $order = $this->orderRepository->search(new Criteria([$orderId]), $context)->first();
         $event = new CheckoutOrderPlacedEvent($context, $order, TestDefaults::SALES_CHANNEL);
 
         $subscriber = new SetOrderStateAction(
             $this->getContainer()->get(Connection::class),
             $this->getContainer()->get('logger'),
-            $this->getContainer()->get(OrderService::class)
+            $this->getContainer()->get(OrderService::class),
         );
 
         /** @var FlowFactory $flowFactory */
         $flowFactory = $this->getContainer()->get(FlowFactory::class);
         $flow = $flowFactory->create($event);
-        $flow->setConfig($config);
+        $flow->setConfig(['order_delivery' => 'cancelled']);
 
-        $subscriber->handleFlow($flow);
+        static::expectException(StateMachineException::class);
+        static::expectExceptionMessage('The StateMachine named "order_delivery" was not found.');
 
-        $orderStateAfterAction = $this->getOrderState(Uuid::fromHexToBytes($orderId));
-        static::assertSame($expects['order'], $orderStateAfterAction);
-
-        $orderDeliveryStateAfterAction = $this->getOderDeliveryState(Uuid::fromHexToBytes($orderId));
-        static::assertSame($expects['order_delivery'], $orderDeliveryStateAfterAction);
-
-        $orderTransactionStateAfterAction = $this->getOrderTransactionState(Uuid::fromHexToBytes($orderId));
-        static::assertSame($expects['order_transaction'], $orderTransactionStateAfterAction);
+        $this->connection->transactional(function () use ($subscriber, $flow): void {
+            $subscriber->handleFlow($flow);
+        });
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public static function statusProvider(): array
+    public function testDoesNotThrowWhenEntityNotFoundAndInsideATransactionWithSavepointNesting(): void
     {
-        return [
-            'Set three states success' => [
-                [
-                    'order' => 'cancelled',
-                    'order_delivery' => 'cancelled',
-                    'order_transaction' => 'cancelled',
-                ],
-                [
-                    'order' => 'cancelled',
-                    'order_delivery' => 'cancelled',
-                    'order_transaction' => 'cancelled',
-                ],
-            ],
-            'Set one state success' => [
-                [
-                    'order' => 'in_progress',
-                ],
-                [
-                    'order' => 'in_progress',
-                    'order_delivery' => 'open',
-                    'order_transaction' => 'open',
-                ],
-            ],
-            'Set state not success' => [
-                [
-                    'order' => 'done',
-                ],
-                [
-                    'order' => 'open',
-                    'order_delivery' => 'open',
-                    'order_transaction' => 'open',
-                ],
-            ],
-            'Set state allow force transition' => [
-                [
-                    'order' => 'completed',
-                    'order_delivery' => 'returned',
-                    'order_transaction' => 'refunded',
-                    'force_transition' => true,
-                ],
-                [
-                    'order' => 'completed',
-                    'order_delivery' => 'returned',
-                    'order_transaction' => 'refunded',
-                ],
-            ],
-            'Set state allow force transition only one state' => [
-                [
-                    'order_delivery' => 'returned',
-                    'force_transition' => true,
-                ],
-                [
-                    'order' => 'open',
-                    'order_delivery' => 'returned',
-                    'order_transaction' => 'open',
-                ],
-            ],
-            'Set state allow force transition with not existing state' => [
-                [
-                    'open' => '',
-                    'order_delivery' => 'fake_state',
-                    'force_transition' => true,
-                ],
-                [
-                    'order' => 'open',
-                    'order_delivery' => 'open',
-                    'order_transaction' => 'open',
-                ],
-            ],
-            'Set state not allow force transition' => [
-                [
-                    'order' => 'completed',
-                    'order_delivery' => 'returned',
-                    'order_transaction' => 'refunded',
-                    'force_transition' => false,
-                ],
-                [
-                    'order' => 'open',
-                    'order_delivery' => 'open',
-                    'order_transaction' => 'open',
-                ],
-            ],
-            'Set state not allow force transition with not existing state' => [
-                [
-                    'order' => 'fake_state',
-                    'order_delivery' => '',
-                    'order_transaction' => false,
-                    'force_transition' => false,
-                ],
-                [
-                    'order' => 'open',
-                    'order_delivery' => 'open',
-                    'order_transaction' => 'open',
-                ],
-            ],
-        ];
+        // Because this test needs to change savepoint nesting we need to commit the current transaction, as we cannot
+        // change this property inside a running transaction.
+        $this->connection->commit();
+        $this->connection->setNestTransactionsWithSavepoints(true);
+        $this->connection->beginTransaction();
+
+        $orderId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+
+        $orderData = $this->getOrderData($orderId, $context);
+        $orderData[0]['deliveries'] = [];
+        $this->orderRepository->create($orderData, $context);
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $context)->first();
+        $event = new CheckoutOrderPlacedEvent($context, $order, TestDefaults::SALES_CHANNEL);
+
+        $subscriber = new SetOrderStateAction(
+            $this->getContainer()->get(Connection::class),
+            $this->getContainer()->get('logger'),
+            $this->getContainer()->get(OrderService::class),
+        );
+
+        /** @var FlowFactory $flowFactory */
+        $flowFactory = $this->getContainer()->get(FlowFactory::class);
+        $flow = $flowFactory->create($event);
+        $flow->setConfig(['order_delivery' => 'cancelled']);
+
+        $this->connection->transactional(function () use ($subscriber, $flow): void {
+            $subscriber->handleFlow($flow);
+        });
+
+        // No exception was thrown
+        static::addToAssertionCount(1);
     }
 
     private function prepareFlowSequences(string $orderState, string $orderDeliveryState, string $orderTransactionState): void
@@ -295,7 +228,7 @@ class SetOrderStateActionTest extends TestCase
         );
     }
 
-    private function getOderDeliveryState(string $orderId): string
+    private function getOrderDeliveryState(string $orderId): string
     {
         return $this->connection->fetchOne(
             '

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
@@ -187,6 +187,18 @@ class SetOrderStateActionTest extends TestCase
             ],
         ];
 
+        yield 'Test aware with config no states success' => [
+            [
+                'order' => 'done',
+            ],
+            4,
+            [
+                'order' => 'open',
+                'orderDelivery' => null,
+                'orderTransaction' => null,
+            ],
+        ];
+
         yield 'Test aware with config state allow force transition' => [
             [
                 'order' => 'completed',
@@ -199,6 +211,62 @@ class SetOrderStateActionTest extends TestCase
                 'order' => 'completed',
                 'orderDelivery' => 'returned',
                 'orderTransaction' => 'refunded',
+            ],
+        ];
+
+        yield 'Test aware with config state allow force transition and only one state' => [
+            [
+                'order' => 'completed',
+                'force_transition' => true,
+            ],
+            4,
+            [
+                'order' => 'open',
+                'orderDelivery' => null,
+                'orderTransaction' => null,
+            ],
+        ];
+
+        yield 'Test aware with config state allow force transition and non existing state' => [
+            [
+                'order' => 'fake_state',
+                'order_delivery' => '',
+                'force_transition' => true,
+            ],
+            4,
+            [
+                'order' => 'open',
+                'orderDelivery' => null,
+                'orderTransaction' => null,
+            ],
+        ];
+
+        yield 'Test aware with config state disallow force transition' => [
+            [
+                'order' => 'completed',
+                'order_delivery' => 'returned',
+                'order_transaction' => 'refunded',
+                'force_transition' => false,
+            ],
+            14,
+            [
+                'order' => 'open',
+                'orderDelivery' => 'open',
+                'orderTransaction' => 'open',
+            ],
+        ];
+
+        yield 'Test aware with config state disallow force transition and non existing state' => [
+            [
+                'order' => 'fake_state',
+                'order_delivery' => '',
+                'force_transition' => false,
+            ],
+            4,
+            [
+                'order' => 'open',
+                'orderDelivery' => null,
+                'orderTransaction' => null,
             ],
         ];
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Executing the `SetOrderStateAction` inside a transaction with a config wanting to set the order delivery state for an order that has no deliveries rightfully leads to an exception. However, this exception is immediately caught, logged and the connection is rolled back.

As Doctrine will not handle rolling back nested transactions properly unless nesting them with save points is enabled, this marks the connection as rollback only. This will then lead to another exception when the outer transaction, not knowing that the inner transaction was rolled back and trying to commit, which fails as the connection is marked as rollback only.

This new exception is not only misleading in the origin of the error, but also not rethrowing the error will make it very hard to know where it comes from anyways.

### 2. What does this change do, exactly?

Makes the `SetOrderStateAction` rethrow the error if it is running inside a nested transaction and nesting transactions with save points is not enabled. This prevents the original error from becoming masked by nested transaction errors whilst keeping the original intention of silencing flows during normal use cases.

### 3. Describe each step to reproduce the issue or behavior.

1. Create a flow that reacts to e.g. order state change to completed and immediately sets the delivery status to shipped
2. Change the order state of some order to completed inside a transaction using the state machine registry.
3. Profit

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb4f98a</samp>

This pull request fixes a bug that could cause flow errors to be ignored when updating order delivery states inside nested transactions. It also improves the test coverage and documentation of the `SetOrderStateAction` class and its related test class `SetOrderStateActionTest`. It updates the changelog with the relevant information.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb4f98a</samp>

*  Add a changelog entry for the fix ([link](https://github.com/shopware/shopware/pull/3398/files?diff=unified&w=0#diff-cee65e8990671a1b9ecd9d8ec930a1349d328f849c2161e76f97cf6612073486R1-R9))
*  Rethrow `ShopwareHttpException` in `SetOrderStateAction::update` if inside a nested transaction without save points ([link](https://github.com/shopware/shopware/pull/3398/files?diff=unified&w=0#diff-a38dbea771883758a27f2ff00e018c441b232eb27f4b5c2d2421b5d4043b72a2L95-R102))
*  Add `DateTimeImmutable` and `StateMachineException` to the `use` statements in `SetOrderStateActionTest` ([link](https://github.com/shopware/shopware/pull/3398/files?diff=unified&w=0#diff-dba7ac8e5f236e40f33f786c41ca89285da2d7725c520d9867cf1512201914f1R5), [link](https://github.com/shopware/shopware/pull/3398/files?diff=unified&w=0#diff-dba7ac8e5f236e40f33f786c41ca89285da2d7725c520d9867cf1512201914f1R30))
*  Fix typos in `getOderDeliveryState` method calls and name in `SetOrderStateActionTest` ([link](https://github.com/shopware/shopware/pull/3398/files?diff=unified&w=0#diff-dba7ac8e5f236e40f33f786c41ca89285da2d7725c520d9867cf1512201914f1L78-R80), [link](https://github.com/shopware/shopware/pull/3398/files?diff=unified&w=0#diff-dba7ac8e5f236e40f33f786c41ca89285da2d7725c520d9867cf1512201914f1L99-R101), [link](https://github.com/shopware/shopware/pull/3398/files?diff=unified&w=0#diff-dba7ac8e5f236e40f33f786c41ca89285da2d7725c520d9867cf1512201914f1L137-R211), [link](https://github.com/shopware/shopware/pull/3398/files?diff=unified&w=0#diff-dba7ac8e5f236e40f33f786c41ca89285da2d7725c520d9867cf1512201914f1L298-R372))
*  Add test methods for `SetOrderStateAction` behavior when entity not found and transaction nesting mode varies ([link](https://github.com/shopware/shopware/pull/3398/files?diff=unified&w=0#diff-dba7ac8e5f236e40f33f786c41ca89285da2d7725c520d9867cf1512201914f1R108-R179))
