### PR TITLE
feat: mark autoPrefixer as deprecated

### DIFF
--- a/changelog/_unreleased/2024-08-19-mark-autoprefixer-as-deprecated.md
+++ b/changelog/_unreleased/2024-08-19-mark-autoprefixer-as-deprecated.md
@@ -1,0 +1,9 @@
+---
+title: Mark autoprefixer as deprecated
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+# Storefront
+* Added deprecation notice when using Autoprefixer in ThemeCompiler

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -341,6 +341,8 @@ class ThemeCompiler implements ThemeCompilerInterface
         }
 
         if ($this->autoPrefix === true) {
+            Feature::triggerDeprecationOrThrow('v6.7.0.0', 'Autoprefixer is deprecated and will be removed without replacement, including the config storefront.theme.auto_prefix_css.');
+
             $autoPreFixer = new Autoprefixer($cssOutput);
             /** @var string|false $cssOutput */
             $cssOutput = $autoPreFixer->compile($this->debug);


### PR DESCRIPTION
### 1. Why is this change necessary?
Regarding the [ADR ](https://github.com/shopware/shopware/blob/trunk/adr/2023-04-03-disable-css-autoprefixer.md?plain=1#L89).

### 2. What does this change do, exactly?
Add a deprecation message when using the autoPrefixer

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
