### PR TITLE
keep element keys when sortByPositions

### DIFF
--- a/src/Core/Content/Property/PropertyGroupCollection.php
+++ b/src/Core/Content/Property/PropertyGroupCollection.php
@@ -34,7 +34,7 @@ class PropertyGroupCollection extends EntityCollection
 
     public function sortByPositions(): void
     {
-        usort($this->elements, function (Entity $a, Entity $b) {
+        uasort($this->elements, function (Entity $a, Entity $b) {
             $posA = $a->getTranslation('position') ?? $a->getPosition() ?? 0;
             $posB = $b->getTranslation('position') ?? $b->getPosition() ?? 0;
             if ($posA === $posB) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Calling sortByPositions changes the keys in the collection so that operations on the collection are not possible as before, since the collection expects to have identifiers as element keys.

### 2. What does this change do, exactly?
Replace usort with uasort 😎🤷‍♂️

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
