### PR TITLE
NEXT-0000 - refactor: Deprecated unused twig variable selectQuantityThreshold

### DIFF
--- a/changelog/_unreleased/2023-12-18-deprecated-unused-variables-selectquantitythreshold.md
+++ b/changelog/_unreleased/2023-12-18-deprecated-unused-variables-selectquantitythreshold.md
@@ -1,0 +1,9 @@
+---
+title: Deprecated unused variables selectQuantityThreshold
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Deprecated unused variables `selectQuantityThreshold` from the templates `storefront/component/buy-widget/buy-widget-form.html.twig`, `storefront/page/product-detail/buy-widget-form.html.twig` and `storefront/component/line-item/element/quantity.html.twig`

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-cart/offcanvas-cart.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-cart/offcanvas-cart.plugin.js
@@ -94,8 +94,6 @@ export default class OffCanvasCartPlugin extends Plugin {
             Iterator.iterate(selects, select => select.addEventListener('change', this._onChangeProductQuantity.bind(this)));
         }
 
-        // Quantity changes will be made with an input field
-        // instead of a select when `selectQuantityThreshold` is reached.
         if (numberInputs) {
             Iterator.iterate(numberInputs, (input) => {
                 input.addEventListener('change', Debouncer.debounce(

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
@@ -17,6 +17,7 @@
                     {% block buy_widget_buy_quantity_container %}
                         {% if showQuantitySelect %}
                             <div class="col-4 d-flex justify-content-end">
+                                {# @deprecated tag:v6.7.0 - Unused variable selectQuantityThreshold will be removed without replacement #}
                                 {% set selectQuantityThreshold = 100 %}
                                 {% block buy_widget_buy_quantity_input_group %}
                                     <div class="input-group product-detail-quantity-group quantity-selector-group" data-quantity-selector="true">

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
@@ -57,6 +57,7 @@
                                            value="{{ redirectParameters }}">
                                 {% endblock %}
 
+                                {# @deprecated tag:v6.7.0 - Unused variable selectQuantityThreshold will be removed without replacement #}
                                 {% set selectQuantityThreshold = 100 %}
                                 {% block component_line_item_quantity_select %}
                                     {% block component_line_item_quantity_select_input %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
@@ -21,6 +21,7 @@
                     {% block page_product_detail_buy_quantity_container %}
                         {% if showQuantitySelect %}
                             <div class="col-4 d-flex justify-content-end">
+                                {# @deprecated tag:v6.7.0 - Unused variable selectQuantityThreshold will be removed without replacement #}
                                 {% set selectQuantityThreshold = 100 %}
                                 {% block page_product_detail_buy_quantity %}
                                     {% block page_product_detail_buy_quantity_input_group %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Remove not needed variables.

### 2. What does this change do, exactly?
Deprecate the unused variable `selectQuantityThreshold`.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/pull/3090

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.