### PR TITLE
phpstan.neon.dist: remove references to non-existant exclude-files

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -35,18 +35,12 @@ parameters:
 
     excludePaths:
         - src/WebInstaller/Resources/
-        - src/WebInstaller/ecs.php
         - src/WebInstaller/vendor
         - src/WebInstaller/Tests/_fixtures
         - tests/e2e/cypress
 
-        - src/Core/DevOps/StaticAnalyze/Rector/ClassPackageRector.php
         # vendor patches over autoload files
         - src/Core/Framework/Adapter/Doctrine/Patch/AbstractAsset.php
-
-        # Symfony interface typehints `Predis\ClientInterface` which is by default not available
-        - src/Core/Framework/Adapter/Cache/ShopwareRedisAdapter.php
-        - src/Core/Framework/Adapter/Cache/ShopwareRedisTagAwareAdapter.php
 
         # node_modules
         - src/**/node_modules/*


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

latest PHPStan release errors on non-existant exclude-files

### 2. What does this change do, exactly?

fixes the phpstan config

### 3. Describe each step to reproduce the issue or behaviour.

run phptan [1.11.9](https://github.com/phpstan/phpstan/releases/tag/1.11.9) on the codebase

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
