### PR TITLE
NEXT-00000 - Return 401 status code on failed login

### DIFF
--- a/changelog/_unreleased/2024-06-19-return-401-status-code-on-failed-login.md
+++ b/changelog/_unreleased/2024-06-19-return-401-status-code-on-failed-login.md
@@ -1,0 +1,17 @@
+---
+title: Return 401 status code on failed login
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Core
+
+* Added a 401 status code to the login response when the login fails in the administration.
+
+___
+
+# Storefront
+* Added a 401 status code to the login response when the login fails in the storefront.
+

--- a/src/Core/Framework/Api/Controller/AuthController.php
+++ b/src/Core/Framework/Api/Controller/AuthController.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Api\Controller;
 
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Shopware\Core\Framework\Api\Controller\Exception\AuthThrottledException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\RateLimiter\Exception\RateLimitExceededException;
@@ -49,7 +50,11 @@ class AuthController extends AbstractController
         $psr7Request = $this->psrHttpFactory->createRequest($request);
         $psr7Response = $this->psrHttpFactory->createResponse($response);
 
-        $response = $this->authorizationServer->respondToAccessTokenRequest($psr7Request, $psr7Response);
+        try {
+            $response = $this->authorizationServer->respondToAccessTokenRequest($psr7Request, $psr7Response);
+        } catch (OAuthServerException $e) {
+            throw new OAuthServerException($e->getMessage(), $e->getCode(), $e->getErrorType(), 401);
+        }
 
         $this->rateLimiter->reset(RateLimiter::OAUTH, $cacheKey);
 

--- a/src/Storefront/Controller/AuthController.php
+++ b/src/Storefront/Controller/AuthController.php
@@ -86,6 +86,7 @@ class AuthController extends StorefrontController
             'waitTime' => $request->get('waitTime'),
             'errorSnippet' => $request->get('errorSnippet'),
             'data' => $data,
+            'statusCode' => (bool) $request->get('loginError') ? 401 : 200
         ]);
     }
 

--- a/src/Storefront/Controller/StorefrontController.php
+++ b/src/Storefront/Controller/StorefrontController.php
@@ -106,6 +106,10 @@ abstract class StorefrontController extends AbstractController
 
         $response->headers->set('Content-Type', 'text/html');
 
+        if ($parameters['statusCode'] ?? null) {
+            $response->setStatusCode($parameters['statusCode']);
+        }
+
         return $response;
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
A failed login in the storefront will return a response with the statuscode 200. This should be a 401.
A failed login in the administration will return a response with the statuscode 400. This should be a 401.

### 2. What does this change do, exactly?
This changes the statuscode for a failed login attempt in the storefront/administration to a 401.

### 3. Describe each step to reproduce the issue or behaviour.
Go to the default administration login. Fail your login and check the statuscode. It is a 400.
Go to the default storefront login. Fail your login and check the statuscode. Its is a 200.

### 4. Please link to the relevant issues (if any).
/ 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
