### PR TITLE
Update ProductDetailRoute.php

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
@@ -158,8 +158,8 @@ class ProductDetailRoute extends AbstractProductDetailRoute
     {
         $criteria = (new Criteria())
             ->addFilter(new EqualsFilter('product.parentId', $productId))
-            ->addSorting(new FieldSorting('product.price'))
             ->addSorting(new FieldSorting('product.available', FieldSorting::DESCENDING))
+            ->addSorting(new FieldSorting('product.price'))
             ->setLimit(1);
 
         $criteria->setTitle('product-detail-route::find-best-variant');


### PR DESCRIPTION
### 1. Why is this change necessary?
ProductDetailRoute::findBestVariant doesn't get the cheapest available variant. it still get's the cheapest variant, no matter if it's available or not.

### 2. What does this change do, exactly?
changed the priority of the sorting.

### 3. Describe each step to reproduce the issue or behaviour.
- Mark parent product as displayParent = true
- the cheapest variant has to be not available
- open the main product

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
