### PR TITLE
NEXT-33918 - Remove unnecessary param

### DIFF
--- a/changelog/_unreleased/2024-02-22-seourlplaceholderhandler-removed-unnecessary-param-from-method-call.md
+++ b/changelog/_unreleased/2024-02-22-seourlplaceholderhandler-removed-unnecessary-param-from-method-call.md
@@ -1,6 +1,6 @@
 ---
 title: SeoUrlPlaceholderHandler - removed unnecessary param from method call
-issue: 00000
+issue: NEXT-33918
 author: Matheus Gontijo
 author_email: matheus@matheusgontijo.com
 author_github: matheusgontijo

--- a/changelog/_unreleased/2024-02-22-seourlplaceholderhandler-removed-unnecessary-param-from-method-call.md
+++ b/changelog/_unreleased/2024-02-22-seourlplaceholderhandler-removed-unnecessary-param-from-method-call.md
@@ -1,0 +1,15 @@
+---
+title: SeoUrlPlaceholderHandler - removed unnecessary param from method call
+issue: 00000
+author: Matheus Gontijo
+author_email: matheus@matheusgontijo.com
+author_github: matheusgontijo
+---
+Simply removed unnecessary param from method call on `SeoUrlPlaceholderHandler` class.
+
+```
+-$path = $this->router->generate($name, $parameters, RouterInterface::ABSOLUTE_PATH);
++$path = $this->router->generate($name, $parameters);
+```
+
+The third param `RouterInterface::ABSOLUTE_PATH` is already the same by default. So, we don't need it anyways.

--- a/src/Core/Content/Seo/SeoUrlPlaceholderHandler.php
+++ b/src/Core/Content/Seo/SeoUrlPlaceholderHandler.php
@@ -33,7 +33,7 @@ class SeoUrlPlaceholderHandler implements SeoUrlPlaceholderHandlerInterface
      */
     public function generate($name, array $parameters = []): string
     {
-        $path = $this->router->generate($name, $parameters, RouterInterface::ABSOLUTE_PATH);
+        $path = $this->router->generate($name, $parameters);
 
         $request = $this->requestStack->getMainRequest();
         $basePath = $request ? $request->getBasePath() : '';


### PR DESCRIPTION
Simply removed unnecessary param from method call on `SeoUrlPlaceholderHandler` class.

```diff
-$path = $this->router->generate($name, $parameters, RouterInterface::ABSOLUTE_PATH);
+$path = $this->router->generate($name, $parameters);
```

The third param `RouterInterface::ABSOLUTE_PATH` is already the same by default. So, we don't need it anyways.