### PR TITLE
fix: Make sure that each customer can only create one review per product

### DIFF
--- a/changelog/_unreleased/2024-03-03-ensure-that-each-customer-can-create-only-one-review-per-product.md
+++ b/changelog/_unreleased/2024-03-03-ensure-that-each-customer-can-create-only-one-review-per-product.md
@@ -1,0 +1,10 @@
+---
+title: Ensure that each customer can create only one review per product
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed the `Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewSaveRoute` to consider the correct property when validating that the product review for a customer already exists
+* Changed the `Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewSaveRoute` to not consider the name and mail from the request

--- a/src/Core/Framework/DataAbstractionLayer/Validation/EntityExists.php
+++ b/src/Core/Framework/DataAbstractionLayer/Validation/EntityExists.php
@@ -35,10 +35,7 @@ class EntityExists extends Constraint
      */
     public function __construct(array $options)
     {
-        $options = array_merge(
-            ['criteria' => new Criteria()],
-            $options
-        );
+        $options['criteria'] ??= new Criteria();
 
         if (!\is_string($options['entity'] ?? null)) {
             throw new MissingOptionsException(sprintf('Option "entity" must be given for constraint %s', self::class), ['entity']);
@@ -48,7 +45,7 @@ class EntityExists extends Constraint
             throw new MissingOptionsException(sprintf('Option "context" must be given for constraint %s', self::class), ['context']);
         }
 
-        if (!($options['criteria'] ?? null) instanceof Criteria) {
+        if (!$options['criteria'] instanceof Criteria) {
             throw new InvalidOptionsException(sprintf('Option "criteria" must be an instance of Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria for constraint %s', self::class), ['criteria']);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Validation/EntityNotExists.php
+++ b/src/Core/Framework/DataAbstractionLayer/Validation/EntityNotExists.php
@@ -35,10 +35,7 @@ class EntityNotExists extends Constraint
      */
     public function __construct(array $options)
     {
-        $options = array_merge(
-            ['criteria' => new Criteria()],
-            $options
-        );
+        $options['criteria'] ??= new Criteria();
 
         if (!\is_string($options['entity'] ?? null)) {
             throw new MissingOptionsException(sprintf('Option "entity" must be given for constraint %s', self::class), ['entity']);
@@ -48,7 +45,7 @@ class EntityNotExists extends Constraint
             throw new MissingOptionsException(sprintf('Option "context" must be given for constraint %s', self::class), ['context']);
         }
 
-        if (!($options['criteria'] ?? null) instanceof Criteria) {
+        if (!$options['criteria'] instanceof Criteria) {
             throw new InvalidOptionsException(sprintf('Option "criteria" must be an instance of Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria for constraint %s', self::class), ['criteria']);
         }
 

--- a/src/Storefront/Controller/ProductController.php
+++ b/src/Storefront/Controller/ProductController.php
@@ -119,8 +119,6 @@ class ProductController extends StorefrontController
     #[Route(path: '/product/{productId}/rating', name: 'frontend.detail.review.save', defaults: ['XmlHttpRequest' => true, '_loginRequired' => true], methods: ['POST'])]
     public function saveReview(string $productId, RequestDataBag $data, SalesChannelContext $context): Response
     {
-        $this->checkReviewsActive($context);
-
         try {
             $this->productReviewSaveRoute->save($productId, $data, $context);
         } catch (ConstraintViolationException $formViolations) {

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewSaveRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewSaveRouteTest.php
@@ -15,7 +15,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -65,6 +64,9 @@ class ProductReviewSaveRouteTest extends TestCase
             'title' => 'foo',
             'content' => 'bar',
             'points' => 3,
+            'name' => 'Should be overwritten by customer name',
+            'lastName' => 'Should be overwritten by customer name',
+            'email' => 'Should be overwritten by customer mail',
         ]);
 
         $salesChannelContext = $this->createMock(SalesChannelContext::class);
@@ -74,11 +76,10 @@ class ProductReviewSaveRouteTest extends TestCase
         $customer->setFirstName('Max');
         $customer->setLastName('Mustermann');
         $customer->setEmail('foo@example.com');
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId('test');
+        $salesChannelId = 'test';
 
         $salesChannelContext->expects(static::once())->method('getCustomer')->willReturn($customer);
-        $salesChannelContext->expects(static::exactly(4))->method('getSalesChannel')->willReturn($salesChannel);
+        $salesChannelContext->expects(static::once())->method('getSalesChannelId')->willReturn($salesChannelId);
         $salesChannelContext->expects(static::exactly(4))->method('getContext')->willReturn($context);
 
         $this->validator->expects(static::once())->method('getViolations')->willReturn(new ConstraintViolationList());
@@ -90,7 +91,7 @@ class ProductReviewSaveRouteTest extends TestCase
                 [
                     'productId' => $productId,
                     'customerId' => $customer->getId(),
-                    'salesChannelId' => $salesChannel->getId(),
+                    'salesChannelId' => $salesChannelId,
                     'languageId' => $context->getLanguageId(),
                     'externalUser' => $customer->getFirstName(),
                     'externalEmail' => $customer->getEmail(),
@@ -104,7 +105,7 @@ class ProductReviewSaveRouteTest extends TestCase
 
         $event = new ReviewFormEvent(
             $context,
-            $salesChannel->getId(),
+            $salesChannelId,
             new MailRecipientStruct(['noreply@example.com' => 'noreply@example.com']),
             new RequestDataBag([
                 'title' => 'foo',


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the validation is not correct, such that the `id` of the product review will be compared with the customer id. Therefore it is possible to create multiple reviews per product (if one is omitting the id, which usually does not happen in the normal storefront). Furthermore it would be possible to overwrite the name or email from the request, which also does not happen.

### 2. What does this change do, exactly?
Fix the validation and always use the values from the customer object and cleanup some other stuff.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
