### PR TITLE
NEXT-00000 - Add column assigned pages to CMS list

### DIFF
--- a/changelog/_unreleased/2024-03-18-add-assigned-pages-to-cms-list.md
+++ b/changelog/_unreleased/2024-03-18-add-assigned-pages-to-cms-list.md
@@ -1,0 +1,9 @@
+---
+title: NEXT-00000 - Add column assigned pages to CMS list 
+issue: NEXT-00000
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: @amenk
+---
+# Administration
+* Added new column `assignedPages` to `sw-cms-list` which displays up to 5 categories and products a page is assigned to. To not clutter the interface, the column is hidden by default.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/index.js
@@ -38,6 +38,7 @@ export default {
                 gridView: 10,
                 cardView: 9,
             },
+            associationLimit: 5,
             term: '',
             currentPageType: null,
             showMediaModal: false,
@@ -94,6 +95,8 @@ export default {
 
         listCriteria() {
             const criteria = new Criteria(this.page, this.limit);
+            criteria.getAssociation('categories').setLimit(this.associationLimit);
+            criteria.getAssociation('products').setLimit(this.associationLimit);
             criteria.addAssociation('previewMedia')
                 .addSorting(Criteria.sort(this.sortBy, this.sortDirection));
 
@@ -492,6 +495,11 @@ export default {
                 label: this.$tc('sw-cms.list.gridHeaderAssignments'),
                 sortable: false,
             }, {
+                property: 'assignedPages',
+                label: this.$tc('sw-cms.list.gridHeaderAssignedPages'),
+                sortable: false,
+                visible: false,
+            }, {
                 property: 'createdAt',
                 label: this.$tc('sw-cms.list.gridHeaderCreated'),
                 sortable: false,
@@ -542,6 +550,18 @@ export default {
         getPageCount(page) {
             const pageCount = this.getPageCategoryCount(page) + this.getPageProductCount(page);
             return pageCount > 0 ? pageCount : '-';
+        },
+
+        getPages(page) {
+            let items = page.categories.map((item) => item.name);
+            items = items.concat(page.products.map((item) => item.name));
+
+            let pages = items.join(', ');
+            if (items.length < this.getPageCount(page)) {
+                pages = pages + ', ...';
+            }
+
+            return pages;
         },
 
         optionContextDeleteDisabled(page) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
@@ -297,6 +297,13 @@
                                     {% endblock %}
 
                                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                                    {% block sw_cms_list_listing_list_data_grid_column_assignment_list %}
+                                    <template #column-assignedPages="{ item }">
+                                        {{ getPages(item) }}
+                                    </template>
+                                    {% endblock %}
+
+                                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                                     {% block sw_cms_list_listing_list_data_grid_column_created %}
                                     <template #column-createdAt="{ item }">
                                         {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit' }) }}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -26,6 +26,7 @@
       "gridHeaderType": "Typ",
       "gridHeaderAssignment": "Zugewiesene Kategorien",
       "gridHeaderAssignments": "Zuordnungen",
+      "gridHeaderAssignedPages": "Zugewiesene Seiten",
       "gridHeaderCreated": "Erstellt",
       "gridHeaderUpdated": "Bearbeitungsdatum"
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -26,6 +26,7 @@
       "gridHeaderType": "Type",
       "gridHeaderAssignment": "Assigned categories",
       "gridHeaderAssignments": "Assignments",
+      "gridHeaderAssignedPages": "Assigned pages",
       "gridHeaderCreated": "Created",
       "gridHeaderUpdated": "Updated date"
     },


### PR DESCRIPTION
Add a new column which displays the actual assigned pages.

We are aware, that this can clutter the interface, depending on the structure of the shop - so the column is initially hidden but still should serve value and help editors to find the correct page.

### 1. Why is this change necessary?

It helps the editor to better identify page layouts.

### 2. What does this change do, exactly?

I adds an (hidden by default) column to the CMS list.
For performance reasons up to 5 associations per type are shown, a "..." indicated if not all entries are shown.

### 3. Describe each step to reproduce the issue or behaviour.

1. Navigate to content -> shopping experiences
2. Toggle the list view
3. open the list settings
4. chose the column Assigned pages

![Screenshot with the new column](https://github.com/shopware/shopware/assets/1087128/e0fe31d7-98ee-48a5-ba92-e8ab9821eded)

### 4. Please link to the relevant issues (if any).

none

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
