### PR TITLE
NEXT-34921 - chore: Add native array return type to all event subscribers getSubscribedEvents

### DIFF
--- a/changelog/_unreleased/2024-04-06-add-native-array-return-type-to-getsubscribedevents.md
+++ b/changelog/_unreleased/2024-04-06-add-native-array-return-type-to-getsubscribedevents.md
@@ -1,0 +1,12 @@
+---
+title: Add native array return type to getSubscribedEvents()
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added native `array` return type to `Shopware\Core\System\UsageData\Subscriber\ShopIdChangedSubscriber::getSubscribedEvents()` and `Shopware\Core\System\UsageData\Consent\ConsentReporter::getSubscribedEvents()`
+___
+# Storefront
+* Added native `array` return type to `Shopware\Storefront\Framework\Twig\TwigDateRequestListener::getSubscribedEvents()`

--- a/src/Core/System/UsageData/Consent/ConsentReporter.php
+++ b/src/Core/System/UsageData/Consent/ConsentReporter.php
@@ -27,7 +27,7 @@ class ConsentReporter implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ConsentStateChangedEvent::class => 'reportConsent',

--- a/src/Core/System/UsageData/Subscriber/ShopIdChangedSubscriber.php
+++ b/src/Core/System/UsageData/Subscriber/ShopIdChangedSubscriber.php
@@ -24,7 +24,7 @@ class ShopIdChangedSubscriber implements EventSubscriberInterface
     ) {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             ShopIdDeletedEvent::class => 'handleShopIdDeleted',

--- a/src/Storefront/Framework/Twig/TwigDateRequestListener.php
+++ b/src/Storefront/Framework/Twig/TwigDateRequestListener.php
@@ -21,10 +21,7 @@ class TwigDateRequestListener implements EventSubscriberInterface
     {
     }
 
-    /**
-     * @return array<string, string|array{0: string, 1: int}|list<array{0: string, 1?: int}>>
-     */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [KernelEvents::REQUEST => 'onKernelRequest'];
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
Fix deprecations:
![image](https://github.com/shopware/shopware/assets/6317761/2c92f2dc-3ad8-40ea-815d-42a20143f182)

### 2. What does this change do, exactly?
Add native array return type.

### 3. Describe each step to reproduce the issue or behaviour.
Run in debug mode.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
