### PR TITLE
feat: add healthcheck structure

### DIFF
--- a/src/Core/Framework/Api/HealthCheck/Model/Result.php
+++ b/src/Core/Framework/Api/HealthCheck/Model/Result.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Shopware\Core\Framework\Api\HealthCheck\Model;
+
+use InvalidArgumentException;
+
+class Result
+{
+    public function __construct(
+        private readonly string $name,
+        private readonly Status $status = Status::Healthy,
+        private readonly string $errorMessage = ''
+    )
+    {
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function status(): Status
+    {
+        return $this->status;
+    }
+
+    public function healthy(): bool
+    {
+        return $this->status === Status::Healthy;
+    }
+
+    public function errorMessage(): string
+    {
+        return $this->errorMessage;
+    }
+}

--- a/src/Core/Framework/Api/HealthCheck/Model/Status.php
+++ b/src/Core/Framework/Api/HealthCheck/Model/Status.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Shopware\Core\Framework\Api\HealthCheck\Model;
+
+enum Status
+{
+    case Healthy;
+
+    case Error;
+
+    case Warning;
+
+    case Deprecation;
+
+    case SKIPPED;
+}

--- a/src/Core/Framework/Api/HealthCheck/Service/Check.php
+++ b/src/Core/Framework/Api/HealthCheck/Service/Check.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Shopware\Core\Framework\Api\HealthCheck\Service;
+
+use Shopware\Core\Framework\Api\HealthCheck\Model\Result;
+
+interface Check
+{
+    public function run(): Result;
+
+    public function dependsOn(): array;
+}

--- a/src/Core/Framework/Api/HealthCheck/Service/Check.php
+++ b/src/Core/Framework/Api/HealthCheck/Service/Check.php
@@ -8,5 +8,5 @@ interface Check
 {
     public function run(): Result;
 
-    public function dependsOn(): array;
+    public function priority(): int;
 }

--- a/src/Core/Framework/Api/HealthCheck/Service/Check/Cache.php
+++ b/src/Core/Framework/Api/HealthCheck/Service/Check/Cache.php
@@ -6,7 +6,6 @@ use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Framework\Api\HealthCheck\Model\Result;
 use Shopware\Core\Framework\Api\HealthCheck\Model\Status;
 use Shopware\Core\Framework\Api\HealthCheck\Service\Check;
-use \Redis;
 
 class Cache implements Check
 {
@@ -37,8 +36,8 @@ class Cache implements Check
         return new Result('Cache', Status::Healthy);
     }
 
-    public function dependsOn(): array
+    public function priority(): int
     {
-        return [];
+        return 0;
     }
 }

--- a/src/Core/Framework/Api/HealthCheck/Service/Check/Cache.php
+++ b/src/Core/Framework/Api/HealthCheck/Service/Check/Cache.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Shopware\Core\Framework\Api\HealthCheck\Service\Check;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Shopware\Core\Framework\Api\HealthCheck\Model\Result;
+use Shopware\Core\Framework\Api\HealthCheck\Model\Status;
+use Shopware\Core\Framework\Api\HealthCheck\Service\Check;
+use \Redis;
+
+class Cache implements Check
+{
+    public function __construct(private readonly CacheItemPoolInterface $cacheItemPool)
+    {
+    }
+
+    public function run(): Result
+    {
+        $randomKey = bin2hex(random_bytes(3));
+        $item = $this->cacheItemPool->getItem(sprintf("health-check%s", $randomKey));
+        $item->set('true');
+        $saved = $this->cacheItemPool->save($item);
+        if (! $saved) {
+            return new Result('Cache', Status::Error, 'Items can not be saved in cache.');
+        }
+
+        $itemFromCache = $this->cacheItemPool->getItem(sprintf("health-check%s", $randomKey));
+        if ($itemFromCache->get() !== 'true') {
+            return new Result('Cache', Status::Error, 'Items can not be saved in cache.');
+        }
+
+        $isDeleted = $this->cacheItemPool->deleteItem(sprintf("health-check%s", $randomKey));
+        if (! $isDeleted) {
+            return new Result('Cache', Status::Error, 'Items can not be deleted from cache.');
+        }
+
+        return new Result('Cache', Status::Healthy);
+    }
+
+    public function dependsOn(): array
+    {
+        return [];
+    }
+}

--- a/src/Core/Framework/Api/HealthCheck/Service/Check/Database.php
+++ b/src/Core/Framework/Api/HealthCheck/Service/Check/Database.php
@@ -25,8 +25,8 @@ class Database implements Check
         }
     }
 
-    public function dependsOn(): array
+    public function priority(): int
     {
-       return [];
+       return 0;
     }
 }

--- a/src/Core/Framework/Api/HealthCheck/Service/Check/Database.php
+++ b/src/Core/Framework/Api/HealthCheck/Service/Check/Database.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Shopware\Core\Framework\Api\HealthCheck\Service\Check;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Shopware\Core\Framework\Api\HealthCheck\Model\Result;
+use Shopware\Core\Framework\Api\HealthCheck\Model\Status;
+use Shopware\Core\Framework\Api\HealthCheck\Service\Check;
+
+class Database implements Check
+{
+
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    public function run(): Result
+    {
+        try {
+            $this->connection->executeQuery('SELECT 1')->fetchOne();
+            return new Result('Database', Status::Healthy);
+        } catch (Exception $e) {
+            return new Result('Database', Status::Error);
+        }
+    }
+
+    public function dependsOn(): array
+    {
+       return [];
+    }
+}

--- a/src/Core/Framework/Api/HealthCheck/Service/Check/ScheduledTasks.php
+++ b/src/Core/Framework/Api/HealthCheck/Service/Check/ScheduledTasks.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Shopware\Core\Framework\Api\HealthCheck\Service\Check;
+
+use Shopware\Core\Framework\Api\HealthCheck\Model\Result;
+use Shopware\Core\Framework\Api\HealthCheck\Model\Status;
+use Shopware\Core\Framework\Api\HealthCheck\Service\Check;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
+
+class ScheduledTasks implements Check
+{
+    public function __construct(
+        private readonly EntityRepository $scheduledTaskRepository
+    )
+    {
+    }
+
+    public function run(): Result
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(
+            new EqualsFilter('status', ScheduledTaskDefinition::STATUS_FAILED)
+        );
+
+        $failedCount = $this->scheduledTaskRepository->search($criteria, Context::createDefaultContext())->count();
+        if ($failedCount > 0) {
+            return new Result('ScheduledTasks', Status::Error, 'There are failed scheduled tasks');
+        }
+
+        // check for overdue tasks (some calculation against intervals... and last execution time (x3 maybe?)...)
+        $overdueTasks = $this->getOverdueTasks();
+        if (! empty($overdueTasks)) {
+            return new Result('ScheduledTasks', Status::Error, 'There are overdue scheduled tasks');
+        }
+
+        return new Result('ScheduledTasks', Status::Healthy);
+    }
+
+
+    public function getOverdueTasks()
+    {
+        return [];
+    }
+
+    public function dependsOn(): array
+    {
+        return [Database::class];
+    }
+}

--- a/src/Core/Framework/Api/HealthCheck/Service/Check/ScheduledTasks.php
+++ b/src/Core/Framework/Api/HealthCheck/Service/Check/ScheduledTasks.php
@@ -46,8 +46,8 @@ class ScheduledTasks implements Check
         return [];
     }
 
-    public function dependsOn(): array
+    public function priority(): int
     {
-        return [Database::class];
+        return 10;
     }
 }

--- a/src/Core/Framework/Api/HealthCheck/Service/Manager.php
+++ b/src/Core/Framework/Api/HealthCheck/Service/Manager.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Shopware\Core\Framework\Api\HealthCheck\Service;
+
+use Shopware\Core\Framework\Api\HealthCheck\Model\Result;
+use Shopware\Core\Framework\Api\HealthCheck\Model\Status;
+use SplStack;
+
+class Manager
+{
+    private array $checksMap;
+
+    /**
+     * @param iterable<Check> $checks
+     */
+    public function __construct(private readonly iterable $checks)
+    {
+        $this->checksMap = [];
+        foreach ($checks as $check) {
+            $this->checksMap[get_class($check)] = $check;
+        }
+    }
+
+    /**
+     * @return array<Result>
+     */
+    public function healthCheck(): array
+    {
+        $graph = $this->getDependencyGraph();
+
+        $traverseResults = $this->dfsResults($graph);
+        // skip deadlocked dependencies..
+        foreach ($this->checksMap as $check) {
+            if (!isset($traverseResults[get_class($check)])) {
+                $traverseResults[get_class($check)] = new Result(
+                    get_class($check),
+                    Status::SKIPPED,
+                    'Deadlocked dependency'
+                );
+            }
+        }
+
+        return array_values($traverseResults);
+    }
+
+    public function dfsResults(array $dependencyGraph): array
+    {
+        $sortedDependencyGraph = $this->getSortedDependencyGraph($dependencyGraph);
+        $stack = new SplStack();
+        foreach ($sortedDependencyGraph as $check) {
+            $stack->push($check);
+        }
+
+        $visited = [];
+        $results = [];
+        while (! $stack->isEmpty()) {
+            $check = $stack->pop();
+            if (isset($visited[$check])) {
+                continue;
+            }
+
+            $visited[$check] = true;
+            $dependencies = $this->checksMap[$check]->dependsOn();
+            $results[$check] = $this->runCheck($dependencies, $results, $check);
+        }
+
+        return $results;
+    }
+
+    private function getDependencyGraph(): array
+    {
+        $dependencyGraph = [];
+        foreach ($this->checks as $check) {
+            $dependencyGraph[get_class($check)] = $check->dependsOn();
+        }
+
+        return $dependencyGraph;
+    }
+
+    /**
+     * @param array $dependencyGraph
+     * @return array
+     */
+    private function getSortedDependencyGraph(array $dependencyGraph): array
+    {
+        $sortedDependencyGraph = $dependencyGraph;
+        uasort($sortedDependencyGraph, function (array $a, array $b) {
+            return count($a) - count($b);
+        });
+
+        return array_keys($sortedDependencyGraph);
+    }
+
+    /**
+     * @param $dependencies
+     * @param array $results
+     * @param string $check
+     * @return array
+     */
+    private function runCheck($dependencies, array $results, string $check): Result
+    {
+        foreach ($dependencies as $dependency) {
+            if (! empty($results[$dependency]) && $results[$dependency]->healthy()) {
+                return new Result($check, Status::SKIPPED, 'Dependency check failed');
+            }
+        }
+
+        return $this->checksMap[$check]->run();
+    }
+
+}

--- a/src/Core/Framework/App/Command/HealthCheckCommand.php
+++ b/src/Core/Framework/App/Command/HealthCheckCommand.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Command;
+
+use Shopware\Core\Framework\Api\HealthCheck\Service\Manager;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:health_check', description: 'Health check for the app system')]
+class HealthCheckCommand extends Command
+{
+    public function __construct(private readonly Manager $manager)
+    {
+        parent::__construct(null);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->manager->healthCheck();
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Core/Framework/DependencyInjection/api.xml
+++ b/src/Core/Framework/DependencyInjection/api.xml
@@ -57,7 +57,7 @@
         </service>
 
         <service id="Shopware\Core\Framework\Api\Controller\HealthCheckController" public="true">
-            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Framework\Api\HealthCheck\Service\Manager"/>
         </service>
 
         <service id="Shopware\Core\Framework\Api\Controller\IndexingController" public="true">

--- a/src/Core/Framework/DependencyInjection/health.xml
+++ b/src/Core/Framework/DependencyInjection/health.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="Shopware\Core\Framework\App\Command\HealthCheckCommand">
+            <argument type="service" id="Shopware\Core\Framework\Api\HealthCheck\Service\Manager"/>
+            <tag name="console.command"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Api\HealthCheck\Service\Manager">
+            <argument type="tagged_iterator" tag="shopware.health_check"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Api\HealthCheck\Service\Check\Database" autowire="true" autoconfigure="true">
+            <tag name="shopware.health_check"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Api\HealthCheck\Service\Check\Cache" autowire="true" autoconfigure="true">
+            <tag name="shopware.health_check"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Api\HealthCheck\Service\Check\ScheduledTasks" autowire="true" autoconfigure="true">
+            <tag name="shopware.health_check"/>
+        </service>
+    </services>
+</container>

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -98,6 +98,7 @@ class Framework extends Bundle
         $loader->load('rate-limiter.xml');
         $loader->load('increment.xml');
         $loader->load('flag.xml');
+        $loader->load('health.xml');
 
         if ($container->getParameter('kernel.environment') === 'test') {
             $loader->load('services_test.xml');

--- a/tests/unit/Core/Framework/Api/Health/Service/ManagerTest.php
+++ b/tests/unit/Core/Framework/Api/Health/Service/ManagerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Shopware\Tests\Unit\Core\Framework\Api\Health\Service;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Api\HealthCheck\Model\Result;
+use Shopware\Core\Framework\Api\HealthCheck\Service\Check;
+use Shopware\Core\Framework\Api\HealthCheck\Service\Manager;
+
+class ManagerTest extends TestCase
+{
+    public function testHealthy()
+    {
+        $check1 = $this->createMock(Check\Database::class);
+        $check2 = $this->createMock(Check\Cache::class);
+        $manager = new Manager([$check1, $check2]);
+
+        $check1->expects($this->once())
+            ->method('run')
+            ->willReturn($result1 = $this->createMock(Result::class));
+
+        $check2->expects($this->once())
+            ->method('run')
+            ->willReturn($result2 = $this->createMock(Result::class));
+
+
+        $check1->expects($this->any())
+            ->method('dependsOn')
+            ->willReturn([]);
+
+        $check2->expects($this->any())
+            ->method('dependsOn')
+            ->willReturn([]);
+
+        $result = $manager->healthCheck();
+        $this->assertEquals([$result1, $result2], $result);
+    }
+
+    public function testDeadlocked()
+    {
+        $check1 = $this->createMock(Check::class);
+        $check2 = $this->createMock(Check::class);
+
+        $check1->expects($this->any())
+            ->method('dependsOn')
+            ->willReturn([Check\Database::class]);
+
+        $check2->expects($this->any())
+            ->method('dependsOn')
+            ->willReturn([Check\Database::class]);
+
+        $check1->expects($this->never())
+            ->method('run');
+
+        $check2->expects($this->never())
+            ->method('run');
+
+        $manager = new Manager([$check1, $check2]);
+
+        $manager->healthCheck();
+    }
+}


### PR DESCRIPTION
Adding a general structure PoC for a more structured health-check solution.

The general structure:
- Manager: orchestrator whose main responsibility is to run the actual tests and handle any associated complexities. e.g: check dependencies, running all checks..etc
- Check: the interface that implements the actual HealthCheck logic
- Result: the model to store the details about the run of the test

All the above is tied together using Symfony DI tagged iterators.

Rough PoC implementations for three potential HealthChecks:
- Database connection
- Cache cache
- CRON jobs

How to add additional Checks?
- Implement a new class from the interface: `Check`
- Tag the service with `shopware.health_check`
