### PR TITLE
fix: add null check for deep link code

### DIFF
--- a/changelog/_unreleased/2024-08-07-add-null-check-for-deep-link-code.md
+++ b/changelog/_unreleased/2024-08-07-add-null-check-for-deep-link-code.md
@@ -1,0 +1,6 @@
+---
+title: Add null check for deep link code
+issue: NEXT-37573
+---
+# Core
+* Added missing null check for `deepLinkCode` in `Shopware\Core\Checkout\Document\Renderer\OrderDocumentCriteriaFactory`.

--- a/src/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactory.php
+++ b/src/Core/Checkout/Document/Renderer/OrderDocumentCriteriaFactory.php
@@ -44,7 +44,7 @@ final class OrderDocumentCriteriaFactory
         $criteria->getAssociation('transactions')->addSorting(new FieldSorting('createdAt'));
         $criteria->getAssociation('deliveries')->addSorting(new FieldSorting('createdAt'));
 
-        if ($deepLinkCode !== '') {
+        if ($deepLinkCode !== null && $deepLinkCode !== '') {
             $criteria->addFilter(new EqualsFilter('deepLinkCode', $deepLinkCode));
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When creating an order from outside the usual flow and not providing a `deepLinkCode` (which is not required and can be `null`), the `OrderDocumentCriteriaFactory` will only check for an empty string, but not null. This leads to a filter inside the resulting `Criteria`, which will return an empty `EntitySearchResult` (even though the filter equals to 'null').

### 2. What does this change do, exactly?
The PR adds the missing null check at the respective location.

### 3. Describe each step to reproduce the issue or behaviour.
1. Create an order without a `deepLinkCode` (with value `NULL`)
2. Try render a document e.g. invoice

### 4. Please link to the relevant issues (if any).
https://issues.shopware.com/issues/NEXT-37573

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
