### PR TITLE
NEXT-33326 - Use AbstractTranslator as type

### DIFF
--- a/changelog/_unreleased/2024-01-23-change-constructor-type.md
+++ b/changelog/_unreleased/2024-01-23-change-constructor-type.md
@@ -1,0 +1,9 @@
+---
+title: Changed type in constructor
+author: Fabian Boensch
+author_github: @En0Ma1259
+ ---
+# Core
+* Changed constructor type
+# Storefront
+* Changed constructor type

--- a/src/Core/Checkout/Document/Twig/DocumentTemplateRenderer.php
+++ b/src/Core/Checkout/Document/Twig/DocumentTemplateRenderer.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Checkout\Document\Twig;
 
 use Shopware\Core\Checkout\Document\DocumentGenerator\Counter;
 use Shopware\Core\Checkout\Document\Event\DocumentTemplateRendererParameterEvent;
-use Shopware\Core\Framework\Adapter\Translation\Translator;
+use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
@@ -26,7 +26,7 @@ class DocumentTemplateRenderer
     public function __construct(
         private readonly TemplateFinder $templateFinder,
         private readonly Environment $twig,
-        private readonly Translator $translator,
+        private readonly AbstractTranslator $translator,
         private readonly AbstractSalesChannelContextFactory $contextFactory,
         private readonly EventDispatcherInterface $eventDispatcher
     ) {

--- a/src/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandler.php
+++ b/src/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandler.php
@@ -10,7 +10,7 @@ use Shopware\Core\Content\ProductExport\Service\ProductExportRendererInterface;
 use Shopware\Core\Content\ProductExport\Struct\ExportBehavior;
 use Shopware\Core\Content\ProductExport\Struct\ProductExportResult;
 use Shopware\Core\Defaults;
-use Shopware\Core\Framework\Adapter\Translation\Translator;
+use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -43,7 +43,7 @@ final class ProductExportPartialGenerationHandler
         private readonly ProductExportFileHandlerInterface $productExportFileHandler,
         private readonly MessageBusInterface $messageBus,
         private readonly ProductExportRendererInterface $productExportRender,
-        private readonly Translator $translator,
+        private readonly AbstractTranslator $translator,
         private readonly SalesChannelContextServiceInterface $salesChannelContextService,
         private readonly SalesChannelContextPersister $contextPersister,
         private readonly Connection $connection,

--- a/src/Storefront/Page/Cms/DefaultMediaResolver.php
+++ b/src/Storefront/Page/Cms/DefaultMediaResolver.php
@@ -4,7 +4,7 @@ namespace Shopware\Storefront\Page\Cms;
 
 use Shopware\Core\Content\Media\Cms\AbstractDefaultMediaResolver;
 use Shopware\Core\Content\Media\MediaEntity;
-use Shopware\Core\Framework\Adapter\Translation\Translator;
+use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Asset\Packages;
 
@@ -18,7 +18,7 @@ class DefaultMediaResolver extends AbstractDefaultMediaResolver
      */
     public function __construct(
         private readonly AbstractDefaultMediaResolver $decorated,
-        private readonly Translator $translator,
+        private readonly AbstractTranslator $translator,
         private readonly Packages $packages
     ) {
     }

--- a/src/Storefront/Pagelet/Newsletter/Account/NewsletterAccountPageletLoader.php
+++ b/src/Storefront/Pagelet/Newsletter/Account/NewsletterAccountPageletLoader.php
@@ -7,7 +7,7 @@ use Shopware\Core\Checkout\Customer\SalesChannel\AbstractAccountNewsletterRecipi
 use Shopware\Core\Content\Newsletter\SalesChannel\AbstractNewsletterSubscribeRoute;
 use Shopware\Core\Content\Newsletter\SalesChannel\AbstractNewsletterUnsubscribeRoute;
 use Shopware\Core\Content\Newsletter\SalesChannel\NewsletterSubscribeRoute;
-use Shopware\Core\Framework\Adapter\Translation\Translator;
+use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -32,7 +32,7 @@ class NewsletterAccountPageletLoader
         private readonly AbstractNewsletterSubscribeRoute $newsletterSubscribeRoute,
         private readonly AbstractNewsletterUnsubscribeRoute $newsletterUnsubscribeRoute,
         private readonly AbstractAccountNewsletterRecipientRoute $newsletterRecipientRoute,
-        private readonly Translator $translator,
+        private readonly AbstractTranslator $translator,
         private readonly SystemConfigService $systemConfigService
     ) {
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
To be able to decorate the Translator class the type must always be AbstractTranslator.

### 2. What does this change do, exactly?
Change types in class constructors

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-33326

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
