### PR TITLE
Update VariantListingUpdater.php

### DIFF
--- a/src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/VariantListingUpdater.php
@@ -144,7 +144,7 @@ class VariantListingUpdater
             $groups = [];
             $configuratorGroupConfig = $config['config']['configuratorGroupConfig'] ?? [];
             foreach ($configuratorGroupConfig as $group) {
-                if ($group['expressionForListings']) {
+                if (array_key_exists('expressionForListings', $group) && $group['expressionForListings']) {
                     $groups[] = $group['id'];
                 }
             }


### PR DESCRIPTION
Check that array key exists


### 1. Why is this change necessary?
Get a warning while running `bin/console dal:refresh:index`

### 2. What does this change do, exactly?
Check that array key exists

### 3. Describe each step to reproduce the issue or behaviour.
run `bin/console dal:refresh:index`
