### PR TITLE
fix: Zero translated string field

### DIFF
--- a/changelog/_unreleased/2024-08-20-allow-0-value-for-translated-string-fields-with-custom-hydrators.md
+++ b/changelog/_unreleased/2024-08-20-allow-0-value-for-translated-string-fields-with-custom-hydrators.md
@@ -1,0 +1,9 @@
+---
+title: Allow "0" value for translated string fields with custom hydrators
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed hydration of translated fields in `Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityHydrator::translate` to check if the value is strictly equal to null and not just empty, to allow the value "0" for translated fields

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -323,11 +323,12 @@ class EntityHydrator
 
         foreach ($translatedFields as $field => $typed) {
             $fieldValue = self::value($row, $root, $field);
-            $translation = $fieldValue ? $typed->getSerializer()->decode($typed, $fieldValue) : null;
+            $translation = $fieldValue !== null ? $typed->getSerializer()->decode($typed, $fieldValue) : null;
+
             $entity->addTranslated($field, $translation);
 
             $chainFieldValue = self::value($row, $chain[0], $field);
-            $entity->$field = $chainFieldValue ? ($fieldValue === $chainFieldValue ? $translation : $typed->getSerializer()->decode($typed, $chainFieldValue)) : null;
+            $entity->$field = $chainFieldValue !== null ? ($fieldValue === $chainFieldValue ? $translation : $typed->getSerializer()->decode($typed, $chainFieldValue)) : null;
         }
     }
 

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/TranslatableTestDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/TranslatableTestDefinition.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+/**
+ * @internal
+ */
+class TranslatableTestDefinition extends EntityDefinition
+{
+    final public const ENTITY_NAME = 'translatable_test';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function getHydratorClass(): string
+    {
+        return TranslatableTestHydrator::class;
+    }
+
+    public function since(): ?string
+    {
+        return '6.0.0.0';
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new IdField('id', 'id'))->addFlags(new ApiAware(), new PrimaryKey()),
+
+            (new TranslatedField('name'))->addFlags(new ApiAware()),
+
+            (new TranslationsAssociationField(TranslatableTestTranslationDefinition::class, 'translatable_test_id'))->addFlags(new Required()),
+        ]);
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/TranslatableTestHydrator.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/TranslatableTestHydrator.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityHydrator;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+
+/**
+ * @internal
+ */
+class TranslatableTestHydrator extends EntityHydrator
+{
+    protected function assign(EntityDefinition $definition, Entity $entity, string $root, array $row, Context $context): Entity
+    {
+        $this->translate($definition, $entity, $row, $root, $context, $definition->getTranslatedFields());
+        $this->hydrateFields($definition, $entity, $root, $row, $context, $definition->getExtensionFields());
+
+        return $entity;
+    }
+}

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/TranslatableTestTranslationDefinition.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/TranslatableTestTranslationDefinition.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
+use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
+
+/**
+ * @internal
+ */
+class TranslatableTestTranslationDefinition extends EntityTranslationDefinition
+{
+    final public const ENTITY_NAME = 'translatable_test_translation';
+
+    public function getEntityName(): string
+    {
+        return self::ENTITY_NAME;
+    }
+
+    public function since(): ?string
+    {
+        return '6.0.0.0';
+    }
+
+    protected function getParentDefinitionClass(): string
+    {
+        return CustomFieldTestDefinition::class;
+    }
+
+    protected function defineFields(): FieldCollection
+    {
+        return new FieldCollection([
+            (new StringField('name', 'name'))->addFlags(new ApiAware(), new Required()),
+        ]);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
For example try to create a variant with the name "0":
![image](https://github.com/user-attachments/assets/58acdc1e-5448-41fc-822e-3b4468b051d1)

### 2. What does this change do, exactly?
Change the hydration of translated properties, to check explicitly against `null` instead of an empty value.

### 3. Describe each step to reproduce the issue or behaviour.
Create a property option with name "0".

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
