### PR TITLE
Add integration tests covering searching and reading translated entities

### DIFF
--- a/changelog/_unreleased/2024-08-08-add-integration-tests-covering-searching-and-reading-translated-entities.md
+++ b/changelog/_unreleased/2024-08-08-add-integration-tests-covering-searching-and-reading-translated-entities.md
@@ -1,0 +1,9 @@
+---
+title: Add integration tests covering searching and reading translated entities
+issue: NEXT-00000
+author: Sven Münnich
+author_email: sven.muennich@pickware.de
+author_github: svenmuennich
+---
+# Core
+* Added integration tests covering `Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntitySearcher::search()` and `Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityReader::read()` when working with translated entities.

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntityReaderTest.php
@@ -1,0 +1,304 @@
+<?php
+/*
+ * Copyright (c) Pickware GmbH. All rights reserved.
+ * This file is part of software that is released under a proprietary license.
+ * You must not copy, modify, distribute, make publicly available, or execute
+ * its contents or parts thereof without express permission by the copyright
+ * holder, unless otherwise permitted by law.
+ */
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Dbal;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\CriteriaFieldsResolver;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\CriteriaQueryBuilder;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityHydrator;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityReader;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser;
+use Shopware\Core\Framework\Test\IdsCollection;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+/**
+ * @internal
+ */
+#[CoversClass(EntityReader::class)]
+class EntityReaderTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private EntityReader $entityReader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->entityReader = new EntityReader(
+            $this->getContainer()->get(Connection::class),
+            $this->getContainer()->get(EntityHydrator::class),
+            $this->getContainer()->get(EntityDefinitionQueryHelper::class),
+            $this->getContainer()->get(SqlQueryParser::class),
+            $this->getContainer()->get(CriteriaQueryBuilder::class),
+            $this->getContainer()->get('logger'),
+            $this->getContainer()->get(CriteriaFieldsResolver::class)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->getContainer()->get(Connection::class)->executeQuery('SET FOREIGN_KEY_CHECKS=1;');
+    }
+
+    public function testReadLoadsTranslationsAssociations(): void
+    {
+        $productId = $this->createProduct(
+            deDeTranslation: 'Deutscher Name',
+            defaultTranslation: null,
+        );
+
+        $criteria = new Criteria();
+        $criteria->addAssociations(['translations']);
+
+        /** @var ProductCollection $products */
+        $products = $this->entityReader->read(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            Context::createDefaultContext(),
+        );
+
+        $translations = $products->get($productId)->get('translations');
+        static::assertCount(2, $translations);
+        $deDeTranslation = $translations->filterByLanguageId($this->getDeDeLanguageId())->first();
+        static::assertEquals('Deutscher Name', $deDeTranslation->get('name'));
+    }
+
+    public function testReadLoadsTranslationsAssociationsWithCriteriaFields(): void
+    {
+        $productId = $this->createProduct(
+            deDeTranslation: 'Deutscher Name',
+            defaultTranslation: null,
+        );
+
+        $criteria = new Criteria();
+        $criteria->addAssociations(['translations']);
+        $criteria->addFields(['translations.name']);
+
+        /** @var ProductCollection $products */
+        $products = $this->entityReader->read(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            Context::createDefaultContext(),
+        );
+
+        $translations = $products->get($productId)->get('translations');
+        static::assertCount(2, $translations);
+        $deDeTranslation = $translations
+            ->filter(fn (Entity $entity) => $entity->get('languageId') === $this->getDeDeLanguageId())
+            ->first();
+        static::assertEquals('Deutscher Name', $deDeTranslation->get('name'));
+    }
+
+    public function testReadLoadsTranslatedFieldsInCorrectLanguage(): void
+    {
+        $productId = $this->createProduct(
+            deDeTranslation: 'Deutscher Name',
+            defaultTranslation: 'Default Name',
+        );
+
+        /** @var ProductCollection $products */
+        $products = $this->entityReader->read(
+            $this->getContainer()->get(ProductDefinition::class),
+            new Criteria(),
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        $translatedFields = $products->get($productId)->get('translated');
+        static::assertEquals('Deutscher Name', $translatedFields['name']);
+    }
+
+    public function testReadLoadsTranslatedFieldsInCorrectLanguageWithCriteriaFields(): void
+    {
+        $productId = $this->createProduct(
+            deDeTranslation: 'Deutscher Name',
+            defaultTranslation: 'Default name',
+        );
+
+        $criteria = new Criteria();
+        // Selecting the name field is necessary to include the the translated value in the result
+        $criteria->addFields(['name']);
+
+        /** @var ProductCollection $products */
+        $products = $this->entityReader->read(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        $translatedFields = $products->get($productId)->get('translated');
+        static::assertCount(1, $translatedFields);
+        static::assertEquals('Deutscher Name', $translatedFields['name']);
+    }
+
+    public function testReadLoadsTranslatedFieldsByApplyingLanguageOverrides(): void
+    {
+        $productId = $this->createProduct(
+            deDeTranslation: null,
+            defaultTranslation: 'Fallback name',
+        );
+
+        $criteria = new Criteria();
+        // Selecting the name field is necessary to include the the translated value in the result
+        $criteria->addFields(['name']);
+
+        /** @var ProductCollection $products */
+        $products = $this->entityReader->read(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        $translatedFields = $products->get($productId)->get('translated');
+        static::assertCount(1, $translatedFields);
+        static::assertEquals('Fallback name', $translatedFields['name']);
+    }
+
+    public function testReadLoadsTranslatedFieldsByApplyingInheritanceAndLanguageOverridesPreferringOwnTranslation(): void
+    {
+        $ids = new IdsCollection();
+        $this->createProduct(
+            deDeTranslation: 'Parent: Deutscher Name',
+            defaultTranslation: 'Parent: Fallback name',
+            productNumber: 'parent-product',
+            ids: $ids,
+        );
+        $productId = $this->createProduct(
+            deDeTranslation: 'Deutscher Name',
+            defaultTranslation: 'Fallback name',
+            parentProductNumber: 'parent-product',
+            ids: $ids,
+        );
+
+        $criteria = new Criteria();
+        // Selecting the name field is necessary to include the the translated value in the result
+        $criteria->addFields(['name']);
+
+        $context = self::createLocalizedContext([
+            $this->getDeDeLanguageId(),
+            Defaults::LANGUAGE_SYSTEM,
+        ]);
+        $context->setConsiderInheritance(true);
+
+        /** @var ProductCollection $products */
+        $products = $this->entityReader->read(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            $context,
+        );
+
+        $translatedFields = $products->get($productId)->get('translated');
+        static::assertCount(1, $translatedFields);
+        static::assertEquals('Deutscher Name', $translatedFields['name']);
+    }
+
+    public function testReadLoadsTranslatedFieldsByApplyingInheritanceAndLanguageOverridesUsingParentTranslationAsFallback(): void
+    {
+        $ids = new IdsCollection();
+        $this->createProduct(
+            deDeTranslation: 'Parent: Deutscher Name',
+            defaultTranslation: 'Parent: Fallback name',
+            productNumber: 'parent-product',
+            ids: $ids,
+        );
+        $productId = $this->createProduct(
+            deDeTranslation: null,
+            defaultTranslation: 'Fallback name',
+            parentProductNumber: 'parent-product',
+            ids: $ids,
+        );
+
+        $criteria = new Criteria();
+        // Selecting the name field is necessary to include the the translated value in the result
+        $criteria->addFields(['name']);
+
+        $context = self::createLocalizedContext([
+            $this->getDeDeLanguageId(),
+            Defaults::LANGUAGE_SYSTEM,
+        ]);
+        $context->setConsiderInheritance(true);
+
+        /** @var ProductCollection $products */
+        $products = $this->entityReader->read(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            $context,
+        );
+
+        $translatedFields = $products->get($productId)->get('translated');
+        static::assertCount(1, $translatedFields);
+        static::assertEquals('Parent: Deutscher Name', $translatedFields['name']);
+    }
+
+    private function createProduct(
+        ?string $deDeTranslation,
+        ?string $defaultTranslation,
+        string $productNumber = 'product-1',
+        ?string $parentProductNumber = null,
+        ?IdsCollection $ids = null
+    ): string {
+        $ids ??= new IdsCollection();
+        $productBuilder = new ProductBuilder($ids, $productNumber);
+        $productBuilder->price(100);
+        if ($deDeTranslation !== null) {
+            $productBuilder->translation($this->getDeDeLanguageId(), 'name', $deDeTranslation);
+        }
+        if ($defaultTranslation !== null) {
+            $productBuilder->translation(Defaults::LANGUAGE_SYSTEM, 'name', $defaultTranslation);
+        }
+        if ($parentProductNumber !== null) {
+            $productBuilder->parent($parentProductNumber);
+        }
+
+        $this->getContainer()->get('product.repository')->create(
+            [$productBuilder->build()],
+            Context::createDefaultContext()
+        );
+
+        return $ids->get($productNumber);
+    }
+
+    /**
+     * @param string[] $languageIdChain
+     */
+    private static function createLocalizedContext(array $languageIdChain): Context
+    {
+        return new Context(
+            source: new SystemSource(),
+            ruleIds: [],
+            currencyId: Defaults::CURRENCY,
+            languageIdChain: $languageIdChain,
+        );
+    }
+}

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcherTest.php
@@ -1,0 +1,425 @@
+<?php
+/*
+ * Copyright (c) Pickware GmbH. All rights reserved.
+ * This file is part of software that is released under a proprietary license.
+ * You must not copy, modify, distribute, make publicly available, or execute
+ * its contents or parts thereof without express permission by the copyright
+ * holder, unless otherwise permitted by law.
+ */
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Dbal;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Content\Test\Category\CategoryBuilder;
+use Shopware\Core\Content\Test\Product\ProductBuilder;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\CriteriaQueryBuilder;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntitySearcher;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
+use Shopware\Core\Framework\Test\IdsCollection;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+
+/**
+ * @internal
+ */
+#[CoversClass(EntitySearcher::class)]
+class EntitySearcherTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    private EntitySearcher $entitySearcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->entitySearcher = new EntitySearcher(
+            $this->getContainer()->get(Connection::class),
+            $this->getContainer()->get(EntityDefinitionQueryHelper::class),
+            $this->getContainer()->get(CriteriaQueryBuilder::class),
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->getContainer()->get(Connection::class)->executeQuery('SET FOREIGN_KEY_CHECKS=1;');
+    }
+
+    public function testSearchFiltersByTranslatedFieldsInAssociations(): void
+    {
+        $ids = new IdsCollection();
+        $this->createCategory(
+            defaultTranslation: 'Category 1',
+            deDeTranslation: null,
+            ids: $ids,
+        );
+        $this->createCategory(
+            defaultTranslation: 'Category 2',
+            deDeTranslation: 'Kategorie 2',
+            ids: $ids,
+        );
+        $productId1 = $this->createProduct(
+            productNumber: 'product-1',
+            deDeTranslation: 'Deutscher Name',
+            defaultTranslation: 'German name',
+            categories: ['Category 1'],
+            ids: $ids,
+        );
+        $this->createProduct(
+            productNumber: 'product-2',
+            deDeTranslation: 'Deutsches Produkt',
+            defaultTranslation: 'German product',
+            categories: ['Category 2'],
+            ids: $ids,
+        );
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', 'Deutscher Name'));
+        $criteria->addFilter(new EqualsFilter('categories.name', 'Category 1'));
+
+        $productIds = $this->entitySearcher->search(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        static::assertEquals([$productId1], $productIds->getIds());
+    }
+
+    public function testSearchFiltersByTranslatedFieldsInAssociationsByApplyingLanguageOverrides(): void
+    {
+        $ids = new IdsCollection();
+        $this->createCategory(
+            defaultTranslation: 'category-1',
+            deDeTranslation: 'Kategorie 1',
+            ids: $ids,
+        );
+        $this->createCategory(
+            defaultTranslation: 'category-2',
+            deDeTranslation: 'Kategorie 2',
+            ids: $ids,
+        );
+        $productId1 = $this->createProduct(
+            productNumber: 'product-1',
+            deDeTranslation: 'Deutscher Name',
+            categories: ['category-1'],
+            ids: $ids,
+        );
+        $this->createProduct(
+            productNumber: 'product-2',
+            deDeTranslation: 'Deutsches Produkt',
+            categories: ['category-2'],
+            ids: $ids,
+        );
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', 'Deutscher Name'));
+        $criteria->addFilter(new EqualsFilter('categories.name', 'Kategorie 1'));
+
+        $productIds = $this->entitySearcher->search(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        static::assertEquals([$productId1], $productIds->getIds());
+    }
+
+    public function testSearchFiltersByTranslatedFieldsByApplyingInheritanceAndLanguageOverridesPreferringOwnTranslation(): void
+    {
+        $ids = new IdsCollection();
+        $productId1 = $this->createProduct(
+            productNumber: 'product-1',
+            deDeTranslation: 'Parent: Deutscher Name',
+            defaultTranslation: 'Parent: Fallback name',
+            ids: $ids,
+        );
+        $productId2 = $this->createProduct(
+            productNumber: 'product-2',
+            deDeTranslation: 'Deutscher Name',
+            parentProductNumber: 'product-1',
+            ids: $ids,
+        );
+        // The following product should not be matched because its deDeTranslation takes precedence over the parent's
+        $this->createProduct(
+            productNumber: 'product-3',
+            deDeTranslation: 'Deutsches Produkt',
+            defaultTranslation: 'German product',
+            parentProductNumber: 'product-1',
+            ids: $ids,
+        );
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new ContainsFilter('name', 'Deutscher Name'));
+
+        $productIds = $this->entitySearcher->search(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        static::assertEquals(
+            [
+                $productId1,
+                $productId2,
+            ],
+            $productIds->getIds(),
+        );
+    }
+
+    public function testSearchAppliesTermToTranslatedFields(): void
+    {
+        $productId1 = $this->createProduct(
+            productNumber: 'product-1',
+            deDeTranslation: null,
+            defaultTranslation: 'German name',
+        );
+        $this->createProduct(
+            productNumber: 'product-2',
+            deDeTranslation: 'Deutsches Produkt',
+            defaultTranslation: 'German product',
+        );
+
+        $criteria = new Criteria();
+        $criteria->setTerm('German name');
+
+        $productIds = $this->entitySearcher->search(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        static::assertEquals([$productId1], $productIds->getIds());
+    }
+
+    public function testSearchAppliesTermToTranslatedFieldsByApplyingLanguageOverrides(): void
+    {
+        $productId1 = $this->createProduct(
+            productNumber: 'product-1',
+            deDeTranslation: 'Deutscher Name',
+            defaultTranslation: 'German name',
+        );
+        $this->createProduct(
+            productNumber: 'product-2',
+            deDeTranslation: 'Deutsches Produkt',
+            defaultTranslation: 'German product',
+        );
+
+        $criteria = new Criteria();
+        $criteria->setTerm('Deutscher Name');
+
+        $productIds = $this->entitySearcher->search(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        static::assertEquals([$productId1], $productIds->getIds());
+    }
+
+    public function testSearchAppliesQueryToTranslatedFields(): void
+    {
+        $productId1 = $this->createProduct(
+            productNumber: 'product-1',
+            deDeTranslation: null,
+            defaultTranslation: 'German name',
+        );
+        $this->createProduct(
+            productNumber: 'product-2',
+            deDeTranslation: 'Deutsches Produkt',
+            defaultTranslation: 'German product',
+        );
+
+        $criteria = new Criteria();
+        $criteria->addQuery(new ScoreQuery(new EqualsFilter('name', 'German name'), score: 100));
+
+        $productIds = $this->entitySearcher->search(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        static::assertEquals([$productId1], $productIds->getIds());
+    }
+
+    public function testSearchAppliesQueryToTranslatedFieldsByApplyingLanguageOverrides(): void
+    {
+        $productId1 = $this->createProduct(
+            productNumber: 'product-1',
+            deDeTranslation: 'Deutscher Name',
+            defaultTranslation: 'German name',
+        );
+        $this->createProduct(
+            productNumber: 'product-2',
+            deDeTranslation: 'Deutsches Produkt',
+            defaultTranslation: 'German product',
+        );
+
+        $criteria = new Criteria();
+        $criteria->addQuery(new ScoreQuery(new EqualsFilter('name', 'Deutscher Name'), score: 100));
+
+        $productIds = $this->entitySearcher->search(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        static::assertEquals([$productId1], $productIds->getIds());
+    }
+
+    public function testSearchFiltersByAndAppliesQueryToTranslatedFields(): void
+    {
+        $ids = new IdsCollection();
+        $productBuilder1 = $this->buildProduct(
+            deDeTranslation: 'Deutscher Name',
+            productNumber: 'product-1',
+            ids: $ids,
+        );
+        $productBuilder1->translation($this->getDeDeLanguageId(), 'keywords', 'Schlagwort');
+        $productBuilder2 = $this->buildProduct(
+            deDeTranslation: 'Deutsches Produkt',
+            productNumber: 'product-2',
+            ids: $ids,
+        );
+        $this->getContainer()->get('product.repository')->create(
+            [
+                $productBuilder1->build(),
+                $productBuilder2->build(),
+            ],
+            Context::createDefaultContext(),
+        );
+        $productId1 = $ids->get('product-1');
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('keywords', 'Schlagwort'));
+        $criteria->addQuery(new ScoreQuery(new ContainsFilter('name', 'Deutsch'), score: 100));
+
+        $productIds = $this->entitySearcher->search(
+            $this->getContainer()->get(ProductDefinition::class),
+            $criteria,
+            self::createLocalizedContext([
+                $this->getDeDeLanguageId(),
+                Defaults::LANGUAGE_SYSTEM,
+            ]),
+        );
+
+        static::assertEquals([$productId1], $productIds->getIds());
+    }
+
+    private function createProduct(
+        string $productNumber,
+        ?string $deDeTranslation,
+        ?string $defaultTranslation = null,
+        array $categories = [],
+        ?string $parentProductNumber = null,
+        ?IdsCollection $ids = null,
+    ): string {
+        $ids ??= new IdsCollection();
+        $productBuilder = $this->buildProduct(
+            deDeTranslation: $deDeTranslation,
+            defaultTranslation: $defaultTranslation,
+            productNumber: $productNumber,
+            parentProductNumber: $parentProductNumber,
+            ids: $ids,
+        );
+        $productBuilder->categories($categories);
+
+        $this->getContainer()->get('product.repository')->create(
+            [$productBuilder->build()],
+            Context::createDefaultContext()
+        );
+
+        return $ids->get($productNumber);
+    }
+
+    private function buildProduct(
+        ?string $deDeTranslation = null,
+        ?string $defaultTranslation = null,
+        string $productNumber = 'product-1',
+        ?string $parentProductNumber = null,
+        ?IdsCollection $ids = null,
+    ): ProductBuilder {
+        $ids ??= new IdsCollection();
+        $productBuilder = new ProductBuilder($ids, $productNumber);
+        $productBuilder->price(100);
+        if ($deDeTranslation !== null) {
+            $productBuilder->translation($this->getDeDeLanguageId(), 'name', $deDeTranslation);
+        }
+        if ($defaultTranslation !== null) {
+            $productBuilder->translation(Defaults::LANGUAGE_SYSTEM, 'name', $defaultTranslation);
+        }
+        if ($parentProductNumber !== null) {
+            $productBuilder->parent($parentProductNumber);
+        }
+
+        return $productBuilder;
+    }
+
+    private function createCategory(
+        string $defaultTranslation,
+        ?string $deDeTranslation,
+        ?IdsCollection $ids = null
+    ): string {
+        $ids ??= new IdsCollection();
+        // Category does not have a name filed but only translations, hence the default translation must be passed to
+        // the builder as the name
+        $categoryBuilder = new CategoryBuilder($ids, categoryName: $defaultTranslation);
+        if ($deDeTranslation !== null) {
+            $categoryBuilder->translation($this->getDeDeLanguageId(), 'name', $deDeTranslation);
+        }
+
+        $this->getContainer()->get('category.repository')->create(
+            [$categoryBuilder->build()],
+            Context::createDefaultContext(),
+        );
+
+        return $ids->get($defaultTranslation);
+    }
+
+    /**
+     * @param string[] $languageIdChain
+     */
+    private static function createLocalizedContext(array $languageIdChain): Context
+    {
+        return new Context(
+            source: new SystemSource(),
+            ruleIds: [],
+            currencyId: Defaults::CURRENCY,
+            languageIdChain: $languageIdChain,
+        );
+    }
+}

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcherTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/EntitySearcherTest.php
@@ -340,6 +340,9 @@ class EntitySearcherTest extends TestCase
         static::assertEquals([$productId1], $productIds->getIds());
     }
 
+    /**
+     * @param list<string> $categories
+     */
     private function createProduct(
         string $productNumber,
         ?string $deDeTranslation,
@@ -411,7 +414,7 @@ class EntitySearcherTest extends TestCase
     }
 
     /**
-     * @param string[] $languageIdChain
+     * @param list<string> $languageIdChain
      */
     private static function createLocalizedContext(array $languageIdChain): Context
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

https://github.com/shopware/shopware/pull/3819 changes which translated fields are actually selected in database queries, i.e. reducing the selected fields to a minimum. Since those changes have not been covered by any tests yet, this PR adds integration tests that will serve as a baseline for that other PR.

### 2. What does this change do, exactly?

This PR adds integration tests covering `Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntitySearcher::search()` and `Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityReader::read()` when working with translated fields. They should cover at least the scenarios mentioned in https://github.com/shopware/shopware/pull/3819#issuecomment-2270643347 plus more.

### 3. Describe each step to reproduce the issue or behaviour.

n/a

### 4. Please link to the relevant issues (if any).

- https://github.com/shopware/shopware/pull/3819

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
