### PR TITLE
chore: Add `gad_source` parameter to ignored http cache parameters

### DIFF
--- a/changelog/_unreleased/2024-04-02-add-gad_source-parameter-to-ignored-http-cache-parameters.md
+++ b/changelog/_unreleased/2024-04-02-add-gad_source-parameter-to-ignored-http-cache-parameters.md
@@ -1,0 +1,9 @@
+---
+title: Add gad_source parameter to ignored http cache parameters
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added `gad_source` parameter to ignored http cache parameters `shopware.http_cache.ignored_url_parameters`

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -53,6 +53,7 @@ shopware:
             - 'utm_medium'
             - 'utm_campaign'
             - 'utm_content'
+            - 'gad_source'
             - 'cx'
             - 'ie'
             - 'cof'


### PR DESCRIPTION
### 1. Why is this change necessary?
Recently I noticed some non hitting HTTP cache calls, due to a, to me unknown, URL parameter `gad_source`: https://support.google.com/google-ads/answer/13327296?hl=en

### 2. What does this change do, exactly?
Ignore this parameter.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
