### PR TITLE
Fix thumbnail generation for command line

### DIFF
--- a/changelog/_unreleased/2024-06-05-fix-thumbnail-generation-via-command-line.md
+++ b/changelog/_unreleased/2024-06-05-fix-thumbnail-generation-via-command-line.md
@@ -1,0 +1,10 @@
+---
+title: Fix thumbnail generation via command line for -s flag
+issue: TODO
+flag: TODO
+author: Martin Schophaus
+author_email: mschopdev@gmail.com
+author_github: mschop
+---
+# Core
+* Fix thumbnail generation via command line for -s flag

--- a/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
+++ b/src/Core/Content/Media/Commands/GenerateThumbnailsCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Shopware\Core\Content\Media\Subscriber\MediaDeletionSubscriber;
 
 #[AsCommand(
     name: 'media:generate-thumbnails',
@@ -199,6 +200,7 @@ class GenerateThumbnailsCommand extends Command
      */
     private function generateSynchronous(RepositoryIterator $mediaIterator, Context $context): void
     {
+	$context->addState(MediaDeletionSubscriber::SYNCHRONE_FILE_DELETE);
         $totalMediaCount = $mediaIterator->getTotal();
         $this->io->comment(sprintf('Generating Thumbnails for %d files. This may take some time...', $totalMediaCount));
         $this->io->progressStart($totalMediaCount);

--- a/src/Core/Content/Media/Message/GenerateThumbnailsHandler.php
+++ b/src/Core/Content/Media/Message/GenerateThumbnailsHandler.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Shopware\Core\Content\Media\Subscriber\MediaDeletionSubscriber;
 
 /**
  * @internal
@@ -29,10 +30,11 @@ final class GenerateThumbnailsHandler
     public function __invoke(GenerateThumbnailsMessage|UpdateThumbnailsMessage $msg): void
     {
         $context = $msg->getContext();
+	    $context->addState(MediaDeletionSubscriber::SYNCHRONE_FILE_DELETE);
 
         $criteria = new Criteria();
         $criteria->addAssociation('mediaFolder.configuration.mediaThumbnailSizes');
-        $criteria->addFilter(new EqualsAnyFilter('media.id', $msg->getMediaIds()));
+	    $criteria->addFilter(new EqualsAnyFilter('media.id', $msg->getMediaIds()));
 
         /** @var MediaCollection $entities */
         $entities = $this->mediaRepository->search($criteria, $context)->getEntities();


### PR DESCRIPTION
When thumbnails are generated with -s flag, the thumbnail files are generated and directly removed, because the MediaDeletionSubscriber does delete the thumbnail files asynchronous via queue.

By setting the flag in the context, we can prevent that the deletion is done asynchronously.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
It fixes the bug, that thumbnails are directly deleted after generation if invoked via command line `bin/console media:generate-thumbnails -s`.

### 2. What does this change do, exactly?
See above.

### 3. Describe each step to reproduce the issue or behaviour.

1. Delete all thumbnails.
2. Run `bin/console media:generate-thumbnails -s`

### 4. Please link to the relevant issues (if any).
None. I didn't create one yet.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes -> none required / bugfix
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
