### PR TITLE
Improve context switch route. Enable cache hash event

### DIFF
--- a/changelog/_unreleased/2024-10-04-extending-context.md
+++ b/changelog/_unreleased/2024-10-04-extending-context.md
@@ -1,0 +1,22 @@
+---
+title: Extending context
+issue: 
+author: Oliver Skroblin
+author_email: oliver@goblin-coders.de
+author_github: OliverSkroblin
+---
+# Core
+* Deprecated getter functions of `\Shopware\Core\System\SalesChannel\Event\SalesChannelContextCreatedEvent::getSalesChannelContext`
+* Changed visibility of `\Shopware\Core\System\SalesChannel\Event\SalesChannelContextCreatedEvent` variables to public
+* Added `\Shopware\Core\System\SalesChannel\Event\SalesChannelContextCreatedEvent::$session` variable
+* Added `\Shopware\Core\System\SalesChannel\Event\SwitchContextEvent` event to allow more context variables to be persisted
+* Removed `cache_rework` feature flag condition for `\Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheCookieEvent` event.
+___
+# Upgrade Information
+## SalesChannelContextCreatedEvent
+- Search for `\Shopware\Core\System\SalesChannel\Event\SalesChannelContextCreatedEvent::getSalesChannelContext`
+  - replace with `$event->context`
+- Search for `\Shopware\Core\System\SalesChannel\Event\SalesChannelContextCreatedEvent::getContext`
+  - replace with `$event->context->getContext()`
+- Search for `\Shopware\Core\System\SalesChannel\Event\SalesChannelContextCreatedEvent::getUsedToken`
+  - replace with `$event->usedToken`

--- a/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
@@ -223,36 +223,26 @@ class CacheResponseSubscriber implements EventSubscriberInterface
 
     private function buildCacheHash(Request $request, SalesChannelContext $context): string
     {
-        if (Feature::isActive('cache_rework')) {
-            $parts = [
-                HttpCacheCookieEvent::RULE_IDS => $context->getRuleIds(),
-                HttpCacheCookieEvent::VERSION_ID => $context->getVersionId(),
-                HttpCacheCookieEvent::CURRENCY_ID => $context->getCurrencyId(),
-                HttpCacheCookieEvent::TAX_STATE => $context->getTaxState(),
-                HttpCacheCookieEvent::LOGGED_IN_STATE => $context->getCustomer() ? 'logged-in' : 'not-logged-in',
-            ];
+        $parts = [
+            HttpCacheCookieEvent::RULE_IDS => $context->getRuleIds(),
+            HttpCacheCookieEvent::VERSION_ID => $context->getVersionId(),
+            HttpCacheCookieEvent::CURRENCY_ID => $context->getCurrencyId(),
+            HttpCacheCookieEvent::TAX_STATE => $context->getTaxState(),
+            HttpCacheCookieEvent::LOGGED_IN_STATE => $context->getCustomer() ? 'logged-in' : 'not-logged-in',
+        ];
 
-            foreach ($this->cookies as $cookie) {
-                if (!$request->cookies->has($cookie)) {
-                    continue;
-                }
-
-                $parts[$cookie] = $request->cookies->get($cookie);
+        foreach ($this->cookies as $cookie) {
+            if (!$request->cookies->has($cookie)) {
+                continue;
             }
 
-            $event = new HttpCacheCookieEvent($request, $context, $parts);
-            $this->dispatcher->dispatch($event);
-
-            return Hasher::hash($event->getParts());
+            $parts[$cookie] = $request->cookies->get($cookie);
         }
 
-        return Hasher::hash([
-            $context->getRuleIds(),
-            $context->getContext()->getVersionId(),
-            $context->getCurrency()->getId(),
-            $context->getTaxState(),
-            $context->getCustomer() ? 'logged-in' : 'not-logged-in',
-        ]);
+        $event = new HttpCacheCookieEvent($request, $context, $parts);
+        $this->dispatcher->dispatch($event);
+
+        return Hasher::hash($event->getParts());
     }
 
     /**

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -92,7 +92,7 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
             }
 
             $context = $this->factory->create($token, $parameters->getSalesChannelId(), $session);
-            $this->eventDispatcher->dispatch(new SalesChannelContextCreatedEvent($context, $token));
+            $this->eventDispatcher->dispatch(new SalesChannelContextCreatedEvent($context, $token, $session));
 
             $result = $this->ruleLoader->loadByToken($context, $token);
 

--- a/src/Core/System/SalesChannel/Event/SalesChannelContextCreatedEvent.php
+++ b/src/Core/System/SalesChannel/Event/SalesChannelContextCreatedEvent.php
@@ -12,21 +12,32 @@ use Symfony\Contracts\EventDispatcher\Event;
 class SalesChannelContextCreatedEvent extends Event implements ShopwareSalesChannelEvent
 {
     public function __construct(
-        private readonly SalesChannelContext $salesChannelContext,
-        private readonly string $usedToken
+        public readonly SalesChannelContext $context,
+        public readonly string $usedToken,
+        public readonly array $session = []
     ) {
     }
 
+    /**
+     * @deprecated tag:v6.7.0 - Use `$event->context` instead
+     */
     public function getSalesChannelContext(): SalesChannelContext
     {
-        return $this->salesChannelContext;
+        return $this->context;
     }
 
+    /**
+     * @deprecated tag:v6.7.0 - Use `$event->context->getContext()` instead
+     * @return Context
+     */
     public function getContext(): Context
     {
-        return $this->salesChannelContext->getContext();
+        return $this->context->getContext();
     }
 
+    /**
+     * @deprecated tag:v6.7.0 - Use `$event->usedToken` instead
+     */
     public function getUsedToken(): string
     {
         return $this->usedToken;

--- a/src/Core/System/SalesChannel/Event/SwitchContextEvent.php
+++ b/src/Core/System/SalesChannel/Event/SwitchContextEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Shopware\Core\System\SalesChannel\Event;
+
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\Framework\Validation\DataValidationDefinition;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+class SwitchContextEvent
+{
+    public const CONSISTENT_CHECK = self::class . '.consistent_check';
+    public const DATABASE_CHECK = self::class . '.database_check';
+
+    public function __construct(
+        public RequestDataBag $data,
+        public DataValidationDefinition $definition,
+        public array $parameters,
+        public SalesChannelContext $context
+    ) {
+    }
+}

--- a/src/Core/System/SalesChannel/SalesChannel/ContextSwitchRoute.php
+++ b/src/Core/System/SalesChannel/SalesChannel/ContextSwitchRoute.php
@@ -15,6 +15,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextPersister;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\ContextTokenResponse;
 use Shopware\Core\System\SalesChannel\Event\SalesChannelContextSwitchEvent;
+use Shopware\Core\System\SalesChannel\Event\SwitchContextEvent;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Validator\Constraints\Type;
@@ -76,6 +77,10 @@ class ContextSwitchRoute extends AbstractContextSwitchRoute
             ->add(self::STATE_ID, new Type('string'))
         ;
 
+        $event = new SwitchContextEvent($data, $definition, $parameters, $context);
+        $this->eventDispatcher->dispatch($event, SwitchContextEvent::CONSISTENT_CHECK);
+        $parameters = $event->parameters;
+
         $this->validator->validate($parameters, $definition);
 
         $addressCriteria = new Criteria();
@@ -122,6 +127,10 @@ class ContextSwitchRoute extends AbstractContextSwitchRoute
             ->add(self::COUNTRY_ID, new EntityExists(['entity' => 'country', 'context' => $context->getContext()]))
             ->add(self::STATE_ID, new EntityExists(['entity' => 'country_state', 'context' => $context->getContext()]))
         ;
+
+        $event = new SwitchContextEvent($data, $definition, $parameters, $context);
+        $this->eventDispatcher->dispatch($event, SwitchContextEvent::DATABASE_CHECK);
+        $parameters = $event->parameters;
 
         $this->validator->validate($parameters, $definition);
 


### PR DESCRIPTION
### 1. Why is this change necessary?
In many projects it is necessary to store additional parameters in the "session" of a user. However, the route only supports the Shopware core parameters. This change adds an event to allow additional parameters via plugin.
Furthermore, the event for building the cache hash is already activated, since the parameters are 1:1 with the current parameters.