### PR TITLE
Added inner block for order list bulk modal slot

### DIFF
--- a/changelog/_unreleased/2024-10-01-add-new-inner-block-to-order-list-bulk-modal-slot.md
+++ b/changelog/_unreleased/2024-10-01-add-new-inner-block-to-order-list-bulk-modal-slot.md
@@ -1,0 +1,8 @@
+---
+title: Add new inner block to order list bulk slot
+author: Ioannis Pourliotis
+author_email: dev@pourliotis.de 
+author_github: @PheysX
+---
+# Administration
+* Added a new inner block `sw_order_list_bulk_edit_modal_inner` in `src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig` to make data grid bulk modal slot extendable.

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig
@@ -363,6 +363,8 @@
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_order_list_bulk_edit_modal %}
                 <template #bulk-modals="{ selection }">
+                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                    {% block sw_order_list_bulk_edit_modal_inner %}
                     <sw-bulk-edit-modal
                         v-if="showBulkEditModal"
                         ref="bulkEditModal"
@@ -475,6 +477,7 @@
                         </template>
                         {% endblock %}
                     </sw-bulk-edit-modal>
+                    {% endblock %}
                 </template>
                 {% endblock %}
             </sw-data-grid>


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When we want to extend the bulk modal action slot, we have to copy the whole content in our plugin.
So multiple plugins will remove each other.

### 2. What does this change do, exactly?
Added a new inner block`sw_order_list_bulk_edit_modal_inner` in `src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.html.twig` to make data grid bulk modal slot extendable.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
See #2186 


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.