### PR TITLE
Add wishlist criteria titles

### DIFF
--- a/changelog/_unreleased/2024-10-05-add-wishlist-store-api-criteria-title.md
+++ b/changelog/_unreleased/2024-10-05-add-wishlist-store-api-criteria-title.md
@@ -1,0 +1,13 @@
+---
+title: Add criteria titles to wishlist Store APIs
+author: Joshua Behrens
+author_email: code@joshua-behrens.de
+author_github: @JoshuaBehrens
+---
+# Core
+* Change return type of `\Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria::setTitle` from `void` to `self`
+* Add criteria title `wishlist::load-products` to `\Shopware\Core\Checkout\Customer\SalesChannel\LoadWishlistRoute::load`
+___
+# Storefront
+* Add criteria title `wishlist::list` to `\Shopware\Storefront\Controller\WishlistController::ajaxList`
+* Add criteria title `wishlist::page` to `\Shopware\Storefront\Page\Wishlist\WishlistPageLoader::load`

--- a/src/Core/Checkout/Cart/SalesChannel/CartOrderRoute.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartOrderRoute.php
@@ -84,8 +84,8 @@ class CartOrderRoute extends AbstractCartOrderRoute
         $orderId = Profiler::trace('checkout-order::order-persist', fn () => $this->orderPersister->persist($calculatedCart, $context));
 
         $criteria = new Criteria([$orderId]);
-        $criteria->setTitle('order-route::order-loading');
         $criteria
+            ->setTitle('order-route::order-loading')
             ->addAssociation('orderCustomer.customer')
             ->addAssociation('orderCustomer.salutation')
             ->addAssociation('deliveries.shippingMethod')

--- a/src/Core/Checkout/Customer/SalesChannel/LoadWishlistRoute.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LoadWishlistRoute.php
@@ -52,6 +52,10 @@ class LoadWishlistRoute extends AbstractLoadWishlistRoute
     #[Route(path: '/store-api/customer/wishlist', name: 'store-api.customer.wishlist.load', methods: ['GET', 'POST'], defaults: ['_loginRequired' => true, '_entity' => 'product'])]
     public function load(Request $request, SalesChannelContext $context, Criteria $criteria, CustomerEntity $customer): LoadWishlistRouteResponse
     {
+        if ($criteria->getTitle() === null) {
+            $criteria->setTitle('wishlist::load-products');
+        }
+
         if (!$this->systemConfigService->get('core.cart.wishlistEnabled', $context->getSalesChannel()->getId())) {
             throw CustomerException::customerWishlistNotActivated();
         }

--- a/src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/CrossSelling/ProductCrossSellingRoute.php
@@ -87,8 +87,8 @@ class ProductCrossSellingRoute extends AbstractProductCrossSellingRoute
     private function loadCrossSellings(string $productId, SalesChannelContext $context): ProductCrossSellingCollection
     {
         $criteria = new Criteria();
-        $criteria->setTitle('product-cross-selling-route');
         $criteria
+            ->setTitle('product-cross-selling-route')
             ->addAssociation('assignedProducts')
             ->addFilter(new EqualsFilter('product.id', $productId))
             ->addFilter(new EqualsFilter('active', 1))

--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -99,9 +99,8 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
         $associations = $this->getAssociations($productExport, $context);
 
         $criteria = new Criteria();
-        $criteria->setTitle('product-export::products');
-
         $criteria
+            ->setTitle('product-export::products')
             ->addFilter(...$filters)
             ->setOffset($exportBehavior->offset())
             ->setLimit($this->readBufferSize);

--- a/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Criteria.php
@@ -597,9 +597,11 @@ class Criteria extends Struct implements \Stringable
         return $this->title;
     }
 
-    public function setTitle(?string $title): void
+    public function setTitle(?string $title): self
     {
         $this->title = $title;
+
+        return $this;
     }
 
     /**

--- a/src/Storefront/Controller/WishlistController.php
+++ b/src/Storefront/Controller/WishlistController.php
@@ -104,6 +104,7 @@ class WishlistController extends StorefrontController
     public function ajaxList(Request $request, SalesChannelContext $context, CustomerEntity $customer): Response
     {
         $criteria = new Criteria();
+        $criteria->setTitle('wishlist::list');
         $this->eventDispatcher->dispatch(new WishListPageProductCriteriaEvent($criteria, $context, $request));
 
         try {

--- a/src/Storefront/Page/Wishlist/WishlistPageLoader.php
+++ b/src/Storefront/Page/Wishlist/WishlistPageLoader.php
@@ -89,6 +89,7 @@ class WishlistPageLoader
         $offset = $limit * ($page - 1);
 
         return (new Criteria())
+            ->setTitle('wishlist::page')
             ->addSorting(new FieldSorting('wishlists.updatedAt', FieldSorting::ASCENDING))
             ->addAssociation('manufacturer')
             ->addAssociation('options.group')


### PR DESCRIPTION
### 1. Why is this change necessary?

Criterias with titles are nice because with this you can better amend criterias using events and decorators as you know the situation they are used in.

### 2. What does this change do, exactly?

Make `setTitle` return itself so it can be used in a chained manner like other setters.
Set criteria title at 3 code points

### 3. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
