### PR TITLE
NEXT-32270 - add event on modal close

### DIFF
--- a/changelog/_unreleased/2023-11-24-missing-event-on-address-editor-close.md
+++ b/changelog/_unreleased/2023-11-24-missing-event-on-address-editor-close.md
@@ -1,0 +1,8 @@
+---
+title: Missing event on address editor close
+issue: NEXT-0000
+---
+
+# Storefront
+
+* Add event so that actions can follow after a modal close (form submit success)

--- a/src/Storefront/Resources/app/storefront/src/plugin/address-editor/address-editor.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/address-editor/address-editor.plugin.js
@@ -196,6 +196,7 @@ export default class AddressEditorPlugin extends Plugin {
 
                         const shouldBeClosed = ajaxForm.classList.contains(this.options.closeEditorClass);
                         if (shouldBeClosed) {
+                            this.$emitter.publish('registerAjaxSubmitCallbackModalClose', { pseudoModal });
                             pseudoModal.close();
                             PageLoadingIndicatorUtil.create();
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
https://github.com/shopware/shopware/issues/3441

### 2. What does this change do, exactly?
publish an event

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b8c7926</samp>

Added a new event `registerAjaxSubmitCallbackModalClose` to the `address-editor` plugin to enable custom actions after the address editor modal is closed. Updated the changelog with the feature description and issue number.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at b8c7926</samp>

*  Emit a new event `registerAjaxSubmitCallbackModalClose` when the address editor modal is closed after a successful form submission ([link](https://github.com/shopware/shopware/pull/3443/files?diff=unified&w=0#diff-9d7fdc9e673d34c4d3f483b904e363663fae74d66283d745c96b64d181b89f20R199), [link](https://github.com/shopware/shopware/pull/3443/files?diff=unified&w=0#diff-dcbc8a2d959b9b139e6f1fa305439cdf46230a847a8484ac2ec80e443d0eb869R1-R8))
*  Add a changelog entry for the new feature in `changelog/_unreleased/2023-11-24-missing-event-on-address-editor-close.md` ([link](https://github.com/shopware/shopware/pull/3443/files?diff=unified&w=0#diff-dcbc8a2d959b9b139e6f1fa305439cdf46230a847a8484ac2ec80e443d0eb869R1-R8))
