### PR TITLE
fix(admin): Set correct extension data on first load

### DIFF
--- a/changelog/_unreleased/2023-12-05-set-correct-extension-data-on-first-load-of-configuration.md
+++ b/changelog/_unreleased/2023-12-05-set-correct-extension-data-on-first-load-of-configuration.md
@@ -1,0 +1,9 @@
+---
+title: Set correct extension data on first load of configuration
+issue: NEXT-33255
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed the `sw-extension-config` to set the correct extension data when loading the configuration for the first time

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-config/index.ts
@@ -83,11 +83,18 @@ export default Shopware.Component.wrapComponentConfig({
     },
 
     methods: {
+        /**
+         * @deprecated - Shopware 6.7.0.0 method will not be async anymore and return `void`
+         */
         async createdComponent(): Promise<void> {
             if (!this.myExtensions.length) {
-                await this.shopwareExtensionService.updateExtensionData();
+                this.shopwareExtensionService.updateExtensionData().then(this.refreshExtension);
+            } else {
+                this.refreshExtension();
             }
+        },
 
+        refreshExtension(): void {
             this.extension = this.myExtensions.find((ext) => {
                 return ext.name === this.namespace;
             }) ?? null;


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when the extensions are not loaded and `this.myExtensions` is empty, the property `this.extension` will be null, as there is no extension found.

### 2. What does this change do, exactly?
Correct the async behavior of the extension loading.

### 3. Describe each step to reproduce the issue or behaviour.
Reload the configuration of a plugin.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 175d326</samp>

This pull request fixes a performance issue in the `sw-extension-config` component by using a non-blocking approach to set the correct extension data on the first load of the configuration. It also adds a changelog entry for this change in `changelog/_unreleased/2023-12-05-set-correct-extension-data-on-first-load-of-configuration.md`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 175d326</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/shopware/pull/3460/files?diff=unified&w=0#diff-559aca8bace2d43d1d4f49723af57a0c999ac85160df72f44fae0a10306d2911R1-R9))
*  Refactor the `createdComponent` method of the `sw-extension-config` component to use a `then` callback instead of an `await` expression ([link](https://github.com/shopware/shopware/pull/3460/files?diff=unified&w=0#diff-3e794963396572bc7dab3b15c0b955a480830da58f97cdf1d08e82423f14eed5L86-R94))
