### PR TITLE
fix: Default layout assignments

### DIFF
--- a/changelog/_unreleased/2024-07-12-cleanup-acl-rules-for-default-layouts.md
+++ b/changelog/_unreleased/2024-07-12-cleanup-acl-rules-for-default-layouts.md
@@ -1,0 +1,16 @@
+---
+title: Cleanup ACL rules for default layouts
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed context menu of `sw-cms-list` items to allow to set default product layouts directly from the listing
+* Changed `sw-cms-sidebar` to only show the default option when the layout is not already the default layout and add a notification if the layout is the default
+* Changed required ACL of `sw-cms-list` and `sw-cms-sidebar` permissions from `system_config.editor` to `system_config:{read,update,create,delete}`
+* Changed `sw-cms-layout-modal` to load the default layouts if ACL permission `system_config:read` is given instead of `system_config.read`
+* Changed `sw-cms-detail` to load the default layouts if ACL permission `system_config:read` is given instead of `system_config.read`
+* Changed `sw-cms-list` to load the default layouts if ACL permission `system_config:read` is given instead of `system_config.read`
+* Changed `sw-cms-list` to only load user settings if `user_config:read` ACL permission is given
+* Changed `sw-cms-list` to only persist the user settings if permissions `user_config:create` and `user_config:update` are given

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/index.js
@@ -130,7 +130,7 @@ export default {
 
     methods: {
         createdComponent() {
-            if (this.acl.can('system_config.read')) {
+            if (this.acl.can('system_config:read')) {
                 this.getDefaultLayouts();
             }
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.spec.js
@@ -139,7 +139,7 @@ describe('module/sw-cms/component/sw-cms-layout-modal', () => {
     });
 
     it('should display default status', async () => {
-        global.activeAclRoles = ['system_config.read'];
+        global.activeAclRoles = ['system_config:read'];
 
         const wrapper = await createWrapper();
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.js
@@ -52,6 +52,12 @@ export default {
             required: false,
             default: false,
         },
+
+        isDefaultLayout: {
+            type: Boolean,
+            required: false,
+            default: false,
+        },
     },
 
     data() {
@@ -223,15 +229,16 @@ export default {
         },
 
         showDefaultLayoutSelection() {
-            if (!this.acl.can('system_config.editor')) {
+            if (!this.acl.can('system_config:read') || !this.acl.can('system_config:update')
+                || !this.acl.can('system_config:create') || !this.acl.can('system_config:delete')) {
                 return false;
             }
 
-            if (this.page.type === 'product_list') {
-                return true;
+            if (this.page.type === 'product_list' || this.page.type === 'product_detail') {
+                return !this.isDefaultLayout;
             }
 
-            return this.page.type === 'product_detail';
+            return false;
         },
 
         cmsBlocksBySelectedBlockCategory() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
@@ -598,7 +598,7 @@
             </h3>
 
             <p class="sw-cms-sidebar__layout-set-as-default-info-text">
-                {{ $tc('sw-cms.components.setDefaultLayoutModal.infoText') }}
+                {{ $tc('sw-cms.components.setDefaultLayoutModal.infoText', { cmsPageType: this.page.type === 'product_detail' ? $tc('sw-cms.components.setDefaultLayoutModal.productType') : $tc('sw-cms.components.setDefaultLayoutModal.categoryType') }) }}
             </p>
 
             <sw-button

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
@@ -422,7 +422,7 @@ describe('module/sw-cms/component/sw-cms-sidebar', () => {
     });
 
     it('should emit open-layout-set-as-default when clicking on set as default', async () => {
-        global.activeAclRoles = ['system_config.editor'];
+        global.activeAclRoles = ['system_config:read', 'system_config:update', 'system_config:delete', 'system_config:create'];
 
         const wrapper = await createWrapper();
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -338,7 +338,7 @@ export default {
                 });
             }
 
-            if (this.acl.can('system_config.read')) {
+            if (this.acl.can('system_config:read')) {
                 this.getDefaultLayouts();
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
@@ -337,6 +337,7 @@
                     :demo-entity="currentMappingEntity"
                     :demo-entity-id-prop="demoEntityId"
                     :disabled="!acl.can('cms.editor')"
+                    :is-default-layout="isDefaultLayout"
                     @demo-entity-change="onDemoEntityChange"
                     @block-duplicate="onBlockDuplicate"
                     @section-duplicate="onSectionDuplicate"
@@ -362,7 +363,9 @@
                     v-if="showLayoutSetAsDefaultModal"
                     class="sw-cms-detail__confirm-set-as-default-modal"
                     :title="$tc('sw-cms.components.setDefaultLayoutModal.title')"
-                    :text="$tc('sw-cms.components.setDefaultLayoutModal.infoText')"
+                    :text="$tc('sw-cms.components.setDefaultLayoutModal.infoText', {
+                        cmsPageType: this.page.type === 'product_detail' ? $tc('sw-cms.components.setDefaultLayoutModal.productType') : $tc('sw-cms.components.setDefaultLayoutModal.categoryType')
+                    })"
                     @confirm="onConfirmLayoutSetAsDefault"
                     @cancel="onCloseLayoutSetAsDefault"
                     @close="onCloseLayoutSetAsDefault"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/index.js
@@ -157,9 +157,11 @@ export default {
         createdComponent() {
             Shopware.State.commit('adminMenu/collapseSidebar');
 
-            this.loadGridUserSettings();
+            if (this.acl.can('user_config:read')) {
+                this.loadGridUserSettings();
+            }
 
-            if (this.acl.can('system_config.read')) {
+            if (this.acl.can('system_config:read')) {
                 this.getDefaultLayouts();
             }
 
@@ -185,6 +187,12 @@ export default {
         },
 
         saveGridUserSettings() {
+            if (!this.acl.can('user_config:create') || !this.acl.can('user_config:update')) {
+                console.warn('Did not persist user config, as permissions are missing.');
+
+                return;
+            }
+
             this.saveUserSettings(this.cardViewIdentifier, {
                 listMode: this.listMode,
                 sortBy: this.sortBy,
@@ -253,6 +261,22 @@ export default {
                 null,
                 Criteria.count('categoryCount', 'categories.id'),
             ));
+        },
+
+        showDefaultLayoutContextMenu(cmsPage) {
+            if (!this.acl.can('system_config:read')) {
+                return false;
+            }
+
+            if (cmsPage.type === 'product_list') {
+                return this.defaultCategoryId !== cmsPage.id;
+            }
+
+            if (cmsPage.type === 'product_detail') {
+                return this.defaultProductId !== cmsPage.id;
+            }
+
+            return false;
         },
 
         async getDefaultLayouts() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.html.twig
@@ -165,12 +165,17 @@
                                                 {% endblock %}
 
                                                 <sw-context-menu-item
-                                                    v-if="cmsPage.type === 'product_list' && defaultCategoryId !== cmsPage.id"
+                                                    v-if="showDefaultLayoutContextMenu(cmsPage)"
                                                     class="sw-cms-list-item__option-set-as-default"
-                                                    :disabled="!acl.can('system_config.editor')"
+                                                    :disabled="!acl.can('system_config:update') || !acl.can('system_config:create') || !acl.can('system_config:delete')"
                                                     @click="onOpenLayoutSetAsDefault(cmsPage)"
                                                 >
-                                                    {{ $tc('sw-cms.components.cmsListItem.setAsDefaultProductList') }}
+                                                    <template v-if="cmsPage.type == 'product_detail'">
+                                                        {{ $tc('sw-cms.components.cmsListItem.setAsDefaultProductDetail') }}
+                                                    </template>
+                                                    <template v-else>
+                                                        {{ $tc('sw-cms.components.cmsListItem.setAsDefaultProductList') }}
+                                                    </template>
                                                 </sw-context-menu-item>
 
                                                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
@@ -334,12 +339,17 @@
                                         {% endblock %}
 
                                         <sw-context-menu-item
-                                            v-if="item.type === 'product_list' && defaultCategoryId !== item.id"
+                                            v-if="showDefaultLayoutContextMenu(item)"
                                             class="sw-cms-list-item__option-set-as-default"
-                                            :disabled="!acl.can('system_config.editor')"
+                                            :disabled="!acl.can('system_config:update') || !acl.can('system_config:create') || !acl.can('system_config:delete')"
                                             @click="onOpenLayoutSetAsDefault(item)"
                                         >
-                                            {{ $tc('sw-cms.components.cmsListItem.setAsDefaultProductList') }}
+                                            <template v-if="item.type == 'product_detail'">
+                                                {{ $tc('sw-cms.components.cmsListItem.setAsDefaultProductDetail') }}
+                                            </template>
+                                            <template v-else>
+                                                {{ $tc('sw-cms.components.cmsListItem.setAsDefaultProductList') }}
+                                            </template>
                                         </sw-context-menu-item>
 
                                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
@@ -443,7 +453,8 @@
                 v-if="showLayoutSetAsDefaultModal"
                 class="sw-cms-list__confirm-set-as-default-modal"
                 :title="$tc('sw-cms.components.setDefaultLayoutModal.title')"
-                :text="$tc('sw-cms.components.setDefaultLayoutModal.infoText')"
+                :text="$tc('sw-cms.components.setDefaultLayoutModal.infoText', {
+                    cmsPageType: newDefaultLayout.type === 'product_detail' ? $tc('sw-cms.components.setDefaultLayoutModal.productType') : $tc('sw-cms.components.setDefaultLayoutModal.categoryType') })"
                 @confirm="onConfirmLayoutSetAsDefault"
                 @cancel="onCloseLayoutSetAsDefault"
                 @close="onCloseLayoutSetAsDefault"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/de-DE.json
@@ -722,7 +722,9 @@
     "components": {
       "setDefaultLayoutModal": {
         "title": "Standardlayout zuweisen",
-        "infoText": "Bitte beachte, dass alle Kategorien, die derzeit einem Standardlayout zugewiesen sind, diesem Layout zugewiesen werden und dass neu erstellte Kategorien diesem Layout automatisch zugewiesen werden. Möchtest Du dieses Layout wirklich als Standard verwenden?"
+        "infoText": "Bitte beachte, dass alle {cmsPageType}, die derzeit einem Standardlayout zugewiesen sind, diesem Layout zugewiesen werden und dass neu erstellte {cmsPageType} diesem Layout automatisch zugewiesen werden. Möchtest Du dieses Layout wirklich als Standard verwenden?",
+        "productType": "Produkte",
+        "categoryType": "Kategorien"
       },
       "cmsLayoutModal": {
         "actionCancel": "Abbrechen",

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/snippet/en-GB.json
@@ -722,7 +722,9 @@
     "components": {
       "setDefaultLayoutModal": {
         "title": "Assign default layout",
-        "infoText": "Please note that all categories that are currently assigned to a default layout will be reassigned to this layout and newly created category will automatically be assigned to it as well. Do you really want to use this layout as default?"
+        "infoText": "Please note that all {cmsPageType} that are currently assigned to a default layout will be reassigned to this layout and newly created {cmsPageType} will automatically be assigned to it as well. Do you really want to use this layout as default?",
+        "productType": "products",
+        "categoryType": "categories"
       },
       "cmsLayoutModal": {
         "actionCancel": "Cancel",


### PR DESCRIPTION
### 1. Why is this change necessary?
The ACL permissions `system_config.editor` and `system_config.read` do not exist.

### 2. What does this change do, exactly?
Correct the ACl permissions and cleanup some minor other stuff in the `sw-cms` module. See changelog for all changes.

### 3. Describe each step to reproduce the issue or behaviour.
Try to work with ACL rules.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
