### PR TITLE
NEXT-0000 - Refactor: Remove mocking of simple objects

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8145,81 +8145,6 @@ parameters:
 			path: tests/unit/Core/Content/Flow/Api/FlowActionCollectorTest.php
 
 		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerAffiliateAndCampaignCodeActionTest.php
-
-		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array will always evaluate to true\\.$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerTagActionTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerTagActionTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderAffiliateAndCampaignCodeActionTest.php
-
-		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array will always evaluate to true\\.$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderTagActionTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderTagActionTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/ChangeCustomerGroupActionTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/ChangeCustomerStatusActionTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/GenerateDocumentActionTest.php
-
-		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array will always evaluate to true\\.$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/RemoveCustomerTagActionTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/RemoveCustomerTagActionTest.php
-
-		-
-			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertIsArray\\(\\) with array will always evaluate to true\\.$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/RemoveOrderTagActionTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/RemoveOrderTagActionTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 2
-			path: tests/unit/Core/Content/Flow/Dispatching/Storer/MessageStorerTest.php
-
-		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Shopware\\\\\\\\Core\\\\\\\\Framework\\\\\\\\Context' and Shopware\\\\Core\\\\Framework\\\\Context will always evaluate to true\\.$#"
 			count: 1
 			path: tests/unit/Core/Content/Flow/Events/BeforeLoadStorableFlowDataEventTest.php
@@ -8235,24 +8160,9 @@ parameters:
 			path: tests/unit/Core/Content/Flow/Events/BeforeLoadStorableFlowDataEventTest.php
 
 		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\StorableFlow is not allowed\\. The object is very basic and can be constructed$#"
-			count: 5
-			path: tests/unit/Core/Content/Flow/Events/FlowSendMailActionEventTest.php
-
-		-
 			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
 			count: 1
 			path: tests/unit/Core/Content/Flow/Rule/OrderCreatedByAdminRuleTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
-			count: 2
-			path: tests/unit/Core/Content/Flow/Rule/OrderDeliveryStatusRuleTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Rule/OrderStatusRuleTest.php
 
 		-
 			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
@@ -8263,11 +8173,6 @@ parameters:
 			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
 			count: 2
 			path: tests/unit/Core/Content/Flow/Rule/OrderTrackingCodeRuleTest.php
-
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Cart is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Content/Flow/Rule/OrderTransactionStatusRuleTest.php
 
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Symfony\\\\\\\\Component\\\\\\\\Mime\\\\\\\\Email' and Shopware\\\\Core\\\\Content\\\\Mail\\\\Service\\\\Mail will always evaluate to true\\.$#"
@@ -8394,26 +8299,11 @@ parameters:
 			count: 1
 			path: tests/unit/Core/Framework/Util/AfterSortTest.php
 
-		-
-			message: "#^Mocking of Shopware\\\\Core\\\\System\\\\Tax\\\\TaxEntity is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Framework/Webhook/BusinessEventEncoderTest.php
 
 		-
 			message: "#^Mocking of GuzzleHttp\\\\Client is not allowed\\. The object is very basic and can be constructed$#"
 			count: 2
 			path: tests/unit/Core/Installer/Finish/NotifierTest.php
-
-		-
-			message: "#^Mocking of GuzzleHttp\\\\Client is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Installer/License/LicenseFetcherTest.php
-
-		-
-			message: "#^Mocking of GuzzleHttp\\\\Client is not allowed\\. The object is very basic and can be constructed$#"
-			count: 1
-			path: tests/unit/Core/Maintenance/System/Service/AppUrlVerifierTest.php
-
 		-
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Shopware\\\\\\\\Core\\\\\\\\System\\\\\\\\CustomEntity\\\\\\\\Xml\\\\\\\\Config\\\\\\\\AdminUi\\\\\\\\XmlElements\\\\\\\\AdminUi' and Shopware\\\\Core\\\\System\\\\CustomEntity\\\\Xml\\\\Config\\\\AdminUi\\\\XmlElements\\\\AdminUi will always evaluate to true\\.$#"
 			count: 1

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerAffiliateAndCampaignCodeActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerAffiliateAndCampaignCodeActionTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddCustomerAffiliateAndCampaignCodeAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -27,15 +28,11 @@ class AddCustomerAffiliateAndCampaignCodeActionTest extends TestCase
 
     private AddCustomerAffiliateAndCampaignCodeAction $action;
 
-    private MockObject&StorableFlow $flow;
-
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
         $this->repository = $this->createMock(EntityRepository::class);
         $this->action = new AddCustomerAffiliateAndCampaignCodeAction($this->connection, $this->repository);
-
-        $this->flow = $this->createMock(StorableFlow::class);
     }
 
     public function testRequirements(): void
@@ -60,36 +57,37 @@ class AddCustomerAffiliateAndCampaignCodeActionTest extends TestCase
     public function testActionWithExpectedUpdate(array $config, array $existedData, array $expected): void
     {
         $this->connection->expects(static::once())->method('fetchAssociative')->willReturn($existedData);
-        $this->flow->expects(static::exactly(2))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::once())->method('getConfig')->willReturn($config);
 
-        $withData = [[...[
-            'id' => $this->flow->getData('customerId'),
-        ], ...$expected]];
+        $customerId = Uuid::randomHex();
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            CustomerAware::CUSTOMER_ID => $customerId,
+        ]);
+        $flow->setConfig($config);
 
-        $this->repository->expects(static::once())->method('update')->with($withData);
+        $expected['id'] = $customerId;
+        $this->repository->expects(static::once())->method('update')->with([$expected]);
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithNotAware(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(false);
-        $this->flow->expects(static::never())->method('getData');
+        $flow = new StorableFlow('foo', Context::createDefaultContext());
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithEmptyConfig(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::once())->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('getConfig')->willReturn([]);
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            CustomerAware::CUSTOMER_ID => Uuid::randomHex(),
+        ]);
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public static function actionExecuteProvider(): \Generator

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerTagActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/AddCustomerTagActionTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddCustomerTagAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Test\TestDataCollection;
@@ -25,14 +26,10 @@ class AddCustomerTagActionTest extends TestCase
 
     private AddCustomerTagAction $action;
 
-    private MockObject&StorableFlow $flow;
-
     protected function setUp(): void
     {
         $this->repository = $this->createMock(EntityRepository::class);
         $this->action = new AddCustomerTagAction($this->repository);
-
-        $this->flow = $this->createMock(StorableFlow::class);
     }
 
     public function testRequirements(): void
@@ -55,35 +52,37 @@ class AddCustomerTagActionTest extends TestCase
     #[DataProvider('actionExecutedProvider')]
     public function testActionExecuted(array $config, array $expected): void
     {
-        $this->flow->expects(static::exactly(2))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::once())->method('getConfig')->willReturn($config);
-        $customerId = $this->flow->getData('customerId');
+        $customerId = Uuid::randomHex();
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            CustomerAware::CUSTOMER_ID => $customerId,
+        ]);
+        $flow->setConfig($config);
 
         $this->repository->expects(static::once())
             ->method('update')
             ->with([['id' => $customerId, 'tags' => $expected]]);
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithNotAware(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(false);
-        $this->flow->expects(static::never())->method('getData');
+        $flow = new StorableFlow('foo', Context::createDefaultContext());
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithEmptyConfig(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::exactly(1))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('getConfig')->willReturn([]);
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            CustomerAware::CUSTOMER_ID => Uuid::randomHex(),
+        ]);
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public static function actionExecutedProvider(): \Generator
@@ -104,14 +103,10 @@ class AddCustomerTagActionTest extends TestCase
     /**
      * @param array<string> $ids
      *
-     * @return array<string, mixed>
+     * @return array<string, true>
      */
     private static function keys(array $ids): array
     {
-        $return = \array_combine($ids, \array_fill(0, \count($ids), true));
-
-        static::assertIsArray($return);
-
-        return $return;
+        return \array_combine($ids, \array_fill(0, \count($ids), true));
     }
 }

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderAffiliateAndCampaignCodeActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderAffiliateAndCampaignCodeActionTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddOrderAffiliateAndCampaignCodeAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -27,15 +28,11 @@ class AddOrderAffiliateAndCampaignCodeActionTest extends TestCase
 
     private AddOrderAffiliateAndCampaignCodeAction $action;
 
-    private MockObject&StorableFlow $flow;
-
     protected function setUp(): void
     {
         $this->connection = $this->createMock(Connection::class);
         $this->repository = $this->createMock(EntityRepository::class);
         $this->action = new AddOrderAffiliateAndCampaignCodeAction($this->connection, $this->repository);
-
-        $this->flow = $this->createMock(StorableFlow::class);
     }
 
     public function testRequirements(): void
@@ -60,38 +57,39 @@ class AddOrderAffiliateAndCampaignCodeActionTest extends TestCase
     public function testActionExecuted(array $config, array $existedData, array $expected): void
     {
         $this->connection->expects(static::once())->method('fetchAssociative')->willReturn($existedData);
-        $this->flow->expects(static::exactly(2))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::once())->method('getConfig')->willReturn($config);
 
-        $withData = [[...[
-            'id' => $this->flow->getData('orderId'),
-        ], ...$expected]];
+        $orderId = Uuid::randomHex();
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            OrderAware::ORDER_ID => $orderId,
+        ]);
+        $flow->setConfig($config);
+
+        $expected['id'] = $orderId;
 
         $this->repository->expects(static::once())
             ->method('update')
-            ->with($withData);
+            ->with([$expected]);
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithNotAware(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(false);
-        $this->flow->expects(static::never())->method('getData');
-        $this->repository->expects(static::never())->method('update');
+        $flow = new StorableFlow('foo', Context::createDefaultContext());
 
-        $this->action->handleFlow($this->flow);
+        $this->repository->expects(static::never())->method('update');
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithEmptyConfig(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::once())->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('getConfig')->willReturn([]);
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            OrderAware::ORDER_ID => Uuid::randomHex(),
+        ]);
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public static function actionExecutedProvider(): \Generator

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderTagActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/AddOrderTagActionTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Action\AddOrderTagAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Test\TestDataCollection;
@@ -25,14 +26,10 @@ class AddOrderTagActionTest extends TestCase
 
     private AddOrderTagAction $action;
 
-    private MockObject&StorableFlow $flow;
-
     protected function setUp(): void
     {
         $this->repository = $this->createMock(EntityRepository::class);
         $this->action = new AddOrderTagAction($this->repository);
-
-        $this->flow = $this->createMock(StorableFlow::class);
     }
 
     public function testRequirements(): void
@@ -55,33 +52,37 @@ class AddOrderTagActionTest extends TestCase
     #[DataProvider('actionExecutedProvider')]
     public function testActionExecuted(array $config, array $expected): void
     {
-        $this->flow->expects(static::exactly(2))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::once())->method('getConfig')->willReturn($config);
+        $orderId = Uuid::randomHex();
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            OrderAware::ORDER_ID => $orderId,
+        ]);
+        $flow->setConfig($config);
+
         $this->repository->expects(static::once())
             ->method('update')
-            ->with([['id' => $this->flow->getData(OrderAware::ORDER_ID), 'tags' => $expected]]);
+            ->with([['id' => $orderId, 'tags' => $expected]]);
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithNotAware(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(false);
-        $this->flow->expects(static::never())->method('getData');
+        $flow = new StorableFlow('foo', Context::createDefaultContext());
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithEmptyConfig(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::exactly(1))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('getConfig')->willReturn([]);
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            OrderAware::ORDER_ID => Uuid::randomHex(),
+        ]);
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public static function actionExecutedProvider(): \Generator
@@ -102,14 +103,10 @@ class AddOrderTagActionTest extends TestCase
     /**
      * @param array<string> $ids
      *
-     * @return array<string, mixed>
+     * @return array<string, true>
      */
     private static function keys(array $ids): array
     {
-        $return = \array_combine($ids, \array_fill(0, \count($ids), true));
-
-        static::assertIsArray($return);
-
-        return $return;
+        return \array_combine($ids, \array_fill(0, \count($ids), true));
     }
 }

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/ChangeCustomerStatusActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/ChangeCustomerStatusActionTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Action\ChangeCustomerStatusAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -23,14 +24,10 @@ class ChangeCustomerStatusActionTest extends TestCase
 
     private ChangeCustomerStatusAction $action;
 
-    private MockObject&StorableFlow $flow;
-
     protected function setUp(): void
     {
         $this->repository = $this->createMock(EntityRepository::class);
         $this->action = new ChangeCustomerStatusAction($this->repository);
-
-        $this->flow = $this->createMock(StorableFlow::class);
     }
 
     public function testRequirements(): void
@@ -48,33 +45,36 @@ class ChangeCustomerStatusActionTest extends TestCase
 
     public function testActionExecuted(): void
     {
-        $this->flow->expects(static::exactly(2))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::once())->method('getConfig')->willReturn(['active' => true]);
+        $customerId = Uuid::randomHex();
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            CustomerAware::CUSTOMER_ID => $customerId,
+        ]);
+        $flow->setConfig(['active' => true]);
 
         $this->repository->expects(static::once())
             ->method('update')
-            ->with([['id' => $this->flow->getData('customerId'), 'active' => true]]);
+            ->with([['id' => $customerId, 'active' => true]]);
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithNotAware(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(false);
-        $this->flow->expects(static::never())->method('getData');
+        $flow = new StorableFlow('foo', Context::createDefaultContext());
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithEmptyConfig(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::exactly(1))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('getConfig')->willReturn([]);
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            CustomerAware::CUSTOMER_ID => Uuid::randomHex(),
+        ]);
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 }

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/GenerateDocumentActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/GenerateDocumentActionTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Content\Flow\Dispatching\Action\GenerateDocumentAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -26,8 +27,6 @@ class GenerateDocumentActionTest extends TestCase
 {
     private MockObject&DocumentGenerator $documentGenerator;
 
-    private MockObject&StorableFlow $flow;
-
     private GenerateDocumentAction $action;
 
     protected function setUp(): void
@@ -38,8 +37,6 @@ class GenerateDocumentActionTest extends TestCase
             $this->documentGenerator,
             $this->createMock(LoggerInterface::class),
         );
-
-        $this->flow = $this->createMock(StorableFlow::class);
     }
 
     public function testRequirements(): void
@@ -61,14 +58,14 @@ class GenerateDocumentActionTest extends TestCase
     #[DataProvider('actionExecutedProvider')]
     public function testActionExecuted(array $config, int $expected): void
     {
-        $this->flow->expects(static::exactly(2))->method('hasData')->willReturn(true);
-        $this->flow->expects(static::exactly(2))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::exactly(1))->method('getContext')->willReturn(Context::createDefaultContext());
-
-        $this->flow->expects(static::once())->method('getConfig')->willReturn($config);
+        $orderId = Uuid::randomHex();
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            OrderAware::ORDER_ID => $orderId,
+            MailAware::SALES_CHANNEL_ID => Uuid::randomHex(),
+        ]);
+        $flow->setConfig($config);
 
         $documentType = $config['documentTypes'][0]['documentType'] ?? $config['documentType'] ?? null;
-        $orderId = $this->flow->getData(OrderAware::ORDER_ID);
         $fileType = $config['documentTypes'][0]['fileType'] ?? $config['fileType'] ?? FileTypes::PDF;
         $conf = $config['documentTypes'][0]['config'] ?? $config['config'] ?? [];
         $static = $config['documentTypes'][0]['static'] ?? $config['static'] ?? false;
@@ -79,7 +76,7 @@ class GenerateDocumentActionTest extends TestCase
             ->method('generate')
             ->with($documentType, [$orderId => $operation], Context::createDefaultContext());
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public static function actionExecutedProvider(): \Generator

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/RemoveCustomerTagActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/RemoveCustomerTagActionTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Action\RemoveCustomerTagAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Test\TestDataCollection;
@@ -25,14 +26,10 @@ class RemoveCustomerTagActionTest extends TestCase
 
     private RemoveCustomerTagAction $action;
 
-    private MockObject&StorableFlow $flow;
-
     protected function setUp(): void
     {
         $this->repository = $this->createMock(EntityRepository::class);
         $this->action = new RemoveCustomerTagAction($this->repository);
-
-        $this->flow = $this->createMock(StorableFlow::class);
     }
 
     public function testRequirements(): void
@@ -55,40 +52,40 @@ class RemoveCustomerTagActionTest extends TestCase
     #[DataProvider('actionExecutedProvider')]
     public function testActionExecuted(array $config, array $expected): void
     {
-        $this->flow->expects(static::exactly(2))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::once())->method('getConfig')->willReturn($config);
-
-        $customerId = $this->flow->getData(CustomerAware::CUSTOMER_ID);
-        $withData = array_map(fn ($id) => [
-            'customerId' => $customerId,
-            'tagId' => $id['id'],
-        ], $expected);
+        $customerId = Uuid::randomHex();
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            CustomerAware::CUSTOMER_ID => $customerId,
+        ]);
+        $flow->setConfig($config);
 
         $this->repository->expects(static::once())
             ->method('delete')
-            ->with($withData);
+            ->with(array_map(fn ($id) => [
+                CustomerAware::CUSTOMER_ID => $customerId,
+                'tagId' => $id['id'],
+            ], $expected));
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithNotAware(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(false);
-        $this->flow->expects(static::never())->method('getData');
+        $flow = new StorableFlow('foo', Context::createDefaultContext());
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithEmptyConfig(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::exactly(1))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('getConfig')->willReturn([]);
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            CustomerAware::CUSTOMER_ID => Uuid::randomHex(),
+        ]);
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public static function actionExecutedProvider(): \Generator
@@ -109,14 +106,10 @@ class RemoveCustomerTagActionTest extends TestCase
     /**
      * @param array<string> $ids
      *
-     * @return array<string, mixed>
+     * @return array<string, true>
      */
     private static function keys(array $ids): array
     {
-        $return = \array_combine($ids, \array_fill(0, \count($ids), true));
-
-        static::assertIsArray($return);
-
-        return $return;
+        return \array_combine($ids, \array_fill(0, \count($ids), true));
     }
 }

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/RemoveOrderTagActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/RemoveOrderTagActionTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Action\RemoveOrderTagAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Test\TestDataCollection;
@@ -25,14 +26,10 @@ class RemoveOrderTagActionTest extends TestCase
 
     private RemoveOrderTagAction $action;
 
-    private MockObject&StorableFlow $flow;
-
     protected function setUp(): void
     {
         $this->repository = $this->createMock(EntityRepository::class);
         $this->action = new RemoveOrderTagAction($this->repository);
-
-        $this->flow = $this->createMock(StorableFlow::class);
     }
 
     public function testRequirements(): void
@@ -55,40 +52,40 @@ class RemoveOrderTagActionTest extends TestCase
     #[DataProvider('actionExecutedProvider')]
     public function testActionExecuted(array $config, array $expected): void
     {
-        $this->flow->expects(static::exactly(2))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::once())->method('getConfig')->willReturn($config);
-
-        $orderId = $this->flow->getData(OrderAware::ORDER_ID);
-        $withData = array_map(fn ($id) => [
-            'orderId' => $orderId,
-            'tagId' => $id['id'],
-        ], $expected);
+        $orderId = Uuid::randomHex();
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            OrderAware::ORDER_ID => $orderId,
+        ]);
+        $flow->setConfig($config);
 
         $this->repository->expects(static::once())
             ->method('delete')
-            ->with($withData);
+            ->with(array_map(fn ($id) => [
+                'orderId' => $orderId,
+                'tagId' => $id['id'],
+            ], $expected));
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithNotAware(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(false);
-        $this->flow->expects(static::never())->method('getData');
+        $flow = new StorableFlow('foo', Context::createDefaultContext());
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public function testActionWithEmptyConfig(): void
     {
-        $this->flow->expects(static::once())->method('hasData')->willReturn(true);
-        $this->flow->expects(static::exactly(1))->method('getData')->willReturn(Uuid::randomHex());
-        $this->flow->expects(static::once())->method('getConfig')->willReturn([]);
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
+            OrderAware::ORDER_ID => Uuid::randomHex(),
+        ]);
+
         $this->repository->expects(static::never())->method('update');
 
-        $this->action->handleFlow($this->flow);
+        $this->action->handleFlow($flow);
     }
 
     public static function actionExecutedProvider(): \Generator
@@ -109,14 +106,10 @@ class RemoveOrderTagActionTest extends TestCase
     /**
      * @param array<string> $ids
      *
-     * @return array<string, mixed>
+     * @return array<string, true>
      */
     private static function keys(array $ids): array
     {
-        $return = \array_combine($ids, \array_fill(0, \count($ids), true));
-
-        static::assertIsArray($return);
-
-        return $return;
+        return \array_combine($ids, \array_fill(0, \count($ids), true));
     }
 }

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/MessageStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/MessageStorerTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\Aware\MessageAware;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
@@ -72,46 +71,27 @@ class MessageStorerTest extends TestCase
 
     public function testRestoreHasStored(): void
     {
-        $storer = new MessageStorer();
-
         $mail = new Email();
         $mail->html('text/plain');
 
-        /** @var MockObject&StorableFlow $storable */
-        $storable = $this->createMock(StorableFlow::class);
+        $flow = new StorableFlow('foo', Context::createDefaultContext(), [
+            MessageAware::MESSAGE => \serialize($mail),
+        ]);
 
-        $storable->expects(static::exactly(1))
-            ->method('hasStore')
-            ->willReturn(true);
+        $storer = new MessageStorer();
+        $storer->restore($flow);
 
-        $storable->expects(static::exactly(1))
-            ->method('getStore')
-            ->willReturn(\serialize($mail));
-
-        $storable->expects(static::exactly(1))
-            ->method('setData')
-            ->with(MessageAware::MESSAGE, $mail);
-
-        $storer->restore($storable);
+        static::assertEquals($mail, $flow->getData(MessageAware::MESSAGE));
     }
 
     public function testRestoreEmptyStored(): void
     {
         $storer = new MessageStorer();
 
-        /** @var MockObject&StorableFlow $storable */
-        $storable = $this->createMock(StorableFlow::class);
+        $flow = new StorableFlow('foo', Context::createDefaultContext());
 
-        $storable->expects(static::exactly(1))
-            ->method('hasStore')
-            ->willReturn(false);
+        $storer->restore($flow);
 
-        $storable->expects(static::never())
-            ->method('getStore');
-
-        $storable->expects(static::never())
-            ->method('setData');
-
-        $storer->restore($storable);
+        static::assertEmpty($flow->data());
     }
 }

--- a/tests/unit/Core/Content/Flow/Events/FlowSendMailActionEventTest.php
+++ b/tests/unit/Core/Content/Flow/Events/FlowSendMailActionEventTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Unit\Core\Content\Flow\Events;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Content\Flow\Events\FlowSendMailActionEvent;
@@ -19,61 +18,19 @@ use Shopware\Core\Framework\Validation\DataBag\DataBag;
 #[CoversClass(FlowSendMailActionEvent::class)]
 class FlowSendMailActionEventTest extends TestCase
 {
-    public function testGetContextWithFlowEvent(): void
+    public function testEventConstructorParameters(): void
     {
-        $event = $this->createMock(StorableFlow::class);
-        $event->expects(static::once())
-            ->method('getContext')
-            ->willReturn(Context::createDefaultContext());
-
-        $mailTemplate = new MailTemplateEntity();
-
-        $mailEvent = new FlowSendMailActionEvent(new DataBag(), $mailTemplate, $event);
-        $context = $mailEvent->getContext();
-
-        static::assertEquals($context, Context::createDefaultContext());
-    }
-
-    public function testGetDataBag(): void
-    {
-        $mailTemplate = new MailTemplateEntity();
-        $flowEvent = $this->createMock(StorableFlow::class);
+        $context = Context::createDefaultContext();
+        $flow = new StorableFlow('foo', $context);
 
         $expectDataBag = new DataBag(['data' => 'data']);
-        $event = new FlowSendMailActionEvent($expectDataBag, $mailTemplate, $flowEvent);
-        $actualDataBag = $event->getDataBag();
-
-        static::assertEquals($actualDataBag, $expectDataBag);
-    }
-
-    public function testGetMailTemplate(): void
-    {
-        $mailTemplate = new MailTemplateEntity();
-        $flowEvent = $this->createMock(StorableFlow::class);
-
-        $event = new FlowSendMailActionEvent(new DataBag(), $mailTemplate, $flowEvent);
-
-        static::assertEquals($mailTemplate, $event->getMailTemplate());
-    }
-
-    public function testGetStorableFlow(): void
-    {
-        $event = $this->createMock(StorableFlow::class);
-
         $mailTemplate = new MailTemplateEntity();
 
-        $mailEvent = new FlowSendMailActionEvent(new DataBag(), $mailTemplate, $event);
+        $event = new FlowSendMailActionEvent($expectDataBag, $mailTemplate, $flow);
 
-        static::assertEquals($event, $mailEvent->getStorableFlow());
-    }
-
-    public function testGetStorableFlowHasOriginalFlowEvent(): void
-    {
-        /** @var StorableFlow&MockObject $event */
-        $event = $this->createMock(StorableFlow::class);
-
-        $mailTemplate = new MailTemplateEntity();
-        $mailEvent = new FlowSendMailActionEvent(new DataBag(), $mailTemplate, $event);
-        static::assertEquals($event, $mailEvent->getStorableFlow());
+        static::assertSame($context, $event->getContext());
+        static::assertSame($expectDataBag, $event->getDataBag());
+        static::assertSame($mailTemplate, $event->getMailTemplate());
+        static::assertSame($flow, $event->getStorableFlow());
     }
 }

--- a/tests/unit/Core/Content/Flow/Rule/OrderDeliveryStatusRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderDeliveryStatusRuleTest.php
@@ -64,10 +64,11 @@ class OrderDeliveryStatusRuleTest extends TestCase
         $orderDeliveryCollection->add($orderDelivery);
         $order = new OrderEntity();
         $order->setDeliveries($orderDeliveryCollection);
-
-        $cart = $this->createMock(Cart::class);
-        $context = $this->createMock(SalesChannelContext::class);
-        $scope = new FlowRuleScope($order, $cart, $context);
+        $scope = new FlowRuleScope(
+            $order,
+            new Cart('test'),
+            $this->createMock(SalesChannelContext::class)
+        );
 
         $this->rule->assign(['stateIds' => $selectedOrderStateIds, 'operator' => $operator]);
         static::assertSame($expected, $this->rule->match($scope));
@@ -86,9 +87,11 @@ class OrderDeliveryStatusRuleTest extends TestCase
         $order->setDeliveries(new OrderDeliveryCollection());
         $orderDeliveryCollection = new OrderDeliveryCollection();
         $order->setDeliveries($orderDeliveryCollection);
-        $cart = $this->createMock(Cart::class);
-        $context = $this->createMock(SalesChannelContext::class);
-        $scope = new FlowRuleScope($order, $cart, $context);
+        $scope = new FlowRuleScope(
+            $order,
+            new Cart('test'),
+            $this->createMock(SalesChannelContext::class)
+        );
 
         $this->rule->assign(['stateIds' => [Uuid::randomHex()], 'operator' => Rule::OPERATOR_EQ]);
         static::assertFalse($this->rule->match($scope));

--- a/tests/unit/Core/Content/Flow/Rule/OrderStatusRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderStatusRuleTest.php
@@ -57,10 +57,11 @@ class OrderStatusRuleTest extends TestCase
     {
         $order = new OrderEntity();
         $order->setStateId($orderStateId);
-
-        $cart = $this->createMock(Cart::class);
-        $context = $this->createMock(SalesChannelContext::class);
-        $scope = new FlowRuleScope($order, $cart, $context);
+        $scope = new FlowRuleScope(
+            $order,
+            new Cart('test'),
+            $this->createMock(SalesChannelContext::class)
+        );
 
         $this->rule->assign(['stateIds' => $selectedOrderStateIds, 'operator' => $operator]);
         static::assertSame($expected, $this->rule->match($scope));

--- a/tests/unit/Core/Content/Flow/Rule/OrderTransactionStatusRuleTest.php
+++ b/tests/unit/Core/Content/Flow/Rule/OrderTransactionStatusRuleTest.php
@@ -69,10 +69,11 @@ class OrderTransactionStatusRuleTest extends TestCase
         $orderTransactionCollection->add($orderTransaction);
         $order = new OrderEntity();
         $order->setTransactions($orderTransactionCollection);
-
-        $cart = $this->createMock(Cart::class);
-        $context = $this->createMock(SalesChannelContext::class);
-        $scope = new FlowRuleScope($order, $cart, $context);
+        $scope = new FlowRuleScope(
+            $order,
+            new Cart('test'),
+            $this->createMock(SalesChannelContext::class)
+        );
 
         $this->rule->assign(['stateIds' => $selectedOrderStateIds, 'operator' => $operator]);
         static::assertSame($expected, $this->rule->match($scope));

--- a/tests/unit/Core/Framework/Webhook/BusinessEventEncoderTest.php
+++ b/tests/unit/Core/Framework/Webhook/BusinessEventEncoderTest.php
@@ -18,8 +18,9 @@ class BusinessEventEncoderTest extends TestCase
 {
     public function testEncodeData(): void
     {
-        $tax = $this->createMock(TaxEntity::class);
-        $tax->expects(static::once())->method('getInternalEntityName')->willReturn('tax');
+        $tax = new TaxEntity();
+        // Needed that the `_entityName` property is set correctly
+        $tax->getApiAlias();
 
         $data = [
             'tax' => $tax,

--- a/tests/unit/Core/Maintenance/System/Service/AppUrlVerifierTest.php
+++ b/tests/unit/Core/Maintenance/System/Service/AppUrlVerifierTest.php
@@ -4,9 +4,8 @@ namespace Shopware\Tests\Unit\Core\Maintenance\System\Service;
 
 use Doctrine\DBAL\Connection;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\TransferException;
+use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -20,110 +19,114 @@ use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 #[CoversClass(AppUrlVerifier::class)]
 class AppUrlVerifierTest extends TestCase
 {
-    private Client&MockObject $guzzleMock;
+    private MockHandler $mockHandler;
+
+    private Client $client;
 
     private Connection&MockObject $connection;
 
     protected function setUp(): void
     {
-        $this->guzzleMock = $this->createMock(Client::class);
+        $this->mockHandler = new MockHandler();
+        $this->client = new Client(['handler' => $this->mockHandler]);
         $this->connection = $this->createMock(Connection::class);
     }
 
     public function testAppUrlReachableReturnsTrueIfAppEnvIsNotProd(): void
     {
-        $this->guzzleMock->expects(static::never())
-            ->method('get');
-
-        $verifier = new AppUrlVerifier($this->guzzleMock, $this->connection, 'dev', false);
+        $verifier = new AppUrlVerifier($this->client, $this->connection, 'dev', false);
 
         static::assertTrue($verifier->isAppUrlReachable(new SymfonyRequest()));
+
+        $request = $this->mockHandler->getLastRequest();
+        static::assertNull($request);
     }
 
     public function testAppUrlReachableReturnsTrueIfAppUrlCheckIsDisabled(): void
     {
-        $this->guzzleMock->expects(static::never())
-            ->method('get');
-
-        $verifier = new AppUrlVerifier($this->guzzleMock, $this->connection, 'prod', true);
+        $verifier = new AppUrlVerifier($this->client, $this->connection, 'prod', true);
 
         static::assertTrue($verifier->isAppUrlReachable(new SymfonyRequest()));
+
+        $request = $this->mockHandler->getLastRequest();
+        static::assertNull($request);
     }
 
     public function testAppUrlReachableReturnsTrueIfRequestIsMadeToSameDomain(): void
     {
-        $this->guzzleMock->expects(static::never())
-            ->method('get');
-
-        $verifier = new AppUrlVerifier($this->guzzleMock, $this->connection, 'prod', false);
+        $verifier = new AppUrlVerifier($this->client, $this->connection, 'prod', false);
 
         $request = SymfonyRequest::create(EnvironmentHelper::getVariable('APP_URL') . '/api/_info/config');
 
         static::assertTrue($verifier->isAppUrlReachable($request));
+
+        $request = $this->mockHandler->getLastRequest();
+        static::assertNull($request);
     }
 
     public function testAppUrlReachableReturnsTrueIfAppUrlIsReachable(): void
     {
-        $this->guzzleMock->expects(static::once())
-            ->method('get')
-            ->with(
-                EnvironmentHelper::getVariable('APP_URL') . '/api/_info/version',
-                [
-                    'headers' => [
-                        'Authorization' => 'Bearer Token',
-                    ],
-                    RequestOptions::TIMEOUT => 1,
-                    RequestOptions::CONNECT_TIMEOUT => 1,
-                ]
-            )->willReturn(new Response());
+        $this->mockHandler->append(new Response());
 
-        $verifier = new AppUrlVerifier($this->guzzleMock, $this->connection, 'prod', false);
+        $verifier = new AppUrlVerifier($this->client, $this->connection, 'prod', false);
 
         $request = SymfonyRequest::create('http://some.host/api/_info/config');
         $request->headers->set('Authorization', 'Bearer Token');
 
         static::assertTrue($verifier->isAppUrlReachable($request));
+
+        $request = $this->mockHandler->getLastRequest();
+        static::assertNotNull($request);
+
+        static::assertSame('GET', $request->getMethod());
+        static::assertSame(
+            EnvironmentHelper::getVariable('APP_URL') . '/api/_info/version',
+            (string) $request->getUri()
+        );
+
+        $authHeader = $request->getHeader('Authorization');
+        static::assertContains('Bearer Token', $authHeader);
+
+        $requestOptions = $this->mockHandler->getLastOptions();
+        static::assertSame(1, $requestOptions['timeout']);
+        static::assertSame(1, $requestOptions['connect_timeout']);
     }
 
     public function testAppUrlReachableReturnsFalseOnNot200Status(): void
     {
-        $this->guzzleMock->expects(static::once())
-            ->method('get')
-            ->with(
-                EnvironmentHelper::getVariable('APP_URL') . '/api/_info/version',
-                [
-                    'headers' => [
-                        'Authorization' => 'Bearer Token',
-                    ],
-                    RequestOptions::TIMEOUT => 1,
-                    RequestOptions::CONNECT_TIMEOUT => 1,
-                ]
-            )->willReturn(new Response(404));
+        $this->mockHandler->append(new Response(404));
 
-        $verifier = new AppUrlVerifier($this->guzzleMock, $this->connection, 'prod', false);
+        $verifier = new AppUrlVerifier($this->client, $this->connection, 'prod', false);
 
         $request = SymfonyRequest::create('http://some.host/api/_info/config');
         $request->headers->set('Authorization', 'Bearer Token');
 
         static::assertFalse($verifier->isAppUrlReachable($request));
+
+        $request = $this->mockHandler->getLastRequest();
+        static::assertNotNull($request);
+
+        static::assertSame('GET', $request->getMethod());
+        static::assertSame(
+            EnvironmentHelper::getVariable('APP_URL') . '/api/_info/version',
+            (string) $request->getUri()
+        );
+
+        $authHeader = $request->getHeader('Authorization');
+        static::assertContains('Bearer Token', $authHeader);
+
+        $requestOptions = $this->mockHandler->getLastOptions();
+        static::assertSame(1, $requestOptions['timeout']);
+        static::assertSame(1, $requestOptions['connect_timeout']);
     }
 
     public function testAppUrlReachableReturnsFalseOnException(): void
     {
-        $this->guzzleMock->expects(static::once())
-            ->method('get')
-            ->with(
-                EnvironmentHelper::getVariable('APP_URL') . '/api/_info/version',
-                [
-                    'headers' => [
-                        'Authorization' => 'Bearer Token',
-                    ],
-                    RequestOptions::TIMEOUT => 1,
-                    RequestOptions::CONNECT_TIMEOUT => 1,
-                ]
-            )->willThrowException(new TransferException());
+        $client = new Client([
+            'handler' => MockHandler::createWithMiddleware([new Response(500)]),
+        ]);
 
-        $verifier = new AppUrlVerifier($this->guzzleMock, $this->connection, 'prod', false);
+        $verifier = new AppUrlVerifier($client, $this->connection, 'prod', false);
 
         $request = SymfonyRequest::create('http://some.host/api/_info/config');
         $request->headers->set('Authorization', 'Bearer Token');
@@ -137,7 +140,7 @@ class AppUrlVerifierTest extends TestCase
             ->method('fetchOne')
             ->willReturn('0');
 
-        $verifier = new AppUrlVerifier($this->guzzleMock, $this->connection, 'prod', false);
+        $verifier = new AppUrlVerifier($this->client, $this->connection, 'prod', false);
 
         static::assertFalse($verifier->hasAppsThatNeedAppUrl());
     }
@@ -148,7 +151,7 @@ class AppUrlVerifierTest extends TestCase
             ->method('fetchOne')
             ->willReturn('1');
 
-        $verifier = new AppUrlVerifier($this->guzzleMock, $this->connection, 'prod', false);
+        $verifier = new AppUrlVerifier($this->client, $this->connection, 'prod', false);
 
         static::assertTrue($verifier->hasAppsThatNeedAppUrl());
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Together with #3499 and #3503 this PR should remove the mocking of simple objects from tests.

### 2. What does this change do, exactly?
Do not mock simple objects.

I created no changelog, as I think it is not relevant, if I should add one, please let me know.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
