### PR TITLE
NEXT-35209 - correct usage of copyable property in password fields

### DIFF
--- a/changelog/_unreleased/2024-04-13-correct-copy-able-to-copyable-for-text-field.md
+++ b/changelog/_unreleased/2024-04-13-correct-copy-able-to-copyable-for-text-field.md
@@ -1,0 +1,16 @@
+---
+title: correct copy-able to copyable for text-field
+issue: NEXT-35209
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Administration
+
+* Removed the `copy-able` property with value `false` from the `sw-password-field` in module `sw-verify-user-modal` in block `sw_settings_user_detail_content_confirm_password_modal_input__confirm_password`.
+* Removed the `copy-able` property with value `false` from the `sw-password-field` in module `sw-first-run-wizard-welcome` in block `sw_first_run_wizard_welcome_confirm_language_switch_modal_text`.
+* Removed the `copy-able` property with value `false` from the `sw-password-field` in module `sw-users-permissions-user-listing` in block `sw_settings_user_list_delete_modal_input__confirm_password`.
+* Removed the `copy-able` property with value `false` from the `sw-password-field` in module `sw-users-permissions-user-create` in block `sw_settings_user_detail_content_password`.
+* Removed the `copy-able` property with value `false` from the `sw-password-field` in module `sw-users-permissions-user-detail` in block `sw_settings_user_detail_content_password`.
+* Changed the `copy-able` property to `copyable` with same value in `sw-password-field` in module `sw-users-permissions-user-detail` of blocks `sw_settings_user_detail_detail_modal_inner_field_access_key` and `sw_settings_user_detail_detail_modal_inner_field_secret_access_key_field`.

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-verify-user-modal/sw-verify-user-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-verify-user-modal/sw-verify-user-modal.html.twig
@@ -13,7 +13,6 @@
         class="sw-settings-user-detail__confirm-password"
         name="sw-field--confirm-password"
         :password-toggle-able="true"
-        :copy-able="false"
         autocomplete="new-password"
         :label="$tc('sw-users-permissions.users.user-detail.passwordConfirmation.labelConfirmPassword')"
         :placeholder="$tc('sw-users-permissions.users.user-detail.passwordConfirmation.placeholderConfirmPassword')"

--- a/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-welcome/sw-first-run-wizard-welcome.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-first-run-wizard/view/sw-first-run-wizard-welcome/sw-first-run-wizard-welcome.html.twig
@@ -68,7 +68,6 @@
             v-model:value="user.pw"
             type="password"
             :label="$tc('sw-first-run-wizard.shopwareAccount.passwordPlaceholder')"
-            :copy-able="false"
             @keypress.enter="onConfirmLanguageSwitch"
         />
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/components/sw-users-permissions-user-listing/sw-users-permissions-user-listing.html.twig
@@ -164,7 +164,6 @@
                     required
                     name="sw-field--confirm-password"
                     :password-toggle-able="true"
-                    :copy-able="false"
                     :label="$tc('sw-users-permissions.users.user-detail.passwordConfirmation.labelConfirmPassword')"
                     :placeholder="$tc('sw-users-permissions.users.user-detail.passwordConfirmation.placeholderConfirmPassword')"
                     autocomplete="off"

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-create/sw-users-permissions-user-create.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-create/sw-users-permissions-user-create.html.twig
@@ -8,7 +8,6 @@
     :error="userPasswordError"
     required
     :password-toggle-able="true"
-    :copy-able="false"
     autocomplete="off"
 />
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig
@@ -149,7 +149,6 @@
                             name="sw-field--user-password"
                             :disabled="!acl.can('users_and_permissions.editor')"
                             :label="$tc('sw-users-permissions.users.user-detail.labelPassword')"
-                            :copy-able="false"
                             :error="userPasswordError"
                             autocomplete="off"
                             @update:value="setPassword"
@@ -380,8 +379,8 @@
                 v-model:value="currentIntegration.accessKey"
                 :label="$tc('sw-users-permissions.users.user-detail.modal.idFieldLabel')"
                 :disabled="true"
-                :copy-able="true"
-                :copy-able-tooltip="true"
+                :copyable="true"
+                :copyable-tooltip="true"
             />
             {% endblock %}
 
@@ -395,8 +394,8 @@
                 :label="$tc('sw-users-permissions.users.user-detail.modal.secretFieldLabel')"
                 :disabled="true"
                 :password-toggle-able="false"
-                :copy-able="showSecretAccessKey"
-                :copy-able-tooltip="true"
+                :copyable="showSecretAccessKey"
+                :copyable-tooltip="true"
             />
 
             <sw-password-field
@@ -405,8 +404,8 @@
                 :label="$tc('sw-users-permissions.users.user-detail.modal.secretFieldLabel')"
                 :disabled="true"
                 :password-toggle-able="false"
-                :copy-able="showSecretAccessKey"
-                :copy-able-tooltip="true"
+                :copyable="showSecretAccessKey"
+                :copyable-tooltip="true"
                 autocomplete="off"
             />
             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
`copy-able` has no affect. Correct is `copyable`

### 2. What does this change do, exactly?
- Change the usage of `copy-able` to `copyable`.
- Remove `copy-able` with value `false`

### 3. Describe each step to reproduce the issue or behaviour.
Create a user integration, see there is no button to copy values.
![image](https://github.com/shopware/shopware/assets/135993/2d17a793-dbeb-4254-8851-1c55798ed2ee)

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-35209

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
