### PR TITLE
Fix: product.rating-averaget to product.rating-average for indexing

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/index.js
@@ -64,7 +64,7 @@ export default {
                     'product.many-to-many-id-field',
                     'product.category-denormalizer',
                     'product.cheapest-price',
-                    'product.rating-averaget',
+                    'product.rating-average',
                     'product.stream',
                     'product.search-keyword',
                     'product.seo-url',


### PR DESCRIPTION
### 1. Why is this change necessary?
The indexing will never work properly when name is wrong for allow indexing for rating-average

### 2. What does this change do, exactly?
Changed rating-average indexing name to work perfectly.

### 3. Describe each step to reproduce the issue or behaviour.
Go to the  Caches & indexes in system in settings > select method `Indexers and/or updaters to skip` and select `product.rating-averaget` and then update indexes. It's not working as it need to.

=> How to test(This is my way for this issue)
-> For manual testing Install Adminer extension and go to the Adminer for Admin and select product table and change any rating_average column value manually. Then do as described in step 3. Now check in Adminer, rating_average column is still updated.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
