### PR TITLE
NEXT-35455 - fix dropdown account menu still showing if the offcanvas…

### DIFF
--- a/changelog/_unreleased/2024-04-27-fix-account-menu-display-offcanvas-dropdown.md
+++ b/changelog/_unreleased/2024-04-27-fix-account-menu-display-offcanvas-dropdown.md
@@ -1,0 +1,10 @@
+---
+title: Fix account menu display offcanvas dropdown
+issue: NEXT-35455
+author: Alexander Bischko
+author_email: alexander@bischko.de
+---
+# Storefront
+* Changed `hideClass` to `showClass`
+* Changed `d-none` to `show`
+* invert class add/remove for `showClass`

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/account-menu.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/account-menu.plugin.js
@@ -17,9 +17,9 @@ export default class OffCanvasAccountMenu extends Plugin {
         additionalClass: 'account-menu-offcanvas',
 
         /**
-         * class is used to hide the dropdown on viewports where the offcanvas is used
+         * class is used to show the dropdown on viewports where the offcanvas is not used
          */
-        hiddenClass: 'd-none',
+        showClass: 'show',
 
         /**
          * from which direction the offcanvas opens
@@ -55,7 +55,7 @@ export default class OffCanvasAccountMenu extends Plugin {
 
         this._dropdown = DomAccess.querySelector(trigger.parentNode, `.${this.options.dropdownMenuSelector}`);
 
-        this._dropdown.classList.add(this.options.hiddenClass);
+        this._dropdown.classList.remove(this.options.showClass);
 
         OffCanvas.open(this._dropdown.innerHTML, null, this.options.offcanvasPostion, true, OffCanvas.REMOVE_OFF_CANVAS_DELAY());
         OffCanvas.setAdditionalClassName(this.options.additionalClass);
@@ -79,14 +79,15 @@ export default class OffCanvasAccountMenu extends Plugin {
 
         if (this._dropdown) {
             if (this._isInAllowedViewports() === false) {
-                this._dropdown.classList.remove(this.options.hiddenClass);
+                this._dropdown.classList.add(this.options.showClass);
             } else {
-                this._dropdown.classList.add(this.options.hiddenClass);
+                this._dropdown.classList.remove(this.options.showClass);
             }
         }
 
         this.$emitter.publish('onViewportHasChanged');
     }
+
 
     /**
      * Returns if the browser is in the allowed viewports


### PR DESCRIPTION
### 1. Why is this change necessary?
- Currently the dropdown account menu is still being displayed, even if the offcanvas variant is present.

### 2. What does this change do, exactly?
- Changed `hiddenClass` to `showClass`
- Changed `d-none` to `show`
- switched classList add/remove for `this._dropdown`

### 3. Describe each step to reproduce the issue or behaviour.
- Switch to viewport XS/ SM
- Open the account menu

### 4. Please link to the relevant issues (if any).
- https://issues.shopware.com/issues/NEXT-35455

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
