### PR TITLE
feat: resolve extension parameters in compiler passes

### DIFF
--- a/changelog/_unreleased/2024-04-23-resolve-parameters-in-compiler-passes.md
+++ b/changelog/_unreleased/2024-04-23-resolve-parameters-in-compiler-passes.md
@@ -1,0 +1,11 @@
+---
+title: Resolve extension parameters in Shopware compiler passes
+issue:
+flag:
+author: Philip Standt
+author_email: philip@maphi.net
+author_github: @Ocarthon
+---
+# Core
+* Changed `\Shopware\Core\Framework\DependencyInjection\CompilerPass\CompilerPassConfigTrait` to resolve extension parameters before processing the values.
+

--- a/src/Core/Framework/DependencyInjection/CompilerPass/CompilerPassConfigTrait.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/CompilerPassConfigTrait.php
@@ -13,10 +13,15 @@ trait CompilerPassConfigTrait
      */
     public function getConfig(ContainerBuilder $container, string $bundle): array
     {
+        $config = $container->getExtensionConfig($bundle);
+
+        $resolvingBag = $container->getParameterBag();
+        $config = $resolvingBag->resolveValue($config);
+
         return (new Processor())
             ->processConfiguration(
                 new Configuration($container->getParameter('kernel.debug')),
-                $container->getExtensionConfig($bundle)
+                $config,
             );
     }
 }

--- a/tests/integration/Core/Framework/DependencyInjection/CompilerPass/CompilerPassConfigTraitTest.php
+++ b/tests/integration/Core/Framework/DependencyInjection/CompilerPass/CompilerPassConfigTraitTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\DependencyInjection\CompilerPass;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DependencyInjection\CompilerPass\CompilerPassConfigTrait;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ValidateEnvPlaceholdersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
+
+/**
+ * @internal
+ */
+#[CoversClass(CompilerPassConfigTraitTest::class)]
+class CompilerPassConfigTraitTest extends TestCase
+{
+    public function testAutoConfigure(): void
+    {
+        $parameterBag = new EnvPlaceholderParameterBag();
+        $container = new ContainerBuilder($parameterBag);
+        $container->setParameter('kernel.debug', true);
+
+        $container->registerExtension(new MockFrameworkExtension());
+        $container->prependExtensionConfig('framework', [
+            'http_cache' => [
+                'default_ttl' => '%env(int:DUMMY_ENV)%',
+            ],
+        ]);
+
+        $container->addCompilerPass(new ValidateEnvPlaceholdersPass());
+        $container->addCompilerPass(new ExampleCompilerPass());
+
+        $this->expectNotToPerformAssertions();
+        $container->compile(true);
+    }
+}
+
+/**
+ * @internal
+ */
+class ExampleCompilerPass implements CompilerPassInterface
+{
+    use CompilerPassConfigTrait;
+
+    public function process(ContainerBuilder $container): void
+    {
+        $this->getConfig($container, 'framework');
+    }
+}
+
+/**
+ * @internal
+ */
+class MockFrameworkExtension implements ExtensionInterface
+{
+    public function load(array $configs, ContainerBuilder $container): void
+    {
+    }
+
+    public function getNamespace(): string
+    {
+        return '';
+    }
+
+    public function getXsdValidationBasePath(): string|false
+    {
+        return false;
+    }
+
+    public function getAlias(): string
+    {
+        return 'framework';
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
`CompilerPassConfigTrait` is used in some shopware compiler passes to read the configuration of the framework extension. The problem is, that parameters (e.g. `'%env(DUMMY_ENV)%'`) will not get resolved. If the Symfony configuration class requires specific types, they may not be satisfied without the resolved values. This will lead to a crash of the kernel.

### 2. What does this change do, exactly?
Before processing the extension config values in shopware compiler passes, resolve the parameters.


### 3. Describe each step to reproduce the issue or behaviour.
* Put the following into `config/packages/messenger.yaml`
 ```yaml
 framework:
    messenger:
        transports:
            test:
                dsn: ''
                retry_strategy:
                    max_retries: '%env(int:DUMMY_ENV_VAR)%'
 ```
* Run `bin/console` -> Kernel will fail to start with the error `Invalid type for path "framework.messenger.transports.test.retry_strategy.max_retries". Expected "int", but got "string".`

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
