### PR TITLE
feat: pass columns to grid row, fix inline editing. Fixes #4629

### DIFF
--- a/changelog/_unreleased/2024-10-05-pass-columns-to-sw-grid-row-fix-inline-editing.md
+++ b/changelog/_unreleased/2024-10-05-pass-columns-to-sw-grid-row-fix-inline-editing.md
@@ -1,0 +1,9 @@
+---
+title: Pass columns to sw-grid-row. Fix inline editing
+issue: NEXT-38143
+author: runelaenen
+author_email: rune@laenen.me
+author_github: @runelaenen
+---
+# Administration
+* Added `columns` property to `sw-grid-row`

--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid-row/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid-row/index.js
@@ -61,11 +61,16 @@ Component.register('sw-grid-row', {
             // eslint-disable-next-line vue/no-boolean-default
             default: true,
         },
+
+        columns: {
+            type: Array,
+            required: false,
+            default: null,
+        },
     },
 
     data() {
         return {
-            columns: [],
             isEditingActive: false,
             inlineEditingCls: 'is--inline-editing',
             id: utils.createId(),

--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/sw-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/sw-grid.html.twig
@@ -120,6 +120,7 @@
                             :index="index"
                             :allow-inline-edit="allowInlineEdit"
                             :class="['sw-grid__row--' + index, { 'is--selected': isSelected(item.id), 'is--deleted': item.isDeleted, 'is--new': item.isLocal }]"
+                            :columns="columns"
                             @inline-edit-finish="onInlineEditFinish"
                             @inline-edit-start="onInlineEditStart"
                         >


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
For inline edit to work in sw-grid grids (not entity grids, they override parts of this) like the Snippet Set list, the columns need to be made available in the sw-grid-row component.

### 2. What does this change do, exactly?
Pass the columns from the sw-grid to sw-grid-row.

### 3. Describe each step to reproduce the issue or behaviour.
Go to Snippet Sets settings page. Double click on grid row. It will not start the Inline edit because the sw-grid-row does not know about the columns so cannot check if they have inline editing enabled.

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/4629
NEXT-38143

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
