### PR TITLE
NEXT-30575 - Remove HTML sanitization from mail header and footer fields

### DIFF
--- a/changelog/_unreleased/2024-01-04-remove-html-sanitization-from-mail-header-and-mail-footer-fields.md
+++ b/changelog/_unreleased/2024-01-04-remove-html-sanitization-from-mail-header-and-mail-footer-fields.md
@@ -1,0 +1,9 @@
+---
+title: Remove HTML sanitization from mail header and mail footer fields
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+issue: NEXT-30575
+---
+# Core
+- Removed HTML sanitization from mail header and mail footer fields

--- a/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailHeaderFooterTranslation/MailHeaderFooterTranslationDefinition.php
@@ -47,9 +47,9 @@ class MailHeaderFooterTranslationDefinition extends EntityTranslationDefinition
         return new FieldCollection([
             (new StringField('name', 'name'))->addFlags(new Required()),
             (new StringField('description', 'description'))->addFlags(new ApiAware()),
-            (new LongTextField('header_html', 'headerHtml'))->addFlags(new ApiAware(), new AllowHtml()),
+            (new LongTextField('header_html', 'headerHtml'))->addFlags(new ApiAware(), new AllowHtml(false)),
             (new LongTextField('header_plain', 'headerPlain'))->addFlags(new ApiAware()),
-            (new LongTextField('footer_html', 'footerHtml'))->addFlags(new ApiAware(), new AllowHtml()),
+            (new LongTextField('footer_html', 'footerHtml'))->addFlags(new ApiAware(), new AllowHtml(false)),
             (new LongTextField('footer_plain', 'footerPlain'))->addFlags(new ApiAware()),
         ]);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

The HTML sanitizer is active on e-mail HTML headers and footers, despite being inactive on the actual e-mail templates.

### 2. What does this change do, exactly?

It removes HTML sanitization from mail header and mail footer fields.

### 3. Describe each step to reproduce the issue or behaviour.

Add HTML code to the mail header and mail footer fields, then save. The Sanitizer removes part of the code.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-30575

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
