### PR TITLE
perf: improve performance of RepositoryIterator and remove a possible next request

### DIFF
--- a/changelog/_unreleased/2020-09-07-repository-iterator-prevent-predictable-last-empty-request.md
+++ b/changelog/_unreleased/2020-09-07-repository-iterator-prevent-predictable-last-empty-request.md
@@ -1,0 +1,9 @@
+---
+title: Prevent predictable empty request in RepositoryIterator and improve developer experience
+issue: NEXT-11081
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added methods `iterateIds` and `iterateEntities` to class `\Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator` to automatically perform iteration on respectively `fetchIds` and `fetch` with predicted stop when less entries were fetched than limited to

--- a/src/Core/Checkout/Cart/RuleLoader.php
+++ b/src/Core/Checkout/Cart/RuleLoader.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Cart;
 
 use Shopware\Core\Content\Rule\RuleCollection;
+use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -44,14 +45,10 @@ class RuleLoader extends AbstractRuleLoader
         $repositoryIterator = new RepositoryIterator($this->repository, $context, $criteria);
         $rules = new RuleCollection();
 
-        while (($result = $repositoryIterator->fetch()) !== null) {
-            foreach ($result->getEntities() as $rule) {
-                if ($rule->getPayload()) {
-                    $rules->add($rule);
-                }
-            }
-            if ($result->count() < 500) {
-                break;
+        /** @var RuleEntity $rule */
+        foreach ($repositoryIterator->iterateEntities() as $rule) {
+            if ($rule->getPayload()) {
+                $rules->add($rule);
             }
         }
 

--- a/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
+++ b/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Media\Commands;
 
 use Shopware\Core\Content\Media\Aggregate\MediaFolder\MediaFolderCollection;
 use Shopware\Core\Content\Media\MediaCollection;
+use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\Message\UpdateThumbnailsMessage;
 use Shopware\Core\Content\Media\Thumbnail\ThumbnailService;
@@ -162,20 +163,20 @@ class GenerateThumbnailsCommand extends Command
         $errored = 0;
         $errors = [];
 
-        while (($result = $iterator->fetch()) !== null) {
-            foreach ($result->getEntities() as $media) {
-                try {
-                    if ($this->thumbnailService->updateThumbnails($media, $context, $this->isStrict) > 0) {
-                        ++$generated;
-                    } else {
-                        ++$skipped;
-                    }
-                } catch (\Throwable $e) {
-                    ++$errored;
-                    $errors[] = [\sprintf('Cannot process file %s (id: %s) due error: %s', $media->getFileName(), $media->getId(), $e->getMessage())];
+        /** @var MediaEntity $media */
+        foreach ($iterator->iterateEntities() as $media) {
+            try {
+                if ($this->thumbnailService->updateThumbnails($media, $context, $this->isStrict) > 0) {
+                    ++$generated;
+                } else {
+                    ++$skipped;
                 }
+            } catch (\Throwable $e) {
+                ++$errored;
+                $errors[] = [\sprintf('Cannot process file %s (id: %s) due error: %s', $media->getFileName(), $media->getId(), $e->getMessage())];
             }
-            $this->io->progressAdvance($result->count());
+
+            $this->io->progressAdvance();
         }
 
         return [

--- a/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/ProductStreamUpdater.php
@@ -108,21 +108,23 @@ class ProductStreamUpdater extends AbstractProductStreamUpdater
             );
         });
 
-        while ($matches = $iterator->fetchIds()) {
-            foreach ($matches as $id) {
-                if (!\is_string($id)) {
-                    continue;
-                }
-                $ids[] = $id;
-                $insert->addInsert('product_stream_mapping', [
-                    'product_id' => Uuid::fromHexToBytes($id),
-                    'product_version_id' => $version,
-                    'product_stream_id' => $binary,
-                ]);
+        foreach ($iterator->iterateIds() as $id) {
+            if (!\is_string($id)) {
+                continue;
             }
+            $ids[] = $id;
+            $insert->addInsert('product_stream_mapping', [
+                'product_id' => Uuid::fromHexToBytes($id),
+                'product_version_id' => $version,
+                'product_stream_id' => $binary,
+            ]);
 
-            $insert->execute();
+            if (count($ids) >= $criteria->getLimit()) {
+                $insert->execute();
+            }
         }
+
+        $insert->execute();
 
         $message->getContext()->setConsiderInheritance($considerInheritance);
 

--- a/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
+++ b/src/Core/Content/Product/DataAbstractionLayer/SearchKeywordUpdater.php
@@ -112,12 +112,10 @@ class SearchKeywordUpdater implements ResetInterface
 
         $iterator = $this->getIterator($ids, $context, $configFields);
 
-        while ($products = $iterator->fetch()) {
-            foreach ($products->getEntities() as $product) {
-                // overwrite fetched products if translations for that product exists
-                // otherwise we use the already fetched product from the parent language
-                $existingProducts[$product->getId()] = $product;
-            }
+        foreach ($iterator->iterateEntities() as $product) {
+            // overwrite fetched products if translations for that product exists
+            // otherwise we use the already fetched product from the parent language
+            $existingProducts[$product->getId()] = $product;
         }
 
         foreach ($existingProducts as $product) {

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
@@ -3,8 +3,10 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common;
 
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
@@ -115,5 +117,37 @@ class RepositoryIterator
         }
 
         return $result;
+    }
+
+    /**
+     * @return iterable<Entity|PartialEntity>
+     */
+    public function iterateEntities(): iterable
+    {
+        while (($entityResult = $this->fetch()) instanceof EntitySearchResult) {
+            // yield from is okay, as getElements keys by unique key
+            yield from $entityResult->getElements();
+
+            if ($entityResult->count() < $this->criteria->getLimit()) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * @return iterable<string>|iterable<array<string, string>>
+     */
+    public function iterateIds(): iterable
+    {
+        while (\is_array($ids = $this->fetchIds())) {
+            // do not use yield from to ensure re-keying
+            foreach ($ids as $id) {
+                yield $id;
+            }
+
+            if (\count($ids) < $this->criteria->getLimit()) {
+                break;
+            }
+        }
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/RepositoryIteratorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/RepositoryIteratorTest.php
@@ -6,15 +6,21 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Dbal;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductEvents;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\RepositoryIterator;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\EntitySearchedEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateCollection;
+use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateEntity;
 use Shopware\Core\System\SystemConfig\SystemConfigCollection;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * @internal
@@ -72,19 +78,11 @@ class RepositoryIteratorTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $ids = new IdsCollection();
-
-        $builder = new ProductBuilder($ids, 'product1');
-        $builder->price(1);
-        $productRepository->create([$builder->build()], $context);
-
-        $builder = new ProductBuilder($ids, 'product2');
-        $builder->price(2);
-        $productRepository->create([$builder->build()], $context);
-
-        $builder = new ProductBuilder($ids, 'product3');
-        $builder->price(3);
-        $productRepository->create([$builder->build()], $context);
+        $productRepository->create([
+            (new ProductBuilder(new IdsCollection(), 'product1'))->price(1)->build(),
+            (new ProductBuilder(new IdsCollection(), 'product2'))->price(1)->build(),
+            (new ProductBuilder(new IdsCollection(), 'product3'))->price(1)->build(),
+        ], $context);
 
         $criteria = new Criteria();
         $criteria->setLimit(1);
@@ -95,5 +93,186 @@ class RepositoryIteratorTest extends TestCase
             ++$totalFetchedIds;
         }
         static::assertEquals($totalFetchedIds, 3);
+    }
+
+    public function testFetchNotObviousEmptyNextRequestAutoIncrement(): void
+    {
+        /** @var EntityRepository<ProductCollection> $productRepository */
+        $productRepository = $this->getContainer()->get('product.repository');
+        /** @var EventDispatcher $eventDispatcher */
+        $eventDispatcher = $this->getContainer()->get('event_dispatcher');
+
+        $context = Context::createDefaultContext();
+
+        $productRepository->create([
+            (new ProductBuilder(new IdsCollection(), 'product1'))->price(1)->build(),
+            (new ProductBuilder(new IdsCollection(), 'product2'))->price(1)->build(),
+            (new ProductBuilder(new IdsCollection(), 'product3'))->price(1)->build(),
+        ], $context);
+
+        $criteria = new Criteria();
+        $criteria->setTitle('test__product_iteration');
+        // 3 products will be fetched in pairs of 2
+        // The last response will obviously have 1 (less than 2) item and this already indicates end
+        // so this should not need an additional search
+        $criteria->setLimit(2);
+
+        $searchesCount = 0;
+        $eventDispatcher->addListener(EntitySearchedEvent::class, function (EntitySearchedEvent $event) use (&$searchesCount): void {
+            if ($event->getCriteria()->getTitle() === 'test__product_iteration') {
+                ++$searchesCount;
+            }
+        });
+
+        $iterator = new RepositoryIterator($productRepository, $context, $criteria);
+
+        foreach ($iterator->iterateIds() as $_) {
+            // fetch all ids and count searches
+        }
+
+        static::assertSame(2, $searchesCount, '2 searches are enough to fetch 3 products by limit 2');
+
+        $searchesCount = 0;
+
+        foreach ($iterator->iterateEntities() as $_) {
+            // fetch all entities and count searches
+        }
+
+        static::assertSame(2, $searchesCount, '2 searches are enough to fetch 3 products by limit 2');
+    }
+
+    public function testFetchNotObviousEmptyNextRequestLimitOffset(): void
+    {
+        /** @var EntityRepository<CountryStateCollection> $countryStateRepository */
+        $countryStateRepository = $this->getContainer()->get('country_state.repository');
+        /** @var EventDispatcher $eventDispatcher */
+        $eventDispatcher = $this->getContainer()->get('event_dispatcher');
+
+        $context = Context::createDefaultContext();
+
+        $criteria = new Criteria();
+        $criteria->setTitle('test__country_state_iteration');
+        // 16 German country states will be fetched in pairs of 5
+        // The last response will obviously have 1 (less than 5) item and this already indicates end
+        // so this should not need an additional search
+        $criteria->setLimit(5);
+        $criteria->addFilter(new EqualsFilter('country.iso', 'DE'));
+
+        $searchesCount = 0;
+        $eventDispatcher->addListener(EntitySearchedEvent::class, function (EntitySearchedEvent $event) use (&$searchesCount): void {
+            if ($event->getCriteria()->getTitle() === 'test__country_state_iteration') {
+                ++$searchesCount;
+            }
+        });
+
+        $iterator = new RepositoryIterator($countryStateRepository, $context, $criteria);
+
+        $countFetchedIds = 0;
+
+        foreach ($iterator->iterateIds() as $_) {
+            // fetch all ids and count searches
+            $countFetchedIds++;
+        }
+
+        static::assertSame(4, $searchesCount, '4 searches are enough to fetch 16 German country states by limit 5');
+        static::assertSame(16, $countFetchedIds);
+
+        $searchesCount = 0;
+        $countFetchedEntities = 0;
+
+        foreach ($iterator->iterateEntities() as $_) {
+            // fetch all ids and count searches
+            $countFetchedEntities++;
+        }
+
+        static::assertSame(4, $searchesCount, '4 searches are enough to fetch 16 German country states by limit 5');
+        static::assertSame(16, $countFetchedEntities);
+    }
+
+    public function testAutomaticIdIteration(): void
+    {
+        /** @var EntityRepository<ProductCollection> $countryStateRepository */
+        $countryStateRepository = $this->getContainer()->get('country_state.repository');
+
+        $context = Context::createDefaultContext();
+
+        $criteria = new Criteria();
+        $criteria->setLimit(5); // 16 are expected therefore multiple requests are needed
+        $criteria->addFilter(new EqualsFilter('country.iso', 'DE'));
+
+        $iterator = new RepositoryIterator($countryStateRepository, $context, $criteria);
+        $idsRun1 = [...$iterator->iterateIds()];
+        $idsRun2 = [...$iterator->iterateIds()];
+
+        static::assertNotEmpty($idsRun1);
+        static::assertCount(16, $idsRun1, 'We expected 16 DE states but got less, this could be a array-key issue');
+        static::assertEqualsCanonicalizing($idsRun1, $idsRun2);
+    }
+
+    public function testAutomaticEntityIteration(): void
+    {
+        /** @var EntityRepository<ProductCollection> $countryStateRepository */
+        $countryStateRepository = $this->getContainer()->get('country_state.repository');
+
+        $context = Context::createDefaultContext();
+
+        $criteria = new Criteria();
+        $criteria->setLimit(5); // 16 are expected therefore multiple requests are needed
+        $criteria->addFilter(new EqualsFilter('country.iso', 'DE'));
+
+        $iterator = new RepositoryIterator($countryStateRepository, $context, $criteria);
+        $entitiesRun1 = [...$iterator->iterateEntities()];
+        $entitiesRun2 = [...$iterator->iterateEntities()];
+
+        static::assertNotEmpty($entitiesRun1);
+        static::assertCount(16, $entitiesRun1, 'We expected 16 DE states but got less, this could be a array-key issue');
+
+        foreach ($entitiesRun1 as $state) {
+            static::assertInstanceOf(CountryStateEntity::class, $state);
+            static::assertArrayHasKey($state->getUniqueIdentifier(), $entitiesRun2);
+        }
+    }
+
+    public function testAutomaticEntityIterationCanBeStartedAgainEvenAfterAnException(): void
+    {
+        /** @var EntityRepository<ProductCollection> $countryStateRepository */
+        $countryStateRepository = $this->getContainer()->get('country_state.repository');
+        /** @var EventDispatcher $eventDispatcher */
+        $eventDispatcher = $this->getContainer()->get('event_dispatcher');
+
+        $context = Context::createDefaultContext();
+
+        $criteria = new Criteria();
+        $criteria->setTitle('test__country_state_exception_iteration');
+        $criteria->setLimit(5); // 16 are expected therefore multiple requests are needed
+        $criteria->addFilter(new EqualsFilter('country.iso', 'DE'));
+
+        $searchesCount = 0;
+        $iterator = new RepositoryIterator($countryStateRepository, $context, $criteria);
+
+        $eventDispatcher->addListener(EntitySearchedEvent::class, function (EntitySearchedEvent $event) use (&$searchesCount): void {
+            if ($event->getCriteria()->getTitle() === 'test__country_state_exception_iteration') {
+                ++$searchesCount;
+            }
+
+            if ($searchesCount == 2) {
+                throw new \RuntimeException('This is expected', 1716055400);
+            }
+        });
+
+        try {
+            foreach ($iterator->iterateEntities() as $_) {
+                // fetch all entities and count searches
+            }
+
+            static::fail('This should have been failing earlier');
+        } catch (\RuntimeException $exception) {
+            static::assertSame(1716055400, $exception->getCode(), 'This is not the exception we expected');
+        }
+
+        // this should now run again normally
+        $entitiesRun1 = [...$iterator->iterateEntities()];
+        static::assertNotEmpty($entitiesRun1);
+        static::assertCount(16, $entitiesRun1, 'We expected 16 DE states but got less, this could be a array-key issue');
     }
 }

--- a/tests/unit/Core/Content/Media/UnusedMediaPurgerTest.php
+++ b/tests/unit/Core/Content/Media/UnusedMediaPurgerTest.php
@@ -110,7 +110,7 @@ class UnusedMediaPurgerTest extends TestCase
 
                     self::assertCount(0, $filters);
                     self::assertEquals(0, $criteria->getOffset());
-                    self::assertEquals(50, $criteria->getLimit());
+                    self::assertEquals(2, $criteria->getLimit());
 
                     return [$id1, $id2];
                 },
@@ -123,8 +123,8 @@ class UnusedMediaPurgerTest extends TestCase
                     $filters = $criteria->getFilters();
 
                     self::assertCount(0, $filters);
-                    self::assertEquals(50, $criteria->getOffset());
-                    self::assertEquals(50, $criteria->getLimit());
+                    self::assertEquals(2, $criteria->getOffset());
+                    self::assertEquals(2, $criteria->getLimit());
 
                     return [$id3, $id4];
                 },
@@ -141,7 +141,7 @@ class UnusedMediaPurgerTest extends TestCase
         );
 
         $purger = new UnusedMediaPurger($repo, $this->createMock(Connection::class), new EventDispatcher());
-        $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia()));
+        $media = array_merge([], ...iterator_to_array($purger->getNotUsedMedia(2)));
 
         static::assertEquals([$media1, $media2, $media3, $media4], $media);
     }


### PR DESCRIPTION
### 0. Context

This is a follow-up pull request to https://github.com/shopware/shopware/pull/1311 . The reasoning did not change but I rebased, add a test and moved the change from the CartRuleLoader into the RuleLoader as this has been moved.

### 1. Why is this change necessary?

The RuleLoader already makes this educated guess that there won't be a next result when the current iteration doesn't fill the required criteria limit. Why don't do this in general?

### 2. What does this change do, exactly?

Add an other state to the already stateful RepositoryIterator that knows when to stop.
During test writing I noticed, that path coverage needs a different entity definition, that is iterated differently. But to reset an iterator you need to know how to reset the criteria. So I added a reset method as well.

### 3. Describe each step to reproduce the issue or behaviour.

1. Load rules
2. Load a lot of rules
3. This seems to take more time than I want to
4. Aha! The last response is empty anyway?
5. Let's just skip it
6. …
7. Load products
8. Load a lot of products
9. This seems to take more time than I want to
10. Wait a minute. I have done this before. Let's copy pasta

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-11081

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
