### PR TITLE
[NEXT-0000] Allow customFields on mapping on newsletter_recipient

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/service/custom-field.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/custom-field.service.js
@@ -122,7 +122,7 @@ export default function createCustomFieldService() {
         'shipping_method',
         'tax',
         'unit',
-        'newsletter_recipient'
+        'newsletter_recipient',
     ];
 
     return {

--- a/src/Administration/Resources/app/administration/src/app/service/custom-field.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/custom-field.service.js
@@ -122,6 +122,7 @@ export default function createCustomFieldService() {
         'shipping_method',
         'tax',
         'unit',
+        'newsletter_recipient'
     ];
 
     return {

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-detail/index.js
@@ -12,7 +12,7 @@ const { Criteria } = Shopware.Data;
 export default {
     template,
 
-    inject: ['repositoryFactory', 'acl'],
+    inject: ['repositoryFactory', 'acl', 'customFieldDataProviderService'],
 
     mixins: [
         Mixin.getByName('notification'),
@@ -26,6 +26,7 @@ export default {
             languages: [],
             salesChannels: [],
             isLoading: false,
+            customFieldSets: null,
         };
     },
 
@@ -67,6 +68,8 @@ export default {
                     this.isLoading = false;
                 });
             });
+
+            this.loadCustomFieldSets();
         },
 
         onClickSave() {
@@ -80,5 +83,11 @@ export default {
                 });
             });
         },
+
+        loadCustomFieldSets() {
+            this.customFieldDataProviderService.getCustomFieldSets('newsletter_recipient').then((sets) => {
+                this.customFieldSets = sets;
+            });
+        }
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-detail/index.js
@@ -88,6 +88,6 @@ export default {
             this.customFieldDataProviderService.getCustomFieldSets('newsletter_recipient').then((sets) => {
                 this.customFieldSets = sets;
             });
-        }
+        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-detail/sw-newsletter-recipient-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-detail/sw-newsletter-recipient-detail.html.twig
@@ -170,17 +170,17 @@
             </sw-card>
 
             {% block sw_newsletter_recipient_detail_custom_fields %}
-                <sw-card
-                    v-if="newsletterRecipient && customFieldSets && customFieldSets.length > 0"
-                    position-identifier="newsletter-customFields"
-                    :title="$tc('sw-settings-custom-field.general.mainMenuItemGeneral')"
-                >
-                    <sw-custom-field-set-renderer
-                        :entity="newsletterRecipient"
-                        :disabled="!acl.can('newsletter_recipient.editor')"
-                        :sets="customFieldSets"
-                    />
-                </sw-card>
+            <sw-card
+                v-if="newsletterRecipient && customFieldSets && customFieldSets.length > 0"
+                position-identifier="newsletter-customFields"
+                :title="$tc('sw-settings-custom-field.general.mainMenuItemGeneral')"
+            >
+                <sw-custom-field-set-renderer
+                    :entity="newsletterRecipient"
+                    :disabled="!acl.can('newsletter_recipient.editor')"
+                    :sets="customFieldSets"
+                />
+            </sw-card>
             {% endblock %}
         </sw-card-view>
     </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-detail/sw-newsletter-recipient-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-newsletter-recipient/page/sw-newsletter-recipient-detail/sw-newsletter-recipient-detail.html.twig
@@ -168,6 +168,20 @@
 
                 {% endblock %}
             </sw-card>
+
+            {% block sw_newsletter_recipient_detail_custom_fields %}
+                <sw-card
+                    v-if="newsletterRecipient && customFieldSets && customFieldSets.length > 0"
+                    position-identifier="newsletter-customFields"
+                    :title="$tc('sw-settings-custom-field.general.mainMenuItemGeneral')"
+                >
+                    <sw-custom-field-set-renderer
+                        :entity="newsletterRecipient"
+                        :disabled="!acl.can('newsletter_recipient.editor')"
+                        :sets="customFieldSets"
+                    />
+                </sw-card>
+            {% endblock %}
         </sw-card-view>
     </template>
     {% endblock %}

--- a/src/Core/Content/DependencyInjection/newsletter_recipient.xml
+++ b/src/Core/Content/DependencyInjection/newsletter_recipient.xml
@@ -39,6 +39,7 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="shopware.rate_limiter" />
             <argument type="service" id="Symfony\Component\HttpFoundation\RequestStack" />
+            <argument type="service" id="Shopware\Core\System\SalesChannel\StoreApiCustomFieldMapper"/>
         </service>
 
         <service id="Shopware\Core\Content\Newsletter\SalesChannel\NewsletterConfirmRoute" public="true">

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
@@ -83,7 +83,7 @@ class NewsletterSubscribeRoute extends AbstractNewsletterSubscribeRoute
         private readonly SystemConfigService $systemConfigService,
         private readonly RateLimiter $rateLimiter,
         private readonly RequestStack $requestStack,
-        protected readonly StoreApiCustomFieldMapper $customFieldMapper
+        private readonly StoreApiCustomFieldMapper $customFieldMapper
     ) {
     }
 

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Newsletter\SalesChannel;
 
 use Shopware\Core\Checkout\Customer\Service\EmailIdnConverter;
+use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientDefinition;
 use Shopware\Core\Content\Newsletter\Aggregate\NewsletterRecipient\NewsletterRecipientEntity;
 use Shopware\Core\Content\Newsletter\Event\NewsletterConfirmEvent;
 use Shopware\Core\Content\Newsletter\Event\NewsletterRegisterEvent;
@@ -25,6 +26,7 @@ use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\NoContentResponse;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\StoreApiCustomFieldMapper;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Attribute\Route;
@@ -80,7 +82,8 @@ class NewsletterSubscribeRoute extends AbstractNewsletterSubscribeRoute
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly SystemConfigService $systemConfigService,
         private readonly RateLimiter $rateLimiter,
-        private readonly RequestStack $requestStack
+        private readonly RequestStack $requestStack,
+        protected readonly StoreApiCustomFieldMapper $customFieldMapper
     ) {
     }
 
@@ -126,7 +129,8 @@ class NewsletterSubscribeRoute extends AbstractNewsletterSubscribeRoute
             'street',
             'salutationId',
             'option',
-            'storefrontUrl'
+            'storefrontUrl',
+            'customFields'
         );
 
         $recipientId = $this->getNewsletterRecipientId($data['email'], $context);
@@ -143,6 +147,12 @@ class NewsletterSubscribeRoute extends AbstractNewsletterSubscribeRoute
         }
 
         $data = $this->completeData($data, $context);
+        if ($dataBag->get('customFields') instanceof RequestDataBag) {
+            $data['customFields'] = $this->customFieldMapper->map(
+                NewsletterRecipientDefinition::ENTITY_NAME,
+                $dataBag->get('customFields')
+            );
+        }
 
         $this->newsletterRecipientRepository->upsert([$data], $context->getContext());
 

--- a/tests/unit/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRouteTest.php
+++ b/tests/unit/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRouteTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidator;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\StoreApiCustomFieldMapper;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
@@ -88,6 +89,7 @@ class NewsletterSubscribeRouteTest extends TestCase
             $systemConfig,
             $this->createMock(RateLimiter::class),
             $this->createMock(RequestStack::class),
+            $this->createMock(StoreApiCustomFieldMapper::class),
         );
 
         $newsletterSubscribeRoute->subscribe($requestData, $this->salesChannelContext, false);
@@ -135,6 +137,7 @@ class NewsletterSubscribeRouteTest extends TestCase
             $systemConfig,
             $this->createMock(RateLimiter::class),
             $this->createMock(RequestStack::class),
+            $this->createMock(StoreApiCustomFieldMapper::class),
         );
 
         $newsletterSubscribeRoute->subscribe($requestData, $this->salesChannelContext, false);
@@ -255,6 +258,7 @@ class NewsletterSubscribeRouteTest extends TestCase
             $this->createMock(SystemConfigService::class),
             $rateLimiterMock,
             $requestStack,
+            $this->createMock(StoreApiCustomFieldMapper::class),
         );
 
         $newsletterSubscribeRoute->subscribe($requestData, $this->salesChannelContext, false);
@@ -290,6 +294,7 @@ class NewsletterSubscribeRouteTest extends TestCase
             $this->createMock(SystemConfigService::class),
             $rateLimiterMock,
             $requestStack,
+            $this->createMock(StoreApiCustomFieldMapper::class),
         );
 
         static::expectException(NewsletterException::class);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To allow customFields mapping on newsletter_recipient, and allow customFields to be set via `NewsletterRecipientSubscribeRoute`

### 2. What does this change do, exactly?
Add "newsletter_recipient", to customFieldService to allow mapping of customFieldSets
Add `StoreApiCustomFieldMapper` to `NewsletterRecipientSubscribeRoute`


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
