### PR TITLE
NEXT-00000 - Fix clearing of form-preserver storage on cms-form submit

### DIFF
--- a/changelog/_unreleased/2024-06-07-fix-cms-form-data-not-cleared-from-localstorage-after-submission.md
+++ b/changelog/_unreleased/2024-06-07-fix-cms-form-data-not-cleared-from-localstorage-after-submission.md
@@ -1,0 +1,10 @@
+---
+title: Fix cms form data not cleared from localstorage after submission
+issue: 00000
+author: Paik Paustian
+author_email: mail@paik.dev
+author_github: hype09
+---
+# Storefront
+* Changed `FormCmsHandler` to reset form after successful AJAX submission.
+* Changed `FormPreserverPlugin` to clear localstorage-cache on both `submit` and `reset` form events.

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
@@ -76,6 +76,9 @@ export default class FormCmsHandler extends Plugin {
         this.$emitter.publish('beforeSubmit');
 
         this.sendAjaxFormSubmit();
+
+        // Reset form after successful submission to clear form contents.
+        this.el.reset();
     }
 
     _handleResponse(res) {

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-preserver.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-preserver.plugin.js
@@ -224,12 +224,13 @@ export default class FormPreserverPlugin extends Plugin {
     }
 
     /**
-     * Registers a submit event to the form to clear the storage.
+     * Registers a submit / reset event handler to the form to clear the storage.
      *
      * @private
      */
     _registerFormEvent() {
-        this.el.addEventListener('submit', this._onSubmit.bind(this));
+        this.el.addEventListener('submit', () => this._clearStorage());
+        this.el.addEventListener('reset', () => this._clearStorage());
     }
 
     /**
@@ -238,7 +239,7 @@ export default class FormPreserverPlugin extends Plugin {
      *
      * @private
      */
-    _onSubmit() {
+    _clearStorage() {
         this.storedKeys.forEach((storedKey) => {
             this.storage.removeItem(storedKey);
         });

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-cms-handler.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-cms-handler.plugin.test.js
@@ -1,0 +1,30 @@
+/* eslint-disable */
+import FormCmsHandlerPlugin from 'src/plugin/forms/form-cms-handler.plugin';
+
+describe('Form CMS Handler tests', () => {
+
+    let formCmsHandlerPlugin = undefined;
+    let formElement = undefined;
+    let mockHttpClient = undefined;
+
+    beforeEach(() => {
+        formElement = document.createElement('form');
+        formCmsHandlerPlugin = new FormCmsHandlerPlugin(formElement);
+
+        mockHttpClient = {post: jest.fn()};
+        formCmsHandlerPlugin._client = mockHttpClient;
+    });
+
+    test('form cms handler plugin exists', () => {
+        expect(typeof formCmsHandlerPlugin).toBe('object');
+    });
+
+    test('form cms handler resets form after successful ajax submission', () => {
+        const resetSpy = jest.spyOn(formElement, 'reset');
+
+        formElement.dispatchEvent(new Event('submit'));
+
+        expect(mockHttpClient.post).toHaveBeenCalled();
+        expect(resetSpy).toHaveBeenCalled();
+    });
+});

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-preserver.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-preserver.plugin.test.js
@@ -150,4 +150,16 @@ describe('Form Preserver tests', () => {
         expect(Storage.getItem(`test.cars2`)).toBe('volvo,audi');
     });
 
+    test.each(['submit', 'reset'])('form preserver clears storage on form submission / reset', (eventType) => {
+        const element = document.querySelector(`[name=checkboxtest]`);
+        element.checked = true;
+        element.dispatchEvent(new Event('change'));
+
+        expect(Storage.getItem(`test.checkboxtest`)).toBe('true');
+
+        const form = document.querySelector('#test');
+        form.dispatchEvent(new Event(eventType));
+
+        expect(Storage.getItem('test.checkboxtest')).toBeNull();
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

When the CMS contact form is filled out and submitted, I expect that the local storage that preserves the entered information is cleared and not shown to me again when I reload the page.

Currently, when I enter information into the contact form and submit, the form data is not cleared from local storage. If I navigate to the contact form page again (or re-open the contact form modal, if its embedded in one), the data that I previously entered and that was successfully submitted is still there.

### 2. What does this change do, exactly?

The `FormCmsHandler` now calls `.reset()` on the form element after it was sucessfully submitted via AJAX, which clears the content from the form in the DOM and also emits a `reset` event.

The `FormPreserver` now listens to both `submit` and `reset` events and clears the local storage cache if either is dispatched.

Thus, the form data is correctly cleared from localstorage after an AJAX submission.

### 3. Describe each step to reproduce the issue or behaviour.

- Go to CMS contact form page / open CMS contact form modal
- Enter all required information and click on the "submit" button
- Navigate away from the page
- Navigate to the form page / modal again
- The submitted content is still there.

### 4. Please link to the relevant issues (if any).

- https://github.com/shopware/shopware/issues/3719

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] ~I have written or adjusted the documentation according to my changes~
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
