### PR TITLE
NEXT-00000 - setup of tests now works correctly for plugins

### DIFF
--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -351,22 +352,22 @@ class TestBootstrapper
 
     private function install(): void
     {
-        $installCommand = (new Application($this->getKernel()))->find('system:install');
+        $application = new Application($this->getKernel());
 
-        $returnCode = $installCommand->run(
+        $returnCode = $application->doRun(
             new ArrayInput(
                 [
+                    'command' => 'system:install',
                     '--create-database' => true,
                     '--force' => true,
                     '--drop-database' => true,
                     '--basic-setup' => true,
                     '--no-assign-theme' => true,
-                ],
-                $installCommand->getDefinition()
+                ]
             ),
             $this->getOutput()
         );
-        if ($returnCode !== 0) {
+        if ($returnCode !== Command::SUCCESS) {
             throw new \RuntimeException('system:install failed');
         }
 
@@ -377,28 +378,23 @@ class TestBootstrapper
     private function installPlugins(): void
     {
         $application = new Application($this->getKernel());
-        $refreshCommand = $application->find('plugin:refresh');
-        $refreshCommand->run(new ArrayInput([], $refreshCommand->getDefinition()), $this->getOutput());
+        $application->doRun(new ArrayInput(['command' => 'plugin:refresh']), $this->getOutput());
 
         $kernel = KernelLifecycleManager::bootKernel();
 
         $application = new Application($kernel);
-        $installCommand = $application->find('plugin:install');
-        $definition = $installCommand->getDefinition();
 
         foreach ($this->activePlugins as $activePlugin) {
             $args = [
+                'command' => 'plugin:install',
                 '--activate' => true,
                 '--reinstall' => true,
                 'plugins' => [$activePlugin],
             ];
 
-            $returnCode = $installCommand->run(
-                new ArrayInput($args, $definition),
-                $this->getOutput()
-            );
+            $returnCode = $application->doRun(new ArrayInput($args), $this->getOutput());
 
-            if ($returnCode !== 0) {
+            if ($returnCode !== Command::SUCCESS) {
                 throw new \RuntimeException('system:install failed');
             }
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
During bootstrapping during the tests, the plugins get installed. This currently fails with error message 
```
Symfony\Component\Console\Input\ArrayInput::getFirstArgument(): Return value must be of type ?string, array returned
```

### 2. What does this change do, exactly?
Changed call of the sub-commands during setup to how it is shown in the updated symfony docs.
See https://github.com/symfony/symfony/issues/52580#issuecomment-1822311945
This is the page in Symfony docs: https://symfony.com/doc/current/console/calling_commands.html

### 3. Describe each step to reproduce the issue or behaviour.
Run tests with plugins present.

### 4. Please link to the relevant issues (if any).
closes #3435 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f40024b</samp>

Refactored the `TestBootstrapper` class to use existing methods and constants from the `Application` and `Command` classes. This made the code more consistent and easier to understand.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f40024b</samp>

*  Refactor `install` and `installPlugins` methods in `TestBootstrapper.php` to use `doRun` method of `Application` class and simplify input and output handling ([link](https://github.com/shopware/shopware/pull/3445/files?diff=unified&w=0#diff-415856bce7b1ce403ab3f0a85540c2127bfb68e18c7c6fe9061d1a57269414e1L354-R360), [link](https://github.com/shopware/shopware/pull/3445/files?diff=unified&w=0#diff-415856bce7b1ce403ab3f0a85540c2127bfb68e18c7c6fe9061d1a57269414e1L380-R389))
*  Compare command return codes to `Command::SUCCESS` constant instead of literal `0` for clarity and consistency in `TestBootstrapper.php` ([link](https://github.com/shopware/shopware/pull/3445/files?diff=unified&w=0#diff-415856bce7b1ce403ab3f0a85540c2127bfb68e18c7c6fe9061d1a57269414e1L364-R370), [link](https://github.com/shopware/shopware/pull/3445/files?diff=unified&w=0#diff-415856bce7b1ce403ab3f0a85540c2127bfb68e18c7c6fe9061d1a57269414e1L396-R397))
*  Import `Command` class from Symfony Console component in `TestBootstrapper.php` to use its constants ([link](https://github.com/shopware/shopware/pull/3445/files?diff=unified&w=0#diff-415856bce7b1ce403ab3f0a85540c2127bfb68e18c7c6fe9061d1a57269414e1R14))
