### PR TITLE
NEXT-00000 - Add initial sorting functionality to customer detail order view

### DIFF
--- a/changelog/_unreleased/2024-01-04-add-initial-sorting-to-customer-detail-order-view.md
+++ b/changelog/_unreleased/2024-01-04-add-initial-sorting-to-customer-detail-order-view.md
@@ -1,0 +1,8 @@
+---
+title: Add initial sorting functionality to customer detail order view
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Administration
+* Added `sortBy` and `sortDirection` properties to the data object in `Resources/app/administration/src/module/sw-customer/component/sw-customer-detail-base.html.twig` to enable initial sorting functionality for the customer detail order view.

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
@@ -28,6 +28,8 @@ export default {
             term: '',
             // todo after NEXT-2291: to be removed if new emptyState-Splashscreens are implemented
             orderIcon: 'regular-shopping-bag',
+            sortBy: 'orderDateTime',
+            sortDirection: 'DESC',
         };
     },
 
@@ -102,6 +104,8 @@ export default {
             }
             criteria.addAssociation('stateMachineState')
                 .addAssociation('currency');
+
+            criteria.addSorting(Criteria.sort(this.sortBy, this.sortDirection));
 
             this.orderRepository.search(criteria).then((orders) => {
                 this.orders = orders;


### PR DESCRIPTION
### 1. Why is this change necessary?

The customer detail order view has no initial sorting.

### 2. What does this change do, exactly?

This change sorts the shown orders in the customer detail order view by `orderDateTime` initially.

### 3. Describe each step to reproduce the issue or behaviour.

Open the orders in the customer detail order view, they are not sorted.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
