### PR TITLE
refactor: Deprecate `legacy` format of `system:config:get` command

### DIFF
--- a/changelog/_unreleased/2024-09-08-deprecate-legacy-format-in-system-config-get-command.md
+++ b/changelog/_unreleased/2024-09-08-deprecate-legacy-format-in-system-config-get-command.md
@@ -1,0 +1,9 @@
+---
+title: Deprecate legacy format in system:config:get command
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Deprecated `--format=legacy` in the `system:config:get` command, the new default format will be `--format=default` which supports multiple nested config array levels

--- a/src/Core/System/SystemConfig/Command/ConfigGet.php
+++ b/src/Core/System/SystemConfig/Command/ConfigGet.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\System\SystemConfig\Command;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -22,6 +23,9 @@ class ConfigGet extends Command
     private const FORMAT_SCALAR = 'scalar';
     private const FORMAT_JSON = 'json';
     private const FORMAT_JSON_PRETTY = 'json-pretty';
+    /**
+     * @deprecated tag:v6.7.0 - the legacy format will be removed, new default will be `self::FORMAT_DEFAULT`
+     */
     private const FORMAT_LEGACY = 'legacy';
 
     private const ALLOWED_FORMATS = [
@@ -45,7 +49,7 @@ class ConfigGet extends Command
         $this
             ->addArgument('key', InputArgument::REQUIRED)
             ->addOption('salesChannelId', 's', InputOption::VALUE_OPTIONAL)
-            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Supported formats: ' . implode(', ', self::ALLOWED_FORMATS), self::FORMAT_LEGACY)
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'Supported formats: ' . implode(', ', self::ALLOWED_FORMATS), Feature::isActive('v6.7.0.0') ? self::FORMAT_DEFAULT : self::FORMAT_LEGACY)
         ;
     }
 
@@ -63,6 +67,8 @@ class ConfigGet extends Command
         );
 
         if ($format === self::FORMAT_LEGACY) {
+            Feature::triggerDeprecationOrThrow('v6.7.0.0', 'The legacy format will be removed');
+
             $this->writeConfigLegacy($output, $value);
 
             return self::SUCCESS;

--- a/tests/unit/Core/System/SystemConfig/Command/ConfigGetCommandTest.php
+++ b/tests/unit/Core/System/SystemConfig/Command/ConfigGetCommandTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\System\SystemConfig\Command;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SystemConfig\Command\ConfigGet;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
@@ -75,6 +76,8 @@ class ConfigGetCommandTest extends TestCase
     #[DataProvider('configFormatLegacyProvider')]
     public function testConfigGetLegacy(string $key, string $output): void
     {
+        Feature::skipTestIfActive('v6.7.0.0', $this);
+
         $commandOutput = $this->executeCommand($key, 'legacy');
         static::assertEquals(addslashes($commandOutput), addslashes($output));
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The `legacy` format was only introduced for compatibility reasons, see https://github.com/shopware/shopware/pull/1756 and https://github.com/shopware/shopware/pull/2140
But at that time there was no way to deprecate, using feature flags.

### 2. What does this change do, exactly?
Deprecate the `legacy` format and set `default` format as new default.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
