### PR TITLE
ci(github): Update playwright image

### DIFF
--- a/.github/workflows/02-acceptance.yml
+++ b/.github/workflows/02-acceptance.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'shopware/shopware'
     container:
-      image: mcr.microsoft.com/playwright:v1.44.0-jammy
+      image: mcr.microsoft.com/playwright:v1.45.0-jammy
     needs: docker
     env:
       APP_URL: http://shopware:8000

--- a/changelog/_unreleased/2024-07-04-update-github-playwright-test-image.md
+++ b/changelog/_unreleased/2024-07-04-update-github-playwright-test-image.md
@@ -1,0 +1,9 @@
+---
+title: Update Github playwright test image
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed the playwright test image to `mcr.microsoft.com/playwright:v1.45.0-jammy`


### PR DESCRIPTION
### 1. Why is this change necessary?
Github CI is failing: https://github.com/shopware/shopware/actions/runs/9792349856/job/27038254199#step:6:19
Due to the update of playwright: https://github.com/shopware/shopware/commit/275d58002c83e23da1075b61e9fd3d9ab4466883

### 2. What does this change do, exactly?
Change the playwright image.

### 3. Describe each step to reproduce the issue or behaviour.
Look at the CI.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
