### PR TITLE
Fix: failing assert in bin/console state-machine:dump

### DIFF
--- a/changelog/_unreleased/2024-12-06-fix-assert-in-state-machine-dump.md
+++ b/changelog/_unreleased/2024-12-06-fix-assert-in-state-machine-dump.md
@@ -1,0 +1,9 @@
+---
+title: Fix assert `bin/console state-machine:dump`
+issue: NEXT-00000
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Core
+* Changed assert in `bin/console state-machine:dump`. 

--- a/src/Core/System/StateMachine/Util/StateMachineGraphvizDumper.php
+++ b/src/Core/System/StateMachine/Util/StateMachineGraphvizDumper.php
@@ -172,8 +172,10 @@ class StateMachineGraphvizDumper
         $code = [];
         foreach ($options as $k => $v) {
             \assert(\is_string($k));
-            \assert(\is_string($v));
-            $code[] = \sprintf('%s="%s"', $k, $v);
+            if ($v !== null) {
+                \assert(\is_scalar($v) || $v instanceof \Stringable);
+                $code[] = \sprintf('%s="%s"', $k, $v);
+            }
         }
 
         return implode(' ', $code);


### PR DESCRIPTION
```
bin/console state-machine:dump order.state
```

fails

assert(\is_string($v))

Because there is a 'label' => null entry in the options array.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
