### PR TITLE
NEXT-0000 - add intra community label for invoice renderer

### DIFF
--- a/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
@@ -8,6 +8,9 @@ use Shopware\Core\Checkout\Document\Event\InvoiceOrdersEvent;
 use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Checkout\Document\Twig\DocumentTemplateRenderer;
+use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressEntity;
+use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity;
 use Shopware\Core\Checkout\Order\OrderCollection;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Defaults;
@@ -93,6 +96,10 @@ final class InvoiceRenderer extends AbstractDocumentRenderer
                     $config->merge([
                         'documentDate' => $operation->getConfig()['documentDate'] ?? $now,
                         'documentNumber' => $number,
+                        'intraCommunityDelivery' => $this->isAllowIntraCommunityDelivery(
+                            $operation->getConfig(),
+                            $order->getDeliveries()->first()
+                        ),
                         'custom' => [
                             'invoiceNumber' => $number,
                         ],
@@ -162,5 +169,29 @@ final class InvoiceRenderer extends AbstractDocumentRenderer
             $order->getSalesChannelId(),
             $operation->isPreview()
         );
+    }
+
+    private function isAllowIntraCommunityDelivery(array $config, OrderDeliveryEntity|null $orderDelivery = null): bool
+    {
+        if (empty($config['displayAdditionalNoteDelivery']) || empty($config['deliveryCountries'])) {
+            return false;
+        }
+
+        if (!$orderDelivery) {
+            return false;
+        }
+
+        /** @var OrderAddressEntity $shippingAddress */
+        $shippingAddress = $orderDelivery->getShippingOrderAddress();
+
+        $country = $shippingAddress->getCountry();
+
+        if (!$country) {
+            return false;
+        }
+
+        $isCompanyTaxFree = $country->getCompanyTax()->getEnabled();
+
+        return $isCompanyTaxFree && \in_array($country->getId(), $config['deliveryCountries'], true);
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
It is possible to enable the "intra-community delivery" label in the configuration via the admin, but is not used in the renderer. Therefore, the label is never displayed on the document.

### 2. What does this change do, exactly?
Adding a new method, much like the function used in the old file generator before version 6.5.*. This method checks, if the config is enabled and that all the necessary information is provided to show the label.

### 3. Describe each step to reproduce the issue or behaviour.
Go to settings -> documents -> invoice and enable the "intra-community delivery" label checkbox.
After that render an invoice. Even if the config should enable the label, it is not displayed

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-31015

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
