### PR TITLE
NEXT-00000 - Replace MySQL with DAL implementation in document upload flow

### DIFF
--- a/changelog/_unreleased/2024-03-07-replace-mysql-with-dal-in-document-upload-flow.md
+++ b/changelog/_unreleased/2024-03-07-replace-mysql-with-dal-in-document-upload-flow.md
@@ -1,0 +1,9 @@
+---
+title: Replace MySQL with DAL in document upload flow
+issue: NEXT-00000
+author: Wanne Van Camp
+author_email: info@campit.be
+author_github: @wannevancamp
+---
+# Core
+* Changed MySQL with DAL in document upload flow to trigged DAL events

--- a/src/Core/Checkout/Document/Service/DocumentGenerator.php
+++ b/src/Core/Checkout/Document/Service/DocumentGenerator.php
@@ -206,14 +206,13 @@ class DocumentGenerator
 
         $mediaId = $context->scope(Context::SYSTEM_SCOPE, fn (Context $context): string => $this->mediaService->saveMediaFile($mediaFile, $fileName, $context, 'document'));
 
-        $this->connection->executeStatement(
-            'UPDATE `document` SET `updated_at` = :now, `document_media_file_id` = :mediaId WHERE `id` = :id',
+        $this->documentRepository->update([
             [
-                'id' => Uuid::fromHexToBytes($documentId),
-                'mediaId' => Uuid::fromHexToBytes($mediaId),
+                'id' => $documentId,
+                'documentMediaFileId' => $mediaId,
                 'now' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             ],
-        );
+        ], $context);
 
         return new DocumentIdStruct($documentId, $document->getDeepLinkCode(), $mediaId);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, it's not possible to subscribe to an event when a document is uploaded. MySQL is used instead of DAL.
By replacing MySQL with DAL it becomes possible to hook into the following event.

`DocumentDefinition::ENTITY_NAME.'.written'`

### 2. What does this change do, exactly?
Change MySQL for DAL when a document is uploaded. The impact to performance should be limited

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
https://developer.shopware.com/docs/resources/references/adr/2021-05-14-when-to-use-plain-sql-or-dal.html#when-to-use-plain-sql-or-the-dal

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
