### PR TITLE
NEXT-00000 - Add customer data to CustomerDeletedEvent

### DIFF
--- a/changelog/_unreleased/2024-02-21-add-customer-data-to-customer-deleted-event.md
+++ b/changelog/_unreleased/2024-02-21-add-customer-data-to-customer-deleted-event.md
@@ -1,0 +1,7 @@
+---
+title: Add customer data to CustomerDeletedEvent
+issue: NEXT-000000
+author_github: @jeboehm
+---
+# Core
+* Changed `CustomerDeletedEvent` to include customer data

--- a/src/Core/Checkout/Customer/Event/CustomerDeletedEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerDeletedEvent.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Customer\Event;
 
 use Shopware\Core\Checkout\Customer\CustomerDefinition;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Flow\Dispatching\Aware\ScalarValuesAware;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
@@ -16,7 +17,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CustomerDeletedEvent extends Event implements ShopwareSalesChannelEvent, MailAware, FlowEventAware
+class CustomerDeletedEvent extends Event implements ShopwareSalesChannelEvent, MailAware, ScalarValuesAware, FlowEventAware
 {
     final public const EVENT_NAME = 'checkout.customer.deleted';
 
@@ -68,5 +69,18 @@ class CustomerDeletedEvent extends Event implements ShopwareSalesChannelEvent, M
     {
         return (new EventDataCollection())
             ->add('customer', new EntityType(CustomerDefinition::class));
+    }
+
+    public function getValues(): array
+    {
+        return [
+            'customerId' => $this->customer->getId(),
+            'customerNumber' => $this->customer->getCustomerNumber(),
+            'customerEmail' => $this->customer->getEmail(),
+            'customerFirstName' => $this->customer->getFirstName(),
+            'customerLastName' => $this->customer->getLastName(),
+            'customerCompany' => $this->customer->getCompany(),
+            'customerSalutationId' => $this->customer->getSalutationId(),
+        ];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The customer's data is not available in \Shopware\Core\Checkout\Customer\Event\CustomerDeletedEvent.

### 2. What does this change do, exactly?
It's not possible to use CustomerAware here, because - depending on the timing - the customer might already be deleted when the event is processed.

### 3. Describe each step to reproduce the issue or behaviour.
- Create a flow to notify the administrator via email about a deleted customer
- Try to access customer in the mail template
- Delete customer in the account personal information page
- No mail is sent

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
