### PR TITLE
NEXT-00000 - Sort sales channels in product visibility selection

### DIFF
--- a/changelog/_unreleased/2024-09-19-sort-sales-channels-in-product-visibility-selection.md
+++ b/changelog/_unreleased/2024-09-19-sort-sales-channels-in-product-visibility-selection.md
@@ -1,0 +1,10 @@
+---
+title: Sort sales channels in product visibility selection
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+issue: NEXT-00000
+---
+
+# Administration
+* Changed the order of sales channels in the product visibility selection to be sorted alphabetically.

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-visibility-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-visibility-select/index.js
@@ -4,7 +4,7 @@
 
 import template from './sw-product-visibility-select.html.twig';
 
-const { EntityCollection } = Shopware.Data;
+const { EntityCollection, Criteria } = Shopware.Data;
 const { mapState } = Shopware.Component.getComponentHelper();
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
@@ -12,6 +12,18 @@ export default {
     template,
 
     emits: ['item-add'],
+
+    props: {
+        criteria: {
+            type: Object,
+            required: false,
+            default(props) {
+                const criteria = new Criteria(1, props.resultLimit);
+                criteria.addSorting(Criteria.sort('name', 'ASC'));
+                return criteria;
+            },
+        },
+    },
 
     data() {
         return {


### PR DESCRIPTION
### 1. Why is this change necessary?

In the product visibility selection, the sales channels are not listed in alphabetical order.

### 2. What does this change do, exactly?

It changes the order of sales channels in the product visibility selection to be sorted alphabetically.

### 3. Describe each step to reproduce the issue or behavior.

1. Have more than 1 sales channel
2. Create product, select sales channel
3. Sales channels are not listed in alphabetical order

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
