### PR TITLE
NEXT-00000 - Use correct path to invalid price fields in error messages

### DIFF
--- a/changelog/_unreleased/2023-11-03-use-property-name-in-price-serialization-errors.md
+++ b/changelog/_unreleased/2023-11-03-use-property-name-in-price-serialization-errors.md
@@ -1,0 +1,8 @@
+---
+title: Use property name in price serialization
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Fixed validation path to include the property name of the field, that is validated instead of static `price` as name

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceFieldSerializer.php
@@ -54,13 +54,13 @@ class PriceFieldSerializer extends AbstractFieldSerializer
             }
 
             $constraints = $this->getCachedConstraints($field);
-            $pricePath = $parameters->getPath() . '/price';
+            $pricePath = $parameters->getPath() . '/' . $field->getPropertyName();
 
             foreach ($data->getValue() as $index => $price) {
                 $this->validate($constraints, new KeyValuePair((string) $index, $price, true), $pricePath);
             }
 
-            $this->ensureDefaultPrice($parameters, $data->getValue());
+            $this->ensureDefaultPrice($parameters, $data->getValue(), $field->getPropertyName());
 
             $converted = [];
 
@@ -207,7 +207,7 @@ class PriceFieldSerializer extends AbstractFieldSerializer
     /**
      * @param array<array<string, mixed>> $prices
      */
-    private function ensureDefaultPrice(WriteParameterBag $parameters, array $prices): void
+    private function ensureDefaultPrice(WriteParameterBag $parameters, array $prices, string $propertyName): void
     {
         foreach ($prices as $price) {
             if ($price['currencyId'] === Defaults::CURRENCY) {
@@ -222,7 +222,7 @@ class PriceFieldSerializer extends AbstractFieldSerializer
                 'No price for default currency defined',
                 [],
                 '',
-                '/price',
+                '/' . $propertyName,
                 $prices
             )
         );

--- a/src/Core/Framework/Test/DataAbstractionLayer/FieldSerializer/PriceFieldSerializerTest.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/FieldSerializer/PriceFieldSerializerTest.php
@@ -61,6 +61,7 @@ class PriceFieldSerializerTest extends TestCase
         } catch (WriteConstraintViolationException $e) {
             static::assertCount(1, $e->getViolations());
             static::assertSame('No price for default currency defined', $e->getViolations()->get(0)->getMessage());
+            static::assertSame('/test', $e->getViolations()->get(0)->getPropertyPath());
         }
 
         static::assertNotNull($e);


### PR DESCRIPTION
### 1. Why is this change necessary?

When you update product.purchasePrices via API with an invalid payload, the path says, that /price is wrong. But it is not about the price property. This is confusing and a hell to debug.

### 2. What does this change do, exactly?

Replace a hardcoded value with a variable one.

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3bd9436</samp>

This pull request fixes a bug in the `PriceFieldSerializer` class that caused incorrect validation paths for price fields with custom property names. It also adds a changelog entry and a test case for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3bd9436</samp>

*  Add a changelog entry for the fix ([link](https://github.com/shopware/shopware/pull/3408/files?diff=unified&w=0#diff-18ee5faa9760700d590dd765a359350ce5867c827dde82021b326dbdf5a28b23R1-R8))
*  Use the property name of the field in the price serialization errors instead of a hardcoded `price` string ([link](https://github.com/shopware/shopware/pull/3408/files?diff=unified&w=0#diff-42f306b02f2d2e99c6d1f844cbbb3692698aa1bde71911d6e7ec8b6845f9ec4fL57-R57), [link](https://github.com/shopware/shopware/pull/3408/files?diff=unified&w=0#diff-42f306b02f2d2e99c6d1f844cbbb3692698aa1bde71911d6e7ec8b6845f9ec4fL63-R63), [link](https://github.com/shopware/shopware/pull/3408/files?diff=unified&w=0#diff-42f306b02f2d2e99c6d1f844cbbb3692698aa1bde71911d6e7ec8b6845f9ec4fL210-R210), [link](https://github.com/shopware/shopware/pull/3408/files?diff=unified&w=0#diff-42f306b02f2d2e99c6d1f844cbbb3692698aa1bde71911d6e7ec8b6845f9ec4fL225-R225))
*  Update the `PriceFieldSerializerTest` class to check the validation path with the property name ([link](https://github.com/shopware/shopware/pull/3408/files?diff=unified&w=0#diff-ebc67d6e563e9830095b7c1494d3b9acba9d014ff6b4a8d27f1b14bace46fe3aR64))
