### PR TITLE
feat: changed MailerTransportLoader to use transport factory for local transport type

### DIFF
--- a/changelog/_unreleased/2024-09-10-add-support-for-message-queue-for-local-sendmail-type.md
+++ b/changelog/_unreleased/2024-09-10-add-support-for-message-queue-for-local-sendmail-type.md
@@ -1,0 +1,11 @@
+---
+title: add support for message queue for local sendmail type
+issue: NEXT-38236
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+# Core
+* Changed MailerTransportLoader to use transport factory for local transport type
+
+

--- a/src/Core/Content/Mail/Service/MailerTransportLoader.php
+++ b/src/Core/Content/Mail/Service/MailerTransportLoader.php
@@ -10,7 +10,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mailer\Transport\Dsn;
-use Symfony\Component\Mailer\Transport\SendmailTransport;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mailer\Transport\Transports;
 
@@ -88,7 +87,7 @@ class MailerTransportLoader
 
         return match ($emailAgent) {
             'smtp' => $this->createSmtpTransport($this->configService),
-            'local' => new SendmailTransport($this->getSendMailCommandLineArgument($this->configService)),
+            'local' => $this->createSendmailTransport($this->configService),
             default => throw MailException::givenMailAgentIsInvalid($emailAgent),
         };
     }
@@ -116,6 +115,19 @@ class MailerTransportLoader
             'tls' => 'tls',
             default => null,
         };
+    }
+
+    private function createSendmailTransport(SystemConfigService $configService): TransportInterface
+    {
+        $dsn = new Dsn(
+            scheme: 'sendmail',
+            host: '',
+            options: [
+                'command' => $this->getSendMailCommandLineArgument($configService),
+            ]
+        );
+
+        return $this->envBasedTransport->fromDsnObject($dsn);
     }
 
     private function getSendMailCommandLineArgument(SystemConfigService $configService): string

--- a/tests/unit/Core/Content/Mail/Service/MailerTransportLoaderTest.php
+++ b/tests/unit/Core/Content/Mail/Service/MailerTransportLoaderTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\Mailer\Transport\AbstractTransportFactory;
 use Symfony\Component\Mailer\Transport\NullTransport;
 use Symfony\Component\Mailer\Transport\NullTransportFactory;
 use Symfony\Component\Mailer\Transport\SendmailTransport;
+use Symfony\Component\Mailer\Transport\SendmailTransportFactory;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransportFactory;
 
@@ -238,6 +239,7 @@ class MailerTransportLoaderTest extends TestCase
         return [
             'smtp' => new EsmtpTransportFactory(),
             'null' => new NullTransportFactory(),
+            'sendmail' => new SendmailTransportFactory(),
         ];
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Setting the [message queue](https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue.html#sending-mails-over-the-message-queue) has no effect if "local" is set for mail transport.

### 2. What does this change do, exactly?
Use specific factory to create transport.

### 3. Describe each step to reproduce the issue or behaviour.
set "local" for mail transport, set message_bus in config. Send mail. See it is sent directly.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/4685

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
