### PR TITLE
fix: Remove category criteria for editor links

### DIFF
--- a/changelog/_unreleased/2024-04-21-remove-category-criteria-for-editor-links.md
+++ b/changelog/_unreleased/2024-04-21-remove-category-criteria-for-editor-links.md
@@ -1,0 +1,9 @@
+---
+title: Remove category criteria for editor links
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Removed invalid category criteria in the editor link menu to be able to select categories again

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.html.twig
@@ -89,7 +89,6 @@
         <sw-category-tree-field
             v-else-if="linkCategory === 'navigation'"
             :label="$tc('sw-text-editor-toolbar.link.linkTo')"
-            :category-criteria="entityFilter"
             :placeholder="$tc('sw-text-editor-toolbar.link.placeholderCategory')"
             :categories-collection="categoryCollection"
             single-select

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/sw-text-editor-link-menu.spec.js
@@ -127,29 +127,31 @@ responses.addResponse({
     },
 });
 
+const productData = [
+    {
+        id: 'aaaaaaa524604ccbad6042edce3ac799',
+        attributes: {
+            id: 'aaaaaaa524604ccbad6042edce3ac799',
+            name: 'aaaaaaa524604ccbad6042edce3ac799',
+        },
+        relationships: [],
+    },
+    {
+        id: 'some-id',
+        attributes: {
+            id: 'some-id',
+            name: 'some-name',
+        },
+        relationships: [],
+    },
+];
+
 responses.addResponse({
     method: 'Post',
     url: '/search/product',
     status: 200,
     response: {
-        data: [
-            {
-                id: 'aaaaaaa524604ccbad6042edce3ac799',
-                attributes: {
-                    id: 'aaaaaaa524604ccbad6042edce3ac799',
-                    name: 'aaaaaaa524604ccbad6042edce3ac799',
-                },
-                relationships: [],
-            },
-            {
-                id: 'some-id',
-                attributes: {
-                    id: 'some-id',
-                    name: 'some-name',
-                },
-                relationships: [],
-            },
-        ],
+        data: productData,
     },
 });
 
@@ -210,10 +212,85 @@ describe('components/form/sw-text-editor/sw-text-editor-link-menu', () => {
         });
     });
 
+    it('parses product detail links and reacts to changes correctly', async () => {
+        const wrapper = await createWrapper({
+            value: `${seoDomainPrefix}/detail/aaaaaaa524604ccbad6042edce3ac799#`,
+            type: 'detail',
+        });
+
+        await flushPromises();
+
+        const productSingleSelectInput = wrapper.find('.sw-text-editor-link-menu__entity-single-select input');
+        await productSingleSelectInput.trigger('click');
+
+        await flushPromises();
+
+        expect(wrapper.text()).toContain('sw-text-editor-toolbar.link.linkTo');
+        expect(productSingleSelectInput.element.placeholder).toBe('sw-text-editor-toolbar.link.placeholderProduct');
+
+        const productSingleSelect = wrapper.findComponent('.sw-entity-single-select').vm;
+        expect(productSingleSelect.entity).toBe('product');
+        expect(productSingleSelect.value).toBe('aaaaaaa524604ccbad6042edce3ac799');
+
+        expect(productSingleSelect.criteria).toStrictEqual(
+            expect.objectContaining({
+                limit: 25,
+                page: 1,
+            }),
+        );
+
+        const associations = productSingleSelect.criteria.associations;
+
+        expect(associations).toHaveLength(1);
+        expect(associations[0].association).toBe('options');
+
+        expect(associations[0].criteria.associations).toHaveLength(1);
+        expect(associations[0].criteria.associations[0].association).toBe('group');
+
+        expect(productSingleSelect.criteria.filters).toStrictEqual(expect.objectContaining(
+            [{
+                operator: 'OR',
+                queries: [
+                    { field: 'product.childCount', type: 'equals', value: 0 },
+                    { field: 'product.childCount', type: 'equals', value: null },
+                ],
+                type: 'multi',
+            }],
+        ));
+
+        const results = productSingleSelect.resultCollection;
+        expect(results).toHaveLength(2);
+        expect(results[0]).toEqual(productData[0].attributes);
+        expect(results[1]).toEqual(productData[1].attributes);
+
+        // Valid value set
+        await productSingleSelect.setValue(productData[1]);
+        await wrapper.find('.sw-text-editor-toolbar-button__link-menu-buttons-button-insert').trigger('click');
+        await flushPromises();
+
+        const dispatchedInputEvents = wrapper.emitted('button-click');
+        expect(dispatchedInputEvents[0]).toStrictEqual([
+            {
+                buttonVariant: undefined,
+                displayAsButton: true,
+                newTab: true,
+                type: 'link',
+                value: '124c71d524604ccbad6042edce3ac799/detail/some-id#',
+            },
+        ]);
+
+        // No value set
+        await productSingleSelect.setValue({ id: null });
+        await flushPromises();
+
+        const isDisabled = wrapper.findComponent('.sw-text-editor-toolbar-button__link-menu-buttons-button-insert').attributes('disabled');
+        expect(isDisabled).toBeDefined();
+    });
+
     it('parses category links and reacts to changes correctly', async () => {
         const wrapper = await createWrapper({
             value: `${seoDomainPrefix}/navigation/aaaaaaa524604ccbad6042edce3ac799#`,
-            type: 'link',
+            type: 'navigation',
         });
 
         await flushPromises();
@@ -227,30 +304,13 @@ describe('components/form/sw-text-editor/sw-text-editor-link-menu', () => {
         const categoryTreeField = asyncComponentWrapper.vm.$children[0];
         expect(categoryTreeField.categoryCriteria).toStrictEqual(
             expect.objectContaining({
-                limit: 25,
+                limit: 500,
                 page: 1,
             }),
         );
 
-        const associations = categoryTreeField.categoryCriteria.associations;
-
-        expect(associations).toHaveLength(1);
-        expect(associations[0].association).toBe('options');
-
-        expect(associations[0].criteria.associations).toHaveLength(1);
-        expect(associations[0].criteria.associations[0].association).toBe('group');
-
-
-        expect(categoryTreeField.categoryCriteria.filters).toStrictEqual(expect.objectContaining(
-            [{
-                operator: 'OR',
-                queries: [
-                    { field: 'product.childCount', type: 'equals', value: 0 },
-                    { field: 'product.childCount', type: 'equals', value: null },
-                ],
-                type: 'multi',
-            }],
-        ));
+        expect(categoryTreeField.categoryCriteria.associations).toHaveLength(0);
+        expect(categoryTreeField.categoryCriteria.filters).toHaveLength(0);
 
         expect(categoryTreeField.categoriesCollection).toHaveLength(1);
         expect(categoryTreeField.categoriesCollection[0]).toEqual(categoryData);


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently an invalid criteria is passed to the category tree field when creating a link, i.e. the criteria which is needed for products.

### 2. What does this change do, exactly?
Remove the criteria.

### 3. Describe each step to reproduce the issue or behaviour.
Try to create a link to a category in the admin editor.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
