### PR TITLE
NEXT-00000 - Improve error handling on failing fk resolvers

### DIFF
--- a/changelog/_unreleased/2023-11-18-allow-missing-fk-lookups-and-fail-on-missing-lookup.md
+++ b/changelog/_unreleased/2023-11-18-allow-missing-fk-lookups-and-fail-on-missing-lookup.md
@@ -1,0 +1,14 @@
+---
+title: Allow missing foreign key lookups and fail on missing lookups
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added constructor parameters to `\Shopware\Core\Framework\Api\Sync\FkReference` to get more info on field name, entity name and nullOfMissing behaviour flag
+* Changed `\Shopware\Core\Framework\Api\Sync\AbstractFkResolver::resolve` to allow throwing `\Shopware\Core\Framework\DataAbstractionLayer\Exception\EntityNotFoundException`
+* Added support for `nullOnMissing` and `\Shopware\Core\Framework\DataAbstractionLayer\Exception\EntityNotFoundException` to `\Shopware\Core\Content\Product\Api\ProductNumberFkResolver`
+___
+# API
+* Changed API response, when foreign key resolvers fail from "500 Internal Server Error Warning: Undefined array key" to a 404 response
+* Added optional boolean parameter `nullOnMissing` (default false) for foreign key resolvers, that controls whether resolution fails or falls back to null

--- a/src/Core/Content/Product/Api/ProductNumberFkResolver.php
+++ b/src/Core/Content/Product/Api/ProductNumberFkResolver.php
@@ -7,6 +7,7 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Sync\AbstractFkResolver;
 use Shopware\Core\Framework\Api\Sync\FkReference;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\EntityNotFoundException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -47,6 +48,15 @@ class ProductNumberFkResolver extends AbstractFkResolver
         );
 
         foreach ($map as $reference) {
+            if (!\array_key_exists($reference->value, $hash)) {
+                if ($reference->nullOnMissing) {
+                    $reference->resolved = null;
+                    continue;
+                }
+
+                throw new EntityNotFoundException('product', (string) $reference->value);
+            }
+
             $reference->resolved = $hash[$reference->value];
         }
 

--- a/src/Core/Framework/Api/Sync/AbstractFkResolver.php
+++ b/src/Core/Framework/Api/Sync/AbstractFkResolver.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Api\Sync;
 
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\EntityNotFoundException;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('core')]
@@ -14,6 +15,8 @@ abstract class AbstractFkResolver
 
     /**
      * @param array<FkReference> $map
+     *
+     * @throws EntityNotFoundException
      *
      * @return array<FkReference>
      */

--- a/src/Core/Framework/Api/Sync/FkReference.php
+++ b/src/Core/Framework/Api/Sync/FkReference.php
@@ -12,7 +12,11 @@ class FkReference
 {
     public ?string $resolved = null;
 
-    public function __construct(public mixed $value)
-    {
+    public function __construct(
+        public readonly string $entityName,
+        public readonly string $fieldName,
+        public mixed $value,
+        public readonly bool $nullOnMissing
+    ) {
     }
 }

--- a/src/Core/Framework/Api/Sync/SyncFkResolver.php
+++ b/src/Core/Framework/Api/Sync/SyncFkResolver.php
@@ -83,7 +83,12 @@ class SyncFkResolver
 
                     $resolver = (string) $value['resolver'];
 
-                    $row[$key] = $reference = new FkReference($value['value']);
+                    $row[$key] = $reference = new FkReference(
+                        $definition->getEntityName(),
+                        $field->getPropertyName(),
+                        $value['value'],
+                        $value['nullOnMissing'] ?? false
+                    );
 
                     $map[$resolver][] = $reference;
                 }


### PR DESCRIPTION
### 1. Why is this change necessary?

When I run a resolver for an entity, that is part of the same payload, then the lookup fails as the entity was not yet written. The API response is 

```
500 Internal Server Error
Warning: Undefined array key "testa5ac0d1209b972db6b186c3137f9094b"
```

What I expect is

```
404 Not Found
product for id testa5ac0d1209b972db6b186c3137f9094b not found
```

### 2. What does this change do, exactly?

Throw exceptions instead of PHP failures.

### 3. Describe each step to reproduce the issue or behaviour.

```
$factory = Factory::createAdminApiFactory();
$action = new SyncAction($factory->getActionClientUtils(), new SyncPayloadInterceptorCollection(), $factory->getBaseFactory()->getJsonStreamUtility());

$product1Number = 'test' . \bin2hex(\random_bytes(16));
$product2Number = 'test' . \bin2hex(\random_bytes(16));

$action->sync((new SyncPayload())->withSyncOperations(new SyncOperationCollection([
    (new SyncOperation('product', SyncOperation::ACTION_UPSERT, 'product-upsert1'))->withPayload([
        [
            'name' => 'Product Name 1',
            'productNumber' => $product1Number,
            'stock' => 17,
            'tax' => [
                'name' => 'Tax Product Name 1',
                'taxRate' => 19,
            ],
            'price' => [
                [
                    'currencyId' => 'b7d2554b0ce847cd82f3ac9bd1c0dfca',
                    'net' => 10.0,
                    'gross' => 11.9,
                    'linked' => false,
                ],
            ],
        ],
    ]),
    (new SyncOperation('product', SyncOperation::ACTION_UPSERT, 'product-upsert2'))->withPayload([
        [
            'name' => 'Product Name 2',
            'productNumber' => $product2Number,
            'stock' => 17,
            'tax' => [
                'name' => 'Tax Product Name 2',
                'taxRate' => 19,
            ],
            'price' => [
                [
                    'currencyId' => 'b7d2554b0ce847cd82f3ac9bd1c0dfca',
                    'net' => 10.0,
                    'gross' => 11.9,
                    'linked' => false,
                ],
            ],
            'crossSellings' => [[
                'name' => 'Product CrossSelling 2 to 1',
                'assignedProducts' => [[
                    'productId' => [
                        'resolver' => 'product.number',
                        'value' => $product1Number,
                    ],
                ]],
            ]],
        ],
    ]),
])));
```

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 51f63b6</samp>

This pull request adds a new feature to the sync API, allowing foreign key lookups to handle missing values gracefully. It introduces a new flag `nullOnMissing` for the `FkReference` class, which determines whether to set the reference to null or throw an `EntityNotFoundException` when a foreign key is not found. It also updates the `AbstractFkResolver` interface and the `ProductNumberFkResolver` and `SyncFkResolver` implementations to support this feature. It adds a new unit test and a changelog entry for the feature.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 51f63b6</samp>

*  Add a new changelog entry for the pull request ([link](https://github.com/shopware/shopware/pull/3432/files?diff=unified&w=0#diff-d172d3a2c9fe7d1a8d5923b13e1f54fcc22fd01a619b474aa1a1922f0af9966fR1-R14))
*  Modify the `FkReference` class to accept new parameters for entity name, field name, and nullOnMissing flag ([link](https://github.com/shopware/shopware/pull/3432/files?diff=unified&w=0#diff-59569291d01ac32f6504455c23470f2db221b4a832928855947a06933c7ae29aL15-R20))
*  Update the `AbstractFkResolver` interface to allow throwing an `EntityNotFoundException` when a foreign key lookup fails ([link](https://github.com/shopware/shopware/pull/3432/files?diff=unified&w=0#diff-3c62fcdc662b13215ec30d27958fe506ce09671cb1961b8c943c84028e129f27R5), [link](https://github.com/shopware/shopware/pull/3432/files?diff=unified&w=0#diff-3c62fcdc662b13215ec30d27958fe506ce09671cb1961b8c943c84028e129f27R19-R20))
*  Implement the new logic in the `ProductNumberFkResolver` class to either set the reference to null or throw an exception depending on the nullOnMissing flag ([link](https://github.com/shopware/shopware/pull/3432/files?diff=unified&w=0#diff-8d8a9fdc606aab49ee8e988891cea90f19153164df80a84548a8759ca0afe0c6R10), [link](https://github.com/shopware/shopware/pull/3432/files?diff=unified&w=0#diff-8d8a9fdc606aab49ee8e988891cea90f19153164df80a84548a8759ca0afe0c6R51-R59))
*  Pass the new parameters of the `FkReference` class to its constructor in the `SyncFkResolver` class, using the null coalescing operator to set the default value of the nullOnMissing flag to false ([link](https://github.com/shopware/shopware/pull/3432/files?diff=unified&w=0#diff-1cf41cd8295897abf783bca38a1b54316db1acd8376b46014459e10ee6ef41c0L86-R91))
*  Add a new test method `testFailResolving` to the `SyncFkResolverTest` class, using a mock registry with a dummy and a failing resolver, and asserting the expected behavior of the `SyncFkResolver` when a foreign key lookup fails ([link](https://github.com/shopware/shopware/pull/3432/files?diff=unified&w=0#diff-37b3e1c3f116ccf2b5f3074ae7f8182ab8b628c3bb913a5e2a813303070a7720R12), [link](https://github.com/shopware/shopware/pull/3432/files?diff=unified&w=0#diff-37b3e1c3f116ccf2b5f3074ae7f8182ab8b628c3bb913a5e2a813303070a7720R76-R120))
*  Add a new class `FailingFkResolver` to the `SyncFkResolverTest` file, which implements the `AbstractFkResolver` interface and always throws an exception when resolving a foreign key, unless the nullOnMissing flag is true ([link](https://github.com/shopware/shopware/pull/3432/files?diff=unified&w=0#diff-37b3e1c3f116ccf2b5f3074ae7f8182ab8b628c3bb913a5e2a813303070a7720R142-R163))
