### PR TITLE
Allow editing custom fields for order addresses

### DIFF
--- a/changelog/_unreleased/2024-05-02-allow-order-address-custom-fields-edits.md
+++ b/changelog/_unreleased/2024-05-02-allow-order-address-custom-fields-edits.md
@@ -1,0 +1,9 @@
+---
+title: Allow order address custom fields edits
+issue: NEXT-00000
+author: Yannick Van Velthoven
+author_email: yannick.vanvelthoven@meteor.be
+author_github: yannick-meteor
+---
+# Administration
+* Changed `sw-order-address-selection` template to remove check that only renders address form options when a new address is created.

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/sw-order-address-selection.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/sw-order-address-selection.html.twig
@@ -15,7 +15,6 @@
             :customer="customer"
         >
             <sw-customer-address-form-options
-                v-if="currentAddress._isNew"
                 :address="currentAddress"
                 :customer="customer"
                 :custom-field-sets="customerAddressCustomFieldSets"


### PR DESCRIPTION
This allows custom field sets to be used in Order address edit

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently it is possible to change the custom fields on a customer_address in the Admin. For an order_address, it is possible to set custom field values when creating a new address, however it is not possible to edit the custom fields on an existing order_address

### 2. What does this change do, exactly?
Always renders the address form options / custom fields instead of only for new order addresses

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a custom field for addresses
2. Edit the customer address in an order, the custom fields won't be visible

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
