### PR TITLE
NEXT-32269 - Fix: Make sure that the Storefront scripts are only included once

### DIFF
--- a/changelog/_unreleased/2023-12-06-ensure-that-script-files-are-only-included-once.md
+++ b/changelog/_unreleased/2023-12-06-ensure-that-script-files-are-only-included-once.md
@@ -1,0 +1,9 @@
+---
+title: Ensure that script files are only included once
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Make sure that the same scripts are only included once in the storefront

--- a/src/Storefront/Theme/ThemeScripts.php
+++ b/src/Storefront/Theme/ThemeScripts.php
@@ -109,7 +109,7 @@ class ThemeScripts
             }
         }
 
-        return $mainEntryFiles;
+        return array_unique($mainEntryFiles);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when a plugin has been built with a Shopware version older than 6.6, the file path of the storefront JavaScript has changed, i.e.
- Prior Shopware 6.6: `MyPlugin/src/Resources/app/storefront/dist/storefront/js/my-plugin.js`
- Since Shopware 6.6: `MyPlugin/src/Resources/app/storefront/dist/storefront/js/my-plugin/my-plugin.js`

While in general this should be no problem, when the plugins are updated through the store or so and the folders are completely replaced, I noticed in my local development environment, that this results that the scripts are included twice.

### 2. What does this change do, exactly?
Make sure that the final paths are only present once, when having files with the same name.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5958e68</samp>

This pull request fixes a bug that could cause script files to be included multiple times in the storefront. It changes the `getMainEntryFiles` function in `ThemeScripts.php` to filter out duplicate scripts and adds a changelog entry for the fix.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5958e68</samp>

*  Prevent duplicate script files from being included in the storefront by returning only unique files from `getMainEntryFiles` function ([link](https://github.com/shopware/shopware/pull/3464/files?diff=unified&w=0#diff-8d283160a630b968f8a805265dd78c79df62f0c1a41ab14f0d2465679ea8c6dbL112-R112))
* Add changelog entry to document the issue and the solution ([link](https://github.com/shopware/shopware/pull/3464/files?diff=unified&w=0#diff-db46e1f06227a831eff102a494b3a3671a2b5354f0b9ef528b4531cfbfe26441R1-R9))
