### PR TITLE
NEXT-37757 - Add Context to OrderStateChangeCriteriaEvent

### DIFF
--- a/changelog/_unreleased/2024-08-19-add-context-to-orderstatechangecriteriaevent.md
+++ b/changelog/_unreleased/2024-08-19-add-context-to-orderstatechangecriteriaevent.md
@@ -9,8 +9,6 @@ author: wexoag
 ___
 # Next Major Version Changes
 ## Breaking Change 1:
-* Do this
-## Breaking Change 2:
 change
 ```
 $event = new OrderStateChangeCriteriaEvent($orderId, $criteria);

--- a/changelog/_unreleased/2024-08-19-add-context-to-orderstatechangecriteriaevent.md
+++ b/changelog/_unreleased/2024-08-19-add-context-to-orderstatechangecriteriaevent.md
@@ -1,0 +1,21 @@
+---
+title: Add Context to OrderStateChangeCriteriaEvent
+issue: NEXT-37757
+flag: V6_7_0_0
+author: wexoag
+---
+# Core
+* Added `Context` to `OrderStateChangeCriteriaEvent` which now also implements `ShopwareEvent`
+___
+# Next Major Version Changes
+## Breaking Change 1:
+* Do this
+## Breaking Change 2:
+change
+```
+$event = new OrderStateChangeCriteriaEvent($orderId, $criteria);
+```
+to
+```
+$event = new OrderStateChangeCriteriaEvent($orderId, $criteria, $context);
+```

--- a/src/Core/Checkout/Order/Event/OrderStateChangeCriteriaEvent.php
+++ b/src/Core/Checkout/Order/Event/OrderStateChangeCriteriaEvent.php
@@ -4,11 +4,12 @@ namespace Shopware\Core\Checkout\Order\Event;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class OrderStateChangeCriteriaEvent extends Event
+class OrderStateChangeCriteriaEvent extends Event implements ShopwareEvent
 {
     public function __construct(
         private readonly string $orderId,

--- a/src/Core/Checkout/Order/Event/OrderStateChangeCriteriaEvent.php
+++ b/src/Core/Checkout/Order/Event/OrderStateChangeCriteriaEvent.php
@@ -5,31 +5,54 @@ namespace Shopware\Core\Checkout\Order\Event;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\ShopwareEvent;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
-#[Package('checkout')]
-class OrderStateChangeCriteriaEvent extends Event implements ShopwareEvent
-{
-    public function __construct(
-        private readonly string $orderId,
-        private readonly Criteria $criteria,
-        private readonly Context $context,
-    ) {
-    }
-
-    public function getOrderId(): string
+if (Feature::isActive('v6.7.0.0')) {
+    #[Package('checkout')]
+    class OrderStateChangeCriteriaEvent extends Event implements ShopwareEvent
     {
-        return $this->orderId;
-    }
+        public function __construct(
+            private readonly string $orderId,
+            private readonly Criteria $criteria,
+            private readonly Context $context,
+        ) {
+        }
 
-    public function getCriteria(): Criteria
-    {
-        return $this->criteria;
-    }
+        public function getOrderId(): string
+        {
+            return $this->orderId;
+        }
 
-    public function getContext(): Context
+        public function getCriteria(): Criteria
+        {
+            return $this->criteria;
+        }
+
+        public function getContext(): Context
+        {
+            return $this->context;
+        }
+    }
+} else {
+    #[Package('checkout')]
+    class OrderStateChangeCriteriaEvent extends Event
     {
-        return $this->context;
+        public function __construct(
+            private readonly string $orderId,
+            private readonly Criteria $criteria
+        ) {
+        }
+
+        public function getOrderId(): string
+        {
+            return $this->orderId;
+        }
+
+        public function getCriteria(): Criteria
+        {
+            return $this->criteria;
+        }
     }
 }

--- a/src/Core/Checkout/Order/Event/OrderStateChangeCriteriaEvent.php
+++ b/src/Core/Checkout/Order/Event/OrderStateChangeCriteriaEvent.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Order\Event;
 
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
@@ -11,7 +12,8 @@ class OrderStateChangeCriteriaEvent extends Event
 {
     public function __construct(
         private readonly string $orderId,
-        private readonly Criteria $criteria
+        private readonly Criteria $criteria,
+        private readonly Context $context,
     ) {
     }
 
@@ -23,5 +25,10 @@ class OrderStateChangeCriteriaEvent extends Event
     public function getCriteria(): Criteria
     {
         return $this->criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
     }
 }

--- a/src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
+++ b/src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Event\BusinessEventCollector;
 use Shopware\Core\Framework\Event\BusinessEventCollectorEvent;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
 use Shopware\Core\System\StateMachine\Event\StateMachineStateChangeEvent;
@@ -240,7 +241,11 @@ class OrderStateChangeEventListener implements EventSubscriberInterface
         $criteria->addAssociation('addresses.countryState');
         $criteria->addAssociation('tags');
 
-        $event = new OrderStateChangeCriteriaEvent($orderId, $criteria, $context);
+        if (Feature::isActive('v6.7.0.0')) {
+            $event = new OrderStateChangeCriteriaEvent($orderId, $criteria, $context);
+        } else {
+            $event = new OrderStateChangeCriteriaEvent($orderId, $criteria);
+        }
         $this->eventDispatcher->dispatch($event);
 
         return $criteria;

--- a/src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
+++ b/src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
@@ -208,7 +208,7 @@ class OrderStateChangeEventListener implements EventSubscriberInterface
      */
     private function getOrder(string $orderId, Context $context): OrderEntity
     {
-        $orderCriteria = $this->getOrderCriteria($orderId);
+        $orderCriteria = $this->getOrderCriteria($orderId, $context);
 
         $order = $this->orderRepository
             ->search($orderCriteria, $context)
@@ -221,7 +221,7 @@ class OrderStateChangeEventListener implements EventSubscriberInterface
         return $order;
     }
 
-    private function getOrderCriteria(string $orderId): Criteria
+    private function getOrderCriteria(string $orderId, Context $context): Criteria
     {
         $criteria = new Criteria([$orderId]);
         $criteria->addAssociation('orderCustomer.salutation');
@@ -240,7 +240,7 @@ class OrderStateChangeEventListener implements EventSubscriberInterface
         $criteria->addAssociation('addresses.countryState');
         $criteria->addAssociation('tags');
 
-        $event = new OrderStateChangeCriteriaEvent($orderId, $criteria);
+        $event = new OrderStateChangeCriteriaEvent($orderId, $criteria, $context);
         $this->eventDispatcher->dispatch($event);
 
         return $criteria;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To allow listening for extensions, states, etc. if certain associations should be loaded.

### 2. What does this change do, exactly?
Add Context to a Event

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
