### PR TITLE
chore: Deprecated MailTemplate AttachmentLoader

### DIFF
--- a/changelog/_unreleased/2024-04-03-deprecated-mail-attachmentloader.md
+++ b/changelog/_unreleased/2024-04-03-deprecated-mail-attachmentloader.md
@@ -1,0 +1,10 @@
+---
+title: Deprecated Mail AttachmentLoader
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Deprecated unused service `Shopware\Core\Content\MailTemplate\Service\AttachmentLoader`
+* Deprecated event `Shopware\Core\Content\MailTemplate\Service\Event\AttachmentLoaderCriteriaEvent`

--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -86,6 +86,8 @@
             <argument type="service" id="document.repository"/>
             <argument type="service" id="Shopware\Core\Checkout\Document\Service\DocumentGenerator"/>
             <argument type="service" id="event_dispatcher"/>
+
+            <deprecated package="shopware/core" version="6.7.0.0">tag:v6.7.0 - The unused %service_id% service will be removed in v6.7.0.0</deprecated>
         </service>
     </services>
 </container>

--- a/src/Core/Content/MailTemplate/Service/AttachmentLoader.php
+++ b/src/Core/Content/MailTemplate/Service/AttachmentLoader.php
@@ -8,9 +8,13 @@ use Shopware\Core\Content\MailTemplate\Service\Event\AttachmentLoaderCriteriaEve
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @deprecated tag:v6.7.0 - Will be removed as the service is not used anymore
+ */
 #[Package('services-settings')]
 class AttachmentLoader
 {
@@ -31,6 +35,11 @@ class AttachmentLoader
      */
     public function load(array $documentIds, Context $context): array
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.7.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.7.0.0')
+        );
+
         $attachments = [];
         $criteria = new Criteria($documentIds);
         $criteria->addAssociation('documentMediaFile');

--- a/src/Core/Content/MailTemplate/Service/Event/AttachmentLoaderCriteriaEvent.php
+++ b/src/Core/Content/MailTemplate/Service/Event/AttachmentLoaderCriteriaEvent.php
@@ -3,9 +3,13 @@
 namespace Shopware\Core\Content\MailTemplate\Service\Event;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @deprecated tag:v6.7.0 - Will be removed as the service dispatching this event, will be removed
+ */
 #[Package('services-settings')]
 class AttachmentLoaderCriteriaEvent extends Event
 {
@@ -17,6 +21,11 @@ class AttachmentLoaderCriteriaEvent extends Event
 
     public function getCriteria(): Criteria
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.7.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.7.0.0')
+        );
+
         return $this->criteria;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
While debugging the mail attachments, I did found a service, which seems to be unused, hence it probably should be deprecated and removed in the next major version. Not sure if the test (`Shopware\Core\Content\Test\MailTemplate\Service\AttachmentLoaderTest`) should also be deprecated or not.

### 2. What does this change do, exactly?
Deprecate the `Shopware\Core\Content\MailTemplate\Service\AttachmentLoader` and the event which is dispatched in that service `Shopware\Core\Content\MailTemplate\Service\Event\AttachmentLoaderCriteriaEvent`.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
