### PR TITLE
NEXT-00000 - Add max length constant of text to ElasticSearch indexing

### DIFF
--- a/changelog/_unreleased/2024-08-11-add-max-length-constant-of-text-to-elastic-search-indexing.md
+++ b/changelog/_unreleased/2024-08-11-add-max-length-constant-of-text-to-elastic-search-indexing.md
@@ -1,0 +1,9 @@
+---
+title: Add max length constant of text to ElasticSearch indexing   
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+issue: NEXT-00000
+---
+# Elasticsearch
+* Added `ElasticsearchDefinition::MAX_TEXT_LENGTH` constant to define the maximum length of a text in Elasticsearch indexing.

--- a/changelog/_unreleased/2024-08-11-add-max-length-constant-of-text-to-elastic-search-indexing.md
+++ b/changelog/_unreleased/2024-08-11-add-max-length-constant-of-text-to-elastic-search-indexing.md
@@ -5,5 +5,5 @@ author_email: 25648755+M-arcus@users.noreply.github.com
 author_github: @M-arcus
 issue: NEXT-00000
 ---
-# Elasticsearch
+# Core
 * Added `ElasticsearchDefinition::MAX_TEXT_LENGTH` constant to define the maximum length of a text in Elasticsearch indexing.

--- a/src/Elasticsearch/Framework/ElasticsearchIndexingUtils.php
+++ b/src/Elasticsearch/Framework/ElasticsearchIndexingUtils.php
@@ -16,6 +16,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 #[Package('buyers-experience')]
 class ElasticsearchIndexingUtils
 {
+    public const TEXT_MAX_LENGTH = 32766;
+
     /**
      * @var array<string, array<string, string>>
      */
@@ -72,8 +74,8 @@ WHERE custom_field_set_relation.entity_name = :entity
         // Remove all html elements to save up space
         $text = strip_tags($text);
 
-        if (mb_strlen($text) >= 32766) {
-            return mb_substr($text, 0, 32766);
+        if (mb_strlen($text) >= self::TEXT_MAX_LENGTH) {
+            return mb_substr($text, 0, self::TEXT_MAX_LENGTH);
         }
 
         return $text;


### PR DESCRIPTION
### 1. Why is this change necessary?

Add max length constant of text to ElasticSearch indexing

### 2. What does this change do, exactly?

It turns the magic numbers used in the `stripText` into a constant

### 3. Describe each step to reproduce the issue or behavior.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
