### PR TITLE
Fix - delivery address editing during order creation saving leads to Axios error

### DIFF
--- a/changelog/_unreleased/2024-09-26-fix-delivery-address-editing-during-order-creation-saving-leads-to-axios-error.md
+++ b/changelog/_unreleased/2024-09-26-fix-delivery-address-editing-during-order-creation-saving-leads-to-axios-error.md
@@ -1,0 +1,9 @@
+---
+title: Fix - delivery address editing during order creation saving leads to Axios error
+issue: NEXT-36301
+author: Lily
+author_email: 78275632+LunaDotGit@users.noreply.github.com
+author_github: LunaDotGit
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/index.js` Fix address mapping in function addressOptions to seperately set the mapped objects `id` property.

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-address-selection/index.js
@@ -112,10 +112,12 @@ export default {
 
         addressOptions() {
             const addresses = (this.customer?.addresses || []).map(item => {
-                return {
+                const option = {
                     label: this.addressLabel(item),
                     ...item,
                 };
+                option.id = item.id;
+                return option;
             });
 
             // eslint-disable-next-line no-unused-expressions


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently, it is not possible to create and set a new address in the order detail edit module in the Administration, as this will lead to an Error when selecting the new address and trying to save.


### 2. What does this change do, exactly?
The change fixes the address mapping in the function `addressOptions` to separately set the mapped objects `id` property. When a new address is created, it receives the `id` property, but is not properly accessible via the ...Object destructuring Syntax. To work around this fix, it's set directly in the mapping function to prevent issues when trying to select the address in the select, as it otherwise misses a reference to the id.


### 3. Describe each step to reproduce the issue or behaviour.
- create an order or edit a previously created order in the Administration
- edit the addresses on the order edit detail page and create a new one
- choose the newly created address via dropdown
- attempt to save the order

Before this fix, this would lead to an Axios Error. With the Fix implemented you see the address selected and can save normally.

### 4. Please link to the relevant issues (if any).
- https://github.com/shopware/shopware/issues/4353
- https://shopware.atlassian.net/browse/NEXT-36301

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
