### PR TITLE
Changed unnecessary If-query for product metaTitle

### DIFF
--- a/changelog/_unreleased/2023-11-17-changed-unnecessary-if-query-for-produt-metaTitle.md
+++ b/changelog/_unreleased/2023-11-17-changed-unnecessary-if-query-for-produt-metaTitle.md
@@ -1,8 +1,8 @@
 ---
-title: Changed unnecessary If-Query for produt metaTitle 
+title: NEXT-00000 - Changed unnecessary If-Query for produt metaTitle 
 author: Florian Holtgrefe
 author_email: f.holtgrefe@shopware.com
-author_github: @fholtgrefe-sw
+author_github: fholtgrefe-sw
 ---
 # Storefront
 *  Changed unnecessary If-query in `/Resources/views/storefront/page/product-detail/meta.html.twig` for product metaTitle

--- a/changelog/_unreleased/2023-11-17-changed-unnecessary-if-query-for-produt-metaTitle.md
+++ b/changelog/_unreleased/2023-11-17-changed-unnecessary-if-query-for-produt-metaTitle.md
@@ -1,0 +1,10 @@
+---
+title: Changed unnecessary If-Query for produt metaTitle 
+author: Florian Holtgrefe
+author_email: f.holtgrefe@shopware.com
+author_github: @fholtgrefe-sw
+---
+# Storefront
+*  Changed unnecessary If-query in `/Resources/views/storefront/page/product-detail/meta.html.twig` for product metaTitle
+___
+

--- a/src/Storefront/Resources/views/storefront/page/product-detail/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/meta.html.twig
@@ -44,7 +44,7 @@
 {% endblock %}
 
 {% block layout_head_title_inner %}
-    {% if page.metaInformation.metaTitle %}{{ page.metaInformation.metaTitle }}{% else %}{{ page.product.translated.name }}{% if page.product.variation %} - {% for variation in page.product.variation %}{{ variation.group }}: {{ variation.option }}{% if page.product.variation|last != variation %}{{ " | " }}{% endif %}{% endfor %}{% endif %}{% endif %}
+    {% if page.product.metaTitle %}{{ page.product.metaTitle }}{% else %}{{ page.metaInformation.metaTitle }}{% endif %}
 {% endblock %}
 
 {% block layout_head_canonical %}


### PR DESCRIPTION
### 1. Why is this change necessary?
The If-Query in `Storefront:/Resources/views/storefront/page/product-detail/meta.html.twig` makes no sense cause the Twig variable `page.metaInformation` has always a value. 

### 2. What does this change do, exactly?
Changed the If-query so that when `page.product.metaTitle` has a value that value is used, otherwise `page.metaInformation.metaTitle` is used for the product meta title. 

### 3. Describe each step to reproduce the issue or behaviour.
-

### 4. Please link to the relevant issues (if any).
-

### 5. Checklist

- [x ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fd51f1f</samp>

Simplified the product detail meta title logic in `meta.html.twig` to use the product metaTitle attribute. Added a changelog file to document the change.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at fd51f1f</samp>

*  Simplify the title generation for product detail pages by using the product metaTitle or the page metaInformation metaTitle ([link](https://github.com/shopware/shopware/pull/3429/files?diff=unified&w=0#diff-ba135183896464fdc3505f5c9ceb85f3930daa1d0b2e06f77d23d226e7180cf4L47-R47))
* Create a changelog file to document the change and its author ([link](https://github.com/shopware/shopware/pull/3429/files?diff=unified&w=0#diff-d75d510404c11f6a197f0c671951597a2550b07c8b0eeefec222d498b20f6c5dR1-R10))
