### PR TITLE
NEXT-00000 - Changed media partial loaded event name

### DIFF
--- a/changelog/_unreleased/2024-04-29-media-partial-loaded-event.md
+++ b/changelog/_unreleased/2024-04-29-media-partial-loaded-event.md
@@ -1,0 +1,8 @@
+---
+title: Change media partial loaded event name
+issue: NEXT-00000
+author: Fabian Boensch
+author_github: @En0Ma1259
+---
+# Core
+* Changed `MediaUrlLoader` partial loaded event name

--- a/src/Core/Content/DependencyInjection/media_path.xml
+++ b/src/Core/Content/DependencyInjection/media_path.xml
@@ -9,7 +9,7 @@
             <argument type="service" id="Shopware\Core\Content\Media\Core\Application\AbstractMediaUrlGenerator"/>
 
             <tag name="kernel.event_listener" event="media.loaded" method="loaded" priority="20" />
-            <tag name="kernel.event_listener" event="partial.media.loaded" method="loaded" priority="19" />
+            <tag name="kernel.event_listener" event="media.partial_loaded" method="loaded" priority="19" />
         </service>
 
         <service class="Shopware\Core\Content\Media\Infrastructure\Path\SqlMediaLocationBuilder" id="Shopware\Core\Content\Media\Core\Application\MediaLocationBuilder">


### PR DESCRIPTION
### 1. Why is this change necessary?
MediaUrlLoader partial event is wrong

### 2. What does this change do, exactly?
Changed event name `partial.media.loaded` -> `media.partial_loaded`.
Event name will be generated like this `$this->definition->getEntityName() . '.partial_loaded'` in `PartialEntityLoadedEvent`

### 3. Describe each step to reproduce the issue or behaviour.
Load Partial Media

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
