### PR TITLE
NEXT-33234 - feat: implement product-stream custom field entity select

### DIFF
--- a/changelog/_unreleased/2023-03-24-implement-custom-field-entity-select-for-dynamic-product-groups.md
+++ b/changelog/_unreleased/2023-03-24-implement-custom-field-entity-select-for-dynamic-product-groups.md
@@ -1,0 +1,9 @@
+---
+title: Implement Custom Field entity select for dynamic product groups
+issue: -
+author: Rafael Kraut
+author_email: 14234815+RafaelKr@users.noreply.github.com
+author_github: RafaelKr
+___
+# Administration
+* Update dynamic product group condition component `module/sw-product-stream/component/sw-product-stream-value` to show a `sw-entity-single-select` or `sw-entity-multi-id-select` for custom fields of type `'entity'`. Previously this rendered a text field where you had to insert an UUID. 

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/index.js
@@ -343,6 +343,16 @@ export default {
             return criteria;
         },
 
+        customFieldCriteria() {
+            const criteria = new Criteria(1, 25);
+
+            if (typeof this.searchTerm === 'string' && this.searchTerm.length > 0) {
+                criteria.addQuery(Criteria.contains('name', this.searchTerm), 500);
+            }
+
+            return criteria;
+        },
+
         visibilitiesLabelCallback() {
             return (item) => {
                 if (!item) {
@@ -477,6 +487,16 @@ export default {
             }
 
             return Object.values(category.breadcrumb).join(' / ');
+        },
+
+        isCustomField(fieldName) {
+            const strippedFieldName = fieldName.replace(/customFields\./, '');
+
+            return Object.keys(this.productCustomFields).includes(strippedFieldName);
+        },
+
+        getCustomFieldEntityName(fieldName) {
+            return fieldName.replace(/customFields\./, '');
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/index.js
@@ -489,14 +489,22 @@ export default {
             return Object.values(category.breadcrumb).join(' / ');
         },
 
-        isCustomField(fieldName) {
+        isEntityCustomField(fieldName) {
             const strippedFieldName = fieldName.replace(/customFields\./, '');
+            const customField = this.productCustomFields[strippedFieldName];
 
-            return Object.keys(this.productCustomFields).includes(strippedFieldName);
+            if (!customField) {
+                return false;
+            }
+
+            return customField.type === 'entity';
         },
 
         getCustomFieldEntityName(fieldName) {
-            return fieldName.replace(/customFields\./, '');
+            const strippedFieldName = fieldName.replace(/customFields\./, '');
+            const customField = this.productCustomFields[strippedFieldName];
+
+            return customField.config.entity;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.html.twig
@@ -69,6 +69,73 @@
             />
         </template>
 
+        <template v-else-if="isCustomField(fieldName) && fieldType === 'entity'">
+            {% block sw_product_stream_value_entity_single_value_custom_field %}
+            <sw-entity-single-select
+                v-if="!isMultiSelectValue"
+                v-model:value="actualCondition.value"
+                size="medium"
+                :entity="getCustomFieldEntityName(fieldName)"
+                :criteria="customFieldCriteria"
+                :context="context"
+                :disabled="disabled"
+                show-clearable-button
+                @select-collapsed="onSelectCollapsed"
+                @search-term-change="setSearchTerm"
+            >
+                <template #selection-label-property="{ item }">
+                    <slot
+                        name="selection-label-property"
+                        v-bind="{ item }"
+                    >
+                        {{ item.translated?.name || item.name }}
+                    </slot>
+                </template>
+
+                <template #result-description-property="{ item }">
+                    <slot
+                        name="result-description-property"
+                        v-bind="{ item }"
+                    >
+                        {{ item.translated?.name || item.name }}
+                    </slot>
+                </template>
+            </sw-entity-single-select>
+            {% endblock %}
+
+            {% block sw_product_stream_value_entity_multi_value_custom_field %}
+            <sw-entity-multi-id-select
+                v-else-if="isMultiSelectValue"
+                v-model:ids="multiValue"
+                size="medium"
+                :repository="repositoryFactory.create(getCustomFieldEntityName(fieldName))"
+                :criteria="customFieldCriteria"
+                :context="context"
+                :disabled="disabled"
+                @select-collapsed="onSelectCollapsed"
+                @search-term-change="setSearchTerm"
+            >
+                <template #selection-label-property="{ item }">
+                    <slot
+                        name="selection-label-property"
+                        v-bind="{ item }"
+                    >
+                        {{ item.translated?.name || item.name }}
+                    </slot>
+                </template>
+
+                <template #result-label-property="{ item, searchTerm, highlightSearchTerm }">
+                    <slot
+                        name="result-label-property"
+                        v-bind="{ item, searchTerm, highlightSearchTerm }"
+                    >
+                        {{ item.translated?.name || item.name }}
+                    </slot>
+                </template>
+            </sw-entity-multi-id-select>
+            {% endblock %}
+        </template>
+
         <template v-else-if="fieldType === 'uuid'">
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_product_stream_value_entity_single_value %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/component/sw-product-stream-value/sw-product-stream-value.html.twig
@@ -69,7 +69,7 @@
             />
         </template>
 
-        <template v-else-if="isCustomField(fieldName) && fieldType === 'entity'">
+        <template v-else-if="isEntityCustomField(fieldName)">
             {% block sw_product_stream_value_entity_single_value_custom_field %}
             <sw-entity-single-select
                 v-if="!isMultiSelectValue"

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/index.js
@@ -357,6 +357,7 @@ export default {
                                         type: customField.type,
                                         value: `customFields.${customField.name}`,
                                         label: this.getCustomFieldLabel(customField),
+                                        config: customField.config,
                                     });
                                     return acc;
                                 }, {});


### PR DESCRIPTION
This is a followup PR. #3024 included a bug. It only worked if the custom field name was equal to the entity name. I now noticed this and fixed it accordingly. Please see the second commit what I changed since #3024

> Disclaimer: I tested this in my production project running on SW v6.4.20.2; I rebased these changes on the `trunk` branch and adjusted according to the changes I saw in the git history for each modified file since the last PR I made.
> The only actual changes I did while rebasing from #3024 to trunk was changing `v-model` to `v-model:value` and `v-model:ids`.
> I have no SW 6.5+ environment where I could test my changes.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We created a custom field with type entity on products. Currently when creating a new dynamic product stream you can select the custom field, but you need to enter the UUID value.


### 2. What does this change do, exactly?
This change implements the usage of `sw-entity-single-select`/`sw-entity-multi-id-select` fields in these cases, so we get a nice filterable dropdown.

> **Disclaimer:** This patches an urgent need of a customer of us. This PR could be used as is, but this only patches the UX for `CustomFieldTypes::ENTITY`.
> Many other CustomFieldTypes also require a similar patch **which I won't provide**. A clean solution would be to move the condition rendering for custom fields into an own component. Also the filter type should update when using specific custom field types, e.g. `date`.



### 3. Describe each step to reproduce the issue or behaviour.
1. Create a custom field:
  - type: `Shopware\Core\System\CustomField\CustomFieldTypes::ENTITY` (`'entity'`).
  - config:
  ```php
// use Shopware\Core\System\CustomField\CustomFieldTypes;

[
    'entity' => 'product', // or another entity with a name and some entries
    'componentName' => 'sw-entity-single-select',
    'customFieldType' => CustomFieldTypes::Entity,
    'customFieldPosition' => 10,
    'label' => [
        'en-GB' => 'Entity-Test',
        'de-DE' => 'Entity-Test',
    ],
],
```
2. Go to any product and assign a value to the `Entity Test` custom field. You need to know the UUID of that value for step 5.
3. Create a new dynamic product group
4. Select `Entity-Test` => `equals` or `equalsAny`
5. Now you need to enter the UUID of the entity we selected in step 2 to make the product show up in the preview.

With the change applied we now have a dropdown field where we can select the entity/entities instead of entering plain UUID(s).

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/workflow/2020-08-03-implement-New-Changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.