### PR TITLE
NEXT-36924: Fix StoreApiSeoResolver throwing \TypeError with auth_required=false option

### DIFF
--- a/changelog/_unreleased/2024-06-24-fix-store-api-seo-resolver-priority-and-add-context-check-before-accessing-it.md
+++ b/changelog/_unreleased/2024-06-24-fix-store-api-seo-resolver-priority-and-add-context-check-before-accessing-it.md
@@ -1,0 +1,12 @@
+---
+title:          Fix StoreApiSeoResolver priority and add context check before accessing it
+issue:          NEXT-36924
+author:         Marcel Romeike
+author_email:   m.romeike@basecom.de
+author_github:  @mromeike
+---
+# Core
+* Changed priority of `\Shopware\Core\Content\Seo\SalesChannel\StoreApiSeoResolver::addSeoInformation()`
+  from `10_000` to `11_000`
+* Added a check for availability of `sw-sales-channel-context` before accessing it
+  in `src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php`

--- a/changelog/_unreleased/2024-06-24-fix-store-api-seo-resolver-priority-and-add-context-check-before-accessing-it.md
+++ b/changelog/_unreleased/2024-06-24-fix-store-api-seo-resolver-priority-and-add-context-check-before-accessing-it.md
@@ -10,3 +10,4 @@ author_github:  @mromeike
   from `10_000` to `11_000`
 * Added a check for availability of `sw-sales-channel-context` before accessing it
   in `src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php`
+* Added tests covering the `auth_required=false` store-api route edge-case

--- a/config/routes/test/core_framework.xml
+++ b/config/routes/test/core_framework.xml
@@ -5,4 +5,6 @@
         https://symfony.com/schema/routing/routing-1.0.xsd">
 
     <import resource="../../../tests/integration/Core/Framework/Api/EventListener/FixturesPhp/*TestRoute.php" type="attribute" />
+
+    <import resource="../../../tests/integration/Core/Content/Seo/SalesChannel/FixturesPhp/*TestRoute.php" type="attribute" />
 </routes>

--- a/config/services_test.xml
+++ b/config/services_test.xml
@@ -7,6 +7,13 @@
             <tag name="controller.service_arguments"/>
         </service>
 
+        <service id="Shopware\Tests\Integration\Core\Content\Seo\SalesChannel\FixturesPhp\StoreApiSeoResolverTestRoute">
+            <argument type="service" key="$categoryRoute" id="Shopware\Core\Content\Category\SalesChannel\CategoryRoute"/>
+            <argument type="service" key="$contextFactory" id="Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory"/>
+
+            <tag name="controller.service_arguments"/>
+        </service>
+
         <service id="Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Version\CalculatedPriceFieldTestDefinition">
             <tag name="shopware.entity.definition" />
         </service>

--- a/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
+++ b/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
@@ -48,7 +48,7 @@ class StoreApiSeoResolver implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::RESPONSE => ['addSeoInformation', 10000],
+            KernelEvents::RESPONSE => ['addSeoInformation', 11000],
         ];
     }
 

--- a/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
+++ b/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
@@ -60,14 +60,24 @@ class StoreApiSeoResolver implements EventSubscriberInterface
             return;
         }
 
-        if (!$event->getRequest()->headers->has(PlatformRequest::HEADER_INCLUDE_SEO_URLS)) {
+        $request = $event->getRequest();
+
+        if (!$request->headers->has(PlatformRequest::HEADER_INCLUDE_SEO_URLS)) {
+            return;
+        }
+
+        /** @var SalesChannelContext|null $context */
+        $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
+
+        // This is likely the case for routes with the `auth_required` option set to `false`.
+        if (null === $context) {
             return;
         }
 
         $dataBag = new SeoResolverData();
 
         $this->find($dataBag, $response->getObject());
-        $this->enrich($dataBag, $event->getRequest()->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT));
+        $this->enrich($dataBag, $context);
     }
 
     private function find(SeoResolverData $data, Struct $struct): void

--- a/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
+++ b/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
@@ -66,11 +66,11 @@ class StoreApiSeoResolver implements EventSubscriberInterface
             return;
         }
 
-        /** @var SalesChannelContext|null $context */
         $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
 
-        // This is likely the case for routes with the `auth_required` option set to `false`.
-        if (null === $context) {
+        if (!$context instanceof SalesChannelContext) {
+            // This is likely the case for routes with the `auth_required` option set to `false`,
+            // where the sales-channel-id and context is not resolved by access-token by the other listeners.
             return;
         }
 

--- a/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
+++ b/src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php
@@ -45,6 +45,10 @@ class StoreApiSeoResolver implements EventSubscriberInterface
     ) {
     }
 
+    /**
+     * This subscriber has to trigger before the {@see \Shopware\Core\System\SalesChannel\Api\StoreApiResponseListener},
+     * because it requires access to the `StoreApiResponse`'s struct object, which is not available after encoding it.
+     */
     public static function getSubscribedEvents(): array
     {
         return [

--- a/src/Core/Content/Test/Seo/SalesChannel/StoreApiSeoResolverTest.php
+++ b/src/Core/Content/Test/Seo/SalesChannel/StoreApiSeoResolverTest.php
@@ -107,6 +107,23 @@ class StoreApiSeoResolverTest extends TestCase
         static::assertIsArray($response['cmsPage']['sections'][0]['blocks'][0]['slots'][0]['data']['listing']['elements'][0]['seoUrls']);
     }
 
+    public function testEnabledNoAuthentication(): void
+    {
+        $this->browser->setServerParameter('HTTP_sw-include-seo-urls', '1');
+
+        $this->browser->request('GET', '/store-api/test/store-api-seo-resolver/no-auth-required', ['sales-channel-id' => $this->ids->get('sales-channel')]);
+
+        $content = $this->browser->getResponse()->getContent();
+        static::assertIsString($content);
+
+        $response = json_decode($content, true, 512, \JSON_THROW_ON_ERROR);
+
+        static::assertArrayHasKey('seoUrls', $response);
+        static::assertNull($response['seoUrls']);
+
+        static::assertNull($response['cmsPage']['sections'][0]['blocks'][0]['slots'][0]['data']['listing']['elements'][0]['seoUrls']);
+    }
+
     private function createData(): void
     {
         $product = [

--- a/tests/integration/Core/Content/Seo/SalesChannel/FixturesPhp/StoreApiSeoResolverTestRoute.php
+++ b/tests/integration/Core/Content/Seo/SalesChannel/FixturesPhp/StoreApiSeoResolverTestRoute.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\Seo\SalesChannel\FixturesPhp;
+
+use Shopware\Core\Content\Category\SalesChannel\AbstractCategoryRoute;
+use Shopware\Core\Content\Category\SalesChannel\CategoryRoute;
+use Shopware\Core\Framework\Routing\StoreApiRouteScope;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\System\SalesChannel\Context\AbstractSalesChannelContextFactory;
+use Shopware\Core\System\SalesChannel\StoreApiResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+/**
+ * @internal
+ */
+#[Route(defaults: [PlatformRequest::ATTRIBUTE_ROUTE_SCOPE => [StoreApiRouteScope::ID]])]
+class StoreApiSeoResolverTestRoute
+{
+    public function __construct(
+        private readonly AbstractCategoryRoute              $categoryRoute,
+        private readonly AbstractSalesChannelContextFactory $contextFactory,
+    ) {
+    }
+
+    #[
+        Route(
+            path: '/store-api/test/store-api-seo-resolver/no-auth-required',
+            name: 'store-api.test.store_api_seo_resolver.no_auth_required',
+            defaults: ['auth_required' => false],
+            methods: [Request::METHOD_GET]
+        )
+    ]
+    public function noAuthRequiredAction(Request $request): StoreApiResponse
+    {
+        $salesChannelId = $request->get('sales-channel-id');
+
+        return $this->categoryRoute->load(CategoryRoute::HOME, $request,
+            $this->contextFactory->create(Uuid::randomHex(), $salesChannelId)
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
- Fixes an upstream bug regarding `auth_required` on store-api routes, that whenever the `sw-include-seo-urls` header is set, a PHP `\TypeError` is raised
- The bug is described in detail in the [issue tracker](https://issues.shopware.com/issues/NEXT-36924)

### 2. What does this change do, exactly?
- Changed priority of `\Shopware\Core\Content\Seo\SalesChannel\StoreApiSeoResolver::addSeoInformation()`
  from `10_000` to `11_000`
- Added a check for availability of `sw-sales-channel-context` before accessing it
  in `src/Core/Content/Seo/SalesChannel/StoreApiSeoResolver.php`
- Added tests covering the `auth_required=false` store-api route edge-case

### 3. Describe each step to reproduce the issue or behaviour.
- See [issue tracker](https://issues.shopware.com/issues/NEXT-36924)

### 4. Please link to the relevant issues (if any).
- See [issue tracker](https://issues.shopware.com/issues/NEXT-36924)

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
