### PR TITLE
NEXT-00000 - Deprecate SchemaGenerator and CreateSchemaCommand

### DIFF
--- a/changelog/_unreleased/2024-01-18-deprecate-schema-generator.md
+++ b/changelog/_unreleased/2024-01-18-deprecate-schema-generator.md
@@ -1,0 +1,16 @@
+---
+title: Deprecate CreateSchemaCommand and SchemaGenerator 
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Deprecated `\Shopware\Core\Framework\DataAbstractionLayer\Command\CreateSchemaCommand` and `\Shopware\Core\Framework\DataAbstractionLayer\SchemaGenerator`, use `\Shopware\Core\Framework\DataAbstractionLayer\Command\CreateMigrationCommand` and `\Shopware\Core\Framework\DataAbstractionLayer\MigrationQueryGenerator` instead
+___
+# Next Major Version Changes
+
+## \Shopware\Core\Framework\DataAbstractionLayer\Command\CreateSchemaCommand:
+`\Shopware\Core\Framework\DataAbstractionLayer\Command\CreateSchemaCommand` will be removed. You can use `\Shopware\Core\Framework\DataAbstractionLayer\Command\CreateMigrationCommand` instead.
+
+## \Shopware\Core\Framework\DataAbstractionLayer\SchemaGenerator:
+`\Shopware\Core\Framework\DataAbstractionLayer\SchemaGenerator` will be removed. You can use `\Shopware\Core\Framework\DataAbstractionLayer\MigrationQueryGenerator` instead.

--- a/src/Core/Framework/DataAbstractionLayer/Command/CreateSchemaCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/CreateSchemaCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * @deprecated tag:v6.6.0 - Will be removed, use CreateMigrationCommand instead.
+ * @deprecated tag:v6.7.0 - Will be removed, use CreateMigrationCommand instead.
  */
 #[AsCommand(
     name: 'dal:create:schema',
@@ -39,7 +39,7 @@ class CreateSchemaCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         Feature::triggerDeprecationOrThrow(
-            'v6.6.0.0',
+            'v6.7.0.0',
             Feature::deprecatedMethodMessage(self::class, __METHOD__, 'execute'),
         );
 

--- a/src/Core/Framework/DataAbstractionLayer/Command/CreateSchemaCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/CreateSchemaCommand.php
@@ -5,12 +5,16 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Command;
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\SchemaGenerator;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @deprecated tag:v6.6.0 - Will be removed, use CreateMigrationCommand instead.
+ */
 #[AsCommand(
     name: 'dal:create:schema',
     description: 'Creates the database schema',
@@ -34,6 +38,11 @@ class CreateSchemaCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'execute'),
+        );
+
         $io = new ShopwareStyle($input, $output);
         $io->title('DAL generate schema');
 

--- a/src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
@@ -46,7 +46,7 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @deprecated tag:v6.6.0 - Will be removed, use MigrationQueryGenerator instead.
+ * @deprecated tag:v6.7.0 - Will be removed, use MigrationQueryGenerator instead.
  */
 #[Package('core')]
 class SchemaGenerator
@@ -68,7 +68,7 @@ EOL;
     public function generate(EntityDefinition $definition)
     {
         Feature::triggerDeprecationOrThrow(
-            'v6.6.0.0',
+            'v6.7.0.0',
             Feature::deprecatedMethodMessage(self::class, __METHOD__, 'generate')
         );
 

--- a/src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
@@ -42,10 +42,11 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TreeLevelField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TreePathField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\UpdatedAtField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
+ * @deprecated tag:v6.6.0 - Will be removed, use MigrationQueryGenerator instead.
  */
 #[Package('core')]
 class SchemaGenerator
@@ -66,6 +67,11 @@ EOL;
      */
     public function generate(EntityDefinition $definition)
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.6.0.0',
+            Feature::deprecatedMethodMessage(self::class, __METHOD__, 'generate')
+        );
+
         $table = $definition->getEntityName();
 
         $columns = [];

--- a/tests/unit/Core/Framework/DataAbstractionLayer/SchemaGeneratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/SchemaGeneratorTest.php
@@ -52,13 +52,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\SchemaGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\NumberRange\DataAbstractionLayer\NumberRangeField;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
- * @internal
+ * @deprecated tag:v6.7.0 - Will be removed with \Shopware\Core\Framework\DataAbstractionLayer\SchemaGenerator
  */
 #[Package('core')]
 #[CoversClass(SchemaGenerator::class)]
@@ -68,6 +69,8 @@ class SchemaGeneratorTest extends TestCase
 
     protected function setUp(): void
     {
+        Feature::skipTestIfActive('v6.7.0.0', $this);
+
         $this->registry = new StaticDefinitionInstanceRegistry(
             [
                 TestEntityWithAllPossibleFieldsDefinition::class,


### PR DESCRIPTION
### 1. Why is this change necessary?

https://github.com/shopware/shopware/pull/3511

> Hi @M-arcus thanks for the patch! We will of course merge it, but actually we have plans to deprecate this command and instead we would like to encourage using `\Shopware\Core\Framework\DataAbstractionLayer\Command\CreateMigrationCommand` instead - where there appears to already be support for the fields in question. Would you be interested in deprecating this command and the service?
> 
> Let us know how you want to proceed and if not we will merge this and take care of the rest.

### 2. What does this change do, exactly?

It deprecates SchemaGenerator and CreateSchemaCommand.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/shopware/pull/3511

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
