### PR TITLE
NO-TICKET: fixing and defined but empty aws endpoint key

### DIFF
--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
@@ -29,7 +29,7 @@ class AwsS3v3Factory implements AdapterFactoryInterface
             'region' => $options['region'],
         ];
 
-        if (\array_key_exists('endpoint', $options)) {
+        if (\array_key_exists('endpoint', $options) && $options['endpoint']) {
             $s3Opts['endpoint'] = $options['endpoint'];
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
If you defined an aws endpoint like `%env(AWS_ENDPOINT)%` in your shopware.yaml and set the AWS_ENDPOINT to "".
It generates a false endpoint url. If you dont defined the yaml key endpoint, it works.

### 2. What does this change do, exactly?
This change checks the endpoint key to and existing and not empty check.

### 3. Describe each step to reproduce the issue or behaviour.
See 1. create a aws configuration with an empty `endpoint: ""` key.

### 4. Please link to the relevant issues (if any).
No issue ticket. But see here: https://shopwarecommunity.slack.com/archives/C011VFQT7GB/p1722434704147929

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
