### PR TITLE
NEXT-00000 - Fix reloading of customer orders

### DIFF
--- a/changelog/_unreleased/2024-01-22-fixed-reloading-of-customer-orders.md
+++ b/changelog/_unreleased/2024-01-22-fixed-reloading-of-customer-orders.md
@@ -1,0 +1,8 @@
+---
+title: Fixed reloading of customer orders
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Administration
+* Changed `sw-customer-detail-order` to reload the customer orders when customer changes

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
@@ -57,6 +57,12 @@ export default {
         },
     },
 
+    watch: {
+        customer() {
+            this.createdComponent();
+        },
+    },
+
     created() {
         this.createdComponent();
     },
@@ -64,6 +70,10 @@ export default {
     methods: {
         createdComponent() {
             this.isLoading = true;
+
+            if (this.orders?.criteria) {
+                this.orders.criteria = null;
+            }
 
             this.refreshList();
         },


### PR DESCRIPTION
### 1. Why is this change necessary?

The orders of the customer do not reload if you change from one customer to another customer in the administration.

### 2. What does this change do, exactly?

Fixes reloading of customer orders

### 3. Describe each step to reproduce the issue or behavior.

1. /admin#/sw/customer/detail/<id-1>/order?edit=false
2. Check the orders
3. Same tab: /admin#/sw/customer/detail/<id-">/order?edit=false
4. Same orders appear

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
