### PR TITLE
feat: Add Documents to OrderDelivery

### DIFF
--- a/changelog/_unreleased/2023-12-18-add-documents-to-orderdelivery.md
+++ b/changelog/_unreleased/2023-12-18-add-documents-to-orderdelivery.md
@@ -1,0 +1,9 @@
+---
+title: link-orderdelivery-with-documents
+issue: NEXT-00000
+author: Srihari Thalla
+author_email: daxserver@icloud.com
+author_github: DaxServer
+---
+# Core
+* Add `Document` to `OrderDelivery`

--- a/src/Core/Checkout/Document/DocumentDefinition.php
+++ b/src/Core/Checkout/Document/DocumentDefinition.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Document;
 
 use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -60,6 +61,8 @@ class DocumentDefinition extends EntityDefinition
             (new FkField('order_id', 'orderId', OrderDefinition::class))->addFlags(new ApiAware(), new Required()),
             (new FkField('document_media_file_id', 'documentMediaFileId', MediaDefinition::class))->addFlags(new ApiAware()),
             (new ReferenceVersionField(OrderDefinition::class, 'order_version_id'))->addFlags(new ApiAware(), new Required()),
+            (new FkField('order_delivery_id', 'orderDeliveryId', OrderDeliveryDefinition::class))->addFlags(new ApiAware()),
+            (new ReferenceVersionField(OrderDeliveryDefinition::class, 'order_delivery_version_id'))->addFlags(new ApiAware()),
 
             (new JsonField('config', 'config', [], []))->addFlags(new ApiAware(), new Required()),
             (new BoolField('sent', 'sent'))->addFlags(new ApiAware()),
@@ -70,6 +73,7 @@ class DocumentDefinition extends EntityDefinition
 
             (new ManyToOneAssociationField('documentType', 'document_type_id', DocumentTypeDefinition::class, 'id'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
             (new ManyToOneAssociationField('order', 'order_id', OrderDefinition::class, 'id', false))->addFlags(new ApiAware()),
+            (new ManyToOneAssociationField('orderDelivery', 'order_delivery_id', OrderDeliveryDefinition::class, 'id', false))->addFlags(new ApiAware()),
             (new ManyToOneAssociationField('referencedDocument', 'referenced_document_id', self::class, 'id', false))->addFlags(new ApiAware()),
             (new OneToManyAssociationField('dependentDocuments', self::class, 'referenced_document_id'))->addFlags(new ApiAware()),
             (new ManyToOneAssociationField('documentMediaFile', 'document_media_file_id', MediaDefinition::class, 'id', false))->addFlags(new ApiAware()),

--- a/src/Core/Checkout/Document/DocumentEntity.php
+++ b/src/Core/Checkout/Document/DocumentEntity.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Document;
 
 use Shopware\Core\Checkout\Document\Aggregate\DocumentType\DocumentTypeEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
@@ -27,6 +28,16 @@ class DocumentEntity extends Entity
     protected $orderVersionId;
 
     /**
+     * @var string|null
+     */
+    protected $orderDeliveryId;
+
+    /**
+     * @var string|null
+     */
+    protected $orderDeliveryVersionId;
+
+    /**
      * @var string
      */
     protected $documentTypeId;
@@ -45,6 +56,11 @@ class DocumentEntity extends Entity
      * @var OrderEntity|null
      */
     protected $order;
+
+    /**
+     * @var OrderDeliveryEntity|null
+     */
+    protected $orderDelivery;
 
     /**
      * @var array<string, mixed>
@@ -131,6 +147,36 @@ class DocumentEntity extends Entity
     public function setOrderId(string $orderId): void
     {
         $this->orderId = $orderId;
+    }
+
+    public function getOrderDelivery(): ?OrderDeliveryEntity
+    {
+        return $this->orderDelivery;
+    }
+
+    public function setOrderDelivery(?OrderDeliveryEntity $orderDelivery): void
+    {
+        $this->orderDelivery = $orderDelivery;
+    }
+
+    public function getOrderDeliveryId(): ?string
+    {
+        return $this->orderDeliveryId;
+    }
+
+    public function setOrderDeliveryId(?string $orderDeliveryId): void
+    {
+        $this->orderDeliveryId = $orderDeliveryId;
+    }
+
+    public function getOrderDeliveryVersionId(): ?string
+    {
+        return $this->orderDeliveryVersionId;
+    }
+
+    public function setOrderDeliveryVersionId(?string $orderDeliveryVersionId): void
+    {
+        $this->orderDeliveryVersionId = $orderDeliveryVersionId;
     }
 
     /**

--- a/src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryDefinition.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryDefinition.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Order\Aggregate\OrderDelivery;
 
+use Shopware\Core\Checkout\Document\DocumentDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressDefinition;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDeliveryPosition\OrderDeliveryPositionDefinition;
 use Shopware\Core\Checkout\Order\OrderDefinition;
@@ -91,6 +92,7 @@ class OrderDeliveryDefinition extends EntityDefinition
             (new ManyToOneAssociationField('shippingOrderAddress', 'shipping_order_address_id', OrderAddressDefinition::class, 'id'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
             (new ManyToOneAssociationField('shippingMethod', 'shipping_method_id', ShippingMethodDefinition::class, 'id'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
             (new OneToManyAssociationField('positions', OrderDeliveryPositionDefinition::class, 'order_delivery_id', 'id'))->addFlags(new ApiAware(), new CascadeDelete(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
+            (new OneToManyAssociationField('documents', DocumentDefinition::class, 'order_delivery_id', 'id'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::ASSOCIATION_SEARCH_RANKING)),
         ]);
     }
 }

--- a/src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryEntity.php
+++ b/src/Core/Checkout/Order/Aggregate/OrderDelivery/OrderDeliveryEntity.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Order\Aggregate\OrderDelivery;
 
 use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Document\DocumentCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDeliveryPosition\OrderDeliveryPositionCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -93,6 +94,11 @@ class OrderDeliveryEntity extends Entity
      * @var OrderDeliveryPositionCollection|null
      */
     protected $positions;
+
+    /**
+     * @var DocumentCollection|null
+     */
+    protected $documents;
 
     public function getOrderId(): string
     {
@@ -248,5 +254,15 @@ class OrderDeliveryEntity extends Entity
     public function setShippingOrderAddressVersionId(string $shippingOrderAddressVersionId): void
     {
         $this->shippingOrderAddressVersionId = $shippingOrderAddressVersionId;
+    }
+
+    public function getDocuments(): ?DocumentCollection
+    {
+        return $this->documents;
+    }
+
+    public function setDocuments(DocumentCollection $documents): void
+    {
+        $this->documents = $documents;
     }
 }

--- a/src/Core/Migration/V6_6/Migration1702889650AddDocumentsToOrderDelivery.php
+++ b/src/Core/Migration/V6_6/Migration1702889650AddDocumentsToOrderDelivery.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+class Migration1702889650AddDocumentsToOrderDelivery extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1702889650;
+    }
+
+    public function update(Connection $connection): void
+    {
+        if ($this->columnExists($connection, 'document', 'order_delivery_id')) {
+            return;
+        }
+
+        $sql = <<<SQL
+ALTER TABLE `document`
+    ADD COLUMN `order_delivery_id` BINARY(16) NULL AFTER `order_version_id`,
+    ADD COLUMN `order_delivery_version_id` BINARY(16) NULL AFTER `order_delivery_id`,
+    ADD CONSTRAINT `fk.document.order_delivery_id`
+        FOREIGN KEY (`order_delivery_id`, `order_delivery_version_id`) REFERENCES `order_delivery` (`id`, `version_id`)
+            ON UPDATE CASCADE;
+SQL;
+
+        $connection->executeStatement($sql);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+        // implement update destructive
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
At the moment, it is possible to add documents only to the Order. There exist documents that are related to the OrderDelivery and not the Order, viz. shipping labels, export documents, etc. However, they can only be added to the Order level which makes it not possible to distinguish which delivery it is related to. This PR would enable such behavior towards multiple deliveries per order.

### 2. What does this change do, exactly?
This PR adds `Document` support to `OrderDelivery`. 

### 3. Describe each step to reproduce the issue or behavior.


### 4. Please link to the relevant issues (if any).
See a related [Slack message](https://shopwarecommunity.slack.com/archives/C011VFQT7GB/p1698247465786939).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they failed without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfilled them.