### PR TITLE
ci: Fix admin Jest tests

### DIFF
--- a/.github/workflows/02-unit.yml
+++ b/.github/workflows/02-unit.yml
@@ -137,7 +137,9 @@ jobs:
         run: composer install
 
       - name: Generate Schema
-        run: bin/console framework:schema -s 'entity-schema' src/Administration/Resources/app/administration/test/_mocks_/entity-schema.json
+        run: |
+          composer run framework:schema:dump
+          composer run npm:admin run unit-setup
 
       - name: Run Jest Admin
         run: npm --prefix src/Administration/Resources/app/administration run unit -- --silent


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the admin Jest tests are failing in the GH actions.

### 2. What does this change do, exactly?
Run the admin npm `unit-setup` command.

### 3. Describe each step to reproduce the issue or behaviour.
Look at the GH actions pipelines.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 081412b</samp>

Updated the schema generation and setup for administration unit tests. Used the new `framework:schema:dump` command and added the `unit-setup` script to `.github/workflows/02-unit.yml`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 081412b</samp>

*  Replace `framework:schema` command with `framework:schema:dump` command and add `unit-setup` script to `Generate Schema` step ([link](https://github.com/shopware/shopware/pull/3470/files?diff=unified&w=0#diff-61bf66b2d572336e9a9b58dbd9ac0cd9e2972bda698af400c8dbce0b565a7cdcL140-R142))
