### PR TITLE
chore: Add native return type to subscriber

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Telemetry/EntityTelemetrySubscriber.php
+++ b/src/Core/Framework/DataAbstractionLayer/Telemetry/EntityTelemetrySubscriber.php
@@ -22,7 +22,7 @@ class EntityTelemetrySubscriber implements EventSubscriberInterface
     {
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             EntitySearchedEvent::class => ['emitAssociationsCountMetric', 99],


### PR DESCRIPTION
### 1. Why is this change necessary?
```
Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Shopware\Core\Framework\DataAbstractionLayer\Telemetry\EntityTelemetrySubscriber" now to avoid errors or add an explicit @return annotation to suppress this message.
```

### 2. What does this change do, exactly?
Add the return type.

### 3. Describe each step to reproduce the issue or behaviour.
Look at the deprecations.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
