### PR TITLE
[NEXT-37067] Fix dead form serialize utility guard for empty forms (ts2829)

### DIFF
--- a/changelog/_unreleased/2024-06-28-fix-dead-form-serialize-utility-guard.md
+++ b/changelog/_unreleased/2024-06-28-fix-dead-form-serialize-utility-guard.md
@@ -1,0 +1,9 @@
+---
+title: Fix dead form serialize utility guard
+issue: NEXT-37067
+author: Justus Maier
+author_email: jmaier@notebooksbilliger.de
+author_github: @justusNBB
+---
+# Storefront
+* Fix dead form serialize utility guard for empty forms (ts2829).

--- a/src/Storefront/Resources/app/storefront/src/utility/form/form-serialize.util.js
+++ b/src/Storefront/Resources/app/storefront/src/utility/form/form-serialize.util.js
@@ -39,7 +39,7 @@ export default class FormSerializeUtil {
      */
     static serializeJson(form, strict = true) {
         const formData = FormSerializeUtil.serialize(form, strict);
-        if (formData === {}) return formData;
+        if (Object.keys(formData).length === 0) return {};
         const json = {};
 
         Iterator.iterate(formData, (value, key) => json[key] = value);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
It's not strictly necessary, alternatively the line could just be removed, as it is dead code - the condition is always false, as TypeScript also recognises:
![image](https://github.com/shopware/shopware/assets/73602543/92ae245b-f77c-4b78-a66c-2114ab17161a)



### 2. What does this change do, exactly?
Fix the guard for empty forms


### 3. Describe each step to reproduce the issue or behaviour.
There is no reproduction path for dead code (error ts2839)


### 4. Please link to the relevant issues (if any).
I haven't found any yet, looking for a ticket number to attach this to.

Edit: Thank you, attached NEXT-37067


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change - not possible for dead code, maybe we could add a unit test anyways...
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes - missing a ticket number though
- [x] I have written or adjusted the documentation according to my changes - not required
- [x] This change has comments for package types, values, functions, and non-obvious lines of code - not required
- [x] I have read the contribution requirements and fulfil them.
