### PR TITLE
NEXT-33332 - Prevent invalid config values for currency rounding

### DIFF
--- a/changelog/_unreleased/2024-01-23-prevent-invalid-currency-rounding-configurations.md
+++ b/changelog/_unreleased/2024-01-23-prevent-invalid-currency-rounding-configurations.md
@@ -1,0 +1,12 @@
+---
+title: Prevent invalid values in currency rounding configuration
+issue: NEXT-33332
+author: Felix Schneider
+author_email: felix@wirduzen.de
+author_github: schneider-felix
+---
+# Core
+* Added `Required` flag to values in `CashRoundingConfigField.php`
+
+# Administration
+* Removed `show-clearable-button` attribute from currency rounding interval setting 

--- a/changelog/_unreleased/2024-01-23-prevent-invalid-currency-rounding-configurations.md
+++ b/changelog/_unreleased/2024-01-23-prevent-invalid-currency-rounding-configurations.md
@@ -7,6 +7,6 @@ author_github: schneider-felix
 ---
 # Core
 * Added `Required` flag to values in `CashRoundingConfigField.php`
-
+___
 # Administration
 * Removed `show-clearable-button` attribute from currency rounding interval setting 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/component/sw-settings-price-rounding/sw-settings-price-rounding.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/component/sw-settings-price-rounding/sw-settings-price-rounding.html.twig
@@ -66,7 +66,6 @@
             :help-text="$tc('sw-settings-currency.price-rounding.helpTextInterval')"
             :disabled="itemIntervalDisabled"
             required
-            show-clearable-button
             :options="intervalOptions"
         />
         {% endblock %}
@@ -152,7 +151,6 @@
             :label="$tc('sw-settings-currency.price-rounding.labelInterval')"
             :help-text="$tc('sw-settings-currency.price-rounding.helpTextInterval')"
             required
-            show-clearable-button
             :disabled="totalIntervalDisabled"
             :options="intervalOptions"
         />

--- a/src/Core/Framework/DataAbstractionLayer/Field/CashRoundingConfigField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/CashRoundingConfigField.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer\Field;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldAccessorBuilder\JsonFieldAccessorBuilder;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\CashRoundingConfigFieldSerializer;
 use Shopware\Core\Framework\Log\Package;
 
@@ -14,9 +15,9 @@ class CashRoundingConfigField extends JsonField
         string $propertyName
     ) {
         parent::__construct($storageName, $propertyName, [
-            new IntField('decimals', 'decimals', 0),
-            new FloatField('interval', 'interval'),
-            new BoolField('roundForNet', 'roundForNet'),
+            (new IntField('decimals', 'decimals', 0))->addFlags(new Required()),
+            (new FloatField('interval', 'interval'))->addFlags(new Required()),
+            (new BoolField('roundForNet', 'roundForNet'))->addFlags(new Required()),
         ]);
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Because it is currently possible to enter invalid values into the currency rounding configuration. This leads to 500 internal server errors during the checkout process due to division by zero.

### 2. What does this change do, exactly?

This removes the clearable button from the rounding interval dropdown and adds the required flag in the `CashRoundingConfigField.php`

### 3. Describe each step to reproduce the issue or behaviour.

See the details described in the issue.

### 4. Please link to the relevant issues (if any).

[NEXT-33332](https://issues.shopware.com/issues/NEXT-33332)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


[NEXT-33332]: https://shopware.atlassian.net/browse/NEXT-33332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ