### PR TITLE
Next-34765 - Disallow empty id filters in entity search

### DIFF
--- a/changelog/_unreleased/2024-04-30-disallow-empty-id-filters.md
+++ b/changelog/_unreleased/2024-04-30-disallow-empty-id-filters.md
@@ -1,0 +1,10 @@
+---
+title: Disallow empty id filters in Criteria
+issue: NEXT-34765
+author: Benedikt Brunner
+author_email: benedikt.brunner@pickware.de
+author_github: Benedikt-Brunner
+---
+# Core
+*  Added check to disallow empty id filters when constructing `Criteria`, to avoid accidental loading of all entries from the database.
+

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityReader.php
@@ -588,7 +588,10 @@ class EntityReader implements EntityReaderInterface
             }
         }
 
-        $fieldCriteria->setIds(\array_filter($ids));
+        if (\count($filteredIds = \array_filter($ids)) !== 0) {
+            $fieldCriteria->setIds($filteredIds);
+        }
+
         $fieldCriteria->resetSorting();
         $fieldCriteria->resetFilters();
         $fieldCriteria->resetPostFilters();
@@ -657,10 +660,12 @@ class EntityReader implements EntityReaderInterface
         EntityCollection $collection,
         array $partial
     ): void {
-        // collect all ids of many to many association which already stored inside the struct instances
+        // collect all ids of many-to-many association which already stored inside the struct instances
         $ids = $this->collectManyToManyIds($collection, $association);
 
-        $criteria->setIds($ids);
+        if (\count($ids) !== 0) {
+            $criteria->setIds($ids);
+        }
 
         $referenceClass = $association->getToManyReferenceDefinition();
         /** @var EntityCollection<Entity> $collectionClass */
@@ -807,7 +812,9 @@ class EntityReader implements EntityReaderInterface
         }
         unset($row);
 
-        $fieldCriteria->setIds($ids);
+        if (\count($ids) !== 0) {
+            $fieldCriteria->setIds($ids);
+        }
 
         $referenceClass = $association->getToManyReferenceDefinition();
         /** @var EntityCollection<Entity> $collectionClass */

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -131,9 +131,7 @@ class Criteria extends Struct implements \Stringable
         }
 
         $ids = array_filter($ids);
-        if (empty($ids)) {
-            throw DataAbstractionLayerException::invalidCriteriaIds($ids, 'Ids should not be empty');
-        }
+
         $this->validateIds($ids);
 
         $this->ids = $ids;
@@ -645,6 +643,10 @@ class Criteria extends Struct implements \Stringable
      */
     private function validateIds(array $ids): void
     {
+        if (\count($ids) === 0) {
+            throw DataAbstractionLayerException::invalidCriteriaIds($ids, 'Ids should not be empty');
+        }
+
         foreach ($ids as $id) {
             if (!\is_string($id) && !\is_array($id)) {
                 throw DataAbstractionLayerException::invalidCriteriaIds($ids, 'Ids should be a list of strings or a list of key value pairs, for entities with combined primary keys');

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/CriteriaTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/CriteriaTest.php
@@ -124,6 +124,7 @@ class CriteriaTest extends TestCase
         yield 'non string list' => [[123, 456]];
         yield 'non string key values' => [[[['foo'], ['bar']]]];
         yield 'non string values' => [[[['pk-1' => 123], ['pk-2' => 456]]]];
+        yield 'empty list' => [[]];
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

When fetching entities it is currently possible to pass the `ids`-filter as an empty list resulting in no filter being applied, therefore all entities are part of the result. Then all entities are loaded into memory, since the `ids`-filter disables the `page` and `limit` filters.

### 2. What does this change do, exactly?

This adds a check to see if the `ids`-filter is an empty list and throws an exception informing the user of the api that `"ids may not be empty"`.


### 3. Describe each step to reproduce the issue or behaviour.

  1. Send a request to `...api/search/{entity}` with roughly this body:
     ```
     {
        ...
        limit: 1,
        ids: [],
        ...
     }
     ```
   
   2. Verify that all entities have been loaded / the program has run out of memory


### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-34765


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.

copilot:summary

copilot:walkthrough
