### PR TITLE
fix: Do not use case insensitive validation of vat ids

### DIFF
--- a/changelog/_unreleased/2024-06-25-do-not-use-case-insensitive-validation-of-vat-ids.md
+++ b/changelog/_unreleased/2024-06-25-do-not-use-case-insensitive-validation-of-vat-ids.md
@@ -1,0 +1,10 @@
+---
+title: Do not use case insensitive validation of vat ids
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed `Shopware\Core\Checkout\Cart\Tax\TaxDetector` and `Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerVatIdentificationValidator` to not use a case insensitive matching of vat ids
+* Changed `Shopware\Core\Checkout\Customer\Validation\Constraint\CustomerVatIdentificationValidator` to reduce the amount of database calls

--- a/src/Core/Checkout/Cart/Tax/TaxDetector.php
+++ b/src/Core/Checkout/Cart/Tax/TaxDetector.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Cart\Tax;
 
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\Country\CountryEntity;
@@ -64,7 +65,11 @@ class TaxDetector extends AbstractTaxDetector
         }
 
         if (!empty($vatPattern) && $shippingLocationCountry->getCheckVatIdPattern()) {
-            $regex = '/^' . $vatPattern . '$/i';
+            if (Feature::isActive('v6.7.0.0')) {
+                $regex = '/^' . $vatPattern . '$/';
+            } else {
+                $regex = '/^' . $vatPattern . '$/i';
+            }
 
             foreach ($vatIds as $vatId) {
                 if (!preg_match($regex, $vatId)) {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently a case insensitive validation of the VAT IDs is used. According to the German Wikipedia this is not correct:
> Umsatzsteuer-Identifikationsnummern beginnen immer mit einem [Präfix](https://de.wikipedia.org/wiki/Pr%C3%A4fix) bestehend aus zwei Großbuchstaben des EU-Ländercodes.

https://de.wikipedia.org/wiki/Umsatzsteuer-Identifikationsnummer

Not sure if this a breaking change and it should be behind a feature flag, or if it is okay like this. Also in the database may be invalid vat ids.

### 2. What does this change do, exactly?
Change the matching to be case sensitive. If case insensitive is required, then the Regex should be changed.

Furthermore the `CustomerVatIdentificationValidator` now only uses one database query, instead of two.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
