### PR TITLE
NEXT-38717 Disable delete for global number ranges Fixes #4978

### DIFF
--- a/changelog/_unreleased/2024-10-05-disable-delete-for-global-number-ranges.md
+++ b/changelog/_unreleased/2024-10-05-disable-delete-for-global-number-ranges.md
@@ -1,0 +1,9 @@
+---
+title: Disable delete for Global number ranges
+issue: NEXT-38717
+author: runelaenen
+author_email: rune@laenen.me
+author_github: @runelaenen
+---
+# Administration
+* Added check to disable the delete button for 'Global' number ranges.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-list/index.js
@@ -108,6 +108,10 @@ export default {
             this.showDeleteModal = id;
         },
 
+        canDelete(item) {
+            return !item.type.global;
+        },
+
         onCloseDeleteModal() {
             this.showDeleteModal = false;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-list/sw-settings-number-range-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-list/sw-settings-number-range-list.html.twig
@@ -152,7 +152,7 @@
                             <sw-context-menu-item
                                 class="sw-entity-listing__context-menu-edit-delete"
                                 variant="danger"
-                                :disabled="!acl.can('number_ranges.deleter') || undefined"
+                                :disabled="!canDelete(item) || !acl.can('number_ranges.deleter') || undefined"
                                 @click="onDelete(item.id)"
                             >
                                 {{ $tc('sw-settings-number-range.list.contextMenuDelete') }}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently it is possible to delete 'Global' number ranges, it is however not possible to create them again. This means that if the "Product" number range gets deleted by an admin, the state of the system cannot be fixed (without manually fixing it in the database or...)

### 2. What does this change do, exactly?
Add a check that disables the delete button for Global number ranges. (Currently that is only 'Product')

### 3. Describe each step to reproduce the issue or behaviour.
Go to the Number Ranges settings page.
Check the delete button for Product number range.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/4978
NEXT-38717

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
