### PR TITLE
NEXT-35521 - Add language to flow events

### DIFF
--- a/changelog/_unreleased/2024-04-15-add-language-to-send-mail-event.md
+++ b/changelog/_unreleased/2024-04-15-add-language-to-send-mail-event.md
@@ -1,0 +1,13 @@
+---
+title: add-language-to-send-mail-event
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Core
+
+* Add `LanguageAware` and a `LanguageStorer` class to allow a specific language for flow events
+
+* Add language id property to databag for mail events

--- a/src/Core/Content/DependencyInjection/flow.xml
+++ b/src/Core/Content/DependencyInjection/flow.xml
@@ -249,6 +249,10 @@
             <tag name="flow.storer" priority="999"/>
         </service>
 
+        <service id="Shopware\Core\Content\Flow\Dispatching\Storer\LanguageStorer">
+            <tag name="flow.storer"/>
+        </service>
+
         <service id="Shopware\Core\Content\Flow\Dispatching\FlowFactory" public="true">
             <argument type="tagged_iterator" tag="flow.storer"/>
         </service>

--- a/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\EventData\MailRecipientStruct;
+use Shopware\Core\Framework\Event\LanguageAware;
 use Shopware\Core\Framework\Event\MailAware;
 use Shopware\Core\Framework\Event\OrderAware;
 use Shopware\Core\Framework\Log\Package;
@@ -125,6 +126,7 @@ class SendMailAction extends FlowAction implements DelayableAction
         $data->set('recipients', $recipients);
         $data->set('senderName', $mailTemplate->getTranslation('senderName'));
         $data->set('salesChannelId', $flow->getData(MailAware::SALES_CHANNEL_ID));
+        $data->set('languageId', $flow->getData(LanguageAware::LANGUAGE_ID));
 
         $data->set('templateId', $mailTemplate->getId());
         $data->set('customFields', $mailTemplate->getCustomFields());

--- a/src/Core/Content/Flow/Dispatching/Storer/LanguageStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/LanguageStorer.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Event\FlowEventAware;
 use Shopware\Core\Framework\Event\LanguageAware;
 use Shopware\Core\Framework\Log\Package;
 
-#[Package('business-ops')]
+#[Package('services-settings')]
 class LanguageStorer extends FlowStorer
 {
     /**

--- a/src/Core/Content/Flow/Dispatching/Storer/LanguageStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/LanguageStorer.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Flow\Dispatching\Storer;
+
+use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\LanguageAware;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('business-ops')]
+class LanguageStorer extends FlowStorer
+{
+    /**
+     * @param array<string, mixed> $stored
+     *
+     * @return array<string, mixed>
+     */
+    public function store(FlowEventAware $event, array $stored): array
+    {
+        if (!$event instanceof LanguageAware) {
+            return $stored;
+        }
+
+        $stored[LanguageAware::LANGUAGE_ID] = $event->getLanguageId();
+
+        return $stored;
+    }
+
+    public function restore(StorableFlow $storable): void
+    {
+        if (!$storable->hasStore(LanguageAware::LANGUAGE_ID)) {
+            return;
+        }
+
+        $storable->setData(LanguageAware::LANGUAGE_ID, $storable->getStore(LanguageAware::LANGUAGE_ID));
+    }
+}

--- a/src/Core/Framework/Event/LanguageAware.php
+++ b/src/Core/Framework/Event/LanguageAware.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Event;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('services-settings')]
+#[IsFlowEventAware]
+interface LanguageAware
+{
+    public const LANGUAGE_ID = 'languageId';
+
+    public function getLanguageId(): ?string;
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This change will allow flow events to have a language id. This language id can be used to translate for flow events like for example mails instead of the default language id from the context.

### 2. What does this change do, exactly?
This adds a LanguageAware and LanguageStorer so flow events can have a language id. This language id will also be added when sending mails.


### 3. Describe each step to reproduce the issue or behaviour.
/ 

### 4. Please link to the relevant issues (if any).
/ 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
