### PR TITLE
NEXT-38705 - Remove redundant slash for products without SEO url in sitemap

### DIFF
--- a/changelog/_unreleased/2024-10-06-remove-redundant-slash-for-product-urls-without-seo-url-in-sitemap.md
+++ b/changelog/_unreleased/2024-10-06-remove-redundant-slash-for-product-urls-without-seo-url-in-sitemap.md
@@ -1,0 +1,9 @@
+---
+title: Remove redundant slash for product urls without SEO url in sitemap
+issue: NEXT-38705
+author: Florian Liebig
+author_email: hello@florian-liebig.de
+author_github: @florianliebig
+---
+# Core
+* Changed `ProductUrlProvider` to remove leading slash for products without SEO url

--- a/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/ProductUrlProvider.php
@@ -82,7 +82,7 @@ class ProductUrlProvider extends AbstractUrlProvider
             if (isset($seoUrls[$product['id']])) {
                 $newUrl->setLoc($seoUrls[$product['id']]['seo_path_info']);
             } else {
-                $newUrl->setLoc($this->router->generate('frontend.detail.page', ['productId' => $product['id']]));
+                $newUrl->setLoc(ltrim($this->router->generate('frontend.detail.page', ['productId' => $product['id']]), '/'));
             }
 
             $newUrl->setLastmod(new \DateTime($lastMod));

--- a/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/ProductUrlProviderTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Seo\SeoUrl\SeoUrlCollection;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Content\Sitemap\Provider\ProductUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
@@ -221,8 +222,9 @@ class ProductUrlProviderTest extends TestCase
         $this->createProducts();
 
         // delete all SEO urls
-        $seo = $this->getContainer()->get('seo_url.repository')->search(new Criteria(), $this->salesChannelContext->getContext());
-        foreach ($seo->getEntities() as $entity) {
+        /** @var SeoUrlCollection $seoUrls */
+        $seoUrls = $this->getContainer()->get('seo_url.repository')->search(new Criteria(), $this->salesChannelContext->getContext())->getEntities();
+        foreach ($seoUrls as $entity) {
             $this->getContainer()->get('seo_url.repository')->delete([['id' => $entity->getId()]], $this->salesChannelContext->getContext());
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

When a product does not have a SEO url, it's entry in the sitemap is generated as

https://example.com/detail/{uuid}

### 2. What does this change do, exactly?

For products without seo url it uses ltrim to remove that leading slash to have the same loc format (without leading slash) for products with and without products

### 3. Describe each step to reproduce the issue or behavior.

Create product
Clear seo_url in DB
bin/console sitemap:generate
check /sitemap.xml

Look for double slashes

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/shopware/issues/4963

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
