### PR TITLE
Changed usages of hash algo md5 to xxh128

### DIFF
--- a/changelog/_unreleased/2024-09-18-changed-usages-of-hash-algo-md5-to-xxh128.md
+++ b/changelog/_unreleased/2024-09-18-changed-usages-of-hash-algo-md5-to-xxh128.md
@@ -1,0 +1,14 @@
+---
+title: Changed usages of hash algo md5 to xxh128
+issue: NEXT-38371
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Changed usages of hash algo md5 to xxh128 in several places
+* Changed the Kernel cache hash generation to not hash plugin data which gets hashed again and removed the substr of data
+* Added a Util class to generate hashes, defaulting to use xxh128
+* Changed hash algo for cache key generation from sha256 to use new util class with default xxh128 in \Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator and \Shopware\Core\Framework\Adapter\Twig\ConfigurableFilesystemCache

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5470,3 +5470,8 @@ parameters:
 			message: "#^Call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Shopware\\\\\\\\Storefront\\\\\\\\Page\\\\\\\\Checkout\\\\\\\\Finish\\\\\\\\CheckoutFinishPage' and Shopware\\\\Storefront\\\\Page\\\\Checkout\\\\Finish\\\\CheckoutFinishPage will always evaluate to true\\.$#"
 			count: 5
 			path: tests/unit/Storefront/Page/Checkout/Finish/CheckoutFinishPageLoaderTest.php
+
+		- 	# This is okay, while the class is not included in the phar
+			message: "#^Do not use hash function, use class Shopware\\\\Core\\\\Framework\\\\Util\\\\Hasher instead\\.$#"
+			count: 1
+			path: src/WebInstaller/Kernel.php

--- a/src/Core/Checkout/Cart/CartContextHasher.php
+++ b/src/Core/Checkout/Cart/CartContextHasher.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Cart;
 
 use Shopware\Core\Checkout\Cart\Event\CartContextHashEvent;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -42,6 +43,6 @@ class CartContextHasher
             ->eventDispatcher
             ->dispatch(new CartContextHashEvent($context, $cart, $struct));
 
-        return \hash('sha256', \json_encode($event->getHashStruct(), \JSON_THROW_ON_ERROR) ?: '');
+        return Hasher::hash($event->getHashStruct(), 'sha256');
     }
 }

--- a/src/Core/Checkout/Cart/Error/ErrorCollection.php
+++ b/src/Core/Checkout/Cart/Error/ErrorCollection.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Cart\Error;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Collection;
+use Shopware\Core\Framework\Util\Hasher;
 
 /**
  * @extends Collection<Error>
@@ -106,7 +107,7 @@ class ErrorCollection extends Collection
             $hash .= $element->getId() . json_encode($element->getParameters());
         }
 
-        return hash('xxh64', $hash);
+        return Hasher::hash($hash, 'xxh64');
     }
 
     protected function getExpectedClass(): ?string

--- a/src/Core/Checkout/Customer/Password/LegacyEncoder/Md5.php
+++ b/src/Core/Checkout/Customer/Password/LegacyEncoder/Md5.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Customer\Password\LegacyEncoder;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 
 #[Package('checkout')]
 class Md5 implements LegacyEncoderInterface
@@ -15,10 +16,10 @@ class Md5 implements LegacyEncoderInterface
     public function isPasswordValid(string $password, string $hash): bool
     {
         if (mb_strpos($hash, ':') === false) {
-            return hash_equals($hash, md5($password));
+            return hash_equals($hash, Hasher::hash($password, 'md5'));
         }
         [$md5, $salt] = explode(':', $hash);
 
-        return hash_equals($md5, md5($password . $salt));
+        return hash_equals($md5, Hasher::hash($password . $salt, 'md5'));
     }
 }

--- a/src/Core/Checkout/Customer/Password/LegacyEncoder/Sha256.php
+++ b/src/Core/Checkout/Customer/Password/LegacyEncoder/Sha256.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Customer\Password\LegacyEncoder;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 
 #[Package('checkout')]
 class Sha256 implements LegacyEncoderInterface
@@ -25,7 +26,7 @@ class Sha256 implements LegacyEncoderInterface
     {
         $hash = '';
         for ($i = 0; $i <= $iterations; ++$i) {
-            $hash = hash('sha256', $hash . $password . $salt);
+            $hash = Hasher::hash($hash . $password . $salt, 'sha256');
         }
 
         return $iterations . ':' . $salt . ':' . $hash;

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterConfirmRoute.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidator;
@@ -72,7 +73,7 @@ class RegisterConfirmRoute extends AbstractRegisterConfirmRoute
                 'em' => $dataBag->get('em'),
                 'doubleOptInRegistration' => $customer->getDoubleOptInRegistration(),
             ],
-            $this->getBeforeConfirmValidation(hash('sha1', (string) $customer->getEmail()))
+            $this->getBeforeConfirmValidation(Hasher::hash($customer->getEmail(), 'sha1'))
         );
 
         if ($customer->getDoubleOptInConfirmDate() !== null) {

--- a/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/RegisterRoute.php
@@ -29,6 +29,7 @@ use Shopware\Core\Framework\Event\DataMappingEvent;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\BuildValidationEvent;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
@@ -595,7 +596,7 @@ class RegisterRoute extends AbstractRegisterRoute
             $urlTemplate = '/registration/confirm?em=%%HASHEDEMAIL%%&hash=%%SUBSCRIBEHASH%%';
         }
 
-        $emailHash = hash('sha1', $customer->getEmail());
+        $emailHash = Hasher::hash($customer->getEmail(), 'sha1');
 
         $urlEvent = new CustomerConfirmRegisterUrlEvent($context, $urlTemplate, $emailHash, $customer->getHash(), $customer);
         $this->eventDispatcher->dispatch($urlEvent);

--- a/src/Core/Checkout/Payment/Cart/Token/JWTFactoryV2.php
+++ b/src/Core/Checkout/Payment/Cart/Token/JWTFactoryV2.php
@@ -9,6 +9,7 @@ use Lcobucci\JWT\Validation\Constraint\LooseValidAt;
 use Shopware\Core\Checkout\Payment\PaymentException;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 
 #[Package('checkout')]
@@ -132,6 +133,6 @@ class JWTFactoryV2 implements TokenFactoryInterfaceV2
 
     private static function normalize(string $token): string
     {
-        return substr(hash('sha256', $token), 0, 32);
+        return substr(Hasher::hash($token, 'sha256'), 0, 32);
     }
 }

--- a/src/Core/Checkout/Payment/SalesChannel/CachedPaymentMethodRoute.php
+++ b/src/Core/Checkout/Payment/SalesChannel/CachedPaymentMethodRoute.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -100,7 +100,7 @@ class CachedPaymentMethodRoute extends AbstractPaymentMethodRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Checkout/Shipping/SalesChannel/CachedShippingMethodRoute.php
+++ b/src/Core/Checkout/Shipping/SalesChannel/CachedShippingMethodRoute.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -99,7 +99,7 @@ class CachedShippingMethodRoute extends AbstractShippingMethodRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Content/Category/SalesChannel/CachedCategoryRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CachedCategoryRoute.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Profiling\Profiler;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -98,7 +98,7 @@ class CachedCategoryRoute extends AbstractCategoryRoute
             return null;
         }
 
-        return self::buildName($navigationId) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($navigationId) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Content/Category/SalesChannel/CachedNavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CachedNavigationRoute.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Profiling\Profiler;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
@@ -157,7 +157,7 @@ class CachedNavigationRoute extends AbstractNavigationRoute
             return null;
         }
 
-        return self::buildName($active) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($active) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -369,6 +370,6 @@ class CmsSlotsDataResolver
 
     private function hash(Criteria $criteria): string
     {
-        return md5(serialize($criteria));
+        return Hasher::hash($criteria);
     }
 }

--- a/src/Core/Content/LandingPage/SalesChannel/CachedLandingPageRoute.php
+++ b/src/Core/Content/LandingPage/SalesChannel/CachedLandingPageRoute.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -94,7 +94,7 @@ class CachedLandingPageRoute extends AbstractLandingPageRoute
             return null;
         }
 
-        return self::buildName($landingPageId) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($landingPageId) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Content/Media/Core/Application/AbstractMediaPathStrategy.php
+++ b/src/Core/Content/Media/Core/Application/AbstractMediaPathStrategy.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Content\Media\Core\Application;
 use Shopware\Core\Content\Media\Core\Params\MediaLocationStruct;
 use Shopware\Core\Content\Media\Core\Params\ThumbnailLocationStruct;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 
 /**
  * Global path generator for media files
@@ -79,7 +80,7 @@ abstract class AbstractMediaPathStrategy
             return null;
         }
 
-        $hash = md5($value);
+        $hash = Hasher::hash($value, 'md5');
 
         $slices = \array_slice(str_split($hash, 2), 0, 3);
         $slices = array_map(

--- a/src/Core/Content/Media/File/FileFetcher.php
+++ b/src/Core/Content/Media/File/FileFetcher.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Media\File;
 
 use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\HttpFoundation\Request;
 
 #[Package('buyers-experience')]
@@ -45,7 +46,7 @@ class FileFetcher
             FileInfoHelper::getMimeType($fileName, $extension),
             $extension,
             $bytesWritten,
-            hash_file('md5', $fileName) ?: null
+            Hasher::hash_file($fileName, 'md5') ?: null
         );
     }
 
@@ -84,7 +85,7 @@ class FileFetcher
             $mimeType,
             $extension,
             $writtenBytes,
-            hash_file('md5', $fileName) ?: null
+            Hasher::hash_file($fileName, 'md5') ?: null
         );
     }
 
@@ -95,7 +96,7 @@ class FileFetcher
         \assert($fh !== false);
 
         $blobSize = (int) @fwrite($fh, $blob);
-        $fileHash = $tempFile ? hash_file('md5', $tempFile) : null;
+        $fileHash = $tempFile ? Hasher::hash_file($tempFile, 'md5') : null;
 
         return new MediaFile(
             $tempFile,

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterConfirmRoute.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidator;
@@ -52,7 +53,7 @@ class NewsletterConfirmRoute extends AbstractNewsletterConfirmRoute
             'em' => $dataBag->get('em'),
         ];
 
-        $this->validator->validate($data, $this->getBeforeConfirmSubscribeValidation(hash('sha1', $recipient->getEmail())));
+        $this->validator->validate($data, $this->getBeforeConfirmSubscribeValidation(Hasher::hash($recipient->getEmail(), 'sha1')));
 
         $data['status'] = NewsletterSubscribeRoute::STATUS_OPT_IN;
         $data['confirmedAt'] = new \DateTime();

--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\RateLimiter\Exception\RateLimitExceededException;
 use Shopware\Core\Framework\RateLimiter\RateLimiter;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\BuildValidationEvent;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
@@ -165,7 +166,7 @@ class NewsletterSubscribeRoute extends AbstractNewsletterSubscribeRoute
             return new NoContentResponse();
         }
 
-        $hashedEmail = hash('sha1', $data['email']);
+        $hashedEmail = Hasher::hash($data['email'], 'sha1');
         $url = $this->getSubscribeUrl($context, $hashedEmail, $data['hash'], $data, $recipient);
 
         $event = new NewsletterRegisterEvent($context->getContext(), $recipient, $url, $context->getSalesChannel()->getId());

--- a/src/Core/Content/Product/Cart/ProductCartProcessor.php
+++ b/src/Core/Content/Product/Cart/ProductCartProcessor.php
@@ -27,6 +27,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Profiling\Profiler;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -580,6 +581,6 @@ class ProductCartProcessor implements CartProcessorInterface, CartDataCollectorI
             return $taxRule->getRules()?->getIds() ?: $taxRule->getId();
         }, $context->getTaxRules()->getElements());
 
-        return md5($contextHash . json_encode($activeTaxRules));
+        return Hasher::hash($contextHash . json_encode($activeTaxRules), 'md5');
     }
 }

--- a/src/Core/Content/Product/SalesChannel/CrossSelling/CachedProductCrossSellingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/CrossSelling/CachedProductCrossSellingRoute.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -96,7 +96,7 @@ class CachedProductCrossSellingRoute extends AbstractProductCrossSellingRoute
             return null;
         }
 
-        return self::buildName($productId) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($productId) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Detail/AvailableCombinationResult.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/AvailableCombinationResult.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Product\SalesChannel\Detail;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
+use Shopware\Core\Framework\Util\Hasher;
 
 /**
  * @phpstan-type combination array<string, bool>
@@ -93,6 +94,6 @@ class AvailableCombinationResult extends Struct
         $optionIds = array_values($optionIds);
         sort($optionIds);
 
-        return md5((string) json_encode($optionIds, \JSON_THROW_ON_ERROR));
+        return Hasher::hash($optionIds);
     }
 }

--- a/src/Core/Content/Product/SalesChannel/Detail/CachedProductDetailRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Detail/CachedProductDetailRoute.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -96,7 +96,7 @@ class CachedProductDetailRoute extends AbstractProductDetailRoute
             return null;
         }
 
-        return self::buildName($productId) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($productId) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Listing/CachedProductListingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/CachedProductListingRoute.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -92,7 +92,7 @@ class CachedProductListingRoute extends AbstractProductListingRoute
             return null;
         }
 
-        return self::buildName($categoryId) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($categoryId) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Review/CachedProductReviewRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Review/CachedProductReviewRoute.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -96,7 +96,7 @@ class CachedProductReviewRoute extends AbstractProductReviewRoute
         $event = new ProductDetailRouteCacheKeyEvent($parts, $request, $context, $criteria);
         $this->dispatcher->dispatch($event);
 
-        return self::buildName($productId) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($productId) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Search/CachedProductSearchRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Search/CachedProductSearchRoute.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -91,7 +91,7 @@ class CachedProductSearchRoute extends AbstractProductSearchRoute
             return null;
         }
 
-        return self::NAME . '-' . md5(Json::encode($event->getParts()));
+        return self::NAME . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Content/Product/SalesChannel/Suggest/CachedProductSuggestRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Suggest/CachedProductSuggestRoute.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\RuleAreas;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -92,7 +92,7 @@ class CachedProductSuggestRoute extends AbstractProductSuggestRoute
             return null;
         }
 
-        return self::NAME . '-' . md5(Json::encode($event->getParts()));
+        return self::NAME . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/Content/Seo/SeoUrlGenerator.php
+++ b/src/Core/Content/Seo/SeoUrlGenerator.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Runtime;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\RouterInterface;
@@ -180,7 +181,7 @@ class SeoUrlGenerator
 
     private function getTemplateName(string $template): string
     {
-        return 'seo_url_template_' . \md5($template);
+        return 'seo_url_template_' . Hasher::hash($template);
     }
 
     private function removePrefix(string $subject, string $prefix): string

--- a/src/Core/Content/Sitemap/SalesChannel/CachedSitemapRoute.php
+++ b/src/Core/Content/Sitemap/SalesChannel/CachedSitemapRoute.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\HttpFoundation\Request;
@@ -100,7 +100,7 @@ class CachedSitemapRoute extends AbstractSitemapRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/UseHasherRule.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/UseHasherRule.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\FuncCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
+
+/**
+ * @implements Rule<FuncCall>
+ *
+ * @internal
+ */
+#[Package('core')]
+class UseHasherRule implements Rule
+{
+    use InTestClassTrait;
+
+    private const NOT_ALLOWED_FUNCTIONS = ['md5', 'md5_file', 'sha1', 'sha1_file', 'hash', 'hash_file'];
+    private const HASHER_CLASS = Hasher::class;
+
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    /**
+     * @return array<array-key, RuleError|string>
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if ($this->isInTestClass($scope)) {
+            // if in a test namespace, don't care
+            return [];
+        }
+
+        if (!$node instanceof FuncCall) {
+            return [];
+        }
+
+        if (!$node->name instanceof Node\Name) {
+            return [];
+        }
+
+        if ($scope->getClassReflection()?->getName() === self::HASHER_CLASS) {
+            return [];
+        }
+
+        $name = $node->name->toString();
+
+        if (\in_array($name, self::NOT_ALLOWED_FUNCTIONS, true)) {
+            return [
+                RuleErrorBuilder::message(\sprintf('Do not use %s function, use class %s instead.', $name, self::HASHER_CLASS))->build(),
+            ];
+        }
+
+        return [];
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/rules.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/rules.neon
@@ -15,3 +15,4 @@ rules:
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\MessagesShouldNotUsePHPStanTypes
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\UseCLIContextRule
     - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\NoInconfiguredMetricAllowed
+    - Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules\UseHasherRule

--- a/src/Core/Framework/Adapter/Asset/FlysystemLastModifiedVersionStrategy.php
+++ b/src/Core/Framework/Adapter/Asset/FlysystemLastModifiedVersionStrategy.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Adapter\Asset;
 
 use League\Flysystem\FilesystemOperator;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\Asset\VersionStrategy\VersionStrategyInterface;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 
@@ -38,7 +39,7 @@ class FlysystemLastModifiedVersionStrategy implements VersionStrategyInterface
             return '';
         }
 
-        $cacheKey = 'metaDataFlysystem-' . md5($path);
+        $cacheKey = 'metaDataFlysystem-' . Hasher::hash($path);
 
         $item = $this->cacheAdapter->getItem($cacheKey);
 

--- a/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheCookieEvent;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\MaintenanceModeResolver;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -242,16 +243,16 @@ class CacheResponseSubscriber implements EventSubscriberInterface
             $event = new HttpCacheCookieEvent($request, $context, $parts);
             $this->dispatcher->dispatch($event);
 
-            return md5(json_encode($event->getParts(), \JSON_THROW_ON_ERROR));
+            return Hasher::hash($event->getParts());
         }
 
-        return md5(json_encode([
+        return Hasher::hash([
             $context->getRuleIds(),
             $context->getContext()->getVersionId(),
             $context->getCurrency()->getId(),
             $context->getTaxState(),
             $context->getCustomer() ? 'logged-in' : 'not-logged-in',
-        ], \JSON_THROW_ON_ERROR));
+        ]);
     }
 
     /**

--- a/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
+++ b/src/Core/Framework/Adapter/Cache/Http/HttpCacheKeyGenerator.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Adapter\Cache\Http;
 
 use Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheKeyEvent;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\SalesChannelRequest;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -64,7 +65,7 @@ class HttpCacheKeyGenerator
 
         $parts = $event->getParts();
 
-        return 'http-cache-' . hash('sha256', implode('|', $parts));
+        return 'http-cache-' . Hasher::hash(implode('|', $parts));
     }
 
     private function getRequestUri(Request $request): string

--- a/src/Core/Framework/Adapter/Cache/RedisConnectionFactory.php
+++ b/src/Core/Framework/Adapter/Cache/RedisConnectionFactory.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Adapter\Cache;
 use Predis\ClientInterface;
 use Relay\Relay;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\Cache\Adapter\RedisAdapter;
 
 /**
@@ -39,7 +40,7 @@ class RedisConnectionFactory
      */
     public function create(string $dsn, array $options = [])
     {
-        $configHash = md5(json_encode($options, \JSON_THROW_ON_ERROR));
+        $configHash = Hasher::hash($options);
         $key = $dsn . $configHash . $this->prefix;
 
         if (!isset(self::$connections[$key]) || (

--- a/src/Core/Framework/Adapter/Twig/ConfigurableFilesystemCache.php
+++ b/src/Core/Framework/Adapter/Twig/ConfigurableFilesystemCache.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Adapter\Twig;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Twig\Cache\FilesystemCache;
 
 #[Package('core')]
@@ -33,7 +34,7 @@ class ConfigurableFilesystemCache extends FilesystemCache
 
     public function generateKey(string $name, string $className): string
     {
-        $hash = hash('sha256', $className . $this->configHash . implode('', $this->templateScopes));
+        $hash = Hasher::hash($className . $this->configHash . implode('', $this->templateScopes));
 
         return $this->cacheDirectory . $hash[0] . $hash[1] . '/' . $hash . '.php';
     }

--- a/src/Core/Framework/Adapter/Twig/Extension/PhpSyntaxExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/PhpSyntaxExtension.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Adapter\Twig\TokenParser\ReturnNodeTokenParser;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldVisibility;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Script\Facade\ArrayFacade;
+use Shopware\Core\Framework\Util\Hasher;
 use Squirrel\TwigPhpSyntax\Operator\NotSameAsBinary;
 use Squirrel\TwigPhpSyntax\Operator\SameAsBinary;
 use Squirrel\TwigPhpSyntax\Test\ArrayTest;
@@ -110,7 +111,7 @@ class PhpSyntaxExtension extends AbstractExtension
                     );
                 }
 
-                return md5($var);
+                return Hasher::hash($var, 'md5');
             }),
         ];
     }

--- a/src/Core/Framework/Adapter/Twig/StringTemplateRenderer.php
+++ b/src/Core/Framework/Adapter/Twig/StringTemplateRenderer.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Twig\Exception\StringTemplateRenderingException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Twig\Cache\FilesystemCache;
 use Twig\Environment;
 use Twig\Error\Error;
@@ -63,7 +64,7 @@ class StringTemplateRenderer
      */
     public function render(string $templateSource, array $data, Context $context, bool $htmlEscape = true): string
     {
-        $name = md5($templateSource . !$htmlEscape);
+        $name = Hasher::hash($templateSource . !$htmlEscape);
         $this->twig->setLoader(new ArrayLoader([$name => $templateSource]));
 
         $this->twig->addGlobal('context', $context);

--- a/src/Core/Framework/Adapter/Twig/TemplateFinder.php
+++ b/src/Core/Framework/Adapter/Twig/TemplateFinder.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Adapter\Twig;
 
 use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\NamespaceHierarchyBuilder;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Contracts\Service\ResetInterface;
 use Twig\Cache\FilesystemCache;
 use Twig\Environment;
@@ -146,7 +147,7 @@ class TemplateFinder implements TemplateFinderInterface, ResetInterface
     private function defineCache(array $queue): void
     {
         if ($this->twig->getCache(false) instanceof FilesystemCache) {
-            $configHash = md5((string) json_encode($queue, \JSON_THROW_ON_ERROR));
+            $configHash = Hasher::hash($queue);
 
             $fileSystemCache = new ConfigurableFilesystemCache($this->cacheDir);
             $fileSystemCache->setConfigHash($configHash);

--- a/src/Core/Framework/Api/Serializer/JsonApiDecoder.php
+++ b/src/Core/Framework/Api/Serializer/JsonApiDecoder.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Api\Serializer;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\Serializer\Encoder\DecoderInterface;
 use Symfony\Component\Serializer\Encoder\JsonDecode;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
@@ -51,9 +52,7 @@ class JsonApiDecoder implements DecoderInterface
     {
         $this->validateResourceIdentifier($resource);
 
-        \assert(\is_string($resource['id']));
-        \assert(\is_string($resource['type']));
-        $hash = md5(json_encode(['id' => $resource['id'], 'type' => $resource['type']], \JSON_THROW_ON_ERROR));
+        $hash = $this->getIdentifierHash($resource);
 
         if (!\array_key_exists($hash, $includes)) {
             throw new InvalidArgumentException(
@@ -199,7 +198,7 @@ class JsonApiDecoder implements DecoderInterface
      */
     private function getIdentifierHash(array $resource): string
     {
-        return md5(json_encode(['id' => $resource['id'], 'type' => $resource['type']], \JSON_THROW_ON_ERROR));
+        return Hasher::hash(['id' => $resource['id'], 'type' => $resource['type']]);
     }
 
     /**

--- a/src/Core/Framework/App/Source/SourceResolver.php
+++ b/src/Core/Framework/App/Source/SourceResolver.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Filesystem;
+use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
@@ -142,7 +143,7 @@ class SourceResolver implements ResetInterface
 
     private function cacheKey(AppEntity|Manifest $app): string
     {
-        return md5(match (true) {
+        return Hasher::hash(match (true) {
             $app instanceof AppEntity => $app->getName() . '-' . $app->getVersion(),
             $app instanceof Manifest => $app->getMetadata()->getName() . '-' . $app->getMetadata()->getVersion(),
         });

--- a/src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGenerator.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Cache;
 
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
 #[Package('core')]
@@ -32,7 +33,7 @@ class EntityCacheKeyGenerator
     {
         $ruleIds = $context->getRuleIdsByAreas($areas);
 
-        return md5((string) json_encode([
+        return Hasher::hash([
             $context->getSalesChannelId(),
             $context->getDomainId(),
             $context->getLanguageIdChain(),
@@ -41,12 +42,12 @@ class EntityCacheKeyGenerator
             $context->getTaxState(),
             $context->getItemRounding(),
             $ruleIds,
-        ], \JSON_THROW_ON_ERROR));
+        ]);
     }
 
     public function getCriteriaHash(Criteria $criteria): string
     {
-        return md5((string) json_encode([
+        return Hasher::hash([
             $criteria->getIds(),
             $criteria->getFilters(),
             $criteria->getTerm(),
@@ -59,6 +60,6 @@ class EntityCacheKeyGenerator
             $criteria->getGroupFields(),
             $criteria->getAggregations(),
             $criteria->getAssociations(),
-        ], \JSON_THROW_ON_ERROR));
+        ]);
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -44,6 +44,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteResult;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Util\Json;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -851,7 +852,7 @@ class VersionManager
                 ];
 
                 // deduplicate to prevent deletion errors
-                $entityKey = md5(Json::encode($entity));
+                $entityKey = Hasher::hash($entity);
                 if (isset($handled[$entityKey])) {
                     continue;
                 }

--- a/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\ReferenceVersionField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StorageAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\VersionField;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 
 /**
  * @internal
@@ -41,9 +42,7 @@ class WriteCommandQueue
     {
         $decoded = self::decodeCommandPrimary($registry, $command);
 
-        $string = json_encode($decoded, \JSON_THROW_ON_ERROR);
-
-        return md5($string);
+        return Hasher::hash($decoded);
     }
 
     /**
@@ -151,7 +150,7 @@ class WriteCommandQueue
         }
         sort($decodedPrimaryKey);
 
-        $hash = $definition->getEntityName() . ':' . md5(json_encode($decodedPrimaryKey, \JSON_THROW_ON_ERROR));
+        $hash = $definition->getEntityName() . ':' . Hasher::hash($decodedPrimaryKey);
 
         return $this->entityCommands[$hash] ?? [];
     }

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotFoundException;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
 use Shopware\Core\Framework\Plugin\PluginException;
+use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -172,7 +173,7 @@ class AssetService
     {
         $localManifest = array_combine(
             array_map(fn (SplFileInfo $file) => $file->getRelativePathname(), $files),
-            array_map(fn (SplFileInfo $file) => (string) hash_file('sha256', $file->getPathname()), $files)
+            array_map(fn (SplFileInfo $file) => (string) Hasher::hash_file($file->getPathname(), 'sha256'), $files)
         );
 
         ksort($localManifest);

--- a/src/Core/Framework/Script/Execution/ScriptLoader.php
+++ b/src/Core/Framework/Script/Execution/ScriptLoader.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Adapter\Cache\CacheCompressor;
 use Shopware\Core\Framework\App\Lifecycle\Persister\ScriptPersister;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Twig\Cache\FilesystemCache;
@@ -115,7 +116,7 @@ class ScriptLoader implements EventSubscriberInterface
 
             $lastModified = new \DateTimeImmutable(max($dates));
 
-            $cachePrefix = $script['appName'] ? md5($script['appName'] . $script['appVersion']) : EnvironmentHelper::getVariable('INSTANCE_ID', '');
+            $cachePrefix = $script['appName'] ? Hasher::hash($script['appName'] . $script['appVersion']) : EnvironmentHelper::getVariable('INSTANCE_ID', '');
 
             $includes = array_map(function (array $script) use ($appId) {
                 $script['app_id'] = $appId;

--- a/src/Core/Framework/Test/TestCaseBase/AdminApiTestBehaviour.php
+++ b/src/Core/Framework/Test/TestCaseBase/AdminApiTestBehaviour.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Util\AccessKeyHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestBrowser;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
@@ -146,7 +147,7 @@ trait AdminApiTestBehaviour
         if ($aclPermissions !== null) {
             $aclRoleId = Uuid::randomBytes();
             $user['admin'] = 0;
-            $user['email'] = md5(json_encode($aclPermissions, \JSON_THROW_ON_ERROR)) . '@example.com';
+            $user['email'] = Hasher::hash($aclPermissions) . '@example.com';
             $aclRole = [
                 'id' => $aclRoleId,
                 'name' => 'testPermissions',

--- a/src/Core/Framework/Update/Services/UpdateHtaccess.php
+++ b/src/Core/Framework/Update/Services/UpdateHtaccess.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Update\Services;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Update\Event\UpdatePostFinishEvent;
+use Shopware\Core\Framework\Util\Hasher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -41,7 +42,7 @@ class UpdateHtaccess implements EventSubscriberInterface
             return;
         }
 
-        if (\in_array(md5_file($this->htaccessPath), self::OLD_FILES, true)) {
+        if (\in_array(Hasher::hash_file($this->htaccessPath, 'md5'), self::OLD_FILES, true)) {
             $this->replaceFile($this->htaccessPath);
 
             return;

--- a/src/Core/Framework/Util/Hasher.php
+++ b/src/Core/Framework/Util/Hasher.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Util;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('core')]
+class Hasher
+{
+    public const ALGO = 'xxh128';
+
+    public static function hash(mixed $data, string $algo = self::ALGO, bool $binary = false): string
+    {
+        if (!\is_string($data)) {
+            $data = \json_encode($data, \JSON_THROW_ON_ERROR);
+        }
+
+        return \hash($algo, $data, $binary);
+    }
+
+    public static function hash_file(string $filename, string $algo = self::ALGO, bool $binary = false): string|false
+    {
+        return \hash_file($algo, $filename, $binary);
+    }
+}

--- a/src/Core/Framework/Util/HtmlSanitizer.php
+++ b/src/Core/Framework/Util/HtmlSanitizer.php
@@ -48,13 +48,16 @@ class HtmlSanitizer
 
         $options ??= [];
 
-        $hash = md5(\sprintf('%s%s', json_encode($options, \JSON_THROW_ON_ERROR), $field));
+        $hash = Hasher::hash([
+            $options,
+            $field,
+        ]);
 
         if ($override) {
             $hash .= '-override';
         }
 
-        $textKey = $hash . md5($text);
+        $textKey = $hash . Hasher::hash($text);
         if (isset($this->cache[$textKey])) {
             return $this->cache[$textKey];
         }

--- a/src/Core/Framework/Uuid/Uuid.php
+++ b/src/Core/Framework/Uuid/Uuid.php
@@ -6,6 +6,7 @@ use Ramsey\Uuid\BinaryUtils;
 use Ramsey\Uuid\Generator\RandomGeneratorFactory;
 use Ramsey\Uuid\Generator\UnixTimeGenerator;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\Framework\Uuid\Exception\InvalidUuidLengthException;
 
@@ -127,7 +128,7 @@ class Uuid
      */
     public static function fromStringToHex(string $string): string
     {
-        return self::fromBytesToHex(md5($string, true));
+        return self::fromBytesToHex(Hasher::hash($string, 'md5', true));
     }
 
     public static function isValid(string $id): bool

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\Api\Controller\FallbackController;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Util\VersionParser;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\ConfigCache;
@@ -318,13 +319,11 @@ class Kernel extends HttpKernel
             $plugins[$plugin['name']] = $plugin['version'];
         }
 
-        $pluginHash = md5((string) json_encode($plugins, \JSON_THROW_ON_ERROR));
-
-        return md5((string) \json_encode([
+        return Hasher::hash([
             $this->cacheId,
-            substr((string) $this->shopwareVersionRevision, 0, 8),
-            substr($pluginHash, 0, 8),
-        ], \JSON_THROW_ON_ERROR));
+            (string) $this->shopwareVersionRevision,
+            $plugins,
+        ]);
     }
 
     protected function initializeDatabaseConnectionVariables(): void

--- a/src/Core/System/Country/SalesChannel/CachedCountryRoute.php
+++ b/src/Core/System/Country/SalesChannel/CachedCountryRoute.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\Country\Event\CountryRouteCacheKeyEvent;
 use Shopware\Core\System\Country\Event\CountryRouteCacheTagsEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -97,7 +97,7 @@ class CachedCountryRoute extends AbstractCountryRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/System/Country/SalesChannel/CachedCountryStateRoute.php
+++ b/src/Core/System/Country/SalesChannel/CachedCountryStateRoute.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\Country\Event\CountryStateRouteCacheKeyEvent;
 use Shopware\Core\System\Country\Event\CountryStateRouteCacheTagsEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -97,7 +97,7 @@ class CachedCountryStateRoute extends AbstractCountryStateRoute
             return null;
         }
 
-        return self::buildName($countryId) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($countryId) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/System/Currency/SalesChannel/CachedCurrencyRoute.php
+++ b/src/Core/System/Currency/SalesChannel/CachedCurrencyRoute.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\Currency\Event\CurrencyRouteCacheKeyEvent;
 use Shopware\Core\System\Currency\Event\CurrencyRouteCacheTagsEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -96,7 +96,7 @@ class CachedCurrencyRoute extends AbstractCurrencyRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5((string) Json::encode($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/System/Language/SalesChannel/CachedLanguageRoute.php
+++ b/src/Core/System/Language/SalesChannel/CachedLanguageRoute.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\Language\Event\LanguageRouteCacheKeyEvent;
 use Shopware\Core\System\Language\Event\LanguageRouteCacheTagsEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -96,7 +96,7 @@ class CachedLanguageRoute extends AbstractLanguageRoute
             return null;
         }
 
-        return self::buildName($context->getSalesChannelId()) . '-' . md5(Json::encode($event->getParts()));
+        return self::buildName($context->getSalesChannelId()) . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/System/SalesChannel/Context/CachedBaseContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/CachedBaseContextFactory.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\BaseContext;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -50,7 +51,7 @@ class CachedBaseContextFactory extends AbstractBaseContextFactory
             SalesChannelContextService::COUNTRY_STATE_ID => true,
         ]);
 
-        $key = implode('-', [$name, md5(json_encode($keys, \JSON_THROW_ON_ERROR))]);
+        $key = implode('-', [$name, Hasher::hash($keys)]);
 
         $value = $this->cache->get($key, function (ItemInterface $item) use ($name, $salesChannelId, $options) {
             if (Feature::isActive('cache_rework')) {

--- a/src/Core/System/SalesChannel/Context/CachedSalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/CachedSalesChannelContextFactory.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -42,7 +43,7 @@ class CachedSalesChannelContextFactory extends AbstractSalesChannelContextFactor
 
         ksort($options);
 
-        $key = implode('-', [$name, md5(json_encode($options, \JSON_THROW_ON_ERROR))]);
+        $key = implode('-', [$name, Hasher::hash($options)]);
 
         $value = $this->cache->get($key, function (ItemInterface $item) use ($name, $token, $salesChannelId, $options) {
             if (Feature::isActive('cache_rework')) {

--- a/src/Core/System/Salutation/SalesChannel/CachedSalutationRoute.php
+++ b/src/Core/System/Salutation/SalesChannel/CachedSalutationRoute.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Cache\EntityCacheKeyGenerator;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Json;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\StoreApiResponse;
 use Shopware\Core\System\Salutation\Event\SalutationRouteCacheKeyEvent;
@@ -97,7 +97,7 @@ class CachedSalutationRoute extends AbstractSalutationRoute
             return null;
         }
 
-        return self::buildName() . '-' . md5((string) Json::encode($event->getParts()));
+        return self::buildName() . '-' . Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/System/StateMachine/Util/StateMachineGraphvizDumper.php
+++ b/src/Core/System/StateMachine/Util/StateMachineGraphvizDumper.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\System\StateMachine\Util;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\StateMachine\StateMachineEntity;
 
 #[Package('checkout')]
@@ -100,7 +101,7 @@ class StateMachineGraphvizDumper
 
     private function dotize(string $id): string
     {
-        return hash('sha1', $id);
+        return Hasher::hash($id, 'sha1');
     }
 
     private function escape(string $string): string

--- a/src/Storefront/Framework/Routing/NotFound/NotFoundSubscriber.php
+++ b/src/Storefront/Framework/Routing/NotFound/NotFoundSubscriber.php
@@ -159,7 +159,7 @@ class NotFoundSubscriber implements EventSubscriberInterface, ResetInterface
 
     private function generateKey(string $salesChannelId, string $domainId, string $languageId, Request $request, SalesChannelContext $context): string
     {
-        $key = self::buildName($salesChannelId, $domainId, $languageId) . md5($this->generator->getSalesChannelContextHash($context));
+        $key = self::buildName($salesChannelId, $domainId, $languageId) . $this->generator->getSalesChannelContextHash($context);
 
         $event = new NotFoundPageCacheKeyEvent($key, $request, $context);
 

--- a/src/Storefront/Theme/CachedResolvedConfigLoader.php
+++ b/src/Storefront/Theme/CachedResolvedConfigLoader.php
@@ -4,6 +4,7 @@ namespace Shopware\Storefront\Theme;
 
 use Shopware\Core\Framework\Adapter\Cache\CacheValueCompressor;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -29,7 +30,7 @@ class CachedResolvedConfigLoader extends AbstractResolvedConfigLoader
     {
         $name = self::buildName($themeId);
 
-        $key = md5(implode('-', [$name, $context->getSalesChannelId(), $context->getDomainId()]));
+        $key = Hasher::hash($name . $context->getSalesChannelId() . $context->getDomainId());
 
         $value = $this->cache->get($key, function (ItemInterface $item) use ($name, $themeId, $context) {
             $config = $this->getDecorated()->load($themeId, $context);

--- a/src/Storefront/Theme/MD5ThemePathBuilder.php
+++ b/src/Storefront/Theme/MD5ThemePathBuilder.php
@@ -4,6 +4,7 @@ namespace Shopware\Storefront\Theme;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Util\Hasher;
 
 /**
  * ThemePathBuilder that does not support seeding,
@@ -14,7 +15,7 @@ class MD5ThemePathBuilder extends AbstractThemePathBuilder
 {
     public function assemblePath(string $salesChannelId, string $themeId): string
     {
-        return md5($themeId . $salesChannelId);
+        return Hasher::hash($themeId . $salesChannelId, 'md5');
     }
 
     public function generateNewPath(string $salesChannelId, string $themeId, string $seed): string

--- a/src/Storefront/Theme/SeedingThemePathBuilder.php
+++ b/src/Storefront/Theme/SeedingThemePathBuilder.php
@@ -4,6 +4,7 @@ namespace Shopware\Storefront\Theme;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 #[Package('storefront')]
@@ -26,7 +27,7 @@ class SeedingThemePathBuilder extends AbstractThemePathBuilder
 
     public function generateNewPath(string $salesChannelId, string $themeId, string $seed): string
     {
-        return md5($themeId . $salesChannelId . $seed);
+        return Hasher::hash($themeId . $salesChannelId . $seed);
     }
 
     public function saveSeed(string $salesChannelId, string $themeId, string $seed): void

--- a/src/WebInstaller/Kernel.php
+++ b/src/WebInstaller/Kernel.php
@@ -44,7 +44,7 @@ class Kernel extends BaseKernel
 
     public function getCacheDir(): string
     {
-        return sys_get_temp_dir() . '/shopware-recovery@git_commit_short@' . md5(__DIR__) . '/';
+        return sys_get_temp_dir() . '/shopware-recovery@git_commit_short@' . \hash(__DIR__, 'md5') . '/';
     }
 
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void

--- a/src/WebInstaller/Tests/KernelTest.php
+++ b/src/WebInstaller/Tests/KernelTest.php
@@ -47,7 +47,7 @@ class KernelTest extends TestCase
 
         /** @var string $fileName */
         $fileName = (new \ReflectionClass($kernel))->getFileName();
-        $kernelPath = md5(\dirname($fileName));
+        $kernelPath = \hash(\dirname($fileName), 'md5');
 
         static::assertSame(sys_get_temp_dir() . '/shopware-recovery@git_commit_short@' . $kernelPath . '/', $kernel->getCacheDir());
         static::assertSame(sys_get_temp_dir() . '/shopware-recovery@git_commit_short@' . $kernelPath . '/', $kernel->getLogDir());

--- a/tests/devops/Core/DevOps/Docs/Command/App/DocsAppEventCommandTest.php
+++ b/tests/devops/Core/DevOps/Docs/Command/App/DocsAppEventCommandTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\DevOps\Docs\App\DocsAppEventCommand;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Util\Hasher;
 
 /**
  * @internal
@@ -26,8 +27,8 @@ class DocsAppEventCommandTest extends TestCase
         $savedContents = @file_get_contents($docsAppEventCommand->getListEventPath()) ?: '';
 
         static::assertEquals(
-            md5($savedContents),
-            md5((string) $docsAppEventCommand->render()),
+            Hasher::hash($savedContents, 'md5'),
+            Hasher::hash($docsAppEventCommand->render(), 'md5'),
             'The webhook events app system document is not up to date' . \PHP_EOL
             . 'Run command docs:app-system-events to get new the webhook-events-reference.md file' . \PHP_EOL
             . 'This file also need to be uploaded to gitbook at /resources/references/app-reference/webhook-events-reference.md!'

--- a/tests/e2e/update-api-mock/index.php
+++ b/tests/e2e/update-api-mock/index.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 
+use Shopware\Core\Framework\Util\Hasher;
+
 $uri = $_SERVER['REQUEST_URI'] ?? '/v1/release/update';
 $fileName = __DIR__ . '/update.zip';
 
@@ -17,8 +19,8 @@ if (str_starts_with($uri, '/v1/release/update')) {
         'security_update' => false,
         'uri' => 'http://localhost:8060/update.zip',
         'size' => filesize($fileName),
-        'sha1' => hash('sha1', (string) file_get_contents($fileName)),
-        'sha256' => hash('sha256', (string) file_get_contents($fileName)),
+        'sha1' => Hasher::hash((string) file_get_contents($fileName), 'sha1'),
+        'sha256' => Hasher::hash((string) file_get_contents($fileName), 'sha256'),
         'checks' => [],
         'changelog' => [
             'de' => [

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/AccountServiceTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextServiceParameters;
@@ -212,7 +213,7 @@ class AccountServiceTest extends TestCase
                 ],
             ],
         ]);
-        $this->createCustomerOfSalesChannel($context->getSalesChannel()->getId(), $email, true, true, $idCustomer, '2022-10-21 10:00:00', md5('shopware'), 'Md5');
+        $this->createCustomerOfSalesChannel($context->getSalesChannel()->getId(), $email, true, true, $idCustomer, '2022-10-21 10:00:00', Hasher::hash('shopware', 'md5'), 'Md5');
 
         $customer = $this->accountService->getCustomerByLogin($email, 'shopware', $context);
         static::assertEquals($email, $customer->getEmail());
@@ -244,7 +245,7 @@ class AccountServiceTest extends TestCase
                 ],
             ],
         ]);
-        $this->createCustomerOfSalesChannel($context->getSalesChannel()->getId(), $email, true, true, $idCustomer, '2022-10-21 10:00:00', md5('test'), 'Md5');
+        $this->createCustomerOfSalesChannel($context->getSalesChannel()->getId(), $email, true, true, $idCustomer, '2022-10-21 10:00:00', Hasher::hash('test', 'md5'), 'Md5');
 
         static::expectException(PasswordPoliciesUpdatedException::class);
         static::expectExceptionMessage('Password policies updated.');

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/RegisterRouteTest.php
@@ -25,6 +25,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\CountryAddToSalesChannelTestBehavi
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestDataCollection;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\PlatformRequest;
@@ -399,7 +400,7 @@ class RegisterRouteTest extends TestCase
                 ['CONTENT_TYPE' => 'application/json'],
                 json_encode([
                     'hash' => $customer->getHash(),
-                    'em' => sha1('teg-reg@example.com'),
+                    'em' => Hasher::hash('teg-reg@example.com', 'sha1'),
                 ], \JSON_THROW_ON_ERROR)
             );
 
@@ -461,7 +462,7 @@ class RegisterRouteTest extends TestCase
         /** @var CustomerEntity $customer */
         $customer = $this->customerRepository->search($criteria, Context::createDefaultContext())->first();
 
-        $this->browser->request('POST', '/store-api/account/register-confirm', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['hash' => $customer->getHash(), 'em' => sha1('teg-reg@example.com')], \JSON_THROW_ON_ERROR));
+        $this->browser->request('POST', '/store-api/account/register-confirm', [], [], ['CONTENT_TYPE' => 'application/json'], json_encode(['hash' => $customer->getHash(), 'em' => Hasher::hash('teg-reg@example.com', 'sha1')], \JSON_THROW_ON_ERROR));
 
         static::assertSame(200, $this->browser->getResponse()->getStatusCode());
 
@@ -592,7 +593,7 @@ class RegisterRouteTest extends TestCase
                 ['CONTENT_TYPE' => 'application/json'],
                 json_encode([
                     'hash' => $customer->getHash(),
-                    'em' => sha1('teg-reg@example.com'),
+                    'em' => Hasher::hash('teg-reg@example.com', 'sha1'),
                 ], \JSON_THROW_ON_ERROR)
             );
 

--- a/tests/integration/Core/Checkout/Customer/SalesChannel/ResetPasswordRouteTest.php
+++ b/tests/integration/Core/Checkout/Customer/SalesChannel/ResetPasswordRouteTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestDataCollection;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\Test\TestDefaults;
@@ -217,7 +218,7 @@ class ResetPasswordRouteTest extends TestCase
         ];
 
         if ($addLegacyPassword) {
-            $customer['legacyPassword'] = md5('test');
+            $customer['legacyPassword'] = Hasher::hash('test', 'md5');
             $customer['legacyEncoder'] = 'Md5';
         }
 

--- a/tests/integration/Core/Checkout/Customer/Subscriber/CustomerChangePasswordSubscriberTest.php
+++ b/tests/integration/Core/Checkout/Customer/Subscriber/CustomerChangePasswordSubscriberTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestDataCollection;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\Test\TestDefaults;
@@ -153,7 +154,7 @@ class CustomerChangePasswordSubscriberTest extends TestCase
             'groupId' => TestDefaults::FALLBACK_CUSTOMER_GROUP,
             'email' => $email,
             'password' => null,
-            'legacyPassword' => md5($password),
+            'legacyPassword' => Hasher::hash($password, 'md5'),
             'legacyEncoder' => 'Md5',
             'firstName' => 'encryption',
             'lastName' => 'Mustermann',

--- a/tests/integration/Core/Content/Newsletter/Service/NewsletterRecipientServiceTest.php
+++ b/tests/integration/Core/Content/Newsletter/Service/NewsletterRecipientServiceTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
@@ -186,7 +187,7 @@ class NewsletterRecipientServiceTest extends TestCase
 
         $email = 'unit@test.foo';
         $dataBag = new RequestDataBag([
-            'em' => hash('sha1', $email),
+            'em' => Hasher::hash($email, 'sha1'),
             'hash' => 'b4b45f58088d41289490db956ca19af7',
         ]);
 

--- a/tests/integration/Core/Framework/Api/ApiAwareTest.php
+++ b/tests/integration/Core/Framework/Api/ApiAwareTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayerFieldTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Storefront\Theme\ThemeDefinition;
 
 /**
@@ -26,7 +27,7 @@ class ApiAwareTest extends TestCase
 
     public function testApiAware(): void
     {
-        $cacheId = hash_file('md5', __DIR__ . '/fixtures/api-aware-fields.json');
+        $cacheId = Hasher::hash_file(__DIR__ . '/fixtures/api-aware-fields.json');
         if (!\is_string($cacheId)) {
             static::fail(__DIR__ . '/fixtures/api-aware-fields.json could not be hashed');
         }

--- a/tests/integration/Core/System/UsageData/EntitySync/DispatchEntityMessageHandlerTest.php
+++ b/tests/integration/Core/System/UsageData/EntitySync/DispatchEntityMessageHandlerTest.php
@@ -16,6 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\FieldType\DateInterval;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetDefinition;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
@@ -439,7 +440,7 @@ class DispatchEntityMessageHandlerTest extends TestCase
 
     private static function getPuid(string $name, string $lastName, string $email): string
     {
-        return hash('sha512', \sprintf('%s%s%s', strtolower($name), strtolower($lastName), strtolower($email)));
+        return Hasher::hash(\sprintf('%s%s%s', strtolower($name), strtolower($lastName), strtolower($email)), 'sha512');
     }
 
     /**

--- a/tests/integration/Storefront/Controller/NewsletterControllerTest.php
+++ b/tests/integration/Storefront/Controller/NewsletterControllerTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelFunctionalTestBehaviour;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\TestDefaults;
@@ -97,7 +98,7 @@ class NewsletterControllerTest extends TestCase
 
         $browser->request(
             'GET',
-            '/newsletter-subscribe?em=' . hash('sha1', 'nltest@example.com') . '&hash=' . $recipientEntry->getHash()
+            '/newsletter-subscribe?em=' . Hasher::hash('nltest@example.com', 'sha1') . '&hash=' . $recipientEntry->getHash()
         );
 
         $response = $browser->getResponse();

--- a/tests/integration/Storefront/Controller/RegisterControllerTest.php
+++ b/tests/integration/Storefront/Controller/RegisterControllerTest.php
@@ -22,6 +22,7 @@ use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\MailTemplateTestBehaviour;
 use Shopware\Core\Framework\Test\TestDataCollection;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\QueryDataBag;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
@@ -287,7 +288,7 @@ class RegisterControllerTest extends TestCase
         $queryData = new QueryDataBag();
         $queryData->set('redirectTo', 'frontend.checkout.confirm.page');
         $queryData->set('hash', $customer->first()?->getHash());
-        $queryData->set('em', hash('sha1', $event->getCustomer()->getEmail()));
+        $queryData->set('em', Hasher::hash($event->getCustomer()->getEmail(), 'sha1'));
 
         $response = $registerController->confirmRegistration($this->salesChannelContext, $queryData);
 

--- a/tests/migration/Core/BasicDataUntouchedTest.php
+++ b/tests/migration/Core/BasicDataUntouchedTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Migration\V6_3\Migration1536233560BasicData;
 
 /**
@@ -20,7 +21,7 @@ class BasicDataUntouchedTest extends TestCase
 
         static::assertSame(
             '5f3935e4df6b004d9e0805133db1536efb2ae077',
-            sha1_file($file),
+            Hasher::hash_file($file, 'sha1'),
             'BasicData migration has changed. This is not allowed.'
         );
     }

--- a/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
+++ b/tests/unit/Core/Checkout/Customer/SalesChannel/RegisterConfirmRouteTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Customer\SalesChannel\RegisterConfirmRoute;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Util\Hasher;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\DataValidationDefinition;
 use Shopware\Core\Framework\Validation\DataValidator;
@@ -190,7 +191,7 @@ class RegisterConfirmRouteTest extends TestCase
     {
         return new RequestDataBag([
             'hash' => 'hash',
-            'em' => hash('sha1', 'test@test.test'),
+            'em' => Hasher::hash('test@test.test', 'sha1'),
         ]);
     }
 }

--- a/tests/unit/Core/Content/Product/SalesChannel/Detail/AvailableCombinationLoaderTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Detail/AvailableCombinationLoaderTest.php
@@ -40,11 +40,11 @@ class AvailableCombinationLoaderTest extends TestCase
 
         $combinations = $result->getCombinations();
         static::assertSame([
-            'a3f67ea263a4f2f5cf456e16de744b4b' => [
+            '4b97f87ff3bd2cd72cc6f6f7d2ae49ae' => [
                 'green',
                 'red',
             ],
-            'b6073234fc601007b541885dd70491f1' => [
+            'a6a23a74867cad90ee0c788a48944911' => [
                 'green',
             ],
         ], $combinations);
@@ -70,11 +70,11 @@ class AvailableCombinationLoaderTest extends TestCase
 
         $combinations = $result->getCombinations();
         static::assertSame([
-            'a3f67ea263a4f2f5cf456e16de744b4b' => [
+            '4b97f87ff3bd2cd72cc6f6f7d2ae49ae' => [
                 'green',
                 'red',
             ],
-            'b6073234fc601007b541885dd70491f1' => [
+            'a6a23a74867cad90ee0c788a48944911' => [
                 'green',
             ],
         ], $combinations);

--- a/tests/unit/Core/Framework/Adapter/Twig/StringTemplateRendererTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/StringTemplateRendererTest.php
@@ -73,7 +73,7 @@ TWIG;
         $renderer = new StringTemplateRenderer($environment, sys_get_temp_dir());
 
         $this->expectException(AdapterException::class);
-        $this->expectExceptionMessage('Failed rendering Twig string template due syntax error: "Unexpected "}" in "04e92a9efc07ae62e1ec342418711bbd" at line 1."');
+        $this->expectExceptionMessageMatches('/Failed rendering Twig string template due syntax error: "Unexpected "}" in "[^"]+" at line 1."/');
         $renderer->render($template, [], $context);
     }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
@@ -61,33 +61,33 @@ class EntityCacheKeyGeneratorTest extends TestCase
     {
         yield 'empty' => [
             new Criteria(),
-            '749322be59780dc4034598e25b3cd946',
+            '6f1868158423d60724dd3071c2d6f525',
         ];
 
         yield 'prefix-filter' => [
             (new Criteria())->addFilter(new PrefixFilter('foo', 'bar')),
-            'a3def85d7155b475e330761d1eb8b1f1',
+            '6da5430a8e30985dcf70e1cce8059641',
         ];
 
         // this has a different hash because of a different filter type used
         yield 'suffix-filter' => [
             (new Criteria())->addFilter(new SuffixFilter('foo', 'bar')),
-            'fa6fcaab1e5a33f0c7fdedb61bef8d22',
+            'bc3f8967e44fa629e6a24e76b9060085',
         ];
 
         yield 'filter+sort' => [
             (new Criteria())->addFilter(new PrefixFilter('foo', 'bar'))->addSorting(new FieldSorting('foo')),
-            'c5d7faee1a855cfdf7f4a5a8807ec0f0',
+            'd877f8f5b53b110aafb704ac12a5e579',
         ];
 
         yield 'filter+sort+sort-desc' => [
             (new Criteria())->addFilter(new PrefixFilter('foo', 'bar'))->addSorting(new FieldSorting('foo', FieldSorting::DESCENDING)),
-            'fd5017a9b079d29a790ea9682c11ed74',
+            '937c265ec89cb32660de09457f16c5fd',
         ];
 
         yield 'filter+agg' => [
             (new Criteria())->addFilter(new PrefixFilter('foo', 'bar'))->addAggregation(new TermsAggregation('foo', 'foo')),
-            'c8dcaf7970a7ec0a42e52047f0b60b1a',
+            'c29788d8da490513f252b92f49a91773',
         ];
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Performance
see #4778

### 2. What does this change do, exactly?
- removed the useless re-hashing in [NotFoundSubscriber::generateKey](https://github.com/shopware/shopware/compare/trunk...tinect:feat/NEXT-38371?expand=1#diff-7c60bcc3f674ac4aa62dd0752b2b97bd03f5b4012e15326dc8cde0bf064387a5) of ContextHash
- Changed usages of hash algo md5 to xxh128 in several places
- Kernel::getCacheHash: (total half of time spent)
  - changed algo to xxh128: -32% time spent
  - removed the hashing of plugin data while it is being hashed again and removed the substr: more -50%
- Changed the hashed in the tests

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
Closes #4778
Closes #4774

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
