### PR TITLE
feat: do not delete used assets from additional bundles, that are still in use

### DIFF
--- a/changelog/_unreleased/2024-03-09-do-not-delete-used-assets-from-additional-bundles.md
+++ b/changelog/_unreleased/2024-03-09-do-not-delete-used-assets-from-additional-bundles.md
@@ -1,0 +1,8 @@
+---
+title: Do not delete used assets from additional bundles
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added additional check before deleting assets from additional bundles, whether they are also used by an other plugin and therefore should not be deleted

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -81,8 +81,23 @@ class AssetService
             $bundle = $this->getBundle($bundleName);
 
             if ($bundle instanceof Plugin) {
-                foreach ($this->getAdditionalBundles($bundle) as $bundle) {
-                    $this->removeAssets($bundle->getName());
+                $dependencyList = [];
+
+                foreach ($this->kernel->getBundles() as $kernelBundle) {
+                    if ($kernelBundle instanceof Plugin) {
+                        foreach ($this->getAdditionalBundles($kernelBundle) as $additionalBundle) {
+                            $dependencyList[$additionalBundle->getName()][] = $kernelBundle->getName();
+                        }
+                    }
+                }
+
+                foreach ($this->getAdditionalBundles($bundle) as $additionalBundle) {
+                    // additionalBundle is required by other plugins than just bundle? better skip
+                    if (($dependencyList[$additionalBundle->getName()] ?? []) !== [$bundle->getName()]) {
+                        continue;
+                    }
+
+                    $this->removeAssets($additionalBundle->getName());
                 }
             }
         } catch (PluginNotFoundException) {

--- a/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
@@ -18,7 +18,9 @@ use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Framework\Plugin\Util\AssetService;
 use Shopware\Tests\Unit\Core\Framework\Plugin\_fixtures\ExampleBundle\ExampleBundle;
+use Shopware\Tests\Unit\Core\Framework\Plugin\_fixtures\NeedsFeatureBBundle\NeedsFeatureBPlugin;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -131,8 +133,17 @@ class AssetServiceTest extends TestCase
         $kernel = $this->createMock(KernelInterface::class);
         $kernel
             ->method('getBundle')
-            ->with('ExampleBundle')
-            ->willReturn($this->getBundle());
+            ->willReturnCallback(fn (string $bundleName): ?Bundle => match ($bundleName) {
+                'ExampleBundle' => $this->getBundle(),
+                'NeedsFeatureBPlugin' => $this->getNeedsFeatureBPlugin(),
+                default => null
+            });
+        $kernel
+            ->method('getBundles')
+            ->willReturn([
+                $this->getBundle(),
+                $this->getNeedsFeatureBPlugin(),
+            ]);
 
         $filesystem = new Filesystem(new MemoryFilesystemAdapter());
         $assetService = new AssetService(
@@ -147,12 +158,14 @@ class AssetServiceTest extends TestCase
 
         $filesystem->write('bundles/example/test.txt', 'TEST');
         $filesystem->write('bundles/featurea/test.txt', 'TEST');
+        $filesystem->write('bundles/featureb/test.txt', 'TEST');
 
         $assetService->removeAssetsOfBundle('ExampleBundle');
 
         static::assertFalse($filesystem->has('bundles/example'));
         static::assertFalse($filesystem->has('bundles/example/test.txt'));
         static::assertFalse($filesystem->has('bundles/featurea'));
+        static::assertTrue($filesystem->has('bundles/featureb'), 'Asset has been deleted, although additional bundle is used elsewhere');
     }
 
     public function testCopyAssetsClosesStreamItself(): void
@@ -475,6 +488,11 @@ class AssetServiceTest extends TestCase
     private function getBundle(): ExampleBundle
     {
         return new ExampleBundle(true, __DIR__ . '/_fixtures/ExampleBundle');
+    }
+
+    private function getNeedsFeatureBPlugin(): NeedsFeatureBPlugin
+    {
+        return new NeedsFeatureBPlugin(true, __DIR__ . '/_fixtures/NeedsFeatureBPlugin');
     }
 }
 

--- a/tests/unit/Core/Framework/Plugin/_fixtures/NeedsFeatureBBundle/NeedsFeatureBPlugin.php
+++ b/tests/unit/Core/Framework/Plugin/_fixtures/NeedsFeatureBBundle/NeedsFeatureBPlugin.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Plugin\_fixtures\NeedsFeatureBBundle;
+
+use Shopware\Core\Framework\Parameter\AdditionalBundleParameters;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Tests\Unit\Core\Framework\Plugin\_fixtures\ExampleBundle\FeatureB\FeatureB;
+
+/**
+ * @internal
+ */
+final class NeedsFeatureBPlugin extends Plugin
+{
+    public function getAdditionalBundles(AdditionalBundleParameters $parameters): array
+    {
+        return [
+            new FeatureB(),
+        ];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

When you have two plugins, that make use of the same additional bundle, after removing one, the second is broken because assets are missing. As the manifest is trusted it is not simply readded.

### 2. What does this change do, exactly?

Adds a check before removing assets, when an additional bundle is still required by another plugin.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have two plugins, that make use of the same additional bundle
2. Uninstall one plugin
3. Administration stuff is missing
4. See 404 in the network tab for assets you expect to exist

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
