### PR TITLE
NEXT-00000 - Fix for thumbnail generation

### DIFF
--- a/changelog/_unreleased/2024-01-23-fix-thumbnail-generation-edge-cases.md
+++ b/changelog/_unreleased/2024-01-23-fix-thumbnail-generation-edge-cases.md
@@ -1,0 +1,10 @@
+---
+title: Fix for Thumbnail generation Edge Cases
+issue: NEXT-00000
+author: Kevin Hansen
+author_email: kevin.hansen@banemo.de
+---
+# Core
+* Changed and refactored thumbnail size calculation for Edge Cases 
+* Added new class `ThumbnailSizeCalculator` in `src/Core/Content/ProductStream/Media/Thumbnail`
+* Added new test `ThumbnailSizeCalculatorTest` in `tests/unit/Core/Content/Media/Thumbnail`

--- a/src/Core/Content/DependencyInjection/media.xml
+++ b/src/Core/Content/DependencyInjection/media.xml
@@ -221,7 +221,11 @@
             <argument type="service" id="media_folder.repository"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Content\Media\DataAbstractionLayer\MediaIndexer"/>
+            <argument type="service" id="Shopware\Core\Content\Media\Thumbnail\ThumbnailSizeCalculator"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+        </service>
+
+        <service id="Shopware\Core\Content\Media\Thumbnail\ThumbnailSizeCalculator">
         </service>
 
         <service id="Shopware\Core\Content\Media\MediaService">

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -28,6 +28,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @phpstan-type ImageSize array{width: int, height: int}
+ */
 #[Package('buyers-experience')]
 class ThumbnailService
 {
@@ -41,6 +44,7 @@ class ThumbnailService
         private readonly EntityRepository $mediaFolderRepository,
         private readonly EventDispatcherInterface $dispatcher,
         private readonly EntityIndexer $indexer,
+        private readonly ThumbnailSizeCalculator $thumbnailSizeCalculator,
         private readonly Connection $connection
     ) {
     }
@@ -325,7 +329,7 @@ class ThumbnailService
     }
 
     /**
-     * @return array{width: int, height: int}
+     * @return ImageSize
      */
     private function getOriginalImageSize(\GdImage $image): array
     {
@@ -336,9 +340,9 @@ class ThumbnailService
     }
 
     /**
-     * @param array{width: int, height: int} $imageSize
+     * @param ImageSize $imageSize
      *
-     * @return array{width: int, height: int}
+     * @return ImageSize
      */
     private function calculateThumbnailSize(
         array $imageSize,
@@ -346,56 +350,19 @@ class ThumbnailService
         MediaFolderConfigurationEntity $config
     ): array {
         if (!$config->getKeepAspectRatio()) {
-            $calculatedWidth = $preferredThumbnailSize->getWidth();
-            $calculatedHeight = $preferredThumbnailSize->getHeight();
-
-            $useOriginalSizeInThumbnails = $imageSize['width'] < $calculatedWidth || $imageSize['height'] < $calculatedHeight;
-
-            return $useOriginalSizeInThumbnails ? [
-                'width' => $imageSize['width'],
-                'height' => $imageSize['height'],
-            ] : [
-                'width' => $calculatedWidth,
-                'height' => $calculatedHeight,
-            ];
+            return $this->thumbnailSizeCalculator->determineValidSize(
+                $imageSize,
+                $preferredThumbnailSize->getWidth(),
+                $preferredThumbnailSize->getHeight()
+            );
         }
 
-        if ($imageSize['width'] >= $imageSize['height']) {
-            $factor = $preferredThumbnailSize->getWidth() / $imageSize['width'];
-
-            $calculatedWidth = $preferredThumbnailSize->getWidth();
-            $calculatedHeight = (int) ceil($imageSize['height'] * $factor);
-
-            $useOriginalSizeInThumbnails = $imageSize['width'] < $calculatedWidth || $imageSize['height'] < $calculatedHeight;
-
-            return $useOriginalSizeInThumbnails ? [
-                'width' => $imageSize['width'],
-                'height' => $imageSize['height'],
-            ] : [
-                'width' => $calculatedWidth,
-                'height' => $calculatedHeight,
-            ];
-        }
-
-        $factor = $preferredThumbnailSize->getHeight() / $imageSize['height'];
-
-        $calculatedWidth = (int) ceil($imageSize['width'] * $factor);
-        $calculatedHeight = $preferredThumbnailSize->getHeight();
-
-        $useOriginalSizeInThumbnails = $imageSize['width'] < $calculatedWidth || $imageSize['height'] < $calculatedHeight;
-
-        return $useOriginalSizeInThumbnails ? [
-            'width' => $imageSize['width'],
-            'height' => $imageSize['height'],
-        ] : [
-            'width' => $calculatedWidth,
-            'height' => $calculatedHeight,
-        ];
+        return $this->thumbnailSizeCalculator->calculateSize($imageSize, $preferredThumbnailSize);
     }
 
     /**
-     * @param array{width: int, height: int} $originalImageSize
-     * @param array{width: int, height: int} $thumbnailSize
+     * @param ImageSize $originalImageSize
+     * @param ImageSize $thumbnailSize
      */
     private function createNewImage(\GdImage $mediaImage, MediaType $type, array $originalImageSize, array $thumbnailSize): \GdImage
     {

--- a/src/Core/Content/Media/Thumbnail/ThumbnailSizeCalculator.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailSizeCalculator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Content\Media\Thumbnail;
+
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeEntity;
+
+/**
+ * @phpstan-import-type ImageSize from ThumbnailService
+ */
+class ThumbnailSizeCalculator
+{
+    /**
+     * @param ImageSize $imageSize
+     *
+     * @return ImageSize
+     */
+    public function calculateSize(
+        array $imageSize,
+        MediaThumbnailSizeEntity $preferredThumbnailSize
+    ): array {
+        if ($imageSize['width'] >= $imageSize['height']) {
+            $factor = $preferredThumbnailSize->getWidth() / $imageSize['width'];
+            if ($preferredThumbnailSize->getHeight() < $imageSize['height'] * $factor) {
+                $factor = $preferredThumbnailSize->getHeight() / $imageSize['height'];
+            }
+        } else {
+            $factor = $preferredThumbnailSize->getHeight() / $imageSize['height'];
+            if ($preferredThumbnailSize->getWidth() < $imageSize['width'] * $factor) {
+                $factor = $preferredThumbnailSize->getWidth() / $imageSize['width'];
+            }
+        }
+
+        $calculatedWidth = (int) round($imageSize['width'] * $factor);
+        $calculatedHeight = (int) round($imageSize['height'] * $factor);
+
+        return $this->determineValidSize($imageSize, $calculatedWidth, $calculatedHeight);
+    }
+
+    /**
+     * @param ImageSize $imageSize
+     *
+     * @return ImageSize
+     */
+    public function determineValidSize(
+        array $imageSize,
+        int $thumbnailWith,
+        int $thumbnailHeight
+    ): array {
+        $useOriginalSizeInThumbnails = $imageSize['width'] < $thumbnailWith || $imageSize['height'] < $thumbnailHeight;
+
+        return $useOriginalSizeInThumbnails ? [
+            'width' => $imageSize['width'],
+            'height' => $imageSize['height'],
+        ] : [
+            'width' => $thumbnailWith,
+            'height' => $thumbnailHeight,
+        ];
+    }
+}

--- a/tests/unit/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/tests/unit/Core/Content/Media/Thumbnail/ThumbnailServiceTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\MediaType\DocumentType;
 use Shopware\Core\Content\Media\MediaType\ImageType;
 use Shopware\Core\Content\Media\Thumbnail\ThumbnailService;
+use Shopware\Core\Content\Media\Thumbnail\ThumbnailSizeCalculator;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexer;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
@@ -46,6 +47,8 @@ class ThumbnailServiceTest extends TestCase
 
     private Connection&MockObject $connection;
 
+    private ThumbnailSizeCalculator $thumbnailSizeCalculator;
+
     protected function setUp(): void
     {
         $this->filesystemPublic = $this->createMock(FilesystemOperator::class);
@@ -53,7 +56,7 @@ class ThumbnailServiceTest extends TestCase
         $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
         $this->indexer = $this->createMock(EntityIndexer::class);
         $this->connection = $this->createMock(Connection::class);
-
+        $this->thumbnailSizeCalculator = new ThumbnailSizeCalculator();
         $this->context = Context::createDefaultContext();
     }
 
@@ -73,6 +76,7 @@ class ThumbnailServiceTest extends TestCase
             $staticMediaFolderRepository,
             $this->dispatcher,
             $this->indexer,
+            $this->thumbnailSizeCalculator,
             $this->connection
         );
 
@@ -111,6 +115,7 @@ class ThumbnailServiceTest extends TestCase
             $staticMediaFolderRepository,
             $this->dispatcher,
             $this->indexer,
+            $this->thumbnailSizeCalculator,
             $this->connection
         );
 
@@ -133,6 +138,7 @@ class ThumbnailServiceTest extends TestCase
             $staticMediaFolderRepository,
             $this->dispatcher,
             $this->indexer,
+            $this->thumbnailSizeCalculator,
             $this->connection
         );
 
@@ -163,6 +169,7 @@ class ThumbnailServiceTest extends TestCase
             $staticMediaFolderRepository,
             $this->dispatcher,
             $this->indexer,
+            $this->thumbnailSizeCalculator,
             $this->connection
         );
 
@@ -194,6 +201,7 @@ class ThumbnailServiceTest extends TestCase
             $staticMediaFolderRepository,
             $this->dispatcher,
             $this->indexer,
+            $this->thumbnailSizeCalculator,
             $this->connection
         );
 
@@ -227,6 +235,7 @@ class ThumbnailServiceTest extends TestCase
             $staticMediaFolderRepository,
             $this->dispatcher,
             $this->indexer,
+            $this->thumbnailSizeCalculator,
             $this->connection
         );
 
@@ -268,6 +277,7 @@ class ThumbnailServiceTest extends TestCase
             $staticMediaFolderRepository,
             $this->dispatcher,
             $this->indexer,
+            $this->thumbnailSizeCalculator,
             $this->connection
         );
 
@@ -297,6 +307,7 @@ class ThumbnailServiceTest extends TestCase
             $staticMediaFolderRepository,
             $this->dispatcher,
             $this->indexer,
+            $this->thumbnailSizeCalculator,
             $this->connection
         );
 
@@ -327,6 +338,7 @@ class ThumbnailServiceTest extends TestCase
             $staticMediaFolderRepository,
             $this->dispatcher,
             $this->indexer,
+            $this->thumbnailSizeCalculator,
             $this->connection
         );
 
@@ -354,7 +366,8 @@ class ThumbnailServiceTest extends TestCase
         return [
             // image size, keep aspect ratio, preferred size, expected size
             [['width' => 800, 'height' => 600], true, ['width' => 400, 'height' => 300], ['width' => 400, 'height' => 300]],
-            [['width' => 800, 'height' => 600], false, ['width' => 400, 'height' => 300], ['width' => 400, 'height' => 300]],
+            [['width' => 800, 'height' => 600], false, ['width' => 800, 'height' => 300], ['width' => 800, 'height' => 300]],
+            [['width' => 200, 'height' => 600], false, ['width' => 800, 'height' => 300], ['width' => 200, 'height' => 600]],
         ];
     }
 

--- a/tests/unit/Core/Content/Media/Thumbnail/ThumbnailSizeCalculatorTest.php
+++ b/tests/unit/Core/Content/Media/Thumbnail/ThumbnailSizeCalculatorTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Media\Thumbnail;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Media\Aggregate\MediaThumbnailSize\MediaThumbnailSizeEntity;
+use Shopware\Core\Content\Media\Thumbnail\ThumbnailService;
+use Shopware\Core\Content\Media\Thumbnail\ThumbnailSizeCalculator;
+
+/**
+ * @phpstan-import-type ImageSize from ThumbnailService
+ */
+#[CoversClass(ThumbnailSizeCalculator::class)]
+class ThumbnailSizeCalculatorTest extends TestCase
+{
+    /**
+     * @param array<string, int> $imageSize
+     * @param array<string, int> $preferredThumbnailSize
+     * @param array<string, int> $expectedSize
+     */
+    #[DataProvider('thumbnailSizeProvider')]
+    public function testCalculateSize(array $imageSize, array $preferredThumbnailSize, array $expectedSize): void
+    {
+        $thumbnailSizeEntity = new MediaThumbnailSizeEntity();
+        $thumbnailSizeEntity->setWidth($preferredThumbnailSize['width']);
+        $thumbnailSizeEntity->setHeight($preferredThumbnailSize['height']);
+
+        $thumbnailSizeCalculator = new ThumbnailSizeCalculator();
+        $calculatedSize = $thumbnailSizeCalculator->calculateSize($imageSize, $thumbnailSizeEntity);
+
+        static::assertEquals($expectedSize, $calculatedSize);
+    }
+
+    /**
+     * @return list<array{0: ImageSize, 1: ImageSize, 2: ImageSize}>
+     */
+    public static function thumbnailSizeProvider(): array
+    {
+        return [
+            // image size, preferred size, expected size
+            [['width' => 2000, 'height' => 1000], ['width' => 800, 'height' => 600], ['width' => 800, 'height' => 400]],
+            [['width' => 2000, 'height' => 1000], ['width' => 600, 'height' => 800], ['width' => 600, 'height' => 300]],
+            [['width' => 2000, 'height' => 1000], ['width' => 800, 'height' => 800], ['width' => 800, 'height' => 400]],
+            [['width' => 1000, 'height' => 2000], ['width' => 800, 'height' => 600], ['width' => 300, 'height' => 600]],
+            [['width' => 1000, 'height' => 2000], ['width' => 600, 'height' => 800], ['width' => 400, 'height' => 800]],
+            [['width' => 1000, 'height' => 2000], ['width' => 800, 'height' => 800], ['width' => 400, 'height' => 800]],
+            [['width' => 1000, 'height' => 1000], ['width' => 800, 'height' => 600], ['width' => 600, 'height' => 600]],
+            [['width' => 1000, 'height' => 1000], ['width' => 600, 'height' => 800], ['width' => 600, 'height' => 600]],
+            [['width' => 1000, 'height' => 1000], ['width' => 800, 'height' => 800], ['width' => 800, 'height' => 800]],
+            [['width' => 1200, 'height' => 1000], ['width' => 800, 'height' => 600], ['width' => 720, 'height' => 600]],
+            [['width' => 1200, 'height' => 1000], ['width' => 600, 'height' => 800], ['width' => 600, 'height' => 500]],
+            [['width' => 1200, 'height' => 1000], ['width' => 800, 'height' => 800], ['width' => 800, 'height' => 667]],
+            [['width' => 1000, 'height' => 1200], ['width' => 800, 'height' => 600], ['width' => 500, 'height' => 600]],
+            [['width' => 1000, 'height' => 1200], ['width' => 600, 'height' => 800], ['width' => 600, 'height' => 720]],
+            [['width' => 1000, 'height' => 1200], ['width' => 800, 'height' => 800], ['width' => 667, 'height' => 800]],
+            [['width' => 1560, 'height' => 723], ['width' => 730, 'height' => 500], ['width' => 730, 'height' => 338]],
+            [['width' => 723, 'height' => 1560], ['width' => 730, 'height' => 500], ['width' => 232, 'height' => 500]],
+        ];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
This Commit is an addition to this PR #3253. In the current state there are Edge Cases in which one side of the generated thumbnail can be larger than configured. To address this Issue the new Implementation checks for that and recalculates the factor.

### 2. What does this change do, exactly?

Image width | Image height | Thumbnail width | Thumbnail height | Factor | New width | New height | New factor | Final width | Final height
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
2000 | 1000 | 800 | 600 | 0,4 | 800 | 400 | | 800 | 400
2000 | 1000 | 600 | 800 | 0,3 | 600 | 300 | | 600 | 300
2000 | 1000 | 800 | 800 | 0,4 | 800 | 400 | | 800 | 400
1000 | 2000 | 800 | 600 | 0,3 | 300 | 600 | | 300 | 600
1000 | 2000 | 600 | 800 | 0,4 | 400 | 800 | | 400 | 800
1000 | 2000 | 800 | 800 | 0,4 | 400 | 800 | | 400 | 800
1000 | 1000 | 800 | 600 | 0,8 | 800 | **_800_** | 0,6 | 600 | 600
1000 | 1000 | 600 | 800 | 0,6 | 600 | 600 | | 600 | 600
1000 | 1000 | 800 | 800 | 0,8 | 800 | 800 | | 800 | 800
1200 | 1000 | 800 | 600 | 0,667 | 800 | **_667_** | 0,6 | 720 | 600
1200 | 1000 | 600 | 800 | 0,5 | 600 | 500 | | 600 | 500
1200 | 1000 | 800 | 800 | 0,667 | 800 | 667 | | 800 | 667
1000 | 1200 | 800 | 600 | 0,5 | 500 | 600 | | 500 | 600
1000 | 1200 | 600 | 800 | 0,667 | **_667_** | 800 | 0,6 | 600 | 720
1000 | 1200 | 800 | 800 | 0,667 | 667 | 800 | | 667 | 800

As you can see there are 3 cases in which the new Thumbnail would be larger than allowed. The new factor Calculation addresses this and recalculates the factor. 

Let's take a look at the second to last row as an example. The old calculation would generate a Thumbnail sized 667x800px. The Thumbnail configuration only allows a thumbnail to be 600x800px. The factor is calculated again and the final dimension of the thumbnail is 600x720px.

### 3. Describe each step to reproduce the issue or behaviour.
Upload an Image with unequal dimensions and an active Thumbnail configuration like 1000x1000px.

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
