### PR TITLE
NEXT-00000 - Fix data-grid column ordering

### DIFF
--- a/changelog/_unreleased/2024-08-14-fix-data-grid-column-ordering.md
+++ b/changelog/_unreleased/2024-08-14-fix-data-grid-column-ordering.md
@@ -1,0 +1,9 @@
+---
+title: Fix data-grid column ordering
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `onClickChangeColumnOrderUp` and `onClickChangeColumnOrderDown` methods of `sw-data-grid-settings` component to recieve `column` instead of `index` as parameter. The column index is evaluated from `currentColumns` now.

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-settings/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-settings/index.js
@@ -88,11 +88,15 @@ Component.register('sw-data-grid-settings', {
             this.$emit('change-column-visibility', value, index);
         },
 
-        onClickChangeColumnOrderUp(columnIndex) {
+        onClickChangeColumnOrderUp(column) {
+            const columnIndex = this.currentColumns.findIndex((col) => col.property === column.property);
+
             this.$emit('change-column-order', columnIndex, columnIndex - 1);
         },
 
-        onClickChangeColumnOrderDown(columnIndex) {
+        onClickChangeColumnOrderDown(column) {
+            const columnIndex = this.currentColumns.findIndex((col) => col.property === column.property);
+
             this.$emit('change-column-order', columnIndex, columnIndex + 1);
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-settings/sw-data-grid-settings.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-settings/sw-data-grid-settings.html.twig
@@ -113,7 +113,7 @@
                     size="x-small"
                     square
                     :disabled="index === 0"
-                    @click="onClickChangeColumnOrderUp(index)"
+                    @click="onClickChangeColumnOrderUp(column)"
                 >
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_data_grid_settings_column_control_up_icon %}
@@ -132,7 +132,7 @@
                     square
                     :disabled="index === (currentColumns.length - 1)"
                     class="down"
-                    @click="onClickChangeColumnOrderDown(index)"
+                    @click="onClickChangeColumnOrderDown(column)"
                 >
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_data_grid_settings_column_control_down_icon %}

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-settings/sw-data-grid-settings.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-settings/sw-data-grid-settings.spec.js
@@ -14,6 +14,9 @@ describe('components/data-grid/sw-data-grid-settings', () => {
                 columns: [
                     { property: 'name', label: 'Name' },
                     { property: 'company', label: 'Company' },
+                    { property: 'number', label: 'Number' },
+                    { property: 'date', label: 'Date' },
+                    { property: 'address', label: 'Address' },
                 ],
                 compact: true,
                 previews: false,
@@ -28,8 +31,10 @@ describe('components/data-grid/sw-data-grid-settings', () => {
                     'sw-base-field': await wrapTestComponent('sw-base-field', { sync: true }),
                     'sw-switch-field': await wrapTestComponent('sw-switch-field', { sync: true }),
                     'sw-switch-field-deprecated': await wrapTestComponent('sw-switch-field-deprecated', { sync: true }),
-                    'sw-checkbox-field': true,
-                    'sw-button': true,
+                    'sw-checkbox-field': await wrapTestComponent('sw-checkbox-field', { sync: true }),
+                    'sw-checkbox-field-deprecated': await wrapTestComponent('sw-checkbox-field-deprecated', { sync: true }),
+                    'sw-button': await wrapTestComponent('sw-button', { sync: true }),
+                    'sw-button-deprecated': await wrapTestComponent('sw-button-deprecated', { sync: true }),
                     'sw-icon': true,
                     'sw-context-menu-divider': true,
                     'sw-button-group': true,
@@ -57,6 +62,72 @@ describe('components/data-grid/sw-data-grid-settings', () => {
 
     it('should render a row for each item in column prop', async () => {
         const rows = wrapper.findAll('.sw-data-grid__settings-column-item');
-        expect(rows).toHaveLength(2);
+        expect(rows).toHaveLength(5);
+    });
+
+    it('should order columns correctly', async () => {
+        const expectOrder = (expectedColumns) => {
+            const columns = wrapper.findAll('.sw-data-grid__settings-column-list .sw-field__label');
+
+            expectedColumns.forEach((column, index) => {
+                expect(columns.at(index).text()).toBe(column);
+            });
+        };
+
+        expectOrder(['Name', 'Company', 'Number', 'Date', 'Address']);
+
+        // move company from 1 to 2
+        let companyDownButton = wrapper.find('.sw-data-grid__settings-item--1 .sw-button.down');
+        await companyDownButton.trigger('click');
+
+        expect(wrapper.emitted('change-column-order')[0]).toEqual([1, 2]);
+
+        await wrapper.setProps({
+            columns: [
+                { property: 'name', label: 'Name' },
+                { property: 'number', label: 'Number' },
+                { property: 'company', label: 'Company' },
+                { property: 'date', label: 'Date' },
+                { property: 'address', label: 'Address' },
+            ],
+        });
+
+        expectOrder(['Name', 'Number', 'Company', 'Date', 'Address']);
+
+        // move company from 2 to 3
+        companyDownButton = wrapper.find('.sw-data-grid__settings-item--2 .sw-button.down');
+        await companyDownButton.trigger('click');
+
+        expect(wrapper.emitted('change-column-order')[1]).toEqual([2, 3]);
+
+        await wrapper.setProps({
+            columns: [
+                { property: 'name', label: 'Name' },
+                { property: 'number', label: 'Number' },
+                { property: 'date', label: 'Date' },
+                { property: 'company', label: 'Company' },
+                { property: 'address', label: 'Address' },
+            ],
+        });
+
+        expectOrder(['Name', 'Number', 'Date', 'Company', 'Address']);
+
+        // move date from 2 to 1
+        const dateUpButton = wrapper.find('.sw-data-grid__settings-item--2 .sw-button:not(.down)');
+        await dateUpButton.trigger('click');
+
+        expect(wrapper.emitted('change-column-order')[2]).toEqual([2, 1]);
+
+        await wrapper.setProps({
+            columns: [
+                { property: 'name', label: 'Name' },
+                { property: 'date', label: 'Date' },
+                { property: 'number', label: 'Number' },
+                { property: 'company', label: 'Company' },
+                { property: 'address', label: 'Address' },
+            ],
+        });
+
+        expectOrder(['Name', 'Date', 'Number', 'Company', 'Address']);
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Column ordering in any Data-Grid of Administration is not working as expected.

### 2. What does this change do, exactly?
* Changed `onClickChangeColumnOrderUp` and `onClickChangeColumnOrderDown` methods of `sw-data-grid-settings` component to recieve `column` instead of `index` as parameter. The column index is evaluated from `currentColumns` now.

### 3. Describe each step to reproduce the issue or behaviour.
Administration > order/product overview > open listing settings > move one column down > move the same column down again

**Expected result:** column goes down
**Actual result:** column goes up

When moving multiple different columns, sometimes even other columns jump around.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
