### PR TITLE
Add missing violation snippet for email at path /account/register

### DIFF
--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -73,6 +73,7 @@
     "VIOLATION::CUSTOMER_PASSWORD_NOT_CORRECT": "Das Passwort ist nicht korrekt.",
     "VIOLATION::VAT_ID_FORMAT_NOT_CORRECT": "Die eingegebene USt-IdNr. entspricht nicht der erwarteten Struktur",
     "VIOLATION::ZIP_CODE_INVALID": "Die eingegebene Postleitzahl hat nicht das richtige Format.",
+    "VIOLATION::INVALID_FORMAT_ERROR": "Die eingegebene E-Mail-Adresse entspricht nicht der erwarteten Struktur.",
     "message-default": "Leider ist etwas schief gelaufen",
     "message-404": "Die angeforderte Seite kann nicht gefunden werden.",
     "addToCartError": "Beim Hinzufügen zum Warenkorb ist ein Fehler aufgetreten.",

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -73,6 +73,7 @@
     "VIOLATION::CUSTOMER_PASSWORD_NOT_CORRECT": "Password incorrect.",
     "VIOLATION::VAT_ID_FORMAT_NOT_CORRECT": "The VAT Reg.No. you have entered does not have the correct format.",
     "VIOLATION::ZIP_CODE_INVALID": "The postal code you have entered does not have the correct format.",
+    "VIOLATION::INVALID_FORMAT_ERROR": "The email you have entered does not have the correct format.",
     "message-default": "Unfortunately, something went wrong.",
     "message-404": "The requested page cannot be found.",
     "addToCartError": "An error occurred while trying to add items to the shopping cart.",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
translation for error.VIOLATION::INVALID_FORMAT_ERROR is missing.

### 2. What does this change do, exactly?
add translation in the en-GB and de-DE snippets.

### 3. Describe each step to reproduce the issue or behaviour.
enter x@x as email at path /account/register

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
