### PR TITLE
NEXT-00000 - Fix cloning of structs with enums

### DIFF
--- a/src/Core/Framework/Struct/CloneTrait.php
+++ b/src/Core/Framework/Struct/CloneTrait.php
@@ -12,7 +12,7 @@ trait CloneTrait
         /** @var array<string, object|array<mixed>> $variables */
         $variables = get_object_vars($this);
         foreach ($variables as $key => $value) {
-            if (\is_object($value)) {
+            if (\is_object($value) && !$value instanceof \UnitEnum) {
                 $this->$key = clone $this->$key;
             } elseif (\is_array($value)) {
                 $this->$key = $this->cloneArray($value);
@@ -30,7 +30,7 @@ trait CloneTrait
         $newValue = [];
 
         foreach ($array as $index => $value) {
-            if (\is_object($value)) {
+            if (\is_object($value) && !$value instanceof \UnitEnum) {
                 $newValue[$index] = clone $value;
             } elseif (\is_array($value)) {
                 $newValue[$index] = $this->cloneArray($value);

--- a/tests/unit/Core/Framework/Struct/CloneStructTest.php
+++ b/tests/unit/Core/Framework/Struct/CloneStructTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Struct;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Struct\CloneTrait;
+
+/**
+ * @internal
+ */
+class CloneStructTest extends TestCase
+{
+    public function testClone(): void
+    {
+        $nestedStruct = new CloneStruct();
+        $nestedStruct->backedEnum = CloneStructBackedEnum::Case;
+        $nestedStruct->unitEnum = CloneStructUnitEnum::Case;
+
+        $original = new CloneStruct();
+        $original->arrayOfStructs = [$nestedStruct];
+        $original->backedEnum = CloneStructBackedEnum::Case;
+        $original->nestedStruct = $nestedStruct;
+        $original->unitEnum = CloneStructUnitEnum::Case;
+
+        $clone = clone $original;
+
+        static::assertEquals($original, $clone);
+        static::assertNotSame($original, $clone);
+        
+        static::assertNotSame($original->arrayOfStructs[0], $clone->arrayOfStructs[0]);
+        static::assertNotSame($original->nestedStruct, $clone->nestedStruct);
+    }
+}
+
+/**
+ * @internal
+ */
+class CloneStruct
+{
+    use CloneTrait;
+
+    /**
+     * @var array<array-key, CloneStruct>
+     */
+    public array $arrayOfStructs;
+    public CloneStructBackedEnum $backedEnum;
+    public CloneStructUnitEnum $unitEnum;
+    public CloneStruct $nestedStruct;
+}
+
+
+/**
+ * @internal
+ */
+enum CloneStructBackedEnum: int {
+    case Case = 1;
+}
+
+/**
+ * @internal
+ */
+enum CloneStructUnitEnum {
+    case Case;
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently cloning structs with enums fails.

See #3551

### 2. What does this change do, exactly?

Fixes the `CloneTrait` used by structs to handle enums.


### 3. Describe each step to reproduce the issue or behaviour.

Create a struct containing an enum

```php
enum MyEnum {
    case Case;
}

class MyStruct extends \Shopware\Core\Framework\Struct\Struct
{
    public MyEnum $enum;
}
```

Try to clone that struct

```php
$struct = new MyStruct();
$struct->enum = MyEnum::Case;

dd(clone $struct);
```

### 4. Please link to the relevant issues (if any).

[#3551](https://github.com/shopware/shopware/issues/3551)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

Fixes #3551