### PR TITLE
doc: fix double ' in UPGRADE-6.5.md assets example

### DIFF
--- a/UPGRADE-6.5.md
+++ b/UPGRADE-6.5.md
@@ -2011,7 +2011,7 @@ This was needed to be able to link the asset in the Storefront as the theme asse
 To improve the performance of `theme:compile` and to reduce the confusion of the usage of assets we copy the files only to `theme/[id]`.
 
 To use the updated asset package,
-replace your current `{{ asset('logo.png', '@ThemeName') }}` with `{{ asset('logo.png', 'theme'') }}`
+replace your current `{{ asset('logo.png', '@ThemeName') }}` with `{{ asset('logo.png', 'theme') }}`
 
 ## Moved and changed the `ThemeCompilerEnrichScssVariablesEvent`
 We moved the event `ThemeCompilerEnrichScssVariablesEvent` from `\Shopware\Storefront\Event\ThemeCompilerEnrichScssVariablesEvent` to `\Shopware\Storefront\Theme\Event\ThemeCompilerEnrichScssVariablesEvent`.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The current example produces this error:
`Can not render @Storefront/storefront/page/content/index.html.twig view: Unexpected character "@". with these parameters: {"themeIconConfig":[]}`


### 2. What does this change do, exactly?
Fixes the double '.

### 3. Describe each step to reproduce the issue or behaviour.
Copy old example `{{ asset('logo.png', 'theme'') }}` into your theme eg. `footer.html.twig`. 
If you run a Dockware dev container, this will immediately result in the above error.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
