### PR TITLE
NEXT-00000 - Fix cms product slider offsetWidth error

### DIFF
--- a/changelog/_unreleased/2024-07-30-fix-cms-product-slider-offset-width-error.md
+++ b/changelog/_unreleased/2024-07-30-fix-cms-product-slider-offset-width-error.md
@@ -1,0 +1,9 @@
+---
+title: Fix cms product slider offsetWidth error
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed method `setSliderRowLimit` in `sw-cms-el-product-slider` component to check undefined `productHolder` ref when reading `offsetWidth`.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/component/index.js
@@ -104,7 +104,13 @@ export default {
         },
 
         setSliderRowLimit() {
-            if (this.currentDeviceView === 'mobile' || this.$refs.productHolder.offsetWidth < 500) {
+            const boxWidth = this.$refs.productHolder?.offsetWidth;
+
+            if (boxWidth === undefined) {
+                return;
+            }
+
+            if (this.currentDeviceView === 'mobile' || boxWidth < 500) {
                 this.sliderBoxLimit = 1;
                 return;
             }
@@ -122,7 +128,6 @@ export default {
 
             // Subtract to fake look in storefront which has more width
             const fakeLookWidth = 100;
-            const boxWidth = this.$refs.productHolder.offsetWidth;
             const elGap = 32;
             let elWidth = parseInt(this.element.config.elMinWidth.value.replace('px', ''), 10);
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Adding a product slider to a cms page throws JS error:
`TypeError: Cannot read properties of undefined (reading 'offsetWidth')`

### 2. What does this change do, exactly?
Changed method `setSliderRowLimit` in `sw-cms-el-product-slider` component to check undefined `productHolder` ref when reading `offsetWidth`.

### 3. Describe each step to reproduce the issue or behaviour.
Open browser console > edit cms page > add product slider element

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
