### PR TITLE
NEXT-12399 - Improve product search term scoring on exact matches

### DIFF
--- a/changelog/_unreleased/2024-07-02-improve-product-search-term-scoring-on-exact-matches.md
+++ b/changelog/_unreleased/2024-07-02-improve-product-search-term-scoring-on-exact-matches.md
@@ -1,0 +1,9 @@
+---
+title: Improve product search term scoring on exact matches
+issue: NEXT-12399
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Changed scoring of search terms in `score` method of `ProductSearchTermInterpreter` to provide better search results on exact matches.

--- a/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
+++ b/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
@@ -144,6 +144,20 @@ class ProductSearchTermInterpreterTest extends TestCase
     }
 
     /**
+     * @param list<string> $expected
+     */
+    #[DataProvider('termScoring')]
+    public function testTermScoring(string $term, array $expected): void
+    {
+        $context = Context::createDefaultContext();
+
+        $matches = $this->interpreter->interpret($term, $context);
+        $terms = array_map(fn (SearchTerm $term) => $term->getTerm(), $matches->getTerms());
+
+        static::assertEquals($expected, \array_slice($terms, 0, \count($expected)));
+    }
+
+    /**
      * @return array<array{0: string, 1: list<string>}>
      */
     public static function cases(): array
@@ -362,6 +376,39 @@ class ProductSearchTermInterpreterTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<array{0: string, 1: list<string>}>
+     */
+    public static function termScoring(): array
+    {
+        return [
+            [
+                'Sessel',
+                [
+                    'Sessel',
+                ],
+            ],
+            [
+                'Gelber Sessel',
+                [
+                    'Gelber Sessel',
+                    'Gelber Camping Sessel',
+                    'Klappbarer gelber Camping Sessel',
+                    'Klappbarer gelber Sessel',
+                ],
+            ],
+            [
+                'Klappbarer Camping Sessel',
+                [
+                    'Klappbarer Camping Sessel',
+                    'Klappbarer blauer Camping Sessel',
+                    'Klappbarer gelber Camping Sessel',
+                    'Klappbarer roter Camping Sessel',
+                ],
+            ],
+        ];
+    }
+
     private function setupKeywords(): void
     {
         $keywords = [
@@ -416,6 +463,21 @@ class ProductSearchTermInterpreterTest extends TestCase
             'against',
             'betweencoffee',
             'betweenbike',
+            'Sessel',
+            'Roter Camping Sessel',
+            'Klappbarer roter Sessel',
+            'Roter Sessel',
+            'Klappbarer roter Camping Sessel',
+            'Gelber Camping Sessel',
+            'Klappbarer gelber Sessel',
+            'Gelber Sessel',
+            'Klappbarer gelber Camping Sessel',
+            'Blauer Camping Sessel',
+            'Klappbarer blauer Sessel',
+            'Blauer Sessel',
+            'Klappbarer blauer Camping Sessel',
+            'Camping Sessel',
+            'Klappbarer Camping Sessel',
         ];
 
         $languageId = Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

- Search results are inaccurate/unsatisfying even if there are exact word matches.
- Also, the more words a keyword match contains, the higher the score (score is increased by 4 for each word of a keyword match, even if just one single word of the whole keyword phrase is searched - [code](https://github.com/shopware/shopware/blob/930fb3445d35d999e9ed6456c52d9cbe169d6fd0/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php#L188)).

### 2. What does this change do, exactly?

- Remove the increasing of score per each word inside a keyword match.
- Improve scoring of exactly matching search terms.

### 3. Describe each step to reproduce the issue or behaviour.
See [issue](https://issues.shopware.com/issues/NEXT-12399).

### 4. Please link to the relevant issues (if any).
[NEXT-12399](https://issues.shopware.com/issues/NEXT-12399)

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


[NEXT-12399]: https://shopware.atlassian.net/browse/NEXT-12399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ