### PR TITLE
chore: Add sales channel context getter to CustomerDoubleOptInRegistrationEvent

### DIFF
--- a/changelog/_unreleased/2024-03-11-add-sales-channel-context-getter-to-customerdoubleoptinregistrationevent.md
+++ b/changelog/_unreleased/2024-03-11-add-sales-channel-context-getter-to-customerdoubleoptinregistrationevent.md
@@ -1,0 +1,9 @@
+---
+title: Add sales channel context getter to CustomerDoubleOptInRegistrationEvent
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added method `Shopware\Core\Checkout\Customer\Event\CustomerDoubleOptInRegistrationEvent::getSalesChannelContext` to access the sales channel context

--- a/src/Core/Checkout/Customer/Event/CustomerDoubleOptInRegistrationEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerDoubleOptInRegistrationEvent.php
@@ -69,6 +69,11 @@ class CustomerDoubleOptInRegistrationEvent extends Event implements SalesChannel
         return $this->customer;
     }
 
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
     public function getConfirmUrl(): string
     {
         return $this->confirmUrl;


### PR DESCRIPTION
### 1. Why is this change necessary?
![image](https://github.com/shopware/shopware/assets/6317761/e5d23b0e-8b33-47b3-a1b3-1497df503ba1)

### 2. What does this change do, exactly?
Add sales channel context getter.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
