### PR TITLE
NEXT-00000 - Fix wrong address uses from cart address validator

### DIFF
--- a/changelog/_unreleased/2024-04-30-fix-cart-address-state-validation.md
+++ b/changelog/_unreleased/2024-04-30-fix-cart-address-state-validation.md
@@ -1,0 +1,8 @@
+---
+title: Fix cart address state validation
+issue: NEXT-00000
+author: Alexander Bischko
+author_email: alexander@bischko.de
+---
+# Core
+* Fixed misplaced `getActiveShippingAddress()` and `getActiveBillingAddress()` in the Cart AddressValidator

--- a/src/Core/Checkout/Cart/Address/AddressValidator.php
+++ b/src/Core/Checkout/Cart/Address/AddressValidator.php
@@ -79,12 +79,12 @@ class AddressValidator implements CartValidatorInterface, ResetInterface
 
         if ($customer->getActiveBillingAddress()->getCountry()?->getForceStateInRegistration()) {
             if (!$customer->getActiveBillingAddress()->getCountryState()) {
-                $errors->add(new BillingAddressCountryRegionMissingError($customer->getActiveShippingAddress()));
+                $errors->add(new BillingAddressCountryRegionMissingError($customer->getActiveBillingAddress()));
             }
         }
 
         if ($customer->getActiveShippingAddress()->getCountry()?->getForceStateInRegistration()) {
-            if (!$customer->getActiveBillingAddress()->getCountryState()) {
+            if (!$customer->getActiveShippingAddress()->getCountryState()) {
                 $errors->add(new ShippingAddressCountryRegionMissingError($customer->getActiveShippingAddress()));
             }
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
1. The validator doesn't check the right addresses if the state is mandatory
2. Message appearing in the storefront is confusing customers

### 2. What does this change do, exactly?
Just gets the right addresses in the validator

### 3. Describe each step to reproduce the issue or behaviour.
1. Set the state as a mandatory field on registration.
2. Open the cart
3. See the two weird messages that are saying, that 2 addresses doesn't fulfill the minimum requirements.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfil them.
