### PR TITLE
fix: Remove cover of product line item if media has been deleted

### DIFF
--- a/changelog/_unreleased/2024-08-05-remove-cover-of-line-item-if-media-has-been-deleted.md
+++ b/changelog/_unreleased/2024-08-05-remove-cover-of-line-item-if-media-has-been-deleted.md
@@ -1,0 +1,9 @@
+---
+title: Remove cover of line item if media has been deleted
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed `ProductCartProcessor` to remove the cover of a product if the media has been deleted, which would otherwise result in an error if the customer tries to complete the order

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -301,9 +301,7 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
             $lineItem->setLabel($product->getTranslation('name'));
         }
 
-        if ($product->getCover()) {
-            $lineItem->setCover($product->getCover()->getMedia());
-        }
+        $lineItem->setCover($product->getCover()?->getMedia());
 
         $deliveryTime = null;
         if ($product->getDeliveryTime() !== null) {


### PR DESCRIPTION
### 1. Why is this change necessary?
When a media is deleted, which has been assigned to a product, which is in an existing cart, the order process will fail:
```
An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`xxx`.`order_line_item`, CONSTRAINT `fk.order_line_item.cover_id` FOREIGN KEY (`cover_id`) REFERENCES `media` (`id`) ON DELETE SET NULL ON UPDATE CASCADE)
```

### 2. What does this change do, exactly?
Set the cover to `null` if the media is not existing on the product anymore.

### 3. Describe each step to reproduce the issue or behaviour.
Put an item into the cart, with an cover, remove the media of the cover item, and try to complete the order.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
