### PR TITLE
fix: Linked administration price input with comma values

### DIFF
--- a/changelog/_unreleased/2024-06-21-fix-administration-input-of-linked-prices-and-comma-values.md
+++ b/changelog/_unreleased/2024-06-21-fix-administration-input-of-linked-prices-and-comma-values.md
@@ -1,0 +1,11 @@
+---
+title: Fix administration input of linked prices and comma values
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Removed unused method `keymonitor` from the `sw-price-field` and `sw-product-price-form`
+* Changed `sw-price-field` to not update the value on every input, as this is already done by the number field component
+* Changed `sw-number-field` (in particular `sw-number-field-deprecated`) to dispatch the `input-change` event with the actual value and not just the parsed float value

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-number-field-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-number-field-deprecated/index.js
@@ -155,7 +155,7 @@ Component.extend('sw-number-field-deprecated', 'sw-text-field-deprecated', {
         },
 
         onInput(event) {
-            let val = Number.parseFloat(event.target.value);
+            let val = this.getNumberFromString(event.target.value);
 
             if (!Number.isNaN(val)) {
                 if (this.max && val > this.max) {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
@@ -268,16 +268,12 @@ Component.register('sw-price-field', {
 
         onPriceGrossInputChange(value) {
             if (this.priceForCurrency.linked) {
-                this.priceForCurrency.gross = value;
-
                 this.onPriceGrossChangeDebounce(value);
             }
         },
 
         onPriceNetInputChange(value) {
             if (this.priceForCurrency.linked) {
-                this.priceForCurrency.net = value;
-
                 this.onPriceNetChangeDebounce(value);
             }
         },
@@ -386,13 +382,6 @@ Component.register('sw-price-field', {
 
         convertPrice(value) {
             return value * this.currency.factor;
-        },
-
-        keymonitor(event) {
-            if (event.key === ',') {
-                const value = event.target.value;
-                event.target.value = value.replace(/,/, '.');
-            }
         },
 
         onCloseModal() {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-price-form/index.js
@@ -140,13 +140,6 @@ export default {
             this.displayMaintainCurrencies = false;
         },
 
-        keymonitor(event) {
-            if (event.key === ',') {
-                const value = event.currentTarget.value;
-                event.currentTarget.value = value.replace(/.$/, '.');
-            }
-        },
-
         getTaxLabel(tax) {
             if (this.$te(`global.tax-rates.${tax.name}`)) {
                 return this.$tc(`global.tax-rates.${tax.name}`);


### PR DESCRIPTION
### 1. Why is this change necessary?
https://forum.shopware.com/t/admin-loescht-aus-preis-punkt-komma-waehrend-der-eingabe/98446
If this is accepted in this way, I will also look into the tests of the deprecated number field component.

### 2. What does this change do, exactly?
Cleanup the code and dispatch the correct value of the `sw-number-field` component, additionally see changelog.

### 3. Describe each step to reproduce the issue or behaviour.
Try to enter price values in the administration of linked prices.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
