### PR TITLE
Static plugins improvement

### DIFF
--- a/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
@@ -42,7 +42,7 @@ class PluginCreateCommand extends Command
         $this
             ->addArgument('plugin-name', InputArgument::OPTIONAL, 'Plugin name (PascalCase)')
             ->addArgument('plugin-namespace', InputArgument::OPTIONAL, 'Plugin namespace (PascalCase)')
-            ->addOption('static', null, null, 'Plugin will create in static-plugins folder');
+            ->addOption('static', null, null, 'Plugin will be created in the static-plugins folder');
 
         foreach ($this->generators as $generator) {
             if (!$generator->hasCommandOption()) {
@@ -73,7 +73,7 @@ class PluginCreateCommand extends Command
                 $pluginName = $this->askPascalCaseString('Please enter a plugin name (PascalCase)', $io);
             }
 
-            $directory = $this->projectDir . "/custom/{$staticPrefix}plugins/" . $pluginName;
+            $directory = \sprintf('%s/custom/%splugins/%s', $this->projectDir, $staticPrefix, $pluginName);
 
             if ($this->filesystem->exists($directory)) {
                 $io->error(\sprintf('Plugin directory %s already exists', $directory));

--- a/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
@@ -11,6 +11,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
@@ -41,7 +42,8 @@ class PluginCreateCommand extends Command
     {
         $this
             ->addArgument('plugin-name', InputArgument::OPTIONAL, 'Plugin name (PascalCase)')
-            ->addArgument('plugin-namespace', InputArgument::OPTIONAL, 'Plugin namespace (PascalCase)');
+            ->addArgument('plugin-namespace', InputArgument::OPTIONAL, 'Plugin namespace (PascalCase)')
+            ->addOption('static', null, null, 'Plugin will create in static-plugins folder');
 
         foreach ($this->generators as $generator) {
             if (!$generator->hasCommandOption()) {
@@ -66,12 +68,13 @@ class PluginCreateCommand extends Command
 
         try {
             $pluginName = $input->getArgument('plugin-name');
+            $staticPrefix = $input->getOption('static') ? 'static-' : '';
 
             if (!$pluginName) {
                 $pluginName = $this->askPascalCaseString('Please enter a plugin name (PascalCase)', $io);
             }
 
-            $directory = $this->projectDir . '/custom/plugins/' . $pluginName;
+            $directory = $this->projectDir . "/custom/{$staticPrefix}plugins/" . $pluginName;
 
             if ($this->filesystem->exists($directory)) {
                 $io->error(\sprintf('Plugin directory %s already exists', $directory));

--- a/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
+++ b/src/Core/Framework/Plugin/Command/PluginCreateCommand.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -31,7 +31,7 @@ class ThemeCreateCommand extends Command
     {
         $this
             ->addArgument('theme-name', InputArgument::OPTIONAL, 'Theme name')
-            ->addOption('static', null, null, 'Create Theme in custom/static-plugins folder');
+            ->addOption('static', null, null, 'Theme will be created in the static-plugins folder');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -62,7 +62,7 @@ class ThemeCreateCommand extends Command
 
         $pluginName = ucfirst((string) $themeName);
 
-        $directory = $this->projectDir . "/custom/{$staticPrefix}plugins/" . $pluginName;
+        $directory = \sprintf('%s/custom/%splugins/%s', $this->projectDir, $staticPrefix, $pluginName);
 
         if (file_exists($directory)) {
             $io->error(\sprintf('Plugin directory %s already exists', $directory));

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -7,7 +7,6 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;

--- a/src/Storefront/Theme/Command/ThemeCreateCommand.php
+++ b/src/Storefront/Theme/Command/ThemeCreateCommand.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -30,13 +31,15 @@ class ThemeCreateCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('theme-name', InputArgument::OPTIONAL, 'Theme name');
+            ->addArgument('theme-name', InputArgument::OPTIONAL, 'Theme name')
+            ->addOption('static', null, null, 'Create Theme in custom/static-plugins folder');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $themeName = $input->getArgument('theme-name');
+        $staticPrefix = $input->getOption('static') ? 'static-' : '';
 
         if (!$themeName) {
             $question = new Question('Please enter a theme name: ');
@@ -60,7 +63,7 @@ class ThemeCreateCommand extends Command
 
         $pluginName = ucfirst((string) $themeName);
 
-        $directory = $this->projectDir . '/custom/plugins/' . $pluginName;
+        $directory = $this->projectDir . "/custom/{$staticPrefix}plugins/" . $pluginName;
 
         if (file_exists($directory)) {
             $io->error(\sprintf('Plugin directory %s already exists', $directory));

--- a/tests/unit/Core/Framework/Plugin/Command/PluginCreateCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/PluginCreateCommandTest.php
@@ -79,6 +79,7 @@ class PluginCreateCommandTest extends TestCase
                 'plugin-name' => 'TestPlugin',
                 'plugin-namespace' => 'Test',
                 '--test-option' => true,
+                '--static' => true,
             ],
             'inputs' => [],
             'generators' => [

--- a/tests/unit/Storefront/Theme/Command/ThemeCreateCommandTest.php
+++ b/tests/unit/Storefront/Theme/Command/ThemeCreateCommandTest.php
@@ -47,6 +47,23 @@ class ThemeCreateCommandTest extends TestCase
         static::assertFileExists($expectedDirectory . 'Resources/theme.json');
     }
 
+    public function testSuccessfulCreateAsStaticCommand(): void
+    {
+        $expectedDirectory = $this->projectDir . 'custom/static-plugins/' . self::THEME_NAME . '/src/';
+
+        $commandTester = $this->getCommandTester();
+
+        $commandTester->execute(['theme-name' => self::THEME_NAME, '--static' => true]);
+        $result = preg_replace('/\s+/', ' ', trim($commandTester->getDisplay(true)));
+
+        static::assertIsString($result);
+        static::assertStringContainsString('Creating theme structure under', $result);
+        static::assertDirectoryExists($expectedDirectory);
+        static::assertFileExists($expectedDirectory . 'TestPlugin.php');
+        static::assertDirectoryExists($expectedDirectory . 'Resources');
+        static::assertFileExists($expectedDirectory . 'Resources/theme.json');
+    }
+
     public function testCommandFailsOnDuplicate(): void
     {
         $commandTester = $this->getCommandTester();


### PR DESCRIPTION
### 1. Why is this change necessary?
Easiest scafolding for project related plugin

### 2. What does this change do, exactly?
- Allow PluginCreateCommand.php to create static plugins
- Allow ThemeCreateCommand.php to create static themes

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
