### PR TITLE
[NEXT-0000] Search Preferences, merge user config with default

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-profile/view/sw-profile-index-search-preferences/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-profile/view/sw-profile-index-search-preferences/index.js
@@ -49,9 +49,12 @@ export default {
             }
 
             return defaultSearchPreferences.reduce((accumulator, currentValue) => {
-                const value = this.userSearchPreferences.find((item) => {
+                let value = this.userSearchPreferences.find((item) => {
                     return Object.keys(item)[0] === Object.keys(currentValue)[0];
                 });
+                if (value) {
+                    value = Shopware.Utils.object.deepMergeObject(currentValue, value);
+                }
 
                 accumulator.push(value || currentValue);
 


### PR DESCRIPTION
[NEXT-0000] Merge user config with default to allow showing new options without, it being removed if a user a saved config.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When adding new search config options in administration they aren't show. This is happening once a user has saved "search.preferences"

### 2. What does this change do, exactly?
Merge saved config together with default config.

### 3. Describe each step to reproduce the issue or behaviour.
- Go to `/sw/profile/index/search-preferences` _(Advanced search preferences)_
- Save search preferences
- Add a new option/search preference for X entity.
- Option is now missing since current user has a saved config without the new option.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
