### PR TITLE
NEXT-00000 - Fix missing EntityWriteResult when the same entity is written twice within one sync request

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php
@@ -378,7 +378,7 @@ class EntityWriteResultFactory
                 $payload = $this->getCommandPayload($command);
                 $writeResults[$uniqueId] = new EntityWriteResult(
                     $primaryKey,
-                    $payload,
+                    \array_merge($payload, ($writeResults[$uniqueId] ?? null)?->getPayload() ?? []),
                     $command->getDefinition()->getEntityName(),
                     $operation,
                     $command->getEntityExistence(),


### PR DESCRIPTION
### 1. Why is this change necessary?

Let's say, you use the sync-api to efficiently send multiple sync-operations within a single batch-request. You could update the same product twice with varying payloads. Now let's say, the first payload contains a stock change, while the second update does not.

The current implementation would completely exclude the first payload from the list of `\Shopware\Core\Framework\DataAbstractionLayer\EntityWriteResult`s. This means that every subscriber of `\Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent` will not recognize the change in stock, including `\Shopware\Core\Content\Product\DataAbstractionLayer\ProductIndexer::update`.

Of course, this is just an example of the possible impacts of this bug. But it is a very real scenario, as this is how I came across this bug.

### 2. What does this change do, exactly?

The entity-write-payloads are grouped by a variable called `$uniqueId`. But the problem is that this variable is not really unique in the relevant scope. Currently, it consists of the entity's primary-key. But if you update the same entity twice in a single sync-request, the primary-key is not unique in that scope anymore.

My solution takes the array-key of the variable `$commands` as the new `$uniqueId`. From what I can tell, this variable fulfills every requirement that `$uniqueId` should fulfill, so it was a perfect fit.

The only relevant usage of `$uniqueId` is being an array-key for `$writeResults`. Since those keys are reset at the bottom of the method using `array_values`, I believe this change is not breaking anything.

### 3. Describe each step to reproduce the issue or behaviour.

```http
POST /api/_action/sync HTTP/1.1
Host: localhost
Accept: application/json
Content-Type: application/json

[
    {
        "entity": "product",
        "action": "upsert",
        "payload": [
            {
                "id": "d070b026fb564249a7dbfd62c4881589",
                "stock": 20
            }
        ]
    },
    {
        "entity": "product",
        "action": "upsert",
        "payload": [
            {
                "id": "d070b026fb564249a7dbfd62c4881589",
                "name": "Hello World"
            }
        ]
    }
]
```

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 781327d</samp>

Refactor entity write process to use array keys as unique identifiers and simplify code. Change how `$uniqueId` is assigned in `EntityWriteResultFactory.php`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 781327d</samp>

*  Simplify the assignment of `$uniqueId` by using the array key of `$commands` instead of computing it from `$primaryKey` ([link](https://github.com/shopware/shopware/pull/3405/files?diff=unified&w=0#diff-d3d1ae6bec8a4e6494ce0230563e56fd41d7611929e9ff019bb0580055320086L361-R362)). This avoids potential collisions of different commands with the same primary key and improves the performance and readability of the entity write process. This change affects the file `src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php`.
