### PR TITLE
NEXT-00000 - Fixes #3519 add Last-Modified header to feeds

### DIFF
--- a/changelog/_unreleased/2024-01-17-add-last-modified-to-feeds.md
+++ b/changelog/_unreleased/2024-01-17-add-last-modified-to-feeds.md
@@ -1,0 +1,9 @@
+---
+title: Add Last-Modified header to feeds response
+issue: NEXT-0000
+author: Fabian Blechschmidt
+author_email: fabian@winkelwagen.de
+author_github: @Schrank
+---
+# Storefront
+* Add HTTP header Last-Modified to `store-api.product.export` route (https://exmaple.org/store-api/product-export/{accessKey}/{fileName})

--- a/src/Core/Content/ProductExport/SalesChannel/ExportController.php
+++ b/src/Core/Content/ProductExport/SalesChannel/ExportController.php
@@ -80,10 +80,7 @@ class ExportController
         $contentType = $this->getContentType($productExport->getFileFormat());
         $encoding = $productExport->getEncoding();
 
-        $response = new Response(
-            $content ?: null, 200, [
-                'Content-Type' => $contentType . ';charset=' . $encoding]
-        );
+        $response = new Response($content ?: null, 200, ['Content-Type' => $contentType . ';charset=' . $encoding]);
         $response->setLastModified((new \DateTimeImmutable())->setTimestamp($this->fileSystem->lastModified($filePath)));
         $response->setCharset($encoding);
         return $response;

--- a/src/Core/Content/ProductExport/SalesChannel/ExportController.php
+++ b/src/Core/Content/ProductExport/SalesChannel/ExportController.php
@@ -83,6 +83,7 @@ class ExportController
         $response = new Response($content ?: null, 200, ['Content-Type' => $contentType . ';charset=' . $encoding]);
         $response->setLastModified((new \DateTimeImmutable())->setTimestamp($this->fileSystem->lastModified($filePath)));
         $response->setCharset($encoding);
+
         return $response;
     }
 

--- a/src/Core/Content/ProductExport/SalesChannel/ExportController.php
+++ b/src/Core/Content/ProductExport/SalesChannel/ExportController.php
@@ -80,8 +80,13 @@ class ExportController
         $contentType = $this->getContentType($productExport->getFileFormat());
         $encoding = $productExport->getEncoding();
 
-        return (new Response($content ?: null, 200, ['Content-Type' => $contentType . ';charset=' . $encoding]))
-            ->setCharset($encoding);
+        $response = new Response(
+            $content ?: null, 200, [
+                'Content-Type' => $contentType . ';charset=' . $encoding]
+        );
+        $response->setLastModified((new \DateTimeImmutable())->setTimestamp($this->fileSystem->lastModified($filePath)));
+        $response->setCharset($encoding);
+        return $response;
     }
 
     private function getContentType(string $fileFormat): string

--- a/tests/integration/Core/Content/ProductExport/SalesChannel/ProductExportControllerTest.php
+++ b/tests/integration/Core/Content/ProductExport/SalesChannel/ProductExportControllerTest.php
@@ -172,7 +172,7 @@ class ProductExportControllerTest extends TestCase
         $client->request('GET', getenv('APP_URL') . sprintf('/store-api/product-export/%s/%s', $productExportDe->getAccessKey(), $productExportDe->getFileName()));
 
         $csvRows = explode(\PHP_EOL, (string) $client->getResponse()->getContent());
-
+        static::assertNotNull('Last-Modified', $client->getResponse()->headers->get('Last-Modified'));
         static::assertCount(4, $csvRows);
         static::assertEquals('SwagTheme DE Test', $csvRows[1]);
     }


### PR DESCRIPTION
Get's the lastModified date from the export file and adds it to the header.

Thinks not considered yet:
- Does the file always exist?
- How to test?

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
