### PR TITLE
NEXT-10868 - Use order currency if defined to display line items, default to context currency

### DIFF
--- a/changelog/_unreleased/NEXT-10868-fix-currency-display-for-old-orders.md
+++ b/changelog/_unreleased/NEXT-10868-fix-currency-display-for-old-orders.md
@@ -1,0 +1,11 @@
+---
+title: Use order currency if defined to display line items, default to context currency
+issue: NEXT-10868
+flag:
+author: Melvin Achterhuis & Fabian Blechschmidt
+author_email: fabian@winkelwagen.de
+author_github: Schrank
+---
+
+# Storefront
+*  Fixes display of wrong currency for old orders, because the currency is always used from context instead of order

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
@@ -9,14 +9,15 @@
         <div class="line-item-total-price-value">
             {# Shipping costs discounts always have a price of 0, which might be confusing, therefore we do not show those #}
             {% if lineItem.payload.discountScope != 'delivery' %}
-                {{ lineItem.price.totalPrice|currency(order.currency.isoCode ?? context.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }}
+                {{ lineItem.price.totalPrice|currency(currency) }}{{ 'general.star'|trans|sw_sanitize }}
             {% endif %}
 
             {% set referencePrice = lineItem.price.referencePrice %}
             {% if referencePrice is not null and displayMode == 'offcanvas' %}
                 <br>
                 <small class="line-item-reference-price">
-                    ({{ referencePrice.price|currency(order.currency.isoCode ?? context.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }} / {{ referencePrice.referenceUnit }}&nbsp;{{ referencePrice.unitName }})
+                    ({{ referencePrice.price|currency(currency) }}{{ 'general.star'|trans|sw_sanitize }}
+                    / {{ referencePrice.referenceUnit }}&nbsp;{{ referencePrice.unitName }})
                 </small>
             {% endif %}
         </div>

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
@@ -9,14 +9,14 @@
         <div class="line-item-total-price-value">
             {# Shipping costs discounts always have a price of 0, which might be confusing, therefore we do not show those #}
             {% if lineItem.payload.discountScope != 'delivery' %}
-                {{ lineItem.price.totalPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}
+                {{ lineItem.price.totalPrice|currency(order.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }}
             {% endif %}
 
             {% set referencePrice = lineItem.price.referencePrice %}
             {% if referencePrice is not null and displayMode == 'offcanvas' %}
                 <br>
                 <small class="line-item-reference-price">
-                    ({{ referencePrice.price|currency }}{{ 'general.star'|trans|sw_sanitize }} / {{ referencePrice.referenceUnit }}&nbsp;{{ referencePrice.unitName }})
+                    ({{ referencePrice.price|currency(order.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }} / {{ referencePrice.referenceUnit }}&nbsp;{{ referencePrice.unitName }})
                 </small>
             {% endif %}
         </div>

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
@@ -9,14 +9,14 @@
         <div class="line-item-total-price-value">
             {# Shipping costs discounts always have a price of 0, which might be confusing, therefore we do not show those #}
             {% if lineItem.payload.discountScope != 'delivery' %}
-                {{ lineItem.price.totalPrice|currency(order.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }}
+                {{ lineItem.price.totalPrice|currency(order.currency.isoCode ?? context.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }}
             {% endif %}
 
             {% set referencePrice = lineItem.price.referencePrice %}
             {% if referencePrice is not null and displayMode == 'offcanvas' %}
                 <br>
                 <small class="line-item-reference-price">
-                    ({{ referencePrice.price|currency(order.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }} / {{ referencePrice.referenceUnit }}&nbsp;{{ referencePrice.unitName }})
+                    ({{ referencePrice.price|currency(order.currency.isoCode ?? context.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }} / {{ referencePrice.referenceUnit }}&nbsp;{{ referencePrice.unitName }})
                 </small>
             {% endif %}
         </div>

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig
@@ -79,7 +79,9 @@
 
             {% block component_line_item_type_container_col_total_price %}
                 <div class="line-item-total-price">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' %}
+                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                        currency: lineItem.order.currency.isoCode
+                    } %}
                 </div>
             {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig
@@ -73,7 +73,9 @@
 
             {% block component_line_item_type_discount_col_total_price %}
                 <div class="line-item-total-price">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' %}
+                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                        currency: lineItem.order.currency.isoCode
+                    } %}
                 </div>
             {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig
@@ -118,7 +118,9 @@
 
             {% block component_line_item_type_generic_col_total_price %}
                 <div class="line-item-total-price">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' %}
+                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                        currency: lineItem.order.currency.isoCode
+                    } %}
                 </div>
             {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
@@ -121,7 +121,9 @@
 
             {% block component_line_item_type_product_col_total_price %}
                 <div class="line-item-total-price line-item-price">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' %}
+                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                            currency: lineItem.order.currency.isoCode
+                        } %}
                 </div>
             {% endblock %}
 


### PR DESCRIPTION
Closes #3575

Untested and now time to follow up currently.

Thanks @MelvinAchterhuis for the file and the fix

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
#3575

### 2. What does this change do, exactly?
Use the currency from the order not the session

### 3. Describe each step to reproduce the issue or behaviour.
See #3575

### 4. Please link to the relevant issues (if any).
#3575

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
