### PR TITLE
NEXT-13637 - Add cross selling tab to variants

### DIFF
--- a/changelog/_unreleased/2024-02-10-add-cross-selling-tab-to-variants.md
+++ b/changelog/_unreleased/2024-02-10-add-cross-selling-tab-to-variants.md
@@ -1,0 +1,30 @@
+---
+title: Add cross selling tab to variants
+issue: NEXT-13637
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `sw-product-detail.html.twig` to show cross selling tab for variants.
+* Added `isInherited` and its corresponding watcher and methods to `sw-product-detail-cross-selling` component to add inheritance functionality.
+* Deprecated block `sw_product_detail_empty_state` in `sw-product-detail-cross-selling.html.twig`. Use `sw_product_detail_cross_selling_empty_state_card` instead.
+* Deprecated block `sw_product_detail_empty_state_cross_selling_add` in `sw-product-detail-cross-selling.html.twig`. Use `sw_product_detail_cross_selling_empty_state_actions` instead.
+* Added missing blocks to `sw-product-detail-cross-selling.html.twig`:
+    - `sw_product_detail_cross_selling_empty_state`
+    - `sw_product_detail_cross_selling_empty_state_icon`
+    - `sw_product_detail_cross_selling_empty_state_actions_add`
+* Added new blocks to `sw-product-detail-cross-selling.html.twig`:
+    - `sw_product_detail_cross_selling_empty_state_content`
+    - `sw_product_detail_cross_selling_empty_state_content_child`
+    - `sw_product_detail_cross_selling_empty_state_content_child_inherited`
+    - `sw_product_detail_cross_selling_empty_state_content_child_inherited_link`
+    - `sw_product_detail_cross_selling_empty_state_content_child_not_inherited`
+    - `sw_product_detail_cross_selling_empty_state_content_empty`
+    - `sw_product_detail_cross_selling_empty_state_inherit_switch`
+* Added new and removed unused styles in `sw-product-detail-cross-selling.scss`.
+* Added new snippets:
+    - `sw-product.crossselling.inheritedEmptyStateDescription`
+    - `sw-product.crossselling.notInheritedEmptyStateDescription`
+    - `sw-product.crossselling.linkCrossSellingsOfParent`
+    - `sw-product.crossselling.inheritSwitchLabel`

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.html.twig
@@ -234,7 +234,7 @@
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_product_detail_content_tabs_cross_selling %}
                 <sw-tabs-item
-                    v-show="!isChild && showModeSetting"
+                    v-show="showModeSetting"
                     class="sw-product-detail__tab-cross-selling"
                     :route="{ name: 'sw.product.detail.crossSelling', params: { id: $route.params.id } }"
                     :has-error="swProductDetailCrossSellingError"

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/sw-product-detail.spec.js
@@ -247,13 +247,13 @@ describe('module/sw-product/page/sw-product-detail', () => {
 
         const visibleTabItem = [
             '.sw-product-detail__tab-seo',
+            '.sw-product-detail__tab-cross-selling',
             '.sw-product-detail__tab-reviews',
         ];
 
         const invisibleTabItem = [
             '.sw-product-detail__tab-variants',
             '.sw-product-detail__tab-layout',
-            '.sw-product-detail__tab-cross-selling',
         ];
 
         visibleTabItem.forEach(item => {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/de-DE.json
@@ -477,8 +477,12 @@
       "deleteButtonDelete": "Löschen",
       "linkOpenStreamPreview": "Vorschau öffnen",
       "emptyStateDescription": "Für dieses Produkt existiert noch keine Cross-Selling-Konfiguration.",
+      "inheritedEmptyStateDescription": "Dieses Produkt hat vererbte Cross Sellings vom Hauptprodukt.",
+      "notInheritedEmptyStateDescription": "Du kannst jetzt benutzerdefinierte Cross-Selling-Konfigurationen für diese Variante verwenden.",
       "assignEmptyStateDescription": "Das Cross Selling muss zunächst gespeichert werden, bevor Du Produkte hinzufügen kannst.",
-      "assignPlaceholder": "Durchsuche Produkte ..."
+      "assignPlaceholder": "Durchsuche Produkte ...",
+      "linkCrossSellingsOfParent": "Zeige die Cross Sellings des Hauptprodukts",
+      "inheritSwitchLabel": "Nutze die Cross Sellings des Hauptprodukts"
     },
     "featureSets": {
       "cardTitle": "Wesentliche Merkmale",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/snippet/en-GB.json
@@ -477,8 +477,12 @@
       "deleteButtonDelete": "Delete",
       "linkOpenStreamPreview": "Open preview",
       "emptyStateDescription": "There is no Cross Selling configured for this product, yet.",
+      "inheritedEmptyStateDescription": "This product has inherited cross sellings from its parent.",
+      "notInheritedEmptyStateDescription": "You can now use custom Cross Selling configurations for this variant.",
       "assignEmptyStateDescription": "Save the Cross Selling in order to add products to it.",
-      "assignPlaceholder": "Search products..."
+      "assignPlaceholder": "Search products...",
+      "linkCrossSellingsOfParent": "Show cross sellings of parent product",
+      "inheritSwitchLabel": "Use cross sellings from parent product"
     },
     "featureSets": {
       "cardTitle": "Essential Characteristics",

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/index.js
@@ -27,6 +27,7 @@ export default {
     data() {
         return {
             crossSelling: null,
+            isInherited: false,
         };
     },
 
@@ -37,6 +38,7 @@ export default {
 
         ...mapGetters('swProductDetail', [
             'isLoading',
+            'isChild',
         ]),
 
         ...mapGetters('context', [
@@ -70,9 +72,27 @@ export default {
                 this.loadAssignedProducts(item);
             });
         },
+        'product.crossSellings': {
+            handler(value) {
+                if (!value) {
+                    return;
+                }
+
+                this.isInherited = this.isChild && !this.product.crossSellings.total;
+            },
+            immediate: true,
+        },
+    },
+
+    mounted() {
+        this.mountedComponent();
     },
 
     methods: {
+        mountedComponent() {
+            this.isInherited = this.isChild && !this.product.crossSellings.total;
+        },
+
         loadAssignedProducts(crossSelling) {
             const repository = this.repositoryFactory.create(
                 crossSelling.assignedProducts.entity,
@@ -108,6 +128,14 @@ export default {
             this.crossSelling.limit = 24;
 
             this.product.crossSellings.push(this.crossSelling);
+        },
+
+        restoreInheritance() {
+            this.isInherited = true;
+        },
+
+        removeInheritance() {
+            this.isInherited = false;
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.html.twig
@@ -44,27 +44,112 @@
     {% endblock %}
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+    {% block sw_product_detail_cross_selling_empty_state_card %}
+    {# @deprecated tag:v6.7.0 - Block will be removed. Use `sw_product_detail_cross_selling_empty_state_card` instead. #}
+    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_product_detail_empty_state %}
     <sw-card
         v-else
         position-identifier="sw-product-detail-cross-selling-empty-state"
     >
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_product_detail_cross_selling_empty_state %}
         <sw-empty-state
             :title="$tc('sw-product.crossselling.cardTitleCrossSelling')"
-            :subline="$tc('sw-product.crossselling.emptyStateDescription')"
             :absolute="false"
             empty-module
         >
+            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+            {% block sw_product_detail_cross_selling_empty_state_icon %}
             <template #icon>
                 <img
                     :src="assetFilter('/administration/static/img/empty-states/products-empty-state.svg')"
                     :alt="$tc('sw-product.crossselling.cardTitleCrossSelling')"
                 >
             </template>
+            {% endblock %}
 
+            <template #default>
+                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                {% block sw_product_detail_cross_selling_empty_state_content %}
+                <template v-if="isChild">
+                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                    {% block sw_product_detail_cross_selling_empty_state_content_child %}
+                    <template v-if="isInherited">
+                        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                        {% block sw_product_detail_cross_selling_empty_state_content_child_inherited %}
+                        <p>{{ $tc('sw-product.crossselling.inheritedEmptyStateDescription') }}</p>
+                        {% endblock %}
+
+                        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                        {% block sw_product_detail_cross_selling_empty_state_content_child_inherited_link %}
+                        <router-link
+                            v-if="isChild && isInherited"
+                            :to="{ name: 'sw.product.detail.crossSelling', params: { id: product.parentId } }"
+                            class="sw-product-detail-cross-selling__parent-cross-sellings-link"
+                        >
+                            {{ $tc('sw-product.crossselling.linkCrossSellingsOfParent') }}
+                            <sw-icon
+                                name="regular-long-arrow-right"
+                                small
+                            />
+                        </router-link>
+                        {% endblock %}
+                    </template>
+
+                    <template v-else>
+                        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                        {% block sw_product_detail_cross_selling_empty_state_content_child_not_inherited %}
+                        <p>{{ $tc('sw-product.crossselling.notInheritedEmptyStateDescription') }}</p>
+                        {% endblock %}
+                    </template>
+                    {% endblock %}
+                </template>
+
+                <template v-else>
+                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                    {% block sw_product_detail_cross_selling_empty_state_content_empty %}
+                    <p>{{ $tc('sw-product.crossselling.emptyStateDescription') }}</p>
+                    {% endblock %}
+                </template>
+                {% endblock %}
+
+                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                {% block sw_product_detail_cross_selling_empty_state_inherit_switch %}
+                <template v-if="isChild">
+                    <div
+                        class="sw-product-detail-cross-selling__inherit-toggle-wrapper"
+                        :class="{ 'is--inherited': isInherited }"
+                    >
+                        <sw-switch-field
+                            v-model:value="isInherited"
+                            class="sw-product-detail-cross-selling__inherit-switch"
+                            :disabled="!acl.can('product.editor')"
+                        />
+                        <sw-inheritance-switch
+                            class="sw-product-detail-cross-selling__inheritance-icon"
+                            :is-inherited="isInherited"
+                            :disabled="!acl.can('product.editor')"
+                            @inheritance-restore="restoreInheritance"
+                            @inheritance-remove="removeInheritance"
+                        />
+                        <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+                        <label class="sw-product-detail-cross-selling__inheritance-label">
+                            {{ $tc('sw-product.crossselling.inheritSwitchLabel') }}
+                        </label>
+                    </div>
+                </template>
+                {% endblock %}
+            </template>
+
+            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+            {% block sw_product_detail_cross_selling_empty_state_actions %}
+            {# @deprecated tag:v6.7.0 - Block will be removed. Use `sw_product_detail_cross_selling_empty_state_actions` instead. #}
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_product_detail_empty_state_cross_selling_add %}
             <template #actions>
+                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                {% block sw_product_detail_cross_selling_empty_state_actions_add %}
                 <sw-button
                     v-tooltip="{
                         message: onAddCrossSellingTooltipMessage,
@@ -72,15 +157,19 @@
                         showOnDisabledElements: true
                     }"
                     variant="ghost"
-                    :disabled="!acl.can('product.editor') || !isSystemDefaultLanguage"
+                    :disabled="isInherited || !acl.can('product.editor') || !isSystemDefaultLanguage"
                     @click="onAddCrossSelling"
                 >
                     {{ $tc('sw-product.crossselling.buttonAddCrossSelling') }}
                 </sw-button>
+                {% endblock %}
             </template>
             {% endblock %}
+            {% endblock %}
         </sw-empty-state>
+        {% endblock %}
     </sw-card>
+    {% endblock %}
     {% endblock %}
 </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.scss
@@ -1,30 +1,49 @@
 @import "~scss/variables";
 
 .sw-product-detail-cross-selling {
-    .sw-product-detail-cross-selling__context-button {
+    &__context-button {
         float: right;
         padding-bottom: 20px;
     }
 
-    .sw-product-detail-cross-selling__add-btn {
+    &__add-btn {
         display: block;
         margin: 0 auto;
     }
-}
 
-.sw-product-detail-cross-selling__empty-state {
-    .sw-product-detail-cross-selling__empty-state-inner {
+    .sw-empty-state__description p {
+        font-size: $font-size-s;
+        margin: 20px 0;
+    }
+
+    &__parent-cross-sellings-link {
+        margin-bottom: 20px;
+    }
+
+    &__inherit-toggle-wrapper {
         display: flex;
-        flex-direction: column;
         justify-content: center;
         align-items: center;
-        height: 400px;
+        line-height: 16px;
+        font-size: $font-size-xs;
+        margin-bottom: 20px;
+        color: $color-darkgray-200;
 
-        .sw-product-detail-cross-selling__empty-state-inner--label {
-            max-width: 240px;
-            margin-top: 25px;
-            margin-bottom: 25px;
-            text-align: center;
+        &.is--inherited {
+            color: $color-module-purple-900;
         }
+    }
+
+    &__inherit-switch {
+        margin: 0 10px 0 0;
+
+        .sw-field--switch__input {
+            height: 16px;
+            padding: 0;
+        }
+    }
+
+    &__inheritance-icon {
+        margin-right: 8px;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-cross-selling/sw-product-detail-cross-selling.spec.js
@@ -3,7 +3,7 @@
  */
 
 import { mount } from '@vue/test-utils';
-import { createStore } from 'vuex';
+import productStore from 'src/module/sw-product/page/sw-product-detail/state';
 
 const product = {};
 async function createWrapper() {
@@ -18,36 +18,15 @@ async function createWrapper() {
                 'sw-product-cross-selling-form': true,
                 'sw-empty-state': true,
                 'sw-skeleton': true,
+                'sw-icon': true,
+                'sw-inheritance-switch': true,
+                'sw-switch-field': await wrapTestComponent('sw-switch-field'),
             },
             provide: {
                 repositoryFactory: {
                     create: () => ({ search: () => Promise.resolve('bar') }),
                 },
                 acl: { can: () => true },
-            },
-            mocks: {
-                $store: createStore({
-                    modules: {
-                        swProductDetail: {
-                            namespaced: true,
-                            getters: {
-                                isLoading: () => false,
-                            },
-                            state: {
-                                product: product,
-                            },
-                        },
-                        context: {
-                            namespaced: true,
-
-                            getters: {
-                                isSystemDefaultLanguage() {
-                                    return true;
-                                },
-                            },
-                        },
-                    },
-                }),
             },
         },
     });
@@ -69,19 +48,75 @@ describe('src/module/sw-product/view/sw-product-detail-cross-selling', () => {
     let wrapper;
 
     beforeEach(async () => {
-        wrapper = await createWrapper();
+        if (Shopware.State.get('swProductDetail')) {
+            Shopware.State.unregisterModule('swProductDetail');
+        }
+        Shopware.State.registerModule('swProductDetail', productStore);
+
+        if (Shopware.State.get('context')) {
+            Shopware.State.unregisterModule('context');
+        }
+        Shopware.State.registerModule('context', {
+            namespaced: true,
+
+            getters: {
+                isSystemDefaultLanguage() {
+                    return true;
+                },
+            },
+
+            state: {
+                api: {
+                    assetsPath: '/',
+                },
+            },
+        });
     });
 
     it('should be a Vue.JS component', async () => {
+        wrapper = await createWrapper();
+
         expect(wrapper.vm).toBeTruthy();
     });
 
     it('should load assigned products', async () => {
         const customProduct = buildProduct();
 
+        wrapper = await createWrapper();
         await wrapper.setData({ product: customProduct });
         await flushPromises();
 
         expect(customProduct.crossSellings[0].assignedProducts).toStrictEqual(['bar']);
+    });
+
+    it('should show inherited state when product is a variant', async () => {
+        Shopware.State.commit('swProductDetail/setProduct', {
+            id: 'productId',
+            parentId: 'parentProductId',
+            crossSellings: [],
+        });
+        Shopware.State.commit('swProductDetail/setParentProduct', {
+            id: 'parentProductId',
+        });
+
+        wrapper = await createWrapper();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.isChild).toBe(true);
+        expect(wrapper.vm.isInherited).toBe(true);
+    });
+
+    it('should show empty state for main product', async () => {
+        Shopware.State.commit('swProductDetail/setProduct', {
+            id: 'productId',
+            parentId: null,
+            crossSellings: [],
+        });
+
+        wrapper = await createWrapper();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.isChild).toBe(false);
+        expect(wrapper.vm.isInherited).toBe(false);
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, it's not possible to configure cross sellings for variants via Administration even though it's possible via API.

### 2. What does this change do, exactly?
Add inheritance functionality to `sw-product-detail-cross-selling` component and enable cross selling tab for variants.

### 3. Describe each step to reproduce the issue or behaviour.
Create a product with variants via Administration > go to variant configuration > no cross selling tab is shown

### 4. Please link to the relevant issues (if any).
[NEXT-13637](https://issues.shopware.com/issues/NEXT-13637)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


[NEXT-13637]: https://shopware.atlassian.net/browse/NEXT-13637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ