### PR TITLE
FIX: Cast thumbnail size to integer

### DIFF
--- a/changelog/_unreleased/2024-09-17-cast-thumbnail-size-to-integer.md
+++ b/changelog/_unreleased/2024-09-17-cast-thumbnail-size-to-integer.md
@@ -1,0 +1,9 @@
+---
+title: Cast thumbnail size to integer
+issue: NEXT-00000
+author: Vladislav Sultanov
+author_email: vladislav.sultanov@netlogix.de
+author_github: @TheBreaken
+---
+# Storefront
+* Cast thumbnail size to integer to prevent the error "Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity::getWidth(): Return value must be of type int, string returned"

--- a/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaThumbnail/MediaThumbnailEntity.php
@@ -14,17 +14,11 @@ class MediaThumbnailEntity extends Entity
     use EntityCustomFieldsTrait;
     use EntityIdTrait;
 
-    /**
-     * @var int
-     */
-    protected $width;
+    protected int $width = 0;
 
     protected ?string $path = null;
 
-    /**
-     * @var int
-     */
-    protected $height;
+    protected int $height = 0;
 
     /**
      * @var string

--- a/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
+++ b/src/Core/Content/Media/Core/Application/RemoteThumbnailLoader.php
@@ -87,8 +87,8 @@ class RemoteThumbnailLoader implements ResetInterface
                 $thumbnail = new MediaThumbnailEntity();
                 $thumbnail->assign([
                     'id' => Uuid::randomHex(),
-                    'width' => $size['width'],
-                    'height' => $size['height'],
+                    'width' => (int) $size['width'],
+                    'height' => (int) $size['height'],
                     'url' => $url,
                 ]);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently it is possible to call getWidth() or getHeight() on MediaThumbnailEntity and get the error "Shopware\Core\Content\Media\Aggregate\MediaThumbnail\MediaThumbnailEntity::getWidth(): Return value must be of type int, string returned"


### 2. What does this change do, exactly?

This change make sure that width and height are assigned as integer instead of string

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
