### PR TITLE
fix: Add visibility to block defaults

### DIFF
--- a/changelog/_unreleased/2024-08-09-add-visibility-to-cms-block-defaults.md
+++ b/changelog/_unreleased/2024-08-09-add-visibility-to-cms-block-defaults.md
@@ -1,0 +1,9 @@
+---
+title: Add visibility to cms block defaults
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Added `visibility` to `blockConfigDefaults` in the `sw-cms-detail` component such that switching the page type to "Listing Page" in the administration does not result in an error

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/index.js
@@ -189,6 +189,11 @@ export default {
                 marginLeft: null,
                 marginRight: null,
                 sizingMode: 'boxed',
+                visibility: {
+                    desktop: true,
+                    tablet: true,
+                    mobile: true,
+                },
             };
         },
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Without this change, when you switch the layout type in the administration to "Listing Page" it results in an error and a not visible block: 
![image](https://github.com/user-attachments/assets/e9dbac78-7e36-44ff-ba31-356b4a768875)

Note that on saving it is set anyway:
https://github.com/shopware/shopware/blob/db40a63b963056473632f5709ed38ace84a60ae1/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.js#L58

### 2. What does this change do, exactly?
Add the visibility to the default block configuration, as far as I can see this is the only place where it is used in the default administration.

Not sure where or how to add a test though.

### 3. Describe each step to reproduce the issue or behaviour.
Change the layout type to "Listing Page".

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
