### PR TITLE
NEXT-38705 - Fixed double slash in sitemap url for product w/o seo url

### DIFF
--- a/changelog/_unreleased/2024-10-07-fix-double-slash-in-sitemap-urls-for-entities-without-seo-url.md
+++ b/changelog/_unreleased/2024-10-07-fix-double-slash-in-sitemap-urls-for-entities-without-seo-url.md
@@ -1,0 +1,9 @@
+---
+title: Fix double slash in sitemap urls for entities without seo url
+issue: NEXT-38705
+author: Benny Poensgen
+author_email: poensgen@vanwittlaer.de
+author_github: @vanwittlaer
+---
+# Core
+* Changed `SitemapExporter` to force-trim leading slash in entity urls

--- a/src/Core/Content/Sitemap/Service/SitemapExporter.php
+++ b/src/Core/Content/Sitemap/Service/SitemapExporter.php
@@ -151,7 +151,7 @@ class SitemapExporter implements SitemapExporterInterface
 
             foreach ($result->getUrls() as $url) {
                 $newUrl = clone $url;
-                $newUrl->setLoc(rtrim($host, '/') . '/' . $newUrl->getLoc());
+                $newUrl->setLoc(rtrim($host, '/') . '/' . ltrim($newUrl->getLoc(), '/'));
                 $urls[] = $newUrl;
             }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Bug in SitemapExporter, generates a double slash in sitemap url for products w/o SEO url, like https://example.com//detail/{uuid}

### 2. What does this change do, exactly?
Fixes the above bug in SitemapExporter.php

Tests courtesy by @shyim 


### 3. Describe each step to reproduce the issue or behaviour.
Create product w/o SEO url, generate sitemap

### 4. Please link to the relevant issues (if any).
NEXT-38705 https://github.com/shopware/shopware/issues/4963

### 5. Checklist

- [*] I have rebased my changes to remove merge conflicts
- [*] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [*] I have read the contribution requirements and fulfill them.
