### PR TITLE
Fix Typo in PluginBaseClassNotFoundException

### DIFF
--- a/src/Core/Framework/Plugin/Exception/PluginBaseClassNotFoundException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginBaseClassNotFoundException.php
@@ -12,7 +12,7 @@ class PluginBaseClassNotFoundException extends ShopwareHttpException
     public function __construct(string $baseClass)
     {
         parent::__construct(
-            'The class "{{ baseClass }}" is not found. Probably an class loader error. Check your plugin composer.json',
+            'The class "{{ baseClass }}" is not found. Probably a class loader error. Check your plugin composer.json',
             ['baseClass' => $baseClass]
         );
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The message is displayed to shop admins. We should have correct grammar/spelling here.

### 2. What does this change do, exactly?
Only fix a simple spelling mistake.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
