### PR TITLE
NEXT-00000 - Add option to hide progress for indexing commands

### DIFF
--- a/changelog/_unreleased/2024-08-11-add-no-progress-option-to-indexing-commands.md
+++ b/changelog/_unreleased/2024-08-11-add-no-progress-option-to-indexing-commands.md
@@ -1,0 +1,10 @@
+---
+title: Add no-progress option to indexing commands
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+issue: NEXT-00000
+---
+
+# Core
+* Added `--no-progress` option to commands `es:index`, `es:admin:index`, `dal:refresh:index` to disable progress bars

--- a/src/Core/Framework/DataAbstractionLayer/Command/ConsoleProgressTrait.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/ConsoleProgressTrait.php
@@ -22,8 +22,6 @@ trait ConsoleProgressTrait
      */
     protected $progress;
 
-    protected bool $noProgress = false;
-
     /**
      * @return array<string, string>
      */
@@ -38,7 +36,7 @@ trait ConsoleProgressTrait
 
     public function startProgress(ProgressStartedEvent $event): void
     {
-        if (!$this->io || $this->noProgress) {
+        if (!$this->io) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Command/ConsoleProgressTrait.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/ConsoleProgressTrait.php
@@ -22,6 +22,8 @@ trait ConsoleProgressTrait
      */
     protected $progress;
 
+    protected bool $noProgress = false;
+
     /**
      * @return array<string, string>
      */
@@ -36,7 +38,7 @@ trait ConsoleProgressTrait
 
     public function startProgress(ProgressStartedEvent $event): void
     {
-        if (!$this->io) {
+        if (!$this->io || $this->noProgress) {
             return;
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/Command/RefreshIndexCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/RefreshIndexCommand.php
@@ -51,8 +51,7 @@ class RefreshIndexCommand extends Command implements EventSubscriberInterface
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->io = new ShopwareStyle($input, $output);
-        $this->noProgress = (bool) $input->getOption('no-progress');
+        $this->io = $input->getOption('no-progress') ? null : new ShopwareStyle($input, $output);
 
         $skip = \is_string($input->getOption('skip')) ? explode(',', (string) $input->getOption('skip')) : [];
         $only = \is_string($input->getOption('only')) ? explode(',', (string) $input->getOption('only')) : [];

--- a/src/Core/Framework/DataAbstractionLayer/Command/RefreshIndexCommand.php
+++ b/src/Core/Framework/DataAbstractionLayer/Command/RefreshIndexCommand.php
@@ -43,6 +43,7 @@ class RefreshIndexCommand extends Command implements EventSubscriberInterface
     protected function configure(): void
     {
         $this->addOption('use-queue', null, InputOption::VALUE_NONE, 'Ignore cache and force generation')
+            ->addOption('no-progress', null, null, 'Do not output progress bar')
             ->addOption('skip', null, InputArgument::OPTIONAL, 'Comma separated list of indexer names to be skipped')
             ->addOption('only', null, InputArgument::OPTIONAL, 'Comma separated list of indexer names to be generated')
         ;
@@ -51,6 +52,7 @@ class RefreshIndexCommand extends Command implements EventSubscriberInterface
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = new ShopwareStyle($input, $output);
+        $this->noProgress = (bool) $input->getOption('no-progress');
 
         $skip = \is_string($input->getOption('skip')) ? explode(',', (string) $input->getOption('skip')) : [];
         $only = \is_string($input->getOption('only')) ? explode(',', (string) $input->getOption('only')) : [];

--- a/src/Elasticsearch/Framework/Command/ElasticsearchAdminIndexingCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchAdminIndexingCommand.php
@@ -39,6 +39,7 @@ final class ElasticsearchAdminIndexingCommand extends Command implements EventSu
      */
     protected function configure(): void
     {
+        $this->addOption('no-progress', null, null, 'Do not output progress bar');
         $this->addOption('no-queue', null, null, 'Do not use the queue for indexing');
         $this->addOption('skip', null, InputArgument::OPTIONAL, 'Comma separated list of entity names to be skipped');
         $this->addOption('only', null, InputArgument::OPTIONAL, 'Comma separated list of entity names to be generated');
@@ -47,6 +48,7 @@ final class ElasticsearchAdminIndexingCommand extends Command implements EventSu
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->io = new ShopwareStyle($input, $output);
+        $this->noProgress = (bool) $input->getOption('no-progress');
 
         $skip = \is_string($input->getOption('skip')) ? explode(',', $input->getOption('skip')) : [];
         $only = \is_string($input->getOption('only')) ? explode(',', $input->getOption('only')) : [];

--- a/src/Elasticsearch/Framework/Command/ElasticsearchAdminIndexingCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchAdminIndexingCommand.php
@@ -47,8 +47,7 @@ final class ElasticsearchAdminIndexingCommand extends Command implements EventSu
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->io = new ShopwareStyle($input, $output);
-        $this->noProgress = (bool) $input->getOption('no-progress');
+        $this->io = $input->getOption('no-progress') ? null : new ShopwareStyle($input, $output);
 
         $skip = \is_string($input->getOption('skip')) ? explode(',', $input->getOption('skip')) : [];
         $only = \is_string($input->getOption('only')) ? explode(',', $input->getOption('only')) : [];

--- a/src/Elasticsearch/Framework/Command/ElasticsearchIndexingCommand.php
+++ b/src/Elasticsearch/Framework/Command/ElasticsearchIndexingCommand.php
@@ -12,6 +12,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -42,6 +43,7 @@ class ElasticsearchIndexingCommand extends Command
      */
     protected function configure(): void
     {
+        $this->addOption('no-progress', null, null, 'Do not output progress bar');
         $this->addOption('no-queue', null, null, 'Do not use the queue for indexing');
         $this->addOption('only', null, InputOption::VALUE_REQUIRED, 'Add entities separated by comma to indexing');
     }
@@ -58,7 +60,7 @@ class ElasticsearchIndexingCommand extends Command
             return self::FAILURE;
         }
 
-        $progressBar = new ProgressBar($output);
+        $progressBar = new ProgressBar($input->getOption('no-progress') ? new NullOutput() : $output);
         $progressBar->start();
 
         $entities = $input->getOption('only') ? explode(',', $input->getOption('only')) : [];


### PR DESCRIPTION
### 1. Why is this change necessary?

The indexing commands offer no option to disable output of the progress bars.

### 2. What does this change do, exactly?

It adds an option to hide progress for indexing commands.

### 3. Describe each step to reproduce the issue or behavior.

Execute `bin/console dal:refresh:index -h`, no option to disable progress exists.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
