### PR TITLE
NEXT-36018 - refactor: Unify SendMailAction constants

### DIFF
--- a/changelog/_unreleased/2024-05-02-unify-sendmailaction-constants.md
+++ b/changelog/_unreleased/2024-05-02-unify-sendmailaction-constants.md
@@ -1,0 +1,11 @@
+---
+title: Unify SendMailAction constants
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Deprecated constants `Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig::{ACTION_NAME,MAIL_CONFIG_EXTENSION}` use `Shopware\Core\Content\Flow\Dispatching\Action::{ACTION_NAME,MAIL_CONFIG_EXTENSION}` instead
+* Deprecated constant `Shopware\Core\Content\MailTemplate\MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION` use `Shopware\Core\Content\Flow\Dispatching\Action::ACTION_NAME` instead
+* Deprecated not needed class `Shopware\Core\Content\MailTemplate\MailTemplateActions`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1181,16 +1181,6 @@ parameters:
 			path: src/Core/Content/MailTemplate/Exception/MailTransportFailedException.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Subscriber\\\\MailSendSubscriberConfig\\:\\:getDocumentIds\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Content/MailTemplate/Subscriber/MailSendSubscriberConfig.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Subscriber\\\\MailSendSubscriberConfig\\:\\:getMediaIds\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Content/MailTemplate/Subscriber/MailSendSubscriberConfig.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaThumbnailSize\\\\MediaThumbnailSizeEntity\\:\\:getMediaFolderConfigurations\\(\\) should return Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaFolderConfiguration\\\\MediaFolderConfigurationCollection but returns Shopware\\\\Core\\\\Content\\\\Media\\\\Aggregate\\\\MediaFolderConfiguration\\\\MediaFolderConfigurationCollection\\|null\\.$#"
 			count: 1
 			path: src/Core/Content/Media/Aggregate/MediaThumbnailSize/MediaThumbnailSizeEntity.php

--- a/src/Core/Checkout/Order/Api/OrderActionController.php
+++ b/src/Core/Checkout/Order/Api/OrderActionController.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Driver\Exception;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
 use Shopware\Core\Checkout\Payment\Cart\PaymentRefundProcessor;
 use Shopware\Core\Checkout\Payment\PaymentException;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
@@ -52,7 +53,7 @@ class OrderActionController extends AbstractController
         $mediaIds = $request->request->all('mediaIds');
 
         $context->addExtension(
-            MailSendSubscriberConfig::MAIL_CONFIG_EXTENSION,
+            SendMailAction::MAIL_CONFIG_EXTENSION,
             new MailSendSubscriberConfig(
                 $request->request->get('sendMail', true) === false,
                 $documentIds,

--- a/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
@@ -11,7 +11,6 @@ use Shopware\Core\Content\Mail\Service\AbstractMailService;
 use Shopware\Core\Content\Mail\Service\MailAttachmentsConfig;
 use Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException;
 use Shopware\Core\Content\MailTemplate\Exception\SalesChannelNotFoundException;
-use Shopware\Core\Content\MailTemplate\MailTemplateActions;
 use Shopware\Core\Content\MailTemplate\MailTemplateEntity;
 use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
 use Shopware\Core\Framework\Adapter\Translation\AbstractTranslator;
@@ -35,7 +34,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 #[Package('services-settings')]
 class SendMailAction extends FlowAction implements DelayableAction
 {
-    final public const ACTION_NAME = MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION;
+    final public const ACTION_NAME = 'action.mail.send';
     final public const MAIL_CONFIG_EXTENSION = 'mail-attachments';
 
     private const RECIPIENT_CONFIG_ADMIN = 'admin';
@@ -60,7 +59,7 @@ class SendMailAction extends FlowAction implements DelayableAction
 
     public static function getName(): string
     {
-        return 'action.mail.send';
+        return self::ACTION_NAME;
     }
 
     /**

--- a/src/Core/Content/MailTemplate/MailTemplateActions.php
+++ b/src/Core/Content/MailTemplate/MailTemplateActions.php
@@ -2,10 +2,17 @@
 
 namespace Shopware\Core\Content\MailTemplate;
 
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.7.0 - Class will be removed
+ */
 #[Package('buyers-experience')]
 class MailTemplateActions
 {
-    final public const MAIL_TEMPLATE_MAIL_SEND_ACTION = 'action.mail.send';
+    /**
+     * @deprecated tag:v6.7.0 - Will be removed use `Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction::ACTION_NAME` instead
+     */
+    final public const MAIL_TEMPLATE_MAIL_SEND_ACTION = SendMailAction::ACTION_NAME;
 }

--- a/src/Core/Content/MailTemplate/Subscriber/MailSendSubscriberConfig.php
+++ b/src/Core/Content/MailTemplate/Subscriber/MailSendSubscriberConfig.php
@@ -2,15 +2,22 @@
 
 namespace Shopware\Core\Content\MailTemplate\Subscriber;
 
-use Shopware\Core\Content\MailTemplate\MailTemplateActions;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
 #[Package('buyers-experience')]
 class MailSendSubscriberConfig extends Struct
 {
-    final public const ACTION_NAME = MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION;
-    final public const MAIL_CONFIG_EXTENSION = 'mail-attachments';
+    /**
+     * @deprecated tag:v6.7.0 - Will be removed use `Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction::ACTION_NAME` instead
+     */
+    final public const ACTION_NAME = SendMailAction::ACTION_NAME;
+
+    /**
+     * @deprecated tag:v6.7.0 - Will be removed use `Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction::MAIL_CONFIG_EXTENSION` instead
+     */
+    final public const MAIL_CONFIG_EXTENSION = SendMailAction::MAIL_CONFIG_EXTENSION;
 
     /**
      * @var bool
@@ -51,11 +58,17 @@ class MailSendSubscriberConfig extends Struct
         $this->skip = $skip;
     }
 
+    /**
+     * @return array<string>
+     */
     public function getDocumentIds(): array
     {
         return $this->documentIds;
     }
 
+    /**
+     * @return array<string>
+     */
     public function getMediaIds(): array
     {
         return $this->mediaIds;

--- a/src/Core/Migration/V6_3/Migration1536233560BasicData.php
+++ b/src/Core/Migration/V6_3/Migration1536233560BasicData.php
@@ -17,7 +17,7 @@ use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\DebitPayment;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\InvoicePayment;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\PrePayment;
 use Shopware\Core\Content\Category\CategoryDefinition;
-use Shopware\Core\Content\MailTemplate\MailTemplateActions;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
 use Shopware\Core\Content\Newsletter\Event\NewsletterConfirmEvent;
 use Shopware\Core\Content\Newsletter\Event\NewsletterRegisterEvent;
@@ -2134,7 +2134,7 @@ class Migration1536233560BasicData extends MigrationStep
             [
                 'id' => Uuid::randomBytes(),
                 'event_name' => CheckoutOrderPlacedEvent::EVENT_NAME,
-                'action_name' => MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION,
+                'action_name' => SendMailAction::ACTION_NAME,
                 'config' => json_encode([
                     'mail_template_type_id' => $this->getMailTypeMapping()[MailTemplateTypes::MAILTYPE_ORDER_CONFIRM]['id'],
                 ], \JSON_THROW_ON_ERROR),
@@ -2307,7 +2307,7 @@ class Migration1536233560BasicData extends MigrationStep
             [
                 'id' => Uuid::randomBytes(),
                 'event_name' => CustomerRegisterEvent::EVENT_NAME,
-                'action_name' => MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION,
+                'action_name' => SendMailAction::ACTION_NAME,
                 'config' => json_encode([
                     'mail_template_type_id' => $this->getMailTypeMapping()[MailTemplateTypes::MAILTYPE_CUSTOMER_REGISTER]['id'],
                 ], \JSON_THROW_ON_ERROR),
@@ -2320,7 +2320,7 @@ class Migration1536233560BasicData extends MigrationStep
             [
                 'id' => Uuid::randomBytes(),
                 'event_name' => NewsletterRegisterEvent::EVENT_NAME,
-                'action_name' => MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION,
+                'action_name' => SendMailAction::ACTION_NAME,
                 'config' => json_encode([
                     'mail_template_type_id' => $this->getMailTypeMapping()['newsletterDoubleOptIn']['id'],
                 ], \JSON_THROW_ON_ERROR),
@@ -2333,7 +2333,7 @@ class Migration1536233560BasicData extends MigrationStep
             [
                 'id' => Uuid::randomBytes(),
                 'event_name' => NewsletterConfirmEvent::EVENT_NAME,
-                'action_name' => MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION,
+                'action_name' => SendMailAction::ACTION_NAME,
                 'config' => json_encode([
                     'mail_template_type_id' => $this->getMailTypeMapping()['newsletterRegister']['id'],
                 ], \JSON_THROW_ON_ERROR),

--- a/src/Core/Migration/V6_3/Migration1562240231UserPasswordRecovery.php
+++ b/src/Core/Migration/V6_3/Migration1562240231UserPasswordRecovery.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Migration\V6_3;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
@@ -157,7 +158,7 @@ SQL;
         $connection->insert('event_action', [
             'id' => Uuid::randomBytes(),
             'event_name' => 'user.recovery.request',
-            'action_name' => 'action.mail.send',
+            'action_name' => SendMailAction::ACTION_NAME,
             'config' => json_encode(['mail_template_type_id' => $mailTemplateTypeId], \JSON_THROW_ON_ERROR),
             'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ]);

--- a/src/Core/Migration/V6_3/Migration1562933907ContactForm.php
+++ b/src/Core/Migration/V6_3/Migration1562933907ContactForm.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Migration\V6_3;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\ContactForm\Event\ContactFormEvent;
-use Shopware\Core\Content\MailTemplate\MailTemplateActions;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
@@ -88,7 +88,7 @@ class Migration1562933907ContactForm extends MigrationStep
             [
                 'id' => Uuid::randomBytes(),
                 'event_name' => ContactFormEvent::EVENT_NAME,
-                'action_name' => MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION,
+                'action_name' => SendMailAction::ACTION_NAME,
                 'config' => json_encode(['mail_template_type_id' => $contactFormEmailTemplate['id']], \JSON_THROW_ON_ERROR),
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
             ]

--- a/src/Core/Migration/V6_3/Migration1567431050ContactFormTemplate.php
+++ b/src/Core/Migration/V6_3/Migration1567431050ContactFormTemplate.php
@@ -4,7 +4,7 @@ namespace Shopware\Core\Migration\V6_3;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\ContactForm\Event\ContactFormEvent;
-use Shopware\Core\Content\MailTemplate\MailTemplateActions;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
@@ -92,7 +92,7 @@ SQL;
             $sql,
             [
                 'event_name' => ContactFormEvent::EVENT_NAME,
-                'action_name' => MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION,
+                'action_name' => SendMailAction::ACTION_NAME,
             ]
         )->fetchOne();
 

--- a/src/Core/Migration/V6_3/Migration1570622696CustomerPasswordRecovery.php
+++ b/src/Core/Migration/V6_3/Migration1570622696CustomerPasswordRecovery.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Migration\V6_3;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
@@ -193,7 +194,7 @@ SQL;
         $connection->insert('event_action', [
             'id' => Uuid::randomBytes(),
             'event_name' => 'customer.recovery.request',
-            'action_name' => 'action.mail.send',
+            'action_name' => SendMailAction::ACTION_NAME,
             'config' => json_encode(['mail_template_type_id' => $mailTemplateTypeId], \JSON_THROW_ON_ERROR),
             'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
         ]);

--- a/src/Core/Migration/V6_3/Migration1572425108AddDoubleOptInRegistrationMailTemplate.php
+++ b/src/Core/Migration/V6_3/Migration1572425108AddDoubleOptInRegistrationMailTemplate.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Migration\V6_3;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Shopware\Core\Checkout\Customer\Event\CustomerDoubleOptInRegistrationEvent;
-use Shopware\Core\Content\MailTemplate\MailTemplateActions;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
@@ -182,7 +182,7 @@ class Migration1572425108AddDoubleOptInRegistrationMailTemplate extends Migratio
             [
                 'id' => Uuid::randomBytes(),
                 'event_name' => CustomerDoubleOptInRegistrationEvent::EVENT_NAME,
-                'action_name' => MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION,
+                'action_name' => SendMailAction::ACTION_NAME,
                 'config' => json_encode([
                     'mail_template_type_id' => Uuid::fromBytesToHex($templateTypeId),
                 ], \JSON_THROW_ON_ERROR),

--- a/src/Core/Migration/V6_3/Migration1573569685DoubleOptInGuestMailTemplate.php
+++ b/src/Core/Migration/V6_3/Migration1573569685DoubleOptInGuestMailTemplate.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Migration\V6_3;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Shopware\Core\Checkout\Customer\Event\DoubleOptInGuestOrderEvent;
-use Shopware\Core\Content\MailTemplate\MailTemplateActions;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
@@ -182,7 +182,7 @@ class Migration1573569685DoubleOptInGuestMailTemplate extends MigrationStep
             [
                 'id' => Uuid::randomBytes(),
                 'event_name' => DoubleOptInGuestOrderEvent::EVENT_NAME,
-                'action_name' => MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION,
+                'action_name' => SendMailAction::ACTION_NAME,
                 'config' => json_encode([
                     'mail_template_type_id' => Uuid::fromBytesToHex($templateTypeId),
                 ], \JSON_THROW_ON_ERROR),

--- a/src/Core/Migration/V6_3/Migration1596441551CustomerGroupRegistration.php
+++ b/src/Core/Migration/V6_3/Migration1596441551CustomerGroupRegistration.php
@@ -3,7 +3,7 @@
 namespace Shopware\Core\Migration\V6_3;
 
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Content\MailTemplate\MailTemplateActions;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
@@ -213,7 +213,7 @@ ADD `registration_seo_meta_description` longtext NULL AFTER `registration_only_c
             [
                 'id' => Uuid::randomBytes(),
                 'event_name' => $typeName,
-                'action_name' => MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION,
+                'action_name' => SendMailAction::ACTION_NAME,
                 'config' => json_encode([
                     'mail_template_type_id' => Uuid::fromBytesToHex($typeId),
                 ], \JSON_THROW_ON_ERROR),

--- a/src/Core/Migration/V6_3/Migration1599822061MigrateOrderMails.php
+++ b/src/Core/Migration/V6_3/Migration1599822061MigrateOrderMails.php
@@ -4,8 +4,7 @@ namespace Shopware\Core\Migration\V6_3;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Content\MailTemplate\MailTemplateActions;
-use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
@@ -29,7 +28,7 @@ class Migration1599822061MigrateOrderMails extends MigrationStep
         // migrate existing event_actions
         $events = $connection->fetchAllAssociative(
             'SELECT event_name, config FROM event_action WHERE `action_name` = :action',
-            ['action' => MailTemplateActions::MAIL_TEMPLATE_MAIL_SEND_ACTION]
+            ['action' => SendMailAction::ACTION_NAME]
         );
 
         $mapping = [];
@@ -165,7 +164,7 @@ class Migration1599822061MigrateOrderMails extends MigrationStep
 
             $insert = [
                 'id' => $id,
-                'action_name' => MailSendSubscriberConfig::ACTION_NAME,
+                'action_name' => SendMailAction::ACTION_NAME,
                 'config' => json_encode([
                     'mail_template_id' => $mail['mail_template_id'],
 

--- a/src/Core/Migration/V6_4/Migration1659257296GenerateFlowTemplateDataFromEventAction.php
+++ b/src/Core/Migration/V6_4/Migration1659257296GenerateFlowTemplateDataFromEventAction.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Migration\V6_4;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Flow\Aggregate\FlowTemplate\FlowTemplateDefinition;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
 use Shopware\Core\Framework\Log\Package;
@@ -56,7 +57,7 @@ class Migration1659257296GenerateFlowTemplateDataFromEventAction extends Migrati
                 'sequences' => [
                     [
                         'id' => Uuid::randomHex(),
-                        'actionName' => 'action.mail.send',
+                        'actionName' => SendMailAction::ACTION_NAME,
                         'config' => $config,
                         'parentId' => null,
                         'ruleId' => null,

--- a/src/Core/Migration/V6_4/Migration1659257396DownloadFlow.php
+++ b/src/Core/Migration/V6_4/Migration1659257396DownloadFlow.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Migration\V6_4;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Flow\Aggregate\FlowTemplate\FlowTemplateDefinition;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
 use Shopware\Core\Content\Product\State;
 use Shopware\Core\Defaults;
@@ -166,7 +167,7 @@ class Migration1659257396DownloadFlow extends MigrationStep
                     'flow_id' => $flowId,
                     'rule_id' => null,
                     'parent_id' => $ruleSequenceId,
-                    'action_name' => 'action.mail.send',
+                    'action_name' => SendMailAction::ACTION_NAME,
                     'position' => 2,
                     'true_case' => 1,
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -214,7 +215,7 @@ class Migration1659257396DownloadFlow extends MigrationStep
         if ($mailTemplateId !== null) {
             $sequenceConfig[] = [
                 'id' => Uuid::randomHex(),
-                'actionName' => 'action.mail.send',
+                'actionName' => SendMailAction::ACTION_NAME,
                 'config' => sprintf(
                     '{"recipient": {"data": [], "type": "default"}, "mailTemplateId": "%s", "documentTypeIds": []}',
                     Uuid::fromBytesToHex($mailTemplateId)

--- a/src/Core/Migration/V6_4/Migration1675218708UpdateDeliverOrderedProductDownloadsFlowTemplate.php
+++ b/src/Core/Migration/V6_4/Migration1675218708UpdateDeliverOrderedProductDownloadsFlowTemplate.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Migration\V6_4;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Flow\Aggregate\FlowTemplate\FlowTemplateDefinition;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
@@ -71,7 +72,7 @@ class Migration1675218708UpdateDeliverOrderedProductDownloadsFlowTemplate extend
         if ($mailTemplateId !== null) {
             $sequenceConfig[] = [
                 'id' => Uuid::randomHex(),
-                'actionName' => 'action.mail.send',
+                'actionName' => SendMailAction::ACTION_NAME,
                 'config' => [
                     'recipient' => [
                         'data' => [],

--- a/src/Core/Migration/V6_5/Migration1672934282ReviewFormSendFlow.php
+++ b/src/Core/Migration/V6_5/Migration1672934282ReviewFormSendFlow.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Migration\V6_5;
 
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
@@ -56,7 +57,7 @@ class Migration1672934282ReviewFormSendFlow extends MigrationStep
                 'flow_id' => $flowId,
                 'rule_id' => null,
                 'parent_id' => null,
-                'action_name' => 'action.mail.send',
+                'action_name' => SendMailAction::ACTION_NAME,
                 'position' => 1,
                 'true_case' => 0,
                 'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),

--- a/src/Core/Migration/V6_5/Migration1689257577AddMissingTransactionMailFlow.php
+++ b/src/Core/Migration/V6_5/Migration1689257577AddMissingTransactionMailFlow.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Migration\V6_5;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Shopware\Core\Content\Flow\Aggregate\FlowTemplate\FlowTemplateDefinition;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Migration\MigrationStep;
@@ -83,7 +84,7 @@ class Migration1689257577AddMissingTransactionMailFlow extends MigrationStep
                     'flow_id' => $flowId,
                     'rule_id' => null,
                     'parent_id' => null,
-                    'action_name' => 'action.mail.send',
+                    'action_name' => SendMailAction::ACTION_NAME,
                     'position' => 1,
                     'true_case' => 0,
                     'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
@@ -114,7 +115,7 @@ class Migration1689257577AddMissingTransactionMailFlow extends MigrationStep
         if ($mailTemplate['mailTemplateId'] !== null) {
             $sequenceConfig[] = [
                 'id' => Uuid::randomHex(),
-                'actionName' => 'action.mail.send',
+                'actionName' => SendMailAction::ACTION_NAME,
                 'config' => sprintf(
                     '{"recipient": {"data": [], "type": "default"}, "mailTemplateId": "%s", "documentTypeIds": []}',
                     Uuid::fromBytesToHex($mailTemplate['mailTemplateId'])

--- a/tests/integration/Core/Checkout/Order/SalesChannel/OrderServiceTest.php
+++ b/tests/integration/Core/Checkout/Order/SalesChannel/OrderServiceTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Checkout\Cart\Transaction\Struct\TransactionCollection;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\SalesChannel\OrderService;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Content\MailTemplate\Service\Event\MailSentEvent;
 use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
@@ -222,7 +223,7 @@ class OrderServiceTest extends TestCase
 
         $this->salesChannelContext
             ->getContext()
-            ->addExtension(MailSendSubscriberConfig::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(true, [], []));
+            ->addExtension(SendMailAction::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(true, [], []));
 
         $this->orderService->orderDeliveryStateTransition(
             $orderDeliveryId,
@@ -430,7 +431,7 @@ class OrderServiceTest extends TestCase
 
         $this->salesChannelContext
             ->getContext()
-            ->addExtension(MailSendSubscriberConfig::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(true, [], []));
+            ->addExtension(SendMailAction::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(true, [], []));
 
         $this->orderService->orderTransactionStateTransition(
             $orderTransactionId,

--- a/tests/integration/Core/Content/Flow/SendMailActionTest.php
+++ b/tests/integration/Core/Content/Flow/SendMailActionTest.php
@@ -130,7 +130,7 @@ class SendMailActionTest extends TestCase
 
         if ($hasOrderSettingAttachment) {
             $event->getContext()->addExtension(
-                MailSendSubscriberConfig::MAIL_CONFIG_EXTENSION,
+                SendMailAction::MAIL_CONFIG_EXTENSION,
                 new MailSendSubscriberConfig(
                     false,
                     $documentIds,
@@ -259,7 +259,7 @@ class SendMailActionTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $context->addExtension(MailSendSubscriberConfig::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(false, [], []));
+        $context->addExtension(SendMailAction::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(false, [], []));
 
         $mailTemplateId = $this->retrieveMailTemplateId();
 
@@ -321,7 +321,7 @@ class SendMailActionTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $context->addExtension(MailSendSubscriberConfig::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(false, [], []));
+        $context->addExtension(SendMailAction::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(false, [], []));
 
         $mailTemplateId = $this->retrieveMailTemplateId();
 
@@ -395,7 +395,7 @@ class SendMailActionTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $context->addExtension(MailSendSubscriberConfig::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(false, [], []));
+        $context->addExtension(SendMailAction::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(false, [], []));
 
         $mailTemplateId = $this->retrieveMailTemplateId();
 
@@ -470,7 +470,7 @@ class SendMailActionTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $context->addExtension(MailSendSubscriberConfig::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(false, [], []));
+        $context->addExtension(SendMailAction::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(false, [], []));
 
         $mailTemplateId = $this->retrieveMailTemplateId();
 
@@ -595,7 +595,7 @@ class SendMailActionTest extends TestCase
 
         $context = Context::createDefaultContext();
 
-        $context->addExtension(MailSendSubscriberConfig::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(false, [], []));
+        $context->addExtension(SendMailAction::MAIL_CONFIG_EXTENSION, new MailSendSubscriberConfig(false, [], []));
 
         $mailTemplateId = $this->retrieveMailTemplateId();
 
@@ -680,7 +680,7 @@ class SendMailActionTest extends TestCase
         $mailTemplateId = $this->retrieveMailTemplateId();
 
         $context->addExtension(
-            MailSendSubscriberConfig::MAIL_CONFIG_EXTENSION,
+            SendMailAction::MAIL_CONFIG_EXTENSION,
             new MailSendSubscriberConfig(
                 false,
                 [],


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently there are a duplicated constants, and when developing I was unsure which ones to use.

### 2. What does this change do, exactly?
Unify the constants and deprecate accordingly.

### 3. Describe each step to reproduce the issue or behaviour.
Develop something with mail attachments or mail actions.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
