### PR TITLE
NEXT-00000 - Fix changeset issues

### DIFF
--- a/changelog/_unreleased/2024-05-02-fix-changeset-issues.md
+++ b/changelog/_unreleased/2024-05-02-fix-changeset-issues.md
@@ -1,0 +1,12 @@
+---
+title: Fix changeset issues
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Core
+
+* Fixed issue with changeset where two null values were being seen as a change due to type casting
+* Fixed issue with changeset where a JsonUpdateCommand for the same entity, will replace the previous changeset instead of merging it

--- a/src/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSet.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSet.php
@@ -74,6 +74,13 @@ class ChangeSet extends Struct
         return \array_key_exists($property, $this->after) || $this->isDelete;
     }
 
+    public function merge(ChangeSet $changeSet): void
+    {
+        $this->after = array_merge($this->after, $changeSet->after);
+        $this->state = array_merge($this->state, $changeSet->state);
+        $this->isDelete = $this->isDelete || $changeSet->isDelete;
+    }
+
     public function getApiAlias(): string
     {
         return 'dal_change_set';

--- a/src/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSet.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSet.php
@@ -35,7 +35,7 @@ class ChangeSet extends Struct
 
         // validate data types
         foreach ($changes as $property => $after) {
-            $before = $state[$property];
+            $before = (string) $state[$property];
             $string = (string) $after;
             if ($string === $before) {
                 continue;

--- a/src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/EntityWriteResultFactory.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\ChangeSet;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\ChangeSetAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\DeleteCommand;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand;
@@ -413,6 +414,14 @@ class EntityWriteResultFactory
                     json_encode($command->getPayload(), \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR)
                 );
                 $mergedPayload = array_merge($payload, [$field->getPropertyName() => $decodedPayload]);
+
+                if (isset($writeResults[$uniqueId]) && $command instanceof ChangeSetAware) {
+                    $changeSet = $writeResults[$uniqueId]->getChangeSet();
+
+                    if ($changeSet instanceof ChangeSet) {
+                        $command->getChangeSet()->merge($changeSet);
+                    }
+                }
 
                 $writeResults[$uniqueId] = new EntityWriteResult(
                     $this->getCommandPrimaryKey($command, $primaryKeys),

--- a/tests/unit/Core/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSetTest.php
+++ b/tests/unit/Core/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSetTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Core\Framework\DataAbstractionLayer\Write\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\ChangeSet;
+
+/**
+ * @internal
+ */
+#[CoversClass(ChangeSet::class)]
+final class ChangeSetTest extends TestCase
+{
+    /** @dataProvider changeSetConstructProvider */
+    public function testChangeSetConstruct(array $state, array $payload, bool $expectChanges): void
+    {
+        $changeSet = new ChangeSet($state, $payload, false);
+
+        if ($expectChanges) {
+            static::assertNotEquals(0, count($changeSet->getAfter(null)));
+        } else {
+            static::assertEquals(0, count($changeSet->getAfter(null)));
+        }
+    }
+
+    public static function changeSetConstructProvider(): \Generator
+    {
+        yield 'Do not detect changes when both are zero' => [
+            ['foo' => 0],
+            ['foo' => 0],
+            false,
+        ];
+        yield 'Do not detect changes when both are null' => [
+            ['foo' => null],
+            ['foo' => null],
+            false,
+        ];
+        yield 'Detect changes when there is a difference' => [
+            ['foo' => 0],
+            ['foo' => 1],
+            true,
+        ];
+    }
+
+    public function testChangeSetCanMerge(): void
+    {
+        $changeSet = new ChangeSet(['foo' => 0], ['foo' => 1], false);
+        $changeSet->merge(new ChangeSet(['bar' => 0], ['bar' => 1], false));
+
+        static::assertEquals(2, count($changeSet->getAfter(null)));
+        static::assertEquals(1, $changeSet->getAfter('foo'));
+        static::assertEquals(1, $changeSet->getAfter('bar'));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When we generate a changeset and the before and after property are both `null` this will be seen a merge since the after property is being type casted to a string. This is incorrect, or both should be type casted or none.

When a JsonUpdateCommand is triggered for the same entity, this command will override the previous changeset, leading to incorrect write results.

### 2. What does this change do, exactly?
This change will type cast both the after and the before property.
This change will also merge the changeset from the JsonUpdateCommand and the previous command from the same entity.

### 3. Describe each step to reproduce the issue or behaviour.
/ 

### 4. Please link to the relevant issues (if any).
/ 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
