### PR TITLE
feat: add criteria events for country and country state routes

### DIFF
--- a/changelog/_unreleased/2024-09-23-added-criteria-events-for-country-and-country-state-routes.md
+++ b/changelog/_unreleased/2024-09-23-added-criteria-events-for-country-and-country-state-routes.md
@@ -1,0 +1,9 @@
+---
+title: Added criteria events for country and country state routes
+issue: NEXT-000000
+author: Niklas Wolf
+author_email: wolfniklas94@web.de
+author_github: @niklaswolf
+---
+# Core
+* Added criteria events for country route and country state route

--- a/src/Core/System/Country/Event/CountryCriteriaEvent.php
+++ b/src/Core/System/Country/Event/CountryCriteriaEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Shopware\Core\System\Country\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('buyers-experience')]
+class CountryCriteriaEvent extends Event implements ShopwareSalesChannelEvent
+{
+    public function __construct(
+        private readonly Request $request,
+        private readonly Criteria $criteria,
+        private readonly SalesChannelContext $salesChannelContext
+    ) {
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+}

--- a/src/Core/System/Country/Event/CountryCriteriaEvent.php
+++ b/src/Core/System/Country/Event/CountryCriteriaEvent.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Shopware\Core\System\Country\Event;
 

--- a/src/Core/System/Country/Event/CountryStateCriteriaEvent.php
+++ b/src/Core/System/Country/Event/CountryStateCriteriaEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Shopware\Core\System\Country\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\ShopwareSalesChannelEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('buyers-experience')]
+class CountryStateCriteriaEvent extends Event implements ShopwareSalesChannelEvent
+{
+    public function __construct(
+        private readonly string $countryId,
+        private readonly Request $request,
+        private readonly Criteria $criteria,
+        private readonly SalesChannelContext $salesChannelContext
+    ) {
+    }
+
+    public function getCountryId(): string
+    {
+        return $this->countryId;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->salesChannelContext->getContext();
+    }
+
+    public function getSalesChannelContext(): SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+}

--- a/src/Core/System/Country/Event/CountryStateCriteriaEvent.php
+++ b/src/Core/System/Country/Event/CountryStateCriteriaEvent.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Shopware\Core\System\Country\Event;
 

--- a/src/Core/System/Country/SalesChannel/CountryRoute.php
+++ b/src/Core/System/Country/SalesChannel/CountryRoute.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\Country\CountryCollection;
+use Shopware\Core\System\Country\Event\CountryCriteriaEvent;
 use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -46,6 +47,7 @@ class CountryRoute extends AbstractCountryRoute
 
         $criteria->addFilter(new EqualsFilter('active', true));
 
+        $this->dispatcher->dispatch(new CountryCriteriaEvent($request, $criteria, $context));
         $result = $this->countryRepository->search($criteria, $context);
 
         return new CountryRouteResponse($result);

--- a/src/Core/System/Country/SalesChannel/CountryStateRoute.php
+++ b/src/Core/System/Country/SalesChannel/CountryStateRoute.php
@@ -10,6 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateCollection;
+use Shopware\Core\System\Country\Event\CountryStateCriteriaEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
@@ -52,6 +53,7 @@ class CountryStateRoute extends AbstractCountryStateRoute
         $criteria->addSorting(new FieldSorting('position', FieldSorting::ASCENDING, true));
         $criteria->addSorting(new FieldSorting('name', FieldSorting::ASCENDING));
 
+        $this->dispatcher->dispatch(new CountryStateCriteriaEvent($countryId, $request, $criteria, $context));
         $countryStates = $this->countryStateRepository->search($criteria, $context->getContext());
 
         return new CountryStateRouteResponse($countryStates);


### PR DESCRIPTION
### 1. Why is this change necessary?
It's not possible right now to adjust the criteria with which the country and country-state routes work.

### 2. What does this change do, exactly?
adds criteria-events to the two routes

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
