### PR TITLE
fix: Allow Twig array filters to accept null

### DIFF
--- a/changelog/_unreleased/2024-03-09-allow-twig-array-filters-to-accept-null.md
+++ b/changelog/_unreleased/2024-03-09-allow-twig-array-filters-to-accept-null.md
@@ -1,0 +1,9 @@
+---
+title: Allow Twig array filters to accept null
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed the `Shopware\Core\Framework\Adapter\Twig\SecurityExtension` to accept `null` for the Twig filters `map`, `reduce`, `filter` and `sort`

--- a/src/Core/Framework/Adapter/Twig/SecurityExtension.php
+++ b/src/Core/Framework/Adapter/Twig/SecurityExtension.php
@@ -38,8 +38,12 @@ class SecurityExtension extends AbstractExtension
      *
      * @return array<mixed>
      */
-    public function map(iterable $array, string|callable|\Closure $function): array
+    public function map(?iterable $array, string|callable|\Closure $function): ?array
     {
+        if ($array === null) {
+            return null;
+        }
+
         if (\is_array($function)) {
             $function = implode('::', $function);
         }
@@ -61,8 +65,12 @@ class SecurityExtension extends AbstractExtension
      * @param iterable<mixed> $array
      * @param string|callable(mixed): mixed|\Closure $function
      */
-    public function reduce(iterable $array, string|callable|\Closure $function, mixed $initial = null): mixed
+    public function reduce(?iterable $array, string|callable|\Closure $function, mixed $initial = null): mixed
     {
+        if ($array === null) {
+            return null;
+        }
+
         if (\is_array($function)) {
             $function = implode('::', $function);
         }
@@ -85,8 +93,12 @@ class SecurityExtension extends AbstractExtension
      *
      * @return iterable<mixed>
      */
-    public function filter(iterable $array, string|callable|\Closure $arrow): iterable
+    public function filter(?iterable $array, string|callable|\Closure $arrow): ?iterable
     {
+        if ($array === null) {
+            return null;
+        }
+
         if (\is_array($arrow)) {
             $arrow = implode('::', $arrow);
         }
@@ -110,8 +122,12 @@ class SecurityExtension extends AbstractExtension
      *
      * @return array<mixed>
      */
-    public function sort(iterable $array, string|callable|\Closure|null $arrow = null): array
+    public function sort(?iterable $array, string|callable|\Closure|null $arrow = null): ?array
     {
+        if ($array === null) {
+            return null;
+        }
+
         if (\is_array($arrow)) {
             $arrow = implode('::', $arrow);
         }

--- a/tests/unit/Core/Framework/Adapter/Twig/SecurityExtensionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/SecurityExtensionTest.php
@@ -135,6 +135,26 @@ class SecurityExtensionTest extends TestCase
         );
     }
 
+    public function testAcceptsNull(): void
+    {
+        static::assertSame(
+            '',
+            $this->runTwig('{{ test|map(v => (v ~ "-test"))|join }}', [], ['test' => null])
+        );
+        static::assertSame(
+            '',
+            $this->runTwig('{{ test|reduce((a, b) => a + b)|join }}', [], ['test' => null])
+        );
+        static::assertSame(
+            '',
+            $this->runTwig('{{ test|filter(v => v == "a")|join }}', [], ['test' => null])
+        );
+        static::assertSame(
+            '',
+            $this->runTwig('{{ test|sort|join }}', [], ['test' => null])
+        );
+    }
+
     /**
      * @param array<string> $allowedFunctions
      * @param array<mixed> $variables


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the following (cached) code is generated, when using for example the Twig `filter`-filter (reformatted for some more readability):
```php
$context['_seq'] = twig_ensure_traversable($this->extensions['Shopware\Core\Framework\Adapter\Twig\SecurityExtension']->filter(
    sw_get_attribute(
        $this->env,
        $this->source,
        sw_get_attribute($this->env, $this->source, sw_get_attribute(
            $this->env, $this->source, ($context["page"] ?? null), "cart", [], "any", false, false, false, 1
        ),
        "lineItems", [], "any", false, false, false, 1), "elements", [], "any", false, false, false, 1), function ($__lineItem__) use ($context, $macros) { $context["lineItem"] = $__lineItem__; return (sw_get_attribute($this->env, $this->source, $context["lineItem"], "type", [], "any", false, false, false, 1) == "promotion"); }
    )
);
```

This leads to the problem, that only `twig_ensure_traversable` converts `null` to an empty array, see: https://github.com/twigphp/Twig/blob/v3.8.0/src/Extension/CoreExtension.php#L1230-L1237 but this is only called after the filtering. 

Also other Twig methods, like the [`length`-filter](https://github.com/twigphp/Twig/blob/v3.8.0/src/Extension/CoreExtension.php#L1116), can work with `null`, see for example the following code, which would also yield an error:
```php
$context["hasDifferentPrice"] = (
    twig_length_filter(
        $this->env, 
        $this->extensions['Shopware\Core\Framework\Adapter\Twig\SecurityExtension']->filter(
            ($context["totalVariants"] ?? null), 
            function ($__variant__) use ($context, $macros) { $context["variant"] = $__variant__; return (sw_get_attribute($this->env, $this->source, ($context["variant"] ?? null), "default", [], "any", false, false, false, 18) != null); }
        )
    ) > 0
);
```
 

### 2. What does this change do, exactly?
Also accept `null` as a valid value of the filters.

### 3. Describe each step to reproduce the issue or behaviour.
See above and in the tests.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

### 6. Changes in older versions

This should probably also be changed in the security plugin and in the 6.5.x versions.