### PR TITLE
NEXT-32039 Fix UrlEncodingTwigFilterTest

### DIFF
--- a/src/Storefront/Test/Framework/Twig/Extension/UrlEncodingTwigFilterTest.php
+++ b/src/Storefront/Test/Framework/Twig/Extension/UrlEncodingTwigFilterTest.php
@@ -107,6 +107,7 @@ class UrlEncodingTwigFilterTest extends TestCase
         $media->setFileExtension('png');
         $media->setUploadedAt($uploadTime);
         $media->setFileName('(image with spaces and brackets)');
+        $media->setPath('(image with spaces and brackets).png');
 
         $urls = $urlGenerator->generate(['foo' => UrlParams::fromMedia($media)]);
 


### PR DESCRIPTION
I've fixed the UrlEncodingTwigFilterTest tests.

- The change is necessary for keep the test green.

- I've added the path to media entity. It is mandatory for generate the url params from media.
