### PR TITLE
NEXT-00000 - Add sanitize field name for cms text

### DIFF
--- a/changelog/_unreleased/2024-03-24-add-sanitize-field-for-cms-text-fields.md
+++ b/changelog/_unreleased/2024-03-24-add-sanitize-field-for-cms-text-fields.md
@@ -1,0 +1,10 @@
+---
+title: Add sanitize field for cms text fields
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Administration
+* Added `sanitize-field-name` parameter for cms text fields

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/sw-cms-el-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/component/sw-cms-el-text.html.twig
@@ -15,6 +15,7 @@
         :allow-inline-data-mapping="true"
         :is-inline-edit="true"
         sanitize-input
+        sanitize-field-name="app_cms_block.template"
         enable-transparent-background
         @blur="onBlur"
         @update:value="onInput"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/text/config/sw-cms-el-config-text.html.twig
@@ -47,6 +47,7 @@
                     :value="element.config.content.value"
                     :allow-inline-data-mapping="true"
                     sanitize-input
+                    sanitize-field-name="app_cms_block.template"
                     enable-transparent-background
                     @update:value="onInput"
                     @blur="onBlur"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
It is currently not possible to configure the html sanitizer for the text editor in cms elements. This should normally be configured using the`app_cms_block.template` fields config. Since the text editor does not send the `sanitize-field-name` this config will not be used.

### 2. What does this change do, exactly?
This change adds the `sanitize-field-name` with value `app_cms_block.template`. This will make it possible to configure the html sanitizer in the cms text editor.

### 3. Describe each step to reproduce the issue or behaviour.
This is an example:
1. Configure the html sanitize in `shopware.yaml`
`    html_sanitizer:
      fields:
        - name: app_cms_block.template
          sets: [ "script" ]`
2. Edit a cms text block using the code editor
3. Add a script tag

This tag should not be sanitized but it does get sanitized.

### 4. Please link to the relevant issues (if any).
/ 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
