### PR TITLE
NEXT-36082 - Use absolute path for root plugin

### DIFF
--- a/changelog/_unreleased/2024-05-10-fix-root-composer-plugin.md
+++ b/changelog/_unreleased/2024-05-10-fix-root-composer-plugin.md
@@ -1,0 +1,9 @@
+---
+title: Fix plugin refresh if root composer.json is a plugin
+issue: NEXT-36082
+author: Alexander Stehlik
+author_email: alexander.stehlik@gmail.com
+author_github: astehlik
+---
+# Core
+* Changed behavior of `\Shopware\Core\Framework\Plugin\Util\PluginFinder`: it now returns an absolute path when a Shopware plugin is detected in the `composer.json` file in the project root. This prevents an error in the `refreshPlugins()` method of the `\Shopware\Core\Framework\Plugin\PluginService` which expects all plugin paths to be absolute.

--- a/src/Core/Framework/Plugin/Util/PluginFinder.php
+++ b/src/Core/Framework/Plugin/Util/PluginFinder.php
@@ -156,7 +156,7 @@ class PluginFinder
             $pluginBaseClass = $this->getPluginNameFromPackage($root);
             $plugins[$pluginBaseClass] = (new PluginFromFileSystemStruct())->assign([
                 'baseClass' => $pluginBaseClass,
-                'path' => '.',
+                'path' => $projectDir,
                 'managedByComposer' => true,
                 'composerPackage' => $root,
             ]);

--- a/src/Core/Framework/Test/Plugin/PluginServiceTest.php
+++ b/src/Core/Framework/Test/Plugin/PluginServiceTest.php
@@ -72,6 +72,23 @@ class PluginServiceTest extends TestCase
         static::assertSame('https://www.test.com/support', $plugin->getSupportLink());
     }
 
+    public function testRefreshPluginsWithRootComposerJsonContainingPlugin(): void
+    {
+        $this->pluginService = $this->createPluginService(
+            __DIR__ . '/_fixture/plugins',
+            __DIR__ . '/_fixture/root-plugin',
+            $this->pluginRepo,
+            $this->getContainer()->get('language.repository'),
+            $this->getContainer()->get(PluginFinder::class)
+        );
+
+        $this->pluginService->refreshPlugins($this->context, new NullIO());
+
+        $plugin = $this->fetchSwagTestPluginEntity(baseClass: 'Swag\RootTest\RootPlugin');
+
+        static::assertSame('Root test plugin', $plugin->getTranslated()['label']);
+    }
+
     public function testRefreshPluginWithoutExtraLabelProperty(): void
     {
         $errors = $this->pluginService->refreshPlugins($this->context, new NullIO());
@@ -264,13 +281,13 @@ class PluginServiceTest extends TestCase
         static::assertSame('MIT', $plugin->getLicense());
     }
 
-    private function fetchSwagTestPluginEntity(?Context $context = null): PluginEntity
+    private function fetchSwagTestPluginEntity(?Context $context = null, $baseClass = SwagTestPlugin::class): PluginEntity
     {
         if ($context === null) {
             $context = $this->context;
         }
 
-        $criteria = (new Criteria())->addFilter(new EqualsFilter('baseClass', SwagTestPlugin::class));
+        $criteria = (new Criteria())->addFilter(new EqualsFilter('baseClass', $baseClass));
 
         /** @var PluginEntity|null $first */
         $first = $this->pluginRepo

--- a/src/Core/Framework/Test/Plugin/_fixture/root-plugin/composer.json
+++ b/src/Core/Framework/Test/Plugin/_fixture/root-plugin/composer.json
@@ -1,0 +1,28 @@
+{
+    "name": "swag/root-plugin",
+    "description": "Test description",
+    "version": "v1.0.2",
+    "type": "shopware-platform-plugin",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "shopware AG",
+            "role": "Manufacturer"
+        }
+    ],
+    "require": {
+        "shopware/platform": "^v6.6.2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Swag\\RootTest\\": "src/"
+        }
+    },
+    "extra": {
+        "shopware-plugin-class": "Swag\\RootTest\\RootPlugin",
+        "label": {
+            "en-GB": "Root test plugin",
+            "de-DE": "Root Test plugin"
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The `plugin:refresh` command currently fails when the `composer.json` in the project root is a plugin.

### 2. What does this change do, exactly?

The `\Shopware\Core\Framework\Plugin\Util\PluginFinder` returns an absolute path (using the project dir) when a Shopware plugin is detected in the `composer.json` file in the project root. 

This prevents an error in the `refreshPlugins()` method of the `\Shopware\Core\Framework\Plugin\PluginService` which expects all plugin paths to be absolute.

### 3. Describe each step to reproduce the issue or behaviour.

Add or adjust this in the default root `composer.json` after setting up a clean Shopware project with `shopware/production`:

```json
{
    "type": "shopware-platform-plugin",
    "version": "1.0.0",
    "autoload": {"psr-4": {"Swag\\DemoPlugin\\": "src/"}},
    "extra": {
        "shopware-plugin-class": "Swag\\DemoPlugin\\MyDemoPlugin",
        "label": {
            "de-DE": "Demo Plugin",
            "en-GB": "Demo Plugin"
        }
    }
}
```

Create `src/MyDemoPlugin.php`:

```php
<?php
namespace Swag\DemoPlugin;
class MyDemoPlugin extends \Shopware\Core\Framework\Plugin
{
}
```

Run `plugin:refresh` command.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-36082

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
