### PR TITLE
NEXT-32815 - Added cache clear to build commands

### DIFF
--- a/changelog/_unreleased/2024-01-22-add-cache-clear-to-build-commands.md
+++ b/changelog/_unreleased/2024-01-22-add-cache-clear-to-build-commands.md
@@ -6,4 +6,4 @@ author_email: danil80sch@gmail.com
 author: Danil Schumin
 ---
 # Core
-* Added cache clear to `build-storefront.sh` and `build-administartion.sh`, to avoid unnecessary development issues
+* Added cache clear to `build-storefront.sh` and `build-administartion.sh`, to avoid unnecessary development issues.

--- a/changelog/_unreleased/2024-01-22-add-cache-clear-to-build-commands.md
+++ b/changelog/_unreleased/2024-01-22-add-cache-clear-to-build-commands.md
@@ -1,0 +1,9 @@
+---
+title: Added cache clear to build commands
+date: 2024-01-22
+author_github: @BreakingTV
+author_email: danil80sch@gmail.com
+author: Danil Schumin
+---
+# Core
+* Added cache clear to `build-storefront.sh` and `build-administartion.sh`, to avoid unnecessary development issues

--- a/src/WebInstaller/Resources/flex-config/bin/build-administration.sh
+++ b/src/WebInstaller/Resources/flex-config/bin/build-administration.sh
@@ -69,3 +69,4 @@ fi
 
 (cd "${ADMIN_ROOT}"/Resources/app/administration && npm install && npm run build)
 [[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
+[[ ${SHOPWARE_SKIP_CACHE_CLEAR-""} ]] || "${BIN_TOOL}" cache:clear

--- a/src/WebInstaller/Resources/flex-config/bin/build-storefront.sh
+++ b/src/WebInstaller/Resources/flex-config/bin/build-storefront.sh
@@ -49,3 +49,4 @@ node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
 [[ ${SHOPWARE_SKIP_THEME_COMPILE-""} ]] || "${BIN_TOOL}" theme:compile
+"${BIN_TOOL}" cache:clear # Add config to skip

--- a/src/WebInstaller/Resources/flex-config/bin/build-storefront.sh
+++ b/src/WebInstaller/Resources/flex-config/bin/build-storefront.sh
@@ -49,4 +49,4 @@ node "${STOREFRONT_ROOT}"/Resources/app/storefront/copy-to-vendor.js
 npm --prefix "${STOREFRONT_ROOT}"/Resources/app/storefront run production
 [[ ${SHOPWARE_SKIP_ASSET_COPY-""} ]] ||"${BIN_TOOL}" assets:install
 [[ ${SHOPWARE_SKIP_THEME_COMPILE-""} ]] || "${BIN_TOOL}" theme:compile
-"${BIN_TOOL}" cache:clear # Add config to skip
+[[ ${SHOPWARE_SKIP_CACHE_CLEAR-""} ]] || "${BIN_TOOL}" cache:clear


### PR DESCRIPTION
### 1. Why is this change necessary?
While working on a plugin or a theme, it's easy to get confused and assume that build commands automatically clear the cache. This update aims to clear up that confusion by adding the cache clear to the build commands.

### 2. What does this change do, exactly?
* Add the cache clear command to the end of `build-storefront.sh`
* Add the cache clear command to the end of `build-administartion.sh`

### 3. Describe each step to reproduce the issue or behaviour.
* 

### 4. Please link to the relevant issues (if any).
*

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
