### PR TITLE
NEXT-35068 - Allow RateLimitFactories be used multiple times in one service lifetime

### DIFF
--- a/changelog/_unreleased/2024-01-15-allow-rate-limiter-usage-twice-without-breaking-memoized-configuration.md
+++ b/changelog/_unreleased/2024-01-15-allow-rate-limiter-usage-twice-without-breaking-memoized-configuration.md
@@ -1,0 +1,8 @@
+---
+title: Allow rate limiter usage twice without breaking memoized rate limit configuration
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Changed usage of in-memory config in `\Shopware\Core\Framework\RateLimiter\RateLimiterFactory` to ensure multiple use without breaking configuration

--- a/src/Core/Framework/RateLimiter/RateLimiterFactory.php
+++ b/src/Core/Framework/RateLimiter/RateLimiterFactory.php
@@ -72,9 +72,8 @@ class RateLimiterFactory
         // prevent symfony errors due to customized values
         /** @var RateLimiterConfig $rateLimiterConfig */
         $rateLimiterConfig = \array_filter($this->config, static fn ($key): bool => !\in_array($key, ['enabled', 'reset', 'cache_pool', 'lock_factory', 'limits'], true), \ARRAY_FILTER_USE_KEY);
-        $this->config = $rateLimiterConfig;
 
-        $sfFactory = new SymfonyRateLimiterFactory($this->config, $this->storage, $this->lockFactory);
+        $sfFactory = new SymfonyRateLimiterFactory($rateLimiterConfig, $this->storage, $this->lockFactory);
 
         return $sfFactory->create($key);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

When rate limiters are used multiple times, they enabled key vanishes

### 2. What does this change do, exactly?

Let's pass the cleaned up configuration array to symfony but do not remove the keys in our array so a second call will not fail regarding a broken configuration.

### 3. Describe each step to reproduce the issue or behaviour.

Use rate limits for something else, that is not a request and can be called multiple times in a process lifetime.

### 4. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

copilot:summary

copilot:walkthrough
