### PR TITLE
Add ApiAware flags to productStream definitions

### DIFF
--- a/changelog/_unreleased/2023-11-15-add-api-aware-flags-to-product-stream-definitions.md
+++ b/changelog/_unreleased/2023-11-15-add-api-aware-flags-to-product-stream-definitions.md
@@ -1,0 +1,9 @@
+---
+title: Update product stream definitions to make them ApiAware
+issue: 3419
+author: Sander Drenth
+author_email: sander.drenth@webstores.nl
+author_github: sdrenth
+---
+# Core
+* Added API aware flag to ProductStreamDefinition id field and ProductStreamTranslationDefinition name field

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationDefinition.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamTranslation/ProductStreamTranslationDefinition.php
@@ -45,7 +45,7 @@ class ProductStreamTranslationDefinition extends EntityTranslationDefinition
     protected function defineFields(): FieldCollection
     {
         return new FieldCollection([
-            (new StringField('name', 'name'))->addFlags(new Required()),
+            (new StringField('name', 'name'))->addFlags(new ApiAware(), new Required()),
             (new LongTextField('description', 'description'))->addFlags(new ApiAware()),
             (new CustomFields())->addFlags(new ApiAware()),
         ]);

--- a/src/Core/Content/ProductStream/ProductStreamDefinition.php
+++ b/src/Core/Content/ProductStream/ProductStreamDefinition.php
@@ -56,7 +56,7 @@ class ProductStreamDefinition extends EntityDefinition
     protected function defineFields(): FieldCollection
     {
         return new FieldCollection([
-            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey(), new Required()),
             (new JsonField('api_filter', 'apiFilter'))->addFlags(new WriteProtected()),
             (new BoolField('invalid', 'invalid'))->addFlags(new WriteProtected()),
 


### PR DESCRIPTION
### 1. Why is this change necessary?
This is required in order to be able to filter on productStream.id or productStream.name when using the Store API.

### 2. What does this change do, exactly?
This makes it possible to filter on productStream.id or productStream.name


### 3. Describe each step to reproduce the issue or behaviour.
* Install the mentioned FAQ plugin
* Create a dynamic product group, assign some products
* Create a FAQ group and assign it to the created dynamic group
* Create FAQ item for the created FAQ group

Call the Store API endpoint with the following filters:

To filter by id:
```
{
    "filter": [
        {
            "type": "contains",
            "field": "productStreams.id",
            "value": "{UUID}
        }
    ],
	"associations": {
		"productStreams": ["id", "name"],
	}
}
```

To filter by name:
```
{
    "filter": [
        {
            "type": "contains",
            "field": "productStreams.id",
            "value": "{NAME}
        }
    ],
	"associations": {
		"productStreams": ["id", "name"],
	}
}
```

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/3419

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95df9d8</samp>

This pull request updates the product stream definitions to make them ApiAware, allowing them to be accessed and modified through the API. It adds the ApiAware flag to the `id` and `name` fields of the `ProductStreamDefinition` and `ProductStreamTranslationDefinition` classes, and documents the changes in the changelog.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 95df9d8</samp>

*  Add ApiAware flags to product stream definitions and translations ([link](https://github.com/shopware/shopware/pull/3425/files?diff=unified&w=0#diff-be6a36ec4ce6acc850d8fd9cd9751dbc2b98a602bb4f98dc0a8655bcd0794542L48-R48), [link](https://github.com/shopware/shopware/pull/3425/files?diff=unified&w=0#diff-cb9bd845d06c89db7736d8cfbc1f3cb16123c1077c8a7ffb744e96a5df95f606L59-R59))
* Document the changes in the changelog file ([link](https://github.com/shopware/shopware/pull/3425/files?diff=unified&w=0#diff-7c3fd662ae0ac4c6569a41d32863e1bf92ef230990ff1eaaa8443a54c587d230R1-R9))
