### PR TITLE
[NEXT-0000] Partial fields, seems to use Entity rather than PartialEntity?

### DIFF
--- a/src/Core/Content/Category/CategoryHydrator.php
+++ b/src/Core/Content/Category/CategoryHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class CategoryHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Media/MediaHydrator.php
+++ b/src/Core/Content/Media/MediaHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('buyers-experience')]
 class MediaHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductConfiguratorSetting/ProductConfiguratorSettingHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductConfiguratorSettingHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSelling/ProductCrossSellingHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductCrossSellingHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductCrossSellingAssignedProducts/ProductCrossSellingAssignedProductsHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductCrossSellingAssignedProductsHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductFeatureSetHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductKeywordDictionary/ProductKeywordDictionaryHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductKeywordDictionaryHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductManufacturer/ProductManufacturerHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductManufacturerHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductMedia/ProductMediaHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductMediaHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductPrice/ProductPriceHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductPriceHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductReview/ProductReviewHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductReviewHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductSearchConfigHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchConfigField/ProductSearchConfigFieldHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductSearchConfigFieldHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductSearchKeyword/ProductSearchKeywordHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductSearchKeywordHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityHydrator.php
+++ b/src/Core/Content/Product/Aggregate/ProductVisibility/ProductVisibilityHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductVisibilityHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/ProductHydrator.php
+++ b/src/Core/Content/Product/ProductHydrator.php
@@ -17,7 +17,7 @@ class ProductHydrator extends EntityHydrator
      *
      * @throws \Exception
      */
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingHydrator.php
+++ b/src/Core/Content/Product/SalesChannel/Sorting/ProductSortingHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductSortingHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/ProductExport/ProductExportHydrator.php
+++ b/src/Core/Content/ProductExport/ProductExportHydrator.php
@@ -17,7 +17,7 @@ class ProductExportHydrator extends EntityHydrator
      *
      * @throws \Exception
      */
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterHydrator.php
+++ b/src/Core/Content/ProductStream/Aggregate/ProductStreamFilter/ProductStreamFilterHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductStreamFilterHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/ProductStream/ProductStreamHydrator.php
+++ b/src/Core/Content/ProductStream/ProductStreamHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class ProductStreamHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionHydrator.php
+++ b/src/Core/Content/Property/Aggregate/PropertyGroupOption/PropertyGroupOptionHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class PropertyGroupOptionHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Content/Property/PropertyGroupHydrator.php
+++ b/src/Core/Content/Property/PropertyGroupHydrator.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('inventory')]
 class PropertyGroupHydrator extends EntityHydrator
 {
-    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context, array $partial = []): Entity
     {
         if (isset($row[$root . '.id'])) {
             $entity->id = Uuid::fromBytesToHex($row[$root . '.id']);

--- a/src/Core/Framework/Api/Serializer/JsonEntityEncoder.php
+++ b/src/Core/Framework/Api/Serializer/JsonEntityEncoder.php
@@ -104,7 +104,7 @@ class JsonEntityEncoder
                 continue;
             }
 
-            $object = $struct->getVars()[$property];
+            $object = $struct->getVars()[$property] ?? null;
 
             if ($object instanceof Collection) {
                 $objects = array_values($object->getElements());

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -536,8 +536,6 @@ class EntityHydrator
             $hydratorClass = EntityHydrator::class;
         }
 
-//        dd($partial);
-
         $hydrator = $this->container->get($hydratorClass);
 
         if (!$hydrator instanceof self) {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Chained data using "fields" Criteria Api, seems to be a "correct" Entity _(Though with partial data)_ rather than a PartialEntity

### 2. What does this change do, exactly?
Parse `$partial` to certain methods within EntityHydrator

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.






@mstegmeyer , @OliverSkroblin _(As you two were on the prior to this, NEXT-36403: https://github.com/shopware/shopware/pull/3734 I thought you might be the best guess for an answer 🙂 ) _
There still seems to be an slight isse with partial fields, this will allow support of chained data "properties.group.description".
Where this seems to become a "Entity" rather than PartialEntity.


~ Case, custom entity (ce) with orderLineItem association _(Via admin api)_
Fields: `[autoIncrement, status, createdAt, orderLineItem.unitPrice, orderLineItem.order.salesChannelId, orderLineItem.order.salesChannel.domains.url]`

Now when I check the response _(in Insomnia)_ I can see that "ce" is partial, orderLineItem as well, but the chain after orderLineItem are now the fully entities _(Though with partial data)_ wouldn't it be expected here that "Order" also should be an PartialEntity as it has the fields for "salesChannelId & salesChannel.domains"?
I might be confused here but wouldn't it be better if "$partial" were to be parsed _(Within:hydrateFields, assign, manyToOne)_ and set accordingly via the method `hydrateEntity` and then replace `self::$partial` with the parsed `$partial`?


Note:
I haven't fully tested this as I rant out of time, so ATM this is more ore less a question rather than this is a bug or me being confused.
As EntityHydration::assign has a new parameter, this is a protential minor breaking change