### PR TITLE
NEXT-00000 - Add discount id check when collection promotions

### DIFF
--- a/changelog/_unreleased/2024-06-05-add-discount-id-check-when-collecting-promotions.md
+++ b/changelog/_unreleased/2024-06-05-add-discount-id-check-when-collecting-promotions.md
@@ -1,0 +1,11 @@
+---
+title: Add discount id check when collecting promotions
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Core
+
+* Added discount id check when collecting promotions because a promotion can have multiple discounts.

--- a/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCollector.php
@@ -375,8 +375,8 @@ class PromotionCollector implements CartDataCollectorInterface
                 $factor
             );
 
-            $originalCodeItem = $cart->getLineItems()->filter(function (LineItem $item) use ($code) {
-                if ($item->getReferencedId() === $code) {
+            $originalCodeItem = $cart->getLineItems()->filter(function (LineItem $item) use ($code, $discount) {
+                if ($item->getReferencedId() === $code && $item->getPayloadValue('discountId') === $discount->getId()) {
                     return $item;
                 }
 

--- a/tests/unit/Core/Checkout/Promotion/Cart/PromotionCollectorTest.php
+++ b/tests/unit/Core/Checkout/Promotion/Cart/PromotionCollectorTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Promotion\Cart;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\CartBehavior;
+use Shopware\Core\Checkout\Cart\LineItem\CartDataCollection;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Cart\LineItem\LineItemCollection;
+use Shopware\Core\Checkout\Cart\Order\IdStruct;
+use Shopware\Core\Checkout\Cart\Order\OrderConverter;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountCollection;
+use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
+use Shopware\Core\Checkout\Promotion\Cart\Extension\CartExtension;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionCollector;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionItemBuilder;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
+use Shopware\Core\Checkout\Promotion\Gateway\PromotionGatewayInterface;
+use Shopware\Core\Checkout\Promotion\Gateway\Template\PermittedAutomaticPromotions;
+use Shopware\Core\Checkout\Promotion\Gateway\Template\PermittedGlobalCodePromotions;
+use Shopware\Core\Checkout\Promotion\PromotionCollection;
+use Shopware\Core\Checkout\Promotion\PromotionEntity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\HtmlSanitizer;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+
+#[Package('buyers-experience')]
+#[CoversClass(PromotionCollector::class)]
+final class PromotionCollectorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->gateway = $this->createMock(PromotionGatewayInterface::class);
+        $this->itemBuilder = new PromotionItemBuilder();
+        $this->htmlSanitizer = $this->createMock(HtmlSanitizer::class);
+
+        $this->promotionCollector = new PromotionCollector(
+            $this->gateway,
+            $this->itemBuilder,
+            $this->htmlSanitizer,
+        );
+
+        $this->cart = $this->createMock(Cart::class);
+        $this->context = $this->createMock(SalesChannelContext::class);
+    }
+
+    public function testCollectWithExistingPromotionAndDifferentDiscount(): void
+    {
+        // Arrange
+        $original = new Cart('16d71f1837774b6790cc841c5e213c06');
+        $lineItem = new LineItem('ba3bf911830d4fdfa182bb7c8e89ec71', LineItem::PRODUCT_LINE_ITEM_TYPE, '54873487dacd4ba0a6e567677002cc02');
+        $lineItem2 = new LineItem($lineItem2Id = '77a4e83ed44a4b22993a675010347075', LineItem::DISCOUNT_LINE_ITEM, $code = 'promotions-code');
+        $lineItem2->setPayloadValue('discountId', $discountId1 = '7f659f15b82c40049bef621631ac5335');
+        $lineItem2->addExtension(OrderConverter::ORIGINAL_ID, new IdStruct($lineItem2Id));
+        $original->setLineItems(new LineItemCollection([$lineItem, $lineItem2]));
+
+        $promotion = new PromotionEntity();
+        $promotion->setId($promotionId = '16d71f1837774b6790cc841c5e213c06');
+        $promotion->setCode($code);
+        $promotion->setUseIndividualCodes(true);
+        $promotion->setPriority(1);
+
+        $discount1 = new PromotionDiscountEntity();
+        $discount1->setId($discountId1);
+        $discount1->setScope(PromotionDiscountEntity::SCOPE_CART);
+        $discount1->setType(PromotionDiscountEntity::TYPE_ABSOLUTE);
+        $discount1->setValue(10.0);
+        $discount1->setPromotionId($promotion->getId());
+
+        $discount2 = new PromotionDiscountEntity();
+        $discount2->setId($discountId2 = '03fe425351754bffa2ceab9607883e96');
+        $discount2->setScope(PromotionDiscountEntity::SCOPE_CART);
+        $discount2->setType(PromotionDiscountEntity::TYPE_ABSOLUTE);
+        $discount2->setValue(15.0);
+        $discount2->setPromotionId($promotion->getId());
+
+        $promotion->setDiscounts(new PromotionDiscountCollection([$discount1, $discount2]));
+
+        $promotionData = new CartExtension();
+        $promotionData->addCode($code);
+        $original->addExtension(CartExtension::KEY, $promotionData);
+
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($salesChannelId = 'd3d1d39d521f45c7895ff575b2c23e1e');
+        $this->context->method('getSalesChannel')->willReturn($salesChannel);
+
+        $criteria1 = (new Criteria())->addFilter(new PermittedGlobalCodePromotions([$code], $salesChannelId));
+        $criteria1->addAssociations([
+            'personaRules',
+            'personaCustomers',
+            'cartRules',
+            'orderRules',
+            'discounts.discountRules',
+            'discounts.promotionDiscountPrices',
+            'setgroups',
+            'setgroups.setGroupRules'
+        ]);
+
+        $criteria2 = (new Criteria())->addFilter(new PermittedAutomaticPromotions($salesChannelId));
+        $criteria2->addAssociations([
+            'personaRules',
+            'personaCustomers',
+            'cartRules',
+            'orderRules',
+            'discounts.discountRules',
+            'discounts.promotionDiscountPrices',
+            'setgroups',
+            'setgroups.setGroupRules'
+        ]);
+
+        $this->gateway->method('get')
+            ->willReturnCallback(static function ($criteria) use ($criteria1, $criteria2, $promotion) {
+                if ($criteria == $criteria1) {
+                    return new PromotionCollection([$promotion]);
+                }
+                if ($criteria == $criteria2) {
+                    return new PromotionCollection();
+                }
+            });
+
+        // Act
+        $this->promotionCollector->collect($data = new CartDataCollection(), $original, $this->context, new CartBehavior());
+
+        // Assert
+        $promotions = $data->get(PromotionProcessor::DATA_KEY);
+        $this->assertCount(2, $promotions);
+        $this->assertSame($promotionId, $promotions->first()->getPayloadValue('promotionId'));
+        $this->assertSame($discountId1, $promotions->first()->getPayloadValue('discountId'));
+        $this->assertNotNull($promotions->first()->getExtension(OrderConverter::ORIGINAL_ID));
+
+        $this->assertSame($promotionId, $promotions->last()->getPayloadValue('promotionId'));
+        $this->assertSame($discountId2, $promotions->last()->getPayloadValue('discountId'));
+        $this->assertNull($promotions->last()->getExtension(OrderConverter::ORIGINAL_ID));
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When a promotion includes multiple discounts, some of which do not apply at the time of order creation, the order might later be edited to qualify for the other discounts from the same promotion. These new discount line items will not be saved on the order because we only check the promotion discount code, which remains the same across all discounts. We then append the original code item ID to the new discount line items. This ID (being the same) is later used to compile and push the new line items to the database. Due to the identical IDs, the new discounts will not be pushed.

### 2. What does this change do, exactly?
I added an additional check when filtering the original code item for the discount ID.

### 3. Describe each step to reproduce the issue or behaviour.

1. Set up a promotion that includes multiple discounts. Ensure that these discounts have the same promotion discount code but apply under different conditions.

2. Place an order that initially qualifies for only a subset of the discounts from the promotion.

3. Modify the order so that it now qualifies for the additional discounts from the same promotion.

4. Observe that the new discount line items are not saved on the order. This occurs because the system only checks the promotion discount code, which is the same for all discounts.

### 4. Please link to the relevant issues (if any).
/ 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
