### PR TITLE
fix: 30 days expiration date for the wishlist cookie

### DIFF
--- a/changelog/_unreleased/2024-09-22-changed-wishlist-cookie-from-a-session-cookie-to-a-cookie-valid-for-30-days.md
+++ b/changelog/_unreleased/2024-09-22-changed-wishlist-cookie-from-a-session-cookie-to-a-cookie-valid-for-30-days.md
@@ -1,0 +1,9 @@
+---
+title: Changed wishlist cookie from a session cookie to a cookie valid for 30 days
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed the `wishlist-enabled` cookie from a session cookie to a cookie which is valid for 30 days, as otherwise the user would need to accept that cookie again, after he closed the browser

--- a/src/Storefront/Framework/Cookie/CookieProvider.php
+++ b/src/Storefront/Framework/Cookie/CookieProvider.php
@@ -54,6 +54,7 @@ class CookieProvider implements CookieProviderInterface
             [
                 'snippet_name' => 'cookie.groupComfortFeaturesWishlist',
                 'cookie' => 'wishlist-enabled',
+                'expiration' => '30',
                 'value' => '1',
             ],
             [


### PR DESCRIPTION
### 1. Why is this change necessary?
If the user accepts the wishlist comfort feature, it is not accepted after he closed the browser. A problem is also, that the cookie notice is not shown again, in the next browser session, hence the user will never notice that he has not accepted the wishlist feature.

### 2. What does this change do, exactly?
Make the cookie valid for 30 days, as all other cookies.

### 3. Describe each step to reproduce the issue or behaviour.
Accept the wishlist feature, close the browser, and open it again. The cookie `wishlist-enabled` is not there anymore.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.