### PR TITLE
NEXT-00000 - Fix download link mail

### DIFF
--- a/changelog/_unreleased/2023-12-04-fix-download-link-mail.md
+++ b/changelog/_unreleased/2023-12-04-fix-download-link-mail.md
@@ -1,0 +1,10 @@
+---
+title: Fix download link mail
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Changed `downloads_delivery` mail fixtures to use `rawUrl` instead of `url` for product download link to use the correct sales channel.
+* Added new migration `Migration1701688920FixDownloadLinkMail` to update `downloads_delivery` mail templates.

--- a/src/Core/Migration/Fixtures/mails/downloads_delivery/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/downloads_delivery/de-html.html.twig
@@ -22,7 +22,7 @@
                         <td>
                             {% for download in lineItem.downloads %}
                                 {% if download.accessGranted %}
-                                    {% set downloadLink = url('frontend.account.order.single.download', {'orderId': order.id, 'downloadId': download.id, 'deepLinkCode': order.deepLinkCode}) %}
+                                    {% set downloadLink = rawUrl('frontend.account.order.single.download', {'orderId': order.id, 'downloadId': download.id, 'deepLinkCode': order.deepLinkCode}, salesChannel.domains|first.url) %}
                                     <a href="{{ downloadLink }}" target="_blank">
                                         {{ download.media.fileName }}.{{ download.media.fileExtension }}
                                     </a><br>

--- a/src/Core/Migration/Fixtures/mails/downloads_delivery/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/downloads_delivery/de-plain.html.twig
@@ -7,7 +7,7 @@ Mit dieser E-Mail erhalten Sie die Dateien zu der Bestellung: {{ order.orderNumb
 
 -------------------------------------
 {% for download in lineItem.downloads %}{% if download.accessGranted %}
-{{ download.media.fileName }}.{{ download.media.fileExtension }} - {% set downloadLink = url('frontend.account.order.single.download', {'orderId': order.id, 'downloadId': download.id, 'deepLinkCode': order.deepLinkCode}) %}{{ downloadLink }}
+{{ download.media.fileName }}.{{ download.media.fileExtension }} - {% set downloadLink = rawUrl('frontend.account.order.single.download', {'orderId': order.id, 'downloadId': download.id, 'deepLinkCode': order.deepLinkCode}, salesChannel.domains|first.url) %}{{ downloadLink }}
 {% endif %}{% endfor %}
 
 {% endif %}{% endfor %}

--- a/src/Core/Migration/Fixtures/mails/downloads_delivery/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/downloads_delivery/en-html.html.twig
@@ -22,7 +22,7 @@
                         <td>
                             {% for download in lineItem.downloads %}
                                 {% if download.accessGranted %}
-                                    {% set downloadLink = url('frontend.account.order.single.download', {'orderId': order.id, 'downloadId': download.id, 'deepLinkCode': order.deepLinkCode}) %}
+                                    {% set downloadLink = rawUrl('frontend.account.order.single.download', {'orderId': order.id, 'downloadId': download.id, 'deepLinkCode': order.deepLinkCode}, salesChannel.domains|first.url) %}
                                     <a href="{{ downloadLink }}" target="_blank">
                                         {{ download.media.fileName }}.{{ download.media.fileExtension }}
                                     </a><br>

--- a/src/Core/Migration/Fixtures/mails/downloads_delivery/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/downloads_delivery/en-plain.html.twig
@@ -7,7 +7,7 @@ Attached to this email you will find the files to the order: {{ order.orderNumbe
 
 -------------------------------------
 {% for download in lineItem.downloads %}{% if download.accessGranted %}
-{{ download.media.fileName }}.{{ download.media.fileExtension }} - {% set downloadLink = url('frontend.account.order.single.download', {'orderId': order.id, 'downloadId': download.id, 'deepLinkCode': order.deepLinkCode}) %}{{ downloadLink }}
+{{ download.media.fileName }}.{{ download.media.fileExtension }} - {% set downloadLink = rawUrl('frontend.account.order.single.download', {'orderId': order.id, 'downloadId': download.id, 'deepLinkCode': order.deepLinkCode}, salesChannel.domains|first.url) %}{{ downloadLink }}
 {% endif %}{% endfor %}
 
 {% endif %}{% endfor %}

--- a/src/Core/Migration/V6_6/Migration1701688920FixDownloadLinkMail.php
+++ b/src/Core/Migration/V6_6/Migration1701688920FixDownloadLinkMail.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Migration\Traits\MailUpdate;
+use Shopware\Core\Migration\Traits\UpdateMailTrait;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1701688920FixDownloadLinkMail extends MigrationStep
+{
+    use UpdateMailTrait;
+
+    public function getCreationTimestamp(): int
+    {
+        return 1701688920;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $update = new MailUpdate(
+            MailTemplateTypes::MAILTYPE_DOWNLOADS_DELIVERY,
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/downloads_delivery/en-plain.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/downloads_delivery/en-html.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/downloads_delivery/de-plain.html.twig'),
+            (string) file_get_contents(__DIR__ . '/../Fixtures/mails/downloads_delivery/de-html.html.twig')
+        );
+
+        $this->updateMail($update, $connection);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}

--- a/tests/migration/Core/V6_6/Migration1701688920FixDownloadLinkMailTest.php
+++ b/tests/migration/Core/V6_6/Migration1701688920FixDownloadLinkMailTest.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_6\Migration1701688920FixDownloadLinkMail;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Migration\V6_6\Migration1701688920FixDownloadLinkMail
+ */
+class Migration1701688920FixDownloadLinkMailTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    public function testCreationTimestamp(): void
+    {
+        $migration = new Migration1701688920FixDownloadLinkMail();
+        static::assertSame(1701688920, $migration->getCreationTimestamp());
+    }
+
+    public function testMailTemplateUpdated(): void
+    {
+        $connection = KernelLifecycleManager::getConnection();
+
+        $migration = new Migration1701688920FixDownloadLinkMail();
+        $migration->update($connection);
+
+        $deLangId = $this->fetchLanguageId($connection, 'de-DE');
+        $enLangId = $this->fetchLanguageId($connection, 'en-GB');
+        static::assertNotNull($deLangId);
+        static::assertNotNull($enLangId);
+
+        $template = [
+            'id' => $this->fetchSystemMailTemplateIdFromType(
+                $connection,
+                MailTemplateTypes::MAILTYPE_DOWNLOADS_DELIVERY
+            ),
+            'htmlDe' => (string) file_get_contents(__DIR__ . '/../../../../src/Core/Migration/Fixtures/mails/downloads_delivery/de-html.html.twig'),
+            'plainDe' => (string) file_get_contents(__DIR__ . '/../../../../src/Core/Migration/Fixtures/mails/downloads_delivery/de-plain.html.twig'),
+            'htmlEn' => (string) file_get_contents(__DIR__ . '/../../../../src/Core/Migration/Fixtures/mails/downloads_delivery/en-html.html.twig'),
+            'plainEn' => (string) file_get_contents(__DIR__ . '/../../../../src/Core/Migration/Fixtures/mails/downloads_delivery/en-plain.html.twig'),
+        ];
+
+        $mailTemplateTranslationDe = $this->getMailTemplateTranslation(
+            $connection,
+            $template,
+            $deLangId
+        );
+
+        static::assertEquals($mailTemplateTranslationDe['htmlDe'], $mailTemplateTranslationDe['content_html']);
+        static::assertEquals($mailTemplateTranslationDe['plainDe'], $mailTemplateTranslationDe['content_plain']);
+
+        $mailTemplateTranslationEn = $this->getMailTemplateTranslation(
+            $connection,
+            $template,
+            $enLangId
+        );
+
+        static::assertEquals($mailTemplateTranslationEn['htmlEn'], $mailTemplateTranslationEn['content_html']);
+        static::assertEquals($mailTemplateTranslationEn['plainEn'], $mailTemplateTranslationEn['content_plain']);
+    }
+
+    /**
+     * @param array<string, string|null> $template
+     *
+     * @throws Exception
+     *
+     * @return array<string, string>
+     */
+    private function getMailTemplateTranslation(Connection $connection, array $template, string $langId): array
+    {
+        $sqlString = 'SELECT `content_plain`, `content_html` from `mail_template_translation` WHERE `mail_template_id`= :templateId AND `language_id` = :langId AND `updated_at` IS NULL';
+
+        static::assertNotNull($template['id']);
+        $translation = $connection->fetchAssociative($sqlString, [
+            'langId' => $langId,
+            'templateId' => $template['id'],
+        ]);
+
+        if (!$translation) {
+            static::fail('mail template content empty');
+        }
+
+        return array_merge($template, ['content_html' => $translation['content_html'], 'content_plain' => $translation['content_plain']]);
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Driver\Exception
+     * @throws Exception
+     */
+    private function fetchSystemMailTemplateIdFromType(Connection $connection, string $type): ?string
+    {
+        $templateTypeId = $connection->executeQuery('
+        SELECT `id` from `mail_template_type` WHERE `technical_name` = :type
+        ', ['type' => $type])->fetchOne();
+
+        $templateId = $connection->executeQuery('
+        SELECT `id` from `mail_template` WHERE `mail_template_type_id` = :typeId AND `system_default` = 1 AND `updated_at` IS NULL
+        ', ['typeId' => $templateTypeId])->fetchOne();
+
+        if ($templateId === false || !\is_string($templateId)) {
+            return null;
+        }
+
+        return $templateId;
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function fetchLanguageId(Connection $connection, string $code): ?string
+    {
+        return $connection->fetchOne('
+        SELECT `language`.`id` FROM `language` INNER JOIN `locale` ON `language`.`locale_id` = `locale`.`id` WHERE `code` = :code LIMIT 1
+        ', ['code' => $code]) ?: null;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Download links from downloads delivery mail do not work with multiple sales channels because the domain from another sales channel is used while generating the download link.

### 2. What does this change do, exactly?
Change mail template to use `rawUrl` with sales channel domain instead of `url`.

### 3. Describe each step to reproduce the issue or behaviour.
Create a second sales channel > add a digital product > order the digital product via the second sales channel > set payment status `paid` > try to open download link from mail

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at be2d4c5</samp>

This pull request fixes the download link mail to use the correct sales channel domain. It changes the `url` function to the `rawUrl` function in the mail templates and adds a migration to update the existing mail templates in the database.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at be2d4c5</samp>

*  Add a changelog entry for the fix of the download link mail ([link](https://github.com/shopware/shopware/pull/3455/files?diff=unified&w=0#diff-afad9f1f37295ef5ecfde0bef8efebbb02e7fd9053b82af4e4cd8394071f5d4bR1-R10))
*  Replace the `url` function with the `rawUrl` function in the mail templates to use the correct sales channel domain for the download link ([link](https://github.com/shopware/shopware/pull/3455/files?diff=unified&w=0#diff-f9d478ba249023539d83c7e068e676cda7ec44e828d0f63b18de0be5ce0cab42L25-R25), [link](https://github.com/shopware/shopware/pull/3455/files?diff=unified&w=0#diff-e8d198c8e0e9a26f3c3fe5f38a539124726e989defc15e9b4e625b3773a42f68L10-R10), [link](https://github.com/shopware/shopware/pull/3455/files?diff=unified&w=0#diff-847c3941669990cf9e16856f47d8d5f6c9471ae8e1ecafdb38b85590770eb42aL25-R25), [link](https://github.com/shopware/shopware/pull/3455/files?diff=unified&w=0#diff-4b3500c55509e9b9212d536e0b9383e47344f343bd2ffa687ebdcfa750bf5c38L10-R10))
*  Create a migration class that updates the existing mail templates in the database with the new fixtures (`src/Core/Migration/V6_6/Migration1701688920FixDownloadLinkMail.php`, [link](https://github.com/shopware/shopware/pull/3455/files?diff=unified&w=0#diff-82e310e69395932db27c87b621d3c91ae998dca36155586e53a37f6ab1c3b0b3R1-R42))
