### PR TITLE
feat: add mailTemplateId and mailTemplateTypeId to submit-data

### DIFF
--- a/changelog/_unreleased/2024-09-23-added-mailtemplateid-and-mailtemplatetypeid-to-data-sent-to-mail-action.md
+++ b/changelog/_unreleased/2024-09-23-added-mailtemplateid-and-mailtemplatetypeid-to-data-sent-to-mail-action.md
@@ -1,0 +1,9 @@
+---
+title: Added mailTemplateId and mailTemplateTypeId to data sent to mail action
+issue: NEXT-000000
+author: Niklas Wolf
+author_email: wolfniklas94@web.de
+author_github: @niklaswolf
+___
+# Administration
+* Added mailTemplateId and mailTemplateTypeId to data sent to mail action controller

--- a/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.js
@@ -21,6 +21,8 @@ class MailApiService extends ApiService {
         testMode = false,
         documentIds = [],
         templateData = null,
+        mailTemplateTypeId = null,
+        mailTemplateId = null,
     ) {
         const apiRoute = `/_action/${this.getApiBasePath()}/send`;
 
@@ -38,6 +40,8 @@ class MailApiService extends ApiService {
                 senderName: mailTemplate.senderName ?? mailTemplate.translated?.senderName,
                 documentIds,
                 testMode,
+                mailTemplateTypeId,
+                mailTemplateId,
             },
             {
                 headers: this.getBasicHeaders(),
@@ -47,7 +51,15 @@ class MailApiService extends ApiService {
         });
     }
 
-    testMailTemplate(recipient, mailTemplate, mailTemplateMedia, salesChannelId, documentIds = []) {
+    testMailTemplate(
+        recipient,
+        mailTemplate,
+        mailTemplateMedia,
+        salesChannelId,
+        mailTemplateTypeId,
+        mailTemplateId,
+        documentIds = [],
+    ) {
         return this.sendMailTemplate(
             recipient,
             recipient,
@@ -56,6 +68,9 @@ class MailApiService extends ApiService {
             salesChannelId,
             true,
             documentIds,
+            null,
+            mailTemplateTypeId,
+            mailTemplateId,
         );
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/index.js
@@ -351,6 +351,8 @@ export default {
                 this.mailPreviewContent(),
                 this.mailTemplateMedia,
                 this.testMailSalesChannelId,
+                this.mailTemplate.mailTemplateTypeId,
+                this.mailTemplate.id,
             ).then((response) => {
                 // Size is the length of the mail message, if the size is zero then no mail was sent
                 const isMailSent = response?.size !== 0;

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
@@ -413,6 +413,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
             wrapper.vm.mailTemplate,
             expect.anything(),
             '1a2b3c',
+            undefined,
+            '6666673yd1ssd299si1d837dy1ud628',
         );
     });
 
@@ -451,6 +453,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
             wrapper.vm.mailTemplate,
             expect.anything(),
             '1a2b3c',
+            undefined,
+            '6666673yd1ssd299si1d837dy1ud628',
         );
     });
 
@@ -572,6 +576,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
             mailTemplate,
             expect.anything(),
             '1a2b3c',
+            undefined,
+            '6666673yd1ssd299si1d837dy1ud628',
         );
     });
 
@@ -680,6 +686,8 @@ describe('modules/sw-mail-template/page/sw-mail-template-detail', () => {
             wrapper.vm.mailTemplate,
             expect.anything(),
             '1a2b3c',
+            undefined,
+            '6666673yd1ssd299si1d837dy1ud628',
         );
 
         expect(notificationMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
### 1. Why is this change necessary?
To improve the `FroshPlatformTemplateMail` plugin with support for the test-mail functionality, the data added in this PR is needed in the MailActionController.
https://github.com/FriendsOfShopware/FroshPlatformTemplateMail/issues/34#issuecomment-2363260413

### 2. What does this change do, exactly?
Adds optional data to the payload sent to `\Shopware\Core\Content\MailTemplate\Api\MailActionController::send`
- mailTemplateId
- mailTemplateTypeId 

### 3. Describe each step to reproduce the issue or behaviour.
- use the mail-template test-mail functionality and inspect the request sent to the server

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
