### PR TITLE
feat: add interface to support copy in batches

### DIFF
--- a/changelog/_unreleased/2024-10-10-added-writebatchinterface.md
+++ b/changelog/_unreleased/2024-10-10-added-writebatchinterface.md
@@ -1,0 +1,14 @@
+---
+title: Added WriteBatchInterface
+issue: NEXT-0000
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Added WriteBatchInterface to support custom batch writes in flysystem adapters besides custom s3 solution
+* Added dedicated S3WriteBatchAdapter to support batch writes for S3
+* Changed CopyBatch to check for implemented Interface and use method copyBatch instead of copy
+

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapter.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapter.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Filesystem\Adapter;
+
+use AsyncAws\Core\Result;
+use AsyncAws\S3\S3Client;
+use League\Flysystem\AsyncAwsS3\AsyncAwsS3Adapter;
+use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInput;
+use Shopware\Core\Framework\Adapter\Filesystem\Plugin\WriteBatchInterface;
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('core')]
+class AsyncAwsS3WriteBatchAdapter extends AsyncAwsS3Adapter implements WriteBatchInterface
+{
+    public function writeBatch(CopyBatchInput ...$files): void
+    {
+        /** @var S3Client $s3Client */
+        $s3Client = \Closure::bind(fn () => $this->client, $this, parent::class)();
+
+        // Extract the bucket name, mime type detector and path prefixer from the adapter.
+        $bucketName = \Closure::bind(fn () => $this->bucket, $this, parent::class)();
+
+        $mimeTypeDetector = \Closure::bind(fn () => $this->mimeTypeDetector, $this, parent::class)();
+
+        $prefixer = \Closure::bind(fn () => $this->prefixer, $this, parent::class)();
+
+        // Copy the files in batches of 250 files. This is necessary to have open sockets and not run into the "Too many open files" error.
+        foreach (array_chunk($files, 250) as $filesBatch) {
+            $requests = [];
+
+            foreach ($filesBatch as $file) {
+                $sourceFile = $file->getSourceFile();
+
+                if (\is_string($sourceFile)) {
+                    $sourceFile = @fopen($sourceFile, 'rb');
+
+                    if ($sourceFile === false) {
+                        continue;
+                    }
+                }
+
+                $mimeType = $mimeTypeDetector->detectMimeType($file->getTargetFiles()[0], $sourceFile);
+
+                foreach ($file->getTargetFiles() as $targetFile) {
+                    $options = [
+                        'Bucket' => $bucketName,
+                        'Key' => $prefixer->prefixPath($targetFile),
+                        'Body' => $sourceFile,
+                    ];
+
+                    if ($mimeType !== null) {
+                        $options['ContentType'] = $mimeType;
+                    }
+
+                    $requests[] = $s3Client->putObject($options);
+                }
+            }
+
+            // Resolve the requests in parallel.
+            foreach (Result::wait($requests) as $result) {
+                $result->resolve();
+            }
+
+            // Make sure all handles are closed. To free up the sockets.
+            foreach ($filesBatch as $file) {
+                if (\is_resource($file->getSourceFile())) {
+                    fclose($file->getSourceFile());
+                }
+            }
+        }
+    }
+}

--- a/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3Factory.php
@@ -44,7 +44,7 @@ class AwsS3v3Factory implements AdapterFactoryInterface
 
         $client = new S3Client($s3Opts);
 
-        return new AsyncAwsS3Adapter($client, $options['bucket'], $options['root'], new PortableVisibilityConverter());
+        return new AsyncAwsS3WriteBatchAdapter($client, $options['bucket'], $options['root'], new PortableVisibilityConverter());
     }
 
     public function getType(): string

--- a/src/Core/Framework/Adapter/Filesystem/Plugin/CopyBatch.php
+++ b/src/Core/Framework/Adapter/Filesystem/Plugin/CopyBatch.php
@@ -2,10 +2,8 @@
 
 namespace Shopware\Core\Framework\Adapter\Filesystem\Plugin;
 
-use AsyncAws\Core\Result;
-use AsyncAws\S3\S3Client;
-use League\Flysystem\AsyncAwsS3\AsyncAwsS3Adapter;
 use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemAdapter;
 use League\Flysystem\FilesystemOperator;
 use Shopware\Core\Framework\Log\Package;
 
@@ -14,10 +12,9 @@ class CopyBatch
 {
     public static function copy(FilesystemOperator $filesystem, CopyBatchInput ...$files): void
     {
-        $s3Client = self::getS3Client($filesystem);
-
-        if ($s3Client) {
-            self::copyS3($s3Client[0], $s3Client[1], ...$files);
+        $adapter = self::getAdapter($filesystem);
+        if ($adapter instanceof WriteBatchInterface) {
+            $adapter->writeBatch(...$files);
 
             return;
         }
@@ -38,86 +35,14 @@ class CopyBatch
         }
     }
 
-    /**
-     * Extract the S3 client from the filesystem operator.
-     *
-     * @return array{0: AsyncAwsS3Adapter, 1: S3Client}|null
-     */
-    private static function getS3Client(FilesystemOperator $operator): ?array
+    public static function getAdapter(FilesystemOperator $filesystem): ?FilesystemAdapter
     {
-        if (!class_exists(AsyncAwsS3Adapter::class) || !$operator instanceof Filesystem) {
+        if (!$filesystem instanceof Filesystem) {
             return null;
         }
 
-        $func = \Closure::bind(fn () => $operator->adapter, $operator, $operator::class);
+        $func = \Closure::bind(fn () => $filesystem->adapter, $filesystem, $filesystem::class);
 
-        $adapter = $func();
-
-        if (!$adapter instanceof AsyncAwsS3Adapter) {
-            return null;
-        }
-
-        $func = \Closure::bind(fn () => $adapter->client, $adapter, $adapter::class);
-
-        return [$adapter, $func()];
-    }
-
-    /**
-     * We use the S3 client directly to copy the files in batches and copy the files in parallel.
-     * This is necessary because the Flysystem does not support copying files in parallel or async.
-     */
-    private static function copyS3(AsyncAwsS3Adapter $adapter, S3Client $s3Client, CopyBatchInput ...$files): void
-    {
-        // Extract the bucket name, mime type detector and path prefixer from the adapter.
-        $bucketName = \Closure::bind(fn () => $adapter->bucket, $adapter, $adapter::class)();
-
-        $mimeTypeDetector = \Closure::bind(fn () => $adapter->mimeTypeDetector, $adapter, $adapter::class)();
-
-        $prefixer = \Closure::bind(fn () => $adapter->prefixer, $adapter, $adapter::class)();
-
-        // Copy the files in batches of 250 files. This is necessary to have open sockets and not run into the "Too many open files" error.
-        foreach (array_chunk($files, 250) as $filesBatch) {
-            $requests = [];
-
-            foreach ($filesBatch as $file) {
-                $sourceFile = $file->getSourceFile();
-
-                if (\is_string($sourceFile)) {
-                    $sourceFile = @fopen($sourceFile, 'rb');
-
-                    if ($sourceFile === false) {
-                        continue;
-                    }
-                }
-
-                $mimeType = $mimeTypeDetector->detectMimeType($file->getTargetFiles()[0], $sourceFile);
-
-                foreach ($file->getTargetFiles() as $targetFile) {
-                    $options = [
-                        'Bucket' => $bucketName,
-                        'Key' => $prefixer->prefixPath($targetFile),
-                        'Body' => $sourceFile,
-                    ];
-
-                    if ($mimeType !== null) {
-                        $options['ContentType'] = $mimeType;
-                    }
-
-                    $requests[] = $s3Client->putObject($options);
-                }
-            }
-
-            // Resolve the requests in parallel.
-            foreach (Result::wait($requests) as $result) {
-                $result->resolve();
-            }
-
-            // Make sure all handles are closed. To free up the sockets.
-            foreach ($filesBatch as $file) {
-                if (\is_resource($file->getSourceFile())) {
-                    fclose($file->getSourceFile());
-                }
-            }
-        }
+        return $func();
     }
 }

--- a/src/Core/Framework/Adapter/Filesystem/Plugin/CopyBatchInputFactory.php
+++ b/src/Core/Framework/Adapter/Filesystem/Plugin/CopyBatchInputFactory.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Core\Framework\Adapter\Filesystem\Plugin;
 
-use PHPUnit\Framework\Attributes\CodeCoverageIgnore;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;

--- a/src/Core/Framework/Adapter/Filesystem/Plugin/WriteBatchInterface.php
+++ b/src/Core/Framework/Adapter/Filesystem/Plugin/WriteBatchInterface.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Filesystem\Plugin;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('core')]
+interface WriteBatchInterface
+{
+    public function writeBatch(CopyBatchInput ...$files): void;
+}

--- a/src/Storefront/Theme/ThemeCompiler.php
+++ b/src/Storefront/Theme/ThemeCompiler.php
@@ -41,7 +41,7 @@ class ThemeCompiler implements ThemeCompilerInterface
     public function __construct(
         private readonly FilesystemOperator $filesystem,
         private readonly FilesystemOperator $tempFilesystem,
-        private readonly CopyBatchInputFactory $copyBatchInputFactory,
+        private readonly CopyBatchInputFactory $CopyBatchInputFactory,
         private readonly ThemeFileResolver $themeFileResolver,
         private readonly bool $debug,
         private readonly EventDispatcherInterface $eventDispatcher,
@@ -293,7 +293,7 @@ class ThemeCompiler implements ThemeCompilerInterface
                 $asset = $fs->path('Resources', $asset);
             }
 
-            $collected = [...$collected, ...$this->copyBatchInputFactory->fromDirectory($asset, $outputPath)];
+            $collected = [...$collected, ...$this->CopyBatchInputFactory->fromDirectory($asset, $outputPath)];
         }
 
         return array_values($collected);

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapterTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AsyncAwsS3WriteBatchAdapterTest.php
@@ -1,0 +1,78 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Filesystem\Adapter;
+
+use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\S3\Result\PutObjectOutput;
+use AsyncAws\S3\S3Client;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AsyncAwsS3WriteBatchAdapter;
+use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInput;
+
+/**
+ * @internal
+ */
+#[CoversClass(AsyncAwsS3WriteBatchAdapter::class)]
+class AsyncAwsS3WriteBatchAdapterTest extends TestCase
+{
+    public function testS3(): void
+    {
+        $tmpFile = sys_get_temp_dir() . '/' . uniqid('test', true);
+        file_put_contents($tmpFile, 'test');
+
+        $sourceFile = fopen($tmpFile, 'rb');
+        static::assertIsResource($sourceFile);
+
+        $s3Client = $this->createMock(S3Client::class);
+
+        $result = ResultMockFactory::create(PutObjectOutput::class);
+        $s3Client
+            ->method('putObject')
+            ->with([
+                'Bucket' => 'test',
+                'Key' => 'test.txt',
+                'Body' => $sourceFile,
+                'ContentType' => 'text/plain',
+            ])
+            ->willReturn($result);
+
+        $adapter = new AsyncAwsS3WriteBatchAdapter($s3Client, 'test');
+        $adapter->writeBatch(new CopyBatchInput($sourceFile, ['test.txt']));
+    }
+
+    public function testS3UsingPath(): void
+    {
+        $tmpFile = sys_get_temp_dir() . '/' . uniqid('test', true);
+        file_put_contents($tmpFile, 'test');
+
+        $s3Client = $this->createMock(S3Client::class);
+
+        $result = ResultMockFactory::create(PutObjectOutput::class);
+        $s3Client
+            ->method('putObject')
+            ->willReturnCallback(function (array $input) use ($result) {
+                static::assertSame('test', $input['Bucket']);
+                static::assertSame('test.txt', $input['Key']);
+                static::assertSame('text/plain', $input['ContentType']);
+
+                return $result;
+            });
+
+        $adapter = new AsyncAwsS3WriteBatchAdapter($s3Client, 'test');
+
+        $adapter->writeBatch(new CopyBatchInput($tmpFile, ['test.txt']));
+    }
+
+    public function testS3InvalidFile(): void
+    {
+        $s3Client = $this->createMock(S3Client::class);
+
+        $s3Client
+            ->expects(static::never())
+            ->method('putObject');
+
+        $adapter = new AsyncAwsS3WriteBatchAdapter($s3Client, 'test');
+        $adapter->writeBatch(new CopyBatchInput('invalid', ['test.txt']));
+    }
+}

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Adapter/AwsS3v3FactoryTest.php
@@ -3,10 +3,10 @@
 namespace Shopware\Tests\Unit\Core\Framework\Adapter\Filesystem\Adapter;
 
 use AsyncAws\S3\S3Client;
-use League\Flysystem\AsyncAwsS3\AsyncAwsS3Adapter;
 use League\Flysystem\AsyncAwsS3\PortableVisibilityConverter;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AsyncAwsS3WriteBatchAdapter;
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AwsS3v3Factory;
 
 /**
@@ -46,7 +46,7 @@ class AwsS3v3FactoryTest extends TestCase
         ]);
 
         static::assertEquals(
-            new AsyncAwsS3Adapter($client, 'private', 'foobar', new PortableVisibilityConverter()),
+            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter()),
             (new AwsS3v3Factory())->create($config)
         );
     }
@@ -76,7 +76,7 @@ class AwsS3v3FactoryTest extends TestCase
         ]);
 
         static::assertEquals(
-            new AsyncAwsS3Adapter($client, 'private', 'foobar', new PortableVisibilityConverter()),
+            new AsyncAwsS3WriteBatchAdapter($client, 'private', 'foobar', new PortableVisibilityConverter()),
             (new AwsS3v3Factory())->create($config)
         );
     }

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Plugin/CopyBatchTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Plugin/CopyBatchTest.php
@@ -2,16 +2,14 @@
 
 namespace Shopware\Tests\Unit\Core\Framework\Adapter\Filesystem\Plugin;
 
-use AsyncAws\Core\Test\ResultMockFactory;
-use AsyncAws\S3\Result\PutObjectOutput;
-use AsyncAws\S3\S3Client;
-use League\Flysystem\AsyncAwsS3\AsyncAwsS3Adapter;
 use League\Flysystem\Filesystem;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AsyncAwsS3WriteBatchAdapter;
 use Shopware\Core\Framework\Adapter\Filesystem\MemoryFilesystemAdapter;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatch;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInput;
+use Shopware\Core\Framework\Adapter\Filesystem\Plugin\WriteBatchInterface;
 
 /**
  * @internal
@@ -38,66 +36,23 @@ class CopyBatchTest extends TestCase
         unlink($tmpFile);
     }
 
-    public function testS3(): void
+    public function testCopyWithBatchCopyInterface(): void
     {
+        $adapter = $this->createMock(AsyncAwsS3WriteBatchAdapter::class);
+        $adapter->expects(static::once())->method('writeBatch');
+
+        static::assertInstanceOf(WriteBatchInterface::class, $adapter);
+
+        $fs = new Filesystem($adapter);
+
         $tmpFile = sys_get_temp_dir() . '/' . uniqid('test', true);
         file_put_contents($tmpFile, 'test');
 
-        $sourceFile = fopen($tmpFile, 'rb');
+        $sourceFile = fopen($tmpFile, 'r');
         static::assertIsResource($sourceFile);
+        CopyBatch::copy($fs, new CopyBatchInput($tmpFile, ['test.txt']), new CopyBatchInput($sourceFile, ['test2.txt']));
 
-        $s3Client = $this->createMock(S3Client::class);
-
-        $result = ResultMockFactory::create(PutObjectOutput::class);
-        $s3Client
-            ->method('putObject')
-            ->with([
-                'Bucket' => 'test',
-                'Key' => 'test.txt',
-                'Body' => $sourceFile,
-                'ContentType' => 'text/plain',
-            ])
-            ->willReturn($result);
-
-        $fs = new Filesystem(new AsyncAwsS3Adapter($s3Client, 'test'));
-
-        CopyBatch::copy($fs, new CopyBatchInput($sourceFile, ['test.txt']));
-    }
-
-    public function testS3UsingPath(): void
-    {
-        $tmpFile = sys_get_temp_dir() . '/' . uniqid('test', true);
-        file_put_contents($tmpFile, 'test');
-
-        $s3Client = $this->createMock(S3Client::class);
-
-        $result = ResultMockFactory::create(PutObjectOutput::class);
-        $s3Client
-            ->method('putObject')
-            ->willReturnCallback(function (array $input) use ($result) {
-                static::assertSame('test', $input['Bucket']);
-                static::assertSame('test.txt', $input['Key']);
-                static::assertSame('text/plain', $input['ContentType']);
-
-                return $result;
-            });
-
-        $fs = new Filesystem(new AsyncAwsS3Adapter($s3Client, 'test'));
-
-        CopyBatch::copy($fs, new CopyBatchInput($tmpFile, ['test.txt']));
-    }
-
-    public function testS3InvalidFile(): void
-    {
-        $s3Client = $this->createMock(S3Client::class);
-
-        $s3Client
-            ->expects(static::never())
-            ->method('putObject');
-
-        $fs = new Filesystem(new AsyncAwsS3Adapter($s3Client, 'test'));
-
-        CopyBatch::copy($fs, new CopyBatchInput('invalid', ['test.txt']));
+        unlink($tmpFile);
     }
 
     public function testConstructor(): void

--- a/tests/unit/Storefront/Theme/ThemeCompilerTest.php
+++ b/tests/unit/Storefront/Theme/ThemeCompilerTest.php
@@ -96,7 +96,7 @@ class ThemeCompilerTest extends TestCase
     /**
      * @var CopyBatchInputFactory&MockObject
      */
-    private CopyBatchInputFactory $copyBatchInputFactory;
+    private CopyBatchInputFactory $CopyBatchInputFactory;
 
     protected function setUp(): void
     {
@@ -107,7 +107,7 @@ class ThemeCompilerTest extends TestCase
         $this->scssPhpCompiler = $this->createMock(ScssPhpCompiler::class);
         $this->pathBuilder = new MD5ThemePathBuilder();
         $this->messageBus = new MessageBus();
-        $this->copyBatchInputFactory = $this->createMock(CopyBatchInputFactory::class);
+        $this->CopyBatchInputFactory = $this->createMock(CopyBatchInputFactory::class);
         $this->themeFilesystemResolver = $this->createMock(ThemeFilesystemResolver::class);
 
         $this->filesystem = new Filesystem(new InMemoryFilesystemAdapter());
@@ -165,7 +165,7 @@ class ThemeCompilerTest extends TestCase
             [ThemeFileResolver::STYLE_FILES => FileCollection::createFromArray(['foo'])]
         );
 
-        $this->copyBatchInputFactory->method('fromDirectory')->willThrowException(new \Exception());
+        $this->CopyBatchInputFactory->method('fromDirectory')->willThrowException(new \Exception());
 
         $compiler = $this->getThemeCompiler();
 
@@ -506,7 +506,7 @@ PHP_EOL,
         $this->filesystem->write('temp/test.png', '');
         $png = $this->filesystem->readStream('temp/test.png');
 
-        $this->copyBatchInputFactory->method('fromDirectory')->with('/app-root/Resources/assets', 'theme/test')->willReturn(
+        $this->CopyBatchInputFactory->method('fromDirectory')->with('/app-root/Resources/assets', 'theme/test')->willReturn(
             [
                 new CopyBatchInput($png, ['theme/9a11a759d278b4a55cb5e2c3414733c1/assets/test.png']),
             ]
@@ -586,7 +586,7 @@ PHP_EOL,
         $this->filesystem->createDirectory('theme/current');
         $this->filesystem->write('theme/current/all.js', '');
 
-        $this->copyBatchInputFactory->expects(static::never())
+        $this->CopyBatchInputFactory->expects(static::never())
             ->method('fromDirectory');
 
         $this->scssPhpCompiler->expects(static::once())->method('compileString')->willThrowException(new \Exception());
@@ -796,7 +796,7 @@ PHP_EOL,
         return new ThemeCompiler(
             $this->filesystem,
             $this->tempFilesystem,
-            $this->copyBatchInputFactory,
+            $this->CopyBatchInputFactory,
             $this->themeFileResolver,
             true,
             $this->eventDispatcher,


### PR DESCRIPTION
### 1. Why is this change necessary?
As a manufacturer of a flysystem adapter I want to be able to use the writeBatch-possibilities with a dedicated Interface until flysystem supports it out-of-the-box.

### 2. What does this change do, exactly?
- change the naming of CopyBatch to WriteBatch
- added dedicated WriteBatch-Adapter
- added Interface

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
