### PR TITLE
NEXT-0000 - Feat: Make RuleConfig field names unique

### DIFF
--- a/changelog/_unreleased/2024-01-08-make-rule-config-field-names-unique.md
+++ b/changelog/_unreleased/2024-01-08-make-rule-config-field-names-unique.md
@@ -1,0 +1,10 @@
+---
+title: Make `RuleConfig` field names unique
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed behaviour of `Shopware\Core\Framework\Rule\RuleConfig` to make sure that field names are unique
+* Added method `Shopware\Core\Framework\Rule\RuleConfig::getField` to fetch a field by its name

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8241,11 +8241,6 @@ parameters:
 
 		-
 			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Rule/OrderCreatedByAdminRuleTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
 			count: 2
 			path: tests/unit/Core/Content/Flow/Rule/OrderDeliveryStatusRuleTest.php
 
@@ -8253,16 +8248,6 @@ parameters:
 			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
 			count: 1
 			path: tests/unit/Core/Content/Flow/Rule/OrderStatusRuleTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Rule/OrderTagRuleTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
-			count: 2
-			path: tests/unit/Core/Content/Flow/Rule/OrderTrackingCodeRuleTest.php
 
 		-
 			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"

--- a/src/Core/Framework/Rule/RuleConfig.php
+++ b/src/Core/Framework/Rule/RuleConfig.php
@@ -41,7 +41,7 @@ final class RuleConfig extends Struct
     protected bool $isMatchAny = false;
 
     /**
-     * @var array<array<array<string>|string>|string>
+     * @var array<string, array{name: string, type: string, config: array<string, mixed>}>
      */
     protected array $fields = [];
 
@@ -138,9 +138,17 @@ final class RuleConfig extends Struct
      */
     public function field(string $name, string $type, array $config = []): self
     {
-        $this->fields[] = $this->getFieldTemplate($name, $type, $config);
+        $this->fields[$name] = $this->getFieldTemplate($name, $type, $config);
 
         return $this;
+    }
+
+    /**
+     * @return ?array{name: string, type: string, config: array<string, mixed>}
+     */
+    public function getField(string $name): ?array
+    {
+        return $this->fields[$name] ?? null;
     }
 
     /**
@@ -160,7 +168,7 @@ final class RuleConfig extends Struct
     /**
      * @param array<string, mixed> $config
      *
-     * @return array<string, mixed>
+     * @return array{name: string, type: string, config: array<string, mixed>}
      */
     private function getFieldTemplate(string $name, string $type, array $config): array
     {

--- a/src/Core/Framework/Test/Rule/Api/RuleConfigControllerTest.php
+++ b/src/Core/Framework/Test/Rule/Api/RuleConfigControllerTest.php
@@ -40,8 +40,8 @@ class RuleConfigControllerTest extends TestCase
 
         static::assertCount(1, $customerGroupRouleConfig['fields']);
 
-        static::assertEquals('customerGroupIds', $customerGroupRouleConfig['fields'][0]['name']);
-        static::assertEquals('multi-entity-id-select', $customerGroupRouleConfig['fields'][0]['type']);
-        static::assertEquals(CustomerGroupDefinition::ENTITY_NAME, $customerGroupRouleConfig['fields'][0]['config']['entity']);
+        static::assertEquals('customerGroupIds', $customerGroupRouleConfig['fields']['customerGroupIds']['name']);
+        static::assertEquals('multi-entity-id-select', $customerGroupRouleConfig['fields']['customerGroupIds']['type']);
+        static::assertEquals(CustomerGroupDefinition::ENTITY_NAME, $customerGroupRouleConfig['fields']['customerGroupIds']['config']['entity']);
     }
 }

--- a/tests/unit/Core/Checkout/Cart/Rule/CartShippingCostRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/CartShippingCostRuleTest.php
@@ -198,7 +198,7 @@ class CartShippingCostRuleTest extends TestCase
         $config = (new CartShippingCostRule())->getConfig();
         static::assertEquals([
             'fields' => [
-                [
+                'cartShippingCost' => [
                     'name' => 'cartShippingCost',
                     'type' => 'float',
                     'config' => [],

--- a/tests/unit/Core/Checkout/Cart/Rule/CartTotalPurchasePriceRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/CartTotalPurchasePriceRuleTest.php
@@ -129,7 +129,7 @@ class CartTotalPurchasePriceRuleTest extends TestCase
         static::assertArrayHasKey('fields', $configData);
         static::assertCount(2, $configData['fields']);
         static::assertEquals([
-            [
+            'type' => [
                 'name' => 'type',
                 'type' => 'single-select',
                 'config' => [
@@ -137,7 +137,7 @@ class CartTotalPurchasePriceRuleTest extends TestCase
                     'class' => 'is--max-content',
                 ],
             ],
-            [
+            'amount' => [
                 'name' => 'amount',
                 'type' => 'float',
                 'config' => [],

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemActualStockRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemActualStockRuleTest.php
@@ -221,7 +221,7 @@ class LineItemActualStockRuleTest extends TestCase
         $result = $cartVolumeRule->getConfig()->getData();
 
         static::assertIsArray($result['operatorSet']['operators']);
-        static::assertSame('stock', $result['fields'][0]['name']);
+        static::assertSame('stock', $result['fields']['stock']['name']);
     }
 
     private function createLineItemWithStock(int $stock): LineItem

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemClearanceSaleRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemClearanceSaleRuleTest.php
@@ -139,7 +139,7 @@ class LineItemClearanceSaleRuleTest extends TestCase
 
         $result = $cartVolumeRule->getConfig()->getData();
 
-        static::assertSame('clearanceSale', $result['fields'][0]['name']);
+        static::assertSame('clearanceSale', $result['fields']['clearanceSale']['name']);
     }
 
     private function createLineItemWithClearance(bool $clearanceSaleEnabled): LineItem

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionHeightRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionHeightRuleTest.php
@@ -261,6 +261,6 @@ class LineItemDimensionHeightRuleTest extends TestCase
         $result = $lineItemDimensionHeightRule->getConfig()->getData();
 
         static::assertIsArray($result['operatorSet']['operators']);
-        static::assertSame('dimension', $result['fields'][0]['config']['unit']);
+        static::assertSame('dimension', $result['fields']['amount']['config']['unit']);
     }
 }

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionLengthRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionLengthRuleTest.php
@@ -272,7 +272,7 @@ class LineItemDimensionLengthRuleTest extends TestCase
         $expectedOperatorSet = array_merge(RuleConfig::OPERATOR_SET_NUMBER, [Rule::OPERATOR_EMPTY]);
 
         static::assertSame($expectedOperatorSet, $result->getData()['operatorSet']['operators']);
-        static::assertSame(RuleConfig::UNIT_DIMENSION, $result->getData()['fields'][0]['config']['unit']);
+        static::assertSame(RuleConfig::UNIT_DIMENSION, $result->getData()['fields']['amount']['config']['unit']);
     }
 
     private function createLineItemWithLength(?float $length): LineItem

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionVolumeRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionVolumeRuleTest.php
@@ -248,7 +248,7 @@ class LineItemDimensionVolumeRuleTest extends TestCase
         $result = $lineItemDimensionVolumeRule->getConfig();
 
         static::assertSame(RuleConfig::OPERATOR_SET_NUMBER, $result->getData()['operatorSet']['operators']);
-        static::assertSame(RuleConfig::UNIT_VOLUME, $result->getData()['fields'][0]['config']['unit']);
+        static::assertSame(RuleConfig::UNIT_VOLUME, $result->getData()['fields']['amount']['config']['unit']);
     }
 
     private function createLineItemWithVolume(float $volume): LineItem

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionWeightRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionWeightRuleTest.php
@@ -267,7 +267,7 @@ class LineItemDimensionWeightRuleTest extends TestCase
         $expectedOperatorSet = array_merge(RuleConfig::OPERATOR_SET_NUMBER, [Rule::OPERATOR_EMPTY]);
 
         static::assertSame($expectedOperatorSet, $result->getData()['operatorSet']['operators']);
-        static::assertSame(RuleConfig::UNIT_WEIGHT, $result->getData()['fields'][0]['config']['unit']);
+        static::assertSame(RuleConfig::UNIT_WEIGHT, $result->getData()['fields']['amount']['config']['unit']);
     }
 
     private function createLineItemWithWeight(?float $weight): LineItem

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionWidthRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemDimensionWidthRuleTest.php
@@ -393,8 +393,8 @@ class LineItemDimensionWidthRuleTest extends TestCase
         $expectedOperators[] = Rule::OPERATOR_EMPTY;
 
         static::assertSame($expectedOperators, $result->getData()['operatorSet']['operators']);
-        static::assertSame(RuleConfig::UNIT_DIMENSION, $result->getData()['fields'][0]['config']['unit']);
-        static::assertSame('amount', $result->getData()['fields'][0]['name']);
+        static::assertSame(RuleConfig::UNIT_DIMENSION, $result->getData()['fields']['amount']['config']['unit']);
+        static::assertSame('amount', $result->getData()['fields']['amount']['name']);
     }
 
     private static function createLineItemWithWidth(?float $width): LineItem

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemStockRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemStockRuleTest.php
@@ -226,11 +226,11 @@ class LineItemStockRuleTest extends TestCase
 
         static::assertArrayHasKey('fields', $configData);
         static::assertCount(1, $configData['fields']);
-        static::assertEquals([[
+        static::assertEquals([
             'name' => 'stock',
             'type' => 'int',
             'config' => [],
-        ]], $configData['fields']);
+        ], $configData['fields']['stock']);
     }
 
     private function createLineItem(int $stock, string $id = 'line-item-id'): LineItem

--- a/tests/unit/Core/Checkout/Cart/Rule/PaymentMethodRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/PaymentMethodRuleTest.php
@@ -104,7 +104,7 @@ class PaymentMethodRuleTest extends TestCase
                 'isMatchAny' => true,
             ],
             'fields' => [
-                [
+                'paymentMethodIds' => [
                     'name' => 'paymentMethodIds',
                     'type' => 'multi-entity-id-select',
                     'config' => [

--- a/tests/unit/Core/Checkout/Customer/Rule/AffiliateCodeRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/AffiliateCodeRuleTest.php
@@ -46,7 +46,7 @@ class AffiliateCodeRuleTest extends TestCase
         $config = (new AffiliateCodeRule())->getConfig();
         static::assertEquals([
             'fields' => [
-                [
+                'affiliateCode' => [
                     'name' => 'affiliateCode',
                     'type' => 'string',
                     'config' => [],

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerCreatedByAdminRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerCreatedByAdminRuleTest.php
@@ -47,7 +47,7 @@ class CustomerCreatedByAdminRuleTest extends TestCase
         $config = $rule->getConfig();
         static::assertEquals([
             'fields' => [
-                [
+                'shouldCustomerBeCreatedByAdmin' => [
                     'name' => 'shouldCustomerBeCreatedByAdmin',
                     'type' => 'bool',
                     'config' => [],

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerLoggedInRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerLoggedInRuleTest.php
@@ -46,7 +46,7 @@ class CustomerLoggedInRuleTest extends TestCase
         $config = $rule->getConfig();
         static::assertEquals([
             'fields' => [
-                [
+                'isLoggedIn' => [
                     'name' => 'isLoggedIn',
                     'type' => 'bool',
                     'config' => [],

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerTagRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerTagRuleTest.php
@@ -42,7 +42,7 @@ class CustomerTagRuleTest extends TestCase
                 'isMatchAny' => 1,
             ],
             'fields' => [
-                [
+                'identifiers' => [
                     'name' => 'identifiers',
                     'type' => 'multi-entity-id-select',
                     'config' => [

--- a/tests/unit/Core/Checkout/Customer/Rule/NumberOfReviewsRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/NumberOfReviewsRuleTest.php
@@ -37,7 +37,7 @@ class NumberOfReviewsRuleTest extends TestCase
         $config = (new NumberOfReviewsRule())->getConfig();
         static::assertEquals([
             'fields' => [
-                [
+                'count' => [
                     'name' => 'count',
                     'type' => 'int',
                     'config' => [],

--- a/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Rule/PromotionLineItemRuleTest.php
@@ -62,7 +62,7 @@ class PromotionLineItemRuleTest extends TestCase
                 'isMatchAny' => true,
             ],
             'fields' => [
-                [
+                'identifiers' => [
                     'name' => 'identifiers',
                     'type' => 'multi-entity-id-select',
                     'config' => [

--- a/tests/unit/Core/Checkout/Rule/Rule/Cart/CartAmountRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Cart/CartAmountRuleTest.php
@@ -191,6 +191,6 @@ class CartAmountRuleTest extends TestCase
         $data = (new CartAmountRule())->getConfig()->getData();
 
         static::assertSame(RuleConfig::OPERATOR_SET_NUMBER, $data['operatorSet']['operators']);
-        static::assertSame('amount', $data['fields'][0]['name']);
+        static::assertSame('amount', $data['fields']['amount']['name']);
     }
 }

--- a/tests/unit/Core/Checkout/Rule/Rule/Cart/CartPositionPriceRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Cart/CartPositionPriceRuleTest.php
@@ -201,6 +201,6 @@ class CartPositionPriceRuleTest extends TestCase
         $data = (new CartPositionPriceRule())->getConfig()->getData();
 
         static::assertSame(RuleConfig::OPERATOR_SET_NUMBER, $data['operatorSet']['operators']);
-        static::assertSame('amount', $data['fields'][0]['name']);
+        static::assertSame('amount', $data['fields']['amount']['name']);
     }
 }

--- a/tests/unit/Core/Checkout/Rule/Rule/Cart/CartVolumeRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Cart/CartVolumeRuleTest.php
@@ -195,6 +195,6 @@ class CartVolumeRuleTest extends TestCase
         $result = $cartVolumeRule->getConfig()->getData();
 
         static::assertIsArray($result['operatorSet']['operators']);
-        static::assertSame('volume', $result['fields'][0]['config']['unit']);
+        static::assertSame('volume', $result['fields']['volume']['config']['unit']);
     }
 }

--- a/tests/unit/Core/Checkout/Rule/Rule/Cart/CartWeightRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Cart/CartWeightRuleTest.php
@@ -182,6 +182,6 @@ class CartWeightRuleTest extends TestCase
         $result = $cartVolumeRule->getConfig()->getData();
 
         static::assertIsArray($result['operatorSet']['operators']);
-        static::assertSame('weight', $result['fields'][0]['config']['unit']);
+        static::assertSame('weight', $result['fields']['weight']['config']['unit']);
     }
 }

--- a/tests/unit/Core/Content/Flow/Rule/OrderCreatedByAdminRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderCreatedByAdminRuleTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
-use Shopware\Core\Checkout\CheckoutRuleScope;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Rule\FlowRuleScope;
 use Shopware\Core\Content\Flow\Rule\OrderCreatedByAdminRule;
@@ -43,7 +42,7 @@ class OrderCreatedByAdminRuleTest extends TestCase
         $config = $this->rule->getConfig();
         static::assertEquals([
             'fields' => [
-                [
+                'shouldOrderBeCreatedByAdmin' => [
                     'name' => 'shouldOrderBeCreatedByAdmin',
                     'type' => 'bool',
                     'config' => [],
@@ -77,7 +76,12 @@ class OrderCreatedByAdminRuleTest extends TestCase
     #[DataProvider('getCaseTestMatchValues')]
     public function testMatch(OrderCreatedByAdminRule $rule, OrderEntity $order, bool $isMatching): void
     {
-        $scope = $this->createScope($order);
+        $scope = new FlowRuleScope(
+            $order,
+            new Cart('test'),
+            $this->createMock(SalesChannelContext::class)
+        );
+
         $match = $rule->match($scope);
         static::assertEquals($match, $isMatching);
     }
@@ -107,13 +111,5 @@ class OrderCreatedByAdminRuleTest extends TestCase
             (new OrderEntity())->assign(['createdById' => Uuid::randomHex()]),
             true,
         ];
-    }
-
-    private function createScope(OrderEntity $order): CheckoutRuleScope
-    {
-        $context = $this->createMock(SalesChannelContext::class);
-        $cart = $this->createMock(Cart::class);
-
-        return new FlowRuleScope($order, $cart, $context);
     }
 }

--- a/tests/unit/Core/Content/Flow/Rule/OrderTagRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderTagRuleTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\Cart;
 use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
-use Shopware\Core\Checkout\CheckoutRuleScope;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Content\Flow\Rule\FlowRuleScope;
 use Shopware\Core\Content\Flow\Rule\OrderTagRule;
@@ -53,7 +52,7 @@ class OrderTagRuleTest extends TestCase
                 'isMatchAny' => 1,
             ],
             'fields' => [
-                [
+                'identifiers' => [
                     'name' => 'identifiers',
                     'type' => 'multi-entity-id-select',
                     'config' => [
@@ -101,7 +100,12 @@ class OrderTagRuleTest extends TestCase
         }
         $order->setTags($tagCollection);
 
-        $scope = $this->createScope($order);
+        $scope = new FlowRuleScope(
+            $order,
+            new Cart('test'),
+            $this->createMock(SalesChannelContext::class)
+        );
+
         $this->rule->assign(['identifiers' => $ruleIdentifiers, 'operator' => $operator]);
 
         $match = $this->rule->match($scope);
@@ -128,13 +132,5 @@ class OrderTagRuleTest extends TestCase
         $scope = $this->createMock(CartRuleScope::class);
 
         static::assertFalse($this->rule->match($scope));
-    }
-
-    private function createScope(OrderEntity $order): CheckoutRuleScope
-    {
-        $context = $this->createMock(SalesChannelContext::class);
-        $cart = $this->createMock(Cart::class);
-
-        return new FlowRuleScope($order, $cart, $context);
     }
 }

--- a/tests/unit/Core/Content/Flow/Rule/OrderTrackingCodeRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderTrackingCodeRuleTest.php
@@ -52,13 +52,10 @@ class OrderTrackingCodeRuleTest extends TestCase
         $order = new OrderEntity();
         $order->setDeliveries($orderDeliveryCollection);
 
-        $cart = $this->createMock(Cart::class);
-        $context = $this->createMock(SalesChannelContext::class);
-
         $match = $rule->match(new FlowRuleScope(
             $order,
-            $cart,
-            $context
+            new Cart('test'),
+            $this->createMock(SalesChannelContext::class)
         ));
         static::assertSame($expected, $match);
     }
@@ -107,11 +104,11 @@ class OrderTrackingCodeRuleTest extends TestCase
 
     public function testNoOrderDeliveries(): void
     {
-        $order = new OrderEntity();
-
-        $cart = $this->createMock(Cart::class);
-        $context = $this->createMock(SalesChannelContext::class);
-        $scope = new FlowRuleScope($order, $cart, $context);
+        $scope = new FlowRuleScope(
+            new OrderEntity(),
+            new Cart('test'),
+            $this->createMock(SalesChannelContext::class)
+        );
 
         $this->rule->assign(['isSet' => true]);
         static::assertFalse($this->rule->match($scope));
@@ -143,7 +140,7 @@ class OrderTrackingCodeRuleTest extends TestCase
         static::assertEquals([
             'operatorSet' => null,
             'fields' => [
-                [
+                'isSet' => [
                     'name' => 'isSet',
                     'type' => 'bool',
                     'config' => [],

--- a/tests/unit/Core/Framework/Rule/Container/DaysSinceRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/Container/DaysSinceRuleTest.php
@@ -57,6 +57,6 @@ class DaysSinceRuleTest extends TestCase
             'config' => [
                 'unit' => 'time',
             ],
-        ], $config['fields'][0]);
+        ], $config['fields']['daysPassed']);
     }
 }

--- a/tests/unit/Core/Framework/Rule/RuleConfigTest.php
+++ b/tests/unit/Core/Framework/Rule/RuleConfigTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Rule;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\RuleConfig;
+
+/**
+ * @internal
+ */
+#[Package('business-ops')]
+#[CoversClass(RuleConfig::class)]
+#[Group('rules')]
+class RuleConfigTest extends TestCase
+{
+    public function testNonExistentFieldReturnsNull(): void
+    {
+        $ruleConfig = new RuleConfig();
+
+        static::assertNull($ruleConfig->getField('nonExistent'));
+    }
+
+    public function testFieldIsReturned(): void
+    {
+        $ruleConfig = new RuleConfig();
+
+        $ruleConfig->field('foo', 'int', []);
+
+        $field = $ruleConfig->getField('foo');
+
+        static::assertNotNull($field);
+        static::assertEquals('foo', $field['name']);
+        static::assertEquals('int', $field['type']);
+    }
+
+    public function testFieldIsOverwritten(): void
+    {
+        $ruleConfig = new RuleConfig();
+
+        $ruleConfig->field('foo', 'int', []);
+        $ruleConfig->field('foo', 'string', []);
+
+        $field = $ruleConfig->getField('foo');
+
+        static::assertNotNull($field);
+        static::assertEquals('foo', $field['name']);
+        static::assertEquals('string', $field['type']);
+    }
+}

--- a/tests/unit/Core/System/Currency/Rule/CurrencyRuleTest.php
+++ b/tests/unit/Core/System/Currency/Rule/CurrencyRuleTest.php
@@ -53,7 +53,7 @@ class CurrencyRuleTest extends TestCase
                 'isMatchAny' => true,
             ],
             'fields' => [
-                [
+                'currencyIds' => [
                     'name' => 'currencyIds',
                     'type' => 'multi-entity-id-select',
                     'config' => [


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when changing the `RuleConfig` of a rule using a decoration (in my case I wanted to add a new line item type to the `LineItemOfTypeRule`), it is quite annoying cumbersome to implement this, i.e.
```php
    public function getConfig(): RuleConfig
    {
        $config = parent::getConfig();

        $fields = $config->getData()['fields'] ?? [];
        foreach ($fields as &$field) {
            if ($field['name'] === 'lineItemType') {
                $field['config']['options'][] = 'my_type';
                $config->assign(['fields' => $fields]);

                break;
            }
        }

        return $config;
    }
```

Furthermore if one adds a field with the same name, it is added twice, which leads to an error in the VueJS UI:
![image](https://github.com/shopware/shopware/assets/6317761/393fad6d-33d4-464b-ba3d-890eb2d9fe03)

### 2. What does this change do, exactly?
Make sure that the field is only added once, and add a method to retrieve already added fields.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
