### PR TITLE
NEXT-34181 - Partial check in EntityReader fetchAssociations

### DIFF
--- a/changelog/_unreleased/2024-03-05-fix-partial-many-to-many-criteria.md
+++ b/changelog/_unreleased/2024-03-05-fix-partial-many-to-many-criteria.md
@@ -1,0 +1,7 @@
+---
+title: Changed type in constructor
+author: Fabian Boensch
+author_github: @En0Ma1259
+---
+# Core
+* Added partial check in `fetchAssociations`.

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -1197,6 +1197,10 @@ class EntityReader implements EntityReaderInterface
                 continue;
             }
 
+            if ($partial !== [] && !array_key_exists($association->getPropertyName(), $partial)) {
+                continue;
+            }
+
             if ($association instanceof OneToOneAssociationField || $association instanceof ManyToOneAssociationField) {
                 $this->loadToOne($association, $context, $collection, $criteria, $partial[$association->getPropertyName()] ?? []);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Search criteria will return an error if fields are set, but many-to-many association is set and fields are missing

### 2. What does this change do, exactly?
Checks if search criteria is partial. If so, check if association should be fetched

### 3. Describe each step to reproduce the issue or behaviour.

`/api/search/product`

```json
{
    "limit": 1,
    "fields": [
        "name"
    ],
    "associations": {
        "properties": {}
    }
}
```

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-34181

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
