### PR TITLE
Update customer view and show correct saleschannel info

### DIFF
--- a/changelog/_unreleased/2023-03-28-show-correct-saleschannel-on-customer-view.md
+++ b/changelog/_unreleased/2023-03-28-show-correct-saleschannel-on-customer-view.md
@@ -1,0 +1,9 @@
+---
+title:          show-correct-saleschannel-on-customer-view.md
+issue:          null
+author:         Fabian Blechschmidt
+author_email:   fabian@winkelwagen.de
+author_github:  Schrank
+---
+# Admin
+* Changed customer field to show what sales channel the customer is bound to

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-base-info/sw-customer-base-info.html.twig
@@ -264,7 +264,7 @@
             {% block sw_customer_base_metadata_bound_saleschannel_content %}
             <dd class="sw-customer-base__label-bound-sales-channel">
                 <template v-if="customer.boundSalesChannelId">
-                    {{ customer.salesChannel.translated.name }}
+                    {{ customer.boundSalesChannel.translated.name }}
                 </template>
                 <template v-else>
                     {{ $tc('sw-customer.baseInfo.emptyBoundSalesChannel') }}


### PR DESCRIPTION
The field which defines which sales channel a customer is bound to is bound_saleschannel_id, but it is not used, although the complete template looks like it. This patch fixes it.


### 1. Why is this change necessary?
Because the ~backend~ admin says the customer is bound to a saleschannel but it is wrong

### 2. What does this change do, exactly?
Fixes the wrong info shown here:
![image](https://github.com/shopware/shopware/assets/379680/6fc0c050-899a-4726-9f55-17fe9485c0c3)


### 3. Describe each step to reproduce the issue or behaviour.
Have a customer which has saleschannel_id with a different value than bound_saleschannel_id

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
