### PR TITLE
fix overlapping text in cookie configuration

### DIFF
--- a/changelog/_unreleased/2024-10-04-fix-overlapping-text-in-cookie-configuration-in-safari.md
+++ b/changelog/_unreleased/2024-10-04-fix-overlapping-text-in-cookie-configuration-in-safari.md
@@ -1,0 +1,10 @@
+---
+title: Fix overlapping text in cookie configuration in safari
+issue: NEXT-38706
+author: Joschi
+author_email: joschi.mehta@heptacom.de
+author_github: @NinjaArmy
+---
+# Storefront
+* Adjusting scss in `src/Storefront/Resources/app/storefront/src/scss/layout/_cookie-configuration.scss` to fix overlapping text in cookie configuration in safari. 
+___

--- a/changelog/_unreleased/2024-10-04-fix-overlapping-text-in-cookie-configuration-in-safari.md
+++ b/changelog/_unreleased/2024-10-04-fix-overlapping-text-in-cookie-configuration-in-safari.md
@@ -6,5 +6,5 @@ author_email: joschi.mehta@heptacom.de
 author_github: @NinjaArmy
 ---
 # Storefront
-* Adjusting scss in `src/Storefront/Resources/app/storefront/src/scss/layout/_cookie-configuration.scss` to fix overlapping text in cookie configuration in safari. 
+* Changed scss in `src/Storefront/Resources/app/storefront/src/scss/layout/_cookie-configuration.scss` to fix overlapping text in cookie configuration in safari. 
 ___

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_cookie-configuration.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_cookie-configuration.scss
@@ -27,6 +27,14 @@
     input:not([disabled]) ~ label {
         cursor: pointer;
     }
+
+    @supports (-webkit-hyphens:none) {
+        .form-check .form-check-input {
+            float: none;
+            display: inline-block;
+        }
+    }
+
 }
 
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Fixes overlapping text in the cookie configuration for the safari browser


### 2. What does this change do, exactly?

Removes float: left in safari to avoid overlapping text


### 3. Describe each step to reproduce the issue or behaviour.

Open the cookie configuration in the safari browser and take a look at the text next to the checknboxes


### 4. Please link to the relevant issues (if any).
[This issue](https://github.com/shopware/shopware/issues/4962)

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
