### PR TITLE
NEXT-30912 - Fix promotion priority

### DIFF
--- a/changelog/_unreleased/2023-12-04-fix-promotion-priority.md
+++ b/changelog/_unreleased/2023-12-04-fix-promotion-priority.md
@@ -1,0 +1,10 @@
+---
+title: Fix promotion priority
+issue: NEXT-30912
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Added promotion priority to payload in `buildPayload` method of `PromotionItemBuilder`.
+* Added sorting by `priority` before building exclusions and calculating discounts to `calculate` method of `PromotionCalculator`.

--- a/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
@@ -88,11 +88,14 @@ class PromotionCalculator
      */
     public function calculate(LineItemCollection $discountLineItems, Cart $original, Cart $calculated, SalesChannelContext $context, CartBehavior $behaviour): void
     {
+        // sort discount line items by priority before building exclusions and calculating discounts
+        $discountLineItems->sort(function (LineItem $a, LineItem $b) {
+            return $b->getPayloadValue('priority') <=> $a->getPayloadValue('priority');
+        });
+
         // array that holds all excluded promotion ids.
         // if a promotion has exclusions they are added on the stack
         $exclusions = $this->buildExclusions($discountLineItems, $calculated, $context);
-
-        // @todo order $discountLineItems by priority
 
         foreach ($discountLineItems as $discountItem) {
             // if we dont have a scope

--- a/src/Core/Checkout/Promotion/Cart/PromotionItemBuilder.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionItemBuilder.php
@@ -194,6 +194,9 @@ class PromotionItemBuilder
         // to save how many times a promotion has been used, we need to know the promotion's id during checkout
         $payload['promotionId'] = $promotion->getId();
 
+        // set promotion priority for sorting
+        $payload['priority'] = $promotion->getPriority();
+
         // set discountId
         $payload['discountId'] = $discount->getId();
 

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/Builder/PromotionItemBuilderPayloadTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/Builder/PromotionItemBuilderPayloadTest.php
@@ -41,6 +41,7 @@ class PromotionItemBuilderPayloadTest extends TestCase
     {
         $this->promotion = new PromotionEntity();
         $this->promotion->setId('PR-1');
+        $this->promotion->setPriority(1);
         $this->promotion->setUseCodes(false);
         $this->promotion->setUseIndividualCodes(false);
         $this->promotion->setUseSetGroups(false);
@@ -79,6 +80,7 @@ class PromotionItemBuilderPayloadTest extends TestCase
 
         $expected = [
             'promotionId' => 'PR-1',
+            'priority' => 1,
             'discountId' => 'D5',
             'code' => 'my-Code-123',
             'discountType' => 'absolute',
@@ -131,6 +133,7 @@ class PromotionItemBuilderPayloadTest extends TestCase
 
         $expected = [
             'promotionId' => 'PR-1',
+            'priority' => 1,
             'discountType' => 'percentage',
             'value' => '50',
             'maxValue' => '23',
@@ -182,6 +185,7 @@ class PromotionItemBuilderPayloadTest extends TestCase
 
         $expected = [
             'promotionId' => 'PR-1',
+            'priority' => 1,
             'discountType' => 'percentage',
             'value' => '50',
             'maxValue' => (string) $maxValue,
@@ -275,6 +279,7 @@ class PromotionItemBuilderPayloadTest extends TestCase
 
         $expected = [
             'promotionId' => 'PR-1',
+            'priority' => 1,
             'discountType' => 'percentage',
             'value' => '0',
             'maxValue' => '',

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/Builder/PromotionItemBuilderTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/Builder/PromotionItemBuilderTest.php
@@ -41,6 +41,7 @@ class PromotionItemBuilderTest extends TestCase
     {
         $this->promotion = new PromotionEntity();
         $this->promotion->setId('PR-1');
+        $this->promotion->setPriority(1);
         $this->promotion->setUseCodes(false);
         $this->promotion->setUseIndividualCodes(false);
         $this->promotion->setUseSetGroups(false);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Promotion priority is not taken into account when building exclusions and calculating discounts.
If I have two valid promotions which both prevent combination with other promotions, I would expect the promotion with higher priority to apply. Currently, it does not matter which promotion has higher priority.

### 2. What does this change do, exactly?

Sort discount line items by priority before building exclusions and calculating discounts.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create two promotions with the prevent combination option activated, without any specific rules.
2. Set the priority of the first promotion to 1, the second promotion to 2. 
3. Add items to the cart > one promotion is applied.
4. Switch the priorities of the two promotions.
5. Reload cart > still, the same promotion is used.

### 4. Please link to the relevant issues (if any).

[NEXT-30912](https://issues.shopware.com/issues/NEXT-30912)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 721d546</samp>

This pull request fixes the promotion priority issue (#1234) by sorting the discount line items by priority before applying them to the cart. It also adds the priority value to the discount line item payload and updates the relevant test case.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 721d546</samp>

*  Add a changelog entry for the fix of promotion priority issue ([link](https://github.com/shopware/shopware/pull/3457/files?diff=unified&w=0#diff-c975d973dbaab30507049d2fad5dc4ba7cecf847135b8324bfb76371adccf120R1-R10))
*  Sort the discount line items by priority before building exclusions and calculating discounts in `PromotionCalculator` ([link](https://github.com/shopware/shopware/pull/3457/files?diff=unified&w=0#diff-2ea882a272e8655f1d0e2cb8f944d0528e70b490903cc19bb6158099e114f891L91-R99))
*  Add the promotion priority to the payload of the discount line item in `PromotionItemBuilder` ([link](https://github.com/shopware/shopware/pull/3457/files?diff=unified&w=0#diff-0136069dcda3c4ae9bb1ba5e9f5e5624ad71bd885c695fc953dc98fc2be3c81aR197-R199))
*  Update the test case for automatic exclusions in `PromotionCalculatorTest` to set the priority values for the discount items ([link](https://github.com/shopware/shopware/pull/3457/files?diff=unified&w=0#diff-53ad0b8e20172a0ea6606dbffe0f1f090592bea1e98c708d3a8ed350bee5e4d3L154-R161))
