### PR TITLE
fix(admin): Allow (batch) deletion of categories from the category tree element

### DIFF
--- a/changelog/_unreleased/2024-08-19-fix-deletion-of-categories-from-category.md
+++ b/changelog/_unreleased/2024-08-19-fix-deletion-of-categories-from-category.md
@@ -1,0 +1,9 @@
+---
+title: Fix deletion of categories from category
+issue: NEXT-37713
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed `checkCompatEnabled` to `isCompatEnabled` in the `deleteSelectedElements` of the `sw-tree`-component to allow deletion of categories from the tree element (again)

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/index.js
@@ -680,7 +680,7 @@ Component.register('sw-tree', {
                 return;
             }
 
-            const batchDeleteIsFunction = this.checkCompatEnabled('INSTANCE_LISTENERS')
+            const batchDeleteIsFunction = this.isCompatEnabled('INSTANCE_LISTENERS')
                 ? typeof this.$listeners['batch-delete'] === 'function'
                 : typeof this.$attrs.onBatchDelete === 'function';
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to delete categories of the category tree.

### 2. What does this change do, exactly?
Update the compatibility method to the currently used one.

### 3. Describe each step to reproduce the issue or behaviour.
Try to delete a category in the category tree.

### 4. Please link to the relevant issues (if any).
Closes https://github.com/shopware/shopware/issues/4455

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
