### PR TITLE
NEXT-00000 | Added partial field full path mapping

### DIFF
--- a/changelog/_unreleased/2024-05-23-added-pratial-property-path-attribute.md
+++ b/changelog/_unreleased/2024-05-23-added-pratial-property-path-attribute.md
@@ -1,0 +1,7 @@
+---
+title: Added full partial fields path check
+author: Fabian Boensch
+author_github: @En0Ma1259
+---
+# Core
+* Added mapping in EntityHydrator for full partial field paths check


### PR DESCRIPTION
### 1. Why is this change necessary?
To load fields from an association, you also need to add this field to all previous entities, even, if this entity hasn't this field.
E.g.
```PHP
$criteria->addFields(['properties.group.description', 'properties.description', 'description']);
$productRepository->search($criteria, $context);
```

With this, we would load all descriptions for product property groups. But we also must load the descriptions of our products, although we don't need them.

With this change, it will be possible to do this
```PHP
$criteria->addFields(['properties.group.description']);
$productRepository->search($criteria, $context);
```

### 2. What does this change do, exactly?
Will map the full partial field paths and checks, if they should be loaded or not. Previously only the property was checked and not the full path.

### 3. Describe each step to reproduce the issue or behaviour.
Done in 1.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
