### PR TITLE
feat: move NavigationPageLoadedEvent

### DIFF
--- a/changelog/_unreleased/2024-09-20-move-navigationpageloadedevent-to-end.md
+++ b/changelog/_unreleased/2024-09-20-move-navigationpageloadedevent-to-end.md
@@ -1,0 +1,9 @@
+---
+title: Move NavigationPageLoadedEvent to end
+issue: NEXT-000000
+author: Niklas Wolf
+author_email: wolfniklas94@web.de
+author_github: @niklaswolf
+---
+# Core
+* move NavigationPageLoadedEvent so that the canonical can be changed via event-subscriber

--- a/changelog/_unreleased/2024-09-20-move-navigationpageloadedevent-to-end.md
+++ b/changelog/_unreleased/2024-09-20-move-navigationpageloadedevent-to-end.md
@@ -6,4 +6,4 @@ author_email: wolfniklas94@web.de
 author_github: @niklaswolf
 ---
 # Core
-* move NavigationPageLoadedEvent so that the canonical can be changed via event-subscriber
+* Changed `NavigationPageLoader` to dispatch the `NavigationPageLoadedEvent` after setting the canonical URL, such that the canonical can be changed via an event-subscriber

--- a/src/Storefront/Page/Navigation/NavigationPageLoader.php
+++ b/src/Storefront/Page/Navigation/NavigationPageLoader.php
@@ -53,10 +53,6 @@ class NavigationPageLoader implements NavigationPageLoaderInterface
             $page->setCmsPage($category->getCmsPage());
         }
 
-        $this->eventDispatcher->dispatch(
-            new NavigationPageLoadedEvent($page, $context, $request)
-        );
-
         if ($page->getMetaInformation()) {
             $canonical = ($navigationId === $context->getSalesChannel()->getNavigationCategoryId())
                 ? $this->seoUrlReplacer->generate('frontend.home.page')
@@ -64,6 +60,10 @@ class NavigationPageLoader implements NavigationPageLoaderInterface
 
             $page->getMetaInformation()->setCanonical($canonical);
         }
+
+        $this->eventDispatcher->dispatch(
+            new NavigationPageLoadedEvent($page, $context, $request)
+        );
 
         return $page;
     }


### PR DESCRIPTION
### 1. Why is this change necessary?
The canonical for a navigation page can't be changed via event-subscriber

### 2. What does this change do, exactly?
Moves the dispatch of the NavigationPageLoadedEvent to the end of the NavigationPageLoader, so that all values can be changed via event-subscriber.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).
#2982 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
