### PR TITLE
Added missing twig blocks to admin file order-general-info

### DIFF
--- a/changelog/_unreleased/2024-07-03-Add-twig-blocks-to-order-general-info.md
+++ b/changelog/_unreleased/2024-07-03-Add-twig-blocks-to-order-general-info.md
@@ -1,0 +1,17 @@
+---
+title: Add twig blocks to sw-order-create-general-info.html.twig
+author: Jörg Lautenschlager
+author_email: joerg.lautenschlager@gmail.com
+author_github: @jlaute
+---
+# Administration
+* Added the following twig blocks in `sw-order-create-general-info.html.twig`
+    * `sw_order_create_general_info`
+    * `sw_order_create_general_info_summary`
+    * `sw_order_create_general_info_summary_main`
+    * `sw_order_create_general_info_summary_sub`
+    * `sw_order_create_general_info_order_states`
+    * `sw_order_create_general_info_order_state_payment`
+    * `sw_order_create_general_info_order_state_delivery`
+    * `sw_order_create_general_info_order_state_order`
+    * `sw_order_create_general_info_order_tags`

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-general-info/sw-order-create-general-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-general-info/sw-order-create-general-info.html.twig
@@ -1,7 +1,12 @@
+<!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
 {% block sw_order_create_general_info %}
 <div>
+
+    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_order_create_general_info_summary %}
     <div class="sw-order-create-general-info__summary">
+
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_order_create_general_info_summary_main %}
         <div class="sw-order-create-general-info__summary-main">
             <div class="sw-order-create-general-info__summary-main-header">
@@ -13,6 +18,7 @@
         </div>
         {% endblock %}
 
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_order_create_general_info_summary_sub %}
         <div class="sw-order-create-general-info__summary-sub">
             <div class="sw-order-create-general-info__summary-sub-description">
@@ -23,11 +29,15 @@
             </div>
         </div>
         {% endblock %}
+
     </div>
     {% endblock %}
 
+    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_order_create_general_info_order_states %}
     <div class="sw-order-create-general-info__order-states">
+
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_order_create_general_info_order_state_payment %}
         <div class="sw-order-create-general-info__order-state">
             <sw-order-state-select-v2
@@ -40,6 +50,8 @@
             />
         </div>
         {% endblock %}
+
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_order_create_general_info_order_state_delivery %}
         <div class="sw-order-create-general-info__order-state">
             <sw-order-state-select-v2
@@ -52,6 +64,8 @@
             />
         </div>
         {% endblock %}
+
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_order_create_general_info_order_state_order %}
         <div class="sw-order-create-general-info__order-state">
             <sw-order-state-select-v2
@@ -64,9 +78,11 @@
             />
         </div>
         {% endblock %}
+
     </div>
     {% endblock %}
 
+    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_order_create_general_info_order_tags %}
     <sw-entity-tag-select
         class="sw-order-create-general-info__order-tags"
@@ -77,5 +93,6 @@
         always-show-placeholder
     />
     {% endblock %}
+
 </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-general-info/sw-order-create-general-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-general-info/sw-order-create-general-info.html.twig
@@ -1,5 +1,8 @@
+{% block sw_order_create_general_info %}
 <div>
+    {% block sw_order_create_general_info_summary %}
     <div class="sw-order-create-general-info__summary">
+        {% block sw_order_create_general_info_summary_main %}
         <div class="sw-order-create-general-info__summary-main">
             <div class="sw-order-create-general-info__summary-main-header">
                 {{ summaryMainHeader }}
@@ -8,7 +11,9 @@
                 {{ currencyFilter(cart.price.totalPrice, context.currency.isoCode, context.currency.totalRounding.decimals) }}
             </div>
         </div>
+        {% endblock %}
 
+        {% block sw_order_create_general_info_summary_sub %}
         <div class="sw-order-create-general-info__summary-sub">
             <div class="sw-order-create-general-info__summary-sub-description">
                 {{ $tc('sw-order.generalTab.info.summary.with') }}
@@ -17,9 +22,13 @@
                 {{ context.paymentMethod.translated.distinguishableName }}
             </div>
         </div>
+        {% endblock %}
     </div>
+    {% endblock %}
 
+    {% block sw_order_create_general_info_order_states %}
     <div class="sw-order-create-general-info__order-states">
+        {% block sw_order_create_general_info_order_state_payment %}
         <div class="sw-order-create-general-info__order-state">
             <sw-order-state-select-v2
                 class="sw-order-create-general-info__order-state-payment"
@@ -30,6 +39,8 @@
                 disabled
             />
         </div>
+        {% endblock %}
+        {% block sw_order_create_general_info_order_state_delivery %}
         <div class="sw-order-create-general-info__order-state">
             <sw-order-state-select-v2
                 class="sw-order-create-general-info__order-state-delivery"
@@ -40,6 +51,8 @@
                 disabled
             />
         </div>
+        {% endblock %}
+        {% block sw_order_create_general_info_order_state_order %}
         <div class="sw-order-create-general-info__order-state">
             <sw-order-state-select-v2
                 class="sw-order-create-general-info__order-state-order"
@@ -50,8 +63,11 @@
                 disabled
             />
         </div>
+        {% endblock %}
     </div>
+    {% endblock %}
 
+    {% block sw_order_create_general_info_order_tags %}
     <sw-entity-tag-select
         class="sw-order-create-general-info__order-tags"
         size="small"
@@ -60,4 +76,6 @@
         :placeholder="$tc('sw-order.generalTab.tagSelect.placeholder')"
         always-show-placeholder
     />
+    {% endblock %}
 </div>
+{% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The file `sw-order-create-general-info.html.twig` is hard to extend via an extension, because it has no twig blocks defined. 

### 2. What does this change do, exactly?
This change only adds some twig blocks to the already existing file.

### 3. Describe each step to reproduce the issue or behaviour.
There is nothing to describe.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
