### PR TITLE
feat: changed hash for key of http-cache and twig-cache to use xxh128 instead of sha256

### DIFF
--- a/changelog/_unreleased/2024-09-18-changed-hash-algo-for-cache.md
+++ b/changelog/_unreleased/2024-09-18-changed-hash-algo-for-cache.md
@@ -1,0 +1,13 @@
+---
+title: Changed hash algo for cache
+issue: NEXT-38366
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Changed hash algo for cache key generation from sha256 to xxh128 in \Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator
+* Changed hash algo for cache key generation from sha256 to xxh128 in \Shopware\Core\Framework\Adapter\Twig\ConfigurableFilesystemCache
+

--- a/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
+++ b/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
@@ -64,7 +64,7 @@ class HttpCacheKeyGenerator
 
         $parts = $event->getParts();
 
-        return 'http-cache-' . hash('sha256', implode('|', $parts));
+        return 'http-cache-' . hash('xxh128', implode('|', $parts));
     }
 
     private function getRequestUri(Request $request): string

--- a/src/Core/Framework/Adapter/Twig/ConfigurableFilesystemCache.php
+++ b/src/Core/Framework/Adapter/Twig/ConfigurableFilesystemCache.php
@@ -33,7 +33,7 @@ class ConfigurableFilesystemCache extends FilesystemCache
 
     public function generateKey(string $name, string $className): string
     {
-        $hash = hash('sha256', $className . $this->configHash . implode('', $this->templateScopes));
+        $hash = hash('xxh128', $className . $this->configHash . implode('', $this->templateScopes));
 
         return $this->cacheDirectory . $hash[0] . $hash[1] . '/' . $hash . '.php';
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
sha256 is much slower than xxh128

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
Closes #4774

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
