### PR TITLE
NEXT-36122 - Allow empty string in order customer comment

### DIFF
--- a/changelog/_unreleased/2024-05-14-allow-empty-string-in-order-customer-comment.md
+++ b/changelog/_unreleased/2024-05-14-allow-empty-string-in-order-customer-comment.md
@@ -1,0 +1,9 @@
+---
+title: Allow empty string in order customer comment
+issue: NEXT-36122
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Added `AllowEmptyString()` flag to definition of field `customerComment` in `OrderDefinition` to allow empty string in the customer comment field

--- a/src/Core/Checkout/Order/OrderDefinition.php
+++ b/src/Core/Checkout/Order/OrderDefinition.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowEmptyString;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\CascadeDelete;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\NoConstraint;
@@ -104,7 +105,7 @@ class OrderDefinition extends EntityDefinition
             (new StringField('deep_link_code', 'deepLinkCode'))->addFlags(new ApiAware()),
             (new StringField('affiliate_code', 'affiliateCode'))->addFlags(new ApiAware()),
             (new StringField('campaign_code', 'campaignCode'))->addFlags(new ApiAware()),
-            (new LongTextField('customer_comment', 'customerComment'))->addFlags(new ApiAware()),
+            (new LongTextField('customer_comment', 'customerComment'))->addFlags(new ApiAware(), new AllowEmptyString()),
             (new StringField('source', 'source'))->addFlags(new ApiAware()),
 
             (new StateMachineStateField('state_id', 'stateId', OrderStates::STATE_MACHINE))->addFlags(new Required()),


### PR DESCRIPTION
### 1. Why is this change necessary?

https://issues.shopware.com/issues/NEXT-36122

### 2. What does this change do, exactly?

Add `AllowHtml()` flag to definition of field `customerComment` in `OrderDefinition` to allow sanitized HTML in customer comments.

### 3. Describe each step to reproduce the issue or behavior.

Before pressing buy on the checkout page, enter "<3" as the customer comment. An exception is thrown. Similar behavior in the API.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-36122

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
