### PR TITLE
NEXT-00000 - allow exporting invalid records with import only profiles

### DIFF
--- a/changelog/_unreleased/2024-02-07-import-only-profile-edge-case.md
+++ b/changelog/_unreleased/2024-02-07-import-only-profile-edge-case.md
@@ -1,0 +1,7 @@
+---
+title: Import / Export - Import only profile edge case
+issue: NEXT-00000
+author_github: @jeboehm
+---
+# Core
+* Changed: It is now possible to export invalid records of a failed import with an import only profile.

--- a/src/Core/Content/ImportExport/Service/ImportExportService.php
+++ b/src/Core/Content/ImportExport/Service/ImportExportService.php
@@ -59,7 +59,8 @@ class ImportExportService
     ): ImportExportLogEntity {
         $profileEntity = $this->findProfile($context, $profileId);
 
-        if (!\in_array($profileEntity->getType(), [ImportExportProfileEntity::TYPE_EXPORT, ImportExportProfileEntity::TYPE_IMPORT_EXPORT], true)) {
+        if (!\in_array($profileEntity->getType(), [ImportExportProfileEntity::TYPE_EXPORT, ImportExportProfileEntity::TYPE_IMPORT_EXPORT], true)
+            && $activity !== ImportExportLogEntity::ACTIVITY_INVALID_RECORDS_EXPORT) {
             throw new ProfileWrongTypeException($profileEntity->getId(), $profileEntity->getType());
         }
 

--- a/src/Core/Content/Test/ImportExport/Service/ImportExportServiceTest.php
+++ b/src/Core/Content/Test/ImportExport/Service/ImportExportServiceTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Test\ImportExport\Service;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\ImportExport\Aggregate\ImportExportLog\ImportExportLogEntity;
 use Shopware\Core\Content\ImportExport\Exception\ProfileWrongTypeException;
 use Shopware\Core\Content\ImportExport\Exception\UnexpectedFileTypeException;
 use Shopware\Core\Content\ImportExport\ImportExportProfileEntity;
@@ -238,6 +239,26 @@ class ImportExportServiceTest extends TestCase
             $this->importExportService->prepareImport(Context::createDefaultContext(), $profile['id'], new \DateTimeImmutable(), $uploadedFile);
         } else {
             $this->importExportService->prepareExport(Context::createDefaultContext(), $profile['id'], new \DateTimeImmutable());
+        }
+    }
+
+    #[DataProvider('profileProvider')]
+    public function testExportProfileShouldNotThrowExceptionWhenExportingErrorLog($profile, $task): void
+    {
+        $this->profileRepository->create([$profile], Context::createDefaultContext());
+        $path = tempnam(sys_get_temp_dir(), '');
+        static::assertIsString($path);
+
+        if ($task === 'import') {
+            $this->importExportService->prepareExport(
+                Context::createDefaultContext(),
+                $profile['id'],
+                new \DateTimeImmutable(),
+                null,
+                [],
+                null,
+                ImportExportLogEntity::ACTIVITY_INVALID_RECORDS_EXPORT
+            );
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When using import only profiles it is not possible to see invalid records of a failed import.

### 2. What does this change do, exactly?
ImportExportService uses the same (import-only) profile to generate and export the invalid records, even on console.
The check that ensures that an import-only profile is only used for imports is now skipped when the activity is exporting invalid records.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a random import profile
- Disallow exports
- Set some required fields
- Upload a csv without these missing fields
- The import will fail, it is not possible to export the failed records, users are getting a error message like "The import/export profile with id 018d7e9fc06b76f7bf09ecbcb9364146 can only be used for import"

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
