### PR TITLE
NEXT-31733 - Always save billing address as a new order address

### DIFF
--- a/changelog/_unreleased/2024-03-25-save-billing-address-as-new-order-address-to-prevent-bug-when-editing.md
+++ b/changelog/_unreleased/2024-03-25-save-billing-address-as-new-order-address-to-prevent-bug-when-editing.md
@@ -1,0 +1,9 @@
+---
+title: Save billing address as a new order address with new id on order-creation to prevent a bug when editing order-addresses
+issue: NEXT-31733
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Changed `OrderConverter::convertToOrder` to save the billing address as a new order address with new id on order-creation to prevent a bug when editing order-addresses

--- a/src/Core/Checkout/Cart/Order/OrderConverter.php
+++ b/src/Core/Checkout/Cart/Order/OrderConverter.php
@@ -124,7 +124,6 @@ class OrderConverter
         $data['languageId'] = $context->getLanguageId();
 
         $convertedLineItems = LineItemTransformer::transformCollection($cart->getLineItems());
-        $shippingAddresses = [];
 
         if ($conversionContext->shouldIncludeDeliveries()) {
             $shippingAddresses = AddressTransformer::transformCollection($cart->getDeliveries()->getAddresses(), true);
@@ -147,16 +146,11 @@ class OrderConverter
             if ($activeBillingAddress === null) {
                 throw CartException::addressNotFound('');
             }
-            $customerAddressId = $activeBillingAddress->getId();
 
-            if (\array_key_exists($customerAddressId, $shippingAddresses)) {
-                $billingAddressId = $shippingAddresses[$customerAddressId]['id'];
-            } else {
-                $billingAddress = AddressTransformer::transform($activeBillingAddress);
-                $data['addresses'] = [$billingAddress];
-                $billingAddressId = $billingAddress['id'];
-            }
-            $data['billingAddressId'] = $billingAddressId;
+            $billingAddress = AddressTransformer::transform($activeBillingAddress);
+            $billingAddress['id'] = Uuid::randomHex();
+            $data['billingAddressId'] = $billingAddress['id'];
+            $data['addresses'] = [$billingAddress];
         }
 
         if ($conversionContext->shouldIncludeTransactions()) {


### PR DESCRIPTION
### 1. Why is this change necessary?

https://issues.shopware.com/issues/NEXT-31733

### 2. What does this change do, exactly?

It saves the billing address as a new order address with new ID on order-creation to prevent a bug when editing order-addresses.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create customer with 2 addresses
2. Create order in administration with the same billing and shipping address
3. Open order, select a different billing order-address
4. Press save.
5. Both shipping and billing address change.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-31733

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
