### PR TITLE
NEXT-00000 - Fix performance issues in `EntityLoadedEventFactory`

### DIFF
--- a/changelog/_unreleased/2024-07-01-fix-performance-issues-in-entity-loaded-event-factory.md
+++ b/changelog/_unreleased/2024-07-01-fix-performance-issues-in-entity-loaded-event-factory.md
@@ -1,0 +1,10 @@
+---
+title: Fix performance issues in `EntityLoadedEventFactory`
+issue: NEXT-00000
+author: Cedric Engler
+author_email: cedric.engler@pickware.de
+author_github: @Ceddy610
+---
+# Core
+Enhanced `EntityLoadedEventFactory` performance by using mapping references instead of creating new arrays, reducing memory usage and improving efficiency.
+

--- a/src/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventFactory.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventFactory.php
@@ -28,7 +28,9 @@ class EntityLoadedEventFactory
      */
     public function create(array $entities, Context $context): EntityLoadedContainerEvent
     {
-        $mapping = $this->recursion($entities, []);
+        $mapping = [];
+
+        $this->recursion($entities, $mapping);
 
         $generator = fn (EntityDefinition $definition, array $entities) => new EntityLoadedEvent($definition, $entities, $context);
 
@@ -40,7 +42,9 @@ class EntityLoadedEventFactory
      */
     public function createPartial(array $entities, Context $context): EntityLoadedContainerEvent
     {
-        $mapping = $this->recursion($entities, []);
+        $mapping = [];
+
+        $this->recursion($entities, $mapping);
 
         $generator = fn (EntityDefinition $definition, array $entities) => new PartialEntityLoadedEvent($definition, $entities, $context);
 
@@ -54,7 +58,9 @@ class EntityLoadedEventFactory
      */
     public function createForSalesChannel(array $entities, SalesChannelContext $context): array
     {
-        $mapping = $this->recursion($entities, []);
+        $mapping = [];
+
+        $this->recursion($entities, $mapping);
 
         $generator = fn (EntityDefinition $definition, array $entities) => new EntityLoadedEvent($definition, $entities, $context->getContext());
 
@@ -73,7 +79,9 @@ class EntityLoadedEventFactory
      */
     public function createPartialForSalesChannel(array $entities, SalesChannelContext $context): array
     {
-        $mapping = $this->recursion($entities, []);
+        $mapping = [];
+
+        $this->recursion($entities, $mapping);
 
         $generator = fn (EntityDefinition $definition, array $entities) => new PartialEntityLoadedEvent($definition, $entities, $context->getContext());
 
@@ -103,10 +111,8 @@ class EntityLoadedEventFactory
     /**
      * @param array<mixed> $entities
      * @param array<string, list<Entity>> $mapping
-     *
-     * @return array<string, list<Entity>>
      */
-    private function recursion(array $entities, array $mapping): array
+    private function recursion(array $entities, array &$mapping): void
     {
         foreach ($entities as $entity) {
             if (!$entity instanceof Entity && !$entity instanceof EntityCollection) {
@@ -114,28 +120,24 @@ class EntityLoadedEventFactory
             }
 
             if ($entity instanceof EntityCollection) {
-                $mapping = $this->recursion($entity->getElements(), $mapping);
+                $this->recursion($entity->getElements(), $mapping);
             } else {
-                $mapping = $this->map($entity, $mapping);
+                $this->map($entity, $mapping);
             }
         }
-
-        return $mapping;
     }
 
     /**
      * @param array<string, list<Entity>> $mapping
-     *
-     * @return array<string, list<Entity>>
      */
-    private function map(Entity $entity, array $mapping): array
+    private function map(Entity $entity, array &$mapping): void
     {
         $mapping[$entity->getInternalEntityName()][] = $entity;
 
         $vars = $entity->getVars();
         foreach ($vars as $value) {
             if ($value instanceof Entity) {
-                $mapping = $this->map($value, $mapping);
+                $this->map($value, $mapping);
 
                 continue;
             }
@@ -147,9 +149,7 @@ class EntityLoadedEventFactory
                 continue;
             }
 
-            $mapping = $this->recursion($value, $mapping);
+            $this->recursion($value, $mapping);
         }
-
-        return $mapping;
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This change is necessary to enhance the performance of the EntityLoadedEventFactory. Previously, the factory was creating new arrays for each mapping, which was resource-intensive and could lead to increased memory usage and decreased efficiency, especially when dealing with large datasets.  

### 2. What does this change do, exactly?
This change optimizes the handling of mappings in the EntityLoadedEventFactory. Instead of creating new arrays for each mapping, it now uses references to existing mappings. This reduces memory usage and improves the efficiency of the factory.

### 3. Describe each step to reproduce the issue or behaviour.

1. Fetch a large dataset, such as many orders, via the search endpoint.
2. Observe the memory usage and efficiency of the `EntityLoadedEventFactory`. You would notice that the factory is creating new arrays for each mapping, which is resource-intensive.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
