### PR TITLE
NEXT-36501 fix SetOrderStateAction for multi delivery orders

### DIFF
--- a/changelog/_unreleased/2024-10-04-fix-setorderstateaction-multi-delivery.md
+++ b/changelog/_unreleased/2024-10-04-fix-setorderstateaction-multi-delivery.md
@@ -1,0 +1,9 @@
+---
+title: Fix SetOrderStateAction for multi-delivery and multi-transaction orders
+issue: NEXT-36501
+author: Felix Schneider
+author_email: felix.schneider@wimmelbach.de
+author_github: @schneider-felix
+---
+# Core
+* Fixed the sorting in SetOrderStateAction to update the state of the correct delivery

--- a/changelog/_unreleased/2024-10-04-fix-setorderstateaction-multi-delivery.md
+++ b/changelog/_unreleased/2024-10-04-fix-setorderstateaction-multi-delivery.md
@@ -6,4 +6,4 @@ author_email: felix.schneider@wimmelbach.de
 author_github: @schneider-felix
 ---
 # Core
-* Fixed the sorting in SetOrderStateAction to update the state of the correct delivery
+* Changed the sorting in SetOrderStateAction to update the state of the correct delivery


### PR DESCRIPTION
### 1. Why is this change necessary?

`SetOrderStateAction` did sometimes not change the state of the order delivery correctly. When the order had multiple `order_delivery` entries.

### 2. What does this change do, exactly?

This change ensures the SetOrderStateAction changes the state on the right order delivery and order transaction entities. In the past it would change the state of the delivery discount if the order had a delivery discount. This resulted in the Administration not reflecting the state change. The sorting is now the same as in `src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js`


### 3. Describe each step to reproduce the issue or behaviour.

- Add a new order delivery promotion
- Add a flow to change the order delivery state
- Place an order with the delivery promotion
- Trigger the flow
- Observe that the state change seemingly does not work as expected

### 4. Please link to the relevant issues (if any).

#4364 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
