### PR TITLE
NEXT-00000 - Fix media url loader with unset thumbnails

### DIFF
--- a/changelog/_unreleased/2024-06-20-fix-media-url-loader-with-unset-thumbnails.md
+++ b/changelog/_unreleased/2024-06-20-fix-media-url-loader-with-unset-thumbnails.md
@@ -1,0 +1,9 @@
+---
+title: Fix media url loader with unset thumbnails
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Changed `MediaUrlLoader::loaded` and `MediaUrlLoader::map` methods to skip thumbnails if unset.

--- a/src/Core/Content/Media/Core/Application/MediaUrlLoader.php
+++ b/src/Core/Content/Media/Core/Application/MediaUrlLoader.php
@@ -48,7 +48,7 @@ class MediaUrlLoader
 
             $entity->assign(['url' => $urls[$entity->getUniqueIdentifier()]]);
 
-            if (!$entity->has('thumbnails')) {
+            if (!$entity->has('thumbnails') || $entity->get('thumbnails') === null) {
                 continue;
             }
 
@@ -83,7 +83,7 @@ class MediaUrlLoader
 
             $mapped[$entity->getUniqueIdentifier()] = UrlParams::fromMedia($entity);
 
-            if (!$entity->has('thumbnails')) {
+            if (!$entity->has('thumbnails') || $entity->get('thumbnails') === null) {
                 continue;
             }
 

--- a/tests/unit/Core/Content/Media/Core/Application/MediaUrlLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Core/Application/MediaUrlLoaderTest.php
@@ -34,10 +34,14 @@ class MediaUrlLoaderTest extends TestCase
         $actual = [$entity->get('id') => $entity->get('url')];
 
         if ($entity->has('thumbnails')) {
-            static::assertIsIterable($entity->get('thumbnails'));
-            foreach ($entity->get('thumbnails') as $thumbnail) {
-                static::assertInstanceOf(Entity::class, $thumbnail);
-                $actual[$thumbnail->get('id')] = $thumbnail->get('url');
+            if ($entity->get('thumbnails') !== null) {
+                static::assertIsIterable($entity->get('thumbnails'));
+                foreach ($entity->get('thumbnails') as $thumbnail) {
+                    static::assertInstanceOf(Entity::class, $thumbnail);
+                    $actual[$thumbnail->get('id')] = $thumbnail->get('url');
+                }
+            } else {
+                $actual[$ids->get('thumbnail')] = null;
             }
         }
 
@@ -85,6 +89,20 @@ class MediaUrlLoaderTest extends TestCase
                 'private' => false,
             ]),
             [$ids->get('media') => 'http://localhost:8000/foo/bar.png?946684800'],
+        ];
+
+        yield 'Test with unset thumbnails' => [
+            $ids,
+            (new PartialEntity())->assign([
+                'id' => $ids->get('media'),
+                'path' => '/foo/bar.png',
+                'private' => false,
+                'thumbnails' => null,
+            ]),
+            [
+                $ids->get('media') => 'http://localhost:8000/foo/bar.png',
+                $ids->get('thumbnail') => null,
+            ],
         ];
 
         yield 'Test with thumbnails' => [


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The MediaUrlLoader throws warnings `foreach() argument must be of type array|object, null given` if media entities are loaded without the thumbnails association. The `thumbnails` property is defined on the media entity but its value is null instead of a collection.

### 2. What does this change do, exactly?
Do a null check on the thumbnails property before looping over it.

### 3. Describe each step to reproduce the issue or behaviour.
Do a media repository search without adding the thumbnails association.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
