### PR TITLE
NEXT-00000 - Append slash to sitemap home url

### DIFF
--- a/changelog/_unreleased/2023-11-22-append-slash-to-sitemap-home-url.md
+++ b/changelog/_unreleased/2023-11-22-append-slash-to-sitemap-home-url.md
@@ -1,0 +1,10 @@
+---
+title: Append slash to sitemap home url
+issue: NEXT-00000
+author: Benny Poensgen
+author_email: poensgen@vanwittlaer.de
+author_github: @vanwittlaer
+---
+# Core
+* Changed `\Shopware\Core\Content\Sitemap\Service\SitemapExporter.php`to append a slash to the home url in the sitemap. This is required to determine the base url correctly, in particular when a sales channel domain contains an url slug (like `.../de/`.)
+```

--- a/src/Core/Content/Sitemap/Service/SitemapExporter.php
+++ b/src/Core/Content/Sitemap/Service/SitemapExporter.php
@@ -149,7 +149,7 @@ class SitemapExporter implements SitemapExporterInterface
 
             foreach ($result->getUrls() as $url) {
                 $newUrl = clone $url;
-                $newUrl->setLoc(empty($newUrl->getLoc()) ? $host : $host . '/' . $newUrl->getLoc());
+                $newUrl->setLoc(rtrim($host, '/') . '/' . $newUrl->getLoc());
                 $urls[] = $newUrl;
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In order to determine the base url correclty, when the sales channel domain contains a url slug (like `https:my.tld/de/`), the trailing slash needs to be preserved. Currently, the sitemap generates the url for the home page of a sales channel without the trailing slash. (Note that e.g. the canonical link is generated correctly with the trailing slash.)

### 2. What does this change do, exactly?
Change the SitemapExporter.php to append a trailing slash to the home url.

### 3. Describe each step to reproduce the issue or behaviour.
This can be seen on any off-the-shelf installation. The sitemap lists the home url without trailing slash, whilst the canonical link is correct.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->

<!--
copilot:walkthrough
-->
