### PR TITLE
NEXT-33706 - Fix old links to old documentation and repository

### DIFF
--- a/src/Administration/README.md
+++ b/src/Administration/README.md
@@ -5,13 +5,13 @@ The Administration component is an administrative frontend written in JavaScript
 leverages the Shopware API to administer an instance.
 
 This repository is considered **read-only**. Please send pull requests
-to our [main Shopware repository](https://github.com/shopware/platform). 
+to our [main Shopware repository](https://github.com/shopware/shopware).
 
 Resources
 ---------
 
-  * [Documentation](https://developer.shopware.com/docs/)
-  * [Contributing](https://github.com/shopware/platform#contribution)
-  * [Report issues](https://github.com/shopware/platform/issues) and
-    [send Pull Requests](https://github.com/shopware/platform/pulls)
-    in the [main Shopware repository](https://github.com/shopware/platform)
+  * [Documentation](https://developer.shopware.com)
+  * [Contributing](https://developer.shopware.com/docs/resources/guidelines/code/contribution.html)
+  * [Report issues](https://github.com/shopware/shopware/issues) and
+    [send Pull Requests](https://github.com/shopware/shopware/pulls)
+    in the [main Shopware\Core repository](https://github.com/shopware/shopware)

--- a/src/Core/README.md
+++ b/src/Core/README.md
@@ -4,13 +4,13 @@ Core Component
 The Core component is the e-commerce core for Shopware. It includes an administrative API in PHP and via Rest.
 
 This repository is considered **read-only**. Please send pull requests
-to our [main Shopware repository](https://github.com/shopware/platform). 
+to our [main Shopware repository](https://github.com/shopware/shopware).
 
 Resources
 ---------
 
-  * [Documentation](https://developers.shopware.com)
-  * [Contributing](https://developers.shopware.com/community/contributing-code/)
-  * [Report issues](https://github.com/shopware/platform/issues) and
-    [send Pull Requests](https://github.com/shopware/platform/pulls)
-    in the [main Shopware repository](https://github.com/shopware/platform)
+  * [Documentation](https://developer.shopware.com)
+  * [Contributing](https://developer.shopware.com/docs/resources/guidelines/code/contribution.html)
+  * [Report issues](https://github.com/shopware/shopware/issues) and
+    [send Pull Requests](https://github.com/shopware/shopware/pulls)
+    in the [main Shopware\Core repository](https://github.com/shopware/shopware)

--- a/src/Elasticsearch/README.md
+++ b/src/Elasticsearch/README.md
@@ -5,13 +5,13 @@ The Elasticsearch component is the elasticsearch adapter for the shopware/core.
 It contains the indexing of entities and an adapter for the entity search.
 
 This repository is considered **read-only**. Please send pull requests
-to our [main Shopware repository](https://github.com/shopware/platform). 
+to our [main Shopware repository](https://github.com/shopware/shopware).
 
 Resources
 ---------
 
-  * [Documentation](https://developers.shopware.com)
-  * [Contributing](https://developers.shopware.com/community/contributing-code/)
-  * [Report issues](https://github.com/shopware/platform/issues) and
-    [send Pull Requests](https://github.com/shopware/platform/pulls)
-    in the [main Shopware repository](https://github.com/shopware/platform)
+  * [Documentation](https://developer.shopware.com)
+  * [Contributing](https://developer.shopware.com/docs/resources/guidelines/code/contribution.html)
+  * [Report issues](https://github.com/shopware/shopware/issues) and
+    [send Pull Requests](https://github.com/shopware/shopware/pulls)
+    in the [main Shopware\Core repository](https://github.com/shopware/shopware)

--- a/src/Storefront/README.md
+++ b/src/Storefront/README.md
@@ -4,7 +4,7 @@ Storefront Component
 The Storefront component is a frontend for Shopware\Core written in PHP. 
 
 This repository is considered **read-only**. Please send pull requests
-to our [main Shopware\Core repository](https://github.com/shopware/platform).
+to our [main Shopware\Core repository](https://github.com/shopware/shopware).
 
 
 Getting started
@@ -34,8 +34,8 @@ located in `platform/src/Storefront/Resources/views/storefront/base.html.twig`, 
 Resources
 ---------
 
-  * [Documentation](https://developers.shopware.com)
-  * [Contributing](https://developers.shopware.com/community/contributing-code/)
-  * [Report issues](https://github.com/shopware/platform/issues) and
-    [send Pull Requests](https://github.com/shopware/platform/pulls)
-    in the [main Shopware\Core repository](https://github.com/shopware/platform)
+  * [Documentation](https://developer.shopware.com)
+  * [Contributing](https://developer.shopware.com/docs/resources/guidelines/code/contribution.html)
+  * [Report issues](https://github.com/shopware/shopware/issues) and
+    [send Pull Requests](https://github.com/shopware/shopware/pulls)
+    in the [main Shopware\Core repository](https://github.com/shopware/shopware)


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

* We should avoid dead or old links in documentation

### 2. What does this change do, exactly?

* Use newer links instead of old and dead links (old repository name or Shopware 5 docs)

### 3. Describe each step to reproduce the issue or behaviour.

* Click on „Contributing“ link in README files of core, storefront or elasticsearch.

### 4. Please link to the relevant issues (if any).

* https://issues.shopware.com/issues/NEXT-33706

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
  - no tests needed for docs
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
  - maybe not relevant for a changelog entry?
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
