### PR TITLE
refactor: Product card action template

### DIFF
--- a/changelog/_unreleased/2024-01-05-cleanup-product-card-action-html-twig-template.md
+++ b/changelog/_unreleased/2024-01-05-cleanup-product-card-action-html-twig-template.md
@@ -1,0 +1,13 @@
+---
+title: Cleanup product/card/action.html.twig template
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Deprecated unused function `ViewItemListEvent.fetchProductId` in `app/storefront/src/plugin/google-analytics/events/view-item-list.event.js`
+* Changed `ViewItemListEvent` to use the `data-product-information` attribute of the product box for the product infomation for Shopware version 6.7.0.0
+* Deprecated block `component_product_box_action_meta` from `storefront/component/product/card/action.html.twig`
+* Deprecated blocks `page_product_detail_buy_product_buy_info`, `page_product_detail_product_buy_meta` and `page_product_detail_product_buy_button` from `storefront/component/product/card/action.html.twig` and added replacement blocks `component_product_box_action_buy_info`, `component_product_box_action_buy_meta` and `component_product_box_action_buy_button`
+* Added blocks `page_product_detail_product_buy_button_label` and `page_product_detail_product_buy_button_label` to `storefront/component/product/card/action.html.twig` template

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item-list.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/view-item-list.event.js
@@ -27,22 +27,29 @@ export default class ViewItemListEvent extends AnalyticsEvent
         }
 
         productBoxes.forEach(item => {
-            const id = DomAccessHelper.querySelector(item, 'input[name=product-id]').value;
-            const name = DomAccessHelper.querySelector(item, 'input[name=product-name]').value;
+            /** @deprecated tag:v6.7.0 - Data will be retrieved from the data attribute "data-product-information" instead of hidden inputs. */
+            if (window.Feature.isActive('v6.7.0.0')) {
+                if (item.dataset['productInformation']) {
+                    lineItems.push(JSON.parse(item.dataset['productInformation']));
+                }
+            } else {
+                const id = DomAccessHelper.querySelector(item, 'input[name=product-id]').value;
+                const name = DomAccessHelper.querySelector(item, 'input[name=product-name]').value;
 
-            if (!id || !name) {
-                return;
+                if (!id || !name) {
+                    return;
+                }
+
+                lineItems.push({id, name});
             }
-
-            lineItems.push({
-                id,
-                name,
-            });
         });
 
         return lineItems;
     }
 
+    /**
+     * @deprecated tag:v6.7.0 - Unused function will be removed without replacement
+     */
     fetchProductId(inputs) {
         let productId = null;
 

--- a/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
@@ -25,40 +25,51 @@
                                    value="{{ {productId: id}|json_encode }}">
                         {% endblock %}
 
-                        {% block page_product_detail_buy_product_buy_info %}
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][id]"
-                                   value="{{ id }}">
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][referencedId]"
-                                   value="{{ id }}">
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][type]"
-                                   value="product">
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][stackable]"
-                                   value="1">
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][removable]"
-                                   value="1">
-                            <input type="hidden"
-                                   name="lineItems[{{ id }}][quantity]"
-                                   value="{{ product.minPurchase }}">
+                        {% block component_product_box_action_buy_info %}
+                            {# @deprecated tag:v6.7.0 - Block will be removed, use component_product_box_action_buy_info instead #}
+                            {% block page_product_detail_buy_product_buy_info %}
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][id]"
+                                       value="{{ id }}">
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][referencedId]"
+                                       value="{{ id }}">
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][type]"
+                                       value="product">
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][stackable]"
+                                       value="1">
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][removable]"
+                                       value="1">
+                                <input type="hidden"
+                                       name="lineItems[{{ id }}][quantity]"
+                                       value="{{ product.minPurchase }}">
+                            {% endblock %}
                         {% endblock %}
 
-                        {% block page_product_detail_product_buy_meta %}
-                            <input type="hidden"
-                                   name="product-name"
-                                   value="{{ product.translated.name }}">
+                        {% block component_product_box_action_buy_meta %}
+                            {# @deprecated tag:v6.7.0 - Block will be removed, use component_product_box_action_buy_meta instead #}
+                            {% block page_product_detail_product_buy_meta %}
+                                <input type="hidden"
+                                       name="product-name"
+                                       value="{{ product.translated.name }}">
+                            {% endblock %}
                         {% endblock %}
 
-                        {% block page_product_detail_product_buy_button %}
-                            <div class="d-grid">
-                                <button class="btn btn-buy"
-                                        title="{{ 'listing.boxAddProduct'|trans|striptags }}">
-                                    {{ 'listing.boxAddProduct'|trans|sw_sanitize }}
-                                </button>
-                            </div>
+                        {% block component_product_box_action_buy_button %}
+                            {# @deprecated tag:v6.7.0 - Block will be removed, use component_product_box_action_buy_button instead #}
+                            {% block page_product_detail_product_buy_button %}
+                                <div class="d-grid">
+                                    <button class="btn btn-buy"
+                                            title="{{ 'listing.boxAddProduct'|trans|striptags }}">
+                                        {% block page_product_detail_product_buy_button_label %}
+                                            {{ 'listing.boxAddProduct'|trans|sw_sanitize }}
+                                        {% endblock %}
+                                    </button>
+                                </div>
+                            {% endblock %}
                         {% endblock %}
                     {% endblock %}
                 </form>
@@ -69,20 +80,25 @@
                     <a href="{{ seoUrl('frontend.detail.page', {productId: id}) }}"
                        class="btn btn-light"
                        title="{{ 'listing.boxProductDetails'|trans|striptags }}">
-                        {{ 'listing.boxProductDetails'|trans|sw_sanitize }}
+                        {% block component_product_box_action_detail_label %}
+                            {{ 'listing.boxProductDetails'|trans|sw_sanitize }}
+                        {% endblock %}
                     </a>
                 </div>
             {% endblock %}
         {% endif %}
     </div>
 
-    {% block component_product_box_action_meta %}
-        <input type="hidden"
-               name="product-name"
-               value="{{ product.translated.name }}">
+    {# @deprecated tag:v6.7.0 - Block, including the content will be removed. "product-name" and "product-id" will be hold inside "data-product-information" in box-standard.html.twig instead. #}
+    {% if not feature('v6.7.0.0') %}
+        {% block component_product_box_action_meta %}
+            <input type="hidden"
+                   name="product-name"
+                   value="{{ product.translated.name }}">
 
-        <input type="hidden"
-               name="product-id"
-               value="{{ id }}">
-    {% endblock %}
+            <input type="hidden"
+                   name="product-id"
+                   value="{{ id }}">
+        {% endblock %}
+    {% endif %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-standard.html.twig
@@ -6,7 +6,7 @@
         {% set variation = product.variation %}
         {% set displayParent = product.variantListingConfig.displayParent and product.parentId === null %}
 
-        <div class="card product-box box-{{ layout }}">
+        <div class="card product-box box-{{ layout }}" data-product-information="{{ {id, name}|json_encode }}">
             {% block component_product_box_content %}
                 <div class="card-body">
                     {% block component_product_box_badges %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the blocks in the `product/card/action.html.twig` template are not named consistently. Furthermore there exists an block with two inputs, outside of an form, which are used for the google analytics plugin. One is already present in the actual product form. But to be compatible with the detail button, the information is now added as data attribute to the product box itself.

### 2. What does this change do, exactly?
Rename blocks, deprecate some blocks, cleanup the action template and handling of the `ViewItemListEvent`.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
