### PR TITLE
Add srsltid to ignored url parameters

### DIFF
--- a/changelog/_unreleased/2024-09-27-add.md
+++ b/changelog/_unreleased/2024-09-27-add.md
@@ -1,0 +1,9 @@
+---
+title: Add srsltid parameter to ignored http cache parameters
+issue: NEXT-000000
+author: Wanne Van Camp
+author_email: info@campit.be
+author_github: wannevancamp
+---
+# Core
+* Added `srsltid` parameter to ignored http cache parameters `shopware.http_cache.ignored_url_parameters`

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -59,7 +59,7 @@ shopware:
             - 'ie'
             - 'cof'
             - 'siteurl'
-            - '_ga'
+            - '_ga' # Google Analytics
             - 'adgroupid'
             - 'campaignid'
             - 'adid'

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -65,6 +65,7 @@ shopware:
             - 'adid'
             - 'gclsrc' # Google DoubleClick
             - 'gclid'
+            - 'srsltid' # Google Merchant
             - 'fbclid' # Facebook
             - 'fb_action_ids'
             - 'fb_action_types'


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Recently I noticed some non-hitting HTTP cache calls, due to a new URL parameter `srsltid` from Google Merchant:
https://support.google.com/analytics/thread/288691031/why-google-started-to-use-srsltid-parameter-recently?hl=en


### 2. What does this change do, exactly?
Ignore this parameter.

### 3. Describe each step to reproduce the issue or behaviour.
N/A

### 4. Please link to the relevant issues (if any).
N/A

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
