### PR TITLE
NEXT-0000 - Bugfix partial hydrateEntity manyToOne

### DIFF
--- a/changelog/_unreleased/2024-08-22-partial-hydrate-entity-bug.md
+++ b/changelog/_unreleased/2024-08-22-partial-hydrate-entity-bug.md
@@ -1,0 +1,7 @@
+---
+title: Fix partial hydreateEntity bug
+author: Fabian Boensch
+author_github: @En0Ma1259
+---
+# Core
+* Fixed partial hydrateEntity manyToOne Association bug. "Real" Entity vs PartialEntity

--- a/changelog/_unreleased/2024-08-22-partial-hydrate-entity-bug.md
+++ b/changelog/_unreleased/2024-08-22-partial-hydrate-entity-bug.md
@@ -4,4 +4,4 @@ author: Fabian Boensch
 author_github: @En0Ma1259
 ---
 # Core
-* Fixed partial hydrateEntity manyToOne Association bug. "Real" Entity vs PartialEntity
+* Changed isPartial check in hydrateEntity. Bug with manyToOne Associations. "Real" Entity vs PartialEntity

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
@@ -94,7 +94,7 @@ class EntityHydrator
         }
 
         foreach ($rows as $row) {
-            $collection->add($this->hydrateEntity($definition, $entityClass, $row, $root, $context, $partial));
+            $collection->add($this->hydrateEntity($definition, $entityClass, $row, $root, $context));
         }
 
         return $collection;
@@ -379,7 +379,7 @@ class EntityHydrator
             self::$partialFullPaths[$key] = true;
         }
 
-        return $this->hydrateEntity($field->getReferenceDefinition(), $field->getReferenceDefinition()->getEntityClass(), $row, $association, $context, self::$partial[$field->getPropertyName()] ?? []);
+        return $this->hydrateEntity($field->getReferenceDefinition(), $field->getReferenceDefinition()->getEntityClass(), $row, $association, $context);
     }
 
     /**
@@ -549,11 +549,10 @@ class EntityHydrator
 
     /**
      * @param array<mixed> $row
-     * @param array<string|array<string>> $partial
      */
-    private function hydrateEntity(EntityDefinition $definition, string $entityClass, array $row, string $root, Context $context, array $partial = []): Entity
+    private function hydrateEntity(EntityDefinition $definition, string $entityClass, array $row, string $root, Context $context): Entity
     {
-        $isPartial = $partial !== [];
+        $isPartial = self::$partial !== [];
         $hydratorClass = $definition->getHydratorClass();
         $entityClass = $isPartial ? PartialEntity::class : $entityClass;
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ManyToManyAssociationFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ManyToManyAssociationFieldTest.php
@@ -162,18 +162,21 @@ class ManyToManyAssociationFieldTest extends TestCase
                     ],
                 ],
             ],
+            'cover' => [
+                'position' => -1,
+                'media' => ['fileName' => 'myFile'],
+            ]
         ];
 
         $this->productRepository->create([$data], Context::createDefaultContext());
 
         $criteria = new Criteria([$id]);
-        $criteria->addFields(['productNumber', 'properties.name', 'properties.group.customFields']);
+        $criteria->addFields(['productNumber', 'properties.name', 'properties.group.customFields', 'cover.media.fileName']);
 
         $product = $this->productRepository->search($criteria, Context::createDefaultContext())->first();
         static::assertInstanceOf(PartialEntity::class, $product);
 
         $properties = $product->get('properties');
-
         static::assertInstanceOf(EntityCollection::class, $properties);
 
         $property = $properties->first();
@@ -181,6 +184,12 @@ class ManyToManyAssociationFieldTest extends TestCase
 
         $group = $property->get('group');
         static::assertInstanceOf(PartialEntity::class, $group);
+
+        $cover = $product->get('cover');
+        self::assertInstanceOf(PartialEntity::class, $cover);
+
+        $media = $cover->get('media');
+        self::assertInstanceOf(PartialEntity::class, $media);
 
         static::assertEquals($id, $product->get('productNumber'));
         static::assertFalse($product->has('name'));
@@ -193,5 +202,7 @@ class ManyToManyAssociationFieldTest extends TestCase
         static::assertEquals($groupId, $group->getId());
         static::assertFalse($group->has('name'));
         static::assertEquals('value', $group->get('customFields')['key']);
+
+        self::assertEquals('myFile', $media->get('fileName'));
     }
 }

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ManyToManyAssociationFieldTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/ManyToManyAssociationFieldTest.php
@@ -165,7 +165,7 @@ class ManyToManyAssociationFieldTest extends TestCase
             'cover' => [
                 'position' => -1,
                 'media' => ['fileName' => 'myFile'],
-            ]
+            ],
         ];
 
         $this->productRepository->create([$data], Context::createDefaultContext());
@@ -186,10 +186,10 @@ class ManyToManyAssociationFieldTest extends TestCase
         static::assertInstanceOf(PartialEntity::class, $group);
 
         $cover = $product->get('cover');
-        self::assertInstanceOf(PartialEntity::class, $cover);
+        static::assertInstanceOf(PartialEntity::class, $cover);
 
         $media = $cover->get('media');
-        self::assertInstanceOf(PartialEntity::class, $media);
+        static::assertInstanceOf(PartialEntity::class, $media);
 
         static::assertEquals($id, $product->get('productNumber'));
         static::assertFalse($product->has('name'));
@@ -203,6 +203,6 @@ class ManyToManyAssociationFieldTest extends TestCase
         static::assertFalse($group->has('name'));
         static::assertEquals('value', $group->get('customFields')['key']);
 
-        self::assertEquals('myFile', $media->get('fileName'));
+        static::assertEquals('myFile', $media->get('fileName'));
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Same bug, other attempt.
See also: https://github.com/shopware/shopware/pull/3847
> Chained data using "fields" Criteria Api, seems to be a "correct" Entity (Though with partial data) rather than a PartialEntity

### 2. What does this change do, exactly?
`$partial` method parameter in `hydrateEntity` removed. Static class variable used instead.

### 3. Describe each step to reproduce the issue or behaviour.
Search product with cover via
```php
$productRepository->search((new Criteria())->addFields(['cover.media.fileName']), Context::createDefaultContext());
```
Every Entity should be an instance of PartialEntity. Product, ProductMedia and Media (ManyToOneAssociation)
(No problems with "first" level many-to-one associations like 'cover')

### 4. Please link to the relevant issues (if any).
Related: https://issues.shopware.com/issues/NEXT-36403

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
