### PR TITLE
fix: do not throw errors on finalize-transaction calls with invalidated token

### DIFF
--- a/changelog/_unreleased/2024-10-04-leaner-handling-of-duplicate-finalize-calls.md
+++ b/changelog/_unreleased/2024-10-04-leaner-handling-of-duplicate-finalize-calls.md
@@ -1,0 +1,9 @@
+---
+title: Leaner handling of duplicate finalize calls
+issue: 1234
+author: Bart Vanderstukken
+author_email: bart.vanderstukken@meteor.be
+author_github: @sneakyvv
+---
+# Core
+* Improved handling of duplicate finalize calls

--- a/src/Core/Checkout/Payment/Cart/Token/JWTFactoryV2.php
+++ b/src/Core/Checkout/Payment/Cart/Token/JWTFactoryV2.php
@@ -81,10 +81,6 @@ class JWTFactoryV2 implements TokenFactoryInterfaceV2
             throw PaymentException::invalidToken($token);
         }
 
-        if (!$this->has($token)) {
-            throw PaymentException::tokenInvalidated($token);
-        }
-
         $errorUrl = $jwtToken->claims()->get('eul');
 
         /** @var \DateTimeImmutable $expires */
@@ -97,7 +93,8 @@ class JWTFactoryV2 implements TokenFactoryInterfaceV2
             $jwtToken->claims()->get('sub'),
             $jwtToken->claims()->get('ful'),
             $expires->getTimestamp(),
-            $errorUrl
+            $errorUrl,
+            !$this->has($token),
         );
     }
 

--- a/src/Core/Checkout/Payment/Cart/Token/TokenStruct.php
+++ b/src/Core/Checkout/Payment/Cart/Token/TokenStruct.php
@@ -50,6 +50,11 @@ class TokenStruct extends Struct
      */
     protected $expires;
 
+    /**
+     * @var bool
+     */
+    protected bool $invalidated;
+
     public function __construct(
         ?string $id = null,
         ?string $token = null,
@@ -57,7 +62,8 @@ class TokenStruct extends Struct
         ?string $transactionId = null,
         ?string $finishUrl = null,
         ?int $expires = null,
-        ?string $errorUrl = null
+        ?string $errorUrl = null,
+        bool $invalidated = false,
     ) {
         $this->id = $id;
         $this->token = $token;
@@ -66,6 +72,7 @@ class TokenStruct extends Struct
         $this->finishUrl = $finishUrl;
         $this->expires = $expires ?? 1800;
         $this->errorUrl = $errorUrl;
+        $this->invalidated = $invalidated;
     }
 
     public function getId(): ?string
@@ -111,6 +118,11 @@ class TokenStruct extends Struct
     public function isExpired(): bool
     {
         return $this->expires < time();
+    }
+
+    public function isInvalidated(): bool
+    {
+        return $this->invalidated;
     }
 
     /**

--- a/src/Core/Checkout/Payment/PaymentService.php
+++ b/src/Core/Checkout/Payment/PaymentService.php
@@ -145,7 +145,7 @@ class PaymentService
         if ($token->isInvalidated()) {
             // Token was already handled
             // Check current state of the transaction to determine if we need to throw an exception
-            $stateName = $transaction->getOrderTransaction()->getStateMachineState()->getTechnicalName();
+            $stateName = $transaction->getOrderTransaction()->getStateMachineState()?->getTechnicalName();
             if ($stateName === OrderTransactionStates::STATE_PAID  || $stateName === OrderTransactionStates::STATE_PARTIALLY_PAID) {
                 return $token;
             }


### PR DESCRIPTION
### 1. Why is this change necessary?

Some PSP's will not work as SW intends, i.e. call the finalize payment endpoint when they are not supposed to, causing the user to see an error because of an invalidated token, while we can circumvent the issue in most cases. So instead of being strict, and throw an error in the face of the user, even while the payment has been handled correctly, be a little more loose and do an extra check to see if we can continue nicely.

### 2. What does this change do, exactly?

Instead of being strict and complaining that (aka throwing an error because) a token was already used and thus has been invalidated , check the state of the transaction. If it is already handled, meaning the transaction has been set to paid, just let the PaymentService return the token without actually finalizing the payment (as it was already finalized).

### 3. Describe each step to reproduce the issue or behaviour.

Call the finalize endpoint twice (which would normally be done by a PSP)

### 4. Please link to the relevant issues (if any).

See this issue that was also raised with the Adyen plugin: https://github.com/Adyen/adyen-shopware6/issues/510
Note that even though they may fix it on their side, doesn't mean SW cannot be more compliant.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] ~~I have written or adjusted the documentation according to my changes~~
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
