### PR TITLE
NEXT-00000 Update SalesChannelApiTestBehaviour.php

### DIFF
--- a/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/SalesChannelApiTestBehaviour.php
@@ -182,7 +182,7 @@ trait SalesChannelApiTestBehaviour
             $salesChannelRepository->delete([['id' => $salesChannelIds->firstId()]], Context::createDefaultContext());
         }
 
-        $salesChannel = array_merge([
+        $salesChannel = array_merge_recursive([
             'id' => $salesChannelOverride['id'] ?? Uuid::randomHex(),
             'typeId' => Defaults::SALES_CHANNEL_TYPE_STOREFRONT,
             'name' => 'API Test case sales channel',
@@ -226,7 +226,7 @@ trait SalesChannelApiTestBehaviour
             $email = Uuid::randomHex() . '@example.com';
         }
 
-        $customer = array_merge([
+        $customer = array_merge_recursive([
             'id' => $customerId,
             'salesChannelId' => TestDefaults::SALES_CHANNEL,
             'defaultShippingAddress' => [


### PR DESCRIPTION
This makes a subtle change to the create methods to be able to use them in a broader way, for example by creating saleschannels with more than one domain.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8b0fe67</samp>

Enhance `SalesChannelApiTestBehaviour` to allow more customization of test entities. Use `array_merge_recursive` to merge the default and custom attributes of sales channel and customer entities in `createSalesChannelContext` and `createCustomerAndLogin` functions.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8b0fe67</samp>

* Replace `array_merge` with `array_merge_recursive` in two functions to allow merging nested arrays in parameters ([link](https://github.com/shopware/shopware/pull/3469/files?diff=unified&w=0#diff-79966aefc83ccd217a5748651449bf180081445228de90daf648d7f71da67871L185-R185), [link](https://github.com/shopware/shopware/pull/3469/files?diff=unified&w=0#diff-79966aefc83ccd217a5748651449bf180081445228de90daf648d7f71da67871L229-R229))
