### PR TITLE
NEXT-31466 - Change RegisterRoute.php and RegisterController.php to handle redirectParameters

### DIFF
--- a/changelog/_unreleased/2023-11-03-add-redirectparameters-to-confirmurl.md
+++ b/changelog/_unreleased/2023-11-03-add-redirectparameters-to-confirmurl.md
@@ -1,0 +1,14 @@
+---
+title: Add redirectParameters to confirmUrl
+issue: NEXT-31466 
+author: Benny Poensgen
+author_email: poensgen@vanwittlaer.de
+author_github: vanwittlaer
+---
+# Core
+* Changed \Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute
+to take care of redirectParameters and include them in the emitted double-opt-in event
+___
+# Storefront
+* Changed \Shopware\Storefront\Controller\RegisterController::confirmRegistration() 
+to include redirectParameters in the actual redirect

--- a/src/Storefront/Controller/RegisterController.php
+++ b/src/Storefront/Controller/RegisterController.php
@@ -220,7 +220,11 @@ class RegisterController extends StorefrontController
         $this->addFlash(self::SUCCESS, $this->trans('account.doubleOptInRegistrationSuccessfully'));
 
         if ($redirectTo = $queryDataBag->get('redirectTo')) {
-            return $this->redirectToRoute($redirectTo);
+            /** @var array<string, mixed> $parameters */
+            $parameters = $queryDataBag->all();
+            unset($parameters['em'], $parameters['hash'], $parameters['redirectTo']);
+
+            return $this->redirectToRoute($redirectTo, $parameters);
         }
 
         return $this->redirectToRoute('frontend.account.home.page');

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\CustomerException;
+use Shopware\Core\Checkout\Customer\Event\CustomerDoubleOptInRegistrationEvent;
 use Shopware\Core\Checkout\Customer\SalesChannel\RegisterRoute;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerZipCode;
 use Shopware\Core\Framework\Context;
@@ -480,6 +481,79 @@ class RegisterRouteTest extends TestCase
             ],
             'accountType' => CustomerEntity::ACCOUNT_TYPE_PRIVATE,
             'salutationId' => '',
+        ];
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getSalesChannelId')->willReturn(TestDefaults::SALES_CHANNEL);
+
+        $register->register(new RequestDataBag($data), $salesChannelContext, false);
+    }
+
+    public function testRedirectParameters(): void
+    {
+        $systemConfigService = new StaticSystemConfigService([
+            TestDefaults::SALES_CHANNEL => [
+                'core.loginRegistration.passwordMinLength' => '8',
+                'core.loginRegistration.doubleOptInRegistration' => true,
+                'core.cart.wishlistEnabled' => true,
+            ],
+            'core.systemWideLoginRegistration.isCustomerBoundToSalesChannel' => true,
+        ]);
+
+        $result = $this->createMock(EntitySearchResult::class);
+        $customerEntity = new CustomerEntity();
+        $customerEntity->setDoubleOptInRegistration(true);
+        $customerEntity->setId('customer-1');
+        $customerEntity->setGuest(false);
+        $customerEntity->setEmail('test@test.de');
+        $result->method('first')->willReturn($customerEntity);
+
+        $customerRepository = $this->createMock(EntityRepository::class);
+        $customerRepository->method('search')->willReturn($result);
+
+        $eventDispatcher = $this->createMock(EventDispatcher::class);
+        $eventDispatcher
+                ->expects(static::atLeast(1))
+                ->method('dispatch')
+                ->with(
+                    static::callback(function ($event): bool {
+                        if ($event instanceof CustomerDoubleOptInRegistrationEvent) {
+                            $query = [];
+                            $queryString = \parse_url($event->getConfirmUrl(), \PHP_URL_QUERY);
+                            self::assertIsString($queryString);
+                            \parse_str($queryString, $query);
+                            self::assertArrayHasKey('productId', $query);
+                            self::assertSame('018b906b869273fea7926f161dd23911', $query['productId']);
+                        }
+
+                        return true;
+                    })
+                );
+
+        $register = new RegisterRoute(
+            $eventDispatcher,
+            $this->createMock(NumberRangeValueGeneratorInterface::class),
+            $this->createMock(DataValidator::class),
+            $this->createMock(DataValidationFactoryInterface::class),
+            $this->createMock(DataValidationFactoryInterface::class),
+            $systemConfigService,
+            $customerRepository,
+            $this->createMock(SalesChannelContextPersister::class),
+            $this->createMock(SalesChannelRepository::class),
+            $this->createMock(Connection::class),
+            $this->createMock(SalesChannelContextService::class),
+            $this->createMock(StoreApiCustomFieldMapper::class),
+            $this->createMock(EntityRepository::class),
+        );
+
+        $data = [
+            'email' => 'test@test.de',
+            'billingAddress' => [
+                'countryId' => Uuid::randomHex(),
+            ],
+            'storefrontUrl' => 'http://localhost:8000',
+            'redirectTo' => 'frontend.wishlist.add.after.login',
+            'redirectParameters' => '{"productId":"018b906b869273fea7926f161dd23911"}',
         ];
 
         $salesChannelContext = $this->createMock(SalesChannelContext::class);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This change fixes redirectParameters not passed with the redirect.

### 2. What does this change do, exactly?
Changes in RegisterRoute.php and RegisterController.php to correctly recognize and forware registerParameters that may come with a register request (like in the context of adding a product to a wishlist with double-opt-in active for registration)

### 3. Describe each step to reproduce the issue or behaviour.
Admin: Activate the wishlist and double-opt-in options 
Storefront:
1. Reject all cookies
2. Add product to wishlist
3. Fill in the registration form
4. Click on the confirmation link sent with the doi mail

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-31466

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 067c7f2</samp>

This pull request adds a new feature to allow custom redirect parameters for the double-opt-in registration process. It modifies the `RegisterRoute` and `RegisterController` classes to handle the `redirectParameters` option, and adds a unit test and a changelog entry for the feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 067c7f2</samp>

*  Add `redirectParameters` to confirm URL for double-opt-in registration ([link](https://github.com/shopware/shopware/pull/3402/files?diff=unified&w=0#diff-e804769a1766632490bb308ea8369bc26778d1d5eea0e78159ee85ba8996d089L1-R13))
   * Update `register` method to pass `redirectParameters` to `getDoubleOptInEvent` ([link](https://github.com/shopware/shopware/pull/3402/files?diff=unified&w=0#diff-c97b3becb9f89fbbd2d23f5f134556742c61f3f7952a237e65b51c9b5bd67cabL169-R177))
   * Update `getDoubleOptInEvent` method to include `redirectParameters` in confirm URL ([link](https://github.com/shopware/shopware/pull/3402/files?diff=unified&w=0#diff-c97b3becb9f89fbbd2d23f5f134556742c61f3f7952a237e65b51c9b5bd67cabL224-R243))
   * Update `confirmRegistration` method to use `redirectParameters` for actual redirect ([link](https://github.com/shopware/shopware/pull/3402/files?diff=unified&w=0#diff-c896227b68bf76ed398b89b38a6f82916183a7f595ebe2e6438fdf6eaa716d76L223-R227))
* Add test for `redirectParameters` functionality ([link](https://github.com/shopware/shopware/pull/3402/files?diff=unified&w=0#diff-17b64de6e1f4844889edcda1056fdc934886a75ebb88079daeb7c9212e64358cR10), [link](https://github.com/shopware/shopware/pull/3402/files?diff=unified&w=0#diff-17b64de6e1f4844889edcda1056fdc934886a75ebb88079daeb7c9212e64358cR491-R563))
   * Import `CustomerDoubleOptInRegistrationEvent` class ([link](https://github.com/shopware/shopware/pull/3402/files?diff=unified&w=0#diff-17b64de6e1f4844889edcda1056fdc934886a75ebb88079daeb7c9212e64358cR10))
   * Add `testRedirectParameters` method to check event and confirm URL ([link](https://github.com/shopware/shopware/pull/3402/files?diff=unified&w=0#diff-17b64de6e1f4844889edcda1056fdc934886a75ebb88079daeb7c9212e64358cR491-R563))
