### PR TITLE
NEXT-37141 - Add button for generation of one or more variants without deleting existing ones

### DIFF
--- a/changelog/_unreleased/2024-01-29-add-single-variants.md
+++ b/changelog/_unreleased/2024-01-29-add-single-variants.md
@@ -1,0 +1,9 @@
+---
+title: Add button for generation of one or more variants without deleting existing ones
+issue: NEXT-00000
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Administration
+* Added a new mode for the modal `isAddOnly` to add variants without deleting old ones.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-modal-variant-generation/sw-product-modal-variant-generation.html.twig
@@ -4,7 +4,7 @@
     v-if="!showUploadModal"
     :title="$tc('sw-product.variations.configuratorModal.title')"
     class="sw-product-modal-variant-generation"
-    @modal-close="$emit('modal-close')"
+    @modal-close="onModalCancel"
 >
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
@@ -128,7 +128,7 @@
         {% block sw_product_modal_variant_generation_footer_cancel %}
         <sw-button
             size="small"
-            @click="$emit('modal-close')"
+            @click="onModalCancel"
         >
             {{ $tc('sw-product.variations.cancelVariationsButton') }}
         </sw-button>

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.html.twig
@@ -9,7 +9,7 @@
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_product_variants_overview_option_list_toolbar_container %}
         <sw-container
-            columns="1fr minmax(min-content, max-content) minmax(min-content, 180px) minmax(min-content, 180px)"
+            columns="1fr minmax(min-content, max-content) minmax(min-content, 180px) minmax(min-content, 180px) minmax(min-content, 180px)"
             gap="0 10px"
         >
 
@@ -110,6 +110,20 @@
                 @click="$emit('generator-open')"
             >
                 {{ $tc('sw-product.variations.overview.generateVariants') }}
+            </sw-button>
+
+            <sw-button
+                v-tooltip="{
+                    message: $tc('sw-privileges.tooltip.warning'),
+                    disabled: acl.can('product.creator'),
+                    showOnDisabledElements: true
+                }"
+                variant="ghost"
+                :disabled="!acl.can('product.creator')"
+                class="sw-product-variants__add-action"
+                @click="$emit('add-open')"
+            >
+                {{ $tc('sw-product.variations.overview.addVariants') }}
             </sw-button>
 
             <sw-button

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -387,6 +387,7 @@
         "filterReset": "Zurücksetzen",
         "filter": "Filtern",
         "generateVariants": "Varianten generieren",
+        "addVariants": "Varianten hinzufügen",
         "storefrontDelivery": "Storefront-Darstellung"
       },
       "configuratorModal": {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -387,6 +387,7 @@
         "filterReset": "Reset",
         "filter": "Filter",
         "generateVariants": "Generate variants",
+        "addVariants": "Add variants",
         "storefrontDelivery": "Storefront presentation"
       },
       "configuratorModal": {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-variants/sw-product-detail-variants.html.twig
@@ -138,6 +138,7 @@
             :selected-groups="selectedGroups"
             @variants-finish-update="updateVariantListHasContent"
             @generator-open="openModal('variantGeneration')"
+            @add-open="openModal('variantAdd')"
             @delivery-open="openModal('deliveryModal')"
         />
         {% endblock %}
@@ -153,6 +154,22 @@
         :groups="groups"
         :actual-status="activeTab"
         :selected-groups="selectedGroups"
+        :isAddOnly="false"
+        @modal-close="activeModal = ''"
+        @variations-finish-generate="updateVariations"
+    />
+    {% endblock %}
+
+
+    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+    {% block sw_product_detail_variants_modal_variant_add %}
+    <sw-product-modal-variant-generation
+        v-if="activeModal === 'variantAdd'"
+        :product="productEntity"
+        :groups="groups"
+        :actual-status="activeTab"
+        :selected-groups="selectedGroups"
+        :isAddOnly="true"
         @modal-close="activeModal = ''"
         @variations-finish-generate="updateVariations"
     />


### PR DESCRIPTION
### 1. Why is this change necessary?

There is a currently no easy way to add single variant combinations. When trying to do so, using the "Generate Variants" function will also delete variants, you still might need.

### 2. What does this change do, exactly?

Adds a new mode "onlyAdd" to the modal which will not remove the variants.

Demo:

![variants-poc](https://github.com/shopware/shopware/assets/1087128/1b4ab567-ab97-4c9f-a29d-8cd9447583ee)


### 3. Describe each step to reproduce the issue or behaviour.

1. Go to a variant product
2. Click add variants
3. Select some combinations
4. Click next
5. Variants are only added, not deleted

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### Todos (help wanted)

- [x] Clean the modal preselection when variants are added
- [ ] Jest Tests
- [ ] Fix Button's CSS

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d7ad7d9</samp>

This pull request adds a new feature to the product module, which allows adding variants without deleting existing ones. It adds a new `isAddOnly` option to the `sw-products-variants-generator` helper and the `sw-product-modal-variant-generation` component, and modifies the product detail page and the variant generation modal to use it. It also updates the labels and tooltips of the buttons for generating and adding variants, and the corresponding translations.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d7ad7d9</samp>

*  Add a new prop `isAddOnly` to the `sw-product-modal-variant-generation` component to control whether the modal should only add new variants or also synchronize and delete existing ones ([link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-ea420e5967d93facf6954d8f20ca93259a2188bd84a559675fe5d07051128ebcR44-R49), [link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-92dcd7efc2b93dbf1209d9ef26ddfeaefb2d11f3a80dfa5777e4fa36afc1af78R156), [link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-92dcd7efc2b93dbf1209d9ef26ddfeaefb2d11f3a80dfa5777e4fa36afc1af78L160-R177))
*  Pass the `isAddOnly` prop to the `sw-products-variants-generator` helper, which generates and filters the variant permutations based on the product configuration and the existing variants on the server ([link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-ea420e5967d93facf6954d8f20ca93259a2188bd84a559675fe5d07051128ebcR311), [link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-c0b9359b64314f80afca119ec51bf6ddbed2c94d585aa85af046d5dfecb16277R54), [link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-c0b9359b64314f80afca119ec51bf6ddbed2c94d585aa85af046d5dfecb16277L85-R86), [link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-c0b9359b64314f80afca119ec51bf6ddbed2c94d585aa85af046d5dfecb16277R97))
*  Modify the `filterVariations` method of the `sw-products-variants-generator` helper to skip the creation of the delete queue if the `isAddOnly` flag is true ([link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-c0b9359b64314f80afca119ec51bf6ddbed2c94d585aa85af046d5dfecb16277L123-R135))
*  Add a new button for adding variants to the `sw-product-variants-overview` component, which emits the `add-open` event to open the modal with the `isAddOnly` prop set to true ([link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-ae3259fdedfe62137ddcc40ced60bd72f2af106af8aa8b8cc4d44b19db27fb5dL112-R130))
*  Change the label of the existing button for generating variants to "Synchronize / Generate" in the `sw-product-variants-overview` component, which emits the `generator-open` event to open the modal with the `isAddOnly` prop set to false ([link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-ae3259fdedfe62137ddcc40ced60bd72f2af106af8aa8b8cc4d44b19db27fb5dL112-R130))
*  Add a tooltip for the add button in the `sw-product-variants-overview` component, which shows a warning message if the user does not have the `product.creator` privilege ([link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-ae3259fdedfe62137ddcc40ced60bd72f2af106af8aa8b8cc4d44b19db27fb5dL112-R130))
*  Add a listener for the `add-open` event to the `sw-product-detail-variants` component, which calls the `openModal` method with the `variantAdd` argument to show the modal for adding variants ([link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-92dcd7efc2b93dbf1209d9ef26ddfeaefb2d11f3a80dfa5777e4fa36afc1af78R140))
*  Update the `sw-product` snippet file for the `en-GB` locale, which contains the translations for the product module. Change the translation for the `generateVariants` key to "Synchronize / Generate" and add a new translation for the `addVariants` key as "Add" ([link](https://github.com/shopware/shopware/pull/3416/files?diff=unified&w=0#diff-38ba9297d9626e37eada8d80e7245c2320e74a099152d2210099a45d1b5ef283L385-R386))
