### PR TITLE
Update CartRuleLoader.php

### DIFF
--- a/src/Core/Checkout/Cart/CartRuleLoader.php
+++ b/src/Core/Checkout/Cart/CartRuleLoader.php
@@ -287,6 +287,12 @@ class CartRuleLoader implements ResetInterface
         if ($context->getTaxState() === CartPrice::TAX_STATE_GROSS) {
             $totalCartNetAmount -= $cart->getLineItems()->getPrices()->getCalculatedTaxes()->getAmount();
         }
+
+        // Fix for correct behavior, if $totalCartNetAmount is smaller than 0 (e.g. because of extensions).
+        if($totalCartNetAmount < 0) {
+            $totalCartNetAmount = 0;
+        }
+        
         $taxState = $this->detectTaxType($context, $totalCartNetAmount);
         $previous = $context->getTaxState();
         if ($taxState === $previous) {


### PR DESCRIPTION
### 1. Why is this change necessary?
We need this because with our plugin LenzPlatformCreditManagement, the value of the position price can be lower than 0.
If this fix is not applied the tax state is wrongly set to "gross" instead of "tax-free" in some cases.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
