### PR TITLE
NEXT-37588 - Exclude folder categories from sitemap

### DIFF
--- a/changelog/_unreleased/2024-08-05-exclude-folder-categories-from-sitemap.md
+++ b/changelog/_unreleased/2024-08-05-exclude-folder-categories-from-sitemap.md
@@ -1,0 +1,9 @@
+---
+title: Exclude folder categories from sitemap
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Changed `CategoryUrlProvider::getCategories` to exclude categories of type `folder`.

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -129,6 +129,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
         $query->andWhere('`category`.version_id = :versionId');
         $query->andWhere('`category`.active = 1');
         $query->andWhere('`category`.type != :linkType');
+        $query->andWhere('`category`.type != :folderType');
 
         $excludedCategoryIds = $this->getExcludedCategoryIds($context);
         if (!empty($excludedCategoryIds)) {
@@ -138,6 +139,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
 
         $query->setParameter('versionId', Uuid::fromHexToBytes(Defaults::LIVE_VERSION));
         $query->setParameter('linkType', CategoryDefinition::TYPE_LINK);
+        $query->setParameter('folderType', CategoryDefinition::TYPE_FOLDER);
 
         /** @var list<array{id: string, created_at: string, updated_at: string}> $result */
         $result = $query->executeQuery()->fetchAllAssociative();

--- a/src/Core/Content/Test/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/src/Core/Content/Test/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -87,10 +87,16 @@ class CategoryUrlProviderTest extends TestCase
         static::assertNull($urlResult->getNextOffset());
     }
 
-    public function testExcludeCategoryLink(): void
+    public function testExcludeCategoryLinkAndFolder(): void
     {
         $urlResult = $this->getCategoryUrlProvider()->getUrls($this->salesChannelContext, 10);
-        static::assertCount(4, $urlResult->getUrls());
+        $ids = array_map(fn ($url) => $url->getIdentifier(), $urlResult->getUrls());
+
+        // link
+        static::assertNotContains('0191233394c57345a56e1b4df4db81c3', $ids);
+
+        // folder
+        static::assertNotContains('0191233394c57345a56e1b4df521dca6', $ids);
     }
 
     private function getCategoryUrlProvider(): CategoryUrlProvider
@@ -142,9 +148,16 @@ class CategoryUrlProviderTest extends TestCase
                         'active' => true,
                     ],
                     [
+                        'id' => '0191233394c57345a56e1b4df4db81c3',
                         'name' => 'Sub 5',
                         'active' => true,
                         'type' => CategoryDefinition::TYPE_LINK,
+                    ],
+                    [
+                        'id' => '0191233394c57345a56e1b4df521dca6',
+                        'name' => 'Sub 6',
+                        'active' => true,
+                        'type' => CategoryDefinition::TYPE_FOLDER,
                     ],
                 ],
             ],


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Categories of type `folder` are not excluded in sitemaps which leads to sitemap entries like `http://localhost:8000//navigation/01912319e94f74a38fa91205c60e15fe`, resulting in 404 error pages if visited.

### 2. What does this change do, exactly?
* Changed `CategoryUrlProvider::getCategories` to exclude categories of type `folder`.

### 3. Describe each step to reproduce the issue or behaviour.
Add a category as structuring element and activate it > regenerate sitemap > failing link is present

### 4. Please link to the relevant issues (if any).
[NEXT-15026](https://issues.shopware.com/issues/NEXT-15026) - marked as fixed, but the corresponding [commit](https://github.com/shopware/shopware/commit/8c25ca02ce986b7a15cd360a6c1641cc3f651316) only applies to seo url generation, not sitemap generation

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


[NEXT-15026]: https://shopware.atlassian.net/browse/NEXT-15026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ