### PR TITLE
feat: remove data from filesystems when plugins are uninstalled

### DIFF
--- a/src/Core/Framework/DependencyInjection/plugin.xml
+++ b/src/Core/Framework/DependencyInjection/plugin.xml
@@ -59,6 +59,9 @@
             <argument type="service" id="Shopware\Core\System\CustomEntity\CustomEntityLifecycleService"/>
             <argument type="service" id="Shopware\Core\Framework\Plugin\PluginService"/>
             <argument type="service" id="Shopware\Core\Framework\Plugin\Util\VersionSanitizer"/>
+            <argument type="service" id="kernel"/>
+            <argument type="service" id="Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader"/>
+            <argument type="service" id="parameter_bag"/>
         </service>
 
         <service id="Shopware\Core\Framework\Plugin\PluginManagementService">


### PR DESCRIPTION
### 1. Why is this change necessary?

@mitelg once said

https://github.com/shopware/shopware/pull/206#issuecomment-534982692

> > Are there already cleanup tasks that delete plugin directories on life cycle?
>
> not yet 😊

So we should clean files up like assets and migrations, right?
