### PR TITLE
Fix: Add missing Twig dependency to StorefrontControllerGenerator

### DIFF
--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGenerator.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGenerator.php
@@ -28,6 +28,9 @@ class StorefrontControllerGenerator implements ScaffoldingGenerator
                 <call method="setContainer">
                     <argument type="service" id="service_container"/>
                 </call>
+                <call method="setTwig">
+                     <argument type="service" id="twig"/>
+                 </call>
             </service>
 
     EOL;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->


### 1. Why is this change necessary?

To prevent errors for the Twig dependency: ```
Class ***\ExampleController does not have twig injected. Add to your service definition a method call to setTwig with the twig instance.```
### 2. What does this change do, exactly?

This change adds a missing Twig dependency to the `StorefrontControllerGenerator` class by including a call to the `setTwig` method with the Twig service as its argument. This ensures that any generated controllers have access to the Twig service.

### 3. Describe each step to reproduce the issue or behaviour.

1. Generate a new storefront controller using the CLI `make:plugin:storefront-controller`.
2. Just visit in the browser the route of the controller which renders the example template.

### 4. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.