### PR TITLE
NEXT-34825 - Changed return value to array if object is empty

### DIFF
--- a/changelog/_unreleased/2024-04-05-change-empty-object-to-array.md
+++ b/changelog/_unreleased/2024-04-05-change-empty-object-to-array.md
@@ -1,0 +1,8 @@
+---
+title: Admin `product-listing` - empty sorting return array not object
+issue: NEXT-34825
+author: Fabian Boensch
+author_github: @En0Ma1259
+---
+# Administration
+* Changed `product-listing` `availableSortings` default config to array

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/index.js
@@ -237,6 +237,10 @@ export default {
          * e.g. 'Product sorting entity' => [{ 'test-sorting': 10 }]
          */
         transformProductSortings() {
+            if (this.productSortings.length === 0) {
+                return [];
+            }
+
             const object = {};
 
             this.productSortings.forEach(currentProductSorting => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/sw-cms-el-config-product-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/sw-cms-el-config-product-listing.spec.js
@@ -193,7 +193,7 @@ describe('src/module/sw-cms/elements/product-listing/config', () => {
     it('should update the config when product sortings changes', async () => {
         const wrapper = await createWrapper();
 
-        expect(wrapper.vm.element.config.availableSortings.value).toStrictEqual({});
+        expect(wrapper.vm.element.config.availableSortings.value).toStrictEqual([]);
 
         await wrapper.setData({
             productSortings: [

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/index.js
@@ -49,7 +49,7 @@ Shopware.Service('cmsService').registerCmsElement({
         },
         availableSortings: {
             source: 'static',
-            value: {},
+            value: [],
         },
         defaultSorting: {
             source: 'static',


### PR DESCRIPTION
### 1. Why is this change necessary?
CMS-Element `product-listing` default config for `availableSortings` is an empty object.
If an empty object is saved, the payload will be converted to an empty array in PHP and is saved with `[]` in the database, but should be `{}`.
Therefore, every time someone saves a category with this layout, the JavaScript will detect changes and will save this element config into the `category_translation` `slot_config` field

### 2. What does this change do, exactly?
Change default config from object to array

### 3. Describe each step to reproduce the issue or behaviour.
Save a category layout with a `product-listing`. Look into the request payload or database `slot_config` field

Example payload:
```
{
    "config": {
        ...
        "availableSortings": {
            "value": {},
            "source": "static"
        },
        ...
    }
}
```
should be
```
{
    "config": {
        ...
        "availableSortings": {
            "value": [],
            "source": "static"
        },
        ...
    }
}
```

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-34825

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
