### PR TITLE
fix: Disable icon cache for `box-wishlist`

### DIFF
--- a/changelog/_unreleased/2024-05-23-disable-icon-cache-for-the-wishlist-product-box.md
+++ b/changelog/_unreleased/2024-05-23-disable-icon-cache-for-the-wishlist-product-box.md
@@ -1,0 +1,9 @@
+---
+title: Disable icon cache for the wishlist product box
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed the `box-wishlist.html.twig` template to disable the icon cache, as the box might be removed and hence the icons are missing

--- a/src/Storefront/Resources/views/storefront/component/product/card/box-wishlist.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/box-wishlist.html.twig
@@ -1,6 +1,8 @@
 {% sw_extends '@Storefront/storefront/component/product/card/box-standard.html.twig' %}
 
 {% block component_product_box_content %}
+    {{ sw_icon_cache_disable() }}
+
     <div class="card-body card-body-wishlist">
         {{ block('component_product_box_badges') }}
 
@@ -61,4 +63,6 @@
             </div>
         {% endblock %}
     </div>
+
+    {{ sw_icon_cache_enable() }}
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when one removes the first product from the wishlist, all icons which are defined in the box, are removed as well:
![image](https://github.com/shopware/shopware/assets/6317761/5f731e13-0c54-4c90-83eb-8a0ab5e07f30)
![image](https://github.com/shopware/shopware/assets/6317761/84d1c615-762d-448a-9ca1-c6e1b961b466)

### 2. What does this change do, exactly?
Disable the icon cache for the wishlist product box.

### 3. Describe each step to reproduce the issue or behaviour.
Add some products to the wishlist, and remove the first product (disable the `dev` mode, as the `#icons-solid-x` is also defined in the Symfony toolbar).

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
