### PR TITLE
NEXT-00000 [BUG] Update sw-media-modal-v2.html.twig 

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-modal-v2/sw-media-modal-v2.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-modal-v2/sw-media-modal-v2.html.twig
@@ -118,7 +118,7 @@
                             :file-accept="fileAccept"
                             :upload-tag="uploadTag"
                             :default-folder="entityContext"
-                            :target-folder="folderId"
+                            :target-folder-id="folderId"
                             :allow-multi-select="allowMultiSelect"
                         />
                         {% endblock %}


### PR DESCRIPTION
Change property to allow file upload within current folder.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When using sw-media-modal-v2, Uploading files id uploaded to default folder and not the current folder.


### 2. What does this change do, exactly?
Allow files to be uploaded within the current media folder.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add a new media_folder within "Product Media" _(MyFolder)_
2. Edit or create a product in admin
3. Open media modal _(In the media Section)_ go to a folder within "Product Media" _(Created in step 1.)_
4. Upload a file
5. -File in now uploaded under "Product Media" and not the _(MyFolder)_ created in step 1. 


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
