### PR TITLE
NEXT-0000 - Improve write exception message to include property, that has faulty content

### DIFF
--- a/changelog/_unreleased/2024-01-18-improve-error-message-for-wrong-api-usage-many-to-one-field.md
+++ b/changelog/_unreleased/2024-01-18-improve-error-message-for-wrong-api-usage-many-to-one-field.md
@@ -1,0 +1,8 @@
+---
+title: Improve error message for wrong API usage ManyToOne field
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Added field name to payload path for `FRAMEWORK__WRITE_MALFORMED_INPUT` / `\Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\ExpectedArrayException` when using invalid payload onto ManyToOne fields 

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/ManyToOneAssociationFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/ManyToOneAssociationFieldSerializer.php
@@ -46,7 +46,7 @@ class ManyToOneAssociationFieldSerializer implements FieldSerializerInterface
         }
 
         if (!\is_array($value)) {
-            throw DataAbstractionLayerException::expectedArray($parameters->getPath());
+            throw DataAbstractionLayerException::expectedArray($parameters->getPath() . '/' . $key);
         }
 
         $fkField = $parameters->getDefinition()->getFields()->getByStorageName($field->getStorageName());


### PR DESCRIPTION
### 1. Why is this change necessary?

When you do a bad API request, you do not understand why it is bad.

### 2. What does this change do, exactly?

Add the field name to the path mentioned in the exception.

### 3. Describe each step to reproduce the issue or behaviour.

1. Use the API and create data
2. Send request:
```http
POST /api/seo-url-template
Content-Type: application/json
Accept: application/json

{
    "id": "118f8e56b0da7d81a4392f876b3b5ee6",
    "salesChannel": "foo",
    "entityName": "product",
    "routeName": "foobar",
    "template": "foo"
}
```
3. Get error response with message `Expected data at /0 to be an array`
4. ![Mike sully being confused, annoyed, feeling Weltschmerz](https://i.imgflip.com/3adpwk.png)

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
