### PR TITLE
Update language-widget.html.twig

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/header/actions/language-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/language-widget.html.twig
@@ -1,4 +1,4 @@
-{% block layout_header_actions_language_widget%}
+{% block layout_header_actions_language_widget %}
     {% if position is empty %}
         {% set position = 'top-bar' %}
     {% endif %}


### PR DESCRIPTION
Add missing space between twig block title and delimiter.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Syntax error.

### 2. What does this change do, exactly?
Add missing space between twig block title and delimiter.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
