### PR TITLE
feat: Add event to select variant on product detail page

### DIFF
--- a/changelog/_unreleased/2024-05-16-add-event-to-select-variant-on-product-detail-load.md
+++ b/changelog/_unreleased/2024-05-16-add-event-to-select-variant-on-product-detail-load.md
@@ -1,0 +1,9 @@
+---
+title: Add event to select variant on product detail load
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added event `Shopware\Core\Content\Product\SalesChannel\Detail\Event\ResolveVariantIdEvent` to resolve variant on product detail load

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -471,6 +471,7 @@
             <argument type="service" id="Shopware\Core\Content\Cms\SalesChannel\SalesChannelCmsPageLoader"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\SalesChannelProductDefinition"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\ProductCloseoutFilterFactory"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <service id="Shopware\Core\Content\Product\SalesChannel\Detail\CachedProductDetailRoute" decorates="Shopware\Core\Content\Product\SalesChannel\Detail\ProductDetailRoute" decoration-priority="-1000" public="true">

--- a/src/Core/Content/Product/SalesChannel/Detail/Event/ResolveVariantIdEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/Event/ResolveVariantIdEvent.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\SalesChannel\Detail\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('checkout')]
+class ResolveVariantIdEvent extends Event implements ShopwareSalesChannelEvent
+{
+    public function __construct(
+        private readonly string $productId,
+        private ?string $resolvedVariantId,
+        private readonly SalesChannelContext $salesChannelContext
+    ) {
+    }
+
+    public function getProductId(): string
+    {
+        return $this->productId;
+    }
+
+    public function setResolvedVariantId(?string $resolvedVariantId): void
+    {
+        $this->resolvedVariantId = $resolvedVariantId;
+    }
+
+    public function getResolvedVariantId(): ?string
+    {
+        return $this->resolvedVariantId;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to select a variant on the product detail page

### 2. What does this change do, exactly?
Add an event to change the behavior.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
