### PR TITLE
Dynamic properties

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Entity.php
+++ b/src/Core/Framework/DataAbstractionLayer/Entity.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Struct\Struct;
 
 #[Package('core')]
+#[AllowDynamicProperties]
 class Entity extends Struct
 {
     /**

--- a/src/Core/Framework/Struct/Struct.php
+++ b/src/Core/Framework/Struct/Struct.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Struct;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('core')]
+#[AllowDynamicProperties]
 abstract class Struct implements \JsonSerializable, ExtendableInterface
 {
     // allows to assign array data to this object


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Many deprecated are present in my php log.
For example : Deprecated: Creation of dynamic property Shopware\Core\Content\Category\CategoryEntity::$parentVersionId is deprecated


### 2. What does this change do, exactly?
It allows to set fields that are not declared


### 3. Describe each step to reproduce the issue or behaviour.
open the deprecation log, and navigate on the storefront


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
