### PR TITLE
NEXT-14691 - Add pseudo modal twig blocks

### DIFF
--- a/changelog/_unreleased/2024-03-18-add-pseudo-modal-twig-blocks.md
+++ b/changelog/_unreleased/2024-03-18-add-pseudo-modal-twig-blocks.md
@@ -1,0 +1,17 @@
+---
+title: Add pseudo modal twig blocks
+issue: NEXT-14691
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Storefront
+* Added new blocks to `pseudo-modal.html.twig`:
+    - `component_pseudo_modal`
+    - `component_pseudo_modal_header`
+    - `component_pseudo_modal_title`
+    - `component_pseudo_modal_close_btn`
+    - `component_pseudo_modal_close_btn_content`
+    - `component_pseudo_modal_body`
+    - `component_pseudo_modal_back_btn_content`
+* Deprecated block `product_detail_zoom_modal_close_button_content` in `pseudo-modal.html.twig`. Use block `component_pseudo_modal_close_btn_content` instead.

--- a/src/Storefront/Resources/views/storefront/component/pseudo-modal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/pseudo-modal.html.twig
@@ -1,35 +1,51 @@
-<div class="js-pseudo-modal-template">
-    <div class="modal modal-lg fade"
-         tabindex="-1"
-         role="dialog">
-        <div class="modal-dialog"
-             role="document">
-            <div class="modal-content">
-                <div class="modal-header only-close">
-                    <div class="modal-title js-pseudo-modal-template-title-element h5"></div>
+{% block component_pseudo_modal %}
+    <div class="js-pseudo-modal-template">
+        <div class="modal modal-lg fade"
+             tabindex="-1"
+             role="dialog">
+            <div class="modal-dialog"
+                 role="document">
+                <div class="modal-content">
+                    {% block component_pseudo_modal_header %}
+                        <div class="modal-header only-close">
+                            {% block component_pseudo_modal_title %}
+                                <div class="modal-title js-pseudo-modal-template-title-element h5"></div>
+                            {% endblock %}
 
-                    <button type="button"
-                            class="btn-close close"
-                            data-bs-dismiss="modal"
-                            aria-label="Close">
-                        {% block product_detail_zoom_modal_close_button_content %}
-                        {% endblock %}
-                    </button>
-                </div>
-                <div class="modal-body js-pseudo-modal-template-content-element">
+                            {% block component_pseudo_modal_close_btn %}
+                                <button type="button"
+                                        class="btn-close close"
+                                        data-bs-dismiss="modal"
+                                        aria-label="Close">
+                                    {% block component_pseudo_modal_close_btn_content %}
+                                        {# @deprecated tag:v6.7.0 - Block will be removed. Use `component_pseudo_modal_close_btn_content` instead. #}
+                                        {% block product_detail_zoom_modal_close_button_content %}{% endblock %}
+                                    {% endblock %}
+                                </button>
+                            {% endblock %}
+                        </div>
+                    {% endblock %}
+
+                    {% block component_pseudo_modal_body %}
+                        <div class="modal-body js-pseudo-modal-template-content-element">
+                        </div>
+                    {% endblock %}
                 </div>
             </div>
-        </div>
-        <template class="js-pseudo-modal-back-btn-template">
-            {# Back button will be rendered by `AjaxModalPlugin` if a `data-prev-url` is given in order to toggle between modals. #}
 
-            {# Attributes `data-url` and `href` will be set automatically by `AjaxModalPlugin`. #}
-            {% block component_pseudo_modal_back_btn %}
-                <button class="js-pseudo-modal-back-btn btn btn-outline-primary" data-ajax-modal="true" data-url="#" href="#">
-                    {% sw_icon 'arrow-left' style { size: 'sm', class: 'me-1' } %}
-                    {{ 'general.back'|trans }}
-                </button>
-            {% endblock %}
-        </template>
+            <template class="js-pseudo-modal-back-btn-template">
+                {# Back button will be rendered by `AjaxModalPlugin` if a `data-prev-url` is given in order to toggle between modals. #}
+
+                {# Attributes `data-url` and `href` will be set automatically by `AjaxModalPlugin`. #}
+                {% block component_pseudo_modal_back_btn %}
+                    <button class="js-pseudo-modal-back-btn btn btn-outline-primary" data-ajax-modal="true" data-url="#" href="#">
+                        {% block component_pseudo_modal_back_btn_content %}
+                            {% sw_icon 'arrow-left' style { size: 'sm', class: 'me-1' } %}
+                            {{ 'general.back'|trans }}
+                        {% endblock %}
+                    </button>
+                {% endblock %}
+            </template>
+        </div>
     </div>
-</div>
+{% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Pseudo modal template is missing many twig blocks which may be used to override/extend the template easily from themes/plugins.

### 2. What does this change do, exactly?
Add the missing twig blocks and deprecate an inappropriately named block.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
[NEXT-14691](https://issues.shopware.com/issues/NEXT-14691)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


[NEXT-14691]: https://shopware.atlassian.net/browse/NEXT-14691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ