### PR TITLE
NEXT-33056 - Add title attribute to sw_cms_list_item

### DIFF
--- a/changelog/_unreleased/2024-01-11-add-title-attribute-to-sw_cms_list_item.md
+++ b/changelog/_unreleased/2024-01-11-add-title-attribute-to-sw_cms_list_item.md
@@ -1,0 +1,9 @@
+---
+title: Add title attribute to sw_cms_list_item
+issue: NEXT-00000
+author: Jonas Wrosch
+author_email: jonas.wrosch@netlogix.de
+author_github: @nlx-jonas
+---
+# Administration
+* Added translated name as a title attribute to the layout item in shopping experiences to make distinguishing abbreviated titles easier 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/sw-cms-list-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/sw-cms-list-item.html.twig
@@ -3,6 +3,7 @@
 <div
     class="sw-cms-list-item"
     :class="componentClasses"
+    :title="page.translated.name"
 >
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To make distinguishing abbreviated shopping experience layout titles easier.

### 2. What does this change do, exactly?
Adding a title attribute to the sw_cms_list_item (name of the twig block), displaying the page.translated.name.

### 3. Describe each step to reproduce the issue or behaviour.
Go to the admin dashboard and open "Shopping Experiences". Some of the layouts with longer names are very similar in the beginning and will get abbreviated with "...". This makes it hard up to impossible to distinguish them as a redacteur.

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
