### PR TITLE
Make Sales Channel Entrypoints configurable

### DIFF
--- a/changelog/_unreleased/2024-10-04-make-entrypoints-configurable.md
+++ b/changelog/_unreleased/2024-10-04-make-entrypoints-configurable.md
@@ -1,0 +1,28 @@
+---
+title: Make Entrypoints Configurable
+issue: NEXT-38707
+author: runelaenen
+author_email: rune@laenen.me
+author_github: @runelaenen
+---
+# Core
+* Added SalesChannelEntrypointService which uses the new SalesChannelEntrypointEvent to look for custom entrypoints and read configuration from the given SalesChannelEntity.
+* Added SalesChannelEntrypointRoute to read custom entrypoints from active Sales Channel
+* Added `entrypointIds` JSON field to the SalesChannel entity
+* Changed known usages of core category ids in
+  * CategoryBreadcrumbBuilder
+  * CategoryListRoute
+  * CategoryUrlProvider
+  * NavigationPageSeoUrlRoute
+  * NavigationRoute
+  * TreeBuildingNavigationRoute
+___
+# API
+* Added SalesChannelEntrypointController `/api/_action/sales-channel/{salesChannelId}/entrypoint` to add admin API to return the list of known custom entrypoint.
+___
+# Administration
+* Added `entryPointService` to consume SalesChannelEntrypointController
+* Added category selector for each known custom entrypoint in `sw-sales-channel-detail-base`
+___
+# Storefront
+* Added automatical loading of all known and configured custom entrypoints into HeaderPagelet

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/index.js
@@ -5,6 +5,7 @@
 import './service/export-template.service';
 import './product-export-templates';
 import './service/domain-link.service';
+import EntryPointService from './service/entry-point.service';
 import './service/sales-channel-favorites.service';
 import './component/structure/sw-admin-menu-extension';
 import './component/structure/sw-sales-channel-menu';
@@ -35,6 +36,14 @@ Shopware.Component.register('sw-sales-channel-detail-product-comparison', () => 
 Shopware.Component.register('sw-sales-channel-detail-product-comparison-preview', () => import('./view/sw-sales-channel-detail-product-comparison-preview'));
 Shopware.Component.register('sw-sales-channel-products-assignment-modal', () => import('./component/sw-sales-channel-products-assignment-modal'));
 /* eslint-enable max-len, sw-deprecation-rules/private-feature-declarations */
+
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+Shopware.Service().register('entryPointService', () => {
+    return new EntryPointService(
+        Shopware.Application.getContainer('init').httpClient,
+        Shopware.Service().get('loginService'),
+    );
+});
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 Module.register('sw-sales-channel', {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/service/entry-point.service.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/service/entry-point.service.js
@@ -1,0 +1,27 @@
+/**
+ * @package buyers-experience
+ */
+// eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
+export default class EntryPointService {
+    constructor(httpClient, loginService) {
+        this.httpClient = httpClient;
+        this.loginService = loginService;
+        this.name = 'entrypointService';
+    }
+
+    list(salesChannelId) {
+        const headers = this.getAuthHeaders();
+
+        return this.httpClient
+            .get(`/_action/sales-channel/${salesChannelId}/entrypoint`, { headers })
+            .then(response => response.data);
+    }
+
+    getAuthHeaders() {
+        return {
+            Accept: 'application/json',
+            Authorization: `Bearer ${this.loginService.getToken()}`,
+            'Content-Type': 'application/json',
+        };
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/service/entry-point.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/service/entry-point.service.spec.js
@@ -1,0 +1,31 @@
+/**
+ * @package buyers-experience
+ */
+
+import EntryPointService from 'src/module/sw-sales-channel/service/entry-point.service';
+
+const token = 'fce2c5c0-518c-4f16-b893-4f0913c07efe';
+
+describe('module/sw-sales-channel/service/entry-point.service.spec.js', () => {
+    let service;
+
+    beforeEach(async () => {
+        const httpClient = {
+            get: jest.fn(() => Promise.resolve({
+                data: [{
+                    additional: '51b8d69c91144798b7c59c5fd26a53c2',
+                }],
+            })),
+        };
+
+        const loginService = {
+            getToken: jest.fn(() => token),
+        };
+
+        service = new EntryPointService(httpClient, loginService);
+    });
+
+    it('list > should return list of custom entrypoints', async () => {
+        expect(service.list()).toEqual([{ additional: '51b8d69c91144798b7c59c5fd26a53c2' }]);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/index.js
@@ -24,6 +24,7 @@ export default {
         'productExportService',
         'repositoryFactory',
         'knownIpsService',
+        'entryPointService',
         'acl',
     ],
 
@@ -101,6 +102,8 @@ export default {
             mainCategoriesCollection: null,
             footerCategoriesCollection: null,
             serviceCategoriesCollection: null,
+            customEntrypoints: null,
+            customEntrypointCategoriesCollection: [],
         };
     },
 
@@ -493,6 +496,12 @@ export default {
             this.knownIps = ips;
         });
 
+        this.entryPointService.list(this.salesChannel.id).then((customEntrypoints) => {
+            this.customEntrypoints = customEntrypoints;
+
+            this.createCustomEntrypointCategoryCollections();
+        });
+
         this.createCategoryCollections();
     },
 
@@ -675,8 +684,22 @@ export default {
             this.createCategoriesCollection(this.serviceCategoryCriteria, 'serviceCategoriesCollection');
         },
 
+        createCustomEntrypointCategoryCollections() {
+            this.customEntrypoints.forEach((entrypoint) => {
+                const criteria = new Criteria(1, 25);
+                criteria.addFilter(Criteria.equals('id', this.salesChannel.entrypointIds[entrypoint] || null));
+
+                this.createCustomEntrypointCategoriesCollection(criteria, entrypoint);
+            });
+        },
+
         async createCategoriesCollection(criteria, collectionName) {
             this[collectionName] = await this.categoryRepository.search(criteria, Shopware.Context.api);
+        },
+
+        async createCustomEntrypointCategoriesCollection(criteria, entrypoint) {
+            this.customEntrypointCategoriesCollection[entrypoint] =
+                await this.categoryRepository.search(criteria, Shopware.Context.api);
         },
 
         onMainSelectionAdd(item) {
@@ -701,6 +724,14 @@ export default {
 
         onServiceSelectionRemove() {
             this.salesChannel.serviceCategoryId = null;
+        },
+
+        onCustomEntrypointSelectionAdd(entrypoint, item) {
+            this.salesChannel.entrypointIds[entrypoint] = item.id;
+        },
+
+        onCustomEntrypointSelectionRemove(entrypoint) {
+            this.salesChannel.entrypointIds[entrypoint] = null;
         },
 
         buildDisabledPaymentAlert(snippet, collection, property = 'name') {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.html.twig
@@ -157,6 +157,23 @@
         {% endblock %}
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+        {% block sw_sales_channel_detail_base_general_input_custom_entrypoint %}
+        <template v-for="entrypoint in customEntrypoints" v-bind:key="entrypoint">
+            <sw-category-tree-field
+                v-if="!isProductComparison && customEntrypointCategoriesCollection[entrypoint]"
+                :categories-collection="customEntrypointCategoriesCollection[entrypoint]"
+                :placeholder="serviceCategoryPlaceholder"
+                :single-select="true"
+                :label="$tc('sw-sales-channel.detail.customEntrypoint.'+entrypoint)"
+                :disabled="!acl.can('sales_channel.editor') || undefined"
+                class="sw-sales-channel-detail__select-custom-entrypoint"
+                @selection-add="(item) => onCustomEntrypointSelectionAdd(entrypoint, item)"
+                @selection-remove="onCustomEntrypointSelectionRemove(entrypoint)"
+            />
+        </template>
+        {% endblock %}
+
+        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_sales_channel_detail_base_general_input_customer_group %}
         <sw-entity-single-select
             v-if="!isProductComparison"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/view/sw-sales-channel-detail-base/sw-sales-channel-detail-base.spec.js
@@ -55,6 +55,9 @@ async function createWrapper() {
                 knownIpsService: {
                     getKnownIps: () => Promise.resolve(),
                 },
+                entryPointService: {
+                    list: () => Promise.resolve(),
+                },
                 repositoryFactory: {
                     create: () => ({
                         search: () => {

--- a/src/Core/Content/Category/CategoryException.php
+++ b/src/Core/Content/Category/CategoryException.php
@@ -13,7 +13,6 @@ use Symfony\Component\HttpFoundation\Response;
 class CategoryException extends HttpException
 {
     public const SERVICE_CATEGORY_NOT_FOUND = 'CHECKOUT__SERVICE_CATEGORY_NOT_FOUND';
-
     public const FOOTER_CATEGORY_NOT_FOUND = 'CHECKOUT__FOOTER_CATEGORY_NOT_FOUND';
     public const AFTER_CATEGORY_NOT_FOUND = 'CONTENT__AFTER_CATEGORY_NOT_FOUND';
 

--- a/src/Core/Content/Category/Event/SalesChannelEntrypointEvent.php
+++ b/src/Core/Content/Category/Event/SalesChannelEntrypointEvent.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Core\Content\Category\Event;
+
+use Shopware\Core\Framework\Event\SalesChannelAware;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+
+#[Package('inventory')]
+class SalesChannelEntrypointEvent implements SalesChannelAware
+{
+    /**
+     * @var array<string>
+     */
+    private array $entrypoints;
+
+    public function __construct(
+        private readonly SalesChannelEntity $salesChannel,
+        private readonly ?SalesChannelContext $salesChannelContext,
+    ) {
+        $this->entrypoints = [];
+    }
+
+    public function addEntrypointType(string $entrypointType): void
+    {
+        $this->entrypoints[] = $entrypointType;
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public function getEntrypoints(): array
+    {
+        return $this->entrypoints;
+    }
+
+    public function getSalesChannelContext(): ?SalesChannelContext
+    {
+        return $this->salesChannelContext;
+    }
+
+    public function getSalesChannelId(): string
+    {
+        return $this->salesChannel->getId();
+    }
+
+    public function getSalesChannel(): SalesChannelEntity
+    {
+        return $this->salesChannel;
+    }
+}

--- a/src/Core/Content/Category/SalesChannel/CategoryListRoute.php
+++ b/src/Core/Content/Category/SalesChannel/CategoryListRoute.php
@@ -22,8 +22,10 @@ class CategoryListRoute extends AbstractCategoryListRoute
      *
      * @param SalesChannelRepository<CategoryCollection> $categoryRepository
      */
-    public function __construct(private readonly SalesChannelRepository $categoryRepository)
-    {
+    public function __construct(
+        private readonly SalesChannelRepository $categoryRepository,
+        private readonly SalesChannelEntrypointService $entrypointService
+    ) {
     }
 
     public function getDecorated(): AbstractCategoryListRoute
@@ -34,11 +36,7 @@ class CategoryListRoute extends AbstractCategoryListRoute
     #[Route(path: '/store-api/category', name: 'store-api.category.search', defaults: ['_entity' => 'category'], methods: ['GET', 'POST'])]
     public function load(Criteria $criteria, SalesChannelContext $context): CategoryListRouteResponse
     {
-        $rootIds = array_filter([
-            $context->getSalesChannel()->getNavigationCategoryId(),
-            $context->getSalesChannel()->getFooterCategoryId(),
-            $context->getSalesChannel()->getServiceCategoryId(),
-        ]);
+        $rootIds = $this->entrypointService->getEntrypointIds($context->getSalesChannel(), $context);
 
         if (!empty($rootIds)) {
             $filter = new OrFilter();

--- a/src/Core/Content/Category/SalesChannel/NavigationRoute.php
+++ b/src/Core/Content/Category/SalesChannel/NavigationRoute.php
@@ -39,7 +39,8 @@ class NavigationRoute extends AbstractNavigationRoute
     public function __construct(
         private readonly Connection $connection,
         private readonly SalesChannelRepository $categoryRepository,
-        private readonly EventDispatcherInterface $dispatcher
+        private readonly EventDispatcherInterface $dispatcher,
+        private readonly SalesChannelEntrypointService $entrypointService
     ) {
     }
 
@@ -216,11 +217,7 @@ class NavigationRoute extends AbstractNavigationRoute
 
     private function validate(string $activeId, ?string $path, SalesChannelContext $context): void
     {
-        $ids = array_filter([
-            $context->getSalesChannel()->getFooterCategoryId(),
-            $context->getSalesChannel()->getServiceCategoryId(),
-            $context->getSalesChannel()->getNavigationCategoryId(),
-        ]);
+        $ids = $this->entrypointService->getEntrypointIds($context->getSalesChannel(), $context);
 
         foreach ($ids as $id) {
             if ($this->isChildCategory($activeId, $path, $id)) {

--- a/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointCollection.php
+++ b/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointCollection.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Core\Content\Category\SalesChannel;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Collection;
+
+/**
+ * @extends Collection<SalesChannelEntrypointStruct>
+ */
+#[Package('inventory')]
+class SalesChannelEntrypointCollection extends Collection
+{
+    /**
+     * @return array|string[]
+     */
+    public function getFlat(): array
+    {
+        return $this->map(fn (SalesChannelEntrypointStruct $entrypoint) => $entrypoint->getCategoryId());
+    }
+
+    protected function getExpectedClass(): ?string
+    {
+        return SalesChannelEntrypointStruct::class;
+    }
+}

--- a/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointController.php
+++ b/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointController.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Core\Content\Category\SalesChannel;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[Route(defaults: ['_routeScope' => ['api']])]
+#[Package('inventory')]
+class SalesChannelEntrypointController extends AbstractController
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly SalesChannelEntrypointService $entrypointService,
+        private readonly EntityRepository $salesChannelRepository
+    ) {
+    }
+
+    public static function buildName(string $id): string
+    {
+        return 'sales-channel-entrypoint-route-' . $id;
+    }
+
+    public function getDecorated(): AbstractNavigationRoute
+    {
+        throw new DecorationPatternException(self::class);
+    }
+
+    #[Route(path: '/api/_action/sales-channel/{salesChannelId}/entrypoint', name: 'api.action.sales-channel.entrypoint.getList', defaults: ['_acl' => ['sales_channel:read']], methods: ['GET'])]
+    public function getSalesChannelEntrypoint(string $salesChannelId, Context $context): JsonResponse
+    {
+        $salesChannel = $this->salesChannelRepository->search(new Criteria([$salesChannelId]), $context)->first();
+        if (!$salesChannel instanceof SalesChannelEntity) {
+            return new JsonResponse([]);
+        }
+        $entrypoints = $this->entrypointService->getCustomEntrypoints($salesChannel);
+
+        return new JsonResponse($entrypoints);
+    }
+}

--- a/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointRoute.php
+++ b/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointRoute.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Core\Content\Category\SalesChannel;
+
+use Shopware\Core\Framework\Adapter\Cache\Event\AddCacheTagEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+#[Route(defaults: ['_routeScope' => ['store-api']])]
+#[Package('inventory')]
+class SalesChannelEntrypointRoute
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly SalesChannelEntrypointService $entrypointService,
+        private readonly EventDispatcherInterface $dispatcher,
+    ) {
+    }
+
+    public static function buildName(string $id): string
+    {
+        return 'sales-channel-entrypoint-route-' . $id;
+    }
+
+    public function getDecorated(): AbstractNavigationRoute
+    {
+        throw new DecorationPatternException(self::class);
+    }
+
+    #[Route(path: '/store-api/entry-point', name: 'store-api.entrypoint', methods: ['GET', 'POST'])]
+    public function load(
+        SalesChannelContext $context
+    ): SalesChannelEntrypointRouteResponse {
+        $tags = [
+            self::buildName($context->getSalesChannelId()),
+        ];
+
+        $this->dispatcher->dispatch(new AddCacheTagEvent(...$tags));
+
+        $entryPointIds = $this->entrypointService->getCustomEntrypointIds($context->getSalesChannel(), $context);
+
+        return new SalesChannelEntrypointRouteResponse($entryPointIds);
+    }
+}

--- a/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointRouteResponse.php
+++ b/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointRouteResponse.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Core\Content\Category\SalesChannel;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\StoreApiResponse;
+
+#[Package('inventory')]
+class SalesChannelEntrypointRouteResponse extends StoreApiResponse
+{
+    /**
+     * @var SalesChannelEntrypointCollection
+     */
+    protected $object;
+
+    public function __construct(SalesChannelEntrypointCollection $object)
+    {
+        parent::__construct($object);
+    }
+
+    public function getEntrypoints(): SalesChannelEntrypointCollection
+    {
+        return $this->object;
+    }
+}

--- a/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointService.php
+++ b/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointService.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Core\Content\Category\SalesChannel;
+
+use Shopware\Core\Content\Category\Event\SalesChannelEntrypointEvent;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+#[Package('inventory')]
+class SalesChannelEntrypointService
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher
+    ) {
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public function getEntrypointIds(SalesChannelEntity $salesChannel, ?SalesChannelContext $context = null): array
+    {
+        $entrypointIds = [
+            'footer-navigation' => $salesChannel->getFooterCategoryId(),
+            'service-navigation' => $salesChannel->getServiceCategoryId(),
+            'main-navigation' => $salesChannel->getNavigationCategoryId(),
+        ];
+
+        return array_filter(array_merge(
+            $entrypointIds,
+            $this->getCustomEntrypointIds($salesChannel, $context)->getFlat()
+        ));
+    }
+
+    /**
+     * @return array|string[]
+     */
+    public function getCustomEntrypoints(SalesChannelEntity $salesChannel, ?SalesChannelContext $context = null): array
+    {
+        $event = new SalesChannelEntrypointEvent($salesChannel, $context);
+        $this->eventDispatcher->dispatch($event);
+
+        return $event->getEntrypoints();
+    }
+
+    public function getCustomEntrypointIds(
+        SalesChannelEntity $salesChannel,
+        ?SalesChannelContext $context
+    ): SalesChannelEntrypointCollection {
+        $configuredEntrypoints = $salesChannel->getEntrypointIds();
+        if (empty($configuredEntrypoints)) {
+            return new SalesChannelEntrypointCollection();
+        }
+
+        $entrypointIds = [];
+        foreach ($this->getCustomEntrypoints($salesChannel, $context) as $customEntrypoint) {
+            if (empty($configuredEntrypoints[$customEntrypoint])) {
+                continue;
+            }
+
+            $entrypointIds[$customEntrypoint] = new SalesChannelEntrypointStruct(
+                $customEntrypoint,
+                $configuredEntrypoints[$customEntrypoint]
+            );
+        }
+
+        return new SalesChannelEntrypointCollection($entrypointIds);
+    }
+
+    public function getEntrypointId(
+        string $entrypoint,
+        SalesChannelEntity $salesChannelEntity,
+        SalesChannelContext $context
+    ): ?SalesChannelEntrypointStruct {
+        $entrypoints = $this->getEntrypointIds($salesChannelEntity, $context);
+
+        if (\array_key_exists($entrypoint, $entrypoints)) {
+            return new SalesChannelEntrypointStruct($entrypoint, $entrypoints[$entrypoint]);
+        }
+
+        return null;
+    }
+}

--- a/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointStruct.php
+++ b/src/Core/Content/Category/SalesChannel/SalesChannelEntrypointStruct.php
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Core\Content\Category\SalesChannel;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+#[Package('inventory')]
+class SalesChannelEntrypointStruct extends Struct
+{
+    /**
+     * @var string
+     */
+    protected $entrypoint;
+
+    /**
+     * @var string
+     */
+    protected $categoryId;
+
+    public function __construct(
+        string $entrypoint,
+        string $categoryId
+    ) {
+        $this->entrypoint = $entrypoint;
+        $this->categoryId = $categoryId;
+    }
+
+    public function getEntrypoint(): string
+    {
+        return $this->entrypoint;
+    }
+
+    public function setEntrypoint(string $entrypoint): void
+    {
+        $this->entrypoint = $entrypoint;
+    }
+
+    public function getCategoryId(): string
+    {
+        return $this->categoryId;
+    }
+
+    public function setCategoryId(string $categoryId): void
+    {
+        $this->categoryId = $categoryId;
+    }
+
+    public function getApiAlias(): string
+    {
+        return 'sales_channel_entrypoint';
+    }
+}

--- a/src/Core/Content/DependencyInjection/category.xml
+++ b/src/Core/Content/DependencyInjection/category.xml
@@ -21,6 +21,23 @@
             <tag name="shopware.sales_channel.entity.definition"/>
         </service>
 
+        <service id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService">
+            <argument type="service" id="event_dispatcher"/>
+        </service>
+
+        <service id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointRoute" public="true">
+            <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService"/>
+            <argument type="service" id="event_dispatcher"/>
+        </service>
+
+        <service id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointController" public="true">
+            <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService"/>
+            <argument type="service" id="sales_channel.repository"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
+
         <service id="Shopware\Core\Content\Category\Service\NavigationLoader">
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\NavigationRoute"/>
@@ -30,6 +47,7 @@
             <argument type="service" id="Doctrine\DBAL\Connection"/>
             <argument type="service" id="sales_channel.category.repository"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService"/>
         </service>
 
         <service id="Shopware\Core\Content\Category\SalesChannel\CachedNavigationRoute" decorates="Shopware\Core\Content\Category\SalesChannel\NavigationRoute" decoration-priority="-1000" public="true">
@@ -43,6 +61,7 @@
 
         <service id="Shopware\Core\Content\Category\SalesChannel\TreeBuildingNavigationRoute" decorates="Shopware\Core\Content\Category\SalesChannel\NavigationRoute" decoration-priority="-2000" public="true">
             <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\TreeBuildingNavigationRoute.inner"/>
+            <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService"/>
         </service>
 
         <service id="Shopware\Core\Content\Category\SalesChannel\CachedCategoryRoute" decorates="Shopware\Core\Content\Category\SalesChannel\CategoryRoute" decoration-priority="-1000" public="true">
@@ -63,6 +82,7 @@
 
         <service id="Shopware\Core\Content\Category\SalesChannel\CategoryListRoute" public="true">
             <argument type="service" id="sales_channel.category.repository"/>
+            <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService"/>
         </service>
 
         <service id="Shopware\Core\Content\Category\DataAbstractionLayer\CategoryIndexer">
@@ -91,6 +111,7 @@
             <argument type="service" id="category.repository"/>
             <argument type="service" id="sales_channel.product.repository"/>
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService"/>
         </service>
 
         <service id="Shopware\Core\Content\Category\Service\CategoryUrlGenerator">

--- a/src/Core/Content/DependencyInjection/sitemap.xml
+++ b/src/Core/Content/DependencyInjection/sitemap.xml
@@ -59,6 +59,7 @@
             <argument type="service" id="Shopware\Core\Content\Category\CategoryDefinition"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory"/>
             <argument type="service" id="router"/>
+            <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService"/>
 
             <tag name="shopware.sitemap_url_provider"/>
         </service>

--- a/src/Core/Content/Resources/config/routes.xml
+++ b/src/Core/Content/Resources/config/routes.xml
@@ -14,6 +14,7 @@
     <import resource="../../ProductExport/**/*Controller.php" type="attribute" />
     <import resource="../../Seo/Api/**/*Controller.php" type="attribute" />
     <import resource="../../Breadcrumb/SalesChannel/**/*Route.php" type="attribute" />
+    <import resource="../../Category/SalesChannel/**/*Controller.php" type="attribute" />
     <import resource="../../Category/SalesChannel/**/*Route.php" type="attribute" />
     <import resource="../../LandingPage/SalesChannel/**/*Route.php" type="attribute" />
     <import resource="../../Product/SalesChannel/**/*Route.php" type="attribute" />

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Content\Sitemap\Struct\Url;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
@@ -31,7 +32,8 @@ class CategoryUrlProvider extends AbstractUrlProvider
         private readonly Connection $connection,
         private readonly CategoryDefinition $definition,
         private readonly IteratorFactory $iteratorFactory,
-        private readonly RouterInterface $router
+        private readonly RouterInterface $router,
+        private readonly SalesChannelEntrypointService $entrypointService,
     ) {
     }
 
@@ -115,11 +117,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
         ]);
 
         $wheres = [];
-        $categoryIds = array_filter([
-            $context->getSalesChannel()->getNavigationCategoryId(),
-            $context->getSalesChannel()->getFooterCategoryId(),
-            $context->getSalesChannel()->getServiceCategoryId(),
-        ]);
+        $categoryIds = $this->entrypointService->getEntrypointIds($context->getSalesChannel(), $context);
 
         foreach ($categoryIds as $id) {
             $wheres[] = '`category`.path LIKE ' . $query->createNamedParameter('%|' . $id . '|%');

--- a/src/Core/Migration/V6_6/Migration1728033363AddSalesChannelEntrypointIds.php
+++ b/src/Core/Migration/V6_6/Migration1728033363AddSalesChannelEntrypointIds.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1728033363AddSalesChannelEntrypointIds extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1728033363;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addColumn($connection, 'sales_channel', 'entrypoint_ids', 'JSON');
+    }
+}

--- a/src/Core/System/SalesChannel/SalesChannelDefinition.php
+++ b/src/Core/System/SalesChannel/SalesChannelDefinition.php
@@ -115,6 +115,7 @@ class SalesChannelDefinition extends EntityDefinition
             (new ReferenceVersionField(CategoryDefinition::class, 'footer_category_version_id'))->addFlags(new ApiAware(), new Required()),
             (new FkField('service_category_id', 'serviceCategoryId', CategoryDefinition::class))->addFlags(new ApiAware()),
             (new ReferenceVersionField(CategoryDefinition::class, 'service_category_version_id'))->addFlags(new ApiAware(), new Required()),
+            new JsonField('entrypoint_ids', 'entrypointIds'),
             (new FkField('mail_header_footer_id', 'mailHeaderFooterId', MailHeaderFooterDefinition::class))->addFlags(new ApiAware()),
             (new FkField('hreflang_default_domain_id', 'hreflangDefaultDomainId', SalesChannelDomainDefinition::class))->addFlags(new ApiAware()),
             (new TranslatedField('name'))->addFlags(new ApiAware()),

--- a/src/Core/System/SalesChannel/SalesChannelEntity.php
+++ b/src/Core/System/SalesChannel/SalesChannelEntity.php
@@ -159,6 +159,11 @@ class SalesChannelEntity extends Entity
     protected $serviceCategoryVersionId;
 
     /**
+     * @var array<mixed>|null
+     */
+    protected $entrypointIds;
+
+    /**
      * @var string|null
      */
     protected $name;
@@ -753,6 +758,22 @@ class SalesChannelEntity extends Entity
     public function setNavigationCategory(CategoryEntity $navigationCategory): void
     {
         $this->navigationCategory = $navigationCategory;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getEntrypointIds(): ?array
+    {
+        return $this->entrypointIds;
+    }
+
+    /**
+     * @param string[]|null $entrypointIds
+     */
+    public function setEntrypointIds(?array $entrypointIds): void
+    {
+        $this->entrypointIds = $entrypointIds;
     }
 
     /**

--- a/src/Storefront/DependencyInjection/seo.xml
+++ b/src/Storefront/DependencyInjection/seo.xml
@@ -14,6 +14,7 @@
         <service id="Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute">
             <argument type="service" id="Shopware\Core\Content\Category\CategoryDefinition"/>
             <argument type="service" id="Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder"/>
+            <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService"/>
 
             <tag name="shopware.seo_url.route"/>
         </service>

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -243,6 +243,7 @@
             <argument type="service" id="Shopware\Core\System\Currency\SalesChannel\CurrencyRoute"/>
             <argument type="service" id="Shopware\Core\System\Language\SalesChannel\LanguageRoute"/>
             <argument type="service" id="Shopware\Core\Content\Category\Service\NavigationLoader"/>
+            <argument type="service" id="Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService" />
         </service>
 
         <service id="Shopware\Storefront\Pagelet\Footer\FooterPageletLoader">

--- a/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
+++ b/src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
@@ -4,6 +4,7 @@ namespace Shopware\Storefront\Framework\Seo\SeoUrlRoute;
 
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlMapping;
 use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteConfig;
@@ -27,7 +28,8 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
      */
     public function __construct(
         private readonly CategoryDefinition $categoryDefinition,
-        private readonly CategoryBreadcrumbBuilder $breadcrumbBuilder
+        private readonly CategoryBreadcrumbBuilder $breadcrumbBuilder,
+        private readonly SalesChannelEntrypointService $entrypointService
     ) {
     }
 
@@ -86,19 +88,10 @@ class NavigationPageSeoUrlRoute implements SeoUrlRouteInterface
         }
         $path = array_filter(explode('|', (string) $category->getPath()));
 
-        $navigationId = $salesChannel->getNavigationCategoryId();
-        if ($navigationId === $category->getId() || \in_array($navigationId, $path, true)) {
-            return $navigationId;
-        }
-
-        $footerId = $salesChannel->getFooterCategoryId();
-        if ($footerId === $category->getId() || \in_array($footerId, $path, true)) {
-            return $footerId;
-        }
-
-        $serviceId = $salesChannel->getServiceCategoryId();
-        if ($serviceId === $category->getId() || \in_array($serviceId, $path, true)) {
-            return $serviceId;
+        foreach ($this->entrypointService->getEntrypointIds($salesChannel) as $entrypointId) {
+            if ($entrypointId === $category->getId() || \in_array($entrypointId, $path, true)) {
+                return $entrypointId;
+            }
         }
 
         return null;

--- a/src/Storefront/Pagelet/Header/HeaderPagelet.php
+++ b/src/Storefront/Pagelet/Header/HeaderPagelet.php
@@ -40,7 +40,14 @@ class HeaderPagelet extends NavigationPagelet
     protected $serviceMenu;
 
     /**
+     * @var array|Tree[]
+     */
+    protected $customEntrypoints;
+
+    /**
      * @internal
+     *
+     * @param Tree[] $customEntrypoints
      */
     public function __construct(
         Tree $navigation,
@@ -48,13 +55,15 @@ class HeaderPagelet extends NavigationPagelet
         CurrencyCollection $currencies,
         LanguageEntity $activeLanguage,
         CurrencyEntity $activeCurrency,
-        CategoryCollection $serviceMenu
+        CategoryCollection $serviceMenu,
+        array $customEntrypoints
     ) {
         $this->languages = $languages;
         $this->currencies = $currencies;
         $this->activeLanguage = $activeLanguage;
         $this->activeCurrency = $activeCurrency;
         $this->serviceMenu = $serviceMenu;
+        $this->customEntrypoints = $customEntrypoints;
 
         parent::__construct($navigation);
     }
@@ -82,5 +91,13 @@ class HeaderPagelet extends NavigationPagelet
     public function getServiceMenu(): CategoryCollection
     {
         return $this->serviceMenu;
+    }
+
+    /**
+     * @return array|Tree[]
+     */
+    public function getCustomEntrypoints(): array
+    {
+        return $this->customEntrypoints;
     }
 }

--- a/tests/integration/Core/Content/Category/SalesChannel/SalesChannelEntrypointRouteTest.php
+++ b/tests/integration/Core/Content/Category/SalesChannel/SalesChannelEntrypointRouteTest.php
@@ -1,0 +1,72 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Content\Category\SalesChannel;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\Event\SalesChannelEntrypointEvent;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
+use Shopware\Core\Framework\Test\TestDataCollection;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+#[Group('store-api')]
+class SalesChannelEntrypointRouteTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+    use SalesChannelApiTestBehaviour;
+
+    private KernelBrowser $browser;
+
+    private TestDataCollection $ids;
+
+    private EventDispatcherInterface $listener;
+
+    protected function setUp(): void
+    {
+        $this->listener = $this->getContainer()->get(EventDispatcherInterface::class);
+
+        $this->ids = new TestDataCollection();
+
+        $this->createData();
+
+        $this->browser = $this->createCustomSalesChannelBrowser([
+            'id' => $this->ids->create('sales-channel'),
+            'entrypointIds' => ['additional' => $this->ids->get('additionalEntrypointId')],
+        ]);
+    }
+
+    public function testCmsPageResolved(): void
+    {
+        $this->listener->addListener(SalesChannelEntrypointEvent::class, function (SalesChannelEntrypointEvent $event): void {
+            $event->addEntrypointType('additional');
+        });
+
+        $this->browser->request(
+            'GET',
+            '/store-api/entry-point'
+        );
+        $content = $this->browser->getResponse()->getContent();
+
+        static::assertStringContainsString($this->ids->get('additionalEntrypointId'), (string) $content);
+    }
+
+    private function createData(): void
+    {
+        $data = [
+            'id' => $this->ids->create('additionalEntrypointId'),
+            'name' => 'Custom entry point',
+            'type' => 'folder',
+            'active' => true,
+        ];
+
+        $this->getContainer()->get('category.repository')
+            ->create([$data], Context::createDefaultContext());
+    }
+}

--- a/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService;
 use Shopware\Core\Content\Sitemap\Provider\CategoryUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Defaults;
@@ -97,6 +98,7 @@ class CategoryUrlProviderTest extends TestCase
             $this->getContainer()->get(CategoryDefinition::class),
             $this->getContainer()->get(IteratorFactory::class),
             $this->getContainer()->get(RouterInterface::class),
+            $this->getContainer()->get(SalesChannelEntrypointService::class),
         );
     }
 

--- a/tests/migration/Core/V6_6/Migration1728033363AddSalesChannelEntrypointIdsTest.php
+++ b/tests/migration/Core/V6_6/Migration1728033363AddSalesChannelEntrypointIdsTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_6;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Migration\V6_6\Migration1728033363AddSalesChannelEntrypointIds;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+#[CoversClass(Migration1728033363AddSalesChannelEntrypointIds::class)]
+class Migration1728033363AddSalesChannelEntrypointIdsTest extends TestCase
+{
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testMigration(): void
+    {
+        $migration = new Migration1728033363AddSalesChannelEntrypointIds();
+        static::assertSame(1728033363, $migration->getCreationTimestamp());
+
+        // make sure a migration can run multiple times without failing
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+    }
+}

--- a/tests/unit/Core/Content/Category/SalesChannel/SalesChannelEntrypointServiceTest.php
+++ b/tests/unit/Core/Content/Category/SalesChannel/SalesChannelEntrypointServiceTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Category\SalesChannel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\Event\SalesChannelEntrypointEvent;
+use Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+#[CoversClass(SalesChannelEntrypointService::class)]
+class SalesChannelEntrypointServiceTest extends TestCase
+{
+    private EventDispatcher $eventDispatcher;
+
+    private SalesChannelEntrypointService $entrypointService;
+
+    private SalesChannelEntity $salesChannel;
+
+    protected function setUp(): void
+    {
+        $this->eventDispatcher = new EventDispatcher();
+        $this->entrypointService = new SalesChannelEntrypointService($this->eventDispatcher);
+
+        $this->salesChannel = new SalesChannelEntity();
+        $this->salesChannel->setId(Uuid::randomHex());
+    }
+
+    public function testLoadsCoreEntrypoints(): void
+    {
+        $navigationCategoryId = Uuid::randomHex();
+        $this->salesChannel->setNavigationCategoryId($navigationCategoryId);
+        $serviceCategoryId = Uuid::randomHex();
+        $this->salesChannel->setServiceCategoryId($serviceCategoryId);
+        $footerCategoryId = Uuid::randomHex();
+        $this->salesChannel->setFooterCategoryId($footerCategoryId);
+
+        $entrypoints = $this->entrypointService->getEntrypointIds($this->salesChannel);
+
+        static::assertContains($navigationCategoryId, $entrypoints);
+        static::assertContains($serviceCategoryId, $entrypoints);
+        static::assertContains($footerCategoryId, $entrypoints);
+    }
+
+    public function testLoadsCustomEntrypoints(): void
+    {
+        $this->salesChannel->setNavigationCategoryId(Uuid::randomHex());
+
+        $additionalId = Uuid::randomHex();
+        $this->eventDispatcher->addListener(
+            SalesChannelEntrypointEvent::class,
+            function (SalesChannelEntrypointEvent $event): void {
+                $event->addEntrypointType('additional');
+            }
+        );
+        $this->salesChannel->setEntrypointIds(['additional' => $additionalId]);
+
+        $entrypoints = $this->entrypointService->getEntrypointIds($this->salesChannel);
+
+        static::assertContains($additionalId, $entrypoints);
+    }
+}

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Content\Product\ProductEntity;
@@ -58,7 +59,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntity], [$categoryEntity]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->getSalesChannelEntrypointServiceMock()
         );
 
         $product = $this->getProductEntity($streamIds, $categoryIds);
@@ -79,7 +81,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntity], [$categoryEntity]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->getSalesChannelEntrypointServiceMock()
         );
         $product = $this->getProductEntity($streamIds, $categoryIds);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
@@ -94,7 +97,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([], []),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->getSalesChannelEntrypointServiceMock()
         );
 
         $product = $this->getProductEntity($streamIds, $categoryIds);
@@ -115,7 +119,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([], [$categoryEntity]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->getSalesChannelEntrypointServiceMock()
         );
         $product = $this->getProductEntity($streamIds, $categoryIds);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
@@ -135,7 +140,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([], [$categoryEntity]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->getSalesChannelEntrypointServiceMock()
         );
         $product = $this->getProductEntity($streamIds, []);
         $categoryEntity = $categoryBreadcrumbBuilder->getProductSeoCategory($product, $this->salesChannelContext);
@@ -161,7 +167,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->getSalesChannelEntrypointServiceMock()
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c01', $this->salesChannelContext->getContext());
@@ -195,7 +202,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->getSalesChannelEntrypointServiceMock()
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c02', $this->salesChannelContext->getContext());
@@ -229,7 +237,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->getSalesChannelEntrypointServiceMock()
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c03', $this->salesChannelContext->getContext());
@@ -264,7 +273,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([$categoryEntityOne], [$categoryEntityOne]),
             $this->getProductRepositoryMock([$product], [$product]),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->getSalesChannelEntrypointServiceMock()
         );
 
         $result = $categoryBreadcrumbBuilder->getProductBreadcrumbUrls($product->getId(), '', $this->salesChannelContext);
@@ -289,7 +299,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         $categoryBreadcrumbBuilder = new CategoryBreadcrumbBuilder(
             $this->getCategoryRepositoryMock([], []),
             $this->getProductRepositoryMock([], []),
-            $this->getConnectionMock()
+            $this->getConnectionMock(),
+            $this->getSalesChannelEntrypointServiceMock()
         );
         $result = $categoryBreadcrumbBuilder->getProductSeoCategory($productEntity, $this->salesChannelContext);
 
@@ -374,6 +385,11 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         );
 
         return $productRepositoryMock;
+    }
+
+    private function getSalesChannelEntrypointServiceMock(): SalesChannelEntrypointService
+    {
+        return static::createStub(SalesChannelEntrypointService::class);
     }
 
     /**

--- a/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
+++ b/tests/unit/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRouteTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Storefront\Framework\Seo\SeoUrlRoute;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Category\SalesChannel\SalesChannelEntrypointService;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
@@ -25,7 +26,8 @@ class NavigationPageSeoUrlRouteTest extends TestCase
     {
         $navigationPageSeoUrlRoute = new NavigationPageSeoUrlRoute(
             new CategoryDefinition(),
-            static::createStub(CategoryBreadcrumbBuilder::class)
+            static::createStub(CategoryBreadcrumbBuilder::class),
+            static::createStub(SalesChannelEntrypointService::class),
         );
 
         $salesChannel = new SalesChannelEntity();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently there are 3 usable entrypoints (main navigation, service navigation and footer navigation). If it is necessary to add an additional entrypoint there are lots of hoops to jump through to make this possible.

### 2. What does this change do, exactly?
To make this easier this change introduces a new Event that gathers custom entrypoints.
The current 'core' entrypoints are unchanged, so the additions in this PR are entirely backwards compatible.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
NEXT-38707

https://github.com/shopware/shopware/issues/4964

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
