### PR TITLE
NEXT-00000 - Do not add promotion when cart price is zero

### DIFF
--- a/changelog/_unreleased/2024-05-08-do-not-process-promotions-when-cart-price-is-zero.md
+++ b/changelog/_unreleased/2024-05-08-do-not-process-promotions-when-cart-price-is-zero.md
@@ -1,0 +1,11 @@
+---
+title: Do not process promotions when cart price is zero
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Core
+
+* Added check to prevent promotions from being processed when the cart price is zero, this will prevent promotions from being applied to free products. Otherwise the system will throw a 500 error when trying to apply an absolute promotion to a free product.

--- a/src/Core/Checkout/Promotion/Cart/Error/PromotionsOnCartPriceZeroError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/PromotionsOnCartPriceZeroError.php
@@ -12,7 +12,7 @@ class PromotionsOnCartPriceZeroError extends Error
 
     public function __construct(protected array $promotions)
     {
-        $this->message = sprintf('Promotions %s were excluded for cart because the price of the cart is zero.', implode(', ',$this->promotions));
+        $this->message = sprintf('Promotions %s were excluded for cart because the price of the cart is zero.', implode(', ', $this->promotions));
 
         parent::__construct($this->message);
     }
@@ -37,7 +37,7 @@ class PromotionsOnCartPriceZeroError extends Error
         return self::KEY;
     }
 
-    public function getPromotions(): string
+    public function getPromotions(): array
     {
         return $this->promotions;
     }
@@ -50,7 +50,7 @@ class PromotionsOnCartPriceZeroError extends Error
     public function getParameters(): array
     {
         return [
-            'promotions' => $this->promotions,
+            'promotions' => implode(', ', $this->promotions),
         ];
     }
 }

--- a/src/Core/Checkout/Promotion/Cart/Error/PromotionsOnCartPriceZeroError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/PromotionsOnCartPriceZeroError.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Promotion\Cart\Error;
+
+use Shopware\Core\Checkout\Cart\Error\Error;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('buyers-experience')]
+class PromotionsOnCartPriceZeroError extends Error
+{
+    private const KEY = 'promotions-on-cart-price-zero-error';
+
+    public function __construct(protected array $promotions)
+    {
+        $this->message = sprintf('Promotions %s were excluded for cart because the price of the cart is zero.', implode(', ',$this->promotions));
+
+        parent::__construct($this->message);
+    }
+
+    public function isPersistent(): bool
+    {
+        return false;
+    }
+
+    public function getId(): string
+    {
+        return self::KEY;
+    }
+
+    public function getLevel(): int
+    {
+        return self::LEVEL_NOTICE;
+    }
+
+    public function getMessageKey(): string
+    {
+        return self::KEY;
+    }
+
+    public function getPromotions(): string
+    {
+        return $this->promotions;
+    }
+
+    public function blockOrder(): bool
+    {
+        return false;
+    }
+
+    public function getParameters(): array
+    {
+        return [
+            'promotions' => $this->promotions,
+        ];
+    }
+}

--- a/src/Core/Checkout/Promotion/Cart/PromotionProcessor.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionProcessor.php
@@ -10,6 +10,7 @@ use Shopware\Core\Checkout\Cart\LineItem\CartDataCollection;
 use Shopware\Core\Checkout\Cart\LineItem\Group\LineItemGroupBuilder;
 use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
 use Shopware\Core\Checkout\Promotion\Cart\Error\AutoPromotionNotFoundError;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionsOnCartPriceZeroError;
 use Shopware\Core\Checkout\Promotion\Exception\InvalidPriceDefinitionException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Profiling\Profiler;
@@ -71,6 +72,15 @@ class PromotionProcessor implements CartProcessorInterface
 
             /** @var LineItemCollection $discountLineItems */
             $discountLineItems = $data->get(self::DATA_KEY);
+
+            if ($toCalculate->getPrice()->getTotalPrice() === 0.0) {
+                $toCalculate->addErrors(
+                    new PromotionsOnCartPriceZeroError($discountLineItems->fmap(fn($lineItem) => $lineItem->getLabel()))
+                );
+
+                return;
+            }
+
 
             // calculate the whole cart with the
             // new list of created promotion discount line items

--- a/src/Core/Checkout/Promotion/Cart/PromotionProcessor.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionProcessor.php
@@ -81,7 +81,6 @@ class PromotionProcessor implements CartProcessorInterface
                 return;
             }
 
-
             // calculate the whole cart with the
             // new list of created promotion discount line items
             $items = new LineItemCollection($discountLineItems);

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -324,7 +324,8 @@
     "colonCharacter": ":",
     "orderGuestLoginTitle": "Authentifizierung",
     "orderGuestLoginDescription": "Um Ihre Bestellung einsehen zu können, geben Sie bitte zuerst Ihre E-Mail-Adresse sowie die Postleitzahl aus Ihrer verwendeten Rechnungsadresse ein.",
-    "orderGuestLoginWrongCredentials": "Die eingegebenen Daten konnten leider keiner Bestellung zugeordnet werden."
+    "orderGuestLoginWrongCredentials": "Die eingegebenen Daten konnten leider keiner Bestellung zugeordnet werden.",
+    "promotions-on-cart-price-zero-error": "Promotionen %promotions% wurden vom Warenkorb ausgeschlossen, da der Preis des Warenkorbs null beträgt."
   },
   "address": {
     "streetLabel": "Straße und Hausnummer",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -471,7 +471,8 @@
     "salutation-missing-billing-address": "There's no salutation configured for your active billing address, please set one <a href=\"%url%\">here</a>.",
     "salutation-missing-shipping-address": "There's no salutation configured for your active shipping address, please set one <a href=\"%url%\">here</a>.",
     "country-region-missing-billing-address": "There's no country region configured for your active billing address, please set one <a href=\"%url%\">here</a>.",
-    "country-region-missing-shipping-address": "There's no country region configured for your active shipping address, please set one <a href=\"%url%\">here</a>."
+    "country-region-missing-shipping-address": "There's no country region configured for your active shipping address, please set one <a href=\"%url%\">here</a>.",
+    "promotions-on-cart-price-zero-error": "Promotions %promotions% were excluded for cart because the price of the cart is zero"
   },
   "listing": {
     "filterTitleText": "Filter",

--- a/tests/integration/Core/Checkout/Cart/Processor/PromotionProcessorTest.php
+++ b/tests/integration/Core/Checkout/Cart/Processor/PromotionProcessorTest.php
@@ -1,0 +1,77 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Checkout\Cart\Processor;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartBehavior;
+use Shopware\Core\Checkout\Cart\Error\Error;
+use Shopware\Core\Checkout\Cart\LineItem\CartDataCollection;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionsOnCartPriceZeroError;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
+use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\TestDefaults;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+class PromotionProcessorTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    /**
+     * @param array<LineItem> $items
+     *
+     * @dataProvider processorProvider
+     */
+    public function testProcessor(array $items, CartPrice $cartPrice, ?Error $expectedError): void
+    {
+        $processor = $this->getContainer()->get(PromotionProcessor::class);
+
+        $context = $this->getContainer()->get(SalesChannelContextFactory::class)
+            ->create(Uuid::randomHex(), TestDefaults::SALES_CHANNEL);
+
+        $cart = new Cart('test');
+        $cart->setLineItems(new LineItemCollection($items));
+        $cart->setPrice($cartPrice);
+
+        $new = new Cart('after');
+        $new->setLineItems(new LineItemCollection($items));
+        $new->setPrice($cartPrice);
+
+        $data = new CartDataCollection();
+        $data->set(PromotionProcessor::DATA_KEY, new LineItemCollection());
+
+        $processor->process($data, $cart, $new, $context, new CartBehavior());
+
+        if (null === $expectedError) {
+            static::assertEquals(0, $new->getErrors()->count());
+        } else {
+            static::assertEquals(1, $new->getErrors()->filterInstance($expectedError::class)?->count());
+        }
+    }
+
+    public static function processorProvider(): \Generator
+    {
+        $context = Generator::createSalesChannelContext();
+        $context->setTaxState(CartPrice::TAX_STATE_GROSS);
+        $context->setItemRounding(new CashRoundingConfig(2, 0.01, true));
+
+        yield 'Do not process discounts when cart is zero' => [
+            [new LineItem(Uuid::randomHex(), LineItem::PRODUCT_LINE_ITEM_TYPE, Uuid::randomHex(), 1)],
+            new CartPrice(0, 0, 0, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_GROSS),
+            new PromotionsOnCartPriceZeroError([]),
+        ];
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When a promotion is added to a cart with a total price of zero, there will be an error thrown. This error is thrown for auto promotions or regular promotions.

### 2. What does this change do, exactly?
This change adds an extra check and does not process the discounts when the total price of the cart is zero.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add a product with price 0
2. Add discount via auto promo or via normal promo code
3. A 500 error is thrown

### 4. Please link to the relevant issues (if any).
/ 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
