### PR TITLE
Strip prefix from redis keys in redis incrementer

### DIFF
--- a/changelog/_unreleased/2024-04-08-strip-prefix-from-redis-keys-in-redis-incrementer.md
+++ b/changelog/_unreleased/2024-04-08-strip-prefix-from-redis-keys-in-redis-incrementer.md
@@ -1,0 +1,8 @@
+---
+title: Strip prefix from redis keys in redis incrementer
+issue: NEXT-00000
+author: Stefan Poensgen
+author_github: stefanpoensgen
+---
+# Core
+* Changed `RedisIncrementer` to work properly with redis prefix

--- a/src/Core/Framework/Increment/RedisIncrementer.php
+++ b/src/Core/Framework/Increment/RedisIncrementer.php
@@ -41,8 +41,7 @@ class RedisIncrementer extends AbstractIncrementer
             return;
         }
 
-        $keys = $this->redis->keys($this->getKey($cluster));
-        \assert(\is_array($keys));
+        $keys = $this->getKeys($cluster);
 
         foreach ($keys as $key) {
             $this->redis->del($key);
@@ -51,8 +50,7 @@ class RedisIncrementer extends AbstractIncrementer
 
     public function list(string $cluster, int $limit = 5, int $offset = 0): array
     {
-        $keys = $this->redis->keys($this->getKey($cluster));
-        \assert(\is_array($keys));
+        $keys = $this->getKeys($cluster);
 
         if (empty($keys)) {
             return [];
@@ -93,5 +91,25 @@ class RedisIncrementer extends AbstractIncrementer
         }
 
         return sprintf('%s:%s:%s', $this->poolName, $cluster, $key);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getKeys(string $cluster): array
+    {
+        $keys = $this->redis->keys($this->getKey($cluster));
+        \assert(\is_array($keys));
+
+        if (empty($keys) || !\method_exists($this->redis, 'getOption')) {
+            return [];
+        }
+
+        $prefix = $this->redis->getOption(\Redis::OPT_PREFIX);
+        if (\is_string($prefix)) {
+            $keys = \array_map(fn ($key) => \str_starts_with($key, $prefix) ? \substr($key, \strlen($prefix)) : $key, $keys);
+        }
+
+        return $keys;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
When you use REDIS_PREFIX, the Redis incrementer cannot reset or list the given keys because a Redis instance with prefix expects the keys without the prefix.

### 2. What does this change do, exactly?
It strips the prefix from keys.

### 3. Describe each step to reproduce the issue or behaviour.
For example, set REDIS_PREFIX=test.
Use Redis as the incrementer storage.
The list method will return false for each key.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
