### PR TITLE
fix: Do not fail on country change if no labels are present

### DIFF
--- a/changelog/_unreleased/2024-09-22-do-not-throw-an-error-if-no-labels-are-present-on-country-change.md
+++ b/changelog/_unreleased/2024-09-22-do-not-throw-an-error-if-no-labels-are-present-on-country-change.md
@@ -1,0 +1,9 @@
+---
+title: Do not throw an error if no labels are present on country change
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed `CountryStateSelectPlugin` to not throw an error if the labels for the VAT-ID or the state are not present

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-country-state-select.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-country-state-select.plugin.js
@@ -120,14 +120,14 @@ export default class CountryStateSelectPlugin extends Plugin {
         if (vatIdRequired) {
             vatIdFieldInput.setAttribute('required', 'required');
 
-            if (label.textContent.substr(-1, 1) !== '*') {
+            if (label?.textContent && label.textContent.substr(-1, 1) !== '*') {
                 label.textContent = `${label.textContent}*`;
             }
 
             return;
         }
 
-        if (label.textContent.substr(-1, 1) === '*') {
+        if (label?.textContent && label.textContent.substr(-1, 1) === '*') {
             label.textContent = label.textContent.substr(0, label.textContent.length -1);
         }
 
@@ -226,14 +226,14 @@ function updateRequiredState(countryStateSelect, stateRequired, placeholderQuery
         placeholder.setAttribute('disabled', 'disabled');
         countryStateSelect.setAttribute('required', 'required');
 
-        if (label.textContent && label.textContent.substr(-1, 1) !== '*') {
+        if (label?.textContent && label.textContent.substr(-1, 1) !== '*') {
             label.textContent = `${label.textContent.trim()}*`;
         }
 
         return;
     }
 
-    if (label.textContent && label.textContent.substr(-1, 1) === '*') {
+    if (label?.textContent && label.textContent.substr(-1, 1) === '*') {
         label.textContent = label.textContent.substr(0, label.textContent.length -1);
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
In an adjusted registration form, we changed the address form to only work with placeholders instead of labels. While this is of course not true for the default Shopware, this leads to an error, as the label elements cannot be found.

### 2. What does this change do, exactly?
Check if the labels are found, and only adjust the label if it is present.

### 3. Describe each step to reproduce the issue or behaviour.
Remove the labels in the address form and change the country.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
