### PR TITLE
NEXT-00000: Fix AR on Meta Quest 3

### DIFF
--- a/changelog/_unreleased/2024-04-05-fix-ar-on-quest-3.md
+++ b/changelog/_unreleased/2024-04-05-fix-ar-on-quest-3.md
@@ -1,0 +1,11 @@
+---
+title: Fix AR on Quest 3
+issue: NEXT-00000
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+
+# Storefront
+
+* Removed `dom-overlay` from required features to make AR work on Meta Quest 3 browser

--- a/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/WebXrView.ts
+++ b/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/WebXrView.ts
@@ -68,8 +68,8 @@ export default class WebXrView {
         // request session
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         navigator.xr.requestSession( 'immersive-ar', {
-            requiredFeatures: ['local', 'hit-test', 'dom-overlay'],
-            optionalFeatures: ['light-estimation', 'local-floor'],
+            requiredFeatures: ['local', 'hit-test'],
+            optionalFeatures: ['light-estimation', 'local-floor', 'dom-overlay'],
             domOverlay: { root: this.overlay.element },
         } ).then( this.onSessionStarted.bind(this) );
     }


### PR DESCRIPTION
Do not request dom-overlay as required feature

### 1. Why is this change necessary?

AR features are not working on Meta Quest 3

### 2. What does this change do, exactly?

It removes the dom-overlay from the required features,

### 3. Describe each step to reproduce the issue or behaviour.

1. Upload .glb file, for example https://ar-code.com/files/AR-Code-1683008769490.glb as product image
2. Activate AR in the media library
3. Open Product detail page on Meta Quest 3 browser
4. Click the AR button
5. Strange overlay appears

By following https://developer.oculus.com/documentation/web/browser-remote-debugging/ you can connect a local chrome and take a look at the browser console.

You get the error "Feature dom-overlay is not supported for mode: immersive-ar"

![image](https://github.com/shopware/shopware/assets/1087128/0a1574a1-3063-425f-940d-1e45eef816ab)

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
