### PR TITLE
NEXT-32957 - Update dir to delete

### DIFF
--- a/changelog/_unreleased/2024-01-02-delete-old-files-handler.md
+++ b/changelog/_unreleased/2024-01-02-delete-old-files-handler.md
@@ -1,0 +1,7 @@
+---
+ title: Changed dir to delete
+ author: Fabian Boensch
+ author_github: @En0Ma1259
+ ---
+ # Storefront
+ * Changed dir to delete for old theme files

--- a/src/Storefront/Theme/Message/DeleteThemeFilesHandler.php
+++ b/src/Storefront/Theme/Message/DeleteThemeFilesHandler.php
@@ -28,6 +28,6 @@ final class DeleteThemeFilesHandler
             return;
         }
 
-        $this->filesystem->deleteDirectory($message->getThemePath());
+        $this->filesystem->deleteDirectory('theme' . \DIRECTORY_SEPARATOR . $message->getThemePath());
     }
 }

--- a/tests/unit/Storefront/Theme/Message/DeleteThemeFilesHandlerTest.php
+++ b/tests/unit/Storefront/Theme/Message/DeleteThemeFilesHandlerTest.php
@@ -22,7 +22,7 @@ class DeleteThemeFilesHandlerTest extends TestCase
         $message = new DeleteThemeFilesMessage($currentPath, 'salesChannel', 'theme');
 
         $filesystem = $this->createMock(FilesystemOperator::class);
-        $filesystem->expects(static::once())->method('deleteDirectory')->with($currentPath);
+        $filesystem->expects(static::once())->method('deleteDirectory')->with('theme' . \DIRECTORY_SEPARATOR . $currentPath);
 
         $handler = new DeleteThemeFilesHandler(
             $filesystem,


### PR DESCRIPTION
### 1. Why is this change necessary?
DeleteThemeFilesHandler tries to delete old theme dir. Unfortunately the path is wrong and nothing is deleted.

### 2. What does this change do, exactly?
Changes the path to the real directory.

Relates to e.g. https://github.com/shopware/shopware/blob/trunk/src/Storefront/Theme/ThemeCompiler.php#L479

Otherwise ThemeCompiler must be changed combined with https://github.com/shopware/shopware/blob/trunk/src/Core/Framework/Resources/config/packages/shopware.yaml#L108C9-L108C9?

### 3. Describe each step to reproduce the issue or behaviour.
Build your theme 2 times. All directories from the first run should be deleted (Default message queue delay 15min)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
