### PR TITLE
NEXT-19836 - Fix german address form validation texts

### DIFF
--- a/changelog/_unreleased/2024-04-05-workaround-english-field-identifiers-in-german-form-violation-texts.md
+++ b/changelog/_unreleased/2024-04-05-workaround-english-field-identifiers-in-german-form-violation-texts.md
@@ -1,0 +1,9 @@
+---
+title: Generalise german form violation texts
+issue: NEXT-19836
+author: Justus Maier
+author_email: jmaier@notebooksbilliger.de
+author_github: @justusNBB
+---
+# Storefront
+* Generalise german `error.VIOLATION::*` texts, working around injected english field names (`%field%`).

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -65,9 +65,9 @@
     "wishlist": "Merkzettel"
   },
   "error": {
-    "VIOLATION::IS_BLANK_ERROR": "%field% darf nicht leer sein.",
-    "VIOLATION::TOO_LOW_ERROR": "%field% darf nicht leer sein.",
-    "VIOLATION::STRICT_CHECK_FAILED_ERROR": "%field% ist ungültig",
+    "VIOLATION::IS_BLANK_ERROR": "Die Eingabe darf nicht leer sein.",
+    "VIOLATION::TOO_LOW_ERROR": "Die Eingabe darf nicht leer sein.",
+    "VIOLATION::STRICT_CHECK_FAILED_ERROR": "Die Eingabe ist ungültig",
     "VIOLATION::CUSTOMER_EMAIL_NOT_UNIQUE": "Diese E-Mail-Adresse ist bereits registriert.",
     "VIOLATION::CUSTOMER_PASSWORD_NOT_CORRECT": "Das Passwort ist nicht korrekt.",
     "VIOLATION::VAT_ID_FORMAT_NOT_CORRECT": "Die eingegebene USt-IdNr. entspricht nicht der erwarteten Struktur",
@@ -78,7 +78,7 @@
     "FRAMEWORK__INVALID_UUID": "Die gewählte Zahlungsart konnte nicht gefunden werden.",
     "CHECKOUT__UNKNOWN_PAYMENT_METHOD": "Die gewählte Zahlungsart konnte nicht gefunden werden.",
     "productNotFound": "Produkt \"%number%\" konnte nicht gefunden werden.",
-    "VIOLATION::TOO_SHORT_ERROR": "%field% ist zu kurz.",
+    "VIOLATION::TOO_SHORT_ERROR": "Die Eingabe ist zu kurz.",
     "product-not-found": "Das Produkt wurde nicht gefunden.",
     "message-403-ajax": "Die Sitzung ist abgelaufen. Bitte laden Sie die Seite neu und versuchen Sie es erneut.",
     "message-403": "Die Sitzung ist abgelaufen. Bitte kehren Sie zur letzten Seite zurück neu und versuchen Sie  es erneut.",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Because https://issues.shopware.com/issues/NEXT-19836 is still valid

### 2. What does this change do, exactly?
Generalising german address form error text translations:
> Lastname darf nicht leer sein.

becomes
> Die Eingabe darf nicht leer sein.

This is a workaround and needs to be applied to all other languages but english.

### 3. Describe each step to reproduce the issue or behaviour.
Trigger the address form error texts in german:
See https://issues.shopware.com/issues/NEXT-19836


### 4. Please link to the relevant issues (if any).
Even with this fix, https://issues.shopware.com/issues/NEXT-19836 should likely be reopened and potentially cleaned up further: Either use a general text for all languages or fix the mechanism composing translations...


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change - no tests required
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes - I'm not sure if the changes in this PR solve the issue...
- [x] I have written or adjusted the documentation according to my changes - not needed
- [x] This change has comments for package types, values, functions, and non-obvious lines of code - not needed
- [x] I have read the contribution requirements and fulfil them. 
