### PR TITLE
don't use a media Fallback for static assets ( #1461 )

### DIFF
--- a/changelog/_unreleased/2024-09-15-remove-phpfallback-for-media-locations.md
+++ b/changelog/_unreleased/2024-09-15-remove-phpfallback-for-media-locations.md
@@ -1,0 +1,9 @@
+---
+title: Removes Fallback to php for static assets
+issue: NEXT-38057
+author: Jonas Hünig
+author_email: jonas@huenig.name
+author_github: jonashrem
+---
+# Core
+* Removes Fallback to php for static assets from .htaccess


### PR DESCRIPTION
### 1. Why is this change necessary?
See  #1461

This removes the fallback handling for static assets in location where no php handling is expected.

With this, the load on servers can be reduces.

### 2. What does this change do, exactly?
Apache will no longer run the index php in the folders theme,media,thumbnail,bundles|css,fonts,js,recovery and sitemap

### 3. Describe each step to reproduce the issue or behaviour.
Open a non existing File on a shopware installation.

Without the patch, you will get a Shopware 404.
With this patch, the webserver will generate the 404.

### 4. Please link to the relevant issues (if any).
#1461

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
