### PR TITLE
NEXT-00000 - Add product video functionality

### DIFF
--- a/changelog/_unreleased/2024-03-05-add-product-video-functionality.md
+++ b/changelog/_unreleased/2024-03-05-add-product-video-functionality.md
@@ -1,0 +1,16 @@
+---
+title: Add product video functionality
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Added `core.listing.autoplayVideoInListing` system config.
+___
+# Storefront
+* Added `utilities/video.html.twig` template.
+* Added block `component_line_item_video` to `component/line-item/element/image.html.twig` template.
+* Added block `component_product_box_video` to `component/product/card/box-standard.html.twig` template.
+* Added video implementation to `component/line-item/element/image.html.twig`, `component/product/card/box-standard.html.twig`, `component/product/quickview/minimal.html.twig`, `element/cms-element-image-gallery.html.twig` and `layout/header/search-suggest.html.twig` templates.
+* Added `.gallery-slider-thumbnails-play-button` styles in `component/_gallery-slider.scss`.

--- a/src/Core/System/Resources/config/listing.xml
+++ b/src/Core/System/Resources/config/listing.xml
@@ -14,6 +14,14 @@
         </input-field>
 
         <input-field type="bool">
+            <name>autoplayVideoInListing</name>
+            <label>Autoplay videos in listings</label>
+            <label lang="de-DE">Videos in Produktlistings automatisch abspielen</label>
+            <helpText>In product listings, videos configured as product media cover are played automatically. Deactivate to display first frame of video only.</helpText>
+            <helpText lang="de-DE">In Produktlisten werden Videos, die als Produktmedien-Cover konfiguriert sind, automatisch abgespielt. Deaktivieren, um nur den ersten Frame des Videos anzuzeigen.</helpText>
+        </input-field>
+
+        <input-field type="bool">
             <name>hideCloseoutProductsWhenOutOfStock</name>
             <label>Hide products after clearance</label>
             <label lang="de-DE">Produkte nach Abverkaufende ausblenden</label>

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
@@ -223,6 +223,37 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     max-width: 100%;
 }
 
+.gallery-slider-thumbnails-play-button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+
+    &::before,
+    &::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+    }
+
+    &::before {
+        transform: translate(-50%, -50%);
+        width: 25px;
+        height: 25px;
+        border-radius: 50%;
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+
+    &::after {
+        transform: translate(-40%, -50%);
+        border-top: 6px solid transparent;
+        border-bottom: 6px solid transparent;
+        border-left: 9px solid $white;
+    }
+}
+
 .gallery-slider-thumbnails-controls {
     display: none;
     margin: 0;

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/image.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/image.html.twig
@@ -1,20 +1,34 @@
 {% block component_line_item_image %}
     {% set thumbnail %}
         {% if lineItem.cover.url and lineItem.cover.isSpatialObject() == false %}
-            {% block component_line_item_image_thumbnails %}
-                {% sw_thumbnails 'line-item-img-thumbnails' with {
-                    media: lineItem.cover,
-                    sizes: {
-                        default: '100px'
-                    },
-                    attributes: {
-                        class: 'img-fluid line-item-img',
-                        alt: (lineItem.cover.translated.alt ?: ''),
-                        title: (lineItem.cover.translated.title ?: ''),
-                        loading: 'lazy'
-                    }
-                } %}
-            {% endblock %}
+            {% set attributes = {
+                class: 'img-fluid line-item-img',
+                title: (lineItem.cover.translated.title ?: '')
+            } %}
+
+            {% if lineItem.cover.mimeType starts with 'video/' %}
+                {% block component_line_item_video %}
+                    {% sw_include '@Storefront/storefront/utilities/video.html.twig' with {
+                        media: lineItem.cover,
+                        attributes: attributes
+                    } %}
+                {% endblock %}
+            {% else %}
+                {% set attributes = attributes|merge({
+                    alt: (lineItem.cover.translated.alt ?: ''),
+                    loading: 'lazy'
+                }) %}
+
+                {% block component_line_item_image_thumbnails %}
+                    {% sw_thumbnails 'line-item-img-thumbnails' with {
+                        media: lineItem.cover,
+                        sizes: {
+                            default: '100px'
+                        },
+                        attributes: attributes
+                    } %}
+                {% endblock %}
+            {% endif %}
         {% else %}
             {% if fallbackIcon %}
                 {% block component_line_item_image_fallback_icon %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -30,22 +30,42 @@
                                     {% block component_product_box_image_link_inner %}
                                         {% if cover.url and cover.isSpatialObject() == false %}
                                             {% set attributes = {
-                                                class: 'product-image is-'~displayMode,
-                                                alt: (cover.translated.alt ?: name),
-                                                title: (cover.translated.title ?: name),
-                                                loading: 'lazy'
+                                                class: 'product-image is-' ~ displayMode,
+                                                title: (cover.translated.title ?: name)
                                             } %}
 
-                                            {% if displayMode == 'cover' or displayMode == 'contain' %}
-                                                {% set attributes = attributes|merge({ 'data-object-fit': displayMode }) %}
-                                            {% endif %}
+                                            {% if cover.mimeType starts with 'video/' %}
+                                                {% if config('core.listing.autoplayVideoInListing') %}
+                                                    {% set attributes = attributes|merge({
+                                                        autoplay: true,
+                                                        loop: true
+                                                    }) %}
+                                                {% endif %}
 
-                                            {% block component_product_box_image_thumbnail %}
-                                                {% sw_thumbnails 'product-image-thumbnails' with {
-                                                    media: cover,
-                                                    sizes: sizes
-                                                } %}
-                                            {% endblock %}
+                                                {% block component_product_box_video %}
+                                                    {% sw_include '@Storefront/storefront/utilities/video.html.twig' with {
+                                                        media: cover,
+                                                        attributes: attributes
+                                                    } %}
+                                                {% endblock %}
+                                            {% else %}
+                                                {% set attributes = attributes|merge({
+                                                    alt: (cover.translated.alt ?: name),
+                                                    loading: 'lazy'
+                                                }) %}
+
+                                                {% if displayMode == 'cover' or displayMode == 'contain' %}
+                                                    {% set attributes = attributes|merge({ 'data-object-fit': displayMode }) %}
+                                                {% endif %}
+
+                                                {% block component_product_box_image_thumbnail %}
+                                                    {% sw_thumbnails 'product-image-thumbnails' with {
+                                                        media: cover,
+                                                        sizes: sizes,
+                                                        attributes: attributes
+                                                    } %}
+                                                {% endblock %}
+                                            {% endif %}
                                         {% else %}
                                             {% block component_product_box_image_placeholder %}
                                                 <div class="product-image-placeholder">

--- a/src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/quickview/minimal.html.twig
@@ -8,17 +8,29 @@
                 {% block component_product_quickview_minimal_img %}
                     <div class="col-12 col-md-6 quickview-minimal-image">
                         {% if page.product.media %}
-                            {% sw_thumbnails 'minimal-image-thumbnails' with {
-                                media: page.product.cover.media,
-                                sizes: {
-                                    default: '360px'
-                                },
-                                attributes: {
-                                    class: 'img-fluid quickview-minimal-img',
-                                    alt: ( page.product.cover.translated.alt ?: ''),
-                                    title: (page.product.cover.translated.title ?: '')
-                                }
+                            {% set attributes = {
+                                class: 'img-fluid quickview-minimal-img',
+                                title: (page.product.cover.translated.title ?: '')
                             } %}
+
+                            {% if page.product.cover.media.mimeType starts with 'video/' %}
+                                {% sw_include '@Storefront/storefront/utilities/video.html.twig' with {
+                                    media: page.product.cover.media,
+                                    attributes: attributes
+                                } %}
+                            {% else %}
+                                {% set attributes = attributes|merge({
+                                    alt: ( page.product.cover.translated.alt ?: '')
+                                }) %}
+
+                                {% sw_thumbnails 'minimal-image-thumbnails' with {
+                                    media: page.product.cover.media,
+                                    sizes: {
+                                        default: '360px'
+                                    },
+                                    attributes: attributes
+                                } %}
+                            {% endif %}
                         {% else %}
                             {% sw_icon 'placeholder' style {
                                 size: 'fluid'

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -152,19 +152,9 @@
                                                                             {% if minHeight and (displayMode == "cover" or displayMode == "contain") %} style="min-height: {{ minHeight }}"{% endif %}
                                                                             {% if (displayMode == "standard" and image.isSpatialObject()) %} style="min-height: 240px"{% endif %}>
                                                                             {% set attributes = {
-                                                                                'class': 'img-fluid gallery-slider-image magnifier-image js-magnifier-image',
-                                                                                'alt': (image.translated.alt ?: fallbackImageTitle),
-                                                                                'title': (image.translated.title ?: fallbackImageTitle),
-                                                                                'data-full-image': image.url
+                                                                                class: 'img-fluid gallery-slider-image',
+                                                                                title: (image.translated.title ?: fallbackImageTitle)
                                                                             } %}
-
-                                                                            {% if displayMode == 'cover' or displayMode == 'contain' %}
-                                                                                {% set attributes = attributes|merge({ 'data-object-fit': displayMode }) %}
-                                                                            {% endif %}
-
-                                                                            {% if isProduct %}
-                                                                                {% set attributes = attributes|merge({ 'itemprop': 'image' }) %}
-                                                                            {% endif %}
 
                                                                             {# @experimental stableVersion:v6.7.0 feature:SPATIAL_BASES #}
                                                                             {% block element_image_gallery_inner_item_spatial %}
@@ -199,9 +189,35 @@
                                                                                             {% sw_include '@Storefront/storefront/utilities/ar-overlay.html.twig' %}
                                                                                         {% endif %}
                                                                                     </div>
+                                                                                {% elseif image.mimeType starts with 'video/' %}
+                                                                                    {% set attributes = attributes|merge({ controls: true }) %}
+
+                                                                                    {% if isProduct %}
+                                                                                        {% set attributes = attributes|merge({ itemprop: 'video' }) %}
+                                                                                    {% endif %}
+
+                                                                                    {% sw_include '@Storefront/storefront/utilities/video.html.twig' with {
+                                                                                        media: image,
+                                                                                        attributes: attributes
+                                                                                    } %}
                                                                                 {% else %}
+                                                                                    {% set attributes = attributes|merge({
+                                                                                        class: attributes.class ~ ' magnifier-image js-magnifier-image',
+                                                                                        alt: (image.translated.alt ?: fallbackImageTitle),
+                                                                                        'data-full-image': image.url
+                                                                                    }) %}
+
+                                                                                    {% if displayMode == 'cover' or displayMode == 'contain' %}
+                                                                                        {% set attributes = attributes|merge({ 'data-object-fit': displayMode }) %}
+                                                                                    {% endif %}
+
+                                                                                    {% if isProduct %}
+                                                                                        {% set attributes = attributes|merge({ itemprop: 'image' }) %}
+                                                                                    {% endif %}
+
                                                                                     {% sw_thumbnails 'gallery-slider-image-thumbnails' with {
-                                                                                        media: image
+                                                                                        media: image,
+                                                                                        attributes: attributes
                                                                                     } %}
                                                                                 {% endif %}
                                                                             {% endblock %}
@@ -245,19 +261,9 @@
                                                 <div class="gallery-slider-single-image is-{{ displayMode }} js-magnifier-container"{% if minHeight %} style="min-height: {{ minHeight }}"{% endif %}>
                                                     {% if imageCount > 0 %}
                                                         {% set attributes = {
-                                                            'class': 'img-fluid gallery-slider-image magnifier-image js-magnifier-image',
-                                                            'alt': (mediaItems|first.translated.alt ?: fallbackImageTitle),
-                                                            'title': (mediaItems|first.translated.title ?: fallbackImageTitle),
-                                                            'data-full-image': mediaItems|first.url
+                                                            class: 'img-fluid gallery-slider-image',
+                                                            title: (mediaItems|first.translated.title ?: fallbackImageTitle)
                                                         } %}
-
-                                                        {% if displayMode == 'cover' or displayMode == 'contain' %}
-                                                            {% set attributes = attributes|merge({ 'data-object-fit': displayMode }) %}
-                                                        {% endif %}
-
-                                                        {% if isProduct %}
-                                                            {% set attributes = attributes|merge({ 'itemprop': 'image' }) %}
-                                                        {% endif %}
 
                                                         {# @experimental stableVersion:v6.7.0 feature:SPATIAL_BASES #}
                                                         {% block element_image_gallery_inner_single_spatial %}
@@ -293,9 +299,35 @@
                                                                             {% sw_include '@Storefront/storefront/utilities/ar-overlay.html.twig' %}
                                                                         {% endif %}
                                                                     </div>
+                                                                {% elseif mediaItems|first.mimeType starts with 'video/' %}
+                                                                    {% set attributes = attributes|merge({ controls: true }) %}
+
+                                                                    {% if isProduct %}
+                                                                        {% set attributes = attributes|merge({ itemprop: 'video' }) %}
+                                                                    {% endif %}
+
+                                                                    {% sw_include '@Storefront/storefront/utilities/video.html.twig' with {
+                                                                        media: mediaItems|first,
+                                                                        attributes: attributes
+                                                                    } %}
                                                                 {% else %}
+                                                                    {% set attributes = attributes|merge({
+                                                                        class: attributes.class ~ ' magnifier-image js-magnifier-image',
+                                                                        alt: (mediaItems|first.translated.alt ?: fallbackImageTitle),
+                                                                        'data-full-image': mediaItems|first.url
+                                                                    }) %}
+
+                                                                    {% if displayMode == 'cover' or displayMode == 'contain' %}
+                                                                        {% set attributes = attributes|merge({ 'data-object-fit': displayMode }) %}
+                                                                    {% endif %}
+
+                                                                    {% if isProduct %}
+                                                                        {% set attributes = attributes|merge({ itemprop: 'image' }) %}
+                                                                    {% endif %}
+
                                                                     {% sw_thumbnails 'gallery-slider-image-thumbnails' with {
                                                                         media: mediaItems|first,
+                                                                        attributes: attributes
                                                                     } %}
                                                                 {% endif %}
                                                             {% endfor %}
@@ -346,14 +378,9 @@
                                                                 {% block element_image_gallery_inner_thumbnails_item_inner %}
                                                                     <div class="gallery-slider-thumbnails-item-inner">
                                                                         {% set attributes = {
-                                                                            'class': 'gallery-slider-thumbnails-image',
-                                                                            'alt': (image.translated.alt ?: fallbackImageTitle),
-                                                                            'title': (image.translated.title ?: fallbackImageTitle)
+                                                                            class: 'gallery-slider-thumbnails-image',
+                                                                            title: (image.translated.title ?: fallbackImageTitle)
                                                                         } %}
-
-                                                                        {% if isProduct %}
-                                                                            {% set attributes = attributes|merge({ 'itemprop': 'image' }) %}
-                                                                        {% endif %}
 
                                                                         {# @experimental stableVersion:v6.7.0 feature:SPATIAL_BASES #}
                                                                         {% block element_image_gallery_inner_thumbnails_item_inner_spatial %}
@@ -362,12 +389,32 @@
                                                                                     'size': 'fluid'
                                                                                 } %}
                                                                                 <span class="badge bg-secondary m-1 position-absolute bottom-0 end-0">3D</span>
+                                                                            {% elseif image.mimeType starts with 'video/' %}
+                                                                                {% if isProduct %}
+                                                                                    {% set attributes = attributes|merge({ itemprop: 'video' }) %}
+                                                                                {% endif %}
+
+                                                                                {% sw_include '@Storefront/storefront/utilities/video.html.twig' with {
+                                                                                    media: image,
+                                                                                    attributes: attributes
+                                                                                } %}
+
+                                                                                <div class="gallery-slider-thumbnails-play-button"></div>
                                                                             {% else %}
+                                                                                {% set attributes = attributes|merge({
+                                                                                    alt: (image.translated.alt ?: fallbackImageTitle)
+                                                                                }) %}
+
+                                                                                {% if isProduct %}
+                                                                                    {% set attributes = attributes|merge({ itemprop: 'image' }) %}
+                                                                                {% endif %}
+
                                                                                 {% sw_thumbnails 'gallery-slider-thumbnails-image-thumbnails' with {
                                                                                     media: image,
                                                                                     sizes: {
-                                                                                        'default': '200px'
-                                                                                    }
+                                                                                        default: '200px'
+                                                                                    },
+                                                                                    attributes: attributes
                                                                                 } %}
                                                                             {% endif %}
                                                                         {% endblock %}
@@ -483,7 +530,12 @@
                                                                                         <div class="gallery-slider-item">
                                                                                             {% block element_image_gallery_inner_zoom_modal_slider_item_zoom_container %}
                                                                                                 <div class="image-zoom-container"
-                                                                                                     data-image-zoom="true">
+                                                                                                     {% if not (image.mimeType starts with 'video/') %}data-image-zoom="true"{% endif %}>
+                                                                                                    {% set attributes = {
+                                                                                                        class: 'gallery-slider-image',
+                                                                                                        title: (image.translated.title ?: fallbackImageTitle)
+                                                                                                    } %}
+
                                                                                                     {% block element_image_gallery_inner_zoom_modal_slider_item_image %}
                                                                                                         {# @experimental stableVersion:v6.7.0 feature:SPATIAL_BASES #}
                                                                                                         {% block element_image_gallery_inner_zoom_modal_slider_item_image_spatial %}
@@ -499,14 +551,22 @@
                                                                                                                     loadOriginalImage: true,
                                                                                                                     autoColumnSizes: false
                                                                                                                 } %}
+                                                                                                            {% elseif image.mimeType starts with 'video/' %}
+                                                                                                                {% set attributes = attributes|merge({ controls: true }) %}
+
+                                                                                                                {% sw_include '@Storefront/storefront/utilities/video.html.twig' with {
+                                                                                                                    media: image,
+                                                                                                                    attributes: attributes
+                                                                                                                } %}
                                                                                                             {% else %}
+                                                                                                                {% set attributes = attributes|merge({
+                                                                                                                    class: attributes.class ~ ' js-image-zoom-element js-load-img',
+                                                                                                                    alt: (image.translated.alt ?: fallbackImageTitle)
+                                                                                                                }) %}
+
                                                                                                                 {% sw_thumbnails 'gallery-slider-image-thumbnails' with {
                                                                                                                     media: image,
-                                                                                                                    attributes: {
-                                                                                                                        'class': 'gallery-slider-image js-image-zoom-element js-load-img',
-                                                                                                                        'alt': (image.translated.alt ?: fallbackImageTitle),
-                                                                                                                        'title': (image.translated.title ?: fallbackImageTitle)
-                                                                                                                    },
+                                                                                                                    attributes: attributes,
                                                                                                                     load: false,
                                                                                                                     loadOriginalImage: true,
                                                                                                                     autoColumnSizes: false
@@ -615,6 +675,11 @@
                                                                                             <div class="gallery-slider-thumbnails-item">
                                                                                                 {% block element_image_gallery_inner_zoom_modal_thumbnails_item_inner %}
                                                                                                     <div class="gallery-slider-thumbnails-item-inner">
+                                                                                                        {% set attributes = {
+                                                                                                            class: 'gallery-slider-thumbnails-image',
+                                                                                                            title: (image.translated.title ?: fallbackImageTitle)
+                                                                                                        } %}
+
                                                                                                         {# @experimental stableVersion:v6.7.0 feature:SPATIAL_BASES #}
                                                                                                         {% block element_image_gallery_inner_zoom_modal_thumbnails_item_inner_spatial %}
                                                                                                             {% if image.isSpatialObject() %}
@@ -623,17 +688,25 @@
                                                                                                                     'class': ''
                                                                                                                 } %}
                                                                                                                 <span class="badge bg-secondary m-1 position-absolute bottom-0 end-0">3D</span>
+                                                                                                            {% elseif image.mimeType starts with 'video/' %}
+                                                                                                                {% sw_include '@Storefront/storefront/utilities/video.html.twig' with {
+                                                                                                                    media: image,
+                                                                                                                    attributes: attributes
+                                                                                                                } %}
+
+                                                                                                                <div class="gallery-slider-thumbnails-play-button"></div>
                                                                                                             {% else %}
+                                                                                                                {% set attributes = attributes|merge({
+                                                                                                                    class: attributes.class ~ ' js-load-img',
+                                                                                                                    alt: (image.translated.alt ?: fallbackImageTitle)
+                                                                                                                }) %}
+
                                                                                                                 {% sw_thumbnails 'gallery-slider-thumbnails-image-thumbnails' with {
                                                                                                                     media: image,
                                                                                                                     sizes: {
-                                                                                                                        'default': '200px'
+                                                                                                                        default: '200px'
                                                                                                                     },
-                                                                                                                    attributes: {
-                                                                                                                        'class': 'gallery-slider-thumbnails-image js-load-img',
-                                                                                                                        'alt': (image.translated.alt ?: fallbackImageTitle),
-                                                                                                                        'title': (image.translated.title ?: fallbackImageTitle)
-                                                                                                                    },
+                                                                                                                    attributes: attributes,
                                                                                                                     load: false
                                                                                                                 } %}
                                                                                                             {% endif %}

--- a/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
@@ -15,18 +15,30 @@
                                         <div class="row align-items-center g-0">
                                             {% block layout_search_suggest_result_image %}
                                                 <div class="col-auto search-suggest-product-image-container">
+                                                    {% set attributes = {
+                                                        class: 'search-suggest-product-image',
+                                                        title: (product.cover.media.translated.title ?: '')
+                                                    } %}
+
                                                     {% if product.cover.media.url and product.cover.media.isSpatialObject() == false %}
-                                                        {% sw_thumbnails 'search-suggest-product-image-thumbnails' with {
-                                                            media: product.cover.media,
-                                                            sizes: {
-                                                                default: '100px'
-                                                            },
-                                                            attributes: {
-                                                                class: 'search-suggest-product-image',
-                                                                alt: (product.cover.media.translated.alt ?: ''),
-                                                                title: (product.cover.media.translated.title ?: '')
-                                                            }
-                                                        } %}
+                                                        {% if product.cover.media.mimeType starts with 'video/' %}
+                                                            {% sw_include '@Storefront/storefront/utilities/video.html.twig' with {
+                                                                media: product.cover.media,
+                                                                attributes: attributes
+                                                            } %}
+                                                        {% else %}
+                                                            {% set attributes = attributes|merge({
+                                                                alt: (product.cover.media.translated.alt ?: '')
+                                                            }) %}
+
+                                                            {% sw_thumbnails 'search-suggest-product-image-thumbnails' with {
+                                                                media: product.cover.media,
+                                                                sizes: {
+                                                                    default: '100px'
+                                                                },
+                                                                attributes: attributes
+                                                            } %}
+                                                        {% endif %}
                                                     {% else %}
                                                         {% sw_icon 'placeholder' style {
                                                             size: 'lg'

--- a/src/Storefront/Resources/views/storefront/utilities/video.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/video.html.twig
@@ -1,0 +1,40 @@
+{% block video_utility %}
+    {% if attributes is not defined %}
+        {% set attributes = {} %}
+    {% endif %}
+
+    {% if attributes.title is not defined and media.translated.title is defined %}
+        {% set attributes = attributes|merge({ title: media.translated.title }) %}
+    {% endif %}
+
+    {% if attributes.autoplay is defined and attributes.autoplay is same as(true) %}
+        {% set attributes = attributes|merge({
+            muted: true,
+            playsinline: true,
+        }) %}
+    {% endif %}
+
+    {% if attributes.preload is not defined %}
+        {% set attributes = attributes|merge({ preload: 'metadata' }) %}
+    {% endif %}
+
+    {% set videoAttributes = [] %}
+
+    {% for key, value in attributes %}
+        {% if value != '' %}
+            {% set videoAttribute = key %}
+
+            {% if not value is same as(true) %}
+                {% set videoAttribute = key ~ '="' ~ value ~ '"' %}
+            {% endif %}
+
+            {% set videoAttributes = videoAttributes|merge([videoAttribute]) %}
+        {% endif %}
+    {% endfor %}
+
+    {% block video_utility_video %}
+        <video {{ videoAttributes|join(' ')|raw }}>
+            <source src="{{ media|sw_encode_media_url }}#t=0.001" type="{{ media.mimeType }}">
+        </video>
+    {% endblock %}
+{% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Many modern online shops make use of product videos. With Shopware, videos cannot be used as product media at the moment.

### 2. What does this change do, exactly?

Add video functionality to twig templates related to product media/cover.

### 3. Describe each step to reproduce the issue or behaviour.

Add video to product media > broken image icon is displayed in shop

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
