### PR TITLE
Add event dispatching on customer address upsert

### DIFF
--- a/src/Core/Checkout/Customer/Event/CustomerAddressUpsertedEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerAddressUpsertedEvent.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Event;
+
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareEvent;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CustomerAddressUpsertedEvent extends Event implements ShopwareEvent
+{
+    private CustomerEntity $customer;
+
+    private CustomerAddressEntity $address;
+
+    private Context $context;
+
+    public function __construct(CustomerEntity $customer, CustomerAddressEntity $address, Context $context)
+    {
+        $this->customer = $customer;
+        $this->address = $address;
+        $this->context = $context;
+    }
+
+    public function getCustomer(): CustomerEntity
+    {
+        return $this->customer;
+    }
+
+    public function getAddress(): CustomerAddressEntity
+    {
+        return $this->address;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+}

--- a/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/UpsertAddressRoute.php
@@ -6,6 +6,7 @@ use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressDef
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\CustomerEvents;
+use Shopware\Core\Checkout\Customer\Event\CustomerAddressUpsertedEvent;
 use Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerZipCode;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
@@ -116,6 +117,10 @@ class UpsertAddressRoute extends AbstractUpsertAddressRoute
 
         /** @var CustomerAddressEntity $address */
         $address = $this->addressRepository->search($criteria, $context->getContext())->first();
+
+        // Dispatch event after successful upsert operation -
+        $event = new CustomerAddressUpsertedEvent($customer, $address, $context->getContext());
+        $this->eventDispatcher->dispatch($event);
 
         return new UpsertAddressRouteResponse($address);
     }


### PR DESCRIPTION
Related to #3440

Implements an event dispatch for successful customer address upsert operations in Shopware, enhancing extensibility for developers.

- **Event Creation**: Introduces a new event class `CustomerAddressUpsertedEvent` that extends `Symfony\Contracts\EventDispatcher\Event`. This event is designed to be dispatched after a successful upsert operation of a customer address, containing details about the customer, the address, and the context in which the operation was performed.
- **Event Dispatching**: Modifies the `UpsertAddressRoute::upsert` method to dispatch the `CustomerAddressUpsertedEvent` after the address upsert operation is successfully completed. This allows developers to listen for this event and execute custom logic post-upsert, similar to the existing `CustomerRegisterEvent`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shopware/shopware/issues/3440?shareId=83b2cee9-b75e-4e0d-9323-a00792dd1c82).