### PR TITLE
NEXT-00000 - Generate new token when context not found

### DIFF
--- a/changelog/_unreleased/2024-03-27-generate-new-token-when-context-not-found.md
+++ b/changelog/_unreleased/2024-03-27-generate-new-token-when-context-not-found.md
@@ -1,0 +1,11 @@
+---
+title: generate new token when context not found
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Core
+
+* When you call the `\Shopware\Core\System\SalesChannel\Context\SalesChannelContextService::get` and the context is not found, there will be a context created in memory with the given sales channel context token. You would expect a new token to be generated in this case.

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -61,7 +61,7 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
 
             $session = $this->contextPersister->load($token, $parameters->getSalesChannelId());
 
-            if ($session['expired'] ?? false) {
+            if ($session['expired'] ?? true) {
                 $token = Random::getAlphanumericString(32);
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When we use the `\Shopware\Core\System\SalesChannel\Context\SalesChannelContextService::get` function, a new context token is generated when the session is expired but when the sales channel context can not be found the old token is used to create a a sales channel context in memory. You would expect that a new sales channel context token is generated when the context can not be found.

### 2. What does this change do, exactly?
When the expired parameter can not be found (this means the sales channel context can not be found), we will generate a new token.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a new sales channel context and persist this to the db
2. Save that token
3. Delete the sales channel context from the db
4. Call the `\Shopware\Core\System\SalesChannel\Context\SalesChannelContextService::get` function
5. Check that the context is given with the old token that is actually invalid because there is no sales channel context with that token


### 4. Please link to the relevant issues (if any).
/ 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
