### PR TITLE
NEXT-0000 - correct copytoClipboard to copyStringToClipboard in admin

### DIFF
--- a/changelog/_unreleased/2024-01-06-fix-copytoclipboard-in-admin.md
+++ b/changelog/_unreleased/2024-01-06-fix-copytoclipboard-in-admin.md
@@ -1,0 +1,13 @@
+---
+title: Fix copytoClipboard in admin
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Administration
+
+* Changed usage of method `copyToClipboard` from DomUtil to use the new `copyStringToClipboard` in modules `SwMediaMediaItem`, `SwFieldCopyable`, `SwMailTemplateDetail`, `SwMediaQuickinfo`, `SwSalesChannelDetailBase`, 
+* Removed unused attribute `copy-able` in components `SwVeryfyUserModal`, `SwUserPermissionsUserListing`, `SwUsersPermissionsUserCreate` and `SwUserPermissionsUserDetail` and module `SwFirstRunWizardWelcome`
+* Changed attribute `copy-able` to `copyable` in components `SwUserPermissionsUserDetail` to make field copyable

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-media-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-media-item/index.js
@@ -149,10 +149,12 @@ export default {
         },
 
         copyItemLink(item) {
-            dom.copyToClipboard(item.url);
-            this.createNotificationSuccess({
-                message: this.$tc('sw-media.general.notification.urlCopied.message'),
-            });
+            dom.copyStringToClipboard(item.url)
+                .then(() => {
+                    this.createNotificationSuccess({
+                        message: this.$tc('sw-media.general.notification.urlCopied.message'),
+                    });
+                });
         },
 
         openModalDelete() {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-field-copyable/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-field-copyable/index.js
@@ -52,19 +52,20 @@ Component.register('sw-field-copyable', {
                 return;
             }
 
-            try {
-                domUtils.copyToClipboard(this.copyableText);
-                if (this.tooltip) {
-                    this.tooltipSuccess();
-                } else {
-                    this.notificationSuccess();
-                }
-            } catch (err) {
-                this.createNotificationError({
-                    title: this.$tc('global.default.error'),
-                    message: this.$tc('global.sw-field.notification.notificationCopyFailureMessage'),
+            domUtils.copyStringToClipboard(this.copyableText)
+                .then(() => {
+                    if (this.tooltip) {
+                        this.tooltipSuccess();
+                    } else {
+                        this.notificationSuccess();
+                    }
+                })
+                .catch(() => {
+                    this.createNotificationError({
+                        title: this.$tc('global.default.error'),
+                        message: this.$tc('global.sw-field.notification.notificationCopyFailureMessage'),
+                    });
                 });
-            }
         },
 
         tooltipSuccess() {

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-verify-user-modal/sw-verify-user-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-verify-user-modal/sw-verify-user-modal.html.twig
@@ -13,7 +13,6 @@
         class="sw-settings-user-detail__confirm-password"
         name="sw-field--confirm-password"
         :password-toggle-able="true"
-        :copy-able="false"
         autocomplete="new-password"
         :label="$tc('sw-users-permissions.users.user-detail.passwordConfirmation.labelConfirmPassword')"
         :placeholder="$tc('sw-users-permissions.users.user-detail.passwordConfirmation.placeholderConfirmPassword')"

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-welcome/sw-first-run-wizard-welcome.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-welcome/sw-first-run-wizard-welcome.html.twig
@@ -68,7 +68,6 @@
             v-model:value="user.pw"
             type="password"
             :label="$tc('sw-first-run-wizard.shopwareAccount.passwordPlaceholder')"
-            :copy-able="false"
             @keypress.enter="onConfirmLanguageSwitch"
         />
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -431,7 +431,7 @@ export default {
             }
 
             // non-https polyfill
-            dom.copyToClipboard(variable);
+            dom.copyStringToClipboard(variable);
         },
 
         async onChangeType(id) {

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/index.js
@@ -132,10 +132,12 @@ export default {
 
         copyLinkToClipboard() {
             if (this.item) {
-                dom.copyToClipboard(this.item.url);
-                this.createNotificationSuccess({
-                    message: this.$tc('sw-media.general.notification.urlCopied.message'),
-                });
+                dom.copyStringToClipboard(this.item.url)
+                    .then(() => {
+                        this.createNotificationSuccess({
+                            message: this.$tc('sw-media.general.notification.urlCopied.message'),
+                        });
+                    });
             }
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -555,7 +555,7 @@ export default {
         },
 
         copyToClipboard() {
-            domUtils.copyToClipboard(this.salesChannel.accessKey);
+            domUtils.copyStringToClipboard(this.salesChannel.accessKey);
         },
 
         onStorefrontSelectionChange(storefrontSalesChannelId) {

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
@@ -164,7 +164,6 @@
                     required
                     name="sw-field--confirm-password"
                     :password-toggle-able="true"
-                    :copy-able="false"
                     autocomplete="new-password"
                     :label="$tc('sw-users-permissions.users.user-detail.passwordConfirmation.labelConfirmPassword')"
                     :placeholder="$tc('sw-users-permissions.users.user-detail.passwordConfirmation.placeholderConfirmPassword')"

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-create/sw-users-permissions-user-create.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-create/sw-users-permissions-user-create.html.twig
@@ -8,7 +8,6 @@
     :error="userPasswordError"
     required
     :password-toggle-able="true"
-    :copy-able="false"
 />
 {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig
@@ -151,7 +151,6 @@
                             name="sw-field--user-password"
                             :disabled="!acl.can('users_and_permissions.editor')"
                             :label="$tc('sw-users-permissions.users.user-detail.labelPassword')"
-                            :copy-able="false"
                             :error="userPasswordError"
                             @update:value="setPassword"
                         />
@@ -381,8 +380,8 @@
                 v-model:value="currentIntegration.accessKey"
                 :label="$tc('sw-users-permissions.users.user-detail.modal.idFieldLabel')"
                 :disabled="true"
-                :copy-able="true"
-                :copy-able-tooltip="true"
+                :copyable="true"
+                :copyable-tooltip="true"
             />
             {% endblock %}
 
@@ -396,8 +395,8 @@
                 :label="$tc('sw-users-permissions.users.user-detail.modal.secretFieldLabel')"
                 :disabled="true"
                 :password-toggle-able="false"
-                :copy-able="showSecretAccessKey"
-                :copy-able-tooltip="true"
+                :copyable="showSecretAccessKey"
+                :copyable-tooltip="true"
             />
 
             <sw-password-field
@@ -406,8 +405,8 @@
                 :label="$tc('sw-users-permissions.users.user-detail.modal.secretFieldLabel')"
                 :disabled="true"
                 :password-toggle-able="false"
-                :copy-able="showSecretAccessKey"
-                :copy-able-tooltip="true"
+                :copyable="showSecretAccessKey"
+                :copyable-tooltip="true"
             />
             {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
- Using the copy methods don't work
- `copy-able` is not valid, it is `copyable`
- default of `copyable` is false, so we can remove them

### 2. What does this change do, exactly?
fix the usage of copy method

### 3. Describe each step to reproduce the issue or behaviour.
Go to media, try to copy link e.g.
![image](https://github.com/shopware/shopware/assets/135993/8dd7fd65-44df-4232-ac09-8b7192ec7461)


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
