### PR TITLE
NEXT-0000 - Check invalid rules with DAL before fetching

### DIFF
--- a/changelog/_unreleased/2020-09-07-check-invalid-rules-in-criteria-instead-of-runtime.md
+++ b/changelog/_unreleased/2020-09-07-check-invalid-rules-in-criteria-instead-of-runtime.md
@@ -1,0 +1,8 @@
+---
+title: Check for invalid rules in criteria instead at runtime
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added criteria filter in `\Shopware\Core\Checkout\Cart\RuleLoader::load` to only load valid rules from the database 

--- a/src/Core/Checkout/Cart/RuleLoader.php
+++ b/src/Core/Checkout/Cart/RuleLoader.php
@@ -7,6 +7,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
@@ -36,14 +37,16 @@ class RuleLoader extends AbstractRuleLoader
         $criteria = new Criteria();
         $criteria->addSorting(new FieldSorting('priority', FieldSorting::DESCENDING));
         $criteria->addSorting(new FieldSorting('id'));
+        $criteria->addFilter(new EqualsFilter('invalid', false));
         $criteria->setLimit(500);
         $criteria->setTitle('cart-rule-loader::load-rules');
 
         $repositoryIterator = new RepositoryIterator($this->repository, $context, $criteria);
         $rules = new RuleCollection();
+
         while (($result = $repositoryIterator->fetch()) !== null) {
             foreach ($result->getEntities() as $rule) {
-                if (!$rule->isInvalid() && $rule->getPayload()) {
+                if ($rule->getPayload()) {
                     $rules->add($rule);
                 }
             }


### PR DESCRIPTION
### 0. Context

I am missing a reply from @shyim https://github.com/shopware/shopware/pull/1312#issuecomment-690968290 from https://github.com/shopware/shopware/pull/1312 and I still think the change is valid. So I reopen. I added a changelog but still no test because this has not been tested before. The critical business logic is still in the CartRuleLoader and not in the RuleLoader.

### 1. Why is this change necessary?

Having the DAL check for invalid rules is faster than fetching them first. So I just removed the php check and moved it to the DAL.

### 2. What does this change do, exactly?

Add a filter to the DAL query.

### 3. Describe each step to reproduce the issue or behaviour.

1. Have a loads of rules that you optimized by being invalid
2. Still loads a lot

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
