### PR TITLE
docs: fixed Playwright documentation link

### DIFF
--- a/changelog/_unreleased/2024-03-16-fixed-playwright-documentation-link.md
+++ b/changelog/_unreleased/2024-03-16-fixed-playwright-documentation-link.md
@@ -1,5 +1,5 @@
 ---
-title: Fixed Playwright documentation link
+title: NEXT-34435 - Fixed Playwright documentation link
 issue: NEXT-34435
 author: Matheus Gontijo
 author_github: matheusgontijo
@@ -7,7 +7,7 @@ author_github: matheusgontijo
 
 Fixed Playwright documentation link
 
-```
--https://playwright.dev/docs/
-+https://playwright.dev/docs/intro
+```diff
+- https://playwright.dev/docs/
++ https://playwright.dev/docs/intro
 ```

--- a/changelog/_unreleased/2024-03-16-fixed-playwright-documentation-link.md
+++ b/changelog/_unreleased/2024-03-16-fixed-playwright-documentation-link.md
@@ -1,0 +1,13 @@
+---
+title: Fixed Playwright documentation link
+issue: NEXT-34435
+author: Matheus Gontijo
+author_github: matheusgontijo
+---
+
+Fixed Playwright documentation link
+
+```
+-https://playwright.dev/docs/
++https://playwright.dev/docs/intro
+```

--- a/tests/acceptance/README.md
+++ b/tests/acceptance/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The test suite is build with **Playwright**. For detailed information have a look into the [official documentation](https://playwright.dev/docs/).
+The test suite is build with **Playwright**. For detailed information have a look into the [official documentation](https://playwright.dev/docs/intro).
 
 ## Setup
 


### PR DESCRIPTION
Fixed Playwright documentation link

```diff
- https://playwright.dev/docs/
+ https://playwright.dev/docs/intro
```