### PR TITLE
Add composer name to `plugin:list` output for quicker access

### DIFF
--- a/changelog/_unreleased/2024-08-15-add-composer-name-to-plugin-list-command.md
+++ b/changelog/_unreleased/2024-08-15-add-composer-name-to-plugin-list-command.md
@@ -1,0 +1,6 @@
+---
+title: add-composer-name-to-plugin-list-command
+issue: -
+---
+# Core
+* Add composer name to `plugin:list` output for quicker access

--- a/changelog/_unreleased/2024-08-15-add-composer-name-to-plugin-list-command.md
+++ b/changelog/_unreleased/2024-08-15-add-composer-name-to-plugin-list-command.md
@@ -1,6 +1,6 @@
 ---
 title: add-composer-name-to-plugin-list-command
-issue: -
+issue: NEXT-00000
 ---
 # Core
-* Add composer name to `plugin:list` output for quicker access
+* Added: Add composer name to `plugin:list` output for quicker access

--- a/changelog/_unreleased/2024-08-15-add-composer-name-to-plugin-list-command.md
+++ b/changelog/_unreleased/2024-08-15-add-composer-name-to-plugin-list-command.md
@@ -4,3 +4,4 @@ issue: NEXT-00000
 ---
 # Core
 * Added: Add composer name to `plugin:list` output for quicker access
+* Changed: Cap character limit for label column to 40 characters

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\ComposerPluginLoader;
 use Shopware\Core\Framework\Plugin\PluginCollection;
+use Shopware\Core\Framework\Plugin\PluginEntity;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -82,6 +83,7 @@ class PluginListCommand extends Command
             $io->comment(\sprintf('Filtering for: %s', $filter));
         }
 
+        /** @var PluginEntity $plugin */
         foreach ($plugins as $plugin) {
             $pluginActive = $plugin->getActive();
             $pluginInstalled = $plugin->getInstalledAt();
@@ -90,6 +92,7 @@ class PluginListCommand extends Command
             $pluginTable[] = [
                 $plugin->getName(),
                 $plugin->getLabel(),
+                $plugin->getComposerName() ?? '',
                 $plugin->getVersion(),
                 $pluginUpgradeable,
                 $plugin->getAuthor(),
@@ -120,8 +123,10 @@ class PluginListCommand extends Command
             if (isset($composerInstalledAndRegistered[$composerName])) {
                 continue;
             }
+
             $pluginTable[] = [
                 $plugin['name'],
+                '',
                 '',
                 $plugin['version'],
                 '',
@@ -134,7 +139,7 @@ class PluginListCommand extends Command
         }
 
         $io->table(
-            ['Plugin', 'Label', 'Version', 'Upgrade version', 'Author', 'Installed', 'Active', 'Upgradeable', 'Required by composer'],
+            ['Plugin', 'Label', 'Composer name', 'Version', 'Upgrade version', 'Author', 'Installed', 'Active', 'Upgradeable', 'Required by composer'],
             $pluginTable
         );
         $io->text(

--- a/src/Core/Framework/Plugin/Command/PluginListCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginListCommand.php
@@ -91,7 +91,7 @@ class PluginListCommand extends Command
 
             $pluginTable[] = [
                 $plugin->getName(),
-                $plugin->getLabel(),
+                mb_strimwidth($plugin->getLabel(), 0, 40, '...'),
                 $plugin->getComposerName() ?? '',
                 $plugin->getVersion(),
                 $pluginUpgradeable,

--- a/tests/unit/Core/Framework/Plugin/Command/PluginListCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/PluginListCommandTest.php
@@ -56,6 +56,7 @@ class PluginListCommandTest extends TestCase
             'upgradeVersion' => '3.0.1',
             'name' => 'Plugin List Plugin',
             'label' => 'plp',
+            'composerName' => 'plugin/list',
             'version' => '2.5.3',
             'author' => 'Fabian Blechschmidt',
         ]);
@@ -67,6 +68,7 @@ class PluginListCommandTest extends TestCase
             'upgradeVersion' => '6.0.0',
             'name' => 'Shopware Next',
             'label' => 'swn',
+            'composerName' => null,
             'version' => '5.5.3',
             'author' => 'Shopware AG',
         ]);

--- a/tests/unit/Core/Framework/Plugin/Command/PluginListCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/PluginListCommandTest.php
@@ -80,7 +80,7 @@ class PluginListCommandTest extends TestCase
             'upgradeVersion' => '1.0.0',
             'composerName' => 'shopware/test-plugin',
             'name' => 'Shopware Test',
-            'label' => 'SMP',
+            'label' => 'I\'ve had issues in the past with ridiculously long labels from store plugins, so we just cap the label at max 40 characters.',
             'version' => '0.7.12',
             'author' => 'Shopware AG',
         ]);

--- a/tests/unit/Core/Framework/Plugin/_assertions/PluginListCommandTest-testCommand.txt
+++ b/tests/unit/Core/Framework/Plugin/_assertions/PluginListCommandTest-testCommand.txt
@@ -1,13 +1,13 @@
 Shopware Plugin Service
 =======================
 
--------------------- ------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
-Plugin               Label   Version   Upgrade version   Author                Installed   Active   Upgradeable   Required by composer
--------------------- ------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
-Plugin List Plugin   plp     2.5.3     3.0.1             Fabian Blechschmidt   Yes         Yes      Yes           No
-Shopware Next        swn     5.5.3     6.0.0             Shopware AG           Yes         No       Yes           No
-Shopware Test        SMP     0.7.12    1.0.0             Shopware AG           Yes         No       Yes           Yes
-Somevendor Payment           1.0.7                                             No          No                     Yes
--------------------- ------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
+-------------------- ------- ---------------------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
+Plugin               Label   Composer name          Version   Upgrade version   Author                Installed   Active   Upgradeable   Required by composer
+-------------------- ------- ---------------------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
+Plugin List Plugin   plp     plugin/list            2.5.3     3.0.1             Fabian Blechschmidt   Yes         Yes      Yes           No
+Shopware Next        swn                            5.5.3     6.0.0             Shopware AG           Yes         No       Yes           No
+Shopware Test        SMP     shopware/test-plugin   0.7.12    1.0.0             Shopware AG           Yes         No       Yes           Yes
+Somevendor Payment                                  1.0.7                                             No          No                     Yes
+-------------------- ------- ---------------------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
 
 4 plugins, 3 installed, 1 active , 3 upgradeable

--- a/tests/unit/Core/Framework/Plugin/_assertions/PluginListCommandTest-testCommand.txt
+++ b/tests/unit/Core/Framework/Plugin/_assertions/PluginListCommandTest-testCommand.txt
@@ -1,13 +1,13 @@
 Shopware Plugin Service
 =======================
 
--------------------- ------- ---------------------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
-Plugin               Label   Composer name          Version   Upgrade version   Author                Installed   Active   Upgradeable   Required by composer
--------------------- ------- ---------------------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
-Plugin List Plugin   plp     plugin/list            2.5.3     3.0.1             Fabian Blechschmidt   Yes         Yes      Yes           No
-Shopware Next        swn                            5.5.3     6.0.0             Shopware AG           Yes         No       Yes           No
-Shopware Test        SMP     shopware/test-plugin   0.7.12    1.0.0             Shopware AG           Yes         No       Yes           Yes
-Somevendor Payment                                  1.0.7                                             No          No                     Yes
--------------------- ------- ---------------------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
+-------------------- ------------------------------------------ ---------------------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
+Plugin               Label                                      Composer name          Version   Upgrade version   Author                Installed   Active   Upgradeable   Required by composer
+-------------------- ------------------------------------------ ---------------------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
+Plugin List Plugin   plp                                        plugin/list            2.5.3     3.0.1             Fabian Blechschmidt   Yes         Yes      Yes           No
+Shopware Next        swn                                                               5.5.3     6.0.0             Shopware AG           Yes         No       Yes           No
+Shopware Test        I've had issues in the past with ridi...   shopware/test-plugin   0.7.12    1.0.0             Shopware AG           Yes         No       Yes           Yes
+Somevendor Payment                                                                     1.0.7                                             No          No                     Yes
+-------------------- ------------------------------------------ ---------------------- --------- ----------------- --------------------- ----------- -------- ------------- ----------------------
 
 4 plugins, 3 installed, 1 active , 3 upgradeable


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
For convenience. Often times, I want to `composer remove` a plugin but first I need to check if it is installed or not. And if I'm running `bin/console plugin:refresh`, why not make the composer name copy pastable from there.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
