### PR TITLE
feat: Add path to `OneToOneAssociationField` error message

### DIFF
--- a/changelog/_unreleased/2024-05-28-improve-onetooneassociationfield-error-message-to-include-the-path.md
+++ b/changelog/_unreleased/2024-05-28-improve-onetooneassociationfield-error-message-to-include-the-path.md
@@ -1,0 +1,9 @@
+---
+title: Improve OneToOneAssociationField error message to include the path
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added field name to payload path for `FRAMEWORK__WRITE_MALFORMED_INPUT` / `\Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\ExpectedArrayException` when using invalid payload of `OneToOneAssociationField`

--- a/src/Core/Framework/DataAbstractionLayer/FieldSerializer/OneToOneAssociationFieldSerializer.php
+++ b/src/Core/Framework/DataAbstractionLayer/FieldSerializer/OneToOneAssociationFieldSerializer.php
@@ -40,7 +40,9 @@ class OneToOneAssociationFieldSerializer implements FieldSerializerInterface
         }
 
         if (!\is_array($value)) {
-            throw DataAbstractionLayerException::expectedArray($parameters->getPath());
+            throw DataAbstractionLayerException::expectedArray(
+                sprintf('%s/%s', $parameters->getPath(), $key)
+            );
         }
 
         /** @var Field $keyField */
@@ -94,7 +96,9 @@ class OneToOneAssociationFieldSerializer implements FieldSerializerInterface
         }
 
         if (!\is_array($data->getValue())) {
-            throw DataAbstractionLayerException::expectedArray($parameters->getPath());
+            throw DataAbstractionLayerException::expectedArray(
+                sprintf('%s/%s', $parameters->getPath(), $data->getKey())
+            );
         }
 
         $reference = $field->getReferenceDefinition();

--- a/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/OneToOneAssociationFieldSerializerTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/FieldSerializer/OneToOneAssociationFieldSerializerTest.php
@@ -1,0 +1,159 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\FieldSerializer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\ManyToOneAssociationFieldSerializer;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\OneToOneAssociationFieldSerializer;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteCommandQueue;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\DataStack\KeyValuePair;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityExistence;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\FieldException\ExpectedArrayException;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteCommandExtractor;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteParameterBag;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(ManyToOneAssociationFieldSerializer::class)]
+class OneToOneAssociationFieldSerializerTest extends TestCase
+{
+    public function testExceptionInNormalizationIsThrownIfDataIsNotArray(): void
+    {
+        $this->expectException(ExpectedArrayException::class);
+        static::expectExceptionMessage('Expected data at /0/recoveryCustomer to be an array.');
+
+        new StaticDefinitionInstanceRegistry(
+            [
+                CustomerDefinition::class => $customerDefinition = new CustomerDefinition(),
+                CustomerRecoveryDefinition::class => new CustomerRecoveryDefinition(),
+            ],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+
+        $field = $customerDefinition->getField('recoveryCustomer');
+
+        static::assertInstanceOf(OneToOneAssociationField::class, $field);
+
+        $serializer = new OneToOneAssociationFieldSerializer($this->createMock(WriteCommandExtractor::class));
+
+        $params = new WriteParameterBag(
+            $customerDefinition,
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            '/0',
+            new WriteCommandQueue()
+        );
+
+        $serializer->normalize(
+            $field,
+            ['recoveryCustomer' => 'foobar'],
+            $params,
+        );
+    }
+
+    public function testExceptionInEncodeIsThrownIfDataIsNotArray(): void
+    {
+        $this->expectException(ExpectedArrayException::class);
+        static::expectExceptionMessage('Expected data at /0/recoveryCustomer to be an array.');
+
+        new StaticDefinitionInstanceRegistry(
+            [
+                CustomerDefinition::class => $customerDefinition = new CustomerDefinition(),
+                CustomerRecoveryDefinition::class => new CustomerRecoveryDefinition(),
+            ],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+
+        $field = $customerDefinition->getField('recoveryCustomer');
+
+        static::assertInstanceOf(OneToOneAssociationField::class, $field);
+
+        $serializer = new OneToOneAssociationFieldSerializer($this->createMock(WriteCommandExtractor::class));
+
+        $params = new WriteParameterBag(
+            $customerDefinition,
+            WriteContext::createFromContext(Context::createDefaultContext()),
+            '/0',
+            new WriteCommandQueue()
+        );
+
+        $serializer->encode(
+            $field,
+            $this->createMock(EntityExistence::class),
+            new KeyValuePair('recoveryCustomer', 'foobar', false),
+            $params,
+        )->next();
+    }
+}
+
+/**
+ * @internal
+ */
+class CustomerRecoveryDefinition extends EntityDefinition
+{
+    public function getEntityName(): string
+    {
+        return 'customer_recovery';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
+            (new StringField('hash', 'hash'))->addFlags(new Required()),
+            (new FkField('customer_id', 'customerId', CustomerDefinition::class))->addFlags(new Required()),
+
+            new OneToOneAssociationField(
+                'customer',
+                'customer_id',
+                'id',
+                CustomerDefinition::class,
+                false
+            ),
+        ]);
+    }
+}
+
+/**
+ * @internal
+ */
+class CustomerDefinition extends EntityDefinition
+{
+    public function getEntityName(): string
+    {
+        return 'customer';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new Required(), new PrimaryKey()),
+            (new StringField('first_name', 'first_name'))->addFlags(new Required()),
+            (new StringField('last_name', 'last_name'))->addFlags(new Required()),
+
+            new OneToOneAssociationField(
+                'recoveryCustomer',
+                'id',
+                'customer_id',
+                CustomerRecoveryDefinition::class,
+                false
+            ),
+        ]);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
See https://github.com/shopware/shopware/pull/3722 but for OneToOne associations
![image](https://github.com/shopware/shopware/assets/6317761/6c401498-fd54-47ce-b3e8-1036d5bff04e)

### 2. What does this change do, exactly?
![image](https://github.com/shopware/shopware/assets/6317761/0f4ac346-a134-4f23-bf03-49c6cc9332b5)

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
