### PR TITLE
fix: ensure sequential indexes for ConfigurationService arrays

### DIFF
--- a/changelog/_unreleased/2023-11-23-fix-working-with-feature-flags-in-plugin-configuration.md
+++ b/changelog/_unreleased/2023-11-23-fix-working-with-feature-flags-in-plugin-configuration.md
@@ -1,0 +1,10 @@
+---
+title: Fix working with Feature Flags in Plugin Configuration
+issue: -
+author: Rafael Kraut
+author_email: 14234815+RafaelKr@users.noreply.github.com
+author_github: RafaelKr
+---
+# Core
+* Ensure `Shopware\Core\System\SystemConfig\Service\ConfigurationService::getConfiguration()` returns sequentially
+  indexed Arrays which are reliably encoded as Arrays instead of sometimes resulting in Objects when using json_encode.

--- a/src/Core/System/SystemConfig/Service/ConfigurationService.php
+++ b/src/Core/System/SystemConfig/Service/ConfigurationService.php
@@ -83,10 +83,28 @@ class ConfigurationService
                 $newField['config'] = $field;
                 $card['elements'][$j] = $newField;
             }
+
+            if (is_array($card['elements'])) {
+                $card['elements'] = $this->enforceSequentialIndexes($card['elements']);
+            }
+
             $config[$i] = $card;
         }
 
-        return $config;
+        return $this->enforceSequentialIndexes($config);
+    }
+
+    /**
+     * This ensures that json_encode will use an Array not an Object.
+     *
+     * It prevents JavaScript errors in the Administration if an element inside the array were unset.
+     *
+     * @param  array  $array
+     * @return array
+     */
+    private function enforceSequentialIndexes(array $array): array
+    {
+        return array_values($array);
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

When a plugin defines a config.xml with elements using `<flag>` these elements are removed if the feature flag is not enabled. This could lead to a JavaScript error when opening the Plugin configuration in the Shopware Administration.

It happens because if a configuration element is removed the resulting PHP array is non-sequentially indexed and when using `json_encode` this results in an Object instead of an Array. The Administration then tries to call the JavaScript Array method `every` on an Object which throws an Error.


### 2. What does this change do, exactly?
Ensure `/api/_action/system-config/schema?domain=SwagExamplePlugin.config` returns an Array on top-level and for `$.elements`. In a special scenario it could've returned an Object instead.


### 3. Describe each step to reproduce the issue or behaviour.
1. Create a plugin
2. Add a `src/Resources/config/config.xml` file with the following contents:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/platform/master/src/Core/System/SystemConfig/Schema/config.xsd">
    <card>
        <title>Features</title>
        <title lang="de-DE">Funktionen</title>

        <input-field type="bool">
            <name>feature1</name>
            <label>Feature 1</label>
            <label lang="de-DE">Funktion 1</label>
            <defaultValue>false</defaultValue>
            <flag>CUSTOM_FEATURE_1</flag>
        </input-field>

        <input-field type="bool">
            <name>feature2</name>
            <label>Feature 2</label>
            <label lang="de-DE">Funktion 2</label>
            <defaultValue>false</defaultValue>
            <flag>CUSTOM_FEATURE_2</flag>
        </input-field>

        <input-field type="bool">
            <name>feature3</name>
            <label>Feature 3</label>
            <label lang="de-DE">Funktion 3</label>
            <defaultValue>false</defaultValue>
            <flag>CUSTOM_FEATURE_3</flag>
        </input-field>
    </card>
</config>
```
3. Add a `src/Resources/config/packages/feature.yaml` containing
```yaml
shopware:
  feature:
    flags:
      - name: CUSTOM_FEATURE_1
        default: false
        major: false
        description: "Feature 1"

      - name: CUSTOM_FEATURE_2
        default: false
        major: false
        description: "Feature 2"

      - name: CUSTOM_FEATURE_3
        default: false
        major: false
        description: "Feature 3"
```
4. Add the following to the `.env.local` file:
```env
CUSTOM_FEATURE_3=1
```
5. Install and activate the Plugin
6. Go to the Plugin configuration page in the Administration

If you use watch mode for the administration you will see an JavaScript error with the following message `TypeError: this.config.elements.every is not a function`. This happens because we got the response below:
```json
[
  {
    "title": {
      "en-GB": "Features",
      "de-DE": "Funktionen"
    },
    "name": null,
    "elements": {
      "2": {
        "name": "SwagExamplePlugin.config.feature3",
        "type": "bool",
        "config": {
          "label": {
            "en-GB": "Feature 3",
            "de-DE": "Funktion 3"
          },
          "flag": "CUSTOM_FEATURE_3"
        }
      }
    }
  }
]
```

This happens because usually we have the following PHP array structure:
```php
$elements = [
  0 => [ "name" => "SwagExamplePlugin.config.feature1"],
  1 => [ "name" => "SwagExamplePlugin.config.feature2"],
  2 => [ "name" => "SwagExamplePlugin.config.feature3"],
]
```

When using `json_encode` we will get a JSON Array. But as soon as the PHP array has non-sequential indexes, which happens by calling `unset($elements[0])` and/or `unset($elements[1])` because these features are disabled, we get back an Object.

The actual error then happens when trying to call the Array method `.every` on the Object `card.elements` on line 118:
https://github.com/shopware/shopware/blob/6713786e59bf04336403e65eea0137807d30f76b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js#L115-L126


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 91b4945</samp>

This pull request fixes a bug that caused JSON encoding errors when using feature flags in plugin configuration. It changes the `ConfigurationService` class to reorder the indexes of the configuration arrays and adds a changelog entry for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 91b4945</samp>

*  Add a changelog entry for the fix ([link](https://github.com/shopware/shopware/pull/3442/files?diff=unified&w=0#diff-b0b0f005cbcfeaef95dd5752451c493be31c7ae4185e7edc047808ccf89df808R1-R10))
*  Modify the `getConfiguration` method of the `ConfigurationService` class to ensure sequential indexes in the returned arrays ([link](https://github.com/shopware/shopware/pull/3442/files?diff=unified&w=0#diff-508ec0847f56bb7c28f97dbbc285a4735ead2f3ec4a8343b2f9b65bc542da9e1L86-R110))
   * Use the private helper method `enforceSequentialIndexes` to reorder the indexes of the arrays recursively ([link](https://github.com/shopware/shopware/pull/3442/files?diff=unified&w=0#diff-508ec0847f56bb7c28f97dbbc285a4735ead2f3ec4a8343b2f9b65bc542da9e1L86-R110))
   * Prevent JSON encoding errors when using feature flags in plugin configuration ([link](https://github.com/shopware/shopware/pull/3442/files?diff=unified&w=0#diff-508ec0847f56bb7c28f97dbbc285a4735ead2f3ec4a8343b2f9b65bc542da9e1L86-R110))
