### PR TITLE
Dispatch events after default is successfully set

### DIFF
--- a/changelog/release-6-6-0-3/2024-05-02-missing-event-on-customer-default-address-swap-success.md
+++ b/changelog/release-6-6-0-3/2024-05-02-missing-event-on-customer-default-address-swap-success.md
@@ -1,0 +1,10 @@
+---
+title:              Dispatch events after default is successfully set      # Required
+issue:                                            # Required
+
+author:             Tommy Quissens                          # Optional for shopware employees, Required for external developers
+author_email:       tommy.quissens@meteor.be                   # Optional for shopware employees, Required for external developers
+author_github:      @quisse                                 # Optional
+---
+# Core
+Events are added when a customer successfully swaps their default address. `\Shopware\Core\Checkout\Customer\Event\CustomerDefaultShippingAddressSetEvent` and `\Shopware\Core\Checkout\Customer\Event\CustomerDefaultBillingAddressSetEvent` are added.

--- a/src/Core/Checkout/Customer/Event/CustomerDefaultBillingAddressSetEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerDefaultBillingAddressSetEvent.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Event;
+
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
+use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('checkout')]
+class CustomerDefaultBillingAddressSetEvent extends Event implements SalesChannelAware, ShopwareSalesChannelEvent, FlowEventAware
+{
+    final public const EVENT_NAME = 'checkout.customer.default.billing.address.set.event';
+
+    public function __construct(
+        private readonly SalesChannelContext $salesChannelContext,
+        private readonly CustomerEntity $customer,
+        private string $addressId
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public function getCustomer(): CustomerEntity
+    {
+        return $this->customer;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelContext->getSalesChannel()->getId();
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add('customer', new EntityType(CustomerDefinition::class))
+            ->add('contextToken', new ScalarValueType(ScalarValueType::TYPE_STRING));
+    }
+
+    public function getAddressId(): string
+    {
+        return $this->addressId;
+    }
+
+    public function setAddressId(string $addressId): void
+    {
+        $this->addressId = $addressId;
+    }
+}

--- a/src/Core/Checkout/Customer/Event/CustomerDefaultShippingAddressSetEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerDefaultShippingAddressSetEvent.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Event;
+
+use Shopware\Core\Checkout\Customer\CustomerDefinition;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\EventData\EntityType;
+use Shopware\Core\Framework\Event\EventData\EventDataCollection;
+use Shopware\Core\Framework\Event\EventData\ScalarValueType;
+use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('checkout')]
+class CustomerDefaultShippingAddressSetEvent extends Event implements SalesChannelAware, ShopwareSalesChannelEvent, FlowEventAware
+{
+    final public const EVENT_NAME = 'checkout.customer.default.shipping.address.set.event';
+
+    public function __construct(
+        private readonly SalesChannelContext $salesChannelContext,
+        private readonly CustomerEntity $customer,
+        private string $addressId
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return self::EVENT_NAME;
+    }
+
+    public function getCustomer(): CustomerEntity
+    {
+        return $this->customer;
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannelContext->getSalesChannel()->getId();
+    }
+
+    public static function getAvailableData(): EventDataCollection
+    {
+        return (new EventDataCollection())
+            ->add('customer', new EntityType(CustomerDefinition::class))
+            ->add('contextToken', new ScalarValueType(ScalarValueType::TYPE_STRING));
+    }
+
+    public function getAddressId(): string
+    {
+        return $this->addressId;
+    }
+
+    public function setAddressId(string $addressId): void
+    {
+        $this->addressId = $addressId;
+    }
+}

--- a/src/Core/Checkout/Customer/SalesChannel/SwitchDefaultAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/SwitchDefaultAddressRoute.php
@@ -3,6 +3,8 @@
 namespace Shopware\Core\Checkout\Customer\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Event\CustomerDefaultBillingAddressSetEvent;
+use Shopware\Core\Checkout\Customer\Event\CustomerDefaultShippingAddressSetEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerSetDefaultBillingAddressEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerSetDefaultShippingAddressEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -70,6 +72,19 @@ class SwitchDefaultAddressRoute extends AbstractSwitchDefaultAddressRoute
         }
 
         $this->customerRepository->update([$data], $context->getContext());
+
+        switch ($type) {
+            case self::TYPE_BILLING:
+                $event = new CustomerDefaultBillingAddressSetEvent($context, $customer, $addressId);
+                $this->eventDispatcher->dispatch($event);
+
+                break;
+            default:
+                $event = new CustomerDefaultShippingAddressSetEvent($context, $customer, $addressId);
+                $this->eventDispatcher->dispatch($event);
+
+                break;
+        }
 
         return new NoContentResponse();
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To be able to trigger actions based on default addresses successes

### 2. What does this change do, exactly?
Add some events

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/3439

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
