### PR TITLE
NEXT-00000 - Fix product category selection unchecked

### DIFF
--- a/changelog/_unreleased/2024-08-23-fix-product-category-selection-unchecked.md
+++ b/changelog/_unreleased/2024-08-23-fix-product-category-selection-unchecked.md
@@ -1,0 +1,9 @@
+---
+title: Fix product category selection unchecked
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `sw-category-tree-field` component to only make use of `selectedCategories` and `selectedCategoriesTotal` if `pageId` is set. Otherwise, use `categoriesCollection` directly.

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/index.js
@@ -100,13 +100,17 @@ Component.register('sw-category-tree-field', {
         },
 
         numberOfHiddenTags() {
-            const hiddenTagsLength = this.selectedCategoriesTotal - this.visibleTags.length;
+            const hiddenTagsLength = this.selectedCategoriesItemsTotal - this.visibleTags.length;
 
             return hiddenTagsLength > 0 ? hiddenTagsLength : 0;
         },
 
         selectedCategoriesItemsIds() {
-            return this.selectedCategories;
+            return this.pageId ? this.selectedCategories : this.categoriesCollection.getIds();
+        },
+
+        selectedCategoriesItemsTotal() {
+            return this.pageId ? this.selectedCategoriesTotal : this.categoriesCollection.length;
         },
 
         selectedCategoriesPathIds() {
@@ -286,8 +290,10 @@ Component.register('sw-category-tree-field', {
                     this.isExpanded = false;
                 }
 
-                this.selectedCategories.push(item.id);
-                this.selectedCategoriesTotal += 1;
+                if (this.pageId) {
+                    this.selectedCategories.push(item.id);
+                    this.selectedCategoriesTotal += 1;
+                }
 
                 return true;
             }
@@ -299,9 +305,11 @@ Component.register('sw-category-tree-field', {
         removeItem(item) {
             this.categoriesCollection.remove(item.id);
 
-            const itemIndex = this.selectedCategories.findIndex(id => id === item.id);
-            this.selectedCategories.splice(itemIndex, 1);
-            this.selectedCategoriesTotal -= 1;
+            if (this.pageId) {
+                const itemIndex = this.selectedCategories.findIndex(id => id === item.id);
+                this.selectedCategories.splice(itemIndex, 1);
+                this.selectedCategoriesTotal -= 1;
+            }
 
             if (item.data) {
                 this.$emit('selection-remove', item.data);

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.spec.js
@@ -212,4 +212,36 @@ describe('src/app/component/entity/sw-category-tree-field', () => {
         wrapper.vm.$emit('categories-load-more');
         expect(wrapper.emitted('categories-load-more')).toBeTruthy();
     });
+
+    it('should have checked categories', async () => {
+        const selectedCategories = [{
+            id: 'categoryId-2',
+            attributes: {
+                id: 'categoryId-2',
+            },
+            translated: {
+                name: 'categoryName-2',
+            },
+            relationships: {},
+        }, {
+            id: 'categoryId-4',
+            attributes: {
+                id: 'categoryId-4',
+            },
+            translated: {
+                name: 'categoryName-4',
+            },
+            relationships: {},
+        }];
+        const wrapper = await createWrapper();
+
+        await wrapper.setProps({
+            categoriesCollection: createCategoryCollection(selectedCategories),
+            pageId: null,
+        });
+
+        expect(wrapper.vm.selectedCategoriesItemsIds).toHaveLength(2);
+        expect(wrapper.vm.selectedCategoriesItemsIds[0]).toBe('categoryId-2');
+        expect(wrapper.vm.selectedCategoriesItemsIds[1]).toBe('categoryId-4');
+    });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Already assigned product categories are unchecked in the category tree view.

![category-unchecked](https://github.com/user-attachments/assets/a96c8a69-b93a-430b-8c6c-239829232732)

### 2. What does this change do, exactly?
* Changed `sw-category-tree-field` component to only make use of `selectedCategories` and `selectedCategoriesTotal` if `pageId` is set. Otherwise, use `categoriesCollection` directly.

### 3. Describe each step to reproduce the issue or behaviour.
Create a product, assign categories to it and save > reload the page > go to category selection and click on the category field to open the tree view > assigned categories are unchecked

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
