### PR TITLE
fix(admin): Reload config on namespace change

### DIFF
--- a/changelog/_unreleased/2023-12-05-reload-config-when-the-config-namespace-changes.md
+++ b/changelog/_unreleased/2023-12-05-reload-config-when-the-config-namespace-changes.md
@@ -1,0 +1,9 @@
+---
+title: Reload config when the config namespace changes
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed the `sw-system-config` to reload config when the config namespace (domain) changes

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/index.js
@@ -95,6 +95,13 @@ export default {
             deep: true,
         },
 
+        domain: {
+            immediate: true,
+            handler() {
+                this.createdComponent();
+            },
+        },
+
         isLoading(value) {
             this.$emit('loading-changed', value);
         },


### PR DESCRIPTION
### 1. Why is this change necessary?
I created a custom button, which links to another config form:
```
<div>
    <sw-button
        variant="primary"
        :router-link="{ name: 'sw.extension.config', params: { namespace: 'MyBundleNamespace' } }"
    >{{ $tc('my-config.button') }}</sw-button>
</div>
``` 

And used that as custom config component. On click nothing happens only the URL changes, although when reloading the page, everything works as expected.

### 2. What does this change do, exactly?
Watch the namespace (domain) of the config component and reinitialize the component.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 05dfdc7</samp>

This pull request adds a feature to reload the config data in the `sw-system-config` component when the admin changes the config namespace (domain) in the settings module. It also adds a changelog entry for this feature.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 05dfdc7</samp>

*  Add a changelog entry for the feature of reloading the config when the domain changes ([link](https://github.com/shopware/shopware/pull/3461/files?diff=unified&w=0#diff-cb62ea456167fca7518e3f0a0bcf304dd9b6e9e0ab51059eef986abe70dae49cR1-R9))
*  Add a watcher for the domain property of the sw-system-config component ([link](https://github.com/shopware/shopware/pull/3461/files?diff=unified&w=0#diff-80963bac1530d0a7e83b3caa11c78a2df13cb4ac16acba779ed95c03dbf66463R98-R104))
