### PR TITLE
fix: incorrent-entity-in-treebuildingnavigationroute

### DIFF
--- a/changelog/_unreleased/2024-01-25-fix-incorrent-entity-in-treebuildingnavigationroute.md
+++ b/changelog/_unreleased/2024-01-25-fix-incorrent-entity-in-treebuildingnavigationroute.md
@@ -1,0 +1,11 @@
+---
+title: Fix incorrect _entity name in TreeBuildingNavigationRoute 
+issue: 
+author: Oliver Terp
+author_email: oliver@terp.nrw
+author_github: @oterp
+---
+# API
+* Changed route attribute in method `load()` in `Shopware\Core\Content\Category\SalesChannel\TreeBuildingNavigationRoute` to fix the _entity.
+
+

--- a/src/Core/Content/Category/SalesChannel/TreeBuildingNavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/TreeBuildingNavigationRoute.php
@@ -29,7 +29,7 @@ class TreeBuildingNavigationRoute extends AbstractNavigationRoute
         return $this->decorated;
     }
 
-    #[Route(path: '/store-api/navigation/{activeId}/{rootId}', name: 'store-api.navigation', methods: ['GET', 'POST'], defaults: ['_entity' => 'payment_method'])]
+    #[Route(path: '/store-api/navigation/{activeId}/{rootId}', name: 'store-api.navigation', methods: ['GET', 'POST'], defaults: ['_entity' => 'category'])]
     public function load(string $activeId, string $rootId, Request $request, SalesChannelContext $context, Criteria $criteria): NavigationRouteResponse
     {
         try {


### PR DESCRIPTION
### 1. Why is this change necessary?
In class Shopware\Core\Content\Category\SalesChannel\TreeBuildingNavigationRoute the _entity parameter in the Route attribute points to a wrong entity.

### 2. What does this change do, exactly?

Correct the _entity parameter to the correct entity name.

### 3. Describe each step to reproduce the issue or behaviour.

The API deliver the wrong entity

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
