### PR TITLE
Avoid double submissions on password recovery form

### DIFF
--- a/changelog/_unreleased/2024-09-24-2024-09-24-block-double-password-recovery-form-submissions-md.md
+++ b/changelog/_unreleased/2024-09-24-2024-09-24-block-double-password-recovery-form-submissions-md.md
@@ -1,0 +1,9 @@
+---
+title: {2024-09-24}-Block-double-password-recovery-form-submissions.md
+issue: 1234
+author: Bart Vanderstukken
+author_email: bart.vanderstukken@meteor.be
+author_github: @sneakyvv
+---
+# Storefront
+* Block double password recovery form submissions by disabling the submit button after the first click

--- a/src/Storefront/Resources/views/storefront/page/account/profile/recover-password.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/profile/recover-password.html.twig
@@ -9,7 +9,8 @@
                         <form method="post"
                               class="account-recover-password-form card"
                               action="{{ path('frontend.account.recover.request') }}"
-                              data-form-validation="true">
+                              data-form-validation="true"
+                              data-form-submit-loader="true">
                             {% block page_account_profile_recover_password_title %}
                                 <h1 class="card-title">
                                     {{ 'account.profileRecoverPasswordTitle'|trans }}
@@ -65,8 +66,7 @@
                                             {% block page_account_profile_recover_password_action_send %}
                                                 <button type="submit"
                                                         class="account-recover-password-submit btn btn-primary"
-                                                        title="{{ 'account.profileRecoverPasswordSubmit'|trans }}"
-                                                        onclick="this.disabled = true; this.closest('form').submit();">
+                                                        title="{{ 'account.profileRecoverPasswordSubmit'|trans }}">
                                                     {{ 'account.profileRecoverPasswordSubmit'|trans }}
                                                 </button>
                                             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/account/profile/recover-password.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/profile/recover-password.html.twig
@@ -65,7 +65,8 @@
                                             {% block page_account_profile_recover_password_action_send %}
                                                 <button type="submit"
                                                         class="account-recover-password-submit btn btn-primary"
-                                                        title="{{ 'account.profileRecoverPasswordSubmit'|trans }}">
+                                                        title="{{ 'account.profileRecoverPasswordSubmit'|trans }}"
+                                                        onclick="this.disabled = true; this.closest('form').submit();">
                                                     {{ 'account.profileRecoverPasswordSubmit'|trans }}
                                                 </button>
                                             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

It is now possible to do consecutive submissions of the password recovery form, which can lead to the race condition where a 2nd submission deletes the recovery record of the 1st request while the 1st request is already sending the email but can no longer find a recovery record for the customer, causing a (hard-to-debug) exception to be logged.

### 2. What does this change do, exactly?

Disable the button on submission

### 3. Describe each step to reproduce the issue or behaviour.

Click on the button fast, and provoke the behavior by controlling code execution via a debugger like Xdebug.

### 4. Please link to the relevant issues (if any).

N/A

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] ~~I have written tests and verified that they fail without my change~~
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] ~~I have written or adjusted the documentation according to my changes~~
- [ ] ~~This change has comments for package types, values, functions, and non-obvious lines of code~~
- [x] I have read the contribution requirements and fulfil them.
