### PR TITLE
NEXT-00000 - Fix wishlists variable type in product entity

### DIFF
--- a/changelog/_unreleased/2023-12-31-fix-product-wishlist-type.md
+++ b/changelog/_unreleased/2023-12-31-fix-product-wishlist-type.md
@@ -1,0 +1,10 @@
+---
+title:              Fix 'wishlists' variable type in product entity
+issue:              
+author:             Egor Becker
+author_email:       niro0842@gmail.com
+author_github:      @niro08
+---
+
+# Core
+*  `wishlists` variable type changed from `Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlist\CustomerWishlistCollection` to `Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlistProduct\CustomerWishlistProductCollection` in `ProductEntity` class in order to comply with the `ProductDefinition` and prevent TypeError when trying to load a product with the `wishlists` association

--- a/changelog/_unreleased/2023-12-31-fix-product-wishlist-type.md
+++ b/changelog/_unreleased/2023-12-31-fix-product-wishlist-type.md
@@ -7,4 +7,4 @@ author_github:      @niro08
 ---
 
 # Core
-*  `wishlists` variable type changed from `Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlist\CustomerWishlistCollection` to `Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlistProduct\CustomerWishlistProductCollection` in `ProductEntity` class in order to comply with the `ProductDefinition` and prevent TypeError when trying to load a product with the `wishlists` association
+* Changed `wishlists` variable type from `Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlist\CustomerWishlistCollection` to `Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlistProduct\CustomerWishlistProductCollection` in `ProductEntity` class in order to comply with the `ProductDefinition` and prevent TypeError when trying to load a product with the `wishlists` association

--- a/src/Core/Content/Product/ProductEntity.php
+++ b/src/Core/Content/Product/ProductEntity.php
@@ -3,7 +3,7 @@
 namespace Shopware\Core\Content\Product;
 
 use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryDate;
-use Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlist\CustomerWishlistCollection;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlistProduct\CustomerWishlistProductCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderLineItem\OrderLineItemCollection;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Cms\CmsPageEntity;
@@ -454,7 +454,7 @@ class ProductEntity extends Entity implements \Stringable
     protected $customSearchKeywords;
 
     /**
-     * @var CustomerWishlistCollection|null
+     * @var CustomerWishlistProductCollection|null
      */
     protected $wishlists;
 
@@ -1390,12 +1390,12 @@ class ProductEntity extends Entity implements \Stringable
         $this->customSearchKeywords = $customSearchKeywords;
     }
 
-    public function getWishlists(): ?CustomerWishlistCollection
+    public function getWishlists(): ?CustomerWishlistProductCollection
     {
         return $this->wishlists;
     }
 
-    public function setWishlists(CustomerWishlistCollection $wishlists): void
+    public function setWishlists(CustomerWishlistProductCollection $wishlists): void
     {
         $this->wishlists = $wishlists;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
When calling the $product->getWishlists() function (the "wishlists" association must be added to the criteria), a TypeError error occurs.

### 2. What does this change do, exactly?
Changes `wishlists` variable type from `Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlist\CustomerWishlistCollection` to `Shopware\Core\Checkout\Customer\Aggregate\CustomerWishlistProduct\CustomerWishlistProductCollection` in `ProductEntity` class in order to comply with the `ProductDefinition` and prevent TypeError

### 3. Describe each step to reproduce the issue or behaviour.

- Load any product with 'wishlists' association `$product = $this->productRepository->search((new Criteria([$productId]))->addAssociation('wishlists'), $context)->first()`;
- Try to get product wishlists `$product->getWishlists()`;
- TypeError occurs;

### 4. Please link to the relevant issues (if any).


### 5. Checklist 

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
