### PR TITLE
fix: `componentName` of entity and normal select on type change

### DIFF
--- a/changelog/_unreleased/2024-10-04-fix-component-name-of-custom-fields-on-change.md
+++ b/changelog/_unreleased/2024-10-04-fix-component-name-of-custom-fields-on-change.md
@@ -1,0 +1,10 @@
+---
+title: Fix component name of custom fields on change
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Changed the `sw-custom-field-type-entity` component to force the `componentName` to be either `sw-entity-single-select` or `sw-entity-multi-id-select`
+* Changed the `sw-custom-field-type-select` component to force the `componentName` to be either `sw-single-select` or `sw-multi-select`

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-entity/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-entity/index.js
@@ -117,12 +117,13 @@ export default {
                 }
             }
 
-            if (!this.currentCustomField.config.hasOwnProperty('componentName')) {
+            const componentName = this.currentCustomField.config.componentName;
+            if (!componentName || !['sw-entity-single-select', 'sw-entity-multi-id-select'].includes(componentName)) {
                 this.currentCustomField.config.componentName = 'sw-entity-single-select';
             }
 
             this.multiSelectSwitchDisabled = !this.currentCustomField._isNew;
-            this.multiSelectSwitch = this.currentCustomField.config.componentName === 'sw-entity-multi-id-select';
+            this.multiSelectSwitch = componentName === 'sw-entity-multi-id-select';
         },
 
         onChangeEntityType(entity) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-custom-field/component/sw-custom-field-type-select/index.js
@@ -45,9 +45,12 @@ export default {
                 this.addOption();
             }
 
-            if (!this.currentCustomField.config.hasOwnProperty('componentName')) {
+            const componentName = this.currentCustomField.config.componentName;
+            if (!componentName || !['sw-single-select', 'sw-multi-select'].includes(componentName)) {
                 this.currentCustomField.config.componentName = 'sw-single-select';
             }
+
+            this.multiSelectSwitch = componentName === 'sw-multi-select';
 
             const options = this.currentCustomField.config.options.map(option => {
                 if (Array.isArray(option.label)) {
@@ -62,8 +65,6 @@ export default {
             } else {
                 this.currentCustomField.config.options = options;
             }
-
-            this.multiSelectSwitch = this.currentCustomField.config.componentName === 'sw-multi-select';
         },
 
         addOption() {


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently when you first select custom field type as a entity select, and then switch to the normal select, the `componentName` is not updated.

### 2. What does this change do, exactly?
Validate that we have a correct type for the custom field type.

### 3. Describe each step to reproduce the issue or behaviour.
See 1.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
