### PR TITLE
refactor: Cleanup product media image sorting

### DIFF
--- a/changelog/_unreleased/2024-09-22-simplified-product-media-sorting.md
+++ b/changelog/_unreleased/2024-09-22-simplified-product-media-sorting.md
@@ -1,0 +1,10 @@
+---
+title: Simplified product media sorting
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed product media sorting to be sorted by the MySQL server and not on the PHP side
+* Deprecated protected method `Shopware\Core\Content\Media\Cms\Type\ImageSliderTypeDataResolver::sortItemsByPosition()`

--- a/src/Core/Content/Media/Cms/Type/ImageSliderTypeDataResolver.php
+++ b/src/Core/Content/Media/Cms/Type/ImageSliderTypeDataResolver.php
@@ -17,6 +17,7 @@ use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaCollection;
 use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
 use Shopware\Core\Content\Product\ProductEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('buyers-experience')]
@@ -86,7 +87,6 @@ class ImageSliderTypeDataResolver extends AbstractCmsElementResolver
             if ($sliderItems === null || (is_countable($sliderItems) ? \count($sliderItems) : 0) < 1) {
                 return;
             }
-            $this->sortItemsByPosition($sliderItems);
 
             if ($sliderItemsConfig->getStringValue() === 'product.media') {
                 /** @var ProductEntity $productEntity */
@@ -109,8 +109,13 @@ class ImageSliderTypeDataResolver extends AbstractCmsElementResolver
         }
     }
 
+    /**
+     * @deprecated tag:v6.7.0 - Will be removed without replacement
+     */
     protected function sortItemsByPosition(ProductMediaCollection $sliderItems): void
     {
+        Feature::triggerDeprecationOrThrow('v6.7.0.0', 'Unused method ImageSliderTypeDataResolver::sortItemsByPosition will be removed without replacement');
+
         if (!$sliderItems->first() || !$sliderItems->first()->has('position')) {
             return;
         }

--- a/src/Storefront/Page/Product/ProductPageLoader.php
+++ b/src/Storefront/Page/Product/ProductPageLoader.php
@@ -7,7 +7,6 @@ use Shopware\Core\Content\Cms\Aggregate\CmsBlock\CmsBlockCollection;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\CrossSellingStruct;
 use Shopware\Core\Content\Cms\SalesChannel\Struct\ProductDescriptionReviewsStruct;
 use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaCollection;
-use Shopware\Core\Content\Product\Aggregate\ProductMedia\ProductMediaEntity;
 use Shopware\Core\Content\Product\Cms\CrossSellingCmsElementResolver;
 use Shopware\Core\Content\Product\Cms\ProductDescriptionReviewsCmsElementResolver;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
@@ -17,6 +16,7 @@ use Shopware\Core\Content\Property\Aggregate\PropertyGroupOption\PropertyGroupOp
 use Shopware\Core\Content\Property\PropertyGroupCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\InconsistentCriteriaIdsException;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RoutingException;
@@ -59,15 +59,16 @@ class ProductPageLoader
             ->addAssociation('manufacturer.media')
             ->addAssociation('options.group')
             ->addAssociation('properties.group')
-            ->addAssociation('mainCategories.category')
-            ->addAssociation('media');
+            ->addAssociation('mainCategories.category');
+
+        $criteria->getAssociation('media')->addSorting(
+            new FieldSorting('position')
+        );
 
         $this->eventDispatcher->dispatch(new ProductPageCriteriaEvent($productId, $criteria, $context));
 
         $result = $this->productDetailRoute->load($productId, $request, $context, $criteria);
         $product = $result->getProduct();
-
-        $product->getMedia()?->sort(fn (ProductMediaEntity $a, ProductMediaEntity $b) => $a->getPosition() <=> $b->getPosition());
 
         if ($product->getMedia() && $product->getCover()) {
             $product->setMedia(new ProductMediaCollection(array_merge(

--- a/tests/integration/Core/Content/Media/Cms/Type/ImageSliderTypeDataResolverTest.php
+++ b/tests/integration/Core/Content/Media/Cms/Type/ImageSliderTypeDataResolverTest.php
@@ -319,7 +319,7 @@ class ImageSliderTypeDataResolverTest extends TestCase
     protected function getProductMediaCollection(): ProductMediaCollection
     {
         $productMedia = [];
-        for ($i = 4; $i >= 0; --$i) {
+        for ($i = 0; $i <= 4; ++$i) {
             $mediaId = 'media' . $i;
             $mediaEntity = new MediaEntity();
             $mediaEntity->setId($mediaId);

--- a/tests/unit/Storefront/Page/Product/ProductPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Product/ProductPageLoaderTest.php
@@ -32,6 +32,7 @@ use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\Currency\CurrencyEntity;
@@ -107,6 +108,10 @@ class ProductPageLoaderTest extends TestCase
             ->addAssociation('properties.group')
             ->addAssociation('mainCategories.category')
             ->addAssociation('media');
+
+        $criteria->getAssociation('media')->addSorting(
+            new FieldSorting('position')
+        );
 
         $productDetailRouteMock = $this->createMock(ProductDetailRoute::class);
         $productDetailRouteMock


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the media of products is sorted at different places and I did not understand why and how.

### 2. What does this change do, exactly?
Cleanup the sorting of the media to happen directly in the database, using the criteria.

### 3. Describe each step to reproduce the issue or behaviour.
Try to do something with the product media sorting.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
