### PR TITLE
fix: Added `default` node structure for the `system_config` node

### DIFF
--- a/changelog/_unreleased/2024-07-17-defined-system-config-default-node-structure.md
+++ b/changelog/_unreleased/2024-07-17-defined-system-config-default-node-structure.md
@@ -1,0 +1,9 @@
+---
+title: defined-system-config-default-node-structure
+issue: NEXT-00000
+author: Michał Daniel
+author_email: michal.daniel@webwirkung.ch
+author_github: webwirkung-michal-d
+---
+# Core
+* Added `default` node structure for the `system_config` node - allowing to override system config by environment specific config files

--- a/src/Core/Framework/DependencyInjection/Configuration.php
+++ b/src/Core/Framework/DependencyInjection/Configuration.php
@@ -856,7 +856,10 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('system_config');
 
         $rootNode = $treeBuilder->getRootNode();
-        $rootNode->variablePrototype()->end();
+        $rootNode
+            ->children()
+                ->arrayNode('default')->scalarPrototype()->end()
+            ->end();
 
         return $rootNode;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
https://issues.shopware.com/issues/NEXT-35831 issue introduced possibility to define system config through yaml `shopware.system_config` node. However - current implementation does not allow to merge system_config node settings from multiple, environment dependent yaml files.

### 2. What does this change do, exactly?
Allows to merge `shopware.system_config` yaml nodes from multiple yaml config files.

### 3. Describe each step to reproduce the issue or behaviour.
Create new yaml file for system config e.g: `config/packages/system_config.yaml` with content like:
```
shopware:
    system_config:
        default:
            core.mailerSettings.host: 'some-host'
            core.mailerSettings.port: 465
            core.mailerSettings.emailAgent: 'smtp'
```
Create another yaml file specific for `dev` environment e.g `config/packages/dev/system_config.yaml` with content:
```
shopware:
    system_config:
        default:
            core.mailerSetting.disableDelivery: true
```

Notice now that `vendor/shopware/core/System/SystemConfig/SymfonySystemConfigService.php` receives only configuration from `config/packages/dev/system_config.yaml`, all configurations from base file are compeletelly ommited. 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/webwirkung-michal-d/shopware/blob/fix/system-config-default-node-structure/changelog/_unreleased/2024-07-17-defined-system-config-default-node-structure.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
