### PR TITLE
fix: Correct display of long names of child items in administration order

### DIFF
--- a/changelog/_unreleased/2024-04-09-correct-display-of-long-names-of-child-items-in-administration-order.md
+++ b/changelog/_unreleased/2024-04-09-correct-display-of-long-names-of-child-items-in-administration-order.md
@@ -1,0 +1,9 @@
+---
+title: Correct display of long names of child items in administration order
+issue: -
+author: Joschka
+author_email: joschka@swk-web.com
+author_github: @tschosch51
+---
+# Administration
+* Changed SCSS of `sw-order-nested-line-items-row.scss` to correctly display long names of child items

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-nested-line-items-modal/sw-order-nested-line-items-modal.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-nested-line-items-modal/sw-order-nested-line-items-modal.scss
@@ -1,7 +1,13 @@
 @import "~scss/variables";
 
+.sw-modal__body:has(.sw-order-nested-line-items-modal__container) {
+    overflow-x: scroll;
+}
+
 .sw-order-nested-line-items-modal {
     &__container {
+        display: table;
+        width: 100%;
         margin: -20px 0;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-nested-line-items-row/sw-order-nested-line-items-row.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-nested-line-items-row/sw-order-nested-line-items-row.scss
@@ -9,25 +9,24 @@
         border-left: 1px solid $color-gray-300;
         display: inline-block;
         height: 100%;
-        margin: 0 8px 0 12px;
+        padding: 0 8px 0 12px;
     }
 
     &__label > div {
-        float: left;
+        display: table-cell;
     }
 
     &__label-content {
-        padding: 10px;
+        padding: 10px 10px 10px 0;
     }
 
     &__item {
         flex-grow: 1;
         padding: 10px;
-        height: 42px;
         font-size: $font-size-s;
 
         &:first-child {
-            padding: 0 0 0 20px;
+            padding: 0 0 0 30px;
         }
 
         &:last-child {


### PR DESCRIPTION
### 1. Why is this change necessary?
Broken:
<img width="687" alt="broken" src="https://github.com/shopware/shopware/assets/86104216/0cd27ca4-d743-4902-8af6-e770862ac28c">
Fixed:
<img width="734" alt="fixed" src="https://github.com/shopware/shopware/assets/86104216/c196689e-9683-47e6-b76b-170d29ff500b">

### 2. What does this change do, exactly?
Change scss

### 3. Describe each step to reproduce the issue or behaviour.
Open the modal of a product with child line items in the order in the administration

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
