### PR TITLE
NEXT-0000 - Fix: Send installer notifier requests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8401,11 +8401,6 @@ parameters:
 
 		-
 			message: "#^Mocking of GuzzleHttp\\\\Client is not allowed\\. The object is very basic and can be constructed$#"
-			count: 2
-			path: tests/unit/Core/Installer/Finish/NotifierTest.php
-
-		-
-			message: "#^Mocking of GuzzleHttp\\\\Client is not allowed\\. The object is very basic and can be constructed$#"
 			count: 1
 			path: tests/unit/Core/Installer/License/LicenseFetcherTest.php
 

--- a/src/Core/Installer/Finish/Notifier.php
+++ b/src/Core/Installer/Finish/Notifier.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Installer\Finish;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -35,8 +36,8 @@ class Notifier
         ];
 
         try {
-            $this->client->postAsync($this->apiEndPoint . '/swplatform/tracking/events', ['json' => $payload]);
-        } catch (\Exception) {
+            $this->client->post($this->apiEndPoint . '/swplatform/tracking/events', ['json' => $payload]);
+        } catch (GuzzleException) {
             // ignore
         }
     }

--- a/tests/unit/Core/Installer/Finish/NotifierTest.php
+++ b/tests/unit/Core/Installer/Finish/NotifierTest.php
@@ -3,6 +3,8 @@
 namespace Shopware\Tests\Unit\Core\Installer\Finish;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Installer\Finish\Notifier;
@@ -20,24 +22,26 @@ class NotifierTest extends TestCase
         $idGenerator->expects(static::once())->method('getUniqueId')
             ->willReturn('1234567890');
 
-        $guzzle = $this->createMock(Client::class);
-        $guzzle->expects(static::once())->method('postAsync')
-            ->with(
-                'http://localhost/swplatform/tracking/events',
-                [
-                    'json' => [
-                        'additionalData' => [
-                            'shopwareVersion' => '6.4.12',
-                            'language' => 'en',
-                        ],
-                        'instanceId' => '1234567890',
-                        'event' => Notifier::EVENT_INSTALL_FINISHED,
-                    ],
-                ]
-            );
+        $guzzleHandler = new MockHandler([new Response(200, [], \json_encode([
+            'additionalData' => [
+                'shopwareVersion' => '6.4.12',
+                'language' => 'en',
+            ],
+            'instanceId' => '1234567890',
+            'event' => Notifier::EVENT_INSTALL_FINISHED,
+        ], \JSON_THROW_ON_ERROR))]);
+        $client = new Client(['handler' => $guzzleHandler]);
 
-        $notifier = new Notifier('http://localhost', $idGenerator, $guzzle, '6.4.12');
+        $notifier = new Notifier('http://localhost', $idGenerator, $client, '6.4.12');
         $notifier->doTrackEvent(Notifier::EVENT_INSTALL_FINISHED, ['language' => 'en']);
+
+        $request = $guzzleHandler->getLastRequest();
+        static::assertNotNull($request);
+
+        $uri = $request->getUri();
+        static::assertSame('http', $uri->getScheme());
+        static::assertSame('localhost', $uri->getHost());
+        static::assertSame('/swplatform/tracking/events', $uri->getPath());
     }
 
     public function testTrackEventDoesNotThrowOnException(): void
@@ -46,11 +50,11 @@ class NotifierTest extends TestCase
         $idGenerator->expects(static::once())->method('getUniqueId')
             ->willReturn('1234567890');
 
-        $guzzle = $this->createMock(Client::class);
-        $guzzle->expects(static::once())->method('postAsync')
-            ->willThrowException(new \Exception());
+        $client = new Client([
+            'handler' => MockHandler::createWithMiddleware([new Response(500)]),
+        ]);
 
-        $notifier = new Notifier('http://localhost', $idGenerator, $guzzle, '6.4.12');
+        $notifier = new Notifier('http://localhost', $idGenerator, $client, '6.4.12');
         $notifier->doTrackEvent(Notifier::EVENT_INSTALL_FINISHED, ['language' => 'en']);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The async requests need to be awaited in guzzle, see the following issue: https://github.com/guzzle/guzzle/issues/1127
Therefore the request is never sent, maybe it therefore can also be removed alltogether? :thinking: 

### 2. What does this change do, exactly?
Send the request synchronously, as in this case it makes no sense to send it async. Maybe a timeout should be set instead? :thinking: 

Not sure if a changelog is required for such a change?

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.