### PR TITLE
feat: changed hash algo for bundle manifest from sha256 to xxh128

### DIFF
--- a/changelog/_unreleased/2024-09-18-changed-hash-algo-for-manifest-to-xxh128.md
+++ b/changelog/_unreleased/2024-09-18-changed-hash-algo-for-manifest-to-xxh128.md
@@ -1,0 +1,11 @@
+---
+title: Changed hash algo for manifest to xxh128
+issue: NEXT-38369
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Changed hash algo for bundle manifest used for external storage in \Shopware\Core\Framework\Plugin\Util\AssetService from sha256 to xxh128

--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -173,7 +173,7 @@ class AssetService
     {
         $localManifest = array_combine(
             array_map(fn (SplFileInfo $file) => $file->getRelativePathname(), $files),
-            array_map(fn (SplFileInfo $file) => Hasher::hashFile($file->getPathname(), 'sha256'), $files)
+            array_map(fn (SplFileInfo $file) => Hasher::hashFile($file->getPathname()), $files)
         );
 
         ksort($localManifest);

--- a/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
@@ -251,20 +251,20 @@ class AssetServiceTest extends TestCase
             ],
             'destination-nothing-changed' => [
                 'manifest' => [
-                    'static/js/app.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-                    'one.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-                    'two.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-                    'three.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
+                    'static/js/app.js' => '9b88085012a490e232336863bf269917',
+                    'one.js' => '9b88085012a490e232336863bf269917',
+                    'two.js' => '9b88085012a490e232336863bf269917',
+                    'three.js' => '9b88085012a490e232336863bf269917',
                 ],
                 'expectedWrites' => [],
                 'expectedDeletes' => [],
             ],
             'destination-new-and-removed' => [
                 'manifest' => [
-                    'static/js/app.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-                    'one.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-                    'two.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-                    'four.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
+                    'static/js/app.js' => '9b88085012a490e232336863bf269917',
+                    'one.js' => '9b88085012a490e232336863bf269917',
+                    'two.js' => '9b88085012a490e232336863bf269917',
+                    'four.js' => '9b88085012a490e232336863bf269917',
                 ],
                 'expectedWrites' => [
                     'bundles/administration/three.js' => 'AdminBundle/Resources/public/three.js',
@@ -275,10 +275,10 @@ class AssetServiceTest extends TestCase
             ],
             'destination-content-changed' => [
                 'manifest' => [
-                    'static/js/app.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-                    'one.js' => 'xxx13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b', // incorrect hash to simulate content change
-                    'two.js' => 'xxx13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b', // incorrect hash to simulate content change
-                    'three.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
+                    'static/js/app.js' => '9b88085012a490e232336863bf269917',
+                    'one.js' => 'xxx9b88085012a490e232336863bf269917', // incorrect hash to simulate content change
+                    'two.js' => 'xxx9b88085012a490e232336863bf269917', // incorrect hash to simulate content change
+                    'three.js' => '9b88085012a490e232336863bf269917',
                 ],
                 'expectedWrites' => [
                     'bundles/administration/one.js' => 'AdminBundle/Resources/public/one.js',
@@ -343,10 +343,10 @@ class AssetServiceTest extends TestCase
             }));
 
         $expectedManifestFiles = [
-            'one.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-            'static/js/app.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-            'three.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-            'two.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
+            'one.js' => '9b88085012a490e232336863bf269917',
+            'static/js/app.js' => '9b88085012a490e232336863bf269917',
+            'three.js' => '9b88085012a490e232336863bf269917',
+            'two.js' => '9b88085012a490e232336863bf269917',
         ];
         ksort($expectedManifestFiles);
 
@@ -451,13 +451,13 @@ class AssetServiceTest extends TestCase
 
         $expectedManifestFiles = [
             'administration' => [
-                'one.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-                'static/js/app.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-                'three.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
-                'two.js' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
+                'one.js' => '9b88085012a490e232336863bf269917',
+                'static/js/app.js' => '9b88085012a490e232336863bf269917',
+                'three.js' => '9b88085012a490e232336863bf269917',
+                'two.js' => '9b88085012a490e232336863bf269917',
             ],
             'examplebundle' => [
-                'test.txt' => '13b896d551a100401b0d3982e0729efc2e8d7aeb09a36c0a51e48ec2bd15ea8b',
+                'test.txt' => '9b88085012a490e232336863bf269917',
             ],
         ];
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Using sha256 for hashing is slow.
This will result in transferring the assets once again because the hashes change, but then the check is faster.

### 2. What does this change do, exactly?
change the algo from sha256 to xxh128 in AssetService for BundleManifest file.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
Closes #4776

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
