### PR TITLE
feat: add debug info mail header when staging mode enabled

### DIFF
--- a/changelog/_unreleased/2024-06-08-add-debug-info-mail-header-when-staging-mode-enabled.md
+++ b/changelog/_unreleased/2024-06-08-add-debug-info-mail-header-when-staging-mode-enabled.md
@@ -1,0 +1,9 @@
+---
+title: Add debug info to mail header when staging mode is enabled
+issue: N/A
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@gmail.com
+author_github: MelvinAchterhuis
+---
+# Core
+* Changed `src/Core/Content/Mail/Service/MailService.php` to add debug info to mail header when staging mode is enabled

--- a/changelog/_unreleased/2024-06-08-add-debug-info-mail-header-when-staging-mode-enabled.md
+++ b/changelog/_unreleased/2024-06-08-add-debug-info-mail-header-when-staging-mode-enabled.md
@@ -1,6 +1,6 @@
 ---
 title: Add debug info to mail header when staging mode is enabled
-issue: N/A
+issue: NEXT-00000
 author: Melvin Achterhuis
 author_email: melvin.achterhuis@gmail.com
 author_github: MelvinAchterhuis

--- a/src/Core/Content/Mail/Service/MailService.php
+++ b/src/Core/Content/Mail/Service/MailService.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidator;
+use Shopware\Core\Maintenance\Staging\Event\SetupStagingEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -191,6 +192,14 @@ class MailService extends AbstractMailService
             return null;
         }
 
+        if($this->isTestMode()) {
+            $headers = $mail->getHeaders();
+            $headers->addTextHeader('X-Shopware-Event-Name', $templateData['eventName'] ?? null);
+            $headers->addTextHeader('X-Shopware-Sales-Channel-Id', $salesChannelId);
+            $headers->addTextHeader('X-Shopware-Language-Id', $context->getLanguageId());
+            $mail->setHeaders($headers);
+        }
+
         $this->mailSender->send($mail);
 
         $event = new MailSentEvent($data['subject'], $recipients, $contents, $context, $templateData['eventName'] ?? null);
@@ -320,7 +329,12 @@ class MailService extends AbstractMailService
      */
     private function isTestMode(array $data = []): bool
     {
-        return !empty($data['testMode']);
+        $stagingMode = $this->systemConfigService->getBool(SetupStagingEvent::CONFIG_FLAG);
+        if($stagingMode) {
+            return true;
+        } else {
+            return !empty($data['testMode']);
+        }
     }
 
     /**

--- a/src/Core/Content/Mail/Service/MailService.php
+++ b/src/Core/Content/Mail/Service/MailService.php
@@ -192,7 +192,7 @@ class MailService extends AbstractMailService
             return null;
         }
 
-        if($this->isTestMode()) {
+        if ($this->isTestMode()) {
             $headers = $mail->getHeaders();
             $headers->addTextHeader('X-Shopware-Event-Name', $templateData['eventName'] ?? null);
             $headers->addTextHeader('X-Shopware-Sales-Channel-Id', $salesChannelId);
@@ -330,11 +330,11 @@ class MailService extends AbstractMailService
     private function isTestMode(array $data = []): bool
     {
         $stagingMode = $this->systemConfigService->getBool(SetupStagingEvent::CONFIG_FLAG);
-        if($stagingMode) {
+        if ($stagingMode) {
             return true;
-        } else {
-            return !empty($data['testMode']);
         }
+
+        return !empty($data['testMode']);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
When having multiple sales channels with multiple languages and a lot of custom events / mails it sometimes it is hard to determine which mail in what language exactly has been send. With this information added it should be possible to pinpoint the exact mail template/language/event/flow.

### 2. What does this change do, exactly?
Adds three e-mails headers when staging mode is enabled:

- `X-Shopware-Event-Name`
- `X-Shopware-Language-Id`
- `X-Shopware-Sales-Channel-Id`

![image](https://github.com/shopware/shopware/assets/26538915/acd629d1-92c5-4599-a320-8d26d31964bd)

### 3. Describe each step to reproduce the issue or behaviour.

N/A

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
