### PR TITLE
feat: Add payment method name block

### DIFF
--- a/changelog/_unreleased/2024-07-19-add-component_payment_method_name-block.md
+++ b/changelog/_unreleased/2024-07-19-add-component_payment_method_name-block.md
@@ -1,0 +1,10 @@
+---
+title: Add component_payment_method_name block
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Added Twig block `component_payment_method_name` to the `storefront/component/payment/payment-method.html.twig` template
+* Deprecated empty Twig block `component_payment_fieldset_template` in the `storefront/component/payment/payment-method.html.twig` template

--- a/src/Storefront/Resources/views/storefront/component/payment/payment-method.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/payment/payment-method.html.twig
@@ -36,7 +36,11 @@
 
                             {% block component_payment_method_description %}
                                 <div class="payment-method-description">
-                                    <strong>{{ payment.translated.name }}</strong>
+                                    {% set paymentName = payment.translated.name %}
+                                    {% block component_payment_method_name %}
+                                        <strong>{{ paymentName }}</strong>
+                                    {% endblock %}
+
                                     {% if payment.translated.description %}
                                         {% set paymentDescription = payment.translated.description|raw %}
                                         {% set paymentDescriptionTitle = payment.translated.description|striptags|raw %}
@@ -58,5 +62,6 @@
         </div>
     {% endblock %}
 
+    {# @deprecated tag:v6.7.0 - Block `component_payment_fieldset_template` will be removed without replacement #}
     {% block component_payment_fieldset_template %}{% endblock %}
 </div>


### PR DESCRIPTION
### 1. Why is this change necessary?
Make it easier possible to change the payment method name. Also the empty block `component_payment_fieldset_template` should have been removed in the 6.4 update: https://github.com/shopware/shopware/blob/78dceecccd4494bdb5baf535fae0936ffa0acbf7/changelog/release-6-4-0-0/2021-03-18-6.4-breaking-changes.md?plain=1#L1105

### 2. What does this change do, exactly?
Add a block and variable for easier extension and deprecate the empty block for the next major release.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
