### PR TITLE
NEXT-00000 - Change order list filter entity from customer to order

### DIFF
--- a/changelog/_unreleased/2024-03-02-change-order-list-filter-entity.md
+++ b/changelog/_unreleased/2024-03-02-change-order-list-filter-entity.md
@@ -1,0 +1,9 @@
+---
+title: Change order list filter entity
+issue: NEXT-00000
+author: Wanne Van Camp
+author_email: info@campit.be
+author_github: @wannevancamp
+---
+# Administration
+* Changed entity type from `sw-sidebar-filter-panel` in `src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig`

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -535,7 +535,7 @@
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_order_list_sidebar_filter %}
             <sw-sidebar-filter-panel
-                entity="customer"
+                entity="order"
                 :store-key="storeKey"
                 :filters="listFilters"
                 :defaults="defaultFilters"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The entity type from the order list is set to `customer` instead of `order`. Probably a copy pasta.

### 2. What does this change do, exactly?
/

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
