### PR TITLE
refactor(google-analytics): Warning if ordernumber element is not found

### DIFF
--- a/changelog/_unreleased/2024-10-06-do-not-yield-an-error-if-the-finish-ordernumber-element-cannot-be-found.md
+++ b/changelog/_unreleased/2024-10-06-do-not-yield-an-error-if-the-finish-ordernumber-element-cannot-be-found.md
@@ -1,0 +1,9 @@
+---
+title: Do not yield an error if the `.finish-ordernumber` element cannot be found
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed the Google Analytics `purchase.event` handler to not run into an error if the `.finish-ordernumber` element is missing and instead log a warning

--- a/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/google-analytics/events/purchase.event.js
@@ -13,9 +13,10 @@ export default class PurchaseEvent extends AnalyticsEvent
             return;
         }
 
-        const orderNumberElement = DomAccessHelper.querySelector(document, '.finish-ordernumber');
-
+        const orderNumberElement = document.querySelector('.finish-ordernumber');
         if (!orderNumberElement) {
+            console.warn('Cannot get order number element - Skip order tracking');
+
             return;
         }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When looking into the issue https://github.com/shopware/shopware/issues/4157 I found, that actually the if condition does not make sense, as the event handler will error out, before coming to that.

### 2. What does this change do, exactly?
Do not walk into an JS error, but rather a log a warning.

### 3. Describe each step to reproduce the issue or behaviour.
Remove the `.finish-ordernumber` element on the finish page and try to track the order with Google Analytics.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
