### PR TITLE
Fix updating thumbnails in strict mode

### DIFF
--- a/changelog/_unreleased/2024-08-07-fix-updating-thumbnails-in-strict-mode.md
+++ b/changelog/_unreleased/2024-08-07-fix-updating-thumbnails-in-strict-mode.md
@@ -1,0 +1,10 @@
+---
+title: Fix updating thumbnails in strict mode
+issue: NEXT-0000
+author: Philipp Zabel
+author_email: kontakt@philipp-zabel.de
+author_github: phizab
+---
+
+# Core
+* Added fix for updating thumbnails in strict mode

--- a/src/Core/Content/Media/Thumbnail/ThumbnailService.php
+++ b/src/Core/Content/Media/Thumbnail/ThumbnailService.php
@@ -183,7 +183,7 @@ class ThumbnailService
                 $this->indexer->handle(new MediaIndexingMessage([$media->getId()]));
 
                 return $updated;
-            }, EntityIndexerRegistry::DISABLE_INDEXING);
+            }, EntityIndexerRegistry::DISABLE_INDEXING, MediaDeletionSubscriber::SYNCHRONE_FILE_DELETE);
         });
 
         return \count($update);

--- a/src/Core/Content/Test/Media/Thumbnail/ThumbnailServiceTest.php
+++ b/src/Core/Content/Test/Media/Thumbnail/ThumbnailServiceTest.php
@@ -18,6 +18,7 @@ use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Content\Media\MediaType\DocumentType;
 use Shopware\Core\Content\Media\MediaType\ImageType;
 use Shopware\Core\Content\Media\MediaType\MediaType;
+use Shopware\Core\Content\Media\Subscriber\MediaDeletionSubscriber;
 use Shopware\Core\Content\Media\Thumbnail\ThumbnailService;
 use Shopware\Core\Content\Test\Media\MediaFixtures;
 use Shopware\Core\Framework\Context;
@@ -599,6 +600,9 @@ class ThumbnailServiceTest extends TestCase
 
         $this->thumbnailService->generate(new MediaCollection([$media]), $this->context);
 
+        // ensure synchronous file deletion is not set to be able to test updating thumbnails correctly
+        $this->context->removeState(MediaDeletionSubscriber::SYNCHRONE_FILE_DELETE);
+
         $criteria = new Criteria([$media->getId()]);
         $criteria->addAssociation('thumbnails');
 
@@ -624,6 +628,13 @@ class ThumbnailServiceTest extends TestCase
             static::assertTrue(
                 $this->getPublicFilesystem()->has($thumbnailPath),
                 'Thumbnail: ' . $thumbnailPath . ' does not exist, but it should be regenerated when in strict mode.'
+            );
+
+            $this->runWorker();
+
+            static::assertTrue(
+                $this->getPublicFilesystem()->has($thumbnailPath),
+                'Thumbnail: ' . $thumbnailPath . ' should not be deleted asynchronous after regeneration when in strict mode.'
             );
         } else {
             static::assertFalse(


### PR DESCRIPTION
### 1. Why is this change necessary?
When updating thumbnails in strict mode and the files for a thumbnail were missing before, they might be deleted again after generation, because thumbnail files are deleted asynchronous.

See https://github.com/shopware/shopware/pull/3792#issuecomment-2206220751 for more information.

### 2. What does this change do, exactly?
If thumbnails are updated, old thumbnails will always be deleted synchronous before generating new ones.

### 3. Describe each step to reproduce the issue or behaviour.
1. Delete a file of a thumbnail
2. Run `bin/console media:generate-thumbnails -s` to regenerate this file
3. Run `bin/console messenger:consume async` to handle messages, which will delete the recent created file of the thumbnail

### 4. Please link to the relevant issues (if any).
See https://github.com/shopware/shopware/pull/3748 which handles the same problem.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
