### PR TITLE
NEXT-00000 - Fix breadcrumb styles

### DIFF
--- a/changelog/_unreleased/2023-11-29-fix-breadcrumb-styles.md
+++ b/changelog/_unreleased/2023-11-29-fix-breadcrumb-styles.md
@@ -1,0 +1,12 @@
+---
+title: Fix breadcrumb styles
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Storefront
+* Deprecated SCSS file `Resources/app/storefront/src/scss/page/content/_breadcrumb.scss` will be removed without replacement. Bootstrap container styles are used instead.
+* Removed unused css class `breadcrumb-container` in `Resources/app/storefront/src/scss/skin/shopware/component/_breadcrumb.scss`.
+* Removed `breadcrumb` class from outer breadcrumb container in `Resources/views/storefront/page/content/index.html.twig` to prevent bootstrap styles.
+* Removed `breadcrumb` class from outer breadcrumb container in `Resources/views/storefront/page/content/product-detail.html.twig` to prevent bootstrap styles.

--- a/src/Storefront/Resources/app/storefront/src/scss/base.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/base.scss
@@ -127,6 +127,7 @@ https://sass-guidelin.es/#the-7-1-pattern
 @import 'page/checkout/confirm';
 @import 'page/checkout/finish';
 
+/** @deprecated tag:v6.6.0 - File "_breadcrumb.scss" will be removed without replacement. Bootstrap container styles are used instead. */
 @import 'page/content/breadcrumb';
 
 @import 'page/contact/contact';

--- a/src/Storefront/Resources/app/storefront/src/scss/page/content/_breadcrumb.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/content/_breadcrumb.scss
@@ -1,3 +1,7 @@
+/**
+ * @deprecated tag:v6.6.0 - File "_breadcrumb.scss" will be removed without replacement. Bootstrap container styles are used instead.
+ */
+
 .breadcrumb.cms-breadcrumb {
     padding-left: 20px;
     padding-right: 20px;

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_breadcrumb.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_breadcrumb.scss
@@ -7,18 +7,14 @@ https://getbootstrap.com/docs/5.2/components/breadcrumb
 */
 
 .breadcrumb {
+    .breadcrumb-placeholder {
+        margin: 0 $spacer-sm;
+    }
+
     svg {
         height: $font-size-base;
         width: auto;
         top: 3px;
-    }
-
-    .breadcrumb-container {
-        display: flex;
-    }
-
-    .breadcrumb-placeholder {
-        margin: 0 $spacer-sm;
     }
 
     a {

--- a/src/Storefront/Resources/views/storefront/page/content/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/index.html.twig
@@ -5,7 +5,7 @@
     <div class="container-main">
         {% block page_content %}
             {% block cms_breadcrumb %}
-                <div class="breadcrumb cms-breadcrumb container">
+                <div class="cms-breadcrumb container">
                     {% sw_include '@Storefront/storefront/layout/breadcrumb.html.twig' with {
                         context: context,
                         themeIconConfig: themeIconConfig,

--- a/src/Storefront/Resources/views/storefront/page/content/product-detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/product-detail.html.twig
@@ -8,7 +8,7 @@
     <div class="container-main">
         {% block page_content %}
             {% block cms_breadcrumb %}
-                <div class="breadcrumb cms-breadcrumb container">
+                <div class="cms-breadcrumb container">
                     {% sw_include '@Storefront/storefront/layout/breadcrumb.html.twig' with {
                         context: context,
                         themeIconConfig: themeIconConfig,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currenty the `breadcrumb` css class (bootstrap styled) is used on outer breadcrumb containers which leads to nested `breadcrumb` elements.

### 2. What does this change do, exactly?
Remove the `breadcrumb` class from outer breadcrumb container (cms-breadcrumb), deprecate unnecessary breadcrumb scss file and remove unused `breadcrumb-container` class styles.

### 3. Describe each step to reproduce the issue or behaviour.
Inspect breadcrumbs on category or product detail page.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 82f1306</samp>

This pull request simplifies the breadcrumb styling in the storefront by removing unnecessary classes and margins and using bootstrap container styles. It also adds deprecation comments and changelog entries for the affected files.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 82f1306</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/shopware/pull/3451/files?diff=unified&w=0#diff-52c3540ebfff38b0601de42ae90afe0a15bc1fb6be9510f85ba782525db3ec0dR1-R12))
*  Deprecate the _breadcrumb.scss file and use bootstrap container styles instead ([link](https://github.com/shopware/shopware/pull/3451/files?diff=unified&w=0#diff-f307b3154f8a24dbfe39f407d15b662d4425a900a0744c2f722262c76a8f9ea1R130), [link](https://github.com/shopware/shopware/pull/3451/files?diff=unified&w=0#diff-4e7b09c17f253ad8798e8656bfec63daed0ce11e1e782cea0babc0e6e7bee1e4R1-R4))
*  Adjust the margin of the breadcrumb placeholder element to align with the page content ([link](https://github.com/shopware/shopware/pull/3451/files?diff=unified&w=0#diff-88a6d20ee3bbbdd4f6c26ae72270c2334fb57407e07a631c9391de2395106e6eR10-R13))
*  Remove the unused breadcrumb-container class and the margin for the breadcrumb placeholder element ([link](https://github.com/shopware/shopware/pull/3451/files?diff=unified&w=0#diff-88a6d20ee3bbbdd4f6c26ae72270c2334fb57407e07a631c9391de2395106e6eL16-L23))
*  Remove the breadcrumb class from the outer breadcrumb element in the index.html.twig and product-detail.html.twig templates to avoid conflicts with bootstrap styles ([link](https://github.com/shopware/shopware/pull/3451/files?diff=unified&w=0#diff-d186c1054c970a718d87db6d564f9a2a976e15c15ea2f279417263e82e58239bL8-R8), [link](https://github.com/shopware/shopware/pull/3451/files?diff=unified&w=0#diff-c5137a916d56ec5cc51d43738ede9b9cece1788c8aef170dd858112790e5c897L11-R11))
