### PR TITLE
NEXT-30261 - Fix old kernel usage

### DIFF
--- a/changelog/_unreleased/2024-01-17-fix-redirect-loop.md
+++ b/changelog/_unreleased/2024-01-17-fix-redirect-loop.md
@@ -1,0 +1,9 @@
+---
+title: Fix redirect loop
+issue: NEXT-30261
+---
+
+# Core
+
+* Changed `Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel` to do nothing, when the entrypoint of the application was not called through the new `KernelFactory`
+* Changed `Shopware\Core\Framework\Adapter\Kernel\HttpKernel` to do nothing, when the entrypoint of the application was not called through the new `KernelFactory`

--- a/public/index.php
+++ b/public/index.php
@@ -2,8 +2,12 @@
 
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
+use Shopware\Core\HttpKernel;
 use Shopware\Core\Installer\InstallerKernel;
-use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\TerminableInterface;
 
 $_SERVER['SCRIPT_FILENAME'] = __FILE__;
 
@@ -14,7 +18,6 @@ if (!file_exists(__DIR__ . '/../.env') && !file_exists(__DIR__ . '/../.env.dist'
 }
 
 $_SERVER['APP_RUNTIME_OPTIONS']['prod_envs'] = ['prod', 'e2e'];
-
 
 return function (array $context) {
     $classLoader = require __DIR__ . '/../vendor/autoload.php';
@@ -49,16 +52,30 @@ return function (array $context) {
         return new InstallerKernel($appEnv, $debug);
     }
 
-    $pluginLoader = null;
+    $shopwareHttpKernel = new HttpKernel($appEnv, $debug, $classLoader);
 
     if (EnvironmentHelper::getVariable('COMPOSER_PLUGIN_LOADER', false)) {
-        $pluginLoader = new ComposerPluginLoader($classLoader, null);
+        $shopwareHttpKernel->setPluginLoader(
+            new ComposerPluginLoader($classLoader, null)
+        );
     }
 
-    return KernelFactory::create(
-        environment: $appEnv,
-        debug: $debug,
-        classLoader: $classLoader,
-        pluginLoader: $pluginLoader
-    );
+    return new class($shopwareHttpKernel) implements HttpKernelInterface, TerminableInterface {
+        private HttpKernel $httpKernel;
+
+        public function __construct(HttpKernel $httpKernel)
+        {
+            $this->httpKernel = $httpKernel;
+        }
+
+        public function handle(Request $request, int $type = self::MAIN_REQUEST, bool $catch = true): Response
+        {
+            return $this->httpKernel->handle($request, $type, $catch)->getResponse();
+        }
+
+        public function terminate(Request $request, Response $response): void
+        {
+            $this->httpKernel->terminate($request, $response);
+        }
+    };
 };

--- a/src/Core/Framework/Adapter/Kernel/HttpCacheKernel.php
+++ b/src/Core/Framework/Adapter/Kernel/HttpCacheKernel.php
@@ -46,6 +46,10 @@ class HttpCacheKernel extends HttpCache
 
     public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
+        if (!KernelFactory::$active) {
+            return $this->getKernel()->handle($request, $type, $catch);
+        }
+
         /**
          * When we have an external reverse proxy which is ESI capable, we can't use the internal HttpCache, as it will resolve the ESI tags
          */

--- a/src/Core/Framework/Adapter/Kernel/HttpKernel.php
+++ b/src/Core/Framework/Adapter/Kernel/HttpKernel.php
@@ -40,6 +40,10 @@ class HttpKernel extends SymfonyHttpKernel
 
     public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
+        if (!KernelFactory::$active) {
+            return parent::handle($request, $type, $catch);
+        }
+
         if ($request->attributes->get('exception') !== null) {
             return parent::handle($request, $type, $catch);
         }

--- a/src/Core/Framework/Adapter/Kernel/KernelFactory.php
+++ b/src/Core/Framework/Adapter/Kernel/KernelFactory.php
@@ -27,6 +27,13 @@ class KernelFactory
      */
     public static string $kernelClass = Kernel::class;
 
+    /**
+     * @deprecated tag:v6.6.0 - Will be removed
+     *
+     * @var bool
+     */
+    public static $active = false;
+
     public static function create(
         string $environment,
         bool $debug,
@@ -34,6 +41,8 @@ class KernelFactory
         ?KernelPluginLoader $pluginLoader = null,
         ?Connection $connection = null
     ): HttpKernelInterface {
+        self::$active = true;
+
         if (InstalledVersions::isInstalled('shopware/platform')) {
             $shopwareVersion = InstalledVersions::getVersion('shopware/platform')
                 . '@' . InstalledVersions::getReference('shopware/platform');

--- a/src/Core/Installer/Database/MigrationCollectionFactory.php
+++ b/src/Core/Installer/Database/MigrationCollectionFactory.php
@@ -52,6 +52,10 @@ class MigrationCollectionFactory
             $coreBasePath = $this->projectDir . '/src/Core';
             $storefrontBasePath = $this->projectDir . '/src/Storefront';
             $adminBasePath = $this->projectDir . '/src/Administration';
+        } else if (file_exists($this->projectDir . '/vendor/shopware/platform/src/Core/schema.sql')) {
+            $coreBasePath = $this->projectDir . '/vendor/shopware/platform/src/Core';
+            $storefrontBasePath = $this->projectDir . '/vendor/shopware/platform/src/Storefront';
+            $adminBasePath = $this->projectDir . '/vendor/shopware/platform/src/Administration';
         } else {
             $coreBasePath = $this->projectDir . '/vendor/shopware/core';
             $storefrontBasePath = $this->projectDir . '/vendor/shopware/storefront';

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -6,7 +6,6 @@ use Doctrine\DBAL\Connection;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Database\MySQLFactory;
 use Shopware\Core\Framework\Api\Controller\FallbackController;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
@@ -151,11 +150,6 @@ class Kernel extends HttpKernel
 
     public function handle(Request $request, int $type = HttpKernelInterface::MAIN_REQUEST, bool $catch = true): Response
     {
-        // @deprecated tag:v6.6.0 - remove complete IF statement
-        if (!Feature::isActive('v6.6.0.0')) {
-            return parent::handle($request, $type, $catch);
-        }
-
         if (!$this->booted) {
             $this->boot();
         }

--- a/tests/unit/Framework/Adapter/Kernel/HttpCacheKernelTest.php
+++ b/tests/unit/Framework/Adapter/Kernel/HttpCacheKernelTest.php
@@ -1,0 +1,169 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Framework\Adapter\Kernel;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel;
+use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpCache\Esi;
+use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel
+ */
+class HttpCacheKernelTest extends TestCase
+{
+    public function testOnOldKernelSkips(): void
+    {
+        $before = KernelFactory::$active;
+        KernelFactory::$active = false;
+
+        $core = $this->createMock(StoreInterface::class);
+        $core->expects(static::never())->method('lookup');
+        $core->expects(static::never())->method('write');
+
+        $kernel = $this->getHttpCacheKernel($core);
+
+        $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, false);
+
+        KernelFactory::$active = $before;
+    }
+
+    public function testNoCacheAvailable(): void
+    {
+        $core = $this->createMock(StoreInterface::class);
+        $core->expects(static::once())->method('lookup');
+        $core->expects(static::never())->method('write');
+
+        $kernel = $this->getHttpCacheKernel($core);
+
+        $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, false);
+    }
+
+    public function testOnNewKernelWithCachedResponse(): void
+    {
+        $core = $this->createMock(StoreInterface::class);
+        $cachedResponse = new Response('cached', 200, ['s-maxage' => 3600]);
+        $cachedResponse->setPublic();
+
+        $core->expects(static::once())->method('lookup')->willReturn($cachedResponse);
+        $core->expects(static::never())->method('write');
+
+        $kernel = $this->getHttpCacheKernel($core);
+
+        $response = $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, false);
+        static::assertSame('cached', (string) $response->getContent());
+    }
+
+    public function testMaintenanceRequestMatches(): void
+    {
+        $core = $this->createMock(StoreInterface::class);
+        $cachedResponse = new Response('cached', 200, ['s-maxage' => 3600]);
+        $cachedResponse->setPublic();
+        $cachedResponse->headers->set(HttpCacheKernel::MAINTENANCE_WHITELIST_HEADER, '1.1.1.1');
+
+        $core->expects(static::once())->method('lookup')->willReturn($cachedResponse);
+        $core->expects(static::never())->method('write');
+
+        $kernel = $this->getHttpCacheKernel($core);
+
+        $request = new Request();
+        $request->server->set('REMOTE_ADDR', '1.1.1.1');
+
+        $response = $kernel->handle($request, HttpKernelInterface::MAIN_REQUEST, false);
+
+        // As we match to the maintenance whitelist, we should not get the cached response
+        static::assertNotEquals('cached', (string) $response->getContent());
+    }
+
+    public function testMaintenanceRequestNotMatches(): void
+    {
+        $core = $this->createMock(StoreInterface::class);
+        $cachedResponse = new Response('cached', 200, ['s-maxage' => 3600]);
+        $cachedResponse->setPublic();
+        $cachedResponse->headers->set(HttpCacheKernel::MAINTENANCE_WHITELIST_HEADER, '1.1.1.1');
+
+        $core->expects(static::once())->method('lookup')->willReturn($cachedResponse);
+        $core->expects(static::never())->method('write');
+
+        $kernel = $this->getHttpCacheKernel($core);
+
+        $response = $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, false);
+
+        // As we match to the maintenance whitelist, we should not get the cached response
+        static::assertEquals('cached', (string) $response->getContent());
+    }
+
+    /**
+     * We cannot call the Symfony HttpKernel component, when we use an external reverse proxy which is able to use ESI tags
+     * The Symfony HttpCache component would resolve the ESI <esi:include> tags in the HTML and won't pass them to the external reverse proxy
+     */
+    public function testInternalHttpCacheGetsSkippedOnReverseProxy(): void
+    {
+        $core = $this->createMock(StoreInterface::class);
+        $core->expects(static::never())->method('lookup');
+
+        $core->expects(static::once())->method('write');
+
+        $kernel = $this->getHttpCacheKernel($core, true);
+
+        $kernel->handle(new Request(), HttpKernelInterface::MAIN_REQUEST, false);
+    }
+
+    /**
+     * @dataProvider providerSkipCaching
+     */
+    public function testSubRequestSkipsCache(Request $request, int $type): void
+    {
+        $core = $this->createMock(StoreInterface::class);
+        $core->expects(static::never())->method('lookup');
+        $core->expects(static::never())->method('write');
+
+        $kernel = $this->getHttpCacheKernel($core);
+
+        $kernel->handle($request, $type, false);
+    }
+
+    public static function providerSkipCaching(): \Generator
+    {
+        yield 'post request' => [
+            new Request(server: ['REQUEST_METHOD' => 'POST']),
+            HttpKernelInterface::MAIN_REQUEST,
+        ];
+
+        yield 'sub request' => [
+            new Request(),
+            HttpKernelInterface::SUB_REQUEST,
+        ];
+    }
+
+    public function getInnerKernel(): HttpKernelInterface&MockObject
+    {
+        $inner = $this->createMock(HttpKernelInterface::class);
+        $inner
+            ->method('handle')
+            ->willReturn(new Response());
+
+        return $inner;
+    }
+
+    public function getHttpCacheKernel(StoreInterface&MockObject $core, bool $reverseProxyEnabled = false): HttpCacheKernel
+    {
+        return new HttpCacheKernel(
+            $this->getInnerKernel(),
+            null,
+            new Esi(),
+            [],
+            new EventDispatcher(),
+            $reverseProxyEnabled,
+            $core
+        );
+    }
+}


### PR DESCRIPTION
As we changed the `public/index.php` to the new Kernel, we no longer tested the old kernel. But everyone outside uses the old kernel method.

The old Kernel way, invoked also the new Kernel way, and therefore the RequestTransformer ran twice:

- Run 1: Found SEO URL, rewriting path to /navigation/:id
- Run 2: You are calling /navigation/:id, looks like an internal URL, please call the real one (first URL). and therefore called again the same page

The broken code path:

```
Shopware\Core\HttpKernel (runs request transformer)
   Symfony\Component\HttpKernel\HttpCache\HttpCache (http caching)
       Shopware\Core\Kernel
            Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel (is again the HTTP cache)
                Shopware\Core\Framework\Adapter\Kernel\HttpKernel (runs request transformer)
                    Shopware\Storefront\Controller\Any
```

After this PR and **old** Kernel:

```
Shopware\Core\HttpKernel (runs request transformer)
   Symfony\Component\HttpKernel\HttpCache\HttpCache
       Shopware\Core\Kernel
            Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel (just calls next class)
                Shopware\Core\Framework\Adapter\Kernel\HttpKernel (just calls next class)
                    Shopware\Storefront\Controller\Any
```

After this PR and **new** Kernel:

```
Shopware\Core\Framework\Adapter\Kernel\KernelFactory
    Shopware\Core\Kernel
        Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel (http caching)
            Shopware\Core\Framework\Adapter\Kernel\HttpKernel (runs request transformer)
                Shopware\Storefront\Controller\Any
```