### PR TITLE
Issue #4504 - Fixing visibility of success message after leaving a review

### DIFF
--- a/changelog/_unreleased/2024-10-04-removing-ratingsuccess-variable-in-twig.md
+++ b/changelog/_unreleased/2024-10-04-removing-ratingsuccess-variable-in-twig.md
@@ -1,0 +1,9 @@
+---
+title: Removing ratingSuccess variable in twig
+issue: NEXT-0000
+author: Joschi
+author_email: joschi.mehta@heptacom.de
+author_github: @NinjaArmy
+---
+# Storefront
+* Removed ratingSuccess variable in `Resources/views/storefront/component/review/review.html.twig` to display success messages. Variable comes from the request object, which is set by the controller.

--- a/src/Storefront/Resources/views/storefront/component/review/review.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review.html.twig
@@ -17,8 +17,6 @@
 		{# TODO NEXT-16994 - replace language flag #}
 		{% set foreignReviewsCount = 150 %}
 
-		{% set ratingSuccess = element.data.ratingSuccess %}
-
 		<div class="product-detail-review tab-pane-container">
 			{% block component_review_tab_pane %}
                 <div class="row product-detail-review-content js-review-container">


### PR DESCRIPTION
### 1. Why is this change necessary?

To fix visibility of success messages after submitting and editing revies


### 2. What does this change do, exactly?

Removes the ratingSuccess variable in the twig template to fix visibility after leaving or editing a review. The variable comes from the request object, which is set by the ProductController.


### 3. Describe each step to reproduce the issue or behaviour.

Leave a review on a product and submit it. After submitting or editing the review there is no message displayed. [Related issue](https://github.com/shopware/shopware/issues/4504)


### 4. Please link to the relevant issues (if any).

Already linked above.

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
