### PR TITLE
NEXT-38245: add pagehide event-listener

### DIFF
--- a/changelog/_unreleased/2024-09-16-fix-back-forward-cache-issue-in-language-switch.md
+++ b/changelog/_unreleased/2024-09-16-fix-back-forward-cache-issue-in-language-switch.md
@@ -1,0 +1,9 @@
+---
+title: Fix back/forward cache issue in language switch
+issue: NEXT-38245
+author: Niklas Wolf
+author_email: wolfniklas94@web.de
+author_github: @niklaswolf
+---
+# Storefront
+* Added event-listener for pagehide-event in language switcher to remove loader before switching page

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js
@@ -104,6 +104,11 @@ export default class FormAutoSubmitPlugin extends Plugin {
 
             this._form.removeEventListener('change', onChange);
             this._form.addEventListener('change', onChange);
+
+            // // Remove the loading indicator before leaving the page to not cache it in back/forward-cache.
+            window.addEventListener('pagehide', () => {
+                PageLoadingIndicatorUtil.remove();
+            });
         }
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Loading indicator is cached in back/forward cache because it is not removed before leaving the page.

### 2. What does this change do, exactly?
Adds an event-listener to remove the loader before leaving the page, so that it is not cached in bfcache.

### 3. Describe each step to reproduce the issue or behaviour.
see #4693

### 4. Please link to the relevant issues (if any).
#4693 #4548

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
