### PR TITLE
NEXT-0000  - add intra community delivery label check to InvoiceRenderer

### DIFF
--- a/changelog/_unreleased/2024-01-08-add-intra-community-delivery-label-to-invoice-renderer.md
+++ b/changelog/_unreleased/2024-01-08-add-intra-community-delivery-label-to-invoice-renderer.md
@@ -1,0 +1,9 @@
+---
+title: Add intra-community delivery label to invoice renderer
+issue: NEXT-0000
+author: Cedric Engler
+author_email: cedric.engler@pickware.de
+author_github: @ceddy610
+---
+# Core
+* Added new function `isAllowIntraCommunityDelivery` to `InvoiceRenderer` to check if the intra-community delivery label should be displayed on the invoice


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
It is possible to enable the "intra-community delivery" label in the configuration via the admin, but is not used in the renderer. Therefore, the label is never displayed on the document.

### 2. What does this change do, exactly?
Adding a new method, much like the function used in the old file generator before version `6.5.*`. This method checks, if the config is enabled and that all the necessary information is provided to show the label.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set under Settings > Countries > f.e. Germany > Tax-free (B2B)
2. Go to settings -> documents -> invoice and enable the "intra-community delivery" label checkbox.
3. Create an order with an B2B (net customer) account
4. After that render an invoice of the created order. Even if the config should enable the label, it is not displayed

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-31015

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
