### PR TITLE
Fix silencing flow errors in dispatcher

### DIFF
--- a/changelog/_unreleased/2023-12-05-fix-silencing-flow-errors-in-flow-dispatcher.md
+++ b/changelog/_unreleased/2023-12-05-fix-silencing-flow-errors-in-flow-dispatcher.md
@@ -1,0 +1,10 @@
+---
+title: Fix silencing flow errors in flow dispatcher
+issue:
+author: Maximilian Rüsch
+author_email: maximilian.ruesch@pickware.de
+author_github: maximilianruesch
+---
+# Core
+* Fixed the `FlowDispatcher` to collect and rethrow any errors that occur during execution of flows upon a dispatched event.
+ 

--- a/src/Core/Content/Flow/FlowException.php
+++ b/src/Core/Content/Flow/FlowException.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Content\Flow;
 
+use Shopware\Core\Content\Flow\Exception\ExecuteSequenceException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
@@ -10,6 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 class FlowException extends HttpException
 {
     final public const METHOD_NOT_COMPATIBLE = 'METHOD_NOT_COMPATIBLE';
+    final public const ERRORS_DURING_EXECUTION = 'ERRORS_DURING_EXECUTION';
 
     public static function methodNotCompatible(string $method, string $class): FlowException
     {
@@ -18,6 +20,44 @@ class FlowException extends HttpException
             self::METHOD_NOT_COMPATIBLE,
             'Method {{ method }} is not compatible for {{ class }} class',
             ['method' => $method, 'class' => $class]
+        );
+    }
+
+    /**
+     * @param array<string, \Throwable> $exceptionsByFlowId
+     * @param array<string, string> $flowNamesByFlowId
+     */
+    public static function errorsDuringExecution(array $exceptionsByFlowId, array $flowNamesByFlowId): FlowException
+    {
+        $errorMessage = "Could not execute flows:\n";
+        foreach ($exceptionsByFlowId as $flowId => $exception) {
+            $sequenceString = '';
+            if ($exception instanceof ExecuteSequenceException) {
+                $sequenceString = sprintf('Sequence id: %s ', $exception->getSequenceId());
+            }
+
+            $errorMessage .= sprintf(
+                "Could not execute flow with error message: Flow name: \"%s\" Flow id: \"%s\" %sError Message: %s Error Code: \"%s\"\n",
+                $flowNamesByFlowId[$flowId],
+                $flowId,
+                $sequenceString,
+                $exception->getMessage(),
+                $exception->getCode(),
+            );
+        }
+
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::ERRORS_DURING_EXECUTION,
+            $errorMessage,
+            [
+                'exceptionsByFlowId' => $exceptionsByFlowId,
+                'flowNamesByFlowId' => array_filter(
+                    $flowNamesByFlowId,
+                    fn (string $flowId) => \array_key_exists($flowId, $exceptionsByFlowId),
+                    \ARRAY_FILTER_USE_KEY,
+                ),
+            ],
         );
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

The change from #3398 is seemingly insufficient to uncover flow errors during transactions, thus we need to fix the errors described in the referenced PR on a more general level. This tremendously helps with debugging flow errors inside transactions during e.g. order creation.

> [!NOTE]  
> This fix (or rather the `throw` itself) can also be hidden behind a feature flag for debugging purposes. This PR does not yet implement a feature flag as we believe this error handling should always be active.

### 2. What does this change do, exactly?

Fix the `FlowDispatcher` to not silence errors that happen during flows.

### 3. Describe each step to reproduce the issue or behaviour.

See #3398

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9a71421</samp>

This pull request fixes a bug that caused flow errors to be silenced in the `FlowDispatcher` class. It adds error handling and reporting logic to the class, a new error code and constructor to the `FlowException` class, and a new test case and changelog entry for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9a71421</samp>

*  Add a changelog entry for the fix ([link](https://github.com/shopware/shopware/pull/3458/files?diff=unified&w=0#diff-4f48dbe002c818b455628fae3de0201d35489872f0d5a93d5bad6308250e3902R1-R10))
*  Import `FlowException` class in `FlowDispatcher` ([link](https://github.com/shopware/shopware/pull/3458/files?diff=unified&w=0#diff-de82052c573f9887be73ed5037723d4406f0e968a5ad1596d6c24e864ab965deR9))
*  Initialize arrays to store exceptions and flow names by flow id ([link](https://github.com/shopware/shopware/pull/3458/files?diff=unified&w=0#diff-de82052c573f9887be73ed5037723d4406f0e968a5ad1596d6c24e864ab965deL127-R132))
*  Catch and store different types of exceptions during flow execution ([link](https://github.com/shopware/shopware/pull/3458/files?diff=unified&w=0#diff-de82052c573f9887be73ed5037723d4406f0e968a5ad1596d6c24e864ab965deR145), [link](https://github.com/shopware/shopware/pull/3458/files?diff=unified&w=0#diff-de82052c573f9887be73ed5037723d4406f0e968a5ad1596d6c24e864ab965deL149-R160))
*  Throw a `FlowException` with `errorsDuringExecution` method if any exceptions are stored ([link](https://github.com/shopware/shopware/pull/3458/files?diff=unified&w=0#diff-de82052c573f9887be73ed5037723d4406f0e968a5ad1596d6c24e864ab965deL149-R160))
*  Add `ERRORS_DURING_EXECUTION` constant and `errorsDuringExecution` method to `FlowException` class ([link](https://github.com/shopware/shopware/pull/3458/files?diff=unified&w=0#diff-fb7cc26f1a87e6714a992633d3ba3db0586b4fba2aaf8d84bed74beb415509eeR14), [link](https://github.com/shopware/shopware/pull/3458/files?diff=unified&w=0#diff-fb7cc26f1a87e6714a992633d3ba3db0586b4fba2aaf8d84bed74beb415509eeR25-R62))
*  Import `ExecuteSequenceException` and `FlowException` classes in `FlowDispatcherTest` ([link](https://github.com/shopware/shopware/pull/3458/files?diff=unified&w=0#diff-369fe45ec3a17e490079718007e02bda98da3b2f8c3946a33e424b54ac747ebcR16-R17))
*  Add a test method to simulate and assert the expected behavior of `FlowDispatcher` when multiple flows fail ([link](https://github.com/shopware/shopware/pull/3458/files?diff=unified&w=0#diff-369fe45ec3a17e490079718007e02bda98da3b2f8c3946a33e424b54ac747ebcR259-R316))
