### PR TITLE
NEXT-00000 - Fix unlimited product search character count

### DIFF
--- a/changelog/_unreleased/2024-07-02-limit-character-count-in-product-search.md
+++ b/changelog/_unreleased/2024-07-02-limit-character-count-in-product-search.md
@@ -6,4 +6,13 @@ author_email: lackner.elias@gmail.com
 author_github: @lacknere
 ---
 # Core
-* Added `MAX_CHARACTER_COUNT` constant and `limitCharacterCount` method in `ProductSearchTermInterpreter` to prevent exploding keyword SQL query in case of very long search inputs.
+* Added migration `Migration1720000172AddMaxCharacterCountToProductSearchConfiguration` to add `max_character_count` column to `product_search_config` table.
+* Added `maxCharacterCount` to `Shopware\Core\Content\Product\Aggregate\ProductSearchConfig` definition, entity and hydrator.
+* Added abstract class `Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Limiter\AbstractCharacterLimiter`.
+* Added service `Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Limiter\CharacterLimiter`.
+* Changed method `interpret` of `Shopware\Core\Content\Product\SearchKeyword\ProductSearchTermInterpreter` to limit count of searchable characters in order to prevent exploding keyword SQL queries by using `Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Limiter\CharacterLimiter`.
+___
+# Administration
+* Changed `sw-settings-search` component to consider `maxCharacterCount` in product search config.
+* Added `maxCharacterCount` configuration field in `sw-settings-search-search-behaviour` component.
+* Added snippets `sw-settings-search.generalTab.labelMaximalCharacterCount` and `sw-settings-search.generalTab.helpTextMaximalCharacterCount`.

--- a/changelog/_unreleased/2024-07-02-limit-character-count-in-product-search.md
+++ b/changelog/_unreleased/2024-07-02-limit-character-count-in-product-search.md
@@ -1,0 +1,9 @@
+---
+title: Limit character count in product search
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Added `MAX_CHARACTER_COUNT` constant and `limitCharacterCount` method in `ProductSearchTermInterpreter` to prevent exploding keyword SQL query in case of very long search inputs.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/index.js
@@ -29,8 +29,16 @@ export default {
 
     data: () => {
         return {
-            min: 1,
-            max: 20,
+            limits: {
+                minSearchLength: {
+                    min: 1,
+                    max: 20,
+                },
+                maxCharacterCount: {
+                    min: 20,
+                    max: 100,
+                },
+            },
         };
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/sw-settings-search-search-behaviour.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/sw-settings-search-search-behaviour.html.twig
@@ -31,21 +31,49 @@
     {% endblock %}
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-    {% block sw_settings_search_search_behaviour_search_term_length %}
-    <sw-number-field
-        v-model:value="searchBehaviourConfigs.minSearchLength"
-        v-tooltip="{
-            message: $tc('sw-privileges.tooltip.warning'),
-            disabled: acl.can('product_search_config.editor'),
-            showOnDisabledElements: true
-        }"
-        name="sw-field--searchBehaviourConfigs-minSearchLength"
-        class="sw-settings-search__search-behaviour-term-length"
-        :label="$tc('sw-settings-search.generalTab.labelMinimalSearchTerm')"
-        :disabled="!acl.can('product_search_config.editor')"
-        :min="min"
-        :max="max"
-    />
+    {% block sw_settings_search_search_behaviour_search_limitation_container %}
+    <sw-container
+        columns="1fr 1fr"
+        gap="30px"
+    >
+
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_settings_search_search_behaviour_search_term_length %}
+        <sw-number-field
+            v-model:value="searchBehaviourConfigs.minSearchLength"
+            v-tooltip="{
+                message: $tc('sw-privileges.tooltip.warning'),
+                disabled: acl.can('product_search_config.editor'),
+                showOnDisabledElements: true
+            }"
+            name="sw-field--searchBehaviourConfigs-minSearchLength"
+            class="sw-settings-search__search-behaviour-term-length"
+            :label="$tc('sw-settings-search.generalTab.labelMinimalSearchTerm')"
+            :disabled="!acl.can('product_search_config.editor')"
+            :min="limits.minSearchLength.min"
+            :max="limits.minSearchLength.max"
+        />
+        {% endblock %}
+
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_settings_search_search_behaviour_max_character_count %}
+        <sw-number-field
+            v-model:value="searchBehaviourConfigs.maxCharacterCount"
+            v-tooltip="{
+                message: $tc('sw-privileges.tooltip.warning'),
+                disabled: acl.can('product_search_config.editor'),
+                showOnDisabledElements: true
+            }"
+            name="sw-field--searchBehaviourConfigs-maxCharacterCount"
+            class="sw-settings-search__search-behaviour-max-character-count"
+            :label="$tc('sw-settings-search.generalTab.labelMaximalCharacterCount')"
+            :help-text="$tc('sw-settings-search.generalTab.helpTextMaximalCharacterCount')"
+            :disabled="!acl.can('product_search_config.editor')"
+            :min="limits.maxCharacterCount.min"
+            :max="limits.maxCharacterCount.max"
+        />
+        {% endblock %}
+    </sw-container>
     {% endblock %}
 </sw-card>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/sw-settings-search-search-behaviour.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/sw-settings-search-search-behaviour.scss
@@ -23,8 +23,4 @@
             display: inline;
         }
     }
-
-    &__search-behaviour-term-length.sw-field {
-        width: 50%;
-    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/sw-settings-search-search-behaviour.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-behaviour/sw-settings-search-search-behaviour.spec.js
@@ -11,6 +11,7 @@ async function createWrapper(privileges = []) {
             searchBehaviourConfigs: {
                 andLogic: true,
                 minSearchLength: 2,
+                maxCharacterCount: 60,
             },
         },
 
@@ -81,6 +82,9 @@ describe('module/sw-settings-search/component/sw-settings-search-search-behaviou
         const minSearchLengthElement = wrapper.find('.sw-settings-search__search-behaviour-term-length input');
         expect(minSearchLengthElement.attributes().disabled).toBeDefined();
 
+        const maxCharacterCountElement = wrapper.find('.sw-settings-search__search-behaviour-max-character-count input');
+        expect(maxCharacterCountElement.attributes().disabled).toBeDefined();
+
         await orBehaviourElement.trigger('click');
         expect(orBehaviourElement.element.checked).toBeFalsy();
         expect(wrapper.vm.searchBehaviourConfigs.andLogic).toBe(true);
@@ -108,5 +112,29 @@ describe('module/sw-settings-search/component/sw-settings-search-search-behaviou
         await minSearchLengthElement.setValue(0);
         await minSearchLengthElement.trigger('change');
         expect(wrapper.vm.searchBehaviourConfigs.minSearchLength).toBe(1);
+    });
+
+    it('should be able to change maximal character count between limit value', async () => {
+        const wrapper = await createWrapper([
+            'product_search_config.editor',
+        ]);
+        await flushPromises();
+
+        expect(wrapper.vm.searchBehaviourConfigs.maxCharacterCount).toBe(60);
+
+        const maxCharacterCountElement = wrapper.find('.sw-settings-search__search-behaviour-term-length input');
+        await maxCharacterCountElement.setValue(25);
+        await maxCharacterCountElement.trigger('change');
+        expect(wrapper.vm.searchBehaviourConfigs.maxCharacterCount).toBe(25);
+
+        // take the max value if the current value bigger than the max value.
+        await maxCharacterCountElement.setValue(101);
+        await maxCharacterCountElement.trigger('change');
+        expect(wrapper.vm.searchBehaviourConfigs.maxCharacterCount).toBe(100);
+
+        // take the min value if the current value smaller than the min value.
+        await maxCharacterCountElement.setValue(19);
+        await maxCharacterCountElement.trigger('change');
+        expect(wrapper.vm.searchBehaviourConfigs.maxCharacterCount).toBe(20);
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/page/sw-settings-search/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/page/sw-settings-search/index.js
@@ -32,6 +32,7 @@ export default {
             productSearchConfigs: {
                 andLogic: true,
                 minSearchLength: 2,
+                maxCharacterCount: 60,
             },
             isLoading: false,
             currentSalesChannelId: null,
@@ -145,6 +146,7 @@ export default {
             const defaultConfig = this.productSearchRepository.create();
             defaultConfig.andLogic = this.defaultConfig.andLogic;
             defaultConfig.minSearchLength = this.defaultConfig.minSearchLength;
+            defaultConfig.maxCharacterCount = this.defaultConfig.maxCharacterCount;
             defaultConfig.excludedTerms = [];
             defaultConfig.languageId = Shopware.Context.api.languageId;
             return defaultConfig;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/page/sw-settings-search/sw-settings-search.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/page/sw-settings-search/sw-settings-search.spec.js
@@ -11,12 +11,14 @@ const mockData = [
     {
         andLogic: false,
         minSearchLength: 4,
+        maxCharacterCount: 80,
         excludedTerms: [],
         languageId: '2fbb5fe2e29a4d70aa5854ce7ce3e20b',
     },
     {
         andLogic: true,
         minSearchLength: 4,
+        maxCharacterCount: 80,
         excludedTerms: [],
         languageId: '2fbb5fe2e29a4d70aa5854ce7ce3e20c',
     },
@@ -150,6 +152,7 @@ describe('module/sw-settings-search/page/sw-settings-search', () => {
         wrapper.vm.productSearchConfigs = {
             andLogic: true,
             minSearchLength: 2,
+            maxCharacterCount: 60,
         };
 
         await wrapper.vm.onSaveSearchSettings();
@@ -188,6 +191,7 @@ describe('module/sw-settings-search/page/sw-settings-search', () => {
 
         expect(wrapper.vm.productSearchConfigs.andLogic).toBe(mockData[0].andLogic);
         expect(wrapper.vm.productSearchConfigs.minSearchLength).toBe(mockData[0].minSearchLength);
+        expect(wrapper.vm.productSearchConfigs.maxCharacterCount).toBe(mockData[0].maxCharacterCount);
         expect(wrapper.vm.productSearchConfigs.excludedTerms).toHaveLength(0);
         expect(wrapper.vm.productSearchConfigs.languageId).toBe('2fbb5fe2e29a4d70aa5854ce7ce3e20b');
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/snippet/de-DE.json
@@ -16,6 +16,8 @@
       "labelSearchOrCondition": "“ODER”-Suche",
       "textSearchOrConditionExplain": "Suchergebnisse beinhalten einen der eingegebenen Suchbegriffe.\nBeispiel: \"Jeans Sommer\" findet Suchergebnisse, die entweder den Suchbegriff \"Jeans\" oder den Suchbegriff \"Sommer\" enthalten.",
       "labelMinimalSearchTerm": "Minimale Suchbegrifflänge",
+      "labelMaximalCharacterCount": "Maximale Anzahl an Zeichen",
+      "helpTextMaximalCharacterCount": "Die maximale Anzahl an Zeichen, die für die Suche verwendet werden. Alle Zeichen, die diese Grenze überschreiten, werden ignoriert.",
       "labelExcludedSearchTerms": "Ausgeschlossene Suchbegriffe",
       "textEmptyStateExcludedSearchTerms": "Bisher keine Suchbegriffe ausgeschlossen",
       "buttonAddExcludedSearch": "Suchbegriff ausschließen",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/snippet/en-GB.json
@@ -16,6 +16,8 @@
       "labelSearchOrCondition": "“OR” Search",
       "textSearchOrConditionExplain": "Search results match with any element of the entered search term.\nExample: \"Jeans summer\" will find search results that contain either the search term \"jeans\" or the search term \"summer\".",
       "labelMinimalSearchTerm": "Minimal search term length",
+      "labelMaximalCharacterCount": "Maximal character count",
+      "helpTextMaximalCharacterCount": "The maximum number of characters used for searching. Any characters exceeding this limit will be ignored.",
       "labelExcludedSearchTerms": "Excluded search terms",
       "textEmptyStateExcludedSearchTerms": "No search terms excluded yet",
       "buttonAddExcludedSearch": "Exclude search term",

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -549,6 +549,12 @@
             <tag name="kernel.reset" method="reset"/>
         </service>
 
+        <service id="Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Limiter\CharacterLimiter">
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
+
+            <tag name="kernel.reset" method="reset"/>
+        </service>
+
         <service id="Shopware\Core\Content\Product\DataAbstractionLayer\CheapestPrice\CheapestPriceAccessorBuilder">
             <argument>%shopware.dal.max_rule_prices%</argument>
             <argument type="service" id="logger"/>

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigDefinition.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigDefinition.php
@@ -49,6 +49,7 @@ class ProductSearchConfigDefinition extends EntityDefinition
         return [
             'andLogic' => true,
             'minSearchLength' => 2,
+            'maxCharacterCount' => 60,
             'excludedTerms' => [],
         ];
     }
@@ -65,6 +66,7 @@ class ProductSearchConfigDefinition extends EntityDefinition
             (new FkField('language_id', 'languageId', LanguageDefinition::class))->addFlags(new Required()),
             (new BoolField('and_logic', 'andLogic'))->addFlags(new Required()),
             (new IntField('min_search_length', 'minSearchLength'))->addFlags(new Required()),
+            (new IntField('max_character_count', 'maxCharacterCount'))->addFlags(new Required()),
             new ListField('excluded_terms', 'excludedTerms', StringField::class),
             new OneToOneAssociationField('language', 'language_id', 'id', LanguageDefinition::class, false),
             (new OneToManyAssociationField('configFields', ProductSearchConfigFieldDefinition::class, 'product_search_config_id', 'id'))->addFlags(new CascadeDelete()),

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigEntity.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigEntity.php
@@ -29,6 +29,11 @@ class ProductSearchConfigEntity extends Entity
     protected $minSearchLength;
 
     /**
+     * @var int
+     */
+    protected $maxCharacterCount;
+
+    /**
      * @var array|null
      */
     protected $excludedTerms;
@@ -71,6 +76,16 @@ class ProductSearchConfigEntity extends Entity
     public function setMinSearchLength(int $minSearchLength): void
     {
         $this->minSearchLength = $minSearchLength;
+    }
+
+    public function getMaxCharacterCount(): int
+    {
+        return $this->maxCharacterCount;
+    }
+
+    public function setMaxCharacterCount(int $maxCharacterCount): void
+    {
+        $this->maxCharacterCount = $maxCharacterCount;
     }
 
     public function getExcludedTerms(): ?array

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigHydrator.php
@@ -26,6 +26,9 @@ class ProductSearchConfigHydrator extends EntityHydrator
         if (isset($row[$root . '.minSearchLength'])) {
             $entity->minSearchLength = (int) $row[$root . '.minSearchLength'];
         }
+        if (isset($row[$root . '.maxCharacterCount'])) {
+            $entity->maxCharacterCount = (int) $row[$root . '.maxCharacterCount'];
+        }
         if (\array_key_exists($root . '.excludedTerms', $row)) {
             $entity->excludedTerms = $definition->decode('excludedTerms', self::value($row, $root, 'excludedTerms'));
         }

--- a/src/Core/Content/Test/Product/DataAbstractionLayer/ProductSearchConfigFieldExceptionHandlerTest.php
+++ b/src/Core/Content/Test/Product/DataAbstractionLayer/ProductSearchConfigFieldExceptionHandlerTest.php
@@ -28,6 +28,7 @@ class ProductSearchConfigFieldExceptionHandlerTest extends TestCase
             'languageId' => Defaults::LANGUAGE_SYSTEM,
             'andLogic' => true,
             'minSearchLength' => 3,
+            'maxCharacterCount' => 60,
             'configFields' => [
                 ['id' => $ids->get('field-1'), 'field' => 'test'],
                 ['id' => $ids->get('field-2'), 'field' => 'test'],

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Limiter/AbstractCharacterLimiter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Limiter/AbstractCharacterLimiter.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Limiter;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\Service\ResetInterface;
+
+#[Package('core')]
+abstract class AbstractCharacterLimiter implements ResetInterface
+{
+    public function reset(): void
+    {
+        $this->getDecorated()->reset();
+    }
+
+    abstract public function getDecorated(): AbstractCharacterLimiter;
+
+    /**
+     * @param list<string> $tokens
+     *
+     * @return list<string>
+     */
+    abstract public function limit(array $tokens, Context $context): array;
+}

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Limiter/CharacterLimiter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Limiter/CharacterLimiter.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Limiter;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+#[Package('core')]
+class CharacterLimiter extends AbstractCharacterLimiter
+{
+    private const DEFAULT_MAX_CHARACTER_COUNT = 60;
+
+    /**
+     * @var array<string, int>
+     */
+    private array $maxCharacterCount = [];
+
+    /**
+     * @internal
+     */
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    public function getDecorated(): AbstractCharacterLimiter
+    {
+        throw new DecorationPatternException(self::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function limit(array $tokens, Context $context): array
+    {
+        if (empty($tokens)) {
+            return $tokens;
+        }
+
+        $maxCharacterCount = $this->getMaxCharacterCount($context->getLanguageId());
+
+        if (mb_strlen(implode('', $tokens)) <= $maxCharacterCount) {
+            return $tokens;
+        }
+
+        $word = '';
+        $availableCount = $maxCharacterCount;
+
+        foreach ($tokens as $token) {
+            if (mb_strlen($token) > $availableCount) {
+                $word .= mb_substr($token, 0, $availableCount);
+
+                break;
+            }
+
+            $word .= $token . ' ';
+            $availableCount -= mb_strlen($token);
+        }
+
+        $tokens = explode(' ', trim($word));
+
+        return $tokens;
+    }
+
+    public function reset(): void
+    {
+        $this->maxCharacterCount = [];
+    }
+
+    private function getMaxCharacterCount(string $languageId): int
+    {
+        if (isset($this->maxCharacterCount[$languageId])) {
+            return $this->maxCharacterCount[$languageId];
+        }
+
+        $maxCharacterCount = $this->connection->fetchOne('
+            SELECT `max_character_count`
+            FROM product_search_config
+            WHERE language_id = :languageId
+            LIMIT 1
+        ', ['languageId' => Uuid::fromHexToBytes($languageId)]);
+
+        return $this->maxCharacterCount[$languageId] = (int) ($maxCharacterCount ?? self::DEFAULT_MAX_CHARACTER_COUNT);
+    }
+}

--- a/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
+++ b/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
@@ -96,6 +96,7 @@
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer"/>
             <argument type="service" id="logger"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Filter\TokenFilter"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Limiter\CharacterLimiter"/>
             <argument type="service" id="Shopware\Core\Content\Product\SearchKeyword\KeywordLoader"/>
         </service>
 

--- a/src/Core/Migration/V6_6/Migration1720000172AddMaxCharacterCountToProductSearchConfiguration.php
+++ b/src/Core/Migration/V6_6/Migration1720000172AddMaxCharacterCountToProductSearchConfiguration.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1720000172AddMaxCharacterCountToProductSearchConfiguration extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1720000172;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addColumn($connection, 'product_search_config', 'max_character_count', 'smallint', false, '60');
+    }
+}

--- a/src/Core/System/UsageData/usage-data-allow-list.json
+++ b/src/Core/System/UsageData/usage-data-allow-list.json
@@ -949,6 +949,7 @@
     "languageId",
     "andLogic",
     "minSearchLength",
+    "maxCharacterCount",
     "excludedTerms",
     "createdAt",
     "updatedAt"

--- a/tests/migration/Core/V6_6/Migration1720000172AddMaxCharacterCountToProductSearchConfigurationTest.php
+++ b/tests/migration/Core/V6_6/Migration1720000172AddMaxCharacterCountToProductSearchConfigurationTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_6;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\V6_6\Migration1720000172AddMaxCharacterCountToProductSearchConfiguration;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1720000172AddMaxCharacterCountToProductSearchConfiguration::class)]
+#[Package('core')]
+class Migration1720000172AddMaxCharacterCountToProductSearchConfigurationTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->getContainer()->get(Connection::class);
+    }
+
+    public function testMigrate(): void
+    {
+        $this->rollback();
+        $this->migrate();
+        $this->migrate();
+
+        $manager = $this->connection->createSchemaManager();
+        $columns = $manager->listTableColumns('product_search_config');
+
+        static::assertArrayHasKey('max_character_count', $columns);
+        static::assertTrue($columns['max_character_count']->getNotnull());
+        static::assertSame('60', $columns['max_character_count']->getDefault());
+    }
+
+    private function migrate(): void
+    {
+        (new Migration1720000172AddMaxCharacterCountToProductSearchConfiguration())->update($this->connection);
+    }
+
+    private function rollback(): void
+    {
+        $this->connection->executeStatement('ALTER TABLE `product_search_config` DROP COLUMN `max_character_count`');
+    }
+}

--- a/tests/unit/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
+++ b/tests/unit/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Product\SearchKeyword\KeywordLoader;
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchTermInterpreter;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Filter\TokenFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Limiter\CharacterLimiter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Tokenizer;
 
 /**
@@ -27,6 +28,7 @@ class ProductSearchTermInterpreterTest extends TestCase
             new Tokenizer(3),
             static::createMock(LoggerInterface::class),
             new TokenFilter(static::createMock(Connection::class)),
+            new CharacterLimiter(static::createMock(Connection::class)),
             static::createMock(KeywordLoader::class),
         );
 
@@ -44,6 +46,7 @@ class ProductSearchTermInterpreterTest extends TestCase
             static::createMock(Tokenizer::class),
             static::createMock(LoggerInterface::class),
             new TokenFilter(static::createMock(Connection::class)),
+            new CharacterLimiter(static::createMock(Connection::class)),
             static::createMock(KeywordLoader::class),
         );
 
@@ -79,6 +82,7 @@ class ProductSearchTermInterpreterTest extends TestCase
             new Tokenizer(3),
             static::createMock(LoggerInterface::class),
             new TokenFilter(static::createMock(Connection::class)),
+            new CharacterLimiter(static::createMock(Connection::class)),
             $keywordLoader,
         );
 
@@ -95,7 +99,7 @@ class ProductSearchTermInterpreterTest extends TestCase
                 $tokens = array_keys($tokenSlops);
                 $chars = implode('', $tokens);
 
-                static::assertEquals(ProductSearchTermInterpreter::MAX_CHARACTER_COUNT, mb_strlen($chars));
+                static::assertEquals(60, mb_strlen($chars));
 
                 return true;
             }));
@@ -105,6 +109,7 @@ class ProductSearchTermInterpreterTest extends TestCase
             new Tokenizer(3),
             static::createMock(LoggerInterface::class),
             new TokenFilter(static::createMock(Connection::class)),
+            new CharacterLimiter(static::createMock(Connection::class)),
             $keywordLoader,
         );
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Term/Limiter/CharacterLimiterTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Term/Limiter/CharacterLimiterTest.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Search\Term\Limiter;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Limiter\CharacterLimiter;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+/**
+ * @internal
+ */
+#[CoversClass(CharacterLimiter::class)]
+class CharacterLimiterTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private Context $context;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->context = Context::createDefaultContext();
+        $this->connection = $this->getContainer()->get(Connection::class);
+    }
+
+    /**
+     * @param list<string> $tokens
+     * @param list<string> $expected
+     */
+    #[DataProvider('cases')]
+    public function testCharacterLimiter(int $maxCharacterCount, array $tokens, array $expected): void
+    {
+        $this->updateProductSearchConfig($maxCharacterCount);
+
+        $service = new CharacterLimiter($this->connection);
+        $tokens = $service->limit($tokens, $this->context);
+
+        static::assertEquals($expected, $tokens);
+    }
+
+    /**
+     * @return array<array{int, list<string>, list<string>}>
+     */
+    public static function cases(): array
+    {
+        $tokens = ['Lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'sadipscing', 'elitr', 'sed', 'diam', 'nonumy', 'eirmod', 'tempor', 'invidunt', 'ut', 'labore', 'et', 'dolore', 'magna', 'aliquyam', 'erat', 'sed', 'diam', 'voluptua'];
+
+        return [
+            [
+                20,
+                [],
+                [],
+            ],
+            [
+                20,
+                \array_slice($tokens, 0, 2),
+                \array_slice($tokens, 0, 2),
+            ],
+            [
+                20,
+                $tokens,
+                ['Lorem', 'ipsum', 'dolor', 'sit', 'am'],
+            ],
+            [
+                40,
+                \array_slice($tokens, 0, 6),
+                \array_slice($tokens, 0, 6),
+            ],
+            [
+                40,
+                $tokens,
+                ['Lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'sadipsc'],
+            ],
+            [
+                60,
+                \array_slice($tokens, 0, 10),
+                \array_slice($tokens, 0, 10),
+            ],
+            [
+                60,
+                $tokens,
+                ['Lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'sadipscing', 'elitr', 'sed', 'diam', 'nonum'],
+            ],
+            [
+                80,
+                \array_slice($tokens, 0, 12),
+                \array_slice($tokens, 0, 12),
+            ],
+            [
+                80,
+                $tokens,
+                ['Lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'sadipscing', 'elitr', 'sed', 'diam', 'nonumy', 'eirmod', 'tempor', 'invidun'],
+            ],
+            [
+                100,
+                \array_slice($tokens, 0, 18),
+                \array_slice($tokens, 0, 18),
+            ],
+            [
+                100,
+                $tokens,
+                ['Lorem', 'ipsum', 'dolor', 'sit', 'amet', 'consectetur', 'sadipscing', 'elitr', 'sed', 'diam', 'nonumy', 'eirmod', 'tempor', 'invidunt', 'ut', 'labore', 'et', 'dolore', 'mag'],
+            ],
+        ];
+    }
+
+    private function updateProductSearchConfig(int $maxCharacterCount): void
+    {
+        $this->connection->executeStatement(
+            'UPDATE `product_search_config` SET `max_character_count` = :maxCharacterCount WHERE `language_id` = UNHEX(:id)',
+            [
+                'maxCharacterCount' => $maxCharacterCount,
+                'id' => $this->context->getLanguageId(),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, the product search is unlimited in character count. This can lead to exploding keyword SQL queries when entering a very long search input which makes it easy for attackers to kill a Shopware shop (already happened to one of our customers).

### 2. What does this change do, exactly?
Limit the character count of the product search to a maximum of 60 characters.

### 3. Describe each step to reproduce the issue or behaviour.
In a shop with a lot of products (~2000), enter a very long search string (multiple words, ~250 characters).

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
