### PR TITLE
 NEXT-36826 fix customer preselect at order initial

### DIFF
--- a/changelog/_unreleased/2024-10-05-fix-customer-preselect-at-order-create-initial.md
+++ b/changelog/_unreleased/2024-10-05-fix-customer-preselect-at-order-create-initial.md
@@ -1,0 +1,11 @@
+---
+title: fix-customer-preselect-at-order-create-initial
+issue: NEXT-36826
+author: Robin Valley
+author_email: r.valley@basecom.de
+author_github: @rvalley98
+---
+# Administration
+* change param `customer` to `customerId` from method `navigateToCreateOrder` in `Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js`
+* add customer repository call with customerId from method `createdComponent` in `Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/index.js`
+* add optional param customerId for component `sw-order-create-initial` in `Resources/app/administration/src/module/sw-order/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
@@ -125,9 +125,9 @@ export default {
 
         navigateToCreateOrder() {
             this.$router.push({
-                name: 'sw.order.create',
+                name: 'sw.order.create.initial',
                 params: {
-                    customer: this.customer,
+                    customerId: this.customer.id, // hier ist der customer da
                 },
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-order/index.js
@@ -127,7 +127,7 @@ export default {
             this.$router.push({
                 name: 'sw.order.create.initial',
                 params: {
-                    customerId: this.customer.id, // hier ist der customer da
+                    customerId: this.customer.id,
                 },
             });
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/index.js
@@ -177,7 +177,7 @@ function orderCreateChildren() {
     return {
         initial: {
             component: 'sw-order-create-initial',
-            path: 'initial',
+            path: 'initial/:customerId?',
             meta: {
                 parentPath: 'sw.order.index',
                 privilege: 'order.creator',

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/index.js
@@ -12,13 +12,22 @@ export default {
 
     compatConfig: Shopware.compatConfig,
 
+    inject: ['repositoryFactory'],
+
     created() {
         this.createdComponent();
     },
 
     methods: {
         createdComponent() {
-            const { customer } = this.$route.params;
+            const customerRepository = this.repositoryFactory.create('customer');
+            const { customer, customerId }     = this.$route.params;
+
+            if(customerId) {
+                customerRepository.get(customerId).then(response => {
+                    State.commit('swOrder/setCustomer', response);
+                });
+            }
 
             if (!customer) {
                 return;

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-initial/index.js
@@ -1,4 +1,5 @@
 import template from './sw-order-create-initial.html.twig';
+import RepositoryType from '../../../../core/data/repository.data';
 
 /**
  * @package checkout
@@ -18,22 +19,23 @@ export default {
         this.createdComponent();
     },
 
+    computed: {
+        customerRepository(): RepositoryType<'customer'> {
+            return this.repositoryFactory.create('customer');
+        },
+    },
+
     methods: {
         createdComponent() {
-            const customerRepository = this.repositoryFactory.create('customer');
-            const { customer, customerId }     = this.$route.params;
+            const { customerId } = this.$route.params;
 
-            if(customerId) {
-                customerRepository.get(customerId).then(response => {
-                    State.commit('swOrder/setCustomer', response);
-                });
-            }
-
-            if (!customer) {
+            if (!customerId) {
                 return;
             }
 
-            State.commit('swOrder/setCustomer', customer);
+            this.customerRepository.get(customerId).then(response => {
+                State.commit('swOrder/setCustomer', response);
+            });
         },
 
         onCloseCreateModal() {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When creating a manually order from the customer backend detail view the customer is not preselected

### 2. What does this change do, exactly?
The customer will be preselected

### 3. Describe each step to reproduce the issue or behaviour.
Go to Customers -> Overview
Select a customer
Click on Tab "Orders"
Create a manually order with the "Add Order" Button
In the "New order" modal view the customer is not preselected and you have to search it again

### 4. Please link to the relevant issues (if any).
 #4376 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.