### PR TITLE
NEXT-00000 - Fix transition action names in StateMachineTransitionActions.php

### DIFF
--- a/changelog/_unreleased/2024-02-18-fix-state-machine-action-names
+++ b/changelog/_unreleased/2024-02-18-fix-state-machine-action-names
@@ -1,0 +1,8 @@
+---
+title: Fix state machine action names for paid transitions
+author: Florian Ressel
+author_email: florian@genxtreme.de
+author_github: @resslinger
+---
+# Core
+* Fix state machine action names for paid transitions

--- a/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionActions.php
+++ b/src/Core/System/StateMachine/Aggregation/StateMachineTransition/StateMachineTransitionActions.php
@@ -11,8 +11,8 @@ final class StateMachineTransitionActions
     public const ACTION_COMPLETE = 'complete';
     public const ACTION_DO_PAY = 'do_pay';
     public const ACTION_FAIL = 'fail';
-    public const ACTION_PAID = 'paid';
-    public const ACTION_PAID_PARTIALLY = 'paid_partially';
+    public const ACTION_PAID = 'pay';
+    public const ACTION_PAID_PARTIALLY = 'pay_partially';
     public const ACTION_PROCESS = 'process';
     public const ACTION_PROCESS_UNCONFIRMED = 'process_unconfirmed';
     public const ACTION_REFUND = 'refund';


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The action names for paid transactions is invalid, so I have changed the action names.

### 2. What does this change do, exactly?
The change fix the action names.

### 3. Describe each step to reproduce the issue or behaviour.
Set a order transaction to paid, it will throw an error, that a illegal transaction is submitted.
Change the action names, so the order transaction will be set correctly as paid.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x ] I have read the contribution requirements and fulfil them.
