### PR TITLE
NEXT-34083 - Given source, find migrations recursively on subfolders

### DIFF
--- a/changelog/_unreleased/2024-02-29-given-source-find-migrations-recursively-on-subfolders.md
+++ b/changelog/_unreleased/2024-02-29-given-source-find-migrations-recursively-on-subfolders.md
@@ -1,0 +1,123 @@
+---
+title: Given source, find migrations recursively on subfolders #3584
+issue: NEXT-34083
+author: Raffaele Carelle
+author_email: raffaele.carelle@gmail.com
+author_github: @raffaelecarelle
+---
+# Core
+* Add Shopware\Core\Framework\Migration\MigrationCollection::scanDirectory for find dirs recursively
+* Add Shopware\Core\Framework\Migration\MigrationCollection::extractNamespace for extract, given filename, the namespace
+___
+# Next major version changes
+## Core
+### Change of `Shopware\Core\Framework\Migration\MigrationCollection`
+#### Before
+```
+/**
+     * @throws InvalidMigrationClassException
+     *
+     * @return array<class-string<MigrationStep>, MigrationStep>
+     */
+    private function loadMigrationSteps(): array
+    {
+        $migrations = [];
+
+        foreach ($this->migrationSource->getSourceDirectories() as $directory => $namespace) {
+            if (!is_readable($directory)) {
+                if ($this->logger !== null) {
+                    $this->logger->warning(
+                        'Migration directory "{directory}" for namespace "{namespace}" does not exist or is not readable.',
+                        [
+                            'directory' => $directory,
+                            'namespace' => $namespace,
+                        ]
+                    );
+                }
+
+                continue;
+            }
+
+            $classFiles = scandir($directory, \SCANDIR_SORT_ASCENDING);
+            if (!$classFiles) {
+                continue;
+            }
+
+            foreach ($classFiles as $classFileName) {
+                $path = $directory . '/' . $classFileName;
+                $className = $namespace . '\\' . pathinfo($classFileName, \PATHINFO_FILENAME);
+
+                if (pathinfo($path, \PATHINFO_EXTENSION) !== 'php') {
+                    continue;
+                }
+
+                if (!class_exists($className) && !trait_exists($className) && !interface_exists($className)) {
+                    throw new InvalidMigrationClassException($className, $path);
+                }
+
+                if (!is_subclass_of($className, MigrationStep::class, true)) {
+                    continue;
+                }
+
+                $migrations[$className] = new $className();
+            }
+        }
+
+        return $migrations;
+    }
+```
+#### After
+```
+/**
+     * @throws InvalidMigrationClassException
+     *
+     * @return array<class-string<MigrationStep>, MigrationStep>
+     */
+    private function loadMigrationSteps(): array
+    {
+        $migrations = [];
+
+        foreach ($this->migrationSource->getSourceDirectories() as $directory => $namespace) {
+            if (!is_readable($directory)) {
+                if ($this->logger !== null) {
+                    $this->logger->warning(
+                        'Migration directory "{directory}" for namespace "{namespace}" does not exist or is not readable.',
+                        [
+                            'directory' => $directory,
+                            'namespace' => $namespace,
+                        ]
+                    );
+                }
+
+                continue;
+            }
+
+            $classFiles = $this->scanDirectory($directory);
+
+            if (!$classFiles) {
+                continue;
+            }
+
+            foreach ($classFiles as $filePath) {
+                $namespace = $this->extractNamespace($filePath);
+                $className = $namespace . '\\' . pathinfo($filePath, \PATHINFO_FILENAME);
+
+                if (pathinfo($filePath, \PATHINFO_EXTENSION) !== 'php') {
+                    continue;
+                }
+
+                if (!class_exists($className) && !trait_exists($className) && !interface_exists($className)) {
+                    throw new InvalidMigrationClassException($className, $filePath);
+                }
+
+                if (!is_subclass_of($className, MigrationStep::class, true)) {
+                    continue;
+                }
+
+                $migrations[$className] = new $className();
+            }
+        }
+
+        return $migrations;
+    }
+```

--- a/src/Core/Framework/Migration/MigrationCollection.php
+++ b/src/Core/Framework/Migration/MigrationCollection.php
@@ -192,7 +192,7 @@ class MigrationCollection
         return $migrations;
     }
 
-    private function scanDirectory($dir)
+    private function scanDirectory($dir): array
     {
         $result = [];
 
@@ -210,7 +210,7 @@ class MigrationCollection
         return $result;
     }
 
-    private function extractNamespace($file)
+    private function extractNamespace($file): string
     {
         $ns = null;
         $handle = fopen($file, 'rb');

--- a/src/Core/Framework/Test/Migration/MigrationLoaderTest.php
+++ b/src/Core/Framework/Test/Migration/MigrationLoaderTest.php
@@ -101,6 +101,16 @@ class MigrationLoaderTest extends TestCase
         static::assertEquals(2, $migrations[1]);
     }
 
+    public function testItGetsCorrectMigrationRecursivelyTimestamps(): void
+    {
+        $collection = $this->loader->collect('_test_migrations_valid_recursively');
+        $migrations = $collection->getActiveMigrationTimestamps();
+
+        static::assertCount(2, $migrations);
+        static::assertEquals(1, $migrations[0]);
+        static::assertEquals(2, $migrations[1]);
+    }
+
     public function testThatInvalidMigrationClassesThrowOnLazyInit(): void
     {
         $collection = $this->loader->collect('_test_migrations_invalid_namespace');

--- a/src/Core/Framework/Test/Migration/MigrationTestBehaviour.php
+++ b/src/Core/Framework/Test/Migration/MigrationTestBehaviour.php
@@ -53,6 +53,13 @@ trait MigrationTestBehaviour
             )
         );
 
+        $loader->addSource(
+            new MigrationSource(
+                '_test_migrations_valid_recursively',
+                [__DIR__ . '/_test_migrations_valid_recursively' => 'Shopware\Core\Framework\Test\Migration\_test_migrations_valid_recursively']
+            )
+        );
+
         $this->getContainer()->get(MigrationCollectionLoader::class)->addSource(
             new MigrationSource(
                 self::INTEGRATION_IDENTIFIER(),

--- a/src/Core/Framework/Test/Migration/_test_migrations_valid_recursively/Migration1.php
+++ b/src/Core/Framework/Test/Migration/_test_migrations_valid_recursively/Migration1.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Migration\_test_migrations_valid_recursively;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+class Migration1 extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1;
+    }
+
+    public function update(Connection $connection): void
+    {
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/Framework/Test/Migration/_test_migrations_valid_recursively/Subfolder/Migration2.php
+++ b/src/Core/Framework/Test/Migration/_test_migrations_valid_recursively/Subfolder/Migration2.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\Migration\_test_migrations_valid_recursively\Subfolder;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+class Migration2 extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 2;
+    }
+
+    public function update(Connection $connection): void
+    {
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Many times on enterprise application inside plugin or bundle I've to organized the migrations on subfolders for more readable structure.

es. 
- Migration/
  - Order/
  - Product/
  - Customer/

### 2. What does this change do, exactly?
Given a migration source, the migration classes are sought on directory and its subfolders

### 3. Describe each step to reproduce the issue or behaviour.
Create a inside <plugin-root>/Migration a class and another class inside
<plugin-root>/Migration/Subfolder

migrations are sought on <plugin-root>/Migration/ and <plugin-root>/Migration/Subfolder and executed

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
