### PR TITLE
Hide dots navigation if "Keine" is selected

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -347,7 +347,7 @@
                                 {% endblock %}
 
                                 {% block element_image_gallery_slider_dots %}
-                                    {% if imageCount > 1 and navigationDots %}
+                                    {% if imageCount > 1 and navigationDots != 'Keine' %}
                                         <div class="base-slider-dots {% if imageCount > maxItemsToShowNav %} hide-dots{% elseif imageCount > maxItemsToShowMobileNav %} hide-dots-mobile{% endif %}">
                                             {% block element_image_gallery_slider_dots_buttons %}
                                                 {% for image in mediaItems %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently it is not possible to remove dot navigation from the gallery

### 2. What does this change do, exactly?

Hides dot navigation

### 3. Describe each step to reproduce the issue or behaviour.

Clone product detail layout in the administration.
Open the gallery settings and select "Keine" on "Punkte Navigation"

![Bildschirmfoto 2024-04-02 um 16 47 00](https://github.com/shopware/shopware/assets/6016485/0ef0623b-462b-43b9-945b-f1774f710711)

Save settings. The value is saved as "Keine":
![Bildschirmfoto 2024-04-02 um 16 46 51](https://github.com/shopware/shopware/assets/6016485/72d3be43-8f68-43ff-81f1-9440161dcd26)

So the navigation in the template is not hidden by condition.
I don't know if the value in another languages is also "Keine" is yes, then we need another generic solution here. For example "none" like wiht the "outside"


### 5. Checklist

- [x ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ x] I have read the contribution requirements and fulfil them.
