### PR TITLE
NEXT-00000 - Fix reloading of customer order count

### DIFF
--- a/changelog/_unreleased/2024-01-22-fixed-reloading-of-customer-order-count.md
+++ b/changelog/_unreleased/2024-01-22-fixed-reloading-of-customer-order-count.md
@@ -1,0 +1,8 @@
+---
+title: Fixed reloading of customer order count
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Administration
+* Changed `sw-customer-base-info` to reload the customer order count when customer changes

--- a/changelog/_unreleased/2024-01-22-fixed-reloading-of-customer-order-count.md
+++ b/changelog/_unreleased/2024-01-22-fixed-reloading-of-customer-order-count.md
@@ -1,8 +1,9 @@
 ---
-title: Fixed reloading of customer order count
+title: Fixed reloading of customer orders and customer order count
 author: Marcus Müller
 author_email: 25648755+M-arcus@users.noreply.github.com
 author_github: @M-arcus
 ---
 # Administration
 * Changed `sw-customer-base-info` to reload the customer order count when customer changes
+* Changed `sw-customer-detail-order` to reload the customer orders when customer changes

--- a/changelog/_unreleased/2024-01-22-fixed-reloading-of-customer-orders.md
+++ b/changelog/_unreleased/2024-01-22-fixed-reloading-of-customer-orders.md
@@ -1,8 +1,0 @@
----
-title: Fixed reloading of customer orders
-author: Marcus Müller
-author_email: 25648755+M-arcus@users.noreply.github.com
-author_github: @M-arcus
----
-# Administration
-* Changed `sw-customer-detail-order` to reload the customer orders when customer changes

--- a/changelog/_unreleased/2024-01-22-fixed-reloading-of-customer-orders.md
+++ b/changelog/_unreleased/2024-01-22-fixed-reloading-of-customer-orders.md
@@ -1,0 +1,8 @@
+---
+title: Fixed reloading of customer orders
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Administration
+* Changed `sw-customer-detail-order` to reload the customer orders when customer changes

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/index.js
@@ -108,6 +108,9 @@ export default {
                 });
             },
         },
+        customer() {
+            this.createdComponent();
+        },
     },
 
     created() {

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
@@ -57,6 +57,12 @@ export default {
         },
     },
 
+    watch: {
+        customer() {
+            this.createdComponent();
+        },
+    },
+
     created() {
         this.createdComponent();
     },
@@ -64,6 +70,10 @@ export default {
     methods: {
         createdComponent() {
             this.isLoading = true;
+
+            if (this.orders?.criteria) {
+                this.orders.criteria = null;
+            }
 
             this.refreshList();
         },


### PR DESCRIPTION
### 1. Why is this change necessary?

The value of the order count for the customer does not reload if you change from one customer to another customer in the administration.

### 2. What does this change do, exactly?

It fixes reloading of customer order count when changing to new customer.

### 3. Describe each step to reproduce the issue or behavior.

Enter customer detail view of customer, note the order count, search for another customer, click on search result, wait until loading done. The order count doesn't change.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
