### PR TITLE
NEXT-31979 - Use 'birthdayFieldRequired' Config In 'My Account'

### DIFF
--- a/changelog/_unreleased/2023-12-21-use-birthdayrequired-config-for-my-account.md
+++ b/changelog/_unreleased/2023-12-21-use-birthdayrequired-config-for-my-account.md
@@ -1,0 +1,10 @@
+---
+title:              Use 'birthdayFieldRequired' Config In 'My Account'
+issue:              NEXT-31979
+author:             Alessandro Aussems
+author_email:       me@alessandroaussems.be
+author_github:      @alessandroaussems
+---
+
+# Storefront
+*  Updated `views/storefront/page/account/profile/personal.html.twig` to use `config('core.loginRegistration.birthdayFieldRequired')` like it's used in `views/storefront/component/address/address-personal.html.twig` to make sure the setting is also taking into consideration the 'My Account' section

--- a/src/Storefront/Resources/views/storefront/page/account/profile/personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/profile/personal.html.twig
@@ -19,7 +19,7 @@
                     <select id="personalBirthday"
                             name="birthdayDay"
                             class="form-select{% if formViolations.getViolations('/birthdayDay') is not empty %} is-invalid{% endif %}"
-                            required="required">
+                            {{ config('core.loginRegistration.birthdayFieldRequired') ? 'required="required"' }}>
                         {% if not birthday %}
                             <option selected="selected"
                                     value="">
@@ -48,7 +48,7 @@
                 <div class="form-group col-4 col-md-2">
                     <select name="birthdayMonth"
                             class="form-select{% if formViolations.getViolations('/birthdayMonth') is not empty %} is-invalid{% endif %}"
-                            required="required">
+                            {{ config('core.loginRegistration.birthdayFieldRequired') ? 'required="required"' }}>
                         {% if not birthmonth %}
                             <option selected="selected"
                                     value="">
@@ -80,7 +80,7 @@
 
                     <select name="birthdayYear"
                             class="form-select{% if formViolations.getViolations('/birthdayYear') is not empty %} is-invalid{% endif %}"
-                            required="required">
+                            {{ config('core.loginRegistration.birthdayFieldRequired') ? 'required="required"' }}>
                         {% if not birthyear %}
                             <option selected="selected"
                                     value="">


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes: https://issues.shopware.com/issues/NEXT-31979

### 2. What does this change do, exactly?
Uses core.loginRegistration.birthdayFieldRequired in views/storefront/page/account/profile/personal.html.twig the same way it is used in views/storefront/component/address/address-personal.html.twig

### 3. Describe each step to reproduce the issue or behaviour.
See: https://issues.shopware.com/issues/NEXT-31979

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-31979


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

copilot:summary

copilot:walkthrough
