### PR TITLE
NEXT-00000 - Fix typo in german plaintext defaultMailFooter

### DIFF
--- a/changelog/_unreleased/2023-12-05-fix-default-mail-footer.md
+++ b/changelog/_unreleased/2023-12-05-fix-default-mail-footer.md
@@ -1,0 +1,9 @@
+---
+title: Fix default mail footer
+issue: NEXT-00000
+author: André Buchmann
+author_github: schliesser
+---
+# Core
+* Changed `defaultMailFooter` mail fixtures to fix typo in german plaintext footer.
+* Added new migration `Migration1701776095FixDefaultMailFooter` to update mail footer template.

--- a/src/Core/Migration/Fixtures/mails/defaultMailFooter/de-plain.twig
+++ b/src/Core/Migration/Fixtures/mails/defaultMailFooter/de-plain.twig
@@ -1,6 +1,6 @@
 
 
-        Addresse:
+        Adresse:
         {{ config('core.basicInformation.address')|striptags('<br>')|replace({"<br>":"\n"}) }}
 
         Bankverbindung:

--- a/src/Core/Migration/V6_4/Migration1619428555AddDefaultMailFooter.php
+++ b/src/Core/Migration/V6_4/Migration1619428555AddDefaultMailFooter.php
@@ -34,6 +34,7 @@ class Migration1619428555AddDefaultMailFooter extends MigrationStep
         $connection->insert(MailHeaderFooterDefinition::ENTITY_NAME, [
             'id' => $id,
             'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'system_default' => 1
         ]);
 
         $translations = new Translations(

--- a/src/Core/Migration/V6_6/Migration1701776000SetSystemDefaultForDefaultMailFooter.php
+++ b/src/Core/Migration/V6_6/Migration1701776000SetSystemDefaultForDefaultMailFooter.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooter\MailHeaderFooterDefinition;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooterTranslation\MailHeaderFooterTranslationDefinition;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\Traits\ImportTranslationsTrait;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1701776000SetSystemDefaultForDefaultMailFooter extends MigrationStep
+{
+    use ImportTranslationsTrait;
+
+    private const CHECKSUM_HTML_EN = '097ec7c0960cfff876856b1c4a2849b8';
+    private const CHECKSUM_HTML_DE = '01bb8fbfc798ff789a1b8d97ed5df46c';
+    private const CHECKSUM_PLAIN_EN = '6198b92aa8fbc81a9a91b7ea2ad19eaa';
+    private const CHECKSUM_PLAIN_DE = 'b80230dec50b38ad9991656c476e0f4e';
+
+    public function getCreationTimestamp(): int
+    {
+        return 1701776000;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $languages = array_merge([Defaults::LANGUAGE_SYSTEM],
+            $this->getLanguageIds($connection, 'en-GB'),
+            $this->getLanguageIds($connection, 'de-DE'));
+        $languages = array_unique(array_filter($languages));
+        if (!$languages) {
+            return;
+        }
+
+        $translations = $this->getTranslationIds($connection, $languages);
+        if (empty($translations)) {
+            return;
+        }
+
+        $mailHeaderFooterIds = [];
+        $translationCount = count($translations);
+        foreach ($translations as $translation) {
+            // Check for default content in all translations
+            if (
+                (md5($translation['footer_plain']) === self::CHECKSUM_PLAIN_EN
+                    && md5($translation['footer_html']) === self::CHECKSUM_HTML_EN)
+                || (md5($translation['footer_plain']) === self::CHECKSUM_PLAIN_DE
+                    && md5($translation['footer_html']) === self::CHECKSUM_HTML_DE)
+            ) {
+                $mailHeaderFooterIds[$translation['id']] = ($mailHeaderFooterIds[$translation['id']] ?? 0) + 1;
+            }
+        }
+
+        // verify that no translation has been changed
+        if (count($mailHeaderFooterIds) === 1 && reset($mailHeaderFooterIds) === $translationCount) {
+            $connection->update(
+                MailHeaderFooterDefinition::ENTITY_NAME,
+                [
+                    'system_default' => 1,
+                ],
+                [
+                    'id' => key($mailHeaderFooterIds),
+                ]
+            );
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+
+    /**
+     * @param array<string> $languageIds
+     *
+     * @return mixed[]
+     */
+    private function getTranslationIds(Connection $connection, array $languageIds): array
+    {
+        return $connection->fetchAllAssociative(
+            '
+            SELECT mail_header_footer.id, mail_header_footer_translation.footer_plain, mail_header_footer_translation.footer_html
+
+            FROM mail_header_footer
+
+            INNER JOIN mail_header_footer_translation
+                ON mail_header_footer.id = mail_header_footer_translation.mail_header_footer_id
+
+            WHERE mail_header_footer_translation.language_id IN (:ids)
+            AND mail_header_footer.system_default = 0
+            AND mail_header_footer_translation.updated_at IS NULL
+            AND mail_header_footer.updated_at IS NULL',
+            ['ids' => Uuid::fromHexToBytesList($languageIds)],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+    }
+}

--- a/src/Core/Migration/V6_6/Migration1701776095FixDefaultMailFooter.php
+++ b/src/Core/Migration/V6_6/Migration1701776095FixDefaultMailFooter.php
@@ -69,8 +69,8 @@ class Migration1701776095FixDefaultMailFooter extends MigrationStep
 
             FROM mail_header_footer
 
-                INNER JOIN mail_header_footer_translation
-                    ON mail_header_footer.id = mail_header_footer_translation.mail_header_footer_id
+            INNER JOIN mail_header_footer_translation
+                ON mail_header_footer.id = mail_header_footer_translation.mail_header_footer_id
 
             WHERE mail_header_footer_translation.language_id IN (:ids)
             AND mail_header_footer.system_default = 1

--- a/src/Core/Migration/V6_6/Migration1701776095FixDefaultMailFooter.php
+++ b/src/Core/Migration/V6_6/Migration1701776095FixDefaultMailFooter.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\MailTemplate\Aggregate\MailHeaderFooterTranslation\MailHeaderFooterTranslationDefinition;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\Traits\ImportTranslationsTrait;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1701776095FixDefaultMailFooter extends MigrationStep
+{
+    use ImportTranslationsTrait;
+
+    public function getCreationTimestamp(): int
+    {
+        return 1701776095;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $plainDe = (string) file_get_contents(__DIR__ . '/../Fixtures/mails/defaultMailFooter/de-plain.twig');
+
+        $languages = $this->getLanguageIds($connection, 'de-DE');
+        if (!$languages) {
+            return;
+        }
+
+        $translations = $this->getTranslationIds($connection, $languages);
+        if (empty($translations)) {
+            return;
+        }
+
+        foreach ($translations as $translation) {
+            $connection->update(
+                MailHeaderFooterTranslationDefinition::ENTITY_NAME,
+                [
+                    'footer_plain' => $plainDe,
+                ],
+                [
+                    'language_id' => $translation['language_id'],
+                    'mail_header_footer_id' => $translation['mail_header_footer_id'],
+                ]
+            );
+        }
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+
+    /**
+     * @param array<string> $languageIds
+     *
+     * @return mixed[]
+     */
+    private function getTranslationIds(Connection $connection, array $languageIds): array
+    {
+        return $connection->fetchAllAssociative(
+            '
+            SELECT mail_header_footer_translation.mail_header_footer_id, mail_header_footer_translation.language_id
+
+            FROM mail_header_footer
+
+                INNER JOIN mail_header_footer_translation
+                    ON mail_header_footer.id = mail_header_footer_translation.mail_header_footer_id
+
+            WHERE mail_header_footer_translation.language_id IN (:ids)
+            AND mail_header_footer.system_default = 1
+            AND mail_header_footer_translation.updated_at IS NULL
+            AND mail_header_footer.updated_at IS NULL',
+            ['ids' => Uuid::fromHexToBytesList($languageIds)],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+    }
+}

--- a/tests/migration/Core/V6_6/Migration1701776000SetSystemDefaultForDefaultMailFooterTest.php
+++ b/tests/migration/Core/V6_6/Migration1701776000SetSystemDefaultForDefaultMailFooterTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Core\Migration\V6_6;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Migration\V6_6\Migration1701776000SetSystemDefaultForDefaultMailFooter;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Migration\V6_6\Migration1701776000SetSystemDefaultForDefaultMailFooter
+ */
+class Migration1701776000SetSystemDefaultForDefaultMailFooterTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    public function testCreationTimestamp(): void
+    {
+        $migration = new Migration1701776000SetSystemDefaultForDefaultMailFooter();
+        static::assertSame(1701776000, $migration->getCreationTimestamp());
+    }
+}

--- a/tests/migration/Core/V6_6/Migration1701776095FixDefaultMailFooterTest.php
+++ b/tests/migration/Core/V6_6/Migration1701776095FixDefaultMailFooterTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Core\Migration\V6_6;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Migration\V6_6\Migration1701776095FixDefaultMailFooter;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Migration\V6_6\Migration1701776095FixDefaultMailFooter
+ */
+class Migration1701776095FixDefaultMailFooterTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    public function testCreationTimestamp(): void
+    {
+        $migration = new Migration1701776095FixDefaultMailFooter();
+        static::assertSame(1701776095, $migration->getCreationTimestamp());
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Correct spelling in german

### 2. What does this change do, exactly?

Fix a typo in the german plaintext default mail footer

### 3. Describe each step to reproduce the issue or behaviour.

-

### 4. Please link to the relevant issues (if any).

-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 03eb6f1</samp>

This pull request fixes a spelling error in the German plain text mail footer template. It changes `Addresse` to `Adresse` in the file `src/Core/Migration/Fixtures/mails/defaultMailFooter/de-plain.twig`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 03eb6f1</samp>

* Correct spelling mistake in German plain text mail footer template ([link](https://github.com/shopware/shopware/pull/3456/files?diff=unified&w=0#diff-2939649fda43d49ecad564bc7f3352bdce6d269d3357ea6d15682ae6a201b14fL3-R3))
