### PR TITLE
Only select used fields of `translation` tables

### DIFF
--- a/changelog/_unreleased/2024-08-08-only-select-used-fields-of-translation-tables.md
+++ b/changelog/_unreleased/2024-08-08-only-select-used-fields-of-translation-tables.md
@@ -1,0 +1,9 @@
+---
+title: Only select used fields of `translation` tables
+issue: NEXT-00000
+author: Sven Münnich
+author_email: sven.muennich@pickware.de
+author_github: svenmuennich
+---
+# Core
+* Changed generated database queries that join translation tables to select as few fields as possible to improve performance.

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -39,6 +39,7 @@ class DataAbstractionLayerException extends HttpException
     public const UNABLE_TO_FETCH_FOREIGN_KEY = 'FRAMEWORK__UNABLE_TO_FETCH_FOREIGN_KEY';
     public const REFERENCE_FIELD_BY_STORAGE_NAME_NOT_FOUND = 'FRAMEWORK__REFERENCE_FIELD_BY_STORAGE_NAME_NOT_FOUND';
     public const INCONSISTENT_PRIMARY_KEY = 'FRAMEWORK__INCONSISTENT_PRIMARY_KEY';
+    public const FIELD_NOT_FOUND = 'FRAMEWORK__FIELD_NOT_FOUND';
     public const FIELD_BY_STORAGE_NAME_NOT_FOUND = 'FRAMEWORK__FIELD_BY_STORAGE_NAME_NOT_FOUND';
     public const MISSING_PARENT_FOREIGN_KEY = 'FRAMEWORK__MISSING_PARENT_FOREIGN_KEY';
     public const INVALID_WRITE_INPUT = 'FRAMEWORK__INVALID_WRITE_INPUT';
@@ -248,6 +249,15 @@ class DataAbstractionLayerException extends HttpException
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::MISSING_PARENT_FOREIGN_KEY,
             \sprintf('Can not detect foreign key for parent definition %s', $entity)
+        );
+    }
+
+    public static function fieldNotFound(string $entity, string $propertyName): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::FIELD_NOT_FOUND,
+            \sprintf('Field %s not found in entity %s', $propertyName, $entity)
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/TranslationFieldResolver.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/TranslationFieldResolver.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Dbal\FieldResolver;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\QueryBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
@@ -37,22 +38,95 @@ class TranslationFieldResolver extends AbstractFieldResolver
             throw new \RuntimeException(\sprintf('Can not detect translation definition of entity %s', $definition->getEntityName()));
         }
 
+        $inherited = $definition->isInheritanceAware() && $context->getContext()->considerInheritance();
+
         $alias = $context->getAlias() . '.' . $definition->getEntityName() . '_translation';
+        $fieldAlias = $alias . '.' . $field->getPropertyName();
+        if ($context->getQuery()->hasState($fieldAlias)) {
+            return $alias;
+        }
+        $context->getQuery()->addState($fieldAlias);
+
         if ($context->getQuery()->hasState($alias)) {
+            $this->addTranslationSelects(
+                $context->getQuery(),
+                $translationDefinition,
+                $field,
+                $context->getContext(),
+                $context->getPath(),
+                $alias,
+            );
+
+            if ($inherited) {
+                $this->addTranslationSelects(
+                    $context->getQuery(),
+                    $translationDefinition,
+                    $field,
+                    $context->getContext(),
+                    $context->getPath() . '.parent',
+                    $context->getAlias() . '.parent.' . $definition->getEntityName() . '_translation',
+                );
+            }
+
             return $alias;
         }
         $context->getQuery()->addState($alias);
 
-        $variables = [
-            '#alias#' => EntityDefinitionQueryHelper::escape($alias),
-            '#foreignKey#' => EntityDefinitionQueryHelper::escape($definition->getEntityName() . '_id'),
-            '#on#' => EntityDefinitionQueryHelper::escape($context->getAlias()),
-        ];
+        $this->addTranslationJoin(
+            $context->getQuery(),
+            $definition,
+            $translationDefinition,
+            $field,
+            $context->getContext(),
+            $context->getPath(),
+            $context->getAlias(),
+        );
 
+        if ($inherited) {
+            $this->addTranslationJoin(
+                $context->getQuery(),
+                $definition,
+                $translationDefinition,
+                $field,
+                $context->getContext(),
+                $context->getPath() . '.parent',
+                $context->getAlias() . '.parent',
+            );
+        }
+
+        return $alias;
+    }
+
+    private function addTranslationSelects(
+        QueryBuilder $mainQuery,
+        EntityDefinition $translationDefinition,
+        TranslatedField $field,
+        Context $context,
+        string $path,
+        string $alias,
+    ): void {
+        $translationQuery = $mainQuery->getTranslationQueryBuilder(EntityDefinitionQueryHelper::escape($alias));
+        $translationChain = array_reverse(EntityDefinitionQueryHelper::buildTranslationChain(
+            $path,
+            $context,
+            includeParent: false,
+        ));
+        foreach ($translationChain as $translationTableAlias) {
+            $translationQuery?->addSelect($this->getSelectSQL($translationDefinition, $field, $translationTableAlias));
+        }
+    }
+
+    private function addTranslationJoin(
+        QueryBuilder $query,
+        EntityDefinition $definition,
+        EntityDefinition $translationDefinition,
+        TranslatedField $field,
+        Context $context,
+        string $path,
+        string $alias,
+    ): void {
         $rootVersionFieldName = null;
         $translatedVersionFieldName = null;
-        $versionJoin = '';
-
         if ($definition->isVersionAware()) {
             // field of the translated definition
             $rootVersionFieldName = 'version_id';
@@ -61,78 +135,62 @@ class TranslationFieldResolver extends AbstractFieldResolver
             $translatedVersionFieldName = $definition->getEntityName() . '_version_id';
         }
 
-        $query = $this->getTranslationQuery($definition, $translationDefinition, $context->getPath(), $context->getContext(), $translatedVersionFieldName);
-
-        if ($rootVersionFieldName && $translatedVersionFieldName) {
-            $variables['#rootVersionField#'] = $rootVersionFieldName;
-            $variables['#translatedVersionField#'] = $translatedVersionFieldName;
-            $versionJoin = ' AND #alias#.#translatedVersionField# = #on#.#rootVersionField#';
-        }
-
-        $context->getQuery()->leftJoin(
-            EntityDefinitionQueryHelper::escape($context->getAlias()),
-            '(' . $query->getSQL() . ')',
-            EntityDefinitionQueryHelper::escape($alias),
-            str_replace(
-                array_keys($variables),
-                array_values($variables),
-                '#alias#.#foreignKey# = #on#.`id`' . $versionJoin
-            )
+        $translationQuery = $this->getTranslationQuery(
+            $definition,
+            $this->getSelectSQL($translationDefinition, $field, '#alias#'),
+            $path,
+            $context,
+            $translatedVersionFieldName
         );
-
-        foreach ($query->getParameters() as $key => $value) {
-            $context->getQuery()->setParameter($key, $value);
+        foreach ($translationQuery->getParameters() as $key => $value) {
+            $query->setParameter($key, $value);
         }
 
-        $inherited = $definition->isInheritanceAware() && $context->getContext()->considerInheritance();
-        if (!$inherited) {
-            return $alias;
-        }
-
-        $query = $this->getTranslationQuery($definition, $translationDefinition, $context->getPath() . '.parent', $context->getContext(), $translatedVersionFieldName);
-
+        $translationAlias = $alias . '.' . $definition->getEntityName() . '_translation';
         $variables = [
-            '#alias#' => EntityDefinitionQueryHelper::escape($alias . '.parent'),
+            '#alias#' => EntityDefinitionQueryHelper::escape($translationAlias),
             '#foreignKey#' => EntityDefinitionQueryHelper::escape($definition->getEntityName() . '_id'),
-            '#on#' => EntityDefinitionQueryHelper::escape($context->getAlias() . '.parent'),
+            '#on#' => EntityDefinitionQueryHelper::escape($alias),
         ];
 
+        $versionJoin = '';
         if ($rootVersionFieldName && $translatedVersionFieldName) {
-            $variables['#rootVersionField#'] = $rootVersionFieldName;
-            $variables['#translatedVersionField#'] = $translatedVersionFieldName;
+            $variables['#rootVersionField#'] = EntityDefinitionQueryHelper::escape($rootVersionFieldName);
+            $variables['#translatedVersionField#'] = EntityDefinitionQueryHelper::escape($translatedVersionFieldName);
             $versionJoin = ' AND #alias#.#translatedVersionField# = #on#.#rootVersionField#';
         }
 
-        $context->getQuery()->leftJoin(
-            EntityDefinitionQueryHelper::escape($context->getAlias()),
-            '(' . $query->getSQL() . ')',
-            EntityDefinitionQueryHelper::escape($alias . '.parent'),
-            str_replace(
+        $query->addTranslationJoin(
+            fromAlias: EntityDefinitionQueryHelper::escape($alias),
+            joinAlias: EntityDefinitionQueryHelper::escape($translationAlias),
+            queryBuilder: $translationQuery,
+            joinCondition: str_replace(
                 array_keys($variables),
                 array_values($variables),
-                '#alias#.#foreignKey# = #on#.`id`' . $versionJoin
-            )
+                '#alias#.#foreignKey# = #on#.`id`' . $versionJoin,
+            ),
         );
-
-        return $alias;
     }
 
-    private function getSelectTemplate(EntityDefinition $definition): string
-    {
-        $select = $definition->getFields()->fmap(function (Field $field) {
-            if (!$field instanceof StorageAware) {
-                return null;
-            }
+    private function getSelectSQL(
+        EntityDefinition $translationDefinition,
+        TranslatedField $field,
+        string $alias
+    ): string {
+        $translationField = $translationDefinition->getFields()->get($field->getPropertyName());
+        if (!$translationField || !$translationField instanceof StorageAware) {
+            throw DataAbstractionLayerException::fieldNotFound(
+                $translationDefinition->getEntityName(),
+                $field->getPropertyName(),
+            );
+        }
 
-            return '`#alias#`.' . $field->getStorageName() . ' as `#alias#.' . $field->getPropertyName() . '`';
-        });
-
-        return implode(', ', $select);
+        return EntityDefinitionQueryHelper::escape($alias) . '.' . EntityDefinitionQueryHelper::escape($translationField->getStorageName()) . ' as ' . EntityDefinitionQueryHelper::escape($alias . '.' . $translationField->getPropertyName());
     }
 
     private function getTranslationQuery(
         EntityDefinition $definition,
-        EntityDefinition $translationDefinition,
+        string $select,
         string $on,
         Context $context,
         ?string $versionFieldName = null,
@@ -141,28 +199,26 @@ class TranslationFieldResolver extends AbstractFieldResolver
 
         $query = new QueryBuilder($this->connection);
 
-        $select = $this->getSelectTemplate($translationDefinition);
-
         // first language has to be the "from" part, in this case we have to use the system language to enforce we have a record
         $chain = array_reverse($context->getLanguageIdChain());
 
         $first = array_shift($chain);
         $firstAlias = $on . '.translation';
 
-        $foreignKey = EntityDefinitionQueryHelper::escape($firstAlias) . '.' . $definition->getEntityName() . '_id';
+        $foreignKey = EntityDefinitionQueryHelper::escape($firstAlias) . '.' . EntityDefinitionQueryHelper::escape($definition->getEntityName() . '_id');
 
         // used as join condition
         $query->addSelect($foreignKey);
 
         if ($versionFieldName !== null) {
-            $versionKey = EntityDefinitionQueryHelper::escape($firstAlias) . '.' . $versionFieldName;
+            $versionKey = EntityDefinitionQueryHelper::escape($firstAlias) . '.' . EntityDefinitionQueryHelper::escape($versionFieldName);
             $query->addSelect($versionKey);
         }
 
         // set first language as from part
         $query->addSelect(str_replace('#alias#', $firstAlias, $select));
         $query->from(EntityDefinitionQueryHelper::escape($table), EntityDefinitionQueryHelper::escape($firstAlias));
-        $query->where(EntityDefinitionQueryHelper::escape($firstAlias) . '.language_id = :languageId');
+        $query->where(EntityDefinitionQueryHelper::escape($firstAlias) . '.`language_id` = :languageId');
         $query->setParameter('languageId', Uuid::fromHexToBytes($first));
 
         /*
@@ -174,18 +230,18 @@ class TranslationFieldResolver extends AbstractFieldResolver
          *          `currency.translation`.currency_id,
          *          `currency.translation`.currency_version_id, (optional)
          *          `currency.translation`.`name` as `currency.translation.name`,
-         *          `currency.translation.fallback_1`.`name` as `currency.translation.fallback_1.name`,
-         *          `currency.translation.fallback_2`.`name` as `currency.translation.fallback_2.name`
+         *          `currency.translation.override_1`.`name` as `currency.translation.override_1.name`,
+         *          `currency.translation.override_2`.`name` as `currency.translation.override_2.name`
          *
          *      FROM currency_translation as `currency.translation`
          *
-         *      LEFT JOIN currency_translation as `currency.translation.fallback_1`  (optional)
-         *        ON `currency.translation`.currency_id = `currency.translation.fallback_1`.currency_id
-         *        AND `currency.translation.fallback_1`.language_id = :languageId1 #(parent language)
+         *      LEFT JOIN currency_translation as `currency.translation.override_1`  (optional)
+         *        ON `currency.translation`.currency_id = `currency.translation.override_1`.currency_id
+         *        AND `currency.translation.override_1`.language_id = :languageId1 #(parent language)
          *
-         *      LEFT JOIN currency_translation as `currency.translation.fallback_2` (optional)
-         *        ON `currency.translation`.currency_id = `currency.translation.fallback_2`.currency_id
-         *        AND `currency.translation.fallback_2`.language_id = :languageId2 #(current language)
+         *      LEFT JOIN currency_translation as `currency.translation.override_2` (optional)
+         *        ON `currency.translation`.currency_id = `currency.translation.override_2`.currency_id
+         *        AND `currency.translation.override_2`.language_id = :languageId2 #(current language)
          *
          *      WHERE `currency.translation`.language_id = :languageId #(system language)
          *
@@ -195,9 +251,9 @@ class TranslationFieldResolver extends AbstractFieldResolver
         foreach ($chain as $i => $language) {
             ++$i;
 
-            $condition = '#firstAlias#.#column# = #alias#.#column# AND #alias#.language_id = :languageId' . $i;
+            $condition = '#firstAlias#.#column# = #alias#.#column# AND #alias#.`language_id` = :languageId' . $i;
 
-            $alias = $on . '.translation.fallback_' . $i;
+            $alias = $on . '.translation.override_' . $i;
 
             $variables = [
                 '#column#' => EntityDefinitionQueryHelper::escape($definition->getEntityName() . '_id'),
@@ -206,7 +262,7 @@ class TranslationFieldResolver extends AbstractFieldResolver
             ];
 
             if ($versionFieldName !== null) {
-                $variables['#versionFieldName#'] = $versionFieldName;
+                $variables['#versionFieldName#'] = EntityDefinitionQueryHelper::escape($versionFieldName);
                 $condition .= ' AND #firstAlias#.#versionFieldName# = #alias#.#versionFieldName#';
             }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityHydratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityHydratorTest.php
@@ -149,9 +149,9 @@ class EntityHydratorTest extends TestCase
                 'test.name' => 'example',
                 'test.customTranslated' => '{"custom_test_text": null, "custom_test_check": "0"}',
                 'test.translation.customTranslated' => '{"custom_test_text": null, "custom_test_check": "0"}',
-                'test.translation.fallback_1.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
+                'test.translation.override_1.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
                 'test.parent.translation.customTranslated' => '{"custom_test_text": "PARENT DEUTSCH"}',
-                'test.parent.translation.fallback_1.customTranslated' => '{"custom_test_text": "PARENT ENGLISH", "custom_test_check": "1"}',
+                'test.parent.translation.override_1.customTranslated' => '{"custom_test_text": "PARENT ENGLISH", "custom_test_check": "1"}',
             ],
         ];
 
@@ -170,9 +170,9 @@ class EntityHydratorTest extends TestCase
                 'test.name' => 'example',
                 'test.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
                 'test.translation.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
-                'test.translation.fallback_1.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
+                'test.translation.override_1.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
                 'test.parent.translation.customTranslated' => '{"custom_test_text": "PARENT DEUTSCH"}',
-                'test.parent.translation.fallback_1.customTranslated' => '{"custom_test_text": "PARENT ENGLISH", "custom_test_check": "1"}',
+                'test.parent.translation.override_1.customTranslated' => '{"custom_test_text": "PARENT ENGLISH", "custom_test_check": "1"}',
             ],
         ];
 
@@ -190,9 +190,9 @@ class EntityHydratorTest extends TestCase
                 'test.name' => 'example',
                 'test.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
                 'test.translation.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
-                'test.translation.fallback_1.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
+                'test.translation.override_1.customTranslated' => '{"custom_test_text": null, "custom_test_check": null}',
                 'test.parent.translation.customTranslated' => '{"custom_test_text": null}',
-                'test.parent.translation.fallback_1.customTranslated' => '{"custom_test_text": "PARENT ENGLISH", "custom_test_check": "0"}',
+                'test.parent.translation.override_1.customTranslated' => '{"custom_test_text": "PARENT ENGLISH", "custom_test_check": "0"}',
             ],
         ];
 
@@ -211,11 +211,11 @@ class EntityHydratorTest extends TestCase
                 'test.name' => 'example',
                 'test.customTranslated' => '{}',
                 'test.translation.customTranslated' => '{"custom_test_inheritance": "CHILD ENGLISH"}',
-                'test.translation.fallback_1.customTranslated' => '{"custom_test_inheritance": "CHILD GERMAN"}',
-                'test.translation.fallback_2.customTranslated' => '{"custom_test_inheritance": "CHILD SWISS"}',
+                'test.translation.override_1.customTranslated' => '{"custom_test_inheritance": "CHILD GERMAN"}',
+                'test.translation.override_2.customTranslated' => '{"custom_test_inheritance": "CHILD SWISS"}',
                 'test.parent.translation.customTranslated' => '{"custom_test_text": "PARENT ENGLISH", "custom_test_inheritance": "PARENT ENGLISH"}',
-                'test.parent.translation.fallback_1.customTranslated' => '{"custom_test_check": "0", "custom_test_inheritance": "PARENT GERMAN"}',
-                'test.parent.translation.fallback_2.customTranslated' => '{"custom_test_inheritance": "PARENT SWISS"}',
+                'test.parent.translation.override_1.customTranslated' => '{"custom_test_check": "0", "custom_test_inheritance": "PARENT GERMAN"}',
+                'test.parent.translation.override_2.customTranslated' => '{"custom_test_inheritance": "PARENT SWISS"}',
             ],
         ];
 
@@ -246,7 +246,7 @@ class EntityHydratorTest extends TestCase
                 'test.name' => 'example',
                 'test.customTranslated' => '{"custom_test_text": null, "custom_test_check": "1"}',
                 'test.translation.customTranslated' => '{"custom_test_text": null, "custom_test_check": "1"}',
-                'test.translation.fallback_1.customTranslated' => '{"custom_test_text": "Example", "custom_test_check": null}',
+                'test.translation.override_1.customTranslated' => '{"custom_test_text": "Example", "custom_test_check": null}',
             ],
         ];
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Previously anytime a translated field was part of a query a full sub-select of the respective `_translation` table was joined to the main query. A "full sub-select" means a `SELECT` of all columns of the `_translation` table. This can result in a lot of overhead because depending on the storage engine of the database, e.g. `mediumtext` fields like `product_translation.description` require more page reads (i.e. disk access).

In complex, high cardinality queries, especially when they involve e.g. the `product` table, which doubles the number of joined translation tables due to requiring entity inheritance, this overhead can negatively influence the query execution plans. In fact, the same query (filtering orders based on their line items and respective products) that took a reasonable time in Shopware 6.5 ballooned to several hundred seconds with Shopware 6.6 due to a correction in filter evaluation, which leads to more joins of sub-selects in general.

### 2. What does this change do, exactly?

* This PR reduces the selected fields of joined `_translation` tables to those that are actually needed for filtering or resolving `TranslatedField`s. It does not affect queries of `_translation` tables that are needed for loading translation associations.
* This PR renames `fallback_` join aliases in the generated queries to use `override_` aliases, because their values in fact _override_ the default translations, if available. This is just cosmetics, but IMHO makes the code (and generated queries) easier to understand.
* This PR adds some more escaping to the queries that join `_translation` tables.
* **This PR currently does not add any new tests.** ~I would like to get feedback first on the general approach as well as what kind of tests (unit, integration) are expected for these changes.~ All tests added in https://github.com/shopware/shopware/pull/3839 should still pass.

### 3. Describe each step to reproduce the issue or behaviour.

For simply seeing the difference in the generated SQL queries turn on your database's query log and send the following request to the admin API:
```
POST /api/search/product

{
    "filter": [
        {
            "type": "contains",
            "field": "name",
            "value": "foo"
        }
    ]
}
```

<details>
    <summary>Generated SQL (old)</summary>

    SELECT
        `product`.`id`,
        `product`.`product_number`,
        `product`.`auto_increment`
    FROM `product`
    LEFT JOIN `product` `product.parent`
        ON `product`.`parent_id` = `product.parent`.`id`
        AND `product`.`parent_version_id` = `product.parent`.`version_id`
    LEFT JOIN (
        SELECT
            `product.translation`.product_id,
            `product.translation`.product_version_id,
            `product.translation`.meta_description AS `product.translation.metaDescription`,
            `product.translation`.name AS `product.translation.name`,
            `product.translation`.keywords AS `product.translation.keywords`,
            `product.translation`.description AS `product.translation.description`,
            `product.translation`.meta_title AS `product.translation.metaTitle`,
            `product.translation`.pack_unit AS `product.translation.packUnit`,
            `product.translation`.pack_unit_plural AS `product.translation.packUnitPlural`,
            `product.translation`.custom_search_keywords AS `product.translation.customSearchKeywords`,
            `product.translation`.slot_config AS `product.translation.slotConfig`,
            `product.translation`.custom_fields AS `product.translation.customFields`,
            `product.translation`.created_at AS `product.translation.createdAt`,
            `product.translation`.updated_at AS `product.translation.updatedAt`,
            `product.translation`.product_id AS `product.translation.productId`,
            `product.translation`.language_id AS `product.translation.languageId`,
            `product.translation`.product_version_id AS `product.translation.productVersionId`,
            `product.translation.fallback_1`.meta_description AS `product.translation.fallback_1.metaDescription`,
            `product.translation.fallback_1`.name AS `product.translation.fallback_1.name`,
            `product.translation.fallback_1`.keywords AS `product.translation.fallback_1.keywords`,
            `product.translation.fallback_1`.description AS `product.translation.fallback_1.description`,
            `product.translation.fallback_1`.meta_title AS `product.translation.fallback_1.metaTitle`,
            `product.translation.fallback_1`.pack_unit AS `product.translation.fallback_1.packUnit`,
            `product.translation.fallback_1`.pack_unit_plural AS `product.translation.fallback_1.packUnitPlural`,
            `product.translation.fallback_1`.custom_search_keywords AS `product.translation.fallback_1.customSearchKeywords`,
            `product.translation.fallback_1`.slot_config AS `product.translation.fallback_1.slotConfig`,
            `product.translation.fallback_1`.custom_fields AS `product.translation.fallback_1.customFields`,
            `product.translation.fallback_1`.created_at AS `product.translation.fallback_1.createdAt`,
            `product.translation.fallback_1`.updated_at AS `product.translation.fallback_1.updatedAt`,
            `product.translation.fallback_1`.product_id AS `product.translation.fallback_1.productId`,
            `product.translation.fallback_1`.language_id AS `product.translation.fallback_1.languageId`,
            `product.translation.fallback_1`.product_version_id AS `product.translation.fallback_1.productVersionId`
        FROM `product_translation` `product.translation`
        LEFT JOIN `product_translation` `product.translation.fallback_1`
            ON `product.translation`.`product_id` = `product.translation.fallback_1`.`product_id`
            AND `product.translation.fallback_1`.language_id = :languageId
            AND `product.translation`.product_version_id = `product.translation.fallback_1`.product_version_id
        WHERE
            `product.translation`.language_id = :languageId
    ) `product.product_translation`
        ON `product.product_translation`.`product_id` = `product`.`id`
        AND `product.product_translation`.product_version_id = `product`.version_id
    LEFT JOIN (
        SELECT
            `product.parent.translation`.product_id,
            `product.parent.translation`.product_version_id,
            `product.parent.translation`.meta_description AS `product.parent.translation.metaDescription`,
            `product.parent.translation`.name AS `product.parent.translation.name`,
            `product.parent.translation`.keywords AS `product.parent.translation.keywords`,
            `product.parent.translation`.description AS `product.parent.translation.description`,
            `product.parent.translation`.meta_title AS `product.parent.translation.metaTitle`,
            `product.parent.translation`.pack_unit AS `product.parent.translation.packUnit`,
            `product.parent.translation`.pack_unit_plural AS `product.parent.translation.packUnitPlural`,
            `product.parent.translation`.custom_search_keywords AS `product.parent.translation.customSearchKeywords`,
            `product.parent.translation`.slot_config AS `product.parent.translation.slotConfig`,
            `product.parent.translation`.custom_fields AS `product.parent.translation.customFields`,
            `product.parent.translation`.created_at AS `product.parent.translation.createdAt`,
            `product.parent.translation`.updated_at AS `product.parent.translation.updatedAt`,
            `product.parent.translation`.product_id AS `product.parent.translation.productId`,
            `product.parent.translation`.language_id AS `product.parent.translation.languageId`,
            `product.parent.translation`.product_version_id AS `product.parent.translation.productVersionId`,
            `product.parent.translation.fallback_1`.meta_description AS `product.parent.translation.fallback_1.metaDescription`,
            `product.parent.translation.fallback_1`.name AS `product.parent.translation.fallback_1.name`,
            `product.parent.translation.fallback_1`.keywords AS `product.parent.translation.fallback_1.keywords`,
            `product.parent.translation.fallback_1`.description AS `product.parent.translation.fallback_1.description`,
            `product.parent.translation.fallback_1`.meta_title AS `product.parent.translation.fallback_1.metaTitle`,
            `product.parent.translation.fallback_1`.pack_unit AS `product.parent.translation.fallback_1.packUnit`,
            `product.parent.translation.fallback_1`.pack_unit_plural AS `product.parent.translation.fallback_1.packUnitPlural`,
            `product.parent.translation.fallback_1`.custom_search_keywords AS `product.parent.translation.fallback_1.customSearchKeywords`,
            `product.parent.translation.fallback_1`.slot_config AS `product.parent.translation.fallback_1.slotConfig`,
            `product.parent.translation.fallback_1`.custom_fields AS `product.parent.translation.fallback_1.customFields`,
            `product.parent.translation.fallback_1`.created_at AS `product.parent.translation.fallback_1.createdAt`,
            `product.parent.translation.fallback_1`.updated_at AS `product.parent.translation.fallback_1.updatedAt`,
            `product.parent.translation.fallback_1`.product_id AS `product.parent.translation.fallback_1.productId`,
            `product.parent.translation.fallback_1`.language_id AS `product.parent.translation.fallback_1.languageId`,
            `product.parent.translation.fallback_1`.product_version_id AS `product.parent.translation.fallback_1.productVersionId`
        FROM `product_translation` `product.parent.translation`
        LEFT JOIN `product_translation` `product.parent.translation.fallback_1`
            ON `product.parent.translation`.`product_id` = `product.parent.translation.fallback_1`.`product_id`
            AND `product.parent.translation.fallback_1`.language_id = :languageId
            AND `product.parent.translation`.product_version_id = `product.parent.translation.fallback_1`.product_version_id
        WHERE
            `product.parent.translation`.language_id = :languageId
    ) `product.product_translation.parent`
        ON `product.product_translation.parent`.`product_id` = `product.parent`.`id`
        AND `product.product_translation.parent`.product_version_id = `product.parent`.version_id
    WHERE
        (`product`.`version_id` = :versionId)
        AND ((
            COALESCE(
                `product.translation.fallback_1.name`,
                `product.parent.translation.fallback_1.name`,
                `product.translation.name`,
                `product.parent.translation.name`
            ) LIKE :query
        ))
    LIMIT 500
</details>
<details>
    <summary>Generated SQL (new)</summary>

    SELECT
        `product`.`id`,
        `product`.`product_number`,
        `product`.`auto_increment`
    FROM `product`
    LEFT JOIN `product` `product.parent`
        ON `product`.`parent_id` = `product.parent`.`id`
        AND `product`.`parent_version_id` = `product.parent`.`version_id`
    LEFT JOIN (
        SELECT
            `product.translation`.`product_id`,
            `product.translation`.`product_version_id`,
            `product.translation`.`name` AS `product.translation.name`,
            `product.translation.override_1`.`name` AS `product.translation.override_1.name`
        FROM `product_translation` `product.translation`
        LEFT JOIN `product_translation` `product.translation.override_1`
            ON `product.translation`.`product_id` = `product.translation.override_1`.`product_id`
            AND `product.translation.override_1`.`language_id` = :languageId
            AND `product.translation`.`product_version_id` = `product.translation.override_1`.`product_version_id`
        WHERE
            `product.translation`.`language_id` = :languageId
    ) `product.product_translation`
        ON `product.product_translation`.`product_id` = `product`.`id`
        AND `product.product_translation`.`product_version_id` = `product`.`version_id`
    LEFT JOIN (
        SELECT
            `product.parent.translation`.`product_id`,
            `product.parent.translation`.`product_version_id`,
            `product.parent.translation`.`name` AS `product.parent.translation.name`,
            `product.parent.translation.override_1`.`name` AS `product.parent.translation.override_1.name`
        FROM `product_translation` `product.parent.translation`
        LEFT JOIN `product_translation` `product.parent.translation.override_1`
            ON `product.parent.translation`.`product_id` = `product.parent.translation.override_1`.`product_id`
            AND `product.parent.translation.override_1`.`language_id` = :languageId
            AND `product.parent.translation`.`product_version_id` = `product.parent.translation.override_1`.`product_version_id`
        WHERE
            `product.parent.translation`.`language_id` = :languageId
    ) `product.parent.product_translation`
        ON `product.parent.product_translation`.`product_id` = `product.parent`.`id`
        AND `product.parent.product_translation`.`product_version_id` = `product.parent`.`version_id`
    WHERE
        (`product`.`version_id` = :versionId)
        AND ((
            COALESCE(
                `product.translation.override_1.name`,
                `product.parent.translation.override_1.name`,
                `product.translation.name`,
                `product.parent.translation.name`
            ) LIKE :query
        ))
    LIMIT 500
</details>

That simple example will usually not show a difference in performance (nor query execution plan). The following request is taken from one of our applications and will drastically improve in execution time with the fix (we noticed ~60x speed up in production environments; 215s (old) vs. 3,5s (new); 20k orders, 80k order line items, 1,5k products, MySQL v8.0.34):
```
POST /api/search/order

{
    "filter": [
        {
            "type": "multi",
            "operator": "and",
            "queries": [
                {
                    "type": "equals",
                    "field": "lineItems.type",
                    "value": "product"
                },
                {
                    "type": "not",
                    "operator": "and",
                    "queries": [
                        {
                            "type": "equals",
                            "field": "lineItems.product.id",
                            "value": null
                        }
                    ]
                },
                {
                    "type": "equalsAny",
                    "field": "stateMachineState.technicalName",
                    "value": [
                        "open",
                        "in_progress"
                    ]
                },
                {
                    "type": "equalsAny",
                    "field": "transactions.stateMachineState.technicalName",
                    "value": [
                        "paid",
                        "refunded_partially"
                    ]
                },
                {
                    "type": "multi",
                    "operator": "or",
                    "queries": [
                        {
                            "type": "prefix",
                            "field": "orderNumber",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "billingAddress.firstName",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "billingAddress.lastName",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "billingAddress.company",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "billingAddress.department",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "billingAddress.street",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "billingAddress.additionalAddressLine1",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "billingAddress.additionalAddressLine2",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "billingAddress.zipcode",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "value": "Foo",
                            "field": "billingAddress.city"
                        },
                        {
                            "type": "contains",
                            "field": "billingAddress.country.name",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "customerComment",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "deliveries.shippingOrderAddress.firstName",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "deliveries.shippingOrderAddress.lastName",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "deliveries.shippingOrderAddress.company",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "deliveries.shippingOrderAddress.department",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "deliveries.shippingOrderAddress.street",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "deliveries.shippingOrderAddress.additionalAddressLine1",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "deliveries.shippingOrderAddress.additionalAddressLine2",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "deliveries.shippingOrderAddress.zipcode",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "deliveries.shippingOrderAddress.city",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "deliveries.shippingOrderAddress.country.name",
                            "value": "Foo"
                        },
                        {
                            "field": "deliveries.shippingMethod.name",
                            "type": "contains",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "lineItems.product.name",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "lineItems.product.productNumber",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "lineItems.product.ean",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "lineItems.product.manufacturer.name",
                            "value": "Foo"
                        },
                        {
                            "type": "contains",
                            "field": "lineItems.product.manufacturerNumber",
                            "value": "Foo"
                        }
                    ]
                }
            ]
        }
    ]
}
```

### 4. Please link to the relevant issues (if any).

n/a

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
