### PR TITLE
NEXT-00000 - Fix loading of default currency on product bulk edit

### DIFF
--- a/changelog/_unreleased/2023-11-13-fix-loading-of-default-currency-on-product-bulk-edit.md
+++ b/changelog/_unreleased/2023-11-13-fix-loading-of-default-currency-on-product-bulk-edit.md
@@ -1,0 +1,7 @@
+---
+title: Fix loading of default currency on product bulk edit
+author: Leon Rustmeier
+author_email: l.rustmeier@heptacom.de
+___
+# Administration
+* Change loading of default currency in `module/sw-bulk-edit/page/sw-bulk-edit-product/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
@@ -2,7 +2,7 @@ import template from './sw-bulk-edit-product.html.twig';
 import './sw-bulk-edit-product.scss';
 import swProductDetailState from '../../../sw-product/page/sw-product-detail/state';
 
-const { Component } = Shopware;
+const { Component, Context } = Shopware;
 const { Criteria } = Shopware.Data;
 const { types } = Shopware.Utils;
 const { chunk } = Shopware.Utils.array;
@@ -83,17 +83,13 @@ export default {
         hasSelectedChanges() {
             return Object.values(this.bulkEditProduct).some(field => field.isChanged) || this.bulkEditSelected.length > 0;
         },
+
         customFieldSetCriteria() {
             const criteria = new Criteria(1, null);
 
             criteria.addFilter(Criteria.equals('relations.entityName', 'product'));
 
             return criteria;
-        },
-
-        currencyCriteria() {
-            return (new Criteria(1, 25))
-                .addSorting(Criteria.sort('name', 'ASC'));
         },
 
         taxCriteria() {
@@ -893,8 +889,8 @@ export default {
         },
 
         loadDefaultCurrency() {
-            return this.currencyRepository.search(this.currencyCriteria).then((currencies) => {
-                this.currency = currencies.find(currency => currency.isSystemDefault);
+            return this.currencyRepository.get(Context.app.systemCurrencyId, Context.api).then((currency) => {
+                this.currency = currency;
             });
         },
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When attempting to perform bulk edits on products within a Shopware shop containing more than 25 currencies, which are alphabetically sorted higher than the default currency, you end up with a loading animation and unable to perform bulk edits.

![Bildschirmfoto 2023-11-13 um 18 24 18](https://github.com/shopware/shopware/assets/23141241/4078abce-dc67-465a-9a58-afdfea3962a9)


### 2. What does this change do, exactly?
Improves the way how the default category is loaded in `module/sw-bulk-edit/page/sw-bulk-edit-product/index.js` to prevent the previous behavior and also limit the requested data to only the default currency.

### 3. Describe each step to reproduce the issue or behaviour.
1. Open administration
2. Create more then 25 currencies that are alphabetically sorted higher than the default currency
3. Start a product bulk edit
4. Enjoy infinite loading animations

![shave-meme](https://github.com/shopware/shopware/assets/23141241/9db368b1-7df5-4517-94cb-48860ee0eb6a)


### 4. Please link to the relevant issues (if any).
none

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 178e8cc</samp>

This pull request fixes a bug that caused the wrong currency to be displayed on the product bulk edit page in the administration module. It also refactors the code to use the `Context` and `currencyRepository` objects and improves the code style.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 178e8cc</samp>

*  Add a changelog entry for the fix of loading the default currency on the product bulk edit page ([link](https://github.com/shopware/shopware/pull/3417/files?diff=unified&w=0#diff-4407fcdcb785a9a1f0d6404efb7280cc5723c8d0ce53d5f7e49c0d3a6a86a122R1-R7))
*  Import the `Context` object from Shopware to access the system currency id in the product bulk edit page component (`src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js`, [link](https://github.com/shopware/shopware/pull/3417/files?diff=unified&w=0#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783L5-R5))
*  Simplify the logic of loading the default currency by using the system currency id instead of the `isSystemDefault` flag in the `loadDefaultCurrency` method (`src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js`, [link](https://github.com/shopware/shopware/pull/3417/files?diff=unified&w=0#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783L896-R892))
*  Remove the unused `currencyCriteria` method from the product bulk edit page component (`src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js`, [link](https://github.com/shopware/shopware/pull/3417/files?diff=unified&w=0#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783L94-L98))
*  Add a blank line to separate the `computed` properties from the `methods` in the product bulk edit page component for better readability (`src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js`, [link](https://github.com/shopware/shopware/pull/3417/files?diff=unified&w=0#diff-6f5d780ac16aff8423ac70fc38f2be2bb6a8c8f8da155948ca78a2c2e77cb783R86))
