### PR TITLE
Fix cms form reset on failed ajax form submission

### DIFF
--- a/changelog/_unreleased/2024-08-27-fix-cms-form-reset-on-unsuccessful-ajax-submission.md
+++ b/changelog/_unreleased/2024-08-27-fix-cms-form-reset-on-unsuccessful-ajax-submission.md
@@ -1,0 +1,9 @@
+---
+title: Fix cms form reset on unsuccessful ajax submission
+issue: 00000
+author: Paik Paustian
+author_email: mail@paik.dev
+author_github: hype09
+---
+# Storefront
+* Changed `FormCmsHandler` to reset form only when AJAX submission was successful.

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
@@ -76,9 +76,6 @@ export default class FormCmsHandler extends Plugin {
         this.$emitter.publish('beforeSubmit');
 
         this.sendAjaxFormSubmit();
-
-        // Reset form after successful submission to clear form contents.
-        this.el.reset();
     }
 
     _handleResponse(res) {
@@ -93,6 +90,11 @@ export default class FormCmsHandler extends Plugin {
                     changeContent = false;
                 }
                 content += response[i].alert;
+            }
+
+            // Reset form after successful submission to clear form contents.
+            if (changeContent) {
+                this.el.reset();
             }
 
             this._createResponse(changeContent, content);

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-cms-handler.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-cms-handler.plugin.test.js
@@ -1,19 +1,30 @@
 /* eslint-disable */
 import FormCmsHandlerPlugin from 'src/plugin/forms/form-cms-handler.plugin';
 
+const template = `
+    <div class="cms-block">
+      <form id="test-form"></form>
+    <div>
+`.trim();
+
 describe('Form CMS Handler tests', () => {
 
     let formCmsHandlerPlugin = undefined;
     let formElement = undefined;
-    let mockHttpClient = undefined;
 
     beforeEach(() => {
-        formElement = document.createElement('form');
+        document.body.innerHTML = template;
+        formElement = document.getElementById('test-form');
+        formElement.parentElement.scrollIntoView = jest.fn(); // Used by form-cms-handler plugin, but not implemented by jsdom.
         formCmsHandlerPlugin = new FormCmsHandlerPlugin(formElement);
-
-        mockHttpClient = {post: jest.fn()};
-        formCmsHandlerPlugin._client = mockHttpClient;
     });
+
+    function setupMockHttpClient(responseContent) {
+        const mockHttpClient = {post: jest.fn((url, data, callback) => callback(responseContent))};
+        formCmsHandlerPlugin._client = mockHttpClient;
+
+        return mockHttpClient;
+    }
 
     test('form cms handler plugin exists', () => {
         expect(typeof formCmsHandlerPlugin).toBe('object');
@@ -22,9 +33,22 @@ describe('Form CMS Handler tests', () => {
     test('form cms handler resets form after successful ajax submission', () => {
         const resetSpy = jest.spyOn(formElement, 'reset');
 
+        const mockHttpClient = setupMockHttpClient('[{"type":"success","alert":""}]');
+
         formElement.dispatchEvent(new Event('submit'));
 
         expect(mockHttpClient.post).toHaveBeenCalled();
         expect(resetSpy).toHaveBeenCalled();
+    });
+
+    test('form cms handler does not reset after unsuccessful ajax submission', () => {
+        const resetSpy = jest.spyOn(formElement, 'reset');
+
+        const mockHttpClient = setupMockHttpClient('[{"type":"danger","alert":""}]');
+
+        formElement.dispatchEvent(new Event('submit'));
+
+        expect(mockHttpClient.post).toHaveBeenCalled();
+        expect(resetSpy).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

In #3753, I inadvertently introduced the bug described in #4422.

### 2. What does this change do, exactly?

Instead of always clearing the form after the content is submitted, we only clear it when the submission was actually successful.

### 3. Describe each step to reproduce the issue or behaviour.

- Go to the contact form.
- Enter all the information.
- Ensure the server-side validation fails, e.g. by mis-typing the captcha.
- The form is being reset (which it shouldn't be).

### 4. Please link to the relevant issues (if any).

- Original bug: #3719 
- Original bugfix: #3753
- Introduced bug: #4422

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- ~[ ] I have written or adjusted the documentation according to my changes~
- ~[ ] This change has comments for package types, values, functions, and non-obvious lines of code~
- [x] I have read the contribution requirements and fulfil them.
