### PR TITLE
NEXT-37442 Fix variant listing config when cloning products or deleting variants

### DIFF
--- a/changelog/_unreleased/2024-07-26-fix-variant-listing-config-when-cloning-products-or-deleting-variants.md
+++ b/changelog/_unreleased/2024-07-26-fix-variant-listing-config-when-cloning-products-or-deleting-variants.md
@@ -1,0 +1,12 @@
+---
+title: Fix variant listing config when cloning products or deleting variants
+issue: NEXT-37442
+author: Felix Schneider
+author_email: felix@wirduzen.de
+author_github: schneider-felix
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal`
+to prevent changing the variant listing config of the original product on duplication
+* Changed `src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js`
+to reset mainVariantId when the corresponding variant is deleted

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js
@@ -59,7 +59,8 @@ export default {
         },
 
         async cloneParent(number) {
-            const variantListingConfigOverwrite = this.product.variantListingConfig;
+            // Create shallow copy to prevent changing the original product
+            const variantListingConfigOverwrite = { ...this.product.variantListingConfig };
             if (variantListingConfigOverwrite && variantListingConfigOverwrite.mainVariantId) {
                 variantListingConfigOverwrite.mainVariantId = null;
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/index.js
@@ -650,7 +650,7 @@ export default {
                 return;
             }
 
-            const productEntity = await this.productRepository.get(this.product.id, Shopware.Context.api);
+            const productEntity = await this.productRepository.get(this.product.id);
             const mainVariantId = productEntity.variantListingConfig?.mainVariantId;
 
             if (mainVariantId && variantIds.includes(mainVariantId)) {


### PR DESCRIPTION
I'm not entirely sure whether this change classifies as a BC break, because I changed one JS function to be async.

If that is the case, let me know and I'll revert that change and keep using then().

It would also be very helpful if this change could be backported to 6.5. If I can somehow assist in doing so, let me know.

### 1. Why is this change necessary?

When cloning a product or deleting its variants, the mainVariantId in the storefront presentation settings is not updated accordingly. This can result in a 404 page when navigating to the product from the storefront.

This issue was partially addressed with commit https://github.com/shopware/shopware/commit/c2ed3e9e600bafae63cfe8720820e593226c6f24

However this commit introduced a bug which changes the original product on duplication.

### 2. What does this change do, exactly?

It resets the mainVariantId when the referenced variant, is deleted. 

Additionally we now clone the storefront presentation settings when cloning the product. Previously the original product was also modified because a reference was used.

### 3. Describe each step to reproduce the issue or behaviour.

See ticket.

### 4. Please link to the relevant issues (if any).

https://issues.shopware.com/issues/NEXT-37442

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
