### PR TITLE
NEXT-00000: disable indexing in PaymentMethodIndexer to prevent infinite loop

### DIFF
--- a/changelog/_unreleased/2023-11-20-fix-payment-method-indexing.md
+++ b/changelog/_unreleased/2023-11-20-fix-payment-method-indexing.md
@@ -1,0 +1,9 @@
+---
+title: Fix payment method indexing
+issue: NEXT-000000
+author: Niklas Wolf
+author_email: wolfniklas94@web.de
+author_github: @niklaswolf
+---
+# Core
+* prevent infinite loop during payment method indexing

--- a/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodIndexer.php
+++ b/src/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodIndexer.php
@@ -71,7 +71,8 @@ class PaymentMethodIndexer extends EntityIndexer
 
         // Create a new context with disabled-indexing state, because DAL is used inside to upsert payment methods.
         $newContext = Context::createFrom($message->getContext());
-        $newContext->addState(EntityIndexerRegistry::DISABLE_INDEXING);
+        // Apparently the new context loses the states of the old one during creation. So the old states get added back.
+        $newContext->addState(EntityIndexerRegistry::DISABLE_INDEXING, ...$message->getContext()->getStates());
         $this->distinguishableNameGenerator->generateDistinguishablePaymentNames($newContext);
 
         $this->eventDispatcher->dispatch(new PaymentMethodIndexerEvent($ids, $message->getContext(), $message->getSkip()));

--- a/tests/integration/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodIndexerTest.php
+++ b/tests/integration/Core/Checkout/Payment/DataAbstractionLayer/PaymentMethodIndexerTest.php
@@ -4,15 +4,19 @@ namespace Shopware\Tests\Integration\Core\Checkout\Payment\DataAbstractionLayer;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Payment\DataAbstractionLayer\PaymentMethodIndexer;
+use Shopware\Core\Checkout\Payment\DataAbstractionLayer\PaymentMethodIndexingMessage;
 use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Symfony\Component\Messenger\TraceableMessageBus;
 
 /**
  * @internal
@@ -179,5 +183,52 @@ class PaymentMethodIndexerTest extends TestCase
         /** @var PaymentMethodEntity $invoicePaymentByApp */
         $invoicePaymentByApp = $payments->get($invoicePaymentByAppId);
         static::assertEquals('Rechnung | App', $invoicePaymentByApp->getDistinguishableName());
+    }
+
+    public function testPaymentMethodIndexerNotLooping(): void
+    {
+        // Setup payment method(s)
+        /** @var EntityRepository $paymentRepository */
+        $paymentRepository = $this->getContainer()->get('payment_method.repository');
+        $context = Context::createFrom($this->context);
+        $context->addState(EntityIndexerRegistry::DISABLE_INDEXING, EntityIndexerRegistry::USE_INDEXING_QUEUE);
+        $paymentMethodId = Uuid::randomHex();
+        $paymentRepository->create(
+            [
+                [
+                    'id' => $paymentMethodId,
+                    'name' => [
+                        'en-GB' => 'Credit card',
+                        'de-DE' => 'Kreditkarte',
+                    ],
+                    'technicalName' => 'payment_creditcard_test',
+                    'active' => true,
+                    'plugin' => [
+                        'name' => 'Plugin',
+                        'baseClass' => 'Plugin\MyPlugin',
+                        'autoload' => [],
+                        'version' => '1.0.0',
+                        'label' => [
+                            'en-GB' => 'Plugin (English)',
+                            'de-DE' => 'Plugin (Deutsch)',
+                        ],
+                    ],
+                ],
+            ],
+            $context
+        );
+
+        // Run indexer
+        $ids = [$paymentMethodId];
+        $contextWithQueue = Context::createFrom($this->context);
+        $contextWithQueue->addState(EntityIndexerRegistry::USE_INDEXING_QUEUE);
+        $message = new PaymentMethodIndexingMessage($ids, null, $contextWithQueue);
+        $this->indexer->handle($message);
+
+        // Check messenger if there is another new PaymentMethodIndexingMessage (it shouldn't)
+        /** @var TraceableMessageBus $messageBus */
+        $messageBus = $this->getContainer()->get('messenger.bus.shopware');
+        $messages = $messageBus->getDispatchedMessages();
+        static::assertEmpty($messages);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
PaymentMethodIndexer triggers new PaymentMethodIndexingMessage after indexing.

### 2. What does this change do, exactly?
Disable indexing to prevent infinite loop

### 3. Describe each step to reproduce the issue or behaviour.
see #3430

### 4. Please link to the relevant issues (if any).
closes #3430 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at df0accf</samp>

Fixed a bug that caused infinite recursion when indexing payment methods. Introduced a new context flag to skip indexing during updates in `PaymentMethodIndexer.php`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at df0accf</samp>

* Create a new context with disabled indexing to avoid triggering the indexer again when upserting payment methods ([link](https://github.com/shopware/shopware/pull/3431/files?diff=unified&w=0#diff-53f8457eaa675371a1f1707b26af9f4159ce531ab193f61ad76ed034d0c2e056L7-R12),[link](https://github.com/shopware/shopware/pull/3431/files?diff=unified&w=0#diff-53f8457eaa675371a1f1707b26af9f4159ce531ab193f61ad76ed034d0c2e056L70-R75))
* Pass the new context to the `generateDistinguishablePaymentNames` method, which updates the payment method names to avoid duplicates ([link](https://github.com/shopware/shopware/pull/3431/files?diff=unified&w=0#diff-53f8457eaa675371a1f1707b26af9f4159ce531ab193f61ad76ed034d0c2e056L70-R75))
* Dispatch the `PaymentMethodIndexerEvent` with the original context to notify other listeners of the changes ([link](https://github.com/shopware/shopware/pull/3431/files?diff=unified&w=0#diff-53f8457eaa675371a1f1707b26af9f4159ce531ab193f61ad76ed034d0c2e056L70-R75))
* Import the `Context` and `EntityIndexerRegistry` classes from the `Shopware\Core\Framework` namespace ([link](https://github.com/shopware/shopware/pull/3431/files?diff=unified&w=0#diff-53f8457eaa675371a1f1707b26af9f4159ce531ab193f61ad76ed034d0c2e056L7-R12))
