### PR TITLE
Add check to prevent notification duplication on update

### DIFF
--- a/changelog/_unreleased/2024-02-06-prevent-notfication-duplication-on-system-update-finish.md
+++ b/changelog/_unreleased/2024-02-06-prevent-notfication-duplication-on-system-update-finish.md
@@ -1,0 +1,8 @@
+---
+title: Prevent notification duplication on system:update:finish
+author: Leon Rustmeier
+author_email: l.rustmeier@heptacom.de
+author_github: @leonrustmeier
+---
+# Administration
+* Added check to prevent notification duplication on running system:update:finish without changing the Shopware version

--- a/src/Administration/Notification/Subscriber/UpdateSubscriber.php
+++ b/src/Administration/Notification/Subscriber/UpdateSubscriber.php
@@ -40,7 +40,7 @@ class UpdateSubscriber implements EventSubscriberInterface
      */
     public function updateFinishedDone(UpdatePostFinishEvent $event): void
     {
-        if ($event->getPostUpdateMessage() === '') {
+        if ($event->getPostUpdateMessage() === '' || $event->getOldVersion() === $event->getNewVersion()) {
             return;
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Let's say you have a CI/CD setup in which you execute system:update:finish after every deployment to ensure that all migrations have run. If you then log in to the administration panel, you will be bombarded with notifications stating "Updated successfully to version 6.X.X.X" for each deployment executed in the meantime when that user was not logged in.

### 2. What does this change do, exactly?

It adds a check if the version of Shopware have actually changed before creating the notification entry in the database.


### 3. Describe each step to reproduce the issue or behaviour.

1. Execute bin/console system:update:finish multiple times
2. Log into the Administration
3. Get the same notification about an successful update multiple times.
4. Feel very informed

![image](https://github.com/shopware/shopware/assets/23141241/7a86c8ad-063b-4dc4-99bd-9254e497d02b)


### 4. Please link to the relevant issues (if any).

none

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
