### PR TITLE
Fix to handle Google ReCaptcha double form submit

### DIFF
--- a/changelog/_unreleased/2024-09-16-fix-google-re-captcha-double-form-submit.md
+++ b/changelog/_unreleased/2024-09-16-fix-google-re-captcha-double-form-submit.md
@@ -1,0 +1,9 @@
+---
+title: Fix to handle Google ReCaptcha double form submit
+issue: NEXT-00000
+author: Carlo Cecco
+author_email: 6672778+luminalpark@users.noreply.github.com
+author_github: @luminalpark
+---
+# Storefront
+* Added check for `data-google-re-captcha` attribute presence in the form to `form-auto-submit.plugin.js` and `form-ajax-submit.plugin.js` to avoid calling `sendAjaxFormSubmit`, the `basic-captcha.plugin.js` plugin will call it, if captcha test succeeds.

--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
@@ -18,6 +18,8 @@ export default class GoogleReCaptchaBasePlugin extends Plugin {
         this._formSubmitting = false;
         this.formPluginInstances = window.PluginManager.getPluginInstancesFromElement(this._form);
 
+        this._setGoogleReCaptchaHandleSubmit();
+
         this._registerEvents();
     }
 
@@ -94,5 +96,13 @@ export default class GoogleReCaptchaBasePlugin extends Plugin {
         this._formSubmitting = true;
 
         this.onFormSubmit();
+    }
+
+    _setGoogleReCaptchaHandleSubmit() {
+        this.formPluginInstances.forEach(plugin => {
+            if (typeof plugin.sendAjaxFormSubmit === 'function' && plugin.options.useAjax !== false) {
+                plugin.formSubmittedByCaptcha = true;
+            }
+        });
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js
@@ -155,7 +155,11 @@ export default class FormAjaxSubmitPlugin extends Plugin {
         this._createLoadingIndicators();
         this.$emitter.publish('beforeSubmit');
 
-        this.sendAjaxFormSubmit();
+        const reCaptcha = this._form.querySelector('[data-google-re-captcha^="data-google-re-captcha-v"]');
+
+        if (!reCaptcha) {
+            this.sendAjaxFormSubmit();
+        }
     }
 
     sendAjaxFormSubmit() {

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-ajax-submit.plugin.js
@@ -54,6 +54,8 @@ export default class FormAjaxSubmitPlugin extends Plugin {
         // indicates if form was at least submitted once
         this.loaded = false;
 
+        this.formSubmittedByCaptcha = false;
+
         this._getForm();
 
         if (!this._form) {
@@ -155,9 +157,7 @@ export default class FormAjaxSubmitPlugin extends Plugin {
         this._createLoadingIndicators();
         this.$emitter.publish('beforeSubmit');
 
-        const reCaptcha = this._form.querySelector('[data-google-re-captcha^="data-google-re-captcha-v"]');
-
-        if (!reCaptcha) {
+        if (!this.formSubmittedByCaptcha) {
             this.sendAjaxFormSubmit();
         }
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js
@@ -46,6 +46,8 @@ export default class FormAutoSubmitPlugin extends Plugin {
     };
 
     init() {
+        this.formSubmittedByCaptcha = false;
+
         this._getForm();
 
         if (!this._form) {
@@ -161,9 +163,7 @@ export default class FormAutoSubmitPlugin extends Plugin {
 
         this._saveFocusState(event.target);
 
-        const reCaptcha = this._form.querySelector('[data-google-re-captcha^="data-google-re-captcha-v"]');
-
-        if (!reCaptcha) {
+        if (!this.formSubmittedByCaptcha) {
             this.sendAjaxFormSubmit();
         }
     }

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-auto-submit.plugin.js
@@ -160,7 +160,12 @@ export default class FormAutoSubmitPlugin extends Plugin {
         this.$emitter.publish('beforeSubmit');
 
         this._saveFocusState(event.target);
-        this.sendAjaxFormSubmit();
+
+        const reCaptcha = this._form.querySelector('[data-google-re-captcha^="data-google-re-captcha-v"]');
+
+        if (!reCaptcha) {
+            this.sendAjaxFormSubmit();
+        }
     }
 
     sendAjaxFormSubmit() {


### PR DESCRIPTION
### 1. Why is this change necessary?
FormAutoSubmitPlugin with useAjax= true emits beforeSubmit event and right after executes sendAjaxFormSubmit function.

`GoogleReCaptchaBasePlugin` binds to beforeSubmit event on line 76 and calls sendAjaxFormSubmit as well, resulting in a double form submission.

### 2. What does this change do, exactly?
Checks for `GoogleReCaptcha` V2 or V3 instance on the form and avoid `sendAjaxFormSubmit` to be called from `form-ajax-submit` and `form-auto-submit` plugins

### 3. Describe each step to reproduce the issue or behaviour.
On a form with GoogleReCaptcha active, trigger a sumbit with missing required fields, then fill the missing fields and submit the form.  `form-ajax-submit` or `form-auto-submit` will execute their `sendAjaxFormSubmit` method, `GoogleReCaptcha` will call that method too, causing a double form submission.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/4347


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
