### PR TITLE
fix: Shopping experience demo entity loading

### DIFF
--- a/changelog/_unreleased/2024-08-17-fix-shopping-experience-demo-entity-loading.md
+++ b/changelog/_unreleased/2024-08-17-fix-shopping-experience-demo-entity-loading.md
@@ -1,0 +1,14 @@
+---
+title: Fix Shopping Experience demo entity loading
+issue: NEXT-000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Deprecated `sw-cms-detail.addFirstSection` and `sw-cms-detail.addAdditionalSection` use `sw-cms-detail.onAddSection` instead
+* Deprecated `sw-cms-detail.loadFirstDemoEntity` use `sw-cms-detail.onDemoEntityChange` instead
+* Deprecated `sw-cms-detail.loadDemoCategoryMedia` as the category media will be loaded using an association and therefore also be shown in the administration
+* Changed the product criteria of Shopping experience demo products, to only load main variant products, to show the correct names and descriptions
+* Changed the behavior of the Shopping experience listing preview element, to show only a limited amount of products when the selected preview category has less then 8 products
+

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/component/index.js
@@ -16,15 +16,13 @@ export default {
         Mixin.getByName('cms-element'),
     ],
 
-    data() {
-        return {
-            demoProductCount: 8,
-        };
-    },
-
     computed: {
         currentDemoProducts() {
             return Shopware.Store.get('cmsPageState').currentDemoProducts;
+        },
+
+        demoProductCount() {
+            return this.currentDemoProducts?.length || 8;
         },
 
         demoProductElement() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/sw-cms-el-product-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/sw-cms-el-product-listing.spec.js
@@ -93,17 +93,28 @@ describe('module/sw-cms/elements/product-listing/component/index', () => {
 
         const productBoxes = wrapper.findAllComponents({ name: 'sw-cms-el-product-box' });
 
-        expect(productBoxes).toHaveLength(8);
+        expect(productBoxes).toHaveLength(currentDemoProducts.length);
 
         productBoxes.forEach((productBox, index) => {
-            const expectedDefaultConfig = { ...defaultConfig };
-
             const product = currentDemoProducts[index];
-            if (product) {
-                expectedDefaultConfig.data = { product };
-            }
 
-            expect(productBox.props('element')).toMatchObject(expectedDefaultConfig);
+            expect(productBox.props('element')).toMatchObject({ ...defaultConfig, data: { product } });
+        });
+    });
+
+    it('should use fallback to empty products', async () => {
+        const wrapper = await createWrapper();
+
+        Shopware.Store.get('cmsPageState').setCurrentDemoProducts([]);
+
+        await wrapper.vm.$nextTick();
+
+        const productBoxes = wrapper.findAllComponents({ name: 'sw-cms-el-product-box' });
+
+        expect(productBoxes).toHaveLength(8);
+
+        productBoxes.forEach((productBox) => {
+            expect(productBox.props('element')).toMatchObject({ ...defaultConfig, data: null });
         });
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-create/sw-cms-create.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-create/sw-cms-create.html.twig
@@ -28,7 +28,7 @@
 {% block sw_cms_detail_stage_container %}
 <sw-cms-create-wizard
     :page="page"
-    @on-section-select="addFirstSection($event, 0)"
+    @on-section-select="onAddSection($event, 0)"
     @wizard-complete="onWizardComplete"
 />
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
@@ -267,7 +267,7 @@
                                 :key="0"
                                 :disabled="!acl.can('cms.editor') || undefined"
                                 :force-choose="true"
-                                @stage-section-add="addAdditionalSection($event, 0)"
+                                @stage-section-add="onAddSection($event, 0, true)"
                             />
                         </div>
                         {% endblock %}
@@ -288,7 +288,7 @@
                         <sw-cms-stage-add-section
                             :key="0"
                             :disabled="!acl.can('cms.editor') || undefined"
-                            @stage-section-add="addAdditionalSection($event, 0)"
+                            @stage-section-add="onAddSection($event, 0, true)"
                         />
                         {% endblock %}
 
@@ -321,7 +321,7 @@
                         <sw-cms-stage-add-section
                             :key="page.sections.length + 1"
                             :disabled="!acl.can('cms.editor') || undefined"
-                            @stage-section-add="addAdditionalSection($event, page.sections.length)"
+                            @stage-section-add="onAddSection($event, page.sections.length, true)"
                         />
                         {% endblock %}
                     </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
@@ -107,16 +107,15 @@ async function createWrapper(versionId = '0fa91ce3e96a4bc2be4bd9ce752c3425') {
                                                 source: 'source',
                                             },
                                             mediaId: mediaID,
+                                            media: {
+                                                id: mediaID,
+                                            },
                                         },
                                     ]),
                                 };
                             case 'product':
                                 return {
                                     search: () => Promise.resolve([{ id: productID }]),
-                                };
-                            case 'media':
-                                return {
-                                    get: () => Promise.resolve({ id: mediaID }),
                                 };
                             default:
                                 return {
@@ -298,7 +297,6 @@ describe('module/sw-cms/page/sw-cms-detail', () => {
         await wrapper.setData({
             page: {
                 type: 'product_list',
-
             },
         });
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the preview of Shopping experiences in the administration is somewhat broken and not ideal (for me the media of a category was never resolved for example, although I did not understand why).
Furthermore when a variant of a demo product entity was loaded, and the name was inherited, it was not correctly displayed in the product listing.

### 2. What does this change do, exactly?
See the changelog and also try to cleanup the API of the `sw-cms-detail` class.

### 3. Describe each step to reproduce the issue or behaviour.
Try to preview different entities in the administration for Shopping experience layouts.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
