### PR TITLE
NEXT-0000 AttributeEntityDefinition association with OnDelete::NO_ACTION causes exception error in entity repository

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityDefinition.php
@@ -58,6 +58,10 @@ class AttributeEntityDefinition extends EntityDefinition
             }
 
             foreach ($field['flags'] ?? [] as $flag) {
+                if (!isset($flag['class'])) {
+                    continue;
+                }
+
                 $flagInstance = new $flag['class'](...$flag['args'] ?? []);
 
                 if ($flagInstance instanceof Flag) {


### PR DESCRIPTION
### 1. Why is this change necessary?
This fix entity repository exception with AttributeEntityDefinition with association (es. ManyToOne) with OnDelete::NO_ACTION

### 2. What does this change do, exactly?
Add the check on the flags arrat if the key "class" exists

### 3. Describe each step to reproduce the issue or behaviour.
Create an Entity with new Attribute system. with association field:

```php
#[ForeignKey(entity: 'customer')]
public ?string $customerId = null;

#[ManyToOne(entity: 'customer')]
public ?CustomerEntity $customer = null;
```

Then try to do a search with its entity repository:

```php
$result = $this->entityRepository->search(new Criteria([$id]), $context)->first();
```

This cause a exception:

```
Error: Class name must be a valid object or a string

/app/vendor/shopware/core/Framework/DataAbstractionLayer/AttributeEntityDefinition.php:58
```


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/3773

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
