### PR TITLE
NEXT-00000 - Use subqueries for joins in OrderAdminSearchIndexer

### DIFF
--- a/changelog/_unreleased/2024-06-15-use-subqueries-for-joins-in-order-admin-elasticsearch-indexer.md
+++ b/changelog/_unreleased/2024-06-15-use-subqueries-for-joins-in-order-admin-elasticsearch-indexer.md
@@ -1,0 +1,8 @@
+---
+title: Use subqueries for joins in OrderAdminSearchIndexer
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Changed joins for `order_customer`, `order_address`, `order_delivery`, `document` to sub-queries in `OrderAdminSearchIndexer` to improve performance.


### PR DESCRIPTION
### 1. Why is this change necessary?

When indexing with `OrderAdminSearchIndexer` the indexing drops in performance the more orders and auxiliary data the shop has in its database.

### 2. What does this change do, exactly?

It replaces joins for `order_customer`, `order_address`, `order_delivery`, `document` with optimized sub-queries in `OrderAdminSearchIndexer` to improve performance. The optimized sub-queries only contain relevant fields and only data corresponding to the orders that need to be indexed.

### 3. Describe each step to reproduce the issue or behavior.

Create 100,000 orders with `bin/console framework:demodata`, then execute `bin/console es:admin:index --no-queue --only=order`, it takes unreasonably long.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
