### PR TITLE
fix: Return type of collection iterator

### DIFF
--- a/changelog/_unreleased/2024-01-17-fix-return-type-of-collection-iterator.md
+++ b/changelog/_unreleased/2024-01-17-fix-return-type-of-collection-iterator.md
@@ -1,0 +1,9 @@
+---
+title: Fix return type of collection iterator
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed return typehint of `Shopware\Core\Framework\Struct\Collection::getIterator` to return the correct elements of the collection

--- a/src/Core/Framework/Struct/Collection.php
+++ b/src/Core/Framework/Struct/Collection.php
@@ -206,7 +206,7 @@ abstract class Collection extends Struct implements \IteratorAggregate, \Countab
     }
 
     /**
-     * @return \Generator<TElement>
+     * @return \Traversable<TElement>
      */
     public function getIterator(): \Traversable
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when one is iterating through an collection, the type of the elements is not correctly recognized, since the return typehint of the `getIterator` method is wrong. 

A workaround was to iterate through `Collection::getElements()`, this change should remove the need to call this method.

### 2. What does this change do, exactly?
Fix the return type.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
