### PR TITLE
NEXT-00000 - remove duplicated option in ProductConfiguratorLoader

### DIFF
--- a/changelog/_unreleased/2024-01-06-remove-duplicated-option-setting.md
+++ b/changelog/_unreleased/2024-01-06-remove-duplicated-option-setting.md
@@ -1,0 +1,9 @@
+---
+title: remove duplicated option setting
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+# Core
+* Removed duplicated option setting in `ProductConfiguratorLoader`


### PR DESCRIPTION
### 1. Why is this change necessary?
Just a small pick :-) 

- There are options multiple time added, see [here](https://github.com/shopware/shopware/pull/3496/files#diff-85d288d3df2989a297a3b6ed4bbf376c69c6a40fd03ac7f37d29299d402bb8b8L126)
- reduce cognitive complexity
- early return in `buildCurrentOptions`

### 2. What does this change do, exactly?
See 1

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
