### PR TITLE
allow relative path for localCache Dir

### DIFF
--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -188,9 +188,16 @@ class Kernel extends HttpKernel
 
     public function getCacheDir(): string
     {
+        $cacheDir = EnvironmentHelper::getVariable('APP_CACHE_DIR', 'localCache');
+
+        // if relative convert to absolute
+        if (!realpath($cacheDir) && strpos($cacheDir, '/') !== 0) {
+            $cacheDir = $this->getProjectDir() . '/' . ltrim($cacheDir, '/');
+        }
+
         return sprintf(
             '%s/var/cache/%s_h%s%s',
-            EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()),
+            $cacheDir,
             $this->getEnvironment(),
             $this->getCacheHash(),
             EnvironmentHelper::getVariable('TEST_TOKEN') ?? ''


### PR DESCRIPTION
convert into absolute path to work on all hostings even if base path to localCache changes

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
