### PR TITLE
NEXT-0000 feat: add mediaUpdatedAt to the thumbnail pattern

### DIFF
--- a/changelog/_unreleased/2024-05-21-disable-thumbnail-generation-and-use-external-service.md
+++ b/changelog/_unreleased/2024-05-21-disable-thumbnail-generation-and-use-external-service.md
@@ -27,6 +27,7 @@ This pattern supports the following variables:
    *  `mediaPath`: The path of the media file relative to the mediaUrl.
    *  `width`: The width of the thumbnail.
    *  `height`: The height of the thumbnail.
+   *  `mediaUpdatedAt`: The unix timestamp of the last media change.
 
 For example, consider a scenario where you want to generate a thumbnail with a width of 80px.
-With the pattern set as `{mediaUrl}/{mediaPath}?width={width}`, the resulting URL would be `https://yourshop.example/abc/123/456.jpg?width=80`.
+With the pattern set as `{mediaUrl}/{mediaPath}?width={width}&ts={mediaUpdatedAt}`, the resulting URL would be `https://yourshop.example/abc/123/456.jpg?width=80&ts=1718954838`.

--- a/changelog/_unreleased/2024-06-21-add-mediaupdatedat-to-thumbnailpattern-for-disabled-thumbnail-generation.md
+++ b/changelog/_unreleased/2024-06-21-add-mediaupdatedat-to-thumbnailpattern-for-disabled-thumbnail-generation.md
@@ -1,0 +1,10 @@
+---
+title: Add mediaUpdatedAt to thumbnailPattern for disabled thumbnail generation
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+* Changed `src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php` to add `mediaUpdatedAt` to the thumbnail pattern

--- a/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
+++ b/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
@@ -80,14 +80,14 @@ class RemoteThumbnailLoader implements ResetInterface
 
             $thumbnails = new MediaThumbnailCollection();
             foreach ($thumbnailSizes as $size) {
-                $url = $this->getUrl($baseUrl, $path, $size['width'], $size['height']);
+                $url = $this->getUrl($baseUrl, $path, $size['width'], $size['height'], $updatedAt);
 
                 $thumbnail = new MediaThumbnailEntity();
                 $thumbnail->assign([
                     'id' => Uuid::randomHex(),
                     'width' => $size['width'],
                     'height' => $size['height'],
-                    'url' => $updatedAt === null ? $url : $url . (str_contains($url, '?') ? '&' : '?') . 'ts=' . $updatedAt->getTimestamp(),
+                    'url' => $url,
                 ]);
 
                 $thumbnails->add($thumbnail);
@@ -163,11 +163,11 @@ class RemoteThumbnailLoader implements ResetInterface
         return \rtrim($this->filesystem->publicUrl(''), '/');
     }
 
-    private function getUrl(string $mediaUrl, string $mediaPath, string $width, string $height): string
+    private function getUrl(string $mediaUrl, string $mediaPath, string $width, string $height, ?\DateTimeInterface $mediaUpdatedAt): string
     {
         return str_replace(
-            ['{mediaUrl}', '{mediaPath}', '{width}', '{height}'],
-            [$mediaUrl, $mediaPath, $width, $height],
+            ['{mediaUrl}', '{mediaPath}', '{width}', '{height}', '{mediaUpdatedAt}'],
+            [$mediaUrl, $mediaPath, $width, $height, $mediaUpdatedAt?->getTimestamp() ?: ''],
             $this->pattern
         );
     }

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -321,7 +321,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('remote_thumbnails')
                     ->children()
                         ->booleanNode('enable')->end()
-                        ->scalarNode('pattern')->defaultValue('{mediaUrl}/{mediaPath}?width={width}')->end()
+                        ->scalarNode('pattern')->defaultValue('{mediaUrl}/{mediaPath}?width={width}&ts={mediaUpdatedAt}')->end()
                     ->end()
                 ->end()
                 ->booleanNode('enable_url_upload_feature')->end()

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -276,7 +276,7 @@ shopware:
         url_upload_max_size: 0
         remote_thumbnails:
             enable: false
-            pattern: '{mediaUrl}/{mediaPath}?width={width}'
+            pattern: '{mediaUrl}/{mediaPath}?width={width}&ts={mediaUpdatedAt}'
 
     dal:
         batch_size: 125

--- a/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
+++ b/tests/unit/Core/Content/Media/Core/Application/RemoteThumbnailLoaderTest.php
@@ -41,7 +41,7 @@ class RemoteThumbnailLoaderTest extends TestCase
             new MediaUrlGenerator($filesystem),
             $connection,
             $prefixFilesystem,
-            '{mediaUrl}/{mediaPath}?width={width}'
+            '{mediaUrl}/{mediaPath}?width={width}&ts={mediaUpdatedAt}'
         );
 
         $loader->load([$entity]);
@@ -80,9 +80,9 @@ class RemoteThumbnailLoaderTest extends TestCase
             [
                 'media' => 'http://localhost:8000/foo/bar.png',
                 'thumbnails' => [
-                    'http://localhost:8000/foo/bar.png?width=200',
-                    'http://localhost:8000/foo/bar.png?width=400',
-                    'http://localhost:8000/foo/bar.png?width=600',
+                    'http://localhost:8000/foo/bar.png?width=200&ts=',
+                    'http://localhost:8000/foo/bar.png?width=400&ts=',
+                    'http://localhost:8000/foo/bar.png?width=600&ts=',
                 ],
             ],
         ];
@@ -151,7 +151,7 @@ class RemoteThumbnailLoaderTest extends TestCase
             new MediaUrlGenerator($filesystem),
             $connection,
             $this->createMock(PrefixFilesystem::class),
-            '{mediaUrl}/{mediaPath}?width={width}'
+            '{mediaUrl}/{mediaPath}?width={width}&ts={mediaUpdatedAt}'
         );
 
         $loader->load([$entity]);


### PR DESCRIPTION
### 1. Why is this change necessary?
1. The used CDN might not need the mediaChangedAt-Timestamp while it is handling it on its own.
2. the parameter might need to be defined individually instead of hardcoded `ts`.
3. It is a waste of traffic when there is just ALT- or TITLE-texts changed while it's changing the timestamp.

### 2. What does this change do, exactly?
Adds parameter `ts` defined in the pattern.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
