### PR TITLE
NEXT-00000 - Add new block in analytics template

### DIFF
--- a/changelog/_unreleased/2024-02-23-add-new-block-in-analytics-template.md
+++ b/changelog/_unreleased/2024-02-23-add-new-block-in-analytics-template.md
@@ -1,0 +1,9 @@
+---
+title: Add new block in analytics template
+issue: NEXT-00000
+author: Wanne Van Camp
+author_email: info@campit.be
+author_github: wannevancamp
+---
+# Storefront
+* Added new block `component_head_analytics_gtag_consent` in `src/Storefront/Resources/views/storefront/component/analytics.html.twig`

--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -24,21 +24,23 @@
         {% endif %}
     {% endblock %}
 
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+    {% block component_head_analytics_gtag_consent %}
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() { dataLayer.push(arguments); }
 
-        (() => {
-            const analyticsStorageEnabled = document.cookie.split(';').some((item) => item.trim().includes('google-analytics-enabled=1'));
-            const adsEnabled = document.cookie.split(';').some((item) => item.trim().includes('google-ads-enabled=1'));
+            (() => {
+                const analyticsStorageEnabled = document.cookie.split(';').some((item) => item.trim().includes('google-analytics-enabled=1'));
+                const adsEnabled = document.cookie.split(';').some((item) => item.trim().includes('google-ads-enabled=1'));
 
-            // Always set a default consent for consent mode v2
-            gtag('consent', 'default', {
-                'ad_user_data': adsEnabled ? 'granted' : 'denied',
-                'ad_storage': adsEnabled ? 'granted' : 'denied',
-                'ad_personalization': adsEnabled ? 'granted' : 'denied',
-                'analytics_storage': analyticsStorageEnabled ? 'granted' : 'denied'
-            });
-        })();
-    </script>
+                // Always set a default consent for consent mode v2
+                gtag('consent', 'default', {
+                    'ad_user_data': adsEnabled ? 'granted' : 'denied',
+                    'ad_storage': adsEnabled ? 'granted' : 'denied',
+                    'ad_personalization': adsEnabled ? 'granted' : 'denied',
+                    'analytics_storage': analyticsStorageEnabled ? 'granted' : 'denied'
+                });
+            })();
+        </script>
+    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When building a custom Google Analytics integration, changes must be made to support the new Google Consent Mode v2.

For example, the default Shopware `google-analytics-enabled` cookie can be replaced with a custom one. This requires some small modifications to the `gtag('consent', 'default', {...})` configuration.

Currently, there is no Twig block defined, so we need to overwrite the parent block component_head_analytics. However, calling `{{ parent() }}` when overwriting is not possible because it would cause `gtag('consent', 'default', {...})` to be rendered twice.

Wrapping `gtag` inside a Twig block will resolve this issue.

### 2. What does this change do, exactly?
Add new twig block around new gtag script

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
