### PR TITLE
NEXT-38490 - Add close to single-select component & improve chevron

### DIFF
--- a/changelog/_unreleased/2024-10-06-implement-proper-closing-of-single-select-component.md
+++ b/changelog/_unreleased/2024-10-06-implement-proper-closing-of-single-select-component.md
@@ -1,0 +1,9 @@
+---
+title: Implement proper closing of single-select component
+issue: NEXT-38490
+author: Florian Liebig
+author_email: hello@florian-liebig.de
+author_github: @florianliebig
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig` to properly close on chevron click & show correct chevron

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
@@ -43,11 +43,17 @@
                     />
                 </button>
 
-                <sw-icon
-                    class="sw-select__select-indicator sw-select__select-indicator-expand"
-                    name="regular-chevron-down-xs"
-                    small
+                <button
+                    @click="expanded ? collapse() : expand()"
+                    @click.stop
+                    class="sw-select__select-indicator-hitbox"
+                >
+                    <sw-icon
+                        class="sw-select__select-indicator sw-select__select-indicator-expand"
+                        :name="expanded ? `regular-chevron-up-xs`: `regular-chevron-down-xs`"
+                        small
                 />
+                </button>
             </div>
         </div>
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
@@ -44,15 +44,15 @@
                 </button>
 
                 <button
+                    class="sw-select__select-indicator-hitbox"
                     @click="expanded ? collapse() : expand()"
                     @click.stop
-                    class="sw-select__select-indicator-hitbox"
                 >
                     <sw-icon
                         class="sw-select__select-indicator sw-select__select-indicator-expand"
                         :name="expanded ? `regular-chevron-up-xs`: `regular-chevron-down-xs`"
                         small
-                />
+                    />
                 </button>
             </div>
         </div>

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.spec.js
@@ -66,4 +66,18 @@ describe('components/sw-select-base', () => {
         // expect clear event thrown
         expect(wrapper.emitted('clear')).toHaveLength(1);
     });
+
+    it('should show the correct chevron based on the expanded state', async () => {
+        const wrapper = await createWrapper();
+
+        const chevronButton = wrapper.find('.sw-select__select-indicator');
+
+        await chevronButton.trigger('click');
+
+        expect(wrapper.find('div[name="regular-chevron-up-xs"]').exists()).toBe(true);
+
+        await chevronButton.trigger('click');
+
+        expect(wrapper.find('div[name="regular-chevron-down-xs"]').exists()).toBe(true);
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

Single select currently has no way to close it other than clicking on page body or selecting a value

### 2. What does this change do, exactly?

Implement click handler on the chevron icon.
Implement proper change of the chevron icon (down when closed, up when open)


### 3. Describe each step to reproduce the issue or behaviour.

Go to any administration page which is translateable or has another single select. Open single select, click on chevron

![single-select](https://github.com/user-attachments/assets/5dea6faf-9218-4285-819b-3c144c46725f)


### 4. Please link to the relevant issues (if any).

https://github.com/shopware/shopware/issues/4886

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
