### PR TITLE
feat: add width and height attributes for images to improve Google's Core Web Vitals CLS score

### DIFF
--- a/changelog/_unreleased/2024-14-08-width-height-for-images.md
+++ b/changelog/_unreleased/2024-14-08-width-height-for-images.md
@@ -1,0 +1,9 @@
+---
+title: Add width and height attributes for images
+issue: 
+author: Jesper Ingels
+author_email: jesper.ingels@gmail.com
+author_github: @jesperingels
+---
+# Storefront
+* Added width and height attributes with intrinsic width and height values of the image itself.

--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -33,6 +33,14 @@
         {% set attributes = attributes|merge({ loading: 'eager' }) %}
     {% endif %}
 
+    {% if attributes.width is not defined and media.metaData.width %}
+        {% set attributes = attributes|merge({ 'width': media.metaData.width }) %}
+    {% endif %}
+
+    {% if attributes.height is not defined and media.metaData.height %}
+        {% set attributes = attributes|merge({ 'height': media.metaData.height }) %}
+    {% endif %}
+
     {# uses cms block column count and all available thumbnails to determine the correct image size for the current viewport #}
     {% if media.thumbnails|length > 0 %}
         {% if autoColumnSizes and columns and sizes is not defined %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When images do not have a width or height attribute, the browser doesn't know how much space the image will relatively occupy. Only when the image has been downloaded and is being rendered does the browser know the width and height. This will then cause a layout shift, pushing down any content below the image. This results in a poor user experience and your site will score poorly on Google's Core Web Vitals, negatively impacting the site's SEO ranking.

###  2. What does this change do, exactly?
This change ensures that all images uploaded in Shopware have a width and height attribute assigned to them on the storefront.

###  3. Describe each step to reproduce the issue or behavior.
When inspecting any image in Shopware, it's highly likely that the image doesn't have a width or height attribute. It's also likely that you'll see a layout shift unless some styling is in place to prevent this. However, relying on styling to prevent layout shifts caused by images is unnecessary code, as this can be prevented by simply adding a width and height attribute.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
