### PR TITLE
Fix Missing Document Settings Modal Template prevent creation of cust…

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
@@ -105,7 +105,7 @@ export default {
                 return `sw-order-document-settings-${subComponentName}-modal`;
             }
 
-            return `sw-order-document-settings-${subComponentName}-modal`;
+            return `sw-order-document-settings-modal`;
         },
 
         documentCardStyles() {


### PR DESCRIPTION
…om documents in backend

Custom Documents could not be created on Order in Backend, because sw-order-document-settings-{CUSTOM_DOCUMENT_TYPE}-modal Component is not available. Fallback doesn't work, because component string is wrong.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
