### PR TITLE
fix: Run unit-setup in admin:unit:watch command

### DIFF
--- a/changelog/_unreleased/2024-06-10-run-unit-setup-in-admin-unit-watch-command.md
+++ b/changelog/_unreleased/2024-06-10-run-unit-setup-in-admin-unit-watch-command.md
@@ -1,0 +1,9 @@
+---
+title: Run unit-setup in admin:unit:watch command
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed the `admin:unit:watch` command to run `unit-setup` before watching the tests

--- a/composer.json
+++ b/composer.json
@@ -302,6 +302,7 @@
         "admin:unit:watch": [
             "Composer\\Config::disableProcessTimeout",
             "@framework:schema:dump",
+            "@npm:admin run unit-setup",
             "@npm:admin run unit-watch"
         ],
         "bc-check": [


### PR DESCRIPTION
### 1. Why is this change necessary?
While working on the tests for https://github.com/shopware/shopware/pull/3677 I noticed that the `admin:unit:watch` command was running into many errors. This was due to the reason of an outdated `component-imports.js` file.

### 2. What does this change do, exactly?
Run the generation of the `component-imports.js` before watching the admin unit tests.

### 3. Describe each step to reproduce the issue or behaviour.
Run `admin:unit:watch` with an outdated `component-imports.js` file.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
