### PR TITLE
fix: Allow `association_fields` of `media_default_folder` to be nullable

### DIFF
--- a/changelog/_unreleased/2023-12-15-allow-association_fields-of-media_default_folder-to-be-nullable.md
+++ b/changelog/_unreleased/2023-12-15-allow-association_fields-of-media_default_folder-to-be-nullable.md
@@ -1,0 +1,9 @@
+---
+title: Allow `association_fields` of `media_default_folder` to be nullable
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed deprecated column `association_fields` of `media_default_folder` to be nullable, such that new default folders can be created even though the destructive migrations have not been executed

--- a/src/Core/Migration/V6_6/Migration1679581138RemoveAssociationFields.php
+++ b/src/Core/Migration/V6_6/Migration1679581138RemoveAssociationFields.php
@@ -19,6 +19,9 @@ class Migration1679581138RemoveAssociationFields extends MigrationStep
 
     public function update(Connection $connection): void
     {
+        if ($this->columnExists($connection, 'media_default_folder', 'association_fields')) {
+            $connection->executeStatement('ALTER TABLE `media_default_folder` CHANGE `association_fields` `association_fields` JSON NULL');
+        }
     }
 
     public function updateDestructive(Connection $connection): void


### PR DESCRIPTION
### 1. Why is this change necessary?
```
In ExceptionConverter.php line 114:
                                                                                                                                            
  [Doctrine\DBAL\Exception\NotNullConstraintViolationException (1364)]                                                                      
  An exception occurred while executing a query: SQLSTATE[HY000]: General error: 1364 Field 'association_fields' doesn't have a default value
```
which occurs as the definition of this field has been removed.

### 2. What does this change do, exactly?
Make the column nullable in the `update` part of the migration.

### 3. Describe each step to reproduce the issue or behaviour.
Try to create a media default folder, either with a specified value in `associationFields` or not.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 37235be</samp>

This pull request fixes a bug that could cause errors when creating new media default folders before the `association_fields` column is removed from the `media_default_folder` table. It adds a changelog entry, a migration class that makes the column nullable, and tests for the migration.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 37235be</samp>

*  Add a changelog entry for the pull request ([link](https://github.com/shopware/shopware/pull/3476/files?diff=unified&w=0#diff-7a9d3745c65127107724ba2fd450317faaa392a4d5df40b177caa9a079e90e7cR1-R9))
*  Modify the migration class to make the `association_fields` column nullable before removing it ([link](https://github.com/shopware/shopware/pull/3476/files?diff=unified&w=0#diff-8069116709a41508eeb584fc9978e3281b7aed6e7903f577e486928813c28770R22-R24))
*  Add test cases for the migration class ([link](https://github.com/shopware/shopware/pull/3476/files?diff=unified&w=0#diff-13b83099f650e82923e86062a57cacde1227e66d9e327755c273e4248fcce80aR24-R70))
