### PR TITLE
Fix state attribute compilation logic

### DIFF
--- a/changelog/_unreleased/2024-09-11-fix-state-attribute-on-attributed-entities.md
+++ b/changelog/_unreleased/2024-09-11-fix-state-attribute-on-attributed-entities.md
@@ -1,0 +1,8 @@
+---
+title: Fix state attribute on attributed entities
+author: Nicky Gerritsen
+author_email: nicky@letstalk.nl
+author_github: nickygerritsen
+---
+# Core
+* Added fields with the state attribute to the field collection for attributed entities.

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -77,6 +77,7 @@ class AttributeEntityCompiler
         ManyToMany::class,
         ManyToOne::class,
         OneToOne::class,
+        State::class,
         ReferenceVersion::class,
         CustomFieldsAttr::class,
     ];

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture;
 
 use Shopware\Core\Checkout\Order\OrderEntity;
+use Shopware\Core\Checkout\Order\OrderStates;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\AutoIncrement;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Field;
@@ -16,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Attribute\OneToOne;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Serialized;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\State;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Translations;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity as EntityStruct;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCustomFieldsTrait;
@@ -24,6 +26,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldType\DateInterval;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\PriceCollection;
 use Shopware\Core\Framework\Struct\ArrayEntity;
 use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachineStateEntity;
 
 /**
  * @internal
@@ -116,6 +119,9 @@ class AttributeEntity extends EntityStruct
     #[ForeignKey(entity: 'currency')]
     public ?string $currencyId = null;
 
+    #[State(machine: OrderStates::STATE_MACHINE)]
+    public ?string $stateId = null;
+
     #[ForeignKey(entity: 'currency')]
     public ?string $followId = null;
 
@@ -124,6 +130,9 @@ class AttributeEntity extends EntityStruct
 
     #[OneToOne(entity: 'currency', onDelete: OnDelete::SET_NULL)]
     public ?CurrencyEntity $follow = null;
+
+    #[ManyToOne(entity: 'state_machine_state')]
+    public ?StateMachineStateEntity $state = null;
 
     /**
      * @var array<string, AttributeEntityAgg>|null

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/schema.sql
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/schema.sql
@@ -20,6 +20,7 @@ CREATE TABLE `attribute_entity` (
     `time_zone` VARCHAR(255) NULL,
     `serialized` JSON NULL,
     `currency_id` BINARY(16) NULL,
+    `state_id` BINARY(16) NULL,
     `follow_id` BINARY(16) NULL,
     `created_at` DATETIME(3) NOT NULL,
     `updated_at` DATETIME(3) NULL,
@@ -28,6 +29,7 @@ CREATE TABLE `attribute_entity` (
     CONSTRAINT `json.attribute_entity.json` CHECK (JSON_VALID(`json`)),
     KEY `fk.attribute_entity.currency_id` (`currency_id`),
     CONSTRAINT `fk.attribute_entity.currency_id` FOREIGN KEY (`currency_id`) REFERENCES `currency` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT `fk.attribute_entity.state_id` FOREIGN KEY (`state_id`) REFERENCES `state_machine_state` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE,
     CONSTRAINT `fk.attribute_entity.follow_id` FOREIGN KEY (`follow_id`) REFERENCES `currency` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The `State` attribute was introduced in 2fcdc05740242cac05091935b3ec854f60a80ee7, but it wasn't added to the array of attributes to detect, so no field would be added to the compiled entity.

### 2. What does this change do, exactly?

This adds the `State`  attribute to that array, making the compiler add a field for it.

### 3. Describe each step to reproduce the issue or behaviour.

Try to create an attributed entity with a `State` field and notice that no field is created on the entity definition.


- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
