### PR TITLE
base-slider plugin tries to set attribute on undefined object controlsContainer

### DIFF
--- a/changelog/_unreleased/2024-09-06-fix-base-slider-initAccessibilityTweaks-.md
+++ b/changelog/_unreleased/2024-09-06-fix-base-slider-initAccessibilityTweaks-.md
@@ -1,0 +1,9 @@
+---
+title: fix base-slider plugin _initAccessibilityTweaks method
+issue: NEXT-00000
+author: Carlo Cecco
+author_email: 6672778+luminalpark@users.noreply.github.com
+author_github: @luminalpark
+---
+# Storefront
+* In `base-slider.plugin.js` `_initAccessibilityTweaks` sliderInfo.controlsContainer may be undefined, causing plugin initialization to fail => handling that case.

--- a/changelog/_unreleased/2024-09-06-fix-base-slider-initAccessibilityTweaks-.md
+++ b/changelog/_unreleased/2024-09-06-fix-base-slider-initAccessibilityTweaks-.md
@@ -6,4 +6,4 @@ author_email: 6672778+luminalpark@users.noreply.github.com
 author_github: @luminalpark
 ---
 # Storefront
-* In `base-slider.plugin.js` `_initAccessibilityTweaks` sliderInfo.controlsContainer may be undefined, causing plugin initialization to fail => handling that case.
+* Changed `base-slider.plugin.js` `_initAccessibilityTweaks` : sliderInfo.controlsContainer may be undefined, causing plugin initialization to fail => handling that case.

--- a/src/Storefront/Resources/app/storefront/src/plugin/slider/base-slider.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/slider/base-slider.plugin.js
@@ -190,8 +190,10 @@ export default class BaseSliderPlugin extends Plugin {
     _initAccessibilityTweaks(sliderInfo, wrapperEl) {
         const sliderItems = sliderInfo.slideItems;
 
-        // Remove controls div container from tab index for better accessibility.
-        sliderInfo.controlsContainer.setAttribute('tabindex', '-1');
+        if (sliderInfo.controlsContainer) {
+            // Remove controls div container from tab index for better accessibility.
+            sliderInfo.controlsContainer.setAttribute('tabindex', '-1');
+        }
 
         for (let index = 0; index < sliderItems.length; index++) {
             const item = sliderItems.item(index);

--- a/src/Storefront/Resources/app/storefront/src/plugin/slider/base-slider.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/slider/base-slider.plugin.js
@@ -190,10 +190,8 @@ export default class BaseSliderPlugin extends Plugin {
     _initAccessibilityTweaks(sliderInfo, wrapperEl) {
         const sliderItems = sliderInfo.slideItems;
 
-        if (sliderInfo.controlsContainer) {
-            // Remove controls div container from tab index for better accessibility.
-            sliderInfo.controlsContainer.setAttribute('tabindex', '-1');
-        }
+        // Remove controls div container from tab index for better accessibility.
+        sliderInfo.controlsContainer?.setAttribute('tabindex', '-1');
 
         for (let index = 0; index < sliderItems.length; index++) {
             const item = sliderItems.item(index);


### PR DESCRIPTION
### 1. Why is this change necessary?
base-slider plugin tries to set attribute on undefined object controlsContainer when slider doesn't have controls defined

### 2. What does this change do, exactly?

handle case when controlsContainer is undefined

### 3. Describe each step to reproduce the issue or behaviour.

When a slider doesn't have controls, controlsContainer is undefined.
Method `_initAccessibilityTweaks` tries to set tabindex attribute on undefined object, causing plugin initialization failure

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
