### PR TITLE
NEXT-00000 - Add missing transactions association

### DIFF
--- a/changelog/_unreleased/2024-03-27-add-missing-transactions-association.md
+++ b/changelog/_unreleased/2024-03-27-add-missing-transactions-association.md
@@ -1,0 +1,11 @@
+---
+title: Add missing transactions association
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Storefront
+* Added missing transactions association when using the `\Shopware\Storefront\Controller\AccountOrderController::updateOrder` method. The `\Shopware\Core\Checkout\Order\SalesChannel\OrderService::isPaymentChangeableByTransactionState` method will always return true since the transactions are not loaded on the order.
+

--- a/src/Storefront/Controller/AccountOrderController.php
+++ b/src/Storefront/Controller/AccountOrderController.php
@@ -233,8 +233,10 @@ class AccountOrderController extends StorefrontController
             'changedPayment' => true,
         ]);
 
+        $criteria = new Criteria([$orderId]);
+        $criteria->addAssociation('transactions.stateMachineState');
         /** @var OrderEntity|null $order */
-        $order = $this->orderRoute->load($request, $context, new Criteria([$orderId]))->getOrders()->first();
+        $order = $this->orderRoute->load($request, $context, $criteria)->getOrders()->first();
 
         if ($order === null) {
             throw OrderException::orderNotFound($orderId);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The `\Shopware\Storefront\Controller\AccountOrderController::updateOrder` function loads the order and checks the transaction state in the `\Shopware\Core\Checkout\Order\SalesChannel\OrderService::isPaymentChangeableByTransactionState` but the order transaction association is not loaded so this will always be `null`.

### 2. What does this change do, exactly?
This change adds the missing association when loading the order.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create an order
2. Do a POST to the `frontend.account.edit-order.update-order` route
3. You can now see that the order transactions are always `null`

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
