### PR TITLE
NEXT-00000 - Changed typo in twig block of contact-form

### DIFF
--- a/changelog/_unreleased/2023-11-07-twig-block-spelling-error-in-contact-form.md
+++ b/changelog/_unreleased/2023-11-07-twig-block-spelling-error-in-contact-form.md
@@ -7,4 +7,4 @@ author_github: @AEYCEN
 ---
 
 # Storefront
-* Changed typo in twig block of `contact-form.html.twig` from `cms_form_contact_input_phome` to `cms_form_contact_input_phone`
+* Deprecated typo in twig block of `contact-form.html.twig` from `cms_form_contact_input_phome` to `cms_form_contact_input_phone`

--- a/changelog/_unreleased/2023-11-07-twig-block-spelling-error-in-contact-form.md
+++ b/changelog/_unreleased/2023-11-07-twig-block-spelling-error-in-contact-form.md
@@ -7,4 +7,4 @@ author_github: @AEYCEN
 ---
 
 # Storefront
-* Deprecated typo in twig block of `contact-form.html.twig` from `cms_form_contact_input_phome` to `cms_form_contact_input_phone`
+* Deprecated typo in twig block of `contact-form.html.twig`. Changed from `cms_form_contact_input_phome` to `cms_form_contact_input_phone`

--- a/changelog/_unreleased/2023-11-07-twig-block-spelling-error-in-contact-form.md
+++ b/changelog/_unreleased/2023-11-07-twig-block-spelling-error-in-contact-form.md
@@ -1,0 +1,10 @@
+---
+title: Twig block spelling error in the standard contact form
+issue: NEXT-00000
+author: AEYCEN
+author_email: sucram.mra@gmx.de
+author_github: @AEYCEN
+---
+
+# Storefront
+* Changed typo in twig block of `contact-form.html.twig` from `cms_form_contact_input_phome` to `cms_form_contact_input_phone`

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
@@ -56,16 +56,19 @@
             {% endblock %}
 
             {% block cms_form_contact_input_phone %}
-                {% set phoneNumberFieldRequired = config('core.basicInformation.phoneNumberFieldRequired') == true %}
-                {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
-                    with {
-                    fieldName: 'phone',
-                    required: phoneNumberFieldRequired,
-                    additionalClass: 'col-md-6',
-                    label: 'account.personalPhoneLabel',
-                    placeholder: 'account.personalPhonePlaceholder'
-                }
-                %}
+                {# @deprecated tag:v6.6.0 - Use outer cms_form_contact_input_phone instead #}
+                {% block cms_form_contact_input_phome %}
+                    {% set phoneNumberFieldRequired = config('core.basicInformation.phoneNumberFieldRequired') == true %}
+                    {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
+                        with {
+                        fieldName: 'phone',
+                        required: phoneNumberFieldRequired,
+                        additionalClass: 'col-md-6',
+                        label: 'account.personalPhoneLabel',
+                        placeholder: 'account.personalPhonePlaceholder'
+                    }
+                    %}
+                {% endblock %}
             {% endblock %}
         </div>
 

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
@@ -56,9 +56,8 @@
             {% endblock %}
 
             {% block cms_form_contact_input_phone %}
-                {# @deprecated tag:v6.6.0 - Use outer cms_form_contact_input_phone instead #}
-                {% block cms_form_contact_input_phome %}
-                    {% set phoneNumberFieldRequired = config('core.basicInformation.phoneNumberFieldRequired') == true %}
+                {# @deprecated tag:v6.6.0 - Block will be renamed because of a typo. Use `cms_form_contact_input_phone` instead. #}                {% block cms_form_contact_input_phome %}
+                {% set phoneNumberFieldRequired = config('core.basicInformation.phoneNumberFieldRequired') == true %}
                     {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
                         with {
                         fieldName: 'phone',

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
@@ -55,7 +55,7 @@
                 %}
             {% endblock %}
 
-            {% block cms_form_contact_input_phome %}
+            {% block cms_form_contact_input_phone %}
                 {% set phoneNumberFieldRequired = config('core.basicInformation.phoneNumberFieldRequired') == true %}
                 {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
                     with {

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
@@ -56,8 +56,9 @@
             {% endblock %}
 
             {% block cms_form_contact_input_phone %}
-                {# @deprecated tag:v6.6.0 - Block will be renamed because of a typo. Use `cms_form_contact_input_phone` instead. #}                {% block cms_form_contact_input_phome %}
-                {% set phoneNumberFieldRequired = config('core.basicInformation.phoneNumberFieldRequired') == true %}
+                {# @deprecated tag:v6.6.0 - Block will be renamed because of a typo. Use outer `cms_form_contact_input_phone` instead. #}
+                {% block cms_form_contact_input_phome %}
+                    {% set phoneNumberFieldRequired = config('core.basicInformation.phoneNumberFieldRequired') == true %}
                     {% sw_include '@Storefront/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig'
                         with {
                         fieldName: 'phone',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Its a typo

### 2. What does this change do, exactly?
Correcting the word `phome` to `phone`
The block isnt referenced anywhere

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
#3403 
NEXT-21321

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.