### PR TITLE
feat: removed argument delay from InvalidateCacheTaskHandler

### DIFF
--- a/changelog/_unreleased/2024-08-22-remove-argument-delay-from-invalidatecachetaskhandler.md
+++ b/changelog/_unreleased/2024-08-22-remove-argument-delay-from-invalidatecachetaskhandler.md
@@ -1,0 +1,11 @@
+---
+title: Remove argument delay from InvalidateCacheTaskHandler
+issue: NEXT-37772
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Removed argument `delay` in `InvalidateCacheTaskHandler` from the constructor and simplified the method `run`.

--- a/src/Core/Framework/Adapter/Cache/InvalidateCacheTaskHandler.php
+++ b/src/Core/Framework/Adapter/Cache/InvalidateCacheTaskHandler.php
@@ -18,8 +18,7 @@ final class InvalidateCacheTaskHandler extends ScheduledTaskHandler
     public function __construct(
         EntityRepository $scheduledTaskRepository,
         LoggerInterface $logger,
-        private readonly CacheInvalidator $cacheInvalidator,
-        private readonly int $delay
+        private readonly CacheInvalidator $cacheInvalidator
     ) {
         parent::__construct($scheduledTaskRepository, $logger);
     }
@@ -27,12 +26,6 @@ final class InvalidateCacheTaskHandler extends ScheduledTaskHandler
     public function run(): void
     {
         try {
-            if ($this->delay <= 0) {
-                $this->cacheInvalidator->invalidateExpired();
-
-                return;
-            }
-
             $this->cacheInvalidator->invalidateExpired();
         } catch (\Throwable) {
         }

--- a/src/Core/Framework/DependencyInjection/cache.xml
+++ b/src/Core/Framework/DependencyInjection/cache.xml
@@ -61,7 +61,6 @@
             <argument type="service" id="scheduled_task.repository"/>
             <argument type="service" id="logger"/>
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\CacheInvalidator"/>
-            <argument>%shopware.cache.invalidation.delay%</argument>
 
             <tag name="messenger.message_handler"/>
         </service>


### PR DESCRIPTION
### 1. Why is this change necessary?
delay is no more needed

### 2. What does this change do, exactly?
Removed the argument `delay` in `InvalidateCacheTaskHandler` from the constructor and simplified the method `run`.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
Solves https://github.com/shopware/shopware/issues/4512

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
