### PR TITLE
fix: Also update area rule ids in cart calculation

### DIFF
--- a/tests/unit/Core/Checkout/Cart/CartRuleLoaderTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartRuleLoaderTest.php
@@ -13,11 +13,16 @@ use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\CartFactory;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Checkout\Cart\Processor;
+use Shopware\Core\Checkout\Cart\Rule\AlwaysValidRule;
 use Shopware\Core\Checkout\Cart\RuleLoader;
 use Shopware\Core\Checkout\Cart\Tax\TaxDetector;
 use Shopware\Core\Content\Rule\RuleCollection;
+use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Generator;
 use Symfony\Contracts\Cache\CacheInterface;
 
 /**
@@ -80,5 +85,72 @@ class CartRuleLoaderTest extends TestCase
         );
 
         static::assertSame($calculatedCart, $cartRuleLoader->loadByToken($salesChannelContext, $salesChannelContext->getToken())->getCart());
+    }
+
+    public function testProcessorHasCorrectRuleIds(): void
+    {
+        $salesChannelContext = Generator::createSalesChannelContext(); // $this->createMock(SalesChannelContext::class);
+
+        $rule1 = new RuleEntity();
+        $rule1->setId(Uuid::randomHex());
+        $rule1->setName($rule1->getId());
+        $rule1->setPriority(1);
+        $rule1->setAreas([RuleAreas::PRODUCT_AREA, RuleAreas::PAYMENT_AREA]);
+        $rule1->setPayload(new AlwaysValidRule());
+
+        $rule2 = new RuleEntity();
+        $rule2->setId(Uuid::randomHex());
+        $rule2->setName($rule2->getId());
+        $rule2->setPriority(2);
+        $rule2->setAreas([RuleAreas::PRODUCT_AREA]);
+        $rule2->setPayload(new AlwaysValidRule());
+
+        $rule3 = new RuleEntity();
+        $rule3->setId(Uuid::randomHex());
+        $rule3->setName($rule3->getId());
+        $rule3->setPriority(3);
+        $rule3->setAreas([RuleAreas::PAYMENT_AREA, RuleAreas::PAYMENT_AREA]);
+        $rule3->setPayload(new AlwaysValidRule());
+
+        $ruleIds = [$rule1->getId(), $rule2->getId(), $rule3->getId()];
+        $areaRuleIds = [
+            RuleAreas::PRODUCT_AREA => [$rule1->getId(), $rule2->getId()],
+            RuleAreas::PAYMENT_AREA => [$rule1->getId(), $rule3->getId()],
+        ];
+
+        $ruleLoader = $this->createMock(RuleLoader::class);
+        $ruleLoader
+            ->expects(static::once())
+            ->method('load')
+            ->with($salesChannelContext->getContext())
+            ->willReturn(new RuleCollection([$rule1, $rule2, $rule3]))
+        ;
+
+        $processor = $this->createMock(Processor::class);
+        $processor
+            ->expects(static::exactly(3))
+            ->method('process')
+            ->with(static::isInstanceOf(Cart::class), static::callback(function (SalesChannelContext $context) use ($ruleIds, $areaRuleIds) {
+                static::assertEquals($ruleIds, $context->getRuleIds());
+                static::assertEquals($areaRuleIds, $context->getAreaRuleIds());
+
+                return true;
+            }), static::isInstanceOf(CartBehavior::class))
+        ;
+
+        $cartRuleLoader = new CartRuleLoader(
+            $this->createMock(AbstractCartPersister::class),
+            $processor,
+            new NullLogger(),
+            $this->createMock(CacheInterface::class),
+            $ruleLoader,
+            $this->createMock(TaxDetector::class),
+            $this->createMock(Connection::class),
+            $this->createMock(CartFactory::class),
+        );
+
+        $cart = new Cart('test');
+        $cart->setRuleIds($ruleIds);
+        $cartRuleLoader->loadByCart($salesChannelContext, $cart, new CartBehavior());
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the area rule IDs, which are used in the [`EntityCacheKeyGenerator`](https://github.com/shopware/shopware/blob/trunk/src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php#L33), are not set in the cart context.

### 2. What does this change do, exactly?
Set the area rule IDs. 

I am not sure, if there is a reason why the area rule IDs are not set in the cart calculation. I will create a test and changelog, if the PR will be accepted.

### 3. Describe each step to reproduce the issue or behaviour.
Have a cached route, which is used in the cart, and depends on the `RuleAreas::PRODUCT_AREA` rules.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
