### PR TITLE
Watch multiple themes on multiple sales channel

### DIFF
--- a/src/Storefront/Resources/app/storefront/build/start-hot-reload.js
+++ b/src/Storefront/Resources/app/storefront/build/start-hot-reload.js
@@ -1,33 +1,45 @@
 const createLiveReloadServer = require('./live-reload-server/index');
 const createProxyServer = require('./proxy-server-hot/index');
+const path = require("path");
 
 // starting the live reload server
 const server = createLiveReloadServer();
 
+const projectRootPath = process.env.PROJECT_ROOT
+    ? path.resolve(process.env.PROJECT_ROOT)
+    : path.resolve('../../../../..');
+
+const themeFilesConfigPath = path.resolve(projectRootPath, 'var/theme-files.json');
+let themeFiles = require(themeFilesConfigPath);
+
+
 server.then(() => {
-    const fullUrl = process.env.APP_URL;
     const proxyUrl = new URL(process.env.PROXY_URL || process.env.APP_URL);
-    const proxyPort = process.env.STOREFRONT_PROXY_PORT;
 
-    // first value of array is the http protocol
-    const [schema, domainWithPortAndUri] = fullUrl.split('://');
-    const [domainWithPort, ...uri] = domainWithPortAndUri.split('/');
-    const [domain, port] = domainWithPort.split(':');
+    let port = 9998;
+    Object.values(themeFiles).forEach((theme) => {
+        const fullUrl = theme.domain;
 
-    const proxyServerOptions = {
-        schema,
-        originalHost: domain,
-        appPort: port || 80,
-        proxyHost: proxyUrl.hostname,
-        proxyPort: parseInt(proxyPort || 9998),
-        uri: uri.join('/'),
-    };
+        // first value of array is the http protocol
+        const [schema, domainWithPortAndUri] = fullUrl.split('://');
+        const [domainWithPort, ...uri] = domainWithPortAndUri.split('/');
+        const [domain, domainPort] = domainWithPort.split(':');
 
-    // starting the proxy server
-    createProxyServer(proxyServerOptions).then(({ proxyUrl } ) => {
-        console.log('############');
-        console.log(`Storefront proxy server started at ${proxyUrl}`);
-        console.log('############');
-        console.log('\n');
-    });
+        const proxyServerOptions = {
+            schema,
+            originalHost: domain,
+            appPort: domainPort || 80,
+            proxyHost: proxyUrl.hostname,
+            proxyPort: parseInt(port = port + 2),
+            uri: uri.join('/'),
+        };
+
+        // starting the proxy server
+        createProxyServer(proxyServerOptions).then(({ proxyUrl } ) => {
+            console.log('############');
+            console.log(`${theme.themeName} proxy server started at ${proxyUrl}`);
+            console.log('############');
+            console.log('\n');
+        });
+    })
 });

--- a/src/Storefront/Resources/app/storefront/webpack.config.js
+++ b/src/Storefront/Resources/app/storefront/webpack.config.js
@@ -52,7 +52,14 @@ try {
 }
 
 const useExtensionTwigWatch = process.env.SHOPWARE_STOREFRONT_SKIP_EXTENSION_TWIG_WATCH !== '1';
-let watchFilePaths = isHotMode ? [`${themeFiles.basePath}/**/*.twig`] : [];
+
+let watchFilePaths = [];
+
+if(isHotMode) {
+    Object.values(themeFiles).forEach((theme) => {
+        watchFilePaths.push(`${theme.basePath}/**/*.twig`);
+    });
+}
 
 const pluginEntries = (() => {
     const pluginFile = path.resolve(process.env.PROJECT_ROOT, 'var/plugins.json');
@@ -382,9 +389,15 @@ if (isHotMode) {
             $sw-asset-sitemap-url: '';
         `;
 
-        const collectedImports = [dumpedVariablesImport, assetOverrides, ...themeFiles.style.map((value) => {
-            return `@import "${value.filepath}";\n`;
-        })];
+        const themesStyles = [];
+
+        Object.values(themeFiles).forEach((theme) => {
+            themesStyles.push(...theme.style.map((value) => {
+                return `@import "${value.filepath}";\n`;
+            }));
+        })
+
+        const collectedImports = [dumpedVariablesImport, assetOverrides, ...themesStyles];
 
         return fileComment + scssFeatureConfig + collectedImports.join('');
     })();


### PR DESCRIPTION
I think is usefull to watch all themes in all sales channel for fast developments.

### 1. Why is this change necessary?
In one project we have 3 themes on 3 sales channel. Watch-storefront now on the release 6.6.2.0 watch the FIRST theme that theme:dump can find. But this is very problematic.

### 2. What does this change do, exactly?
My changes dump in theme-files.json all configuration of all themes.

Then I changed the webpack configuration for reflecting theme-files changes and then start one hot-reload-server for each FIRST domain (the first sales channel domain associated with the theme is sufficient)

### 3. Describe each step to reproduce the issue or behaviour.
Create 2 or more sales channel, each associate to different theme

### 4. Please link to the relevant issues (if any).
I don't find any

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
