### PR TITLE
NEXT-00000 - Add missing parameters to StorefrontControllerTestBehavio…

### DIFF
--- a/changelog/_unreleased/2023-11-14-add-params-to-storefront-controller-test-behaviour.md
+++ b/changelog/_unreleased/2023-11-14-add-params-to-storefront-controller-test-behaviour.md
@@ -1,0 +1,8 @@
+---
+title: Add missing parameters to StorefrontControllerTestBehaviour::request
+author: Johannes Przymusinski
+author_email: johannes.przymusinski@jop-software.de
+author_github: cngJo
+---
+# Storefront
+* Match StorefrontControllerTestBehaviour::request's parameters to its underlying \Symfony\Component\BrowserKit\AbstractBrowser::request method

--- a/src/Storefront/Test/Controller/StorefrontControllerTestBehaviour.php
+++ b/src/Storefront/Test/Controller/StorefrontControllerTestBehaviour.php
@@ -17,10 +17,10 @@ trait StorefrontControllerTestBehaviour
     /**
      * @param array<string, mixed> $data
      */
-    public function request(string $method, string $path, array $data): Response
+    public function request(string $method, string $path, array $data, array $files = [], array $server = [], ?string $content = null, bool $changeHistory = true): Response
     {
         $browser = KernelLifecycleManager::createBrowser($this->getKernel());
-        $browser->request($method, EnvironmentHelper::getVariable('APP_URL') . '/' . $path, $data);
+        $browser->request($method, EnvironmentHelper::getVariable('APP_URL') . '/' . $path, $data, $files, $server, $content, $changeHistory);
 
         return $browser->getResponse();
     }


### PR DESCRIPTION
This change adds the parameters

| name | type | default value |
| --- | --- | --- |
| $files | `array` | `[]` |
| $server | `array` | `[]` |
| $content | `?string` | `null` |
| $changeHistory | `bool` | `true` |

and directly passes them to the underlying `\Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour::request` method.

This allows the user of the `StorefrontControllerTestBehaviour` to, e.g., set custom headers to a request made in a test case. 

Those parameters are directly taken from the underlying `\Symfony\Component\BrowserKit\AbstractBrowser::request` method. 

Note for BC: All added parameters have a default value, so it _should_ not be relevant in regard to BC.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

With the current implementation, it's e.g., not possible to set custom headers to the request made to the storefront.
In my case, this was required to test Hmac Validation for a custom Store-Api Endpoint.

### 2. What does this change do, exactly?

It adds multiple parameters to `\Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour::request` to match its underlying `\Symfony\Component\BrowserKit\AbstractBrowser::request` method.

This allows 

### 3. Describe each step to reproduce the issue or behaviour.

Write a test for an StorefrontController and try to set a custom header to the request.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98d5246</samp>

This pull request adds a new feature to the `StorefrontControllerTestBehaviour` class that enables passing more arguments to the browser request in storefront controller tests. It also updates the changelog to document this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 98d5246</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/shopware/pull/3424/files?diff=unified&w=0#diff-c48c9c66358e28ea3a23b6593d104846b46defca9d5e1e201c3b6be3628fad7fR1-R8))
*  Extend the `request` method of the `StorefrontControllerTestBehaviour` class to accept additional arguments ([link](https://github.com/shopware/shopware/pull/3424/files?diff=unified&w=0#diff-67870006bb1c6b1064318f021573f176d7031733f1ca257e5c41dd3df4f3a878L20-R28))
