### PR TITLE
NEXT-00000 - Flow for setting delivery status does not reliably set status for orders with shipping discounts

### DIFF
--- a/changelog/_unreleased/2024-09-23-fix-flow-action-on-order-state-change-with-shipping-discount.md
+++ b/changelog/_unreleased/2024-09-23-fix-flow-action-on-order-state-change-with-shipping-discount.md
@@ -1,0 +1,8 @@
+---
+title: Fix flow for setting delivery status does not reliably set status for orders with shipping discounts
+issue: NEXT-00000
+author: Marina Egner
+author_github: @magraina
+---
+# Core
+* Changed `Shopware\Core\Content\Flow\Dispatching\ActionSetOrderStateAction` to evaluate the primary order delivery via sorting and filtering

--- a/tests/integration/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
+++ b/tests/integration/Core/Content/Flow/Dispatching/Action/SetOrderStateActionTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Cart\Price\Struct\CalculatedPrice;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
 use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryEntity;
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryStates;
 use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionStates;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -42,6 +43,8 @@ class SetOrderStateActionTest extends TestCase
 
     private EntityRepository $orderRepository;
 
+    private EntityRepository $orderDeliveryRepository;
+
     private EntityRepository $flowRepository;
 
     private Connection $connection;
@@ -53,6 +56,7 @@ class SetOrderStateActionTest extends TestCase
         $this->connection = $this->getContainer()->get(Connection::class);
 
         $this->customerRepository = $this->getContainer()->get('customer.repository');
+        $this->orderDeliveryRepository = $this->getContainer()->get('order_delivery.repository');
 
         $this->ids = new TestDataCollection();
 
@@ -140,6 +144,80 @@ class SetOrderStateActionTest extends TestCase
         static::assertNotSame($orderTransactionState, $orderTransactionStateAfterAction);
     }
 
+    public function testSetStateOnOrderDeliveryWithDiscountOnDelivery(): void
+    {
+        $context = Context::createDefaultContext();
+        $flowCreatePayload = [
+            'id' => Uuid::randomHex(),
+            'eventName' => CheckoutOrderPlacedEvent::EVENT_NAME,
+            'name' => 'Test Flow',
+            'active' => true,
+            'sequences' => [
+                [
+                    'id' => Uuid::randomHex(),
+                    'actionName' => SetOrderStateAction::getName(),
+                    'config' => [
+                        'order_delivery' => 'shipped',
+                        'force_transition' => false,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->flowRepository->create([$flowCreatePayload], Context::createDefaultContext());
+        $this->createCustomerAndLogin();
+
+        $customerId = $this->ids->get('customer');
+        $orderId = $this->ids->get('order');
+        $IdForShippingCosts = Uuid::randomHex();
+        $orderDeliveries = [
+            $this->generateOrderDeliveryPayload([
+                'id' => $IdForShippingCosts,
+                'orderId' => $orderId,
+                'shippingCosts' => new CalculatedPrice(
+                    10.00,
+                    10.00,
+                    new CalculatedTaxCollection([]),
+                    new TaxRuleCollection([]),
+                ),
+            ]),
+            $this->generateOrderDeliveryPayload([
+                'orderId' => $orderId,
+                'shippingCosts' => new CalculatedPrice(
+                    -10.00,
+                    -10.00,
+                    new CalculatedTaxCollection([]),
+                    new TaxRuleCollection([]),
+                ),
+            ]),
+        ];
+
+        $this->createOrder($customerId, ['deliveries' => $orderDeliveries, 'id' => $orderId]);
+        $order = $this->orderRepository->search(new Criteria([$orderId]), $context)->first();
+
+        static::assertInstanceOf(OrderEntity::class, $order);
+
+        $event = new CheckoutOrderPlacedEvent($context, $order, TestDefaults::SALES_CHANNEL);
+        $subscriber = new SetOrderStateAction(
+            $this->getContainer()->get(Connection::class),
+            $this->getContainer()->get(OrderService::class),
+        );
+
+        /** @var FlowFactory $flowFactory */
+        $flowFactory = $this->getContainer()->get(FlowFactory::class);
+        $flow = $flowFactory->create($event);
+        $flow->setConfig(['order_delivery' => 'shipped']);
+
+        $subscriber->handleFlow($flow);
+
+        $criteria = new Criteria([$IdForShippingCosts]);
+        $criteria->addAssociation('stateMachineState');
+        $oderDeliveryForShippingCosts = $this->orderDeliveryRepository->search($criteria, $context)->first();
+
+        static::assertInstanceOf(OrderDeliveryEntity::class, $oderDeliveryForShippingCosts);
+        static::assertEquals('shipped', $oderDeliveryForShippingCosts->getStateMachineState()?->getTechnicalName());
+    }
+
     public function testThrowsWhenEntityNotFoundAndInsideATransactionWithoutSavepointNesting(): void
     {
         $this->connection->executeStatement('DELETE FROM `sales_channel` WHERE id = :id', ['id' => Uuid::fromHexToBytes($this->ids->get('sales-channel'))]);
@@ -179,6 +257,36 @@ class SetOrderStateActionTest extends TestCase
         $this->connection->transactional(function () use ($subscriber, $flow): void {
             $subscriber->handleFlow($flow);
         });
+    }
+
+    /**
+     * @param array<int|string, mixed> $payload
+     * @return array<int|string, mixed>
+     */
+    public function generateOrderDeliveryPayload(array $payload = []): array
+    {
+        $payload = array_merge(
+            [
+                'id' => $this->ids->create('delivery'),
+                'stateId' => $this->getContainer()->get(InitialStateIdLoader::class)->get(OrderDeliveryStates::STATE_MACHINE),
+                'shippingMethodId' => $this->getValidShippingMethodId(),
+                'shippingCosts' => new CalculatedPrice(10, 10, new CalculatedTaxCollection(), new TaxRuleCollection()),
+                'shippingDateEarliest' => date(\DATE_ATOM),
+                'shippingDateLatest' => date(\DATE_ATOM),
+                'shippingOrderAddressId' => $this->ids->get('shipping-address'),
+                'trackingCodes' => [],
+                'positions' => [
+                    [
+                        'id' => $this->ids->create('position'),
+                        'orderLineItemId' => $this->ids->create('line-item'),
+                        'price' => new CalculatedPrice(200, 200, new CalculatedTaxCollection(), new TaxRuleCollection()),
+                    ],
+                ],
+            ],
+            $payload,
+        );
+
+        return $payload;
     }
 
     private function prepareFlowSequences(string $orderState, string $orderDeliveryState, string $orderTransactionState): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If an order is created and shipped with a shipping discount, the order state flow that should set the delivery status to Shipped does not take effect.
In this case the order has more then one order delivery and the flow is selecting the wrong one to be changed in state.

### 2. What does this change do, exactly?

Shopware creates additional order deliveries with negative shipping costs when applying shipping costs vouchers. Just using the first or last order delivery without sorting first can result in the wrong order delivery to be used.
This change sorts the delivery based on the total cost of the shipping costs.
The primary order delivery, which is relevant, has a positive total cost on the shipping costs.

### 3. Describe each step to reproduce the issue or behaviour.

- Create a discount for the shipping cost
- Create an order with the discount 
- Send order
- Check delivery status

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
