### PR TITLE
NEXT-37798 - Fix tree view overflow

### DIFF
--- a/changelog/_unreleased/2024-08-23-fix-tree-view-overflow.md
+++ b/changelog/_unreleased/2024-08-23-fix-tree-view-overflow.md
@@ -1,0 +1,9 @@
+---
+title: Fix tree view overflow
+issue: NEXT-37798
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `sw-tree` component styles to always fit width without overflowing.

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.scss
@@ -38,13 +38,11 @@
 
         .tree-items {
             padding: 16px 16px 0;
-            width: max-content;
-            min-width: 100%;
+            width: 100%;
         }
 
         .sw-tree-item {
-            width: max-content;
-            min-width: 100%;
+            width: 100%;
         }
 
         .sw-tree-item__children {
@@ -70,7 +68,6 @@
             overflow: hidden;
             text-overflow: ellipsis;
             padding-right: 8px;
-            max-width: 340px;
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The category tree view overflows with long category names or many nestings - See #3786 

### 2. What does this change do, exactly?
* Changed `sw-tree` component styles to always fit width without overflowing.

### 3. Describe each step to reproduce the issue or behaviour.
Add categories with long names or add some nested subcategories > active indicator and context menu buttons are not visible anymore without using the horizontal scrollbar, which can be far down and not directly seen by the user as well

### 4. Please link to the relevant issues (if any).
[NEXT-37798](https://issues.shopware.com/issues/NEXT-37798) and #3786 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.


[NEXT-37798]: https://shopware.atlassian.net/browse/NEXT-37798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ