### PR TITLE
NEXT-0000 Administration set limit for options in listing

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/page/sw-property-list/index.js
@@ -48,7 +48,8 @@ export default {
 
             criteria.setTerm(this.term);
             criteria.addSorting(Criteria.sort(this.sortBy, this.sortDirection, this.useNaturalSorting));
-            criteria.addAssociation('options');
+            const optionPart = criteria.getAssociation('options');
+            optionPart.setLimit(5);
 
             return criteria;
         },


### PR DESCRIPTION
Limit options as only 5 options are shown, and the rest is hidden with v-if. This is a performant toll once you reach a lot of options within a group.


<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
There's no reason to load ten, hundreds or thousands of options when it's limited with v-if.

### 2. What does this change do, exactly?
Limit options loaded in property_group listing

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
