### PR TITLE
Dispatch Address Validation Events With Correct Name In CheckoutConfirmPageLoader

### DIFF
--- a/changelog/_unreleased/2024-10-04-dispatch-address-validation-events-with-correct-name-in-checkout-confirm-page-loader.md
+++ b/changelog/_unreleased/2024-10-04-dispatch-address-validation-events-with-correct-name-in-checkout-confirm-page-loader.md
@@ -1,0 +1,10 @@
+---
+title:              Dispatch Address Validation Events With Correct Name In CheckoutConfirmPageLoader
+issue:              
+author:             Alessandro Aussems
+author_email:       me@alessandroaussems.be
+author_github:      @alessandroaussems
+---
+
+# Storefront
+*  Updated `src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoader.php` to dispatch the correct event names when dispatching the events

--- a/src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoader.php
+++ b/src/Storefront/Page/Checkout/Confirm/CheckoutConfirmPageLoader.php
@@ -127,7 +127,7 @@ class CheckoutConfirmPageLoader
         }
 
         $validationEvent = new BuildValidationEvent($validation, new DataBag(), $context->getContext());
-        $this->eventDispatcher->dispatch($validationEvent);
+        $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         if ($billingAddress === null) {
             return;
@@ -152,7 +152,7 @@ class CheckoutConfirmPageLoader
         }
 
         $validationEvent = new BuildValidationEvent($validation, new DataBag(), $context->getContext());
-        $this->eventDispatcher->dispatch($validationEvent);
+        $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
 
         if ($shippingAddress === null) {
             return;


### PR DESCRIPTION
### 1. Why is this change necessary?

Because the events are not dispatched with the correct name. Which makes subscribing to them very difficult.


### 2. What does this change do, exactly?

Dispatches the events with the correct name so you can subscribe to them using:

- framework.validation.address.create
- framework.validation.address.update

Example where this is done correctly in the core:

core/Checkout/Customer/SalesChannel/ChangeCustomerProfileRoute.php

```php
private function dispatchValidationEvent(DataValidationDefinition $definition, DataBag $data, Context $context): void
{
    $validationEvent = new BuildValidationEvent($definition, $data, $context);
    $this->eventDispatcher->dispatch($validationEvent, $validationEvent->getName());
}
``` 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
