### PR TITLE
NEXT-36108 NewsletterSubscribe add salesChannelId filter

### DIFF
--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
@@ -249,15 +249,16 @@ class NewsletterSubscribeRoute extends AbstractNewsletterSubscribeRoute
         ];
     }
 
-    private function getNewsletterRecipient(string $identifier, string $value, Context $context): NewsletterRecipientEntity
+    private function getNewsletterRecipient(string $identifier, string $value, SalesChannelContext $context): NewsletterRecipientEntity
     {
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter($identifier, $value));
+        $criteria->addFilter(new EqualsFilter('salesChannelId', $context->getSalesChannelId()));
         $criteria->addAssociation('salutation');
         $criteria->setLimit(1);
 
         /** @var NewsletterRecipientEntity|null $newsletterRecipient */
-        $newsletterRecipient = $this->newsletterRecipientRepository->search($criteria, $context)->getEntities()->first();
+        $newsletterRecipient = $this->newsletterRecipientRepository->search($criteria, $context->getContext())->getEntities()->first();
 
         if (!$newsletterRecipient) {
             throw NewsletterException::recipientNotFound($identifier, $value);


### PR DESCRIPTION
[NEXT-0000] Update getNewsletterRecipient to search for specific recipient from salesChannelId

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Once a newsletter recipient exists on one salesChannel it possible that the wrong recipient is selected, and dispatched along with `NewsletterConfirmEvent` and `NewsletterRegisterEvent` in `NewsletterSubscribeRoute`

### 2. What does this change do, exactly?
Add salesChannelId filter to select newsletter recipient for the correct salesChannel

### 3. Describe each step to reproduce the issue or behaviour.
Add event listender for `NewsletterConfirmEvent` _(dd) or something else_ to show salesChannelId.
Sign up for newsletter on one salesChannel then on another.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
