### PR TITLE
refactor: Changed database:create-migration command to not create Package attribute

### DIFF
--- a/changelog/_unreleased/2024-10-04-do-not-create-log-package-in-plugin-database-migrations.md
+++ b/changelog/_unreleased/2024-10-04-do-not-create-log-package-in-plugin-database-migrations.md
@@ -1,0 +1,9 @@
+---
+title: Do not create log package in plugin database migrations
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed `database:create-migration` command to not create `#[Package('%%package%%')]` attribute on migration

--- a/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
+++ b/src/Core/Framework/Migration/Command/CreateMigrationCommand.php
@@ -77,42 +77,15 @@ class CreateMigrationCommand extends Command
 
         $pluginName = $input->getOption('plugin');
         if ($pluginName) {
-            $pluginBundles = array_filter($this->kernelPluginCollection->all(), static fn (Plugin $value) => mb_strpos($value->getName(), (string) $pluginName) === 0);
+            $this->createPluginMigration($output, $pluginName, $timestamp, $name);
 
-            if (\count($pluginBundles) === 0) {
-                throw new \RuntimeException(\sprintf('Plugin "%s" could not be found.', $pluginName));
-            }
-
-            if (\count($pluginBundles) > 1) {
-                $pluginBundles = array_filter($pluginBundles, static fn (Plugin $value) => $pluginName === $value->getName());
-
-                if (\count($pluginBundles) > 1) {
-                    throw new \RuntimeException(
-                        \sprintf(
-                            'More than one plugin name starting with "%s" was found: %s',
-                            $pluginName,
-                            implode(';', array_keys($pluginBundles))
-                        )
-                    );
-                }
-            }
-
-            $pluginBundle = array_values($pluginBundles)[0];
-
-            $directory = $pluginBundle->getMigrationPath();
-            if (!file_exists($directory) && !mkdir($directory) && !is_dir($directory)) {
-                throw new \RuntimeException(\sprintf('Migration directory "%s" could not be created', $directory));
-            }
-
-            $namespace = $pluginBundle->getMigrationNamespace();
-            $output->writeln(\sprintf('Creating plugin-migration with namespace %s in path %s...', $namespace, $directory));
-        } else {
-            [$_, $major] = explode('.', $this->shopwareVersion);
-            // We create a core-migration in case no plugin was given
-            $directory = $this->coreDir . '/Migration/V6_' . $major;
-            $namespace = 'Shopware\\Core\\Migration\\V6_' . $major;
+            return self::SUCCESS;
         }
 
+        // We create a core-migration in case no directory or plugin was given
+        [$_, $major] = explode('.', $this->shopwareVersion);
+        $directory = $this->coreDir . '/Migration/V6_' . $major;
+        $namespace = 'Shopware\\Core\\Migration\\V6_' . $major;
         $params = [
             '%%timestamp%%' => $timestamp,
             '%%name%%' => $name,
@@ -130,6 +103,51 @@ class CreateMigrationCommand extends Command
         );
 
         return self::SUCCESS;
+    }
+
+    private function createPluginMigration(OutputInterface $output, string $pluginName, int $timestamp, string $name): void
+    {
+        $pluginBundles = array_filter($this->kernelPluginCollection->all(), static fn (Plugin $value) => mb_strpos($value->getName(), (string) $pluginName) === 0);
+
+        if (\count($pluginBundles) === 0) {
+            throw new \RuntimeException(\sprintf('Plugin "%s" could not be found.', $pluginName));
+        }
+
+        if (\count($pluginBundles) > 1) {
+            $pluginBundles = array_filter($pluginBundles, static fn (Plugin $value) => $pluginName === $value->getName());
+
+            if (\count($pluginBundles) > 1) {
+                throw new \RuntimeException(
+                    \sprintf(
+                        'More than one plugin name starting with "%s" was found: %s',
+                        $pluginName,
+                        implode(';', array_keys($pluginBundles))
+                    )
+                );
+            }
+        }
+
+        $pluginBundle = array_values($pluginBundles)[0];
+
+        $directory = $pluginBundle->getMigrationPath();
+        if (!file_exists($directory) && !mkdir($directory) && !is_dir($directory)) {
+            throw new \RuntimeException(\sprintf('Migration directory "%s" could not be created', $directory));
+        }
+
+        $namespace = $pluginBundle->getMigrationNamespace();
+
+        $output->writeln(\sprintf('Creating plugin-migration with namespace %s in path %s...', $namespace, $directory));
+
+        $this->createMigrationFile(
+            $output,
+            $directory,
+            \dirname(__DIR__) . '/Template/MigrationTemplatePlugin.txt',
+            [
+                '%%timestamp%%' => $timestamp,
+                '%%name%%' => $name,
+                '%%namespace%%' => $namespace,
+            ]
+        );
     }
 
     /**

--- a/src/Core/Framework/Migration/Template/MigrationTemplatePlugin.txt
+++ b/src/Core/Framework/Migration/Template/MigrationTemplatePlugin.txt
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace %%namespace%%;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+class Migration%%timestamp%%%%name%% extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return %%timestamp%%;
+    }
+
+    public function update(Connection $connection): void
+    {
+
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is a bit annoying when one is creating plugin migrations, that the `Log\Package` attribute is added, which is only used for Shopware core migrations.

### 2. What does this change do, exactly?
Create custom template for plugin migrations.

### 3. Describe each step to reproduce the issue or behaviour.
Create a plugin migration.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
