### PR TITLE
feat: add direct admin url in staging banner

### DIFF
--- a/changelog/_unreleased/2024-06-10-add-admin-url-to-staging-banner.md
+++ b/changelog/_unreleased/2024-06-10-add-admin-url-to-staging-banner.md
@@ -1,0 +1,9 @@
+---
+title: Add admin url to staging banner
+issue: NEXT-00000
+author: Melvin Achterhuis
+author_email: melvin.achterhuis@gmail.com
+author_github: MelvinAchterhuis
+---
+# Storefront
+* Changed Twig file `/storefront/utilities/staging-info.html.twig` to show direct link to product/category/landing page in admin in the staging banner.

--- a/src/Storefront/Resources/views/storefront/utilities/staging-info.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/staging-info.html.twig
@@ -6,6 +6,30 @@
             <p class="m-0 fw-bold">
                 {{ 'general.stagingModeDescription'|trans }}
             </p>
+
+            {% block staging_info_admin_url_wrapper %}
+                {% block set staging_info_admin_url_base %}
+                    {# When having a custom SHOPWARE_ADMINISTRATION_PATH_NAME defined this block can be extended #}
+                    {% set adminBaseUrl = app.request.attributes.get('sw-sales-channel-absolute-base-url') ~ '/admin#/sw' %}
+                {% endblock %}
+                {% if activeRoute is same as ('frontend.navigation.page') %}
+                    {% set quickViewUrl = adminBaseUrl ~ '/category/index/' ~ app.request.attributes.get('navigationId') %}
+                {% elseif activeRoute is same as ('frontend.detail.page') %}
+                    {% set quickViewUrl = adminBaseUrl ~ '/product/detail/' ~ app.request.attributes.get('productId') %}
+                {% elseif activeRoute is same as ('frontend.landing.page') %}
+                    {% set quickViewUrl = adminBaseUrl ~ '/category/landingPage/' ~ app.request.attributes.get('landingPageId') %}
+                {% endif %}
+
+                {% if quickViewUrl %}
+                    {% sw_icon 'link' style { class : 'flex-shrink-0 ms-2 me-2'} %}
+
+                    <p class="m-0 fw-bold">
+                        <a href="{{ quickViewUrl }}" target="_blank" class="text-white">
+                            {{ page.metaInformation.metaTitle }}
+                        </a>
+                    </p>
+                {% endif %}
+            {% endblock %}
         </div>
     {% endif %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/utilities/staging-info.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/staging-info.html.twig
@@ -8,7 +8,7 @@
             </p>
 
             {% block staging_info_admin_url_wrapper %}
-                {% block set staging_info_admin_url_base %}
+                {% block staging_info_admin_url_base %}
                     {# When having a custom SHOPWARE_ADMINISTRATION_PATH_NAME defined this block can be extended #}
                     {% set adminBaseUrl = app.request.attributes.get('sw-sales-channel-absolute-base-url') ~ '/admin#/sw' %}
                 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Navigate faster to desired item when debugging / testing things.

### 2. What does this change do, exactly?
Adds a direct admin URL to the staging banner when on a navigation/landing or product page

![image](https://github.com/shopware/shopware/assets/26538915/668e514e-cd81-4879-811c-21fe2169920d)

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
