### PR TITLE
NEXT-37525: Allow empty tax provider results

### DIFF
--- a/changelog/_unreleased/2024-08-02-allow-empty-tax-provider-results.md
+++ b/changelog/_unreleased/2024-08-02-allow-empty-tax-provider-results.md
@@ -1,0 +1,6 @@
+---
+title: Allow empty tax provider results
+issue: NEXT-37525
+---
+# Core
+* Adjusted method `process` in `Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor` to not throw the exception object if a tax provider result is empty, but added an early exit instead.

--- a/src/Core/Checkout/Cart/TaxProvider/TaxProviderProcessor.php
+++ b/src/Core/Checkout/Cart/TaxProvider/TaxProviderProcessor.php
@@ -58,10 +58,14 @@ class TaxProviderProcessor
             $exceptions
         );
 
-        if (!$result) {
+        if ($exceptions->hasExceptions()) {
             $this->logger->error($exceptions->getMessage(), ['error' => $exceptions]);
 
             throw $exceptions;
+        }
+
+        if (!$result) {
+            return;
         }
 
         $this->adjustment->adjust($cart, $result, $context);


### PR DESCRIPTION
### 1. Why is this change necessary?
The tax provider processor should allow handling of empty tax provider results e.g. when you use the rule "Always valid" with a tax provider and use further logic in the `provide` method, which might return an empty result.

### 2. What does this change do, exactly?
It allows the handling of empty tax provider results by not throwing the exception object if the result is empty.

### 3. Describe each step to reproduce the issue or behaviour.
See https://issues.shopware.com/issues/NEXT-37525

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-37525

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change => There is no official test case for an empty result yet
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
