### PR TITLE
NEXT-0000 - Fix: Kernel logic in the ci command

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -29,21 +29,24 @@ return static function (array &$context) {
     $env = $input->getParameterOption(['--env', '-e'], $context['APP_ENV'] ?? 'prod', true);
     $debug = ($context['APP_DEBUG'] ?? ($env !== 'prod')) && !$input->hasParameterOption('--no-debug', true);
 
-    $pluginLoader = new ComposerPluginLoader($classLoader, null);
-
     if ($input->getFirstArgument() === 'system:install') {
         $context['INSTALL'] = true;
     }
 
     $_SERVER['DATABASE_URL'] = 'mysql://_placeholder.test';
 
-    $kernel = KernelFactory::create($env, $debug, $classLoader, $pluginLoader);
+    $kernel = KernelFactory::create(
+        environment: $env,
+        debug: $debug,
+        classLoader: $classLoader,
+        pluginLoader: new ComposerPluginLoader($classLoader, null),
+    );
 
-    $application = new Application($kernel->getKernel());
-    $kernel->getKernel()->boot();
+    $application = new Application($kernel);
+    $kernel->boot();
 
     $application->setName('Shopware');
-    $application->setVersion($kernel->getKernel()->getContainer()->getParameter('kernel.shopware_version'));
+    $application->setVersion($kernel->getContainer()->getParameter('kernel.shopware_version'));
 
     return $application;
 };


### PR DESCRIPTION
### 1. Why is this change necessary?
```
❯ php bin/ci
Symfony\Component\ErrorHandler\Error\UndefinedMethodError^ {#80
  #message: "Attempted to call an undefined method named "getKernel" of class "Shopware\Core\Kernel"."
  #code: 0
  #file: "./bin/ci"
  #line: 42
  trace: {
    ./bin/ci:42 {
      {closure}^
      › 
      › $application = new Application($kernel->getKernel());
      › $kernel->getKernel()->boot();
    }
    ./vendor/symfony/runtime/Resolver/DebugClosureResolver.php:25 { …}
    ./vendor/autoload_runtime.php:24 { …}
    ./bin/ci:13 { …}
  }
}
```

### 2. What does this change do, exactly?
Cleanup the kernel logic.

### 3. Describe each step to reproduce the issue or behaviour.
Run `php bin/ci`

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

copilot:summary

copilot:walkthrough
