### PR TITLE
NEXT-0000 - Perf: Only use `searchIds` for import id resolving

### DIFF
--- a/changelog/_unreleased/2024-01-17-use-searchids-for-import-id-resolving.md
+++ b/changelog/_unreleased/2024-01-17-use-searchids-for-import-id-resolving.md
@@ -1,0 +1,9 @@
+---
+title: Use searchIds for import id resolving
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed import serializers to only use `EntityRepository::searchIds` instead of `EntityRepository::search` for resolving ids

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -801,66 +801,6 @@ parameters:
 			path: src/Core/Content/ImportExport/Command/ImportEntityCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CountrySerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CountrySerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CountrySerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no value type specified in iterable type array\\|Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CountrySerializer\\:\\:deserialize\\(\\) return type has no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CountrySerializer\\:\\:deserialize\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CountrySerializer\\:\\:deserialize\\(\\) return type has no value type specified in iterable type array\\|Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CustomerSerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CustomerSerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CustomerSerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no value type specified in iterable type array\\|Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CustomerSerializer\\:\\:deserialize\\(\\) return type has no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CustomerSerializer\\:\\:deserialize\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\CustomerSerializer\\:\\:deserialize\\(\\) return type has no value type specified in iterable type array\\|Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializer.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\LanguageSerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no value type specified in iterable type Traversable\\.$#"
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/LanguageSerializer.php
@@ -1066,36 +1006,6 @@ parameters:
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/ProductSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\SalutationSerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\SalutationSerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\SalutationSerializer\\:\\:deserialize\\(\\) has parameter \\$entity with no value type specified in iterable type array\\|Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\SalutationSerializer\\:\\:deserialize\\(\\) return type has no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\SalutationSerializer\\:\\:deserialize\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\SalutationSerializer\\:\\:deserialize\\(\\) return type has no value type specified in iterable type array\\|Traversable\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/SalutationSerializer.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\PrimaryKeyResolver\\:\\:getValueFromPath\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
@@ -1264,16 +1174,6 @@ parameters:
 			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportExceptionImportRecordEvent\\:\\:getRow\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportExceptionImportRecordEvent.php
-
-		-
-			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getId\\(\\)\\.$#"
-			count: 1
-			path: src/Core/Content/ImportExport/Event/Subscriber/ProductCategoryPathsSubscriber.php
-
-		-
-			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getId\\(\\)\\.$#"
-			count: 4
-			path: src/Core/Content/ImportExport/Event/Subscriber/ProductVariantsSubscriber.php
 
 		-
 			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Exception\\\\DeleteDefaultProfileException\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CountrySerializer.php
@@ -10,14 +10,13 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Country\CountryDefinition;
-use Shopware\Core\System\Country\CountryEntity;
 use Symfony\Contracts\Service\ResetInterface;
 
 #[Package('core')]
 class CountrySerializer extends EntitySerializer implements ResetInterface
 {
     /**
-     * @var array<string>|null[]
+     * @var array<string, string|null>
      */
     private array $cacheCountries = [];
 
@@ -28,11 +27,6 @@ class CountrySerializer extends EntitySerializer implements ResetInterface
     {
     }
 
-    /**
-     * @param array|\Traversable $entity
-     *
-     * @return array|\Traversable
-     */
     public function deserialize(Config $config, EntityDefinition $definition, $entity)
     {
         $deserialized = parent::deserialize($config, $definition, $entity);
@@ -68,12 +62,11 @@ class CountrySerializer extends EntitySerializer implements ResetInterface
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('iso', $iso));
-        $country = $this->countryRepository->search($criteria, Context::createDefaultContext())->first();
 
-        $this->cacheCountries[$iso] = null;
-        if ($country instanceof CountryEntity) {
-            $this->cacheCountries[$iso] = $country->getId();
-        }
+        $this->cacheCountries[$iso] = $this->countryRepository->searchIds(
+            $criteria,
+            Context::createDefaultContext()
+        )->firstId();
 
         return $this->cacheCountries[$iso];
     }

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/CustomerSerializer.php
@@ -2,9 +2,7 @@
 
 namespace Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Entity;
 
-use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
-use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -12,24 +10,23 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Contracts\Service\ResetInterface;
 
 #[Package('core')]
 class CustomerSerializer extends EntitySerializer implements ResetInterface
 {
     /**
-     * @var array<string>|null[]
+     * @var array<string, string|null>
      */
     private array $cacheCustomerGroups = [];
 
     /**
-     * @var array<string>|null[]
+     * @var array<string, string|null>
      */
     private array $cachePaymentMethods = [];
 
     /**
-     * @var array<string>|null[]
+     * @var array<string, string|null>
      */
     private array $cacheSalesChannels = [];
 
@@ -43,11 +40,6 @@ class CustomerSerializer extends EntitySerializer implements ResetInterface
     ) {
     }
 
-    /**
-     * @param array|\Traversable $entity
-     *
-     * @return array|\Traversable
-     */
     public function deserialize(Config $config, EntityDefinition $definition, $entity)
     {
         $entity = \is_array($entity) ? $entity : iterator_to_array($entity);
@@ -56,9 +48,11 @@ class CustomerSerializer extends EntitySerializer implements ResetInterface
 
         $deserialized = \is_array($deserialized) ? $deserialized : iterator_to_array($deserialized);
 
+        $context = Context::createDefaultContext();
+
         if (!isset($deserialized['groupId']) && isset($entity['group'])) {
             $name = $entity['group']['translations']['DEFAULT']['name'] ?? null;
-            $id = $entity['group']['id'] ?? $this->getCustomerGroupId($name);
+            $id = $entity['group']['id'] ?? $this->getCustomerGroupId($name, $context);
 
             if ($id) {
                 $deserialized['groupId'] = $id;
@@ -68,7 +62,7 @@ class CustomerSerializer extends EntitySerializer implements ResetInterface
 
         if (!isset($deserialized['defaultPaymentMethodId']) && isset($entity['defaultPaymentMethod'])) {
             $name = $entity['defaultPaymentMethod']['translations']['DEFAULT']['name'] ?? null;
-            $id = $entity['defaultPaymentMethod']['id'] ?? $this->getDefaultPaymentMethodId($name);
+            $id = $entity['defaultPaymentMethod']['id'] ?? $this->getDefaultPaymentMethodId($name, $context);
 
             if ($id) {
                 $deserialized['defaultPaymentMethodId'] = $id;
@@ -78,7 +72,7 @@ class CustomerSerializer extends EntitySerializer implements ResetInterface
 
         if (!isset($deserialized['salesChannelId']) && isset($entity['salesChannel'])) {
             $name = $entity['salesChannel']['translations']['DEFAULT']['name'] ?? null;
-            $id = $entity['salesChannel']['id'] ?? $this->getSalesChannelId($name);
+            $id = $entity['salesChannel']['id'] ?? $this->getSalesChannelId($name, $context);
 
             if ($id) {
                 $deserialized['salesChannelId'] = $id;
@@ -101,7 +95,7 @@ class CustomerSerializer extends EntitySerializer implements ResetInterface
         $this->cacheSalesChannels = [];
     }
 
-    private function getCustomerGroupId(?string $name): ?string
+    private function getCustomerGroupId(?string $name, Context $context): ?string
     {
         if (!$name) {
             return null;
@@ -113,17 +107,15 @@ class CustomerSerializer extends EntitySerializer implements ResetInterface
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('name', $name));
-        $group = $this->customerGroupRepository->search($criteria, Context::createDefaultContext())->first();
-
-        $this->cacheCustomerGroups[$name] = null;
-        if ($group instanceof CustomerGroupEntity) {
-            $this->cacheCustomerGroups[$name] = $group->getId();
-        }
+        $this->cacheCustomerGroups[$name] = $this->customerGroupRepository->searchIds(
+            $criteria,
+            $context
+        )->firstId();
 
         return $this->cacheCustomerGroups[$name];
     }
 
-    private function getDefaultPaymentMethodId(?string $name): ?string
+    private function getDefaultPaymentMethodId(?string $name, Context $context): ?string
     {
         if (!$name) {
             return null;
@@ -135,17 +127,16 @@ class CustomerSerializer extends EntitySerializer implements ResetInterface
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('name', $name));
-        $paymentMethod = $this->paymentMethodRepository->search($criteria, Context::createDefaultContext())->first();
 
-        $this->cachePaymentMethods[$name] = null;
-        if ($paymentMethod instanceof PaymentMethodEntity) {
-            $this->cachePaymentMethods[$name] = $paymentMethod->getId();
-        }
+        $this->cachePaymentMethods[$name] = $this->paymentMethodRepository->searchIds(
+            $criteria,
+            $context
+        )->firstId();
 
         return $this->cachePaymentMethods[$name];
     }
 
-    private function getSalesChannelId(?string $name): ?string
+    private function getSalesChannelId(?string $name, Context $context): ?string
     {
         if (!$name) {
             return null;
@@ -157,12 +148,11 @@ class CustomerSerializer extends EntitySerializer implements ResetInterface
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('name', $name));
-        $salesChannel = $this->salesChannelRepository->search($criteria, Context::createDefaultContext())->first();
 
-        $this->cacheSalesChannels[$name] = null;
-        if ($salesChannel instanceof SalesChannelEntity) {
-            $this->cacheSalesChannels[$name] = $salesChannel->getId();
-        }
+        $this->cacheSalesChannels[$name] = $this->salesChannelRepository->searchIds(
+            $criteria,
+            $context
+        )->firstId();
 
         return $this->cacheSalesChannels[$name];
     }

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
@@ -69,16 +69,18 @@ class MediaSerializer extends AbstractMediaSerializer implements ResetInterface
             return $deserialized;
         }
 
+        $context = Context::createDefaultContext();
+
         $media = null;
         if (isset($deserialized['id'])) {
-            $media = $this->mediaRepository->search(new Criteria([$deserialized['id']]), Context::createDefaultContext())->getEntities()->first();
+            $media = $this->mediaRepository->search(new Criteria([$deserialized['id']]), $context)->getEntities()->first();
         }
 
         $isNew = $media === null;
 
         if ($isNew || $media->getUrl() !== $url) {
             $entityName = $config->get('sourceEntity') ?? $definition->getEntityName();
-            $deserialized['mediaFolderId'] ??= $this->getMediaFolderId($deserialized['id'] ?? null, $entityName);
+            $deserialized['mediaFolderId'] ??= $this->getMediaFolderId($deserialized['id'] ?? null, $entityName, $context);
 
             $deserialized['id'] ??= Uuid::randomHex();
 
@@ -98,7 +100,7 @@ class MediaSerializer extends AbstractMediaSerializer implements ResetInterface
             }
 
             if ($isNew && $media->getHash()) {
-                $deserialized = $this->fetchExistingMediaByHash($deserialized, $media->getHash());
+                $deserialized = $this->fetchExistingMediaByHash($deserialized, $media->getHash(), $context);
             }
 
             $this->cacheMediaFiles[(string) $deserialized['id']] = [
@@ -148,12 +150,12 @@ class MediaSerializer extends AbstractMediaSerializer implements ResetInterface
         $this->cacheMediaFiles = [];
     }
 
-    private function getMediaFolderId(?string $id, string $entity): string
+    private function getMediaFolderId(?string $id, string $entity, Context $context): string
     {
         if ($id !== null) {
-            $folder = $this->mediaFolderRepository->search(new Criteria([$id]), Context::createDefaultContext())->getEntities()->first();
-            if ($folder !== null) {
-                return $folder->getId();
+            $folderId = $this->mediaFolderRepository->searchIds(new Criteria([$id]), $context)->firstId();
+            if ($folderId !== null) {
+                return $folderId;
             }
         }
 
@@ -161,22 +163,21 @@ class MediaSerializer extends AbstractMediaSerializer implements ResetInterface
         $criteria->addFilter(new EqualsFilter('media_folder.defaultFolder.entity', $entity));
         $criteria->addAssociation('defaultFolder');
 
-        $default = $this->mediaFolderRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
-
-        if ($default !== null) {
-            return $default->getId();
+        $defaultFolderId = $this->mediaFolderRepository->searchIds($criteria, $context)->firstId();
+        if ($defaultFolderId !== null) {
+            return $defaultFolderId;
         }
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('media_folder.defaultFolder.entity', 'import_export_profile'));
         $criteria->addAssociation('defaultFolder');
 
-        $fallback = $this->mediaFolderRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
-        if ($fallback === null) {
+        $fallbackFolderId = $this->mediaFolderRepository->searchIds($criteria, $context)->firstId();
+        if ($fallbackFolderId === null) {
             throw new \RuntimeException('Failed to find default media folder for import_export_profile');
         }
 
-        return $fallback->getId();
+        return $fallbackFolderId;
     }
 
     private function fetchFileFromURL(string $url, string $extension): ?MediaFile
@@ -204,15 +205,14 @@ class MediaSerializer extends AbstractMediaSerializer implements ResetInterface
      *
      * @return array<string, mixed>
      */
-    private function fetchExistingMediaByHash(array $deserialized, string $hash): array
+    private function fetchExistingMediaByHash(array $deserialized, string $hash, Context $context): array
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('metaData.hash', $hash));
 
-        $media = $this->mediaRepository->search($criteria, Context::createDefaultContext())->getEntities()->first();
-
-        if ($media) {
-            $deserialized['id'] = $media->getId();
+        $mediaId = $this->mediaRepository->searchIds($criteria, $context)->firstId();
+        if ($mediaId !== null) {
+            $deserialized['id'] = $mediaId;
         }
 
         return $deserialized;

--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/PriceSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/PriceSerializer.php
@@ -17,7 +17,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Currency\CurrencyCollection;
-use Shopware\Core\System\Currency\CurrencyEntity;
 
 #[Package('core')]
 class PriceSerializer extends FieldSerializer
@@ -37,11 +36,13 @@ class PriceSerializer extends FieldSerializer
             return;
         }
 
+        $context = Context::createDefaultContext();
+
         $isoPrices = [];
         foreach ($prices as $price) {
             $price = $price instanceof Struct ? $price->jsonSerialize() : $price;
             $currencyId = $price['currencyId'];
-            $currency = $this->mapToCurrencyIso($currencyId);
+            $currency = $this->mapToCurrencyIso($currencyId, $context);
 
             if (isset($price['listPrice']) && $price['listPrice'] instanceof Struct) {
                 $price['listPrice'] = $price['listPrice']->jsonSerialize();
@@ -67,8 +68,10 @@ class PriceSerializer extends FieldSerializer
             return null;
         }
 
+        $context = Context::createDefaultContext();
+
         foreach ($record as $currencyIso => $price) {
-            $currency = $this->getCurrencyIdFromIso($currencyIso);
+            $currency = $this->getCurrencyIdFromIso($currencyIso, $context);
 
             if ($currency === null || !$this->isValidPrice($price)) {
                 continue;
@@ -113,17 +116,17 @@ class PriceSerializer extends FieldSerializer
             && filter_var($price['gross'] ?? null, \FILTER_VALIDATE_FLOAT) !== false;
     }
 
-    private function mapToCurrencyIso(string $currencyId): string
+    private function mapToCurrencyIso(string $currencyId, Context $context): string
     {
         $currency = $this->currencyRepository
-            ->search(new Criteria([$currencyId]), Context::createDefaultContext())
+            ->search(new Criteria([$currencyId]), $context)
             ->getEntities()
             ->first();
 
         return $currency ? $currency->getIsoCode() : $currencyId;
     }
 
-    private function getCurrencyIdFromIso(string $iso): ?string
+    private function getCurrencyIdFromIso(string $iso, Context $context): ?string
     {
         if ($iso === 'DEFAULT') {
             return Defaults::CURRENCY;
@@ -135,9 +138,6 @@ class PriceSerializer extends FieldSerializer
             $criteria = (new Criteria())->addFilter(new EqualsFilter('isoCode', $iso));
         }
 
-        /** @var CurrencyEntity|null $currency */
-        $currency = $this->currencyRepository->search($criteria, Context::createDefaultContext())->first();
-
-        return $currency === null ? null : $currency->getId();
+        return $this->currencyRepository->searchIds($criteria, $context)->firstId();
     }
 }

--- a/src/Core/Content/ImportExport/Event/Subscriber/ProductVariantsSubscriber.php
+++ b/src/Core/Content/ImportExport/Event/Subscriber/ProductVariantsSubscriber.php
@@ -91,7 +91,9 @@ class ProductVariantsSubscriber implements EventSubscriberInterface, ResetInterf
             return;
         }
 
-        $payload = $this->getCombinationsPayload($variants, $parentId, $parentPayload['productNumber']);
+        $context = Context::createDefaultContext();
+        $payload = $this->getCombinationsPayload($variants, $parentId, $parentPayload['productNumber'], $context);
+
         $variantIds = array_column($payload, 'id');
         $this->connection->executeStatement(
             'DELETE FROM `product_option` WHERE `product_id` IN (:ids);',
@@ -121,7 +123,7 @@ class ProductVariantsSubscriber implements EventSubscriberInterface, ResetInterf
                 SyncOperation::ACTION_UPSERT,
                 $configuratorSettingPayload
             ),
-        ], Context::createDefaultContext(), new SyncBehavior());
+        ], $context, new SyncBehavior());
     }
 
     public function reset(): void
@@ -176,7 +178,7 @@ class ProductVariantsSubscriber implements EventSubscriberInterface, ResetInterf
      *
      * @return CombinationPayload
      */
-    private function getCombinationsPayload(array $variants, string $parentId, string $productNumber): array
+    private function getCombinationsPayload(array $variants, string $parentId, string $productNumber, Context $context): array
     {
         $combinations = $this->getCombinations($variants);
         $payload = [];
@@ -191,8 +193,8 @@ class ProductVariantsSubscriber implements EventSubscriberInterface, ResetInterf
             foreach ($combination as $option) {
                 [$group, $option] = explode('|', $option);
 
-                $optionId = $this->getOptionId($group, $option);
-                $groupId = $this->getGroupId($group);
+                $optionId = $this->getOptionId($group, $option, $context);
+                $groupId = $this->getGroupId($group, $context);
 
                 $options[] = [
                     'id' => $optionId,
@@ -275,7 +277,7 @@ class ProductVariantsSubscriber implements EventSubscriberInterface, ResetInterf
         return $payload;
     }
 
-    private function getGroupId(string $groupName): string
+    private function getGroupId(string $groupName, Context $context): string
     {
         $groupId = Uuid::fromStringToHex($groupName);
 
@@ -286,20 +288,15 @@ class ProductVariantsSubscriber implements EventSubscriberInterface, ResetInterf
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('name', $groupName));
 
-        $group = $this->groupRepository->search($criteria, Context::createDefaultContext())->first();
+        $this->groupIdCache[$groupId] = $this->groupRepository->searchIds(
+            $criteria,
+            $context
+        )->firstId() ?? $groupId;
 
-        if ($group !== null) {
-            $this->groupIdCache[$groupId] = $group->getId();
-
-            return $group->getId();
-        }
-
-        $this->groupIdCache[$groupId] = $groupId;
-
-        return $groupId;
+        return $this->groupIdCache[$groupId];
     }
 
-    private function getOptionId(string $groupName, string $optionName): string
+    private function getOptionId(string $groupName, string $optionName, Context $context): string
     {
         $optionId = Uuid::fromStringToHex(sprintf('%s.%s', $groupName, $optionName));
 
@@ -311,16 +308,11 @@ class ProductVariantsSubscriber implements EventSubscriberInterface, ResetInterf
         $criteria->addFilter(new EqualsFilter('name', $optionName));
         $criteria->addFilter(new EqualsFilter('group.name', $groupName));
 
-        $option = $this->optionRepository->search($criteria, Context::createDefaultContext())->first();
+        $this->optionIdCache[$optionId] = $this->optionRepository->searchIds(
+            $criteria,
+            $context
+        )->firstId() ?? $optionId;
 
-        if ($option !== null) {
-            $this->optionIdCache[$optionId] = $option->getId();
-
-            return $option->getId();
-        }
-
-        $this->optionIdCache[$optionId] = $optionId;
-
-        return $optionId;
+        return $this->optionIdCache[$optionId];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently in some import export serializers the full entities are loaded, although it is not needed, as only the ids are required.

### 2. What does this change do, exactly?
Only load the ids if the rest of the data is not needed.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
