### PR TITLE
NEXT-00000 - Fix rare bug causing incorrect IllegalTransitionException

### DIFF
--- a/src/Core/Content/Flow/Dispatching/Action/SetOrderStateAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/SetOrderStateAction.php
@@ -185,9 +185,10 @@ class SetOrderStateAction extends FlowAction implements DelayableAction
     {
         $escaped = EntityDefinitionQueryHelper::escape($machine);
         $id = $this->connection->fetchOne(
-            'SELECT state_id FROM ' . $escaped . 'WHERE id = :id',
+            'SELECT state_id FROM ' . $escaped . 'WHERE id = :id AND version_id = :version',
             [
                 'id' => Uuid::fromHexToBytes($machineId),
+                'version' => Uuid::fromHexToBytes(Defaults::LIVE_VERSION),
             ]
         );
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This change is necessary, because the SQL query returns the state that in around 1 in 16 cases will not correspond to the actual machine state if there is an entity version with another state

### 2. What does this change do, exactly?
This change ensures that only the actual machine state (from the live version) will be used as a basis to evaluate the transition within the flow action


### 3. Describe each step to reproduce the issue or behaviour.
Consider states A, B and, C where the only legal transitions are A -> B and B -> C
Let's use the entity `order` as example, though it works for others too.
1. Create a separate version of the `order`. Ensure that this version has a lower hex value than the default live version (and as such will come first in a DB query). The order and its new version should be in the state A at this point.
2. Transition the live version of the order to state B.
3. Trigger the flow action to transition the order to state C.

The expected result would be that the order transitions to C, but in reality we would get an IllegalTransitionException, because the query from `getFromPlaceId` would return state A if the alternate version of the order existed and had a lower ID than the live version ID.

It sounds convoluted but it is an actual bug I have encountered in a project and spent way too much time figuring out.
If any further clarification is needed, feel free to ask.
