### PR TITLE
Backport support of APP_CACHE_DIR

### DIFF
--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -231,7 +231,7 @@ class Kernel extends HttpKernel
     {
         return sprintf(
             '%s/var/cache/%s_h%s%s',
-            $this->getProjectDir(),
+            EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()),
             $this->getEnvironment(),
             $this->getCacheHash(),
             EnvironmentHelper::getVariable('TEST_TOKEN') ?? ''


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
We want to separate the cache directory from the /var folder on Platform.sh as /var is a NFS mount and cache a local one, and it triggers caching issues.
It was done for the 6.6, but it would be great to have it on the 6.5 too, hence this backport.

### 2. What does this change do, exactly?
It gives the possibility to define a new cache folder via APP_CACHE_DIR.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
See https://github.com/shopware/shopware/commit/9997eb7b77e572f22a763455b058c76ae8317a1b

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
