### PR TITLE
NEXT-00000 - Fix minor changelog linting and creation issues

### DIFF
--- a/changelog/_unreleased/2024-08-11-fix-minor-changelog-linting-issues.md
+++ b/changelog/_unreleased/2024-08-11-fix-minor-changelog-linting-issues.md
@@ -1,0 +1,12 @@
+---
+title: Fix minor changelog linting and creation issues
+issue: NEXT-00000
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Changed description of `lint` command to fix grammar issues
+* Added new possible changelog section `# Elasticsearch` to the changelog linter
+* Changed regexes in the changelog linter to be more precise and simple
+* Changed the changelog creator to always prepend the GitHub username with an `@` symbol

--- a/composer.json
+++ b/composer.json
@@ -253,7 +253,7 @@
         "init:e2e": " ",
         "init:js": " ",
         "init:testdb": "Initializes the test database",
-        "lint": "Shorthand for the composer commands 'stylelint', 'eslint', 'ecs', 'lint:changlog' and 'lint:snippets'",
+        "lint": "Shorthand for the composer commands 'stylelint', 'eslint', 'ecs', 'lint:changelog' and 'lint:snippets'",
         "lint:changelog": "Validates changelogs",
         "lint:snippets": "Validates existence of snippets in all core-supported languages",
         "locust:init": " ",

--- a/src/Core/Framework/Changelog/ChangelogSection.php
+++ b/src/Core/Framework/Changelog/ChangelogSection.php
@@ -11,6 +11,7 @@ enum ChangelogSection: string
     case api = 'API';
     case administration = 'Administration';
     case storefront = 'Storefront';
+    case elasticsearch = 'Elasticsearch';
     case upgrade = 'Upgrade Information';
     case major = 'Next Major Version Changes';
 }

--- a/src/Core/Framework/Changelog/Command/ChangelogCreateCommand.php
+++ b/src/Core/Framework/Changelog/Command/ChangelogCreateCommand.php
@@ -78,6 +78,7 @@ class ChangelogCreateCommand extends Command
         $author = $input->getOption('author') ?? $IOHelper->ask('The author of code changes', $default['author']);
         $authorEmail = $input->getOption('author-email') ?? $IOHelper->ask('The author email of code changes', $default['authorEmail']);
         $authorGithub = $input->getOption('author-github') ?? $IOHelper->ask('The author GitHub account', $default['authorGithub']);
+        $authorGithub = '@' . ltrim($authorGithub, '@');
 
         $template = (new ChangelogDefinition())
             ->setTitle($title)

--- a/src/Core/Framework/Changelog/Processor/ChangelogGenerator.php
+++ b/src/Core/Framework/Changelog/Processor/ChangelogGenerator.php
@@ -36,9 +36,9 @@ class ChangelogGenerator extends ChangelogProcessor
     private function replaceSpecialChars(string $name): string
     {
         $name = (string) preg_replace('/[^a-z_\-0-9]/i', '-', $name);
-        $name = (string) preg_replace('/[-]{2,}/', '-', $name);
-        $name = (string) preg_replace('/[-_]+$/', '', $name);
-        $name = (string) preg_replace('/^[-_]+/', '', $name);
+        $name = (string) preg_replace('/-{2,}/', '-', $name);
+        $name = rtrim($name, '-_');
+        $name = ltrim($name, '-_');
 
         return strtolower($name);
     }

--- a/src/Core/Framework/Changelog/Processor/ChangelogValidator.php
+++ b/src/Core/Framework/Changelog/Processor/ChangelogValidator.php
@@ -19,7 +19,7 @@ class ChangelogValidator extends ChangelogProcessor
         $errors = [];
         $entries = !empty($path) ? [$path] : $this->getUnreleasedChangelogFiles();
         foreach ($entries as $entry) {
-            if (preg_match('/^([-\.\w\/]+)$/', $entry) === 0) {
+            if (preg_match('/^([-.\w\/]+)$/', $entry) === 0) {
                 $errors[$entry][] = 'Changelog has invalid filename, please use only alphanumeric characters, dots, dashes and underscores.';
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Minor fixes in changelog parts of the code.

### 2. What does this change do, exactly?

* Changed description of `lint` command to fix grammar issues
* Added new possible changelog section `# Elasticsearch` to the changelog linter
* Changed regexes in the changelog linter to be more precise and simple
* Changed the changelog creator to always prepend the GitHub username with an `@` symbol

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
