### PR TITLE
NEXT-0000 - Refactor: Use double quotes around json encoded objects

### DIFF
--- a/changelog/_unreleased/2024-01-08-replace-single-quotes-around-json-object-attributes-by-double-quotes.md
+++ b/changelog/_unreleased/2024-01-08-replace-single-quotes-around-json-object-attributes-by-double-quotes.md
@@ -1,0 +1,9 @@
+---
+title: Replace single quotes around json object attributes by double quotes
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed templates which contain attributes that contain json encoded objects to use double quotes and use proper escaping everywhere

--- a/src/Storefront/Resources/views/storefront/component/address/address-editor-modal-create-address.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-editor-modal-create-address.html.twig
@@ -33,8 +33,7 @@
                               class="js-close-address-editor"
                               data-form-ajax-submit="true"
                               data-form-validation="true"
-                              {# ludtwig-ignore html-string-quotation #}
-                              data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                              data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
                             {% block component_address_address_editor_modal_create_address_form_hidden_inputs %}
                                 <input type="hidden"

--- a/src/Storefront/Resources/views/storefront/component/address/address-editor-modal-list.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-editor-modal-list.html.twig
@@ -61,8 +61,7 @@
                                                                                                   class="js-close-address-editor"
                                                                                                   method="post"
                                                                                                   data-form-ajax-submit="true"
-                                                                                                {# ludtwig-ignore html-string-quotation #}
-                                                                                                  data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                                                                                                  data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
                                                                                                 {% block component_address_address_editor_modal_list_address_body_action_billing_form_hidden_inputs %}
                                                                                                     <input type="hidden"
@@ -104,8 +103,7 @@
                                                                                                   class="js-close-address-editor"
                                                                                                   method="post"
                                                                                                   data-form-ajax-submit="true"
-                                                                                                {# ludtwig-ignore html-string-quotation #}
-                                                                                                  data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                                                                                                  data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
                                                                                                 {% block component_address_address_editor_modal_list_address_body_action_shipping_form_hidden_inputs %}
                                                                                                     <input type="hidden"

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-form.html.twig
@@ -61,8 +61,7 @@
                         <input type="hidden"
                                name="redirectParameters"
                                data-redirect-parameters="true"
-                               {# ludtwig-ignore html-string-quotation #}
-                               value='{"productId": "{{ product.id }}"}'>
+                               value="{{ {productId: product.id}|json_encode }}">
                     {% endblock %}
 
                     {% block buy_widget_buy_product_buy_info %}

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
@@ -145,8 +145,7 @@
                                     class="product-detail-reviews-link"
                                     data-off-canvas-tabs="true"
                                     data-remote-click="true"
-                                    {# ludtwig-ignore html-string-quotation #}
-                                    data-remote-click-options='{{ remoteClickOptions|json_encode }}'
+                                    data-remote-click-options="{{ remoteClickOptions|json_encode }}"
                                     href="{{ reviewTabHref }}"
                                     aria-controls="review-tab-pane"
                                 >

--- a/src/Storefront/Resources/views/storefront/component/captcha/basicCaptcha.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/captcha/basicCaptcha.html.twig
@@ -15,8 +15,7 @@
 
     <div class="row g-2 basic-captcha"
          data-basic-captcha="true"
-         {# ludtwig-ignore html-string-quotation #}
-         data-basic-captcha-options='{{ basicCaptchaOptions|json_encode }}'>
+         data-basic-captcha-options="{{ basicCaptchaOptions|json_encode }}">
         <div class="form-group {% if additionalClass %} {{ additionalClass }}{% else %}col-md-6{% endif %} basic-captcha-content">
             {% block component_basic_captcha_image %}
                 <div class="basic-captcha-content-code">

--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-boolean.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-boolean.html.twig
@@ -10,8 +10,7 @@
     {% block component_filter_boolean_panel_item %}
         <div class="filter-boolean filter-panel-item"
              data-filter-boolean="true"
-             {# ludtwig-ignore html-string-quotation #}
-             data-filter-boolean-options='{{ filterBooleanOptions|json_encode }}'>
+             data-filter-boolean-options="{{ filterBooleanOptions|json_encode }}">
 
             {% block component_filter_boolean_container %}
                 <div class="form-check">

--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-range.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-range.html.twig
@@ -49,8 +49,7 @@
 {% block component_filter_range %}
     <div class="filter-range filter-panel-item{% if sidebar %} d-grid{% else %} dropdown{% endif %}"
          data-filter-range="true"
-         {# ludtwig-ignore html-string-quotation #}
-         data-filter-range-options='{{ filterRangeOptions|json_encode }}'>
+         data-filter-range-options="{{ filterRangeOptions|json_encode }}">
 
         {% block component_filter_range_toggle %}
             <button class="filter-panel-item-toggle btn"

--- a/src/Storefront/Resources/views/storefront/component/payment/payment-fields.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/payment/payment-fields.html.twig
@@ -21,8 +21,7 @@
                     {% block component_payment_method_collapse_trigger %}
                         <div class="btn btn-link confirm-checkout-collapse-trigger"
                              data-collapse-checkout-confirm-methods="true"
-                             {# ludtwig-ignore html-string-quotation #}
-                             data-collapse-checkout-confirm-methods-options='{{ collapseTriggerLabels|json_encode }}'>
+                             data-collapse-checkout-confirm-methods-options="{{ collapseTriggerLabels|json_encode }}">
                             <span class="confirm-checkout-collapse-trigger-label">
                                 {% block component_payment_method_collapse_trigger_label %}
                                     {{ collapseTriggerLabels.collapseTriggerMoreLabel }}

--- a/src/Storefront/Resources/views/storefront/component/payment/payment-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/payment/payment-form.html.twig
@@ -1,5 +1,4 @@
 {% block page_checkout_change_payment_form %}
-
     {% set formAjaxSubmitOptions = {
         changeTriggerSelectors: ['.payment-method-input']
     } %}
@@ -9,8 +8,7 @@
               name="changePaymentForm"
               action="{{ actionPath }}"
               data-form-auto-submit="true"
-              {# ludtwig-ignore html-string-quotation #}
-              data-form-auto-submit-options='{{ formAjaxSubmitOptions|json_encode }}'
+              data-form-auto-submit-options="{{ formAjaxSubmitOptions|json_encode }}"
               method="post">
 
             {% block page_checkout_change_payment_form_redirect %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/action.html.twig
@@ -24,8 +24,7 @@
                             <input type="hidden"
                                    name="redirectParameters"
                                    data-redirect-parameters="true"
-                                   {# ludtwig-ignore html-string-quotation #}
-                                   value='{"productId": "{{ product.id }}"}'>
+                                   value="{{ {productId: id}|json_encode }}">
                         {% endblock %}
 
                         {% block page_product_detail_buy_product_buy_info %}

--- a/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
@@ -2,7 +2,14 @@
 {% if not feature('v6.7.0.0') %}
     {% set currentPage = searchResult.page %}
 {% endif %}
-{% set paginationConfig = { page: searchResult.page }|json_encode %}
+
+{# @deprecated tag:v6.7.0 - variable `paginationConfig` will not be json encoded #}
+{% if feature('v6.7.0.0') %}
+    {% set paginationConfig = { page: searchResult.page } %}
+{% else %}
+    {% set paginationConfig = { page: searchResult.page }|json_encode %}
+{% endif %}
+
 
 {% if disableEmptyFilter is not defined %}
     {% set disableEmptyFilter = config('core.listing.disableEmptyFilterOptions') %}
@@ -22,10 +29,13 @@
 {% block product_listing %}
     <div class="cms-element-product-listing-wrapper"
          data-listing-pagination="true"
+        {% if feature('v6.7.0.0') %}
+         data-listing-pagination-options="{{ paginationConfig|json_encode }}"
+        {% else %}
          {# ludtwig-ignore html-string-quotation #}
          data-listing-pagination-options='{{ paginationConfig }}'
+        {% endif %}
          data-listing="true"
-         {# ludtwig-ignore html-string-quotation #}
          data-listing-options='{{ listingPagination|json_encode }}'>
 
         {% block element_product_listing_wrapper_content %}

--- a/src/Storefront/Resources/views/storefront/component/review/review-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review-form.html.twig
@@ -14,8 +14,7 @@
               method="post"
               data-form-validation="true"
               data-form-ajax-submit="true"
-              {# ludtwig-ignore html-string-quotation #}
-              data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+              data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
             {% block component_review_form_forward %}
                 <input type="hidden"
@@ -28,8 +27,7 @@
 
                 <input type="hidden"
                        name="forwardParameters"
-                       {# ludtwig-ignore html-string-quotation #}
-                       value='{"productId": "{{ reviews.productId }}"}'>
+                       value="{{ {productId: reviews.productId}|json_encode }}">
             {% endblock %}
 
             {% if reviews.customerReview %}

--- a/src/Storefront/Resources/views/storefront/component/review/review-login.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review-login.html.twig
@@ -23,11 +23,7 @@
 
     <input type="hidden"
            name="redirectParameters"
-           {# ludtwig-ignore html-string-quotation #}
-           value='{
-            "productId": "{{ reviews.productId }}",
-            "id": "{{ cmsPage.id }}",
-            "navigationId": "{{ page.header.navigation.active.id }}"}'>
+           value="{{ {productId: reviews.productId, id: cmsPage.id, navigationId: page.header.navigation.active.id}|json_encode }}">
 {% endblock %}
 
 {% block component_account_login_submit %}

--- a/src/Storefront/Resources/views/storefront/component/review/review-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review-widget.html.twig
@@ -54,8 +54,7 @@
                               action="{{ path('frontend.product.reviews', { productId: product.id, parentId: product.parentId }) }}"
                               method="post"
                               data-form-ajax-submit="true"
-                              {# ludtwig-ignore html-string-quotation #}
-                              data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                              data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
                             {% if app.request.get('limit') %}
                                 <input type="hidden" name="limit" value="{{ app.request.get('limit') }}">

--- a/src/Storefront/Resources/views/storefront/component/review/review.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review.html.twig
@@ -86,8 +86,7 @@
                                                                   action="{{ path('frontend.product.reviews', { productId: product.id, parentId: product.parentId }) }}"
                                                                   method="post"
                                                                   data-form-ajax-submit="true"
-                                                                  {# ludtwig-ignore html-string-quotation #}
-                                                                  data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                                                                  data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
                                                                 {% if app.request.get('limit') %}
                                                                     <input type="hidden" name="limit" value="{{ app.request.get('limit') }}">
@@ -132,8 +131,7 @@
                                                                       action="{{ path('frontend.product.reviews', { productId: product.id, parentId: product.id }) }}"
                                                                       method="post"
                                                                       data-form-ajax-submit="true"
-                                                                      {# ludtwig-ignore html-string-quotation #}
-                                                                      data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                                                                      data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
                                                                     {% if app.request.get('limit') %}
                                                                         <input type="hidden" name="limit" value="{{ app.request.get('limit') }}">
@@ -221,8 +219,7 @@
                                                               action="{{ path('frontend.product.reviews', { productId: product.id, parentId: product.parentId }) }}"
                                                               method="post"
                                                               data-form-ajax-submit="true"
-                                                              {# ludtwig-ignore html-string-quotation #}
-                                                              data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                                                              data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
                                                             {% if app.request.get('limit') %}
                                                                 <input type="hidden" name="limit" value="{{ app.request.get('limit') }}">

--- a/src/Storefront/Resources/views/storefront/component/shipping/shipping-fields.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/shipping/shipping-fields.html.twig
@@ -21,8 +21,7 @@
                     {% block component_shipping_method_collapse_trigger %}
                         <div class="btn btn-link confirm-checkout-collapse-trigger"
                              data-collapse-checkout-confirm-methods="true"
-                             {# ludtwig-ignore html-string-quotation #}
-                             data-collapse-checkout-confirm-methods-options='{{ collapseTriggerLabels|json_encode }}'>
+                             data-collapse-checkout-confirm-methods-options="{{ collapseTriggerLabels|json_encode }}">
                             <span class="confirm-checkout-collapse-trigger-label">
                                 {% block component_shipping_method_collapse_trigger_label %}
                                     {{ collapseTriggerLabels.collapseTriggerMoreLabel }}

--- a/src/Storefront/Resources/views/storefront/component/shipping/shipping-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/shipping/shipping-form.html.twig
@@ -1,5 +1,4 @@
 {% block page_checkout_change_shipping_form %}
-
     {% set formAjaxSubmitOptions = {
         changeTriggerSelectors: ['.shipping-method-input']
     } %}
@@ -9,8 +8,7 @@
               name="changeShippingForm"
               action="{{ actionPath }}"
               data-form-auto-submit="true"
-              {# ludtwig-ignore html-string-quotation #}
-              data-form-auto-submit-options='{{ formAjaxSubmitOptions|json_encode }}'
+              data-form-auto-submit-options="{{ formAjaxSubmitOptions|json_encode }}"
               method="post">
 
             {% block page_checkout_change_shipping_form_redirect %}

--- a/src/Storefront/Resources/views/storefront/component/sorting.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/sorting.html.twig
@@ -4,8 +4,7 @@
 {% if showSorting and sortings|length > 0 %}
     <div class="sorting"
          data-listing-sorting="true"
-         {# ludtwig-ignore html-string-quotation #}
-         data-listing-sorting-options='{{ config|json_encode }}'>
+         data-listing-sorting-options="{{ config|json_encode }}">
         <select class="sorting form-select" aria-label="{{ 'general.sortingLabel'|trans|striptags }}">
             {% for sorting in sortings %}
                 {% set key = sorting.key %}

--- a/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
@@ -10,8 +10,7 @@
                 <form action="{{ path('frontend.search.page') }}"
                       method="get"
                       data-search-widget="true"
-                      {# ludtwig-ignore html-string-quotation #}
-                      data-search-widget-options='{{ searchWidgetOptions|json_encode }}'
+                      data-search-widget-options="{{ searchWidgetOptions|json_encode }}"
                       data-url="{{ path('frontend.search.suggest') }}?search="
                       class="header-search-form">
                     {% block layout_header_search_input_group %}

--- a/src/Storefront/Resources/views/storefront/page/account/newsletter.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/newsletter.html.twig
@@ -19,8 +19,7 @@
               method="post"
               action="{{ path("frontend.account.newsletter") }}"
               data-form-auto-submit="true"
-              {# ludtwig-ignore html-string-quotation #}
-              data-form-auto-submit-options='{{ formAutoSubmitOptions|json_encode }}'>
+              data-form-auto-submit-options="{{ formAutoSubmitOptions|json_encode }}">
 
             {% block page_account_overview_newsletter_content_form_check_control %}
                 <div class="form-check">

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/index.html.twig
@@ -57,8 +57,7 @@
                                               action="{{ path('frontend.account.order.page') }}"
                                               method="post"
                                               data-form-ajax-submit="true"
-                                              {# ludtwig-ignore html-string-quotation #}
-                                              data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                                              data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
                                             {# @deprecated tag:v6.7.0 - variable `criteria` will be removed #}
                                             {% if feature('v6.7.0.0') %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-address.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/confirm-address.html.twig
@@ -54,8 +54,7 @@
                                                title="{{ "account.overviewChangeShipping"|trans|striptags }}"
                                                class="btn btn-light"
                                                data-address-editor="true"
-                                               {# ludtwig-ignore html-string-quotation #}
-                                               data-address-editor-options='{{ addressEditorOptions|json_encode }}'>
+                                               data-address-editor-options="{{ addressEditorOptions|json_encode }}">
                                                 {{ "account.overviewChangeShipping"|trans|sw_sanitize }}
                                             </a>
                                         {% endblock %}
@@ -105,8 +104,7 @@
                                            title="{{ "account.overviewChangeBilling"|trans|striptags }}"
                                            class="btn btn-light"
                                            data-address-editor="true"
-                                           {# ludtwig-ignore html-string-quotation #}
-                                           data-address-editor-options='{{ addressEditorOptions|json_encode }}'>
+                                           data-address-editor-options="{{ addressEditorOptions|json_encode }}">
                                             {{ "account.overviewChangeBilling"|trans|sw_sanitize }}
                                         </a>
                                     {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -210,8 +210,7 @@
               data-form-preserver="true"
               data-form-submit-loader="true"
               data-form-add-history="true"
-              {# ludtwig-ignore html-string-quotation #}
-              data-form-add-history-options='{{ formAddHistoryOptions|json_encode }}'
+              data-form-add-history-options="{{ formAddHistoryOptions|json_encode }}"
               method="post">
             {% block page_checkout_confirm_form_submit %}
                 <div class="d-grid">

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-form.html.twig
@@ -71,8 +71,7 @@
                         <input type="hidden"
                                name="redirectParameters"
                                data-redirect-parameters="true"
-                               {# ludtwig-ignore html-string-quotation #}
-                               value='{"productId": "{{ product.id }}"}'>
+                               value="{{ {productId: product.id}|json_encode }}">
                     {% endblock %}
 
                     {% block page_product_detail_buy_product_buy_info %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget.html.twig
@@ -138,8 +138,7 @@
                                     class="product-detail-reviews-link"
                                     data-off-canvas-tabs="true"
                                     data-remote-click="true"
-                                    {# ludtwig-ignore html-string-quotation #}
-                                    data-remote-click-options='{{ remoteClickOptions|json_encode }}'
+                                    data-remote-click-options="{{ remoteClickOptions|json_encode }}"
                                     href="#review-tab-pane"
                                     aria-controls="review-tab-pane"
                                 >

--- a/src/Storefront/Resources/views/storefront/page/product-detail/review/review-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/review/review-form.html.twig
@@ -14,8 +14,7 @@
               method="post"
               data-form-validation="true"
               data-form-ajax-submit="true"
-              {# ludtwig-ignore html-string-quotation #}
-              data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+              data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
             {% block page_product_detail_review_form_forward %}
                 <input type="hidden"
@@ -28,8 +27,7 @@
 
                 <input type="hidden"
                        name="forwardParameters"
-                       {# ludtwig-ignore html-string-quotation #}
-                       value='{"productId": "{{ reviews.productId }}"}'>
+                       value="{{ {productId: reviews.productId}|json_encode }}">
             {% endblock %}
 
             {% if reviews.customerReview %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/review/review-login.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/review/review-login.html.twig
@@ -17,14 +17,13 @@
 {% endblock %}
 
 {% block component_account_login_form_redirect %}
-	<input type="hidden"
+    <input type="hidden"
            name="redirectTo"
            value="frontend.detail.page">
 
     <input type="hidden"
            name="redirectParameters"
-           {# ludtwig-ignore html-string-quotation #}
-           value='{"productId": "{{ reviews.productId }}"}'>
+           value="{{ {productId: reviews.productId}|json_encode }}">
 {% endblock %}
 
 {% block component_account_login_submit %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/review/review-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/review/review-widget.html.twig
@@ -54,8 +54,7 @@
                               action="{{ path('frontend.product.reviews', { productId: reviews.productId, parentId: reviews.parentId }) }}"
                               method="post"
                               data-form-ajax-submit="true"
-                              {# ludtwig-ignore html-string-quotation #}
-                              data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                              data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
                             {% if app.request.get('limit') %}
                                 <input type="hidden" name="limit" value="{{ app.request.get('limit') }}">
                             {% endif %}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/review/review.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/review/review.html.twig
@@ -84,8 +84,7 @@
                                                                   action="{{ path('frontend.product.reviews', { productId: reviews.productId, parentId: reviews.parentId }) }}"
                                                                   method="post"
                                                                   data-form-ajax-submit="true"
-                                                                  {# ludtwig-ignore html-string-quotation #}
-                                                                  data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                                                                  data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
 
                                                                 {% if app.request.get('limit') %}
                                                                     <input type="hidden" name="limit" value="{{ app.request.get('limit') }}">
@@ -130,8 +129,7 @@
                                                                       action="{{ path('frontend.product.reviews', { productId: reviews.productId, parentId: reviews.parentId }) }}"
                                                                       method="post"
                                                                       data-form-ajax-submit="true"
-                                                                      {# ludtwig-ignore html-string-quotation #}
-                                                                      data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                                                                      data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
                                                                     {% if app.request.get('limit') %}
                                                                         <input type="hidden" name="limit" value="{{ app.request.get('limit') }}">
                                                                     {% endif %}
@@ -214,8 +212,7 @@
                                                               action="{{ path('frontend.product.reviews', { productId: reviews.productId, parentId: reviews.parentId }) }}"
                                                               method="post"
                                                               data-form-ajax-submit="true"
-                                                              {# ludtwig-ignore html-string-quotation #}
-                                                              data-form-ajax-submit-options='{{ formAjaxSubmitOptions|json_encode }}'>
+                                                              data-form-ajax-submit-options="{{ formAjaxSubmitOptions|json_encode }}">
                                                             {% if app.request.get('limit') %}
                                                                 <input type="hidden" name="limit" value="{{ app.request.get('limit') }}">
                                                             {% endif %}


### PR DESCRIPTION
### 1. Why is this change necessary?
It is actually not needed to use single quotes as the twig filter `json_encode` automatically replaces the double quotes by `&quot;`.

### 2. What does this change do, exactly?
Replace single quotes by double quotes and consistently use the twig `json_encode` filter for objects in attributes.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
