### PR TITLE
NEXT-34155 - Search for a composer.json in custom/static-plugins/

### DIFF
--- a/changelog/_unreleased/2024-03-11-include-static-plugins-path-in-testbootstrapper.md
+++ b/changelog/_unreleased/2024-03-11-include-static-plugins-path-in-testbootstrapper.md
@@ -1,0 +1,6 @@
+---
+title: Search for a composer.json in `custom/static-plugins/`
+issue: NEXT-00000
+---
+# Core
+* Changed `\Shopware\Core\TestBootstrapper` to search for a composer.json in `custom/static-plugins/`.

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -311,6 +311,10 @@ class TestBootstrapper
             $pathToComposerJson = $this->getProjectDir() . '/custom/plugins/' . $pluginName . '/composer.json';
 
             if (!\is_file($pathToComposerJson)) {
+                $pathToComposerJson = $this->getProjectDir() . '/custom/static-plugins/' . $pluginName . '/composer.json';
+            }
+
+            if (!\is_file($pathToComposerJson)) {
                 throw new \RuntimeException(sprintf('Could not find plugin: %s at path: %s', $pluginName, $pathToComposerJson));
             }
 

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -311,12 +311,12 @@ class TestBootstrapper
             $pathToComposerJson = $this->getProjectDir() . '/custom/plugins/' . $pluginName . '/composer.json';
             $pathToComposerJsonStaticPlugins = $this->getProjectDir() . '/custom/static-plugins/' . $pluginName . '/composer.json';
 
-            if (!\is_file($pathToComposerJson)) {
-                $pathToComposerJson = $pathToComposerJsonStaticPlugins;
+            if (!\is_file($pathToComposerJson) && !\is_file($pathToComposerJsonStaticPlugins)) {
+                throw new \RuntimeException(sprintf('Could not find plugin: %s in of these paths: %s or %s', $pluginName, $pathToComposerJson, $pathToComposerJsonStaticPlugins));
             }
 
             if (!\is_file($pathToComposerJson)) {
-                throw new \RuntimeException(sprintf('Could not find plugin: %s in of these paths: %s or %s', $pluginName, $pathToComposerJson, $pathToComposerJsonStaticPlugins));
+                $pathToComposerJson = $pathToComposerJsonStaticPlugins;
             }
 
             $plugin = json_decode((string) file_get_contents($pathToComposerJson), true, 512, \JSON_THROW_ON_ERROR);

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -309,13 +309,14 @@ class TestBootstrapper
     {
         foreach ($this->activePlugins as $pluginName) {
             $pathToComposerJson = $this->getProjectDir() . '/custom/plugins/' . $pluginName . '/composer.json';
+            $pathToComposerJsonStaticPlugins = $this->getProjectDir() . '/custom/static-plugins/' . $pluginName . '/composer.json';
 
             if (!\is_file($pathToComposerJson)) {
-                $pathToComposerJson = $this->getProjectDir() . '/custom/static-plugins/' . $pluginName . '/composer.json';
+                $pathToComposerJson = $pathToComposerJsonStaticPlugins;
             }
 
             if (!\is_file($pathToComposerJson)) {
-                throw new \RuntimeException(sprintf('Could not find plugin: %s at path: %s', $pluginName, $pathToComposerJson));
+                throw new \RuntimeException(sprintf('Could not find plugin: %s in of these paths: %s or %s', $pluginName, $pathToComposerJson, $pathToComposerJsonStaticPlugins));
             }
 
             $plugin = json_decode((string) file_get_contents($pathToComposerJson), true, 512, \JSON_THROW_ON_ERROR);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

When you're running PHPUnit tests in the flex template, project specific plugins in the `custom/static-plugins` folder are ignored. A composer.json is only searched in the `custom/plugins` directory.

### 2. What does this change do, exactly?

Changes the `Shopware\Core\TestBootstrapper` to search for the composer.json in `custom/static-plugins`.

### 3. Describe each step to reproduce the issue or behaviour.

In the Flex-Template, put a plugin into the `custom/static-plugins` folder and try running a phpunit test according to the documentation. It will throw an error, that the Plugin could not be found.

```
./vendor/bin/phpunit --configuration="custom/static-plugins/PluginName"

Error in bootstrap script: RuntimeException:
Could not find plugin: PluginName at path:  ...shop/custom/plugins/PluginName/composer.json
```

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ x ] I have rebased my changes to remove merge conflicts
- [ x ] I have written tests and verified that they fail without my change
- [ x ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x ] I have read the contribution requirements and fulfil them.
