### PR TITLE
[NEXT-37386] Add generic CartEvent interface

### DIFF
--- a/changelog/_unreleased/2024-07-22-add-cart-event-interface.md
+++ b/changelog/_unreleased/2024-07-22-add-cart-event-interface.md
@@ -1,0 +1,29 @@
+---
+title: Add generic CartEvent interface
+issue: NEXT-37386
+author: Justus Maier
+author_email: jmaier@notebooksbilliger.de
+author_github: @justusNBB
+---
+# Core
+* Added `Shopware\Core\Checkout\Cart\Event\CartEvent interface` shared by all CartEvents supporting the getCart method
+* Added Cart- & SalesChannelEvent interfaces to CartEvents:
+  * `Core/Checkout/Cart/Event/AfterLineItemAddedEvent`
+  * `Core/Checkout/Cart/Event/AfterLineItemQuantityChangedEvent`
+  * `Core/Checkout/Cart/Event/AfterLineItemRemovedEvent`
+  * `Core/Checkout/Cart/Event/BeforeLineItemAddedEvent`
+  * `Core/Checkout/Cart/Event/BeforeLineItemQuantityChangedEvent`
+  * `Core/Checkout/Cart/Event/BeforeLineItemRemovedEvent`
+  * `Core/Checkout/Cart/Event/CartBeforeSerializationEvent`
+  * `Core/Checkout/Cart/Event/CartChangedEvent`
+  * `Core/Checkout/Cart/Event/CartContextHashEvent`
+  * `Core/Checkout/Cart/Event/CartCreatedEvent`
+  * `Core/Checkout/Cart/Event/CartEvent`
+  * `Core/Checkout/Cart/Event/CartLoadedEvent`
+  * `Core/Checkout/Cart/Event/CartMergedEvent`
+  * `Core/Checkout/Cart/Event/CartSavedEvent`
+  * `Core/Checkout/Cart/Event/CartVerifyPersistEvent`
+  * `Core/Checkout/Cart/Event/LineItemRemovedEvent`
+* Deprecated `Shopware\Core\Checkout\Cart\Event\CartChangedEvent` method `getContext()` should return `Context`, the attribute name `$context` and the (missing) type of attribute `$cart`: Until this is solved CartChangedEvent cannot implement `ShopwareSalesChannelEvent`
+* Added `Shopware\Core\Checkout\Cart\Event\CartChangedEvent` method `getSalesChannelContext()` for consistency
+* Added `Shopware\Core\Checkout\Cart\Event\CartLoadedEvent` method `getContext()` for consistency

--- a/src/Core/Checkout/Cart/Event/AfterLineItemAddedEvent.php
+++ b/src/Core/Checkout/Cart/Event/AfterLineItemAddedEvent.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 #[Package('checkout')]
-class AfterLineItemAddedEvent implements ShopwareSalesChannelEvent
+class AfterLineItemAddedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
      * @var LineItem[]

--- a/src/Core/Checkout/Cart/Event/AfterLineItemQuantityChangedEvent.php
+++ b/src/Core/Checkout/Cart/Event/AfterLineItemQuantityChangedEvent.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 #[Package('checkout')]
-class AfterLineItemQuantityChangedEvent implements ShopwareSalesChannelEvent
+class AfterLineItemQuantityChangedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
      * @var array<array<string, mixed>>

--- a/src/Core/Checkout/Cart/Event/AfterLineItemRemovedEvent.php
+++ b/src/Core/Checkout/Cart/Event/AfterLineItemRemovedEvent.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 #[Package('checkout')]
-class AfterLineItemRemovedEvent implements ShopwareSalesChannelEvent
+class AfterLineItemRemovedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
      * @var LineItem[]

--- a/src/Core/Checkout/Cart/Event/BeforeLineItemAddedEvent.php
+++ b/src/Core/Checkout/Cart/Event/BeforeLineItemAddedEvent.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 #[Package('checkout')]
-class BeforeLineItemAddedEvent implements ShopwareSalesChannelEvent
+class BeforeLineItemAddedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
      * @var LineItem

--- a/src/Core/Checkout/Cart/Event/BeforeLineItemQuantityChangedEvent.php
+++ b/src/Core/Checkout/Cart/Event/BeforeLineItemQuantityChangedEvent.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 #[Package('checkout')]
-class BeforeLineItemQuantityChangedEvent implements ShopwareSalesChannelEvent
+class BeforeLineItemQuantityChangedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
      * @var LineItem

--- a/src/Core/Checkout/Cart/Event/BeforeLineItemRemovedEvent.php
+++ b/src/Core/Checkout/Cart/Event/BeforeLineItemRemovedEvent.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 #[Package('checkout')]
-class BeforeLineItemRemovedEvent implements ShopwareSalesChannelEvent
+class BeforeLineItemRemovedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
      * @var LineItem

--- a/src/Core/Checkout/Cart/Event/CartBeforeSerializationEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartBeforeSerializationEvent.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CartBeforeSerializationEvent extends Event
+class CartBeforeSerializationEvent extends Event implements CartEvent
 {
     /**
      * @param array<string> $customFieldAllowList

--- a/src/Core/Checkout/Cart/Event/CartChangedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartChangedEvent.php
@@ -8,22 +8,24 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CartChangedEvent extends Event
+class CartChangedEvent extends Event implements CartEvent
 {
     /**
+     * @deprecated tag:v6.7.0 - Param $cart will be typed and readonly when implementing ShopwareSalesChannelEvent
+     *
      * @var Cart
      */
     protected $cart;
 
     /**
+     * @deprecated tag:v6.7.0 - Param $context will be renamed to $salesChannelContext when implementing ShopwareSalesChannelEvent
+     *
      * @var SalesChannelContext
      */
     protected $context;
 
-    public function __construct(
-        Cart $cart,
-        SalesChannelContext $context
-    ) {
+    public function __construct(Cart $cart, SalesChannelContext $context)
+    {
         $this->cart = $cart;
         $this->context = $context;
     }
@@ -33,7 +35,17 @@ class CartChangedEvent extends Event
         return $this->cart;
     }
 
+    /**
+     * @deprecated tag:v6.7.0 - Should actually return Context like the other events: Use getSalesChannelContext() instead
+     */
     public function getContext(): SalesChannelContext
+    {
+        // TODO implements ShopwareSalesChannelEvent
+        // return $this->salesChannelContext->getContext();
+        return $this->getSalesChannelContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
     {
         return $this->context;
     }

--- a/src/Core/Checkout/Cart/Event/CartContextHashEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartContextHashEvent.php
@@ -11,7 +11,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CartContextHashEvent extends Event implements ShopwareSalesChannelEvent
+class CartContextHashEvent extends Event implements ShopwareSalesChannelEvent, CartEvent
 {
     public function __construct(
         protected readonly SalesChannelContext $salesChannelContext,

--- a/src/Core/Checkout/Cart/Event/CartCreatedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartCreatedEvent.php
@@ -7,7 +7,7 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CartCreatedEvent extends Event
+class CartCreatedEvent extends Event implements CartEvent
 {
     /**
      * @var Cart

--- a/src/Core/Checkout/Cart/Event/CartEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartEvent.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Cart\Event;
+
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('checkout')]
+interface CartEvent
+{
+    public function getCart(): Cart;
+}

--- a/src/Core/Checkout/Cart/Event/CartLoadedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartLoadedEvent.php
@@ -3,12 +3,14 @@
 namespace Shopware\Core\Checkout\Cart\Event;
 
 use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CartLoadedEvent extends Event
+class CartLoadedEvent extends Event implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
      * @internal
@@ -22,6 +24,11 @@ class CartLoadedEvent extends Event
     public function getCart(): Cart
     {
         return $this->cart;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
     }
 
     public function getSalesChannelContext(): SalesChannelContext

--- a/src/Core/Checkout/Cart/Event/CartMergedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartMergedEvent.php
@@ -10,7 +10,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CartMergedEvent extends Event implements ShopwareSalesChannelEvent
+class CartMergedEvent extends Event implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
      * @internal

--- a/src/Core/Checkout/Cart/Event/CartSavedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartSavedEvent.php
@@ -10,7 +10,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CartSavedEvent extends Event implements ShopwareSalesChannelEvent
+class CartSavedEvent extends Event implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
      * @var SalesChannelContext

--- a/src/Core/Checkout/Cart/Event/CartVerifyPersistEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartVerifyPersistEvent.php
@@ -10,7 +10,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class CartVerifyPersistEvent extends Event implements ShopwareSalesChannelEvent
+class CartVerifyPersistEvent extends Event implements ShopwareSalesChannelEvent, CartEvent
 {
     public function __construct(
         protected SalesChannelContext $context,

--- a/src/Core/Checkout/Cart/Event/LineItemRemovedEvent.php
+++ b/src/Core/Checkout/Cart/Event/LineItemRemovedEvent.php
@@ -11,7 +11,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class LineItemRemovedEvent extends Event implements ShopwareSalesChannelEvent
+class LineItemRemovedEvent extends Event implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
      * @var LineItem

--- a/src/Core/Framework/Adapter/Cache/CacheStateSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/CacheStateSubscriber.php
@@ -51,10 +51,10 @@ class CacheStateSubscriber implements EventSubscriberInterface
 
     public function cartChanged(CartChangedEvent $event): void
     {
-        $event->getContext()->removeState(self::STATE_CART_FILLED);
+        $event->getSalesChannelContext()->removeState(self::STATE_CART_FILLED);
 
         if ($event->getCart()->getLineItems()->count() > 0) {
-            $event->getContext()->addState(self::STATE_CART_FILLED);
+            $event->getSalesChannelContext()->addState(self::STATE_CART_FILLED);
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
It's probably not strictly necessary, more like a nice to have for (downstream) developers, allowing to handle CartEvents more generically.
Example (simplified):
```php
class CartSubscriber implements EventSubscriberInterface
{
    public function __construct(
        private SomeHandler $handler
    ) {
    }

    public static function getSubscribedEvents()
    {
        return [
            AfterLineItemAddedEvent::class => ['onAfterLineItemAdded', -9000],
            AfterLineItemRemovedEvent::class => ['onAfterLineItemRemoved', -9000],
            AfterLineItemQuantityChangedEvent::class => ['onAfterLineItemQuantityChanged', -9000],
        ];
    }

    public function onAfterLineItemAdded(AfterLineItemAddedEvent $event): void
    {
        $this->handler->handle($event->getCart());
    }
    public function onAfterLineItemRemoved(AfterLineItemRemovedEvent $event): void
    {
        $this->handler->handle($event->getCart());
    }
    public function onAfterLineItemQuantityChanged(AfterLineItemChangedEvent $event): void
    {
        $this->handler->handle($event->getCart());
    }
```


### 2. What does this change do, exactly?
Instead of duplicating code (guard, extract data & delegating to a handler usually takes more than one line) for all Events specifically with similar interfaces, subscriptions can be done independently from the implementation easily by depending on a shared interface:

For above example this requires a missing interface for now called `CartEvent` which is implemented (already) by all relevant events. (This is similar to `CartAware` but that is marked internal).
(Alternatively we are forced to use type unions for this, which may become cumbersome because of the long event names.)

Refactored Example:
```php
class CartSubscriber implements EventSubscriberInterface
{
    public function __construct(
        private SomeHandler $handler
    ) {
    }

    public static function getSubscribedEvents()
    {
        return [
            AfterLineItemAddedEvent::class => ['onCartChanged', -9000],
            AfterLineItemRemovedEvent::class => ['onCartChanged', -9000],
            AfterLineItemQuantityChangedEvent::class => ['onCartChanged', -9000],
        ];
    }

    public function onCartChanged(CartEvent $event): void
    {
        $this->handler->handle($event->getCart());
    }


```


### 3. Describe each step to reproduce the issue or behaviour.
Please see the code example above.


### 4. Please link to the relevant issues (if any).
None yet, this is just a draft/idea I want to suggest to help to reduce inconsistency, please check out the inlined `TODO?` comments and feel free to take over, as (I don't know how far you want to go with this and) I can give this only very low priority.


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have not written additional tests, as no new functionality was added, this is a refactoring change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes: not really - mainly deprecations
- [x] This change has comments for package types, values, functions, and non-obvious lines of code - even a TODO 6.7 due to BC :/
- [x] I have read the contribution requirements and fulfil them.
