### PR TITLE
NEXT-0000 - Fix: Do now require a sales channel id for the GenerateDocumentAction

### DIFF
--- a/changelog/_unreleased/2024-01-11-do-not-require-sales-channel-id-for-the-generatedocumentaction.md
+++ b/changelog/_unreleased/2024-01-11-do-not-require-sales-channel-id-for-the-generatedocumentaction.md
@@ -1,0 +1,9 @@
+---
+title: Do not require sales channel id for the GenerateDocumentAction
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed `Shopware\Core\Content\Flow\Dispatching\Action\GenerateDocumentAction` to not require a sales channel id

--- a/src/Core/Content/Flow/Dispatching/Action/GenerateDocumentAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/GenerateDocumentAction.php
@@ -10,7 +10,6 @@ use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Content\Flow\Dispatching\DelayableAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Log\Package;
 
@@ -44,7 +43,7 @@ class GenerateDocumentAction extends FlowAction implements DelayableAction
 
     public function handleFlow(StorableFlow $flow): void
     {
-        if (!$flow->hasData(OrderAware::ORDER_ID) || !$flow->hasData(MailAware::SALES_CHANNEL_ID)) {
+        if (!$flow->hasData(OrderAware::ORDER_ID)) {
             return;
         }
 

--- a/tests/unit/Core/Content/Flow/Dispatching/Action/GenerateDocumentActionTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Action/GenerateDocumentActionTest.php
@@ -13,7 +13,6 @@ use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Content\Flow\Dispatching\Action\GenerateDocumentAction;
 use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Uuid\Uuid;
 
@@ -61,7 +60,6 @@ class GenerateDocumentActionTest extends TestCase
         $orderId = Uuid::randomHex();
         $flow = new StorableFlow('foo', Context::createDefaultContext(), [], [
             OrderAware::ORDER_ID => $orderId,
-            MailAware::SALES_CHANNEL_ID => Uuid::randomHex(),
         ]);
         $flow->setConfig($config);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
As far as I can tell the `GenerateDocumentAction` does not requires a sales channel id.

### 2. What does this change do, exactly?
Remove the check if a sales channel id is set.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
