### PR TITLE
refactor: LoginRoute and AccountService and move logic of the route into the service

### DIFF
--- a/changelog/_unreleased/2023-12-07-refactor-loginroute-and-accountservice.md
+++ b/changelog/_unreleased/2023-12-07-refactor-loginroute-and-accountservice.md
@@ -1,0 +1,12 @@
+---
+title: Refactor LoginRoute and AccountService
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added method `Shopware\Core\Checkout\Customer\SalesChannel\AccountService::loginByCredentials`
+* Changed `Shopware\Core\Checkout\Customer\SalesChannel\LoginRoute` and moved login logic into the `AccountService`
+* Deprecated method `Shopware\Core\Checkout\Customer\SalesChannel\AccountService::login` use `AccountService::loginByCredentials` or `AccountService::loginById` instead
+* Deprecated unused constant `Shopware\Core\Checkout\Customer\CustomerException::CUSTOMER_IS_INACTIVE` and unused method `Shopware\Core\Checkout\Customer\CustomerException::inactiveCustomer`

--- a/phpstan-v66-baseline.neon
+++ b/phpstan-v66-baseline.neon
@@ -167,7 +167,7 @@ parameters:
 
         -
             message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-            count: 2
+            count: 1
             path: src/Core/Checkout/Customer/SalesChannel/AccountService.php
 
         -

--- a/phpstan-v66-baseline.neon
+++ b/phpstan-v66-baseline.neon
@@ -168,11 +168,6 @@ parameters:
         -
             message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
             count: 1
-            path: src/Core/Checkout/Customer/SalesChannel/AccountService.php
-
-        -
-            message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-            count: 1
             path: src/Core/Checkout/Customer/SalesChannel/AddWishlistProductRoute.php
 
         -
@@ -184,11 +179,6 @@ parameters:
             message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
             count: 1
             path: src/Core/Checkout/Customer/SalesChannel/DownloadRoute.php
-
-        -
-            message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-            count: 1
-            path: src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
 
         -
             message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"

--- a/src/Core/Checkout/Customer/CustomerException.php
+++ b/src/Core/Checkout/Customer/CustomerException.php
@@ -24,6 +24,11 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('checkout')]
 class CustomerException extends HttpException
 {
+    /**
+     * @deprecated tag:v6.7.0 - Constant CUSTOMER_IS_INACTIVE will be removed as it is unused
+     */
+    public const CUSTOMER_IS_INACTIVE = 'CHECKOUT__CUSTOMER_IS_INACTIVE';
+
     public const CUSTOMERS_NOT_FOUND = 'CHECKOUT__CUSTOMERS_NOT_FOUND';
     public const CUSTOMER_NOT_FOUND = 'CHECKOUT__CUSTOMER_NOT_FOUND';
     public const CUSTOMER_GROUP_NOT_FOUND = 'CHECKOUT__CUSTOMER_GROUP_NOT_FOUND';
@@ -45,7 +50,6 @@ class CustomerException extends HttpException
     public const WISHLIST_NOT_FOUND = 'CHECKOUT__WISHLIST_NOT_FOUND';
     public const COUNTRY_NOT_FOUND = 'CHECKOUT__CUSTOMER_COUNTRY_NOT_FOUND';
     public const DUPLICATE_WISHLIST_PRODUCT = 'CHECKOUT__DUPLICATE_WISHLIST_PRODUCT';
-    public const CUSTOMER_IS_INACTIVE = 'CHECKOUT__CUSTOMER_IS_INACTIVE';
     public const LEGACY_PASSWORD_ENCODER_NOT_FOUND = 'CHECKOUT__LEGACY_PASSWORD_ENCODER_NOT_FOUND';
     public const NO_HASH_PROVIDED = 'CHECKOUT__NO_HASH_PROVIDED';
     public const WISHLIST_PRODUCT_NOT_FOUND = 'CHECKOUT__WISHLIST_PRODUCT_NOT_FOUND';
@@ -252,8 +256,13 @@ class CustomerException extends HttpException
         );
     }
 
+    /**
+     * @deprecated tag:v6.7.0 - Method will be removed as it is unused
+     */
     public static function inactiveCustomer(string $id): ShopwareHttpException
     {
+        Feature::triggerDeprecationOrThrow('v6.7.0.0', 'Method "CustomerException::inactiveCustomer" will be removed as it is unused.');
+
         return self::customerOptinNotCompleted($id);
     }
 

--- a/src/Core/Checkout/Customer/Exception/CustomerNotFoundByIdException.php
+++ b/src/Core/Checkout/Customer/Exception/CustomerNotFoundByIdException.php
@@ -12,7 +12,7 @@ class CustomerNotFoundByIdException extends CustomerException
     public function __construct(string $id)
     {
         parent::__construct(
-            Response::HTTP_NOT_FOUND,
+            Response::HTTP_UNAUTHORIZED,
             self::CUSTOMER_NOT_FOUND_BY_ID,
             'No matching customer for the id "{{ id }}" was found.',
             ['id' => $id]

--- a/src/Core/Checkout/Customer/Exception/CustomerNotFoundException.php
+++ b/src/Core/Checkout/Customer/Exception/CustomerNotFoundException.php
@@ -12,7 +12,7 @@ class CustomerNotFoundException extends CustomerException
     public function __construct(string $email)
     {
         parent::__construct(
-            Response::HTTP_NOT_FOUND,
+            Response::HTTP_UNAUTHORIZED,
             self::CUSTOMER_NOT_FOUND,
             'No matching customer for the email "{{ email }}" was found.',
             ['email' => $email]

--- a/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
@@ -3,8 +3,6 @@
 namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\CustomerException;
-use Shopware\Core\Checkout\Customer\Exception\BadCredentialsException;
-use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\RateLimiter\Exception\RateLimitExceededException;
@@ -13,7 +11,6 @@ use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\ContextTokenResponse;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
 #[Route(defaults: ['_routeScope' => ['store-api']])]
@@ -50,15 +47,11 @@ class LoginRoute extends AbstractLoginRoute
             }
         }
 
-        try {
-            $token = $this->accountService->loginByCredentials(
-                $email,
-                (string) $data->get('password'),
-                $context
-            );
-        } catch (CustomerNotFoundException $exception) {
-            throw new UnauthorizedHttpException('json', $exception->getMessage());
-        }
+        $token = $this->accountService->loginByCredentials(
+            $email,
+            (string) $data->get('password'),
+            $context
+        );
 
         if (isset($cacheKey)) {
             $this->rateLimiter->reset(RateLimiter::LOGIN_ROUTE, $cacheKey);

--- a/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LoginRoute.php
@@ -3,23 +3,18 @@
 namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\CustomerException;
-use Shopware\Core\Checkout\Customer\Event\CustomerBeforeLoginEvent;
-use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
 use Shopware\Core\Checkout\Customer\Exception\BadCredentialsException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundException;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\RateLimiter\Exception\RateLimitExceededException;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
-use Shopware\Core\System\SalesChannel\Context\CartRestorer;
 use Shopware\Core\System\SalesChannel\ContextTokenResponse;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[Route(defaults: ['_routeScope' => ['store-api']])]
 #[Package('checkout')]
@@ -29,10 +24,7 @@ class LoginRoute extends AbstractLoginRoute
      * @internal
      */
     public function __construct(
-        private readonly EventDispatcherInterface $eventDispatcher,
         private readonly AccountService $accountService,
-        private readonly EntityRepository $customerRepository,
-        private readonly CartRestorer $restorer,
         private readonly RequestStack $requestStack,
         private readonly RateLimiter $rateLimiter
     ) {
@@ -46,17 +38,10 @@ class LoginRoute extends AbstractLoginRoute
     #[Route(path: '/store-api/account/login', name: 'store-api.account.login', methods: ['POST'])]
     public function login(RequestDataBag $data, SalesChannelContext $context): ContextTokenResponse
     {
-        $email = $data->get('email', $data->get('username'));
-
-        if (empty($email) || empty($data->get('password'))) {
-            throw CustomerException::badCredentials();
-        }
-
-        $event = new CustomerBeforeLoginEvent($context, $email);
-        $this->eventDispatcher->dispatch($event);
+        $email = (string) $data->get('email', $data->get('username'));
 
         if ($this->requestStack->getMainRequest() !== null) {
-            $cacheKey = strtolower((string) $email) . '-' . $this->requestStack->getMainRequest()->getClientIp();
+            $cacheKey = strtolower($email) . '-' . $this->requestStack->getMainRequest()->getClientIp();
 
             try {
                 $this->rateLimiter->ensureAccepted(RateLimiter::LOGIN_ROUTE, $cacheKey);
@@ -66,12 +51,12 @@ class LoginRoute extends AbstractLoginRoute
         }
 
         try {
-            $customer = $this->accountService->getCustomerByLogin(
+            $token = $this->accountService->loginByCredentials(
                 $email,
-                $data->get('password'),
+                (string) $data->get('password'),
                 $context
             );
-        } catch (CustomerNotFoundException|BadCredentialsException $exception) {
+        } catch (CustomerNotFoundException $exception) {
             throw new UnauthorizedHttpException('json', $exception->getMessage());
         }
 
@@ -79,20 +64,6 @@ class LoginRoute extends AbstractLoginRoute
             $this->rateLimiter->reset(RateLimiter::LOGIN_ROUTE, $cacheKey);
         }
 
-        $context = $this->restorer->restore($customer->getId(), $context);
-        $newToken = $context->getToken();
-
-        $this->customerRepository->update([
-            [
-                'id' => $customer->getId(),
-                'lastLogin' => new \DateTimeImmutable(),
-                'languageId' => $context->getLanguageId(),
-            ],
-        ], $context->getContext());
-
-        $event = new CustomerLoginEvent($context, $customer, $newToken);
-        $this->eventDispatcher->dispatch($event);
-
-        return new ContextTokenResponse($newToken);
+        return new ContextTokenResponse($token);
     }
 }

--- a/src/Core/Checkout/DependencyInjection/customer.xml
+++ b/src/Core/Checkout/DependencyInjection/customer.xml
@@ -147,10 +147,7 @@
         </service>
 
         <service id="Shopware\Core\Checkout\Customer\SalesChannel\LoginRoute" public="true">
-            <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Checkout\Customer\SalesChannel\AccountService"/>
-            <argument type="service" id="customer.repository"/>
-            <argument type="service" id="Shopware\Core\System\SalesChannel\Context\CartRestorer"/>
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack"/>
             <argument type="service" id="Shopware\Core\Framework\RateLimiter\RateLimiter"/>
         </service>

--- a/src/Storefront/Controller/AuthController.php
+++ b/src/Storefront/Controller/AuthController.php
@@ -34,7 +34,6 @@ use Shopware\Storefront\Page\Account\RecoverPassword\AccountRecoverPasswordPageL
 use Shopware\Storefront\Page\Account\RecoverPassword\AccountRecoverPasswordPageLoader;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -179,7 +178,7 @@ class AuthController extends StorefrontController
 
                 return $this->createActionResponse($request);
             }
-        } catch (BadCredentialsException|UnauthorizedHttpException|CustomerOptinNotCompletedException|CustomerAuthThrottledException $e) {
+        } catch (BadCredentialsException|CustomerNotFoundException|CustomerOptinNotCompletedException|CustomerAuthThrottledException $e) {
             if ($e instanceof CustomerOptinNotCompletedException) {
                 $errorSnippet = $e->getSnippetKey();
             }

--- a/src/Storefront/Page/Account/Order/AccountOrderPageLoader.php
+++ b/src/Storefront/Page/Account/Order/AccountOrderPageLoader.php
@@ -4,7 +4,6 @@ namespace Shopware\Storefront\Page\Account\Order;
 
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\Exception\CustomerNotLoggedInException;
-use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundByIdException;
 use Shopware\Core\Checkout\Customer\SalesChannel\AccountService;
 use Shopware\Core\Checkout\Order\Exception\GuestNotAuthenticatedException;
 use Shopware\Core\Checkout\Order\Exception\WrongGuestCredentialsException;
@@ -21,7 +20,6 @@ use Shopware\Storefront\Framework\Page\StorefrontSearchResult;
 use Shopware\Storefront\Page\GenericPageLoaderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * Do not use direct or indirect repository calls in a PageLoader. Always use a store-api route to get or put data.
@@ -59,14 +57,7 @@ class AccountOrderPageLoader
         $firstOrder = $page->getOrders()->getEntities()->first();
         $orderCustomerId = $firstOrder?->getOrderCustomer()?->getCustomer()?->getId();
         if ($request->get('deepLinkCode') && $orderCustomerId !== null) {
-            try {
-                $this->accountService->loginById(
-                    $orderCustomerId,
-                    $salesChannelContext
-                );
-            } catch (CustomerNotFoundByIdException $exception) {
-                throw new UnauthorizedHttpException('json', $exception->getMessage());
-            }
+            $this->accountService->loginById($orderCustomerId, $salesChannelContext);
         }
 
         $this->eventDispatcher->dispatch(

--- a/tests/integration/Core/Checkout/Cart/SalesChannel/CartServiceTest.php
+++ b/tests/integration/Core/Checkout/Cart/SalesChannel/CartServiceTest.php
@@ -433,7 +433,7 @@ class CartServiceTest extends TestCase
 
         $this->createCustomer($addressId, $mail, $password, $context->getContext());
 
-        $newtoken = $this->accountService->login($mail, $context);
+        $newtoken = $this->accountService->loginByCredentials($mail, $password, $context);
 
         $context = $contextService->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $newtoken));
 

--- a/tests/integration/Core/Checkout/Customer/AccountServiceEventTest.php
+++ b/tests/integration/Core/Checkout/Customer/AccountServiceEventTest.php
@@ -80,7 +80,7 @@ class AccountServiceEventTest extends TestCase
 
         try {
             $this->loginRoute->login($dataBag->toRequestDataBag(), $this->salesChannelContext);
-            $this->accountService->login('', $this->salesChannelContext);
+            $this->accountService->loginByCredentials('', 'shopware', $this->salesChannelContext);
         } catch (BadCredentialsException) {
             // nth
         }
@@ -125,7 +125,7 @@ class AccountServiceEventTest extends TestCase
 
             $eventDidRun = false;
 
-            $this->accountService->login('info@example.com', $this->salesChannelContext);
+            $this->accountService->loginByCredentials('info@example.com', 'shopware', $this->salesChannelContext);
             /** @phpstan-ignore-next-line - $eventDidRun updated value on listener */
             static::assertTrue($eventDidRun, 'Event "' . $eventClass . '" did not run');
 

--- a/tests/integration/Core/Checkout/Customer/CustomerValueResolverTest.php
+++ b/tests/integration/Core/Checkout/Customer/CustomerValueResolverTest.php
@@ -77,7 +77,7 @@ class CustomerValueResolverTest extends TestCase
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_DOMAIN_CURRENCY_ID, $currencyId);
         $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, ['store-api']);
 
-        $request->headers->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $this->loginCustomer(false));
+        $request->headers->set(PlatformRequest::HEADER_CONTEXT_TOKEN, $this->loginCustomer());
 
         if ($loginRequired) {
             $request->attributes->set(PlatformRequest::ATTRIBUTE_LOGIN_REQUIRED, $loginRequired);
@@ -129,13 +129,13 @@ class CustomerValueResolverTest extends TestCase
         ];
     }
 
-    private function loginCustomer(bool $isGuest): string
+    private function loginCustomer(): string
     {
         $email = Uuid::randomHex() . '@example.com';
-        $this->createCustomer($email, $isGuest);
+        $this->createCustomer($email);
 
         try {
-            return $this->accountService->login($email, $this->salesChannelContext, $isGuest);
+            return $this->accountService->loginByCredentials($email, 'shopware', $this->salesChannelContext);
         } catch (BadCredentialsException) {
             // nth
         }

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
@@ -57,6 +57,18 @@ class AccountServiceTest extends TestCase
         static::assertSame($customerId, $customer->getId());
     }
 
+    public function testLoginByCredentials(): void
+    {
+        $salesChannelContext = $this->createSalesChannelContext();
+        $customerId = $this->createCustomerOfSalesChannel($salesChannelContext->getSalesChannelId(), 'foo@bar.com');
+        $token = $this->accountService->loginByCredentials('foo@bar.com', 'shopware', $salesChannelContext);
+
+        $customer = $this->getCustomerFromToken($token, $salesChannelContext->getSalesChannelId());
+
+        static::assertSame('foo@bar.com', $customer->getEmail());
+        static::assertSame($customerId, $customer->getId());
+    }
+
     public function testGetCustomerByLogin(): void
     {
         $email = 'johndoe@example.com';

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/LoginRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/LoginRouteTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Checkout\Customer\CustomerCollection;
+use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundException;
 use Shopware\Core\Checkout\Customer\SalesChannel\LoginRoute;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -26,7 +27,6 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Integration\PaymentHandler\SyncTestPaymentHandler;
 use Shopware\Core\Test\TestDefaults;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 
 /**
  * @internal
@@ -164,7 +164,7 @@ class LoginRouteTest extends TestCase
 
     public function testLoginWithInvalidBoundSalesChannelId(): void
     {
-        static::expectException(UnauthorizedHttpException::class);
+        static::expectException(CustomerNotFoundException::class);
 
         $email = Uuid::randomHex() . '@example.com';
         $salesChannel = $this->createSalesChannel([

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/SendPasswordRecoveryMailRouteTest.php
@@ -123,7 +123,7 @@ class SendPasswordRecoveryMailRouteTest extends TestCase
                 ]
             );
 
-        static::assertSame(404, $this->browser->getResponse()->getStatusCode());
+        static::assertSame(401, $this->browser->getResponse()->getStatusCode());
 
         $response = json_decode($this->browser->getResponse()->getContent() ?: '', true, 512, \JSON_THROW_ON_ERROR);
 

--- a/tests/integration/Core/Framework/RateLimiter/RateLimiterTest.php
+++ b/tests/integration/Core/Framework/RateLimiter/RateLimiterTest.php
@@ -22,7 +22,6 @@ use Shopware\Core\Framework\Test\TestDataCollection;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
-use Shopware\Core\System\SalesChannel\Context\CartRestorer;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\System\User\Api\UserRecoveryController;

--- a/tests/integration/Core/Framework/RateLimiter/RateLimiterTest.php
+++ b/tests/integration/Core/Framework/RateLimiter/RateLimiterTest.php
@@ -127,10 +127,7 @@ class RateLimiterTest extends TestCase
     public function testResetRateLimitLoginRoute(): void
     {
         $route = new LoginRoute(
-            $this->getContainer()->get('event_dispatcher'),
             $this->getContainer()->get(AccountService::class),
-            $this->getContainer()->get('customer.repository'),
-            $this->getContainer()->get(CartRestorer::class),
             $this->getContainer()->get('request_stack'),
             $this->mockResetLimiter([
                 RateLimiter::LOGIN_ROUTE => 1,

--- a/tests/unit/Core/Checkout/Customer/CustomerExceptionTest.php
+++ b/tests/unit/Core/Checkout/Customer/CustomerExceptionTest.php
@@ -163,7 +163,7 @@ class CustomerExceptionTest extends TestCase
         yield CustomerException::CUSTOMER_NOT_FOUND_BY_ID => [
             'callback' => [CustomerException::class, 'customerNotFoundByIdException'],
             'args' => ['id-1'],
-            'statusCode' => Response::HTTP_NOT_FOUND,
+            'statusCode' => Response::HTTP_UNAUTHORIZED,
             'errorCode' => CustomerException::CUSTOMER_NOT_FOUND_BY_ID,
             'message' => 'No matching customer for the id "id-1" was found.',
         ];
@@ -171,7 +171,7 @@ class CustomerExceptionTest extends TestCase
         yield CustomerException::CUSTOMER_NOT_FOUND => [
             'callback' => [CustomerException::class, 'customerNotFound'],
             'args' => ['abc@com'],
-            'statusCode' => Response::HTTP_NOT_FOUND,
+            'statusCode' => Response::HTTP_UNAUTHORIZED,
             'errorCode' => CustomerException::CUSTOMER_NOT_FOUND,
             'message' => 'No matching customer for the email "abc@com" was found.',
         ];

--- a/tests/unit/Core/Checkout/Customer/CustomerExceptionTest.php
+++ b/tests/unit/Core/Checkout/Customer/CustomerExceptionTest.php
@@ -256,14 +256,6 @@ class CustomerExceptionTest extends TestCase
             'message' => 'Guest account is not allowed to login',
         ];
 
-        yield CustomerException::CUSTOMER_IS_INACTIVE => [
-            'callback' => [CustomerException::class, 'inactiveCustomer'],
-            'args' => ['id-1'],
-            'statusCode' => Response::HTTP_UNAUTHORIZED,
-            'errorCode' => CustomerException::CUSTOMER_OPTIN_NOT_COMPLETED,
-            'message' => 'The customer with the id "id-1" has not completed the opt-in.',
-        ];
-
         yield CustomerException::COUNTRY_NOT_FOUND => [
             'callback' => [CustomerException::class, 'countryNotFound'],
             'args' => ['100'],

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
@@ -70,7 +70,7 @@ class AccountServiceTest extends TestCase
         $eventDispatcher = new EventDispatcher();
         $eventDispatcher->addListener(
             CustomerBeforeLoginEvent::class,
-            function (CustomerBeforeLoginEvent $event) use ($salesChannelContext, &$beforeLoginEventCalled) {
+            function (CustomerBeforeLoginEvent $event) use ($salesChannelContext, &$beforeLoginEventCalled): void {
                 $beforeLoginEventCalled = true;
                 static::assertSame('foo@bar.de', $event->getEmail());
                 static::assertSame($salesChannelContext, $event->getSalesChannelContext());
@@ -79,7 +79,7 @@ class AccountServiceTest extends TestCase
 
         $eventDispatcher->addListener(
             CustomerLoginEvent::class,
-            function (CustomerLoginEvent $event) use ($customer, $loggedinSalesChannelContext, &$loginEventCalled) {
+            function (CustomerLoginEvent $event) use ($customer, $loggedinSalesChannelContext, &$loginEventCalled): void {
                 $loginEventCalled = true;
                 static::assertSame($customer, $event->getCustomer());
                 static::assertSame($loggedinSalesChannelContext, $event->getSalesChannelContext());


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the login logic exists in two places, once in the `AccountService` and once in the `LoginRoute`. Furthermore the `login` method of the account service makes it easy to login a customer only by the e-mail address, without validating the login itself. This might easily be used by a third party plugin, to login a customer just by the e-mail address. Also this method is currently only used in the tests.

Also the deprecation for Shopware 6.6 has not been properly removed: 
https://github.com/shopware/shopware/commit/be65da6f9064621b09cd628d6b0a29e98790127b#diff-d1dea29503be91898c1525d571d82ed761339c5bcecb10f1ce59cfd5bd3d1510L212-L214

Where the complete `if` statement should be removed.

### 2. What does this change do, exactly?
Move the login logic completely in the service and deprecate the `AccountService::login` method and instead add a new method which performs the login with the credentials.

Regarding the `CustomerBeforeLoginEvent` of the `loginByCredentials` method, I would move it after the `$customer = $this->getCustomerByLogin($email, $password, $context);` logic, but left it before, as it was the same in the login route. Let me know if that should be changed as well.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d95a74e</samp>

This pull request refactors the login functionality of the `AccountService` and the `LoginRoute` classes, introducing new methods for logging in customers by id or by credentials, and deprecating the old `login` method. It also removes unused and deprecated code from the `CustomerException` class, and adds feature flags and annotations to warn developers of the upcoming changes. Additionally, it fixes some minor issues and adds exception handling, tests and a changelog entry for the refactoring.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at d95a74e</samp>

*  Add a changelog entry for the refactoring ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-3b70b46448b3000305b48524ba76f751ca1f63788080d0955e7c9120cc6b997eR1-R12))
*  Remove the unused and deprecated constant `CUSTOMER_IS_INACTIVE` from the `CustomerException` class ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-0e722497fe7f608a6c98be2096c04e74a2c40df5835b53bea49a2d49b66724b1R27-R31), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-0e722497fe7f608a6c98be2096c04e74a2c40df5835b53bea49a2d49b66724b1L48))
*  Deprecate and feature flag the method `inactiveCustomer` in the `CustomerException` class, as it calls the deprecated method `customerOptinNotCompleted` ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-0e722497fe7f608a6c98be2096c04e74a2c40df5835b53bea49a2d49b66724b1L255-R265))
*  Deprecate and feature flag the method `login` in the `AccountService` class, suggesting to use `loginById` or `loginByCredentials` instead ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-d1dea29503be91898c1525d571d82ed761339c5bcecb10f1ce59cfd5bd3d1510R68-R69), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-d1dea29503be91898c1525d571d82ed761339c5bcecb10f1ce59cfd5bd3d1510R75-R76))
*  Add a new method `loginByCredentials` to the `AccountService` class, which takes an email and a password and returns a token for the logged in customer ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-d1dea29503be91898c1525d571d82ed761339c5bcecb10f1ce59cfd5bd3d1510R114-R127))
*  Modify the method `loginById` in the `AccountService` class, simplifying the logic and replacing the exception type ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-d1dea29503be91898c1525d571d82ed761339c5bcecb10f1ce59cfd5bd3d1510L90-R95), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-d1dea29503be91898c1525d571d82ed761339c5bcecb10f1ce59cfd5bd3d1510L98-R105))
*  Modify the method `loginByCustomer` in the `AccountService` class, adding a line to update the customer language id ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-d1dea29503be91898c1525d571d82ed761339c5bcecb10f1ce59cfd5bd3d1510R171))
*  Deprecate the parameter `$includeGuest` of the method `fetchCustomer` in the `AccountService` class, as it is unused ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-d1dea29503be91898c1525d571d82ed761339c5bcecb10f1ce59cfd5bd3d1510R185-R186))
*  Simplify the logic of the method `fetchCustomer` in the `AccountService` class, removing the unnecessary check for the customer active status ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-d1dea29503be91898c1525d571d82ed761339c5bcecb10f1ce59cfd5bd3d1510L210-R217))
*  Remove the unused method `getCustomerById` from the `AccountService` class ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-d1dea29503be91898c1525d571d82ed761339c5bcecb10f1ce59cfd5bd3d1510L182-L196))
*  Modify the `LoginRoute` class, removing the unused `use` statements, parameters, and properties, and simplifying the logic of the `login` method, using the new `loginByCredentials` method ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-8fe9bd5ee0435df7c04d8021eac507fc1fdb695132da28caa6eb82cd14423d0dL6-R7), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-8fe9bd5ee0435df7c04d8021eac507fc1fdb695132da28caa6eb82cd14423d0dL16), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-8fe9bd5ee0435df7c04d8021eac507fc1fdb695132da28caa6eb82cd14423d0dL22), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-8fe9bd5ee0435df7c04d8021eac507fc1fdb695132da28caa6eb82cd14423d0dL32-R27), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-8fe9bd5ee0435df7c04d8021eac507fc1fdb695132da28caa6eb82cd14423d0dL49-R44), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-8fe9bd5ee0435df7c04d8021eac507fc1fdb695132da28caa6eb82cd14423d0dL69-R56), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-8fe9bd5ee0435df7c04d8021eac507fc1fdb695132da28caa6eb82cd14423d0dL82-R67))
*  Modify the service definition of the `LoginRoute` class in the `customer.xml` file, removing the unused arguments from the constructor call ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-1ecaa56accf54955fe9f4308c7b5393431834c92cedfde9e0524f56d3ddc5352L150-R150))
*  Modify the `AccountOrderPageLoader` class, adding the `use` statements for the exceptions, and adding a try-catch block around the call to the `loginById` method, re-throwing the exception as an HTTP exception ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-43cb5276e4fd3d9b76cab8340cf6360a3b9aae17209262204d1de8f0cca69a9bR7), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-43cb5276e4fd3d9b76cab8340cf6360a3b9aae17209262204d1de8f0cca69a9bR24), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-43cb5276e4fd3d9b76cab8340cf6360a3b9aae17209262204d1de8f0cca69a9bL60-R69))
*  Modify the test methods in the `CartServiceTest`, `AccountServiceEventTest`, and `CustomerValueResolverTest` classes, replacing the calls to the deprecated `login` method with the calls to the new `loginByCredentials` method ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-4eea47743e143b494ebb11ab2d9da7e5b1d4ffbf9abc2927435fa3d4904b7906L436-R436), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-b0ddb9ce6f63972d787e21550a80136bc6a9f109b3ab6869ccdc44742db358efL83-R83), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-b0ddb9ce6f63972d787e21550a80136bc6a9f109b3ab6869ccdc44742db358efL128-R128), [link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-08ec33304dda2f2196235b08e17fd10843362b445d3960ca983845dd934152feL138-R138))
*  Add a new test method `testLoginByCredentials` to the `AccountServiceTest` class, testing the functionality of the new method ([link](https://github.com/shopware/shopware/pull/3465/files?diff=unified&w=0#diff-d81e7762d4bf176065c0eb3670db37f5187d9663437059d2e4283abd9e317734R60-R71))
