### PR TITLE
NEXT-32283 - Update form label formatting in all inconsistent cms-element-form

### DIFF
--- a/changelog/_unreleased/2023-12-05-add-whitespace-control-to-cms-form-label.md
+++ b/changelog/_unreleased/2023-12-05-add-whitespace-control-to-cms-form-label.md
@@ -1,0 +1,10 @@
+---
+title: Add twig whitespace-control to all labels of CMS form elements
+issue: NEXT-00000
+author: AEYCEN
+author_email: aeycen.dev@gmail.com
+author_github: @AEYCEN
+---
+
+# Storefront
+* Updated formatting of labels in all inconsistent `cms-element-form`. This was to standardize input requirement marks by removing any inconsistent whitespace between label translations and the "required"-star mark.

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-privacy.html.twig
@@ -5,7 +5,7 @@
     {% endif %}
 
     {% block cms_form_privacy_opt_in_title %}
-        <div>{{ "general.privacyTitle"|trans }} {{ "general.required"|trans }}</div>
+        <div>{{- "general.privacyTitle"|trans -}} {{- "general.required"|trans -}}</div>
     {% endblock %}
 
     <div class="form-text privacy-notice form-check">

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-select-salutation.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-select-salutation.html.twig
@@ -2,7 +2,7 @@
     <div class="form-group {{ additionalClass }}">
         {% block cms_form_select_salutation_content_label %}
             <label class="form-label" for="form-Salutation">
-                {{ "account.personalSalutationLabel"|trans }}{% if required %} {{ "general.required"|trans }}{% endif %}
+                {{- "account.personalSalutationLabel"|trans -}}{% if required %} {{- "general.required"|trans -}}{% endif %}
             </label>
         {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-textarea.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-textarea.html.twig
@@ -2,7 +2,7 @@
     <div class="form-group {{ additionalClass }}">
         {% block cms_element_form_textarea_label %}
             <label class="form-label" for="form-{{ fieldName }}">
-                {{ label|trans }}{% if required %} {{ "general.required"|trans }}{% endif %}
+                {{- label|trans -}}{% if required %} {{- "general.required"|trans -}}{% endif %}
             </label>
         {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In order to standardize the display of the required inputs of a form with the star next to the label so that there is no whitespace anywhere between the translated label of the input and the star behind it.

### 2. What does this change do, exactly?
Added twig whitespace-control to all labels of CMS form elements which were neglected during standardization.

### 3. Describe each step to reproduce the issue or behaviour.
To easily see the insonsistency, open the contact formular in the footer. Salutation, comment and the privacy notice have the inconsistent whitespace between label and star mark:

![Bildschirmfoto vom 2023-12-05 14-43-04](https://github.com/shopware/shopware/assets/114836625/149bef00-8f38-4cdb-9f9e-e435f510be28)



### 4. Please link to the relevant issues (if any).
-/-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9943762</samp>

This pull request adds twig whitespace-control tags to the labels of various form fields in the CMS form element. This improves the appearance and readability of the labels in the storefront.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 9943762</samp>

*  Add whitespace-control tags to CMS form element labels to remove extra whitespace ([link](https://github.com/shopware/shopware/pull/3459/files?diff=unified&w=0#diff-efb37159acc94e8eec5c8827d974a72fe230b91e94151f6d42eac50afae25e0cL8-R8), [link](https://github.com/shopware/shopware/pull/3459/files?diff=unified&w=0#diff-ea3f2b37ea09559329202f9b77ea428962d5bb7012cbbf59a2bf064aaf4038b3L5-R5), [link](https://github.com/shopware/shopware/pull/3459/files?diff=unified&w=0#diff-432c4f3836368217627b55e30f3f1e91817a3dcfa57c416e1e876e05a46a2634L5-R5))
* Create a changelog entry to document the changes ([link](https://github.com/shopware/shopware/pull/3459/files?diff=unified&w=0#diff-e671e63c86766b34012a70bd773457da4777f827b5cfa2e2e1b49a93faf3dd7fR1-R10))
