### PR TITLE
fix: Open section settings when clicking on "Setting" in the context menu

### DIFF
--- a/changelog/_unreleased/2024-07-09-open-shopping-experience-section-settings-when-clicking-on-setting-in-the-context-menu.md
+++ b/changelog/_unreleased/2024-07-09-open-shopping-experience-section-settings-when-clicking-on-setting-in-the-context-menu.md
@@ -1,0 +1,9 @@
+---
+title: Open Shopping Experience section settings when clicking on "Setting" in the context menu
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed the behavior when clicking the settings item of the context menu of a section to open the section settings instead of opening the page settings and throwing an error

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
@@ -285,10 +285,9 @@ export default {
         },
 
         openSectionSettings(sectionIndex) {
-            this.$refs.pageConfigSidebar.openContent();
-            this.$nextTick(() => {
-                this.$refs.sectionConfigSidebar[sectionIndex].collapseItem();
-            });
+            Shopware.Store.get('cmsPageState').setSection(this.page.sections[sectionIndex]);
+
+            this.$refs.itemConfigSidebar.openContent();
         },
 
         blockIsRemovable(block) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
@@ -52,6 +52,18 @@ async function createWrapper({ cmsBlockRegistry } = { cmsBlockRegistry: null }) 
                 },
             },
         }),
+        actions: {
+            setSelectedSection(section) {
+                this.selectedSection = section;
+            },
+            removeSelectedBlock() {
+                this.selectedBlock = null;
+            },
+            setSection(section) {
+                this.removeSelectedBlock();
+                this.setSelectedSection(section);
+            },
+        },
     });
 
     return mount(await wrapTestComponent('sw-cms-sidebar', {
@@ -125,6 +137,11 @@ async function createWrapper({ cmsBlockRegistry } = { cmsBlockRegistry: null }) 
                 'sw-sidebar-item': {
                     template: '<div class="sw-sidebar-item"><slot #default /></div>',
                     props: ['disabled'],
+                    methods: {
+                        openContent() {
+                            this.isActive = true;
+                        },
+                    },
                 },
                 'sw-sidebar-collapse': {
                     template: '<div class="sw-sidebar-collapse"><slot name="header" /><slot name="content" /></div>',
@@ -616,5 +633,19 @@ describe('module/sw-cms/component/sw-cms-sidebar', () => {
         };
 
         expect(JSON.parse(JSON.stringify(wrapper.vm.page.sections[0].blocks[0]))).toStrictEqual(expectedData);
+    });
+
+    it('should open section settings when clicking settings in section context menu', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm.$refs.itemConfigSidebar.isActive).toBeFalsy();
+        expect(wrapper.vm.selectedSection.id).toBe('1111');
+
+        wrapper.findComponent('#sw-cms-sidebar__section-2222 .sw-cms-sidebar__navigator-section-settings')
+            .vm
+            .$emit('click');
+
+        expect(wrapper.vm.$refs.itemConfigSidebar.isActive).toBeTruthy();
+        expect(wrapper.vm.selectedSection.id).toBe('2222');
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when one is in the admin and clicks the "Setting" item of a section, it opens the layout settings and throws an error (as there is no reference `sectionConfigSidebar`). 

### 2. What does this change do, exactly?
Correct the behavior to open the section settings.

### 3. Describe each step to reproduce the issue or behaviour.
See 1.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
