### PR TITLE
Fix watch storefront multi saleschannel with multi theme

### DIFF
--- a/changelog/_unreleased/2024-10-04-fix-watch-storefront-multi-saleschannel-with-multi-theme.md
+++ b/changelog/_unreleased/2024-10-04-fix-watch-storefront-multi-saleschannel-with-multi-theme.md
@@ -1,0 +1,11 @@
+---
+title:          Fix watch storefront multi saleschannel with multi theme
+issue:          NEXT-0000
+author:         Raffaele Carelle
+author_e_mail:  raffaele.carelle@gmail.com
+author_github:  @raffaelecarelle
+---
+# Storefront
+* Changed `theme:dump`: if there isn't a `theme-id` as argument and there are 2 or more themes, the name of the theme want to dump is asked.
+* Changed `theme:dump`: if there are 2 or more domain url for theme, the url is asked.
+* Changed `start-hot-reload.js` to accept the domain url choose above as original host domain of hot server.

--- a/src/Storefront/Resources/app/storefront/build/start-hot-reload.js
+++ b/src/Storefront/Resources/app/storefront/build/start-hot-reload.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 /* eslint no-console: 0 */
 const httpProxy = require('http-proxy');
 const nodeServer = require('node:http');
@@ -5,9 +7,14 @@ const fs = require('node:fs');
 const { spawn } = require('node:child_process');
 const createLiveReloadServer = require('./live-reload-server/index');
 
+const projectRootPath = process.env.PROJECT_ROOT
+    ? path.resolve(process.env.PROJECT_ROOT)
+    : path.resolve('../../../../..');
+const themeFilesConfigPath = path.resolve(projectRootPath, 'var/theme-files.json');
+const themeFiles = require(themeFilesConfigPath);
 const proxyPort = Number(process.env.STOREFRONT_PROXY_PORT) || 9998;
 const assetPort = Number(process.env.STOREFRONT_ASSETS_PORT) || 9999;
-const appUrlEnv = new URL(process.env.APP_URL);
+const appUrlEnv = new URL(themeFiles.domainUrl || process.env.APP_URL);
 const proxyUrlEnv = new URL(process.env.PROXY_URL || `${appUrlEnv.protocol}//${appUrlEnv.hostname}:${proxyPort}`);
 const keyPath = process.env.STOREFRONT_HTTPS_KEY_FILE || `${process.env.CAROOT}/localhost-key.pem`;
 const certPath = process.env.STOREFRONT_HTTPS_CERTIFICATE_FILE || `${process.env.CAROOT}/localhost.pem`;

--- a/src/Storefront/Theme/Command/ThemeDumpCommand.php
+++ b/src/Storefront/Theme/Command/ThemeDumpCommand.php
@@ -75,7 +75,7 @@ class ThemeDumpCommand extends Command
 
                 \assert(\is_string($themeName));
 
-                $criteria->addFilter(new EqualsFilter('technicalName', $themeName));
+                $criteria->addFilter(new EqualsFilter('name', $themeName));
             }
         } else {
             $criteria->setIds([$themeId]);
@@ -147,11 +147,7 @@ class ThemeDumpCommand extends Command
         $themes = $this->themeRepository->search(new Criteria(), Context::createCLIContext())->getEntities();
 
         foreach ($themes as $theme) {
-            if (!$theme->getTechnicalName()) {
-                continue;
-            }
-
-            $choices[] = $theme->getTechnicalName();
+            $choices[] = $theme->getName();
         }
 
         return $choices;

--- a/tests/integration/Storefront/Theme/Command/ThemeDumpCommandTest.php
+++ b/tests/integration/Storefront/Theme/Command/ThemeDumpCommandTest.php
@@ -26,7 +26,6 @@ use Symfony\Component\Console\Tester\CommandTester;
 /**
  * @internal
  */
-#[CoversClass(ThemeDumpCommand::class)]
 class ThemeDumpCommandTest extends TestCase
 {
     use SalesChannelFunctionalTestBehaviour;
@@ -92,7 +91,7 @@ class ThemeDumpCommandTest extends TestCase
         $userInput = [];
 
         if (!$themeId) {
-            $userInput[] = 'parentTheme';
+            $userInput[] = 'Parent theme';
         }
 
         if (!$domainUrl) {

--- a/tests/integration/Storefront/Theme/Command/ThemeDumpCommandTest.php
+++ b/tests/integration/Storefront/Theme/Command/ThemeDumpCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Integration\Storefront\Theme\Command;
 
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Implemented prompts to select a theme if multiple exist and a domain URL if multiple domains are associated with the theme. These changes improve user experience in handling multi-theme and multi-sales channel setups. Updated `start-hot-reload.js` to use the selected domain URL.

### 1. Why is this change necessary?
These changes improve user experience in handling multi-theme and multi-sales channel webpack watching development 

### 2. What does this change do, exactly?
Implemented prompts to select a theme if multiple exist and a domain URL if multiple domains are associated with the theme. Updated `start-hot-reload.js` to use the selected domain URL.

### 3. Describe each step to reproduce the issue or behaviour.
Add more then one sales channel and more than one theme. theme:dump command dumps only first theme that it can find in the system.

### 4. Please link to the relevant issues (if any).
Fixes #4133