### PR TITLE
fix: Order of the ZIP code and city field

### DIFF
--- a/changelog/_unreleased/2024-04-11-interchange-order-of-city-and-zip-code-field.md
+++ b/changelog/_unreleased/2024-04-11-interchange-order-of-city-and-zip-code-field.md
@@ -1,0 +1,10 @@
+---
+title: Interchange order of city and zip code field
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed the field order of the city and ZIP code to first show the ZIP code and then the city
+* Added blocks `component_address_form_zipcode_field` and `component_address_form_city_field`

--- a/src/Storefront/Resources/views/storefront/component/address/address-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-form.html.twig
@@ -143,7 +143,8 @@
 
             {% block component_address_form_zipcode_city %}
                 {% set zipcodeField %}
-                {% set zipcodeValue = formViolations.getInputData()['zipcode'] ?? data.get('zipcode') %}
+                    {% set zipcodeValue = formViolations.getInputData()['zipcode'] ?? data.get('zipcode') %}
+
                     {% if formViolations.getViolations('/zipcode') is not empty %}
                         {% set violationPath = '/zipcode' %}
                     {% elseif formViolations.getViolations("/#{prefix}/zipcode") is not empty %}
@@ -215,13 +216,17 @@
                     {% endblock %}
                 {% endset %}
 
-                <div class="form-group col-md-4 col-8">
-                    {{ cityField }}
-                </div>
+                {% block component_address_form_zipcode_field %}
+                    <div class="form-group col-md-2 col-4">
+                        {{ zipcodeField }}
+                    </div>
+                {% endblock %}
 
-                <div class="form-group col-md-2 col-4">
-                    {{ zipcodeField }}
-                </div>
+                {% block component_address_form_city_field %}
+                    <div class="form-group col-md-4 col-8">
+                        {{ cityField }}
+                    </div>
+                {% endblock %}
             {% endblock %}
 
             {% block component_address_form_additional_field1 %}


### PR DESCRIPTION
### 1. Why is this change necessary?
https://forum.shopware.com/t/im-registrierungsformular-steht-ort-vor-plz/103671/4
https://github.com/shopware/shopware/commit/46ee0603ba81d7909baa04c603985c537657c000#diff-bec516e908622f4a6c0862196e64e5a62997373658b915cd3153f73fd04253ff

### 2. What does this change do, exactly?
Interchange the order and for good measure, also add blocks.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
