### PR TITLE
NEXT-24683 - Fix administration imageSlider that contains deleted media

### DIFF
--- a/changelog/_unreleased/2024-03-07-fix-imageslider-including-deleted-media.md
+++ b/changelog/_unreleased/2024-03-07-fix-imageslider-including-deleted-media.md
@@ -1,0 +1,9 @@
+---
+title: Fix imageSlider when including deleted media
+issue: NEXT-24683
+author: Communicode AG / Andreas Greif
+author_email: agreif@communicode.de
+author_github: communicode-sw-dev
+---
+# Administration
+* fixed imageSlider: remove deleted images so it won't break when mediaRepository returns null

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/index.js
@@ -79,8 +79,15 @@ export default {
                 criteria.setIds(mediaIds);
 
                 const searchResult = await this.mediaRepository.search(criteria);
+
                 this.mediaItems = mediaIds.map((mediaId) => {
                     return searchResult.get(mediaId);
+                }).filter((mediaItem) => mediaItem !== null);
+
+                this.element.config.sliderItems.value.forEach((item, i) => {
+                    if (searchResult.get(item.mediaId) === null) {
+                        this.onItemRemove({ id: item.mediaId }, i);
+                    }
                 });
             }
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/config/sw-cms-el-config-image-slider.spec.js
@@ -5,7 +5,7 @@
 import { mount } from '@vue/test-utils';
 import 'src/module/sw-cms/mixin/sw-cms-element.mixin';
 
-async function createWrapper(activeTab = 'content') {
+async function createWrapper(activeTab = 'content', sliderItems = []) {
     return mount(await wrapTestComponent('sw-cms-el-config-image-slider', {
         sync: true,
     }), {
@@ -23,7 +23,15 @@ async function createWrapper(activeTab = 'content') {
                 repositoryFactory: {
                     create: () => {
                         return {
-                            search: () => Promise.resolve(),
+                            search: () => Promise.resolve({
+                                get: (mediaId) => {
+                                    /* if media is not found, return null, otherwise return a valid mediaItem */
+                                    return (mediaId === 'deletedId') ? null : {
+                                        id: '0',
+                                        position: 0,
+                                    };
+                                },
+                            }),
                         };
                     },
                 },
@@ -66,7 +74,7 @@ async function createWrapper(activeTab = 'content') {
                 config: {
                     sliderItems: {
                         source: 'static',
-                        value: [],
+                        value: sliderItems,
                         required: true,
                         entity: {
                             name: 'media',
@@ -133,6 +141,10 @@ async function createWrapper(activeTab = 'content') {
                         id: '3',
                         position: 3,
                     },
+                    {
+                        id: 'deletedId',
+                        position: 4,
+                    },
                 ],
             };
         },
@@ -181,7 +193,7 @@ describe('src/module/sw-cms/elements/image-slider/config', () => {
         expect(autoSlideOption.exists()).toBeTruthy();
     });
 
-    it('should be disable delay element and speed element when auto slide switch is falsy', async () => {
+    it('should disable delay element and speed element when auto slide switch is falsy', async () => {
         const wrapper = await createWrapper('settings');
         const delaySlide = wrapper.find('.sw-cms-el-config-image-slider__setting-delay-slide');
         const speedSlide = wrapper.find('.sw-cms-el-config-image-slider__setting-speed-slide');
@@ -189,7 +201,7 @@ describe('src/module/sw-cms/elements/image-slider/config', () => {
         expect(speedSlide.attributes().disabled).toBe('true');
     });
 
-    it('should be not disable delay element and speed element when auto slide switch is truthy', async () => {
+    it('should not disable delay element and speed element when auto slide switch is truthy', async () => {
         const wrapper = await createWrapper('settings');
         await flushPromises();
 
@@ -214,10 +226,28 @@ describe('src/module/sw-cms/elements/image-slider/config', () => {
 
         const items = wrapper.findAll('.sw-media-item');
 
-        expect(items).toHaveLength(4);
+        expect(items).toHaveLength(5);
         expect(items.at(0).text()).toBe('0');
         expect(items.at(1).text()).toBe('2');
         expect(items.at(2).text()).toBe('1');
         expect(items.at(3).text()).toBe('3');
+        expect(items.at(4).text()).toBe('deletedId');
+    });
+
+    it('should remove deleted media from imageSlider', async () => {
+        const sliderItems = [
+            { filename: 'a.jpg', mediaId: 'a' },
+            { filename: 'b.jpg', mediaId: 'b' },
+            { filename: 'c.jpg', mediaId: 'c' },
+            { filename: 'd.jpg', mediaId: 'd' },
+            { filename: 'notfound.jpg', mediaId: 'deletedId' },
+        ];
+
+        const wrapper = await createWrapper('content', sliderItems);
+        await flushPromises();
+        const validItems = wrapper.findAll('.sw-media-item');
+
+        expect(sliderItems).toHaveLength(5);
+        expect(validItems).toHaveLength(4);
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
If the imageSlider on a cms-page contains images that are deleted, it becomes unusable (Error in render: "TypeError: item is null“, see [NEXT-24683](https://issues.shopware.com/issues/NEXT-24683)). The risk is high, as users are not being warned about the images being used (see [NEXT-23018](https://issues.shopware.com/issues/NEXT-23018)). Besides that, images can be deleted by the user, just by confirming the modal. So it can occur quite commonly the customers face a broken imageSlider. This Pull-Request takes care of that, so that the user can continue to work with the imageSlider.

### 2. What does this change do, exactly?
When instanciating the imageSlider in the Administration, it fetches imageData from the mediaRepository. Every image that cannot be found (what means it has been deleted) will be removed from mediaItems and config.sliderItems in the component SwCmsElConfigImageSlider.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a page or a category with an imageSlider.
2. Add one or more images to that slider. Preferably upload new images to that slider, to be sure they are not used elsewhere.
3. Switch over to Media, delete at least one of the images that have been added to the slider. 
4. A modal will appear and ask for confirmation. It will claim that the image is safe to delete. Besides that, the image will always be able to be deleted by the user.
5. Switch back to the page with the imageSlider, which will not be able to show the remaining images.

### 4. Please link to the relevant issues (if any).
- [NEXT-24683](https://issues.shopware.com/issues/NEXT-24683) - Image slider breaks when deleting media files 
- root cause 1: [NEXT-23018](https://issues.shopware.com/issues/NEXT-23018) - Error with images in media: medium shown as not used although used in categories
- root cause 2: [NEXT-31160](https://issues.shopware.com/issues/NEXT-31160) - Media admin: all media-files are declared as "unused medium", regardless of whether and how often they are in use where 

### 5. Checklist
- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


[NEXT-24683]: https://shopware.atlassian.net/browse/NEXT-24683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEXT-23018]: https://shopware.atlassian.net/browse/NEXT-23018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NEXT-24683]: https://shopware.atlassian.net/browse/NEXT-24683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ