### PR TITLE
fix: use translated meta information for landing pages

### DIFF
--- a/changelog/_unreleased/2024-06-09-use-translated-meta-field-for-landing-page.md
+++ b/changelog/_unreleased/2024-06-09-use-translated-meta-field-for-landing-page.md
@@ -1,0 +1,9 @@
+---
+title: Use translated meta information for landing pages
+issue: NEXT-31206
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@gmail.com
+author_github: MelvinAchterhuis
+---
+# Storefront
+* Changed landing page loader `LandingPageLoader.php` to load the translated meta information and respect inheritance.  

--- a/src/Storefront/Page/LandingPage/LandingPageLoader.php
+++ b/src/Storefront/Page/LandingPage/LandingPageLoader.php
@@ -50,10 +50,10 @@ class LandingPageLoader
         $page->setLandingPage($landingPage);
 
         $metaInformation = new MetaInformation();
-        $metaTitle = $landingPage->getMetaTitle() ?? $landingPage->getName();
+        $metaTitle = $landingPage->getTranslation('metaTitle') ?? $landingPage->getTranslation('name');
         $metaInformation->setMetaTitle($metaTitle ?? '');
-        $metaInformation->setMetaDescription($landingPage->getMetaDescription() ?? '');
-        $metaInformation->setMetaKeywords($landingPage->getKeywords() ?? '');
+        $metaInformation->setMetaDescription($landingPage->getTranslation('metaDescription') ?? '');
+        $metaInformation->setMetaKeywords($landingPage->getTranslation('keywords') ?? '');
         $page->setMetaInformation($metaInformation);
 
         $this->eventDispatcher->dispatch(


### PR DESCRIPTION
### 1. Why is this change necessary?
Landing page loader meta information currently doesn't use inheritance and will be empty when no translation is filled in

### 2. What does this change do, exactly?
Loads the translated meta information for title or name, description and keywords

### 3. Describe each step to reproduce the issue or behaviour.
Create a landing page and fill in the meta information. Switch to different language on the storefront, now the meta information is empty:

English (default language):
![image](https://github.com/shopware/shopware/assets/26538915/8927d4c0-0525-44ea-a520-9c2d376d1223)

German:
![image](https://github.com/shopware/shopware/assets/26538915/642a18e8-88a1-49c9-91d1-e0545805ab73)

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-31206

### 5. Checklist
- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
