### PR TITLE
Fix: translation_code_id is used instead of locale_id for Locale (issue #4623)

### DIFF
--- a/src/Core/System/Language/LanguageLoader.php
+++ b/src/Core/System/Language/LanguageLoader.php
@@ -27,9 +27,9 @@ class LanguageLoader implements LanguageLoaderInterface
         $data = $this->connection->createQueryBuilder()
             ->select('LOWER(HEX(language.id)) AS array_key, LOWER(HEX(language.id)) AS id, locale.code, parentLocale.code AS parentCode, LOWER(HEX(language.parent_id)) parentId')
             ->from('language')
-            ->leftJoin('language', 'locale', 'locale', 'language.translation_code_id = locale.id')
+            ->leftJoin('language', 'locale', 'locale', 'language.locale_id = locale.id')
             ->leftJoin('language', 'language', 'parentLanguage', 'language.parent_id = parentLanguage.id')
-            ->leftJoin('parentLanguage', 'locale', 'parentLocale', 'parentLanguage.translation_code_id = parentLocale.id')
+            ->leftJoin('parentLanguage', 'locale', 'parentLocale', 'parentLanguage.locale_id = parentLocale.id')
             ->executeQuery()
             ->fetchAllAssociative();
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
It fixes https://github.com/shopware/shopware/issues/4623


### 2. What does this change do, exactly?
Use locale_id for Locale


### 3. Describe each step to reproduce the issue or behaviour.
See issue

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/4623

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
