### PR TITLE
NEXT-00000 - Cancelled order should not be editable in storefront

### DIFF
--- a/changelog/_unreleased/2024-09-23-cancelled-order-should-not-be-editable.md
+++ b/changelog/_unreleased/2024-09-23-cancelled-order-should-not-be-editable.md
@@ -9,6 +9,6 @@ author_github: @luminalpark
 * Changed `src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php` to check if order is in cancelled state, in that case throw an exception.
 * Changed `src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json` to show error message.
 * Changed `src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json` to show error message.
-
+___
 # Core
 * Changed `src/Core/Checkout/Order/OrderException.php` to define the exception.

--- a/changelog/_unreleased/2024-09-23-cancelled-order-should-not-be-editable.md
+++ b/changelog/_unreleased/2024-09-23-cancelled-order-should-not-be-editable.md
@@ -1,0 +1,14 @@
+---
+title: cancelled order should not be editable in storefront
+issue: NEXT-00000
+author: Carlo Cecco
+author_email: 6672778+luminalpark@users.noreply.github.com
+author_github: @luminalpark
+---
+# Storefront
+* Changed `src/Storefront/Page/Account/Order/AccountEditOrderPageLoader.php` to check if order is in cancelled state, in that case throw an exception.
+* Changed `src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json` to show error message.
+* Changed `src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json` to show error message.
+
+# Core
+* Changed `src/Core/Checkout/Order/OrderException.php` to define the exception.

--- a/src/Core/Checkout/Order/OrderException.php
+++ b/src/Core/Checkout/Order/OrderException.php
@@ -13,6 +13,7 @@ class OrderException extends HttpException
 {
     final public const ORDER_MISSING_ORDER_ASSOCIATION_CODE = 'CHECKOUT__ORDER_MISSING_ORDER_ASSOCIATION';
     final public const ORDER_ORDER_DELIVERY_NOT_FOUND_CODE = 'CHECKOUT__ORDER_ORDER_DELIVERY_NOT_FOUND';
+    final public const ORDER_ORDER_CANCELLED_CODE = 'CHECKOUT__ORDER_ORDER_CANCELLED';
     final public const ORDER_ORDER_NOT_FOUND_CODE = 'CHECKOUT__ORDER_ORDER_NOT_FOUND';
     final public const ORDER_MISSING_ORDER_NUMBER_CODE = 'CHECKOUT__ORDER_MISSING_ORDER_NUMBER';
     final public const ORDER_MISSING_TRANSACTIONS_CODE = 'CHECKOUT__ORDER_MISSING_TRANSACTIONS';
@@ -157,6 +158,16 @@ class OrderException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::ORDER_INVALID_ORDER_ADDRESS_MAPPING,
             'Invalid order address mapping provided. ' . $reason,
+        );
+    }
+
+    public static function orderCancelled(string $orderId): self
+    {
+        return new self(
+            Response::HTTP_FORBIDDEN,
+            self::ORDER_ORDER_CANCELLED_CODE,
+            'Order with id "{{ orderId }}" was cancelled and cannot be edited afterwards.',
+            ['orderId' => $orderId]
         );
     }
 }

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -125,6 +125,7 @@
       "basic-captcha-invalid": "Eingabe ungültig. Bitte versuchen Sie es erneut."
     },
     "CHECKOUT__ORDER_ORDER_ALREADY_PAID": "Die Bestellung mit der Bestellnummer \"%orderNumber%\" wurde bereits bezahlt und kann nicht nachträglich bearbeitet werden.",
+    "CHECKOUT__ORDER_ORDER_CANCELLED": "Die Bestellung mit der Bestellnummer \"%orderNumber%\" wurde storniert und kann nicht nachträglich bearbeitet werden.",
     "CHECKOUT__ORDER_ORDER_NOT_FOUND": "Diese Bestellung konnte nicht gefunden werden.",
     "CHECKOUT__CART_HASH_MISMATCH": "Produkte oder Preise in Deinem Warenkorb haben sich möglicherweise geändert. Bitte überprüfe den Warenkorb, bevor Du die Bestellung aufgibst.",
     "CHECKOUT__CART_INVALID_LINE_ITEM_QUANTITY": "Die angegebene Menge (%quantity%) ist ungültig."

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -125,6 +125,7 @@
       "basic-captcha-invalid": "Incorrect input. Please try again."
     },
     "CHECKOUT__ORDER_ORDER_ALREADY_PAID": "The order with the order number \"%orderNumber%\" was already paid and cannot be edited afterwards.",
+    "CHECKOUT__ORDER_ORDER_CANCELLED": "The order with the order number \"%orderNumber%\" was canceled and cannot be edited afterwards.",
     "CHECKOUT__ORDER_ORDER_NOT_FOUND": "This order could not be found.",
     "CHECKOUT__CART_HASH_MISMATCH": "Products or prices in your shopping cart may have changed. Please check your shopping cart before placing your order.",
     "CHECKOUT__CART_INVALID_LINE_ITEM_QUANTITY": "The quantity (%quantity%) is incorrect."


### PR DESCRIPTION
### 1. Why is this change necessary?
When an order is in `cancelled` state no modification should be possible in storefront, therefore route `frontend.account.edit-order.page` should return an error message.

### 2. What does this change do, exactly?
In `AccountEditOrderPageLoader` check if the order is in `cancelled`, raise an exception if true.

### 3. Describe each step to reproduce the issue or behaviour.
Create an order, change its status to Cancelled, and visit `/account/order/edit/{orderId}`, you can change payment method and complete payment on a cancelled order.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
