### PR TITLE
NEXT-37427 - Stop AJAX transformation as request is sent twice and will not work as expected

### DIFF
--- a/changelog/_unreleased/2024-08-27-add-error-on-unstoppable-submit-events-for-ajax-form-plugin.md
+++ b/changelog/_unreleased/2024-08-27-add-error-on-unstoppable-submit-events-for-ajax-form-plugin.md
@@ -1,0 +1,18 @@
+---
+title: Add error on unstoppable submit events, that should be handled by form-ajax-submit plugin
+issue: NEXT-37427
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Storefront
+* Add check and exception to not handle submit events, that are not cancable
+___
+# Upgrade Information
+
+See `preventDefault` [documentation](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault#notes), that it will fail to stop non-`cancelable`.
+Therefore do event dispatching by ensuring you have the right parameters in the event constructor:
+
+```
+form.dispatchEvent(new Event('submit', { cancelable: true }));
+```

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js
@@ -120,6 +120,10 @@ export default class FormAjaxSubmitPlugin extends Plugin {
      * @private
      */
     _onSubmit(event) {
+        if (!event.cancelable) {
+            throw new Error('The submit event cannot be prevented as it is not cancelable and would be handled by the navigator');
+        }
+
         event.preventDefault();
 
         // checks form validity before submit

--- a/src/Storefront/Resources/app/storefront/test/plugin/forms/form-ajax-submit.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/forms/form-ajax-submit.plugin.test.js
@@ -75,4 +75,24 @@ describe('FormAjaxSubmitPlugin tests', () => {
 
         expect(cb).toHaveBeenCalledTimes(1);
     });
+
+    test('executes callback when submitting form via form submit event', () => {
+        const cb = jest.fn();
+        const formElement = document.querySelector('form');
+
+        formAjaxSubmit.addCallback(cb);
+        formElement.dispatchEvent(new Event('submit', { cancelable: true }));
+
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    test('prevents callback execution when submitting form via non-cancelable form submit event', () => {
+        const cb = jest.fn();
+        const formElement = document.querySelector('form');
+
+        formAjaxSubmit.addCallback(cb);
+        formElement.dispatchEvent(new Event('submit'));
+
+        expect(cb).toHaveBeenCalledTimes(0);
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

Firefox and Chrome apparently behave differently on working with `preventDefault` and `cancelable` submit events. Even if they work the same at least one (Chrome) does not follow documentation and prevents the default action (navigator doing the form request) although the event sent in the related issue (`new Event('submit')`) is not `cancelable`. So Firefox seem to behave correctly and makes the navigator send the request to a widget controller showing just a cart summary as it was not allowed to block the event.

Just to be sure. This needs to be refactored on the long run by someone. The way how this JavaScript plugin works is fine for actions like "Add to basket" which likes either shows a nice offcanvas or can still add the cart but loads the complete offcanvas as page. Not nicely styled but still is manageable to work with. But e.g. the review tab on a product, when the ajax form plugin is triggered differently e.g. to reload the reviews (made up example). If you send it a submit event like this `form.dispatchEvent('submit')` (without the suggested `, { cancelable: true }` from the changelog) Firefox will just show the reviews nothing more.

Try this in your browser right away. Visit https://shopwaredemo.store/Ice-Cream-Container/943363 and run this script which triggers the language change form of the reviews `document.querySelector('form.product-detail-review-language-form').dispatchEvent(new Event('submit'))`. It won't have any reviews so we use do not see the effect right away but it will work out. Either on Chrome or Safari will just reload the reviews (see in the network inspection tool) but on Firefox it will behave as documented and opens the response as document.

### 2. What does this change do, exactly?

It throws an error, when one use the AJAX transformation on a form but a submit event, that cannot be prevented. So whoever who tries to dispatch an event to the form will get a message, that the cancelable property needs to be changed for this to work.

### 3. Describe each step to reproduce the issue or behaviour.

Similar to the description as #4424 but with the pictures included:

* Create a Shopping list
* Try to open the Shopping list
* See the list and
* woopsie.bmp
* Unstyled page "Summary" is shown

Check the screenshots for more details
[issue_shoppinglist1.PNG](https://sbp-issuetracker-attachments.s3.eu-west-1.amazonaws.com/1721909124_66a23f842b6a2_issue_shoppinglist1.PNG)
[issue_shoppinglist2.PNG](https://sbp-issuetracker-attachments.s3.eu-west-1.amazonaws.com/1721909124_66a23f8477550_issue_shoppinglist2.PNG)

### 4. Please link to the relevant issues (if any).

It is related! The solved change is on the SwagCommercial repository but one should not fail into this fail again and having to try to debug it.

#4424 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
