### PR TITLE
NEXT-36503 - Broken fallback translation with fallback of the same locale localization

### DIFF
--- a/changelog/_unreleased/2024-06-04-fallback-language-for-same-localizations.md
+++ b/changelog/_unreleased/2024-06-04-fallback-language-for-same-localizations.md
@@ -1,0 +1,6 @@
+---
+title: Broken fallback translation with fallback of the same locale localization
+issue: NEXT-36503
+---
+# Core
+* Changed ```$fallbackLocale``` check in ```Shopware\Core\Framework\Adapter\Translation\Translator``` in method ```getCatalogue()``` to fix  fallback translation with fallback of the same locale localization

--- a/src/Core/Framework/Adapter/Translation/Translator.php
+++ b/src/Core/Framework/Adapter/Translation/Translator.php
@@ -116,11 +116,10 @@ class Translator extends AbstractTranslator
 
         $fallbackLocale = $this->getFallbackLocale();
 
-        $localization = mb_substr($fallbackLocale, 0, 2);
-        if ($this->isShopwareLocaleCatalogue($catalog) && !$this->isFallbackLocaleCatalogue($catalog, $localization)) {
-            $catalog->addFallbackCatalogue($this->translator->getCatalogue($localization));
+        if ($this->isShopwareLocaleCatalogue($catalog) && !$this->isFallbackLocaleCatalogue($catalog, $fallbackLocale)) {
+            $catalog->addFallbackCatalogue($this->translator->getCatalogue($fallbackLocale));
         } else {
-            // fallback locale and current locale has the same localization -> reset fallback
+            // fallback locale and current locale are the same -> reset fallback
             // or locale is symfony style locale so we shouldn't add shopware fallbacks as it may lead to circular references
             $fallbackLocale = null;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
If we have the same localizations from locales (for example en-GB as default system language and en-US as additional language) fallback language doesn't work from en-GB if we are using en-US language (for example if snippets are missing).

### 2. What does this change do, exactly?
Changes fallback locale check to use the whole locale and not only the localization.

### 3. Describe each step to reproduce the issue or behaviour.
1. Install shopware 6.6.2.0 with default language en-GB and set to "prod".
2. Install SwagLanguagePack to have en-US language.
3. Install some third party plugin, that has no en-US translation by default and that you can easly see the snippet in the storefront.
4. Create sales channel with en-US language and snippet set.
5. Fallback translation will be not used and we could see untranslated snippet key.

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-36503

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
