### PR TITLE
NEXT-00000 - Ensure document date time is the same as order date time format

### DIFF
--- a/changelog/_unreleased/2024-07-15-document-date-time-is-same-as-order-date-time-format.md
+++ b/changelog/_unreleased/2024-07-15-document-date-time-is-same-as-order-date-time-format.md
@@ -1,0 +1,8 @@
+---
+title: Ensure document date time is the same as order date time format
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Change date format in `page_account_order_document_item_detail_date` to be locale dependant instead of hardcoded 'dd/MM/Y HH:mm'

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail-document-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail-document-item.html.twig
@@ -21,7 +21,7 @@
 
         {% block page_account_order_document_item_detail_date %}
             <div class="col-9 col-md-4 document-item document-item-date">
-                {{ document.createdAt|format_date(pattern='dd/MM/Y HH:mm', locale=app.request.locale) }}
+                {{ document.createdAt|format_date(locale=app.request.locale) }}
             </div>
         {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?

It looks silly on German pages. Why do we even need time, when label says date.

### 2. What does this change do, exactly?

Remove format, so format from locale is used instead.

### 3. Describe each step to reproduce the issue or behaviour.

1. Register as customer
2. Place order as customer
3. Login in admin
4. Generate invoice in admin
5. Mark invoice as sent in admin
6. Look into customer order history
7. Be confused why there is no document
8. Go to document settings in admin
9. Activate display in account in admin
10. Reload customer order history
11. > still-no-document-visible-confusion.webp
12. Generate document again in admin
13. Mark 2nd invoice as sent in admin
14. Reload customer order history
15. See document in storefront
16. See two dates rendered differently in storefront
17. > question-browsing-locale.gif
18. Browse code
19. ( ╯°□°)╯ ┻━━┻

<img width="994" alt="Visual representation of format difference" src="https://github.com/shopware/shopware/assets/1133593/0719098b-127a-48e9-8646-00c8e140bdf5">

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
