### PR TITLE
fix: Show all property filters when filterable properties are not restricted

### DIFF
--- a/changelog/_unreleased/2024-05-11-show-all-property-filters-when-filterable-properties-are-not-restricted.md
+++ b/changelog/_unreleased/2024-05-11-show-all-property-filters-when-filterable-properties-are-not-restricted.md
@@ -1,0 +1,9 @@
+---
+title: Show all property filters when filterable properties are not restricted
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed `ProductListingCmsElementResolver` to only restrict the property filters when it is configured in the administration, that the properties should be restricted

--- a/src/Core/Content/Product/Cms/ProductListingCmsElementResolver.php
+++ b/src/Core/Content/Product/Cms/ProductListingCmsElementResolver.php
@@ -9,6 +9,11 @@ use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductListingStruct;
 use Shopware\Core\Content\Product\SalesChannel\Listing\AbstractProductListingRoute;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter\ManufacturerListingFilterHandler;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter\PriceListingFilterHandler;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter\PropertyListingFilterHandler;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter\RatingListingFilterHandler;
+use Shopware\Core\Content\Product\SalesChannel\Listing\Filter\ShippingFreeListingFilterHandler;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
@@ -20,6 +25,14 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 class ProductListingCmsElementResolver extends AbstractCmsElementResolver
 {
+    private const FILTER_REQUEST_PARAMS = [
+        ManufacturerListingFilterHandler::FILTER_ENABLED_REQUEST_PARAM,
+        RatingListingFilterHandler::FILTER_ENABLED_REQUEST_PARAM,
+        ShippingFreeListingFilterHandler::FILTER_ENABLED_REQUEST_PARAM,
+        PriceListingFilterHandler::FILTER_ENABLED_REQUEST_PARAM,
+        PropertyListingFilterHandler::FILTER_ENABLED_REQUEST_PARAM,
+    ];
+
     /**
      * @internal
      */
@@ -159,30 +172,27 @@ class ProductListingCmsElementResolver extends AbstractCmsElementResolver
 
     private function restrictFilters(CmsSlotEntity $slot, Request $request): void
     {
-        // set up the default behavior
-        $defaults = ['manufacturer-filter', 'rating-filter', 'shipping-free-filter', 'price-filter', 'property-filter'];
-
-        $request->request->set('property-whitelist', null);
-
         $config = $slot->get('config');
 
-        if (isset($config['propertyWhitelist']['value']) && (is_countable($config['propertyWhitelist']['value']) ? \count($config['propertyWhitelist']['value']) : 0) > 0) {
-            $request->request->set('property-whitelist', $config['propertyWhitelist']['value']);
+        $enabledFilters = $config['filters']['value'] ?? null;
+        if (\is_string($enabledFilters)) {
+            $enabledFilters = explode(',', $enabledFilters);
+        } else {
+            $enabledFilters = self::FILTER_REQUEST_PARAMS;
         }
 
-        if (!isset($config['filters']['value'])) {
-            return;
+        $propertyWhitelist = $config['propertyWhitelist']['value'] ?? null ?: null;
+
+        // When the property filters are restricted, they are not in the enabledFilters array
+        if (\in_array(PropertyListingFilterHandler::FILTER_ENABLED_REQUEST_PARAM, $enabledFilters, true)
+            || !\is_array($propertyWhitelist)) {
+            $propertyWhitelist = null;
         }
 
-        // apply config settings
-        $config = explode(',', (string) $config['filters']['value']);
+        $request->request->set(PropertyListingFilterHandler::PROPERTY_GROUP_IDS_REQUEST_PARAM, $propertyWhitelist);
 
-        foreach ($defaults as $filter) {
-            if (\in_array($filter, $config, true)) {
-                continue;
-            }
-
-            $request->request->set($filter, false);
+        foreach (self::FILTER_REQUEST_PARAMS as $filterParam) {
+            $request->request->set($filterParam, \in_array($filterParam, $enabledFilters, true));
         }
     }
 }

--- a/src/Core/Content/Product/SalesChannel/Listing/Filter/ManufacturerListingFilterHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Filter/ManufacturerListingFilterHandler.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 class ManufacturerListingFilterHandler extends AbstractListingFilterHandler
 {
+    final public const FILTER_ENABLED_REQUEST_PARAM = 'manufacturer-filter';
+
     public function getDecorated(): AbstractListingFilterHandler
     {
         throw new DecorationPatternException(self::class);
@@ -20,7 +22,7 @@ class ManufacturerListingFilterHandler extends AbstractListingFilterHandler
 
     public function create(Request $request, SalesChannelContext $context): ?Filter
     {
-        if (!$request->request->get('manufacturer-filter', true)) {
+        if (!$request->request->get(self::FILTER_ENABLED_REQUEST_PARAM, true)) {
             return null;
         }
 

--- a/src/Core/Content/Product/SalesChannel/Listing/Filter/PriceListingFilterHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Filter/PriceListingFilterHandler.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 class PriceListingFilterHandler extends AbstractListingFilterHandler
 {
+    final public const FILTER_ENABLED_REQUEST_PARAM = 'price-filter';
+
     public function getDecorated(): AbstractListingFilterHandler
     {
         throw new DecorationPatternException(self::class);
@@ -20,7 +22,7 @@ class PriceListingFilterHandler extends AbstractListingFilterHandler
 
     public function create(Request $request, SalesChannelContext $context): ?Filter
     {
-        if (!$request->request->get('price-filter', true)) {
+        if (!$request->request->get(self::FILTER_ENABLED_REQUEST_PARAM, true)) {
             return null;
         }
 

--- a/src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Filter/PropertyListingFilterHandler.php
@@ -29,6 +29,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 class PropertyListingFilterHandler extends AbstractListingFilterHandler
 {
+    final public const FILTER_ENABLED_REQUEST_PARAM = 'property-filter';
+
     final public const PROPERTY_GROUP_IDS_REQUEST_PARAM = 'property-whitelist';
 
     /**
@@ -49,7 +51,7 @@ class PropertyListingFilterHandler extends AbstractListingFilterHandler
     {
         $groupIds = $request->request->all(self::PROPERTY_GROUP_IDS_REQUEST_PARAM);
 
-        if (!$request->request->get('property-filter', true) && empty($groupIds)) {
+        if (!$request->request->get(self::FILTER_ENABLED_REQUEST_PARAM, true) && empty($groupIds)) {
             return null;
         }
 

--- a/src/Core/Content/Product/SalesChannel/Listing/Filter/RatingListingFilterHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Filter/RatingListingFilterHandler.php
@@ -14,6 +14,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 class RatingListingFilterHandler extends AbstractListingFilterHandler
 {
+    final public const FILTER_ENABLED_REQUEST_PARAM = 'rating-filter';
+
     public function getDecorated(): AbstractListingFilterHandler
     {
         throw new DecorationPatternException(self::class);
@@ -21,7 +23,7 @@ class RatingListingFilterHandler extends AbstractListingFilterHandler
 
     public function create(Request $request, SalesChannelContext $context): ?Filter
     {
-        if (!$request->request->get('rating-filter', true)) {
+        if (!$request->request->get(self::FILTER_ENABLED_REQUEST_PARAM, true)) {
             return null;
         }
 

--- a/src/Core/Content/Product/SalesChannel/Listing/Filter/ShippingFreeListingFilterHandler.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Filter/ShippingFreeListingFilterHandler.php
@@ -14,6 +14,8 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('inventory')]
 class ShippingFreeListingFilterHandler extends AbstractListingFilterHandler
 {
+    final public const FILTER_ENABLED_REQUEST_PARAM = 'shipping-free-filter';
+
     public function getDecorated(): AbstractListingFilterHandler
     {
         throw new DecorationPatternException(self::class);
@@ -21,7 +23,7 @@ class ShippingFreeListingFilterHandler extends AbstractListingFilterHandler
 
     public function create(Request $request, SalesChannelContext $context): ?Filter
     {
-        if (!$request->request->get('shipping-free-filter', true)) {
+        if (!$request->request->get(self::FILTER_ENABLED_REQUEST_PARAM, true)) {
             return null;
         }
 

--- a/tests/integration/Core/Content/Product/Cms/ProductListingCmsElementResolverTest.php
+++ b/tests/integration/Core/Content/Product/Cms/ProductListingCmsElementResolverTest.php
@@ -726,6 +726,22 @@ class ProductListingCmsElementResolverTest extends TestCase
                     'propertyWhitelist' => ['value' => [$sizeId, $textileId]],
                 ],
             ],
+            [
+                [
+                    'manufacturer-filter' => false,
+                    'price-filter' => false,
+                    'rating-filter' => false,
+                    'shipping-free-filter' => false,
+                    'property-filter' => true,
+                    'property-whitelist' => [],
+                ],
+                [
+                    'filters' => [
+                        'value' => 'property-filter',
+                    ],
+                    'propertyWhitelist' => ['value' => [$sizeId, $textileId]],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when one is enabling the "Configure filterable product properties" in the product listing element, and only enable a few filters:
![image](https://github.com/shopware/shopware/assets/6317761/35dce860-fd11-488d-b594-01e00a736f89)

And afterwards disabling it again:
![image](https://github.com/shopware/shopware/assets/6317761/9bdf2ec2-3027-4f05-8fb8-a3a0ceeceb9e)

The administration indicates that all properties are shown again. But it is not the case. In the storefront only the previously enabled properties are shown.

### 2. What does this change do, exactly?
Fix the logic of the `ProductListingCmsElementResolver`.

### 3. Describe each step to reproduce the issue or behaviour.
See 1.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
