### PR TITLE
NEXT-00000 - Fix Google ReCaptcha V3 cannot refresh the token on submit

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-v3.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-v3.plugin.js
@@ -31,7 +31,7 @@ export default class GoogleReCaptchaV3Plugin extends GoogleReCaptchaBasePlugin {
             });
 
             this.grecaptchaInput.value = token;
-            this.formSubmitting = false;
+            this._formSubmitting = false
 
             this._submitInvisibleForm();
         });


### PR DESCRIPTION
### 1. Why is this change necessary?
`this.formSubmitting = false;`

the base plugin using variable `_formSubmitting`, not `formSubmitting`. it leads to the ReCaptcha V3 token not be updated on form submitting next times

### 2. What does this change do, exactly?
Changed to use correct variable `_formSubmitting`

### 3. Describe each step to reproduce the issue or behaviour.
1. Enable Google ReCaptcha V3
2. Open Contact Form -> Inspect HTML remove required from Comment input -> and Submit form without Comment -> See the form validation errors -> Then fill the Comment and Submit again -> Submit Failed /form/contact returns 403 because recaptcha token is expired by first time

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70c87ac</samp>

Renamed a private property in `google-re-captcha-v3.plugin.js` to follow the underscore prefix convention. This improves the code readability and consistency.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 70c87ac</samp>

* Renamed `this.formSubmitting` to `this._formSubmitting` in `google-re-captcha-v3.plugin.js` to follow underscore prefix convention for private properties ([link](https://github.com/shopware/shopware/pull/3415/files?diff=unified&w=0#diff-4901f28fe1d845d169897196c20831e7faf622f0ee358a7d715d2c7d990bf29bL34-R34))
