### PR TITLE
fix: Array shape of the `ErrorCollection`

### DIFF
--- a/src/Core/Checkout/Cart/Error/ErrorCollection.php
+++ b/src/Core/Checkout/Cart/Error/ErrorCollection.php
@@ -42,7 +42,7 @@ class ErrorCollection extends Collection
     }
 
     /**
-     * @return array<array-key, Error|null>
+     * @return array<array-key, Error>
      */
     public function getErrors(): array
     {
@@ -50,7 +50,7 @@ class ErrorCollection extends Collection
     }
 
     /**
-     * @return array<array-key, Error|null>
+     * @return array<array-key, Error>
      */
     public function getWarnings(): array
     {
@@ -58,7 +58,7 @@ class ErrorCollection extends Collection
     }
 
     /**
-     * @return array<array-key, Error|null>
+     * @return array<array-key, Error>
      */
     public function getNotices(): array
     {
@@ -71,7 +71,7 @@ class ErrorCollection extends Collection
     }
 
     /**
-     * @return array<array-key, Error|null>
+     * @return array<array-key, Error>
      */
     public function filterByErrorLevel(int $errorLevel): array
     {


### PR DESCRIPTION
### 1. Why is this change necessary?
As `filterByErrorLevel()` uses `Shopware\Core\Framework\Struct\Collection::fmap` the resulting array cannot contain `null`.

### 2. What does this change do, exactly?
Fix the array shape return type. Not sure if a changelog is required.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
