### PR TITLE
Add support for having ManyToMany associations to versioned entities for attributed entities

### DIFF
--- a/changelog/_unreleased/2024-06-26-allow-attributed-entity-to-have-a-many-to-many-association-with-versioned-entities.md
+++ b/changelog/_unreleased/2024-06-26-allow-attributed-entity-to-have-a-many-to-many-association-with-versioned-entities.md
@@ -1,0 +1,9 @@
+---
+title: Allow attributed entity to have a many to many association with versioned entities
+issue: 
+author: Nicky Gerritsen
+author_email: nicky@letstalk.nl
+author_github: nickygerritsen
+---
+# Core
+* Added support for having ManyToMany associations between attributed entities and versioned entities.

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -56,7 +56,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationFi
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
 
 /**
@@ -89,12 +88,9 @@ class AttributeEntityCompiler
 
     private CamelCaseToSnakeCaseNameConverter $converter;
 
-    private ContainerBuilder $container;
-
-    public function __construct(ContainerBuilder $container)
+    public function __construct()
     {
         $this->converter = new CamelCaseToSnakeCaseNameConverter();
-        $this->container = $container;
     }
 
     /**
@@ -350,9 +346,6 @@ class AttributeEntityCompiler
         $srcProperty = $this->converter->denormalize($entity);
         $refProperty = $this->converter->denormalize($field->entity);
 
-        /** @var DefinitionInstanceRegistry $registry */
-        $registry = $this->container->get(DefinitionInstanceRegistry::class);
-
         $fields = [
             [
                 'class' => FkField::class,
@@ -386,25 +379,13 @@ class AttributeEntityCompiler
             ],
         ];
 
-        // If the target entity is versioned, we need to add the [entity]_version_id field
-        if ($registry->getByClassOrEntityName($field->entity)->isVersionAware()) {
-            $fields[] = [
-                'class' => ReferenceVersionField::class,
-                'translated' => false,
-                'args' => [$field->entity],
-                'flags' => [
-                    PrimaryKey::class => ['class' => PrimaryKey::class],
-                    Required::class => ['class' => Required::class],
-                ],
-            ];
-        }
-
         return [
             'type' => 'mapping',
             'parent' => null,
             'entity_class' => ArrayEntity::class,
             'entity_name' => self::mappingName($entity, $field),
             'fields' => $fields,
+            'entity' => $field->entity,
         ];
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/AttributeMappingDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeMappingDefinition.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\Framework\DataAbstractionLayer;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Flag;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('core')]
@@ -44,6 +47,13 @@ class AttributeMappingDefinition extends MappingEntityDefinition
             }
 
             $fields[] = $instance;
+        }
+
+        // Check if the target entity is a version aware entity, since we need to
+        // add a version field to the mapping entity in that case
+        $entity = $this->meta['entity'];
+        if ($this->registry->getByClassOrEntityName($entity)->isVersionAware()) {
+            $fields[] = (new ReferenceVersionField($entity))->addFlags(new PrimaryKey(), new Required());
         }
 
         return new FieldCollection($fields);

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -111,7 +111,7 @@ class Framework extends Bundle
         }
 
         // make sure to remove services behind a feature flag, before some other compiler passes may reference them, therefore the high priority
-        $container->addCompilerPass(new AttributeEntityCompilerPass(new AttributeEntityCompiler($container)), PassConfig::TYPE_BEFORE_REMOVING, 1000);
+        $container->addCompilerPass(new AttributeEntityCompilerPass(new AttributeEntityCompiler()), PassConfig::TYPE_BEFORE_REMOVING, 1000);
         $container->addCompilerPass(new FeatureFlagCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         $container->addCompilerPass(new EntityCompilerPass());
         $container->addCompilerPass(new MigrationCompilerPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -111,7 +111,7 @@ class Framework extends Bundle
         }
 
         // make sure to remove services behind a feature flag, before some other compiler passes may reference them, therefore the high priority
-        $container->addCompilerPass(new AttributeEntityCompilerPass(new AttributeEntityCompiler()), PassConfig::TYPE_BEFORE_REMOVING, 1000);
+        $container->addCompilerPass(new AttributeEntityCompilerPass(new AttributeEntityCompiler($container)), PassConfig::TYPE_BEFORE_REMOVING, 1000);
         $container->addCompilerPass(new FeatureFlagCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1000);
         $container->addCompilerPass(new EntityCompilerPass());
         $container->addCompilerPass(new MigrationCompilerPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -5,6 +5,10 @@ namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
+use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
+use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
+use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\AttributeEntityDefinition;
@@ -21,6 +25,7 @@ use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\Test\TestDefaults;
 use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\AttributeEntity;
 
 /**
@@ -266,6 +271,7 @@ class AttributeEntityIntegrationTest extends TestCase
             'aggs' => null,
             'currencies' => null,
             'translations' => null,
+            'orders' => null,
             'customFields' => null,
         ], $json);
     }
@@ -634,6 +640,65 @@ class AttributeEntityIntegrationTest extends TestCase
         static::assertEquals('baz', $record->getCustomFieldsValue('bar'));
     }
 
+    public function testManyToManyVersioned(): void
+    {
+        $ids = new IdsCollection();
+
+        $data = [
+            'id' => $ids->get('first-key'),
+            'string' => 'string',
+            'transString' => 'transString',
+            'orders' => [
+                self::order($ids->get('order-1'), $this->getStateMachineState(), $this->getValidCountryId()),
+                self::order($ids->get('order-2'), $this->getStateMachineState(), $this->getValidCountryId()),
+            ],
+        ];
+
+        $result = $this->repository('attribute_entity')
+                       ->create([$data], Context::createDefaultContext());
+
+        static::assertNotEmpty($result->getPrimaryKeys('attribute_entity'));
+        static::assertContains($ids->get('first-key'), $result->getPrimaryKeys('attribute_entity'));
+
+        static::assertNotEmpty($result->getPrimaryKeys('order'));
+        static::assertContains($ids->get('order-1'), $result->getPrimaryKeys('order'));
+        static::assertContains($ids->get('order-2'), $result->getPrimaryKeys('order'));
+
+        $search = $this->repository('attribute_entity')
+                       ->search(new Criteria([$ids->get('first-key')]), Context::createDefaultContext());
+
+        /** @var AttributeEntity $record */
+        $record = $search->get($ids->get('first-key'));
+        static::assertNull($record->orders);
+
+        $criteria = new Criteria([$ids->get('first-key')]);
+        $criteria->addAssociation('orders');
+        $search = $this->repository('attribute_entity')
+                       ->search($criteria, Context::createDefaultContext());
+
+        /** @var AttributeEntity $record */
+        $record = $search->get($ids->get('first-key'));
+        static::assertNotNull($record->orders);
+        static::assertCount(2, $record->orders);
+        static::assertArrayHasKey($ids->get('order-1'), $record->orders);
+        static::assertArrayHasKey($ids->get('order-2'), $record->orders);
+
+        $this->repository('attribute_entity_order')->delete([
+            ['attributeEntityId' => $ids->get('first-key'), 'orderId' => $ids->get('order-1')],
+        ], Context::createDefaultContext());
+
+        $criteria = new Criteria([$ids->get('first-key')]);
+        $criteria->addAssociation('orders');
+        $search = $this->repository('attribute_entity')
+                       ->search($criteria, Context::createDefaultContext());
+
+        /** @var AttributeEntity $record */
+        $record = $search->get($ids->get('first-key'));
+        static::assertNotNull($record->orders);
+        static::assertCount(1, $record->orders);
+        static::assertArrayHasKey($ids->get('order-2'), $record->orders);
+    }
+
     private function repository(string $entity): EntityRepository
     {
         $repository = $this->getContainer()->get($entity . '.repository');
@@ -656,6 +721,40 @@ class AttributeEntityIntegrationTest extends TestCase
             'shortName' => 'Euro',
             'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
             'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function order(string $id, string $stateId, string $countryId): array
+    {
+        $ids = new IdsCollection();
+        $addressId = $ids->get('address-1');
+
+        return [
+            'id' => $id,
+            'itemRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'totalRounding' => json_decode(json_encode(new CashRoundingConfig(2, 0.01, true), \JSON_THROW_ON_ERROR), true, 512, \JSON_THROW_ON_ERROR),
+            'orderDateTime' => '2024-05-06 12:34:56',
+            'price' => new CartPrice(10, 10, 10, new CalculatedTaxCollection(), new TaxRuleCollection(), CartPrice::TAX_STATE_NET),
+            'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),
+            'stateId' => $stateId,
+            'currencyId' => Defaults::CURRENCY,
+            'currencyFactor' => 1,
+            'salesChannelId' => TestDefaults::SALES_CHANNEL,
+            'billingAddressId' => $addressId,
+            'addresses' => [
+                [
+                    'firstName' => 'John',
+                    'lastName' => 'Doe',
+                    'street' => 'Main Street',
+                    'zipcode' => '59438-0403',
+                    'city' => 'City',
+                    'countryId' => $countryId,
+                    'id' => $addressId,
+                ],
+            ],
         ];
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture;
 
+use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AutoIncrement;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Field;
@@ -135,6 +136,12 @@ class AttributeEntity extends EntityStruct
      */
     #[ManyToMany(entity: 'currency', onDelete: OnDelete::CASCADE)]
     public ?array $currencies = null;
+
+    /**
+     * @var array<string, ArrayEntity>|null
+     */
+    #[ManyToMany(entity: 'order', onDelete: OnDelete::CASCADE)]
+    public ?array $orders = null;
 
     /**
      * @var array<string, ArrayEntity>|null

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture;
 
-use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AutoIncrement;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Field;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/schema.sql
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/schema.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS `attribute_entity_order`;
 DROP TABLE IF EXISTS `attribute_entity_currency`;
 DROP TABLE IF EXISTS `attribute_entity_translation`;
 DROP TABLE IF EXISTS `attribute_entity_agg`;
@@ -71,4 +72,15 @@ CREATE TABLE `attribute_entity_agg` (
     `created_at` DATETIME(3) NOT NULL,
     `updated_at` DATETIME(3) NULL,
     PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `attribute_entity_order` (
+    `attribute_entity_id` BINARY(16) NOT NULL,
+    `order_id` BINARY(16) NOT NULL,
+    `order_version_id` BINARY(16) NOT NULL,
+    PRIMARY KEY (`attribute_entity_id`,`order_id`, `order_version_id`),
+    KEY `fk.attribute_entity_order.attribute_entity_id` (`attribute_entity_id`),
+    KEY `fk.attribute_entity_order.order_id` (`order_id`, `order_version_id`),
+    CONSTRAINT `fk.attribute_entity_order.attribute_entity_id` FOREIGN KEY (`attribute_entity_id`) REFERENCES `attribute_entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT `fk.attribute_entity_order.order_id` FOREIGN KEY (`order_id`, `order_version_id`) REFERENCES `order` (`id`, `version_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently you can't have a `ManyToMany` association from an attributed entity to any versioned entity, like order.

### 2. What does this change do, exactly?
This change detects of the target of a `ManyToMany` association is versioned, and if so it adds the version field to the list of fields for the association.

### 3. Describe each step to reproduce the issue or behaviour.
* Create an attributed entity that has a `ManyToMany` association to a versioned entity, like order.
* Try to save the entity with some data in the associated field.

### 4. Please link to the relevant issues (if any).
https://shopwarecommunity.slack.com/archives/C011VFQT7GB/p1718088460270309

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
