### PR TITLE
feat: Allow multiple values for affiliate and campaign code rules

### DIFF
--- a/changelog/_unreleased/2024-10-07-allow-multiple-values-for-affiliate-and-campaign-code-rules.md
+++ b/changelog/_unreleased/2024-10-07-allow-multiple-values-for-affiliate-and-campaign-code-rules.md
@@ -1,0 +1,9 @@
+---
+title: Allow multiple values for affiliate and campaign code rules
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed `AffiliateCodeRule`, `CampaignCodeRule`, `AffiliateCodeOfOrderRule` and `AffiliateCodeOfOrderRule` to allow multiple values for codes

--- a/src/Core/Checkout/Cart/Rule/AffiliateCodeOfOrderRule.php
+++ b/src/Core/Checkout/Cart/Rule/AffiliateCodeOfOrderRule.php
@@ -18,10 +18,12 @@ class AffiliateCodeOfOrderRule extends Rule
 
     /**
      * @internal
+     *
+     * @param array<string> $affiliateCode
      */
     public function __construct(
         protected string $operator = self::OPERATOR_EQ,
-        protected ?string $affiliateCode = null
+        protected ?array $affiliateCode = null
     ) {
         parent::__construct();
     }
@@ -31,6 +33,7 @@ class AffiliateCodeOfOrderRule extends Rule
         if (!$scope instanceof FlowRuleScope) {
             return false;
         }
+
         if (!$this->affiliateCode && $this->operator !== self::OPERATOR_EMPTY) {
             throw CartException::unsupportedValue(\gettype($this->affiliateCode), self::class);
         }
@@ -39,7 +42,13 @@ class AffiliateCodeOfOrderRule extends Rule
             return RuleComparison::isNegativeOperator($this->operator);
         }
 
-        return RuleComparison::string($affiliateCode, $this->affiliateCode ?? '', $this->operator);
+        return RuleComparison::stringArray(
+            $affiliateCode,
+            $this->affiliateCode !== null ? array_values(
+                array_map('mb_strtolower', $this->affiliateCode)
+            ) : [],
+            $this->operator,
+        );
     }
 
     public function getConstraints(): array
@@ -52,7 +61,7 @@ class AffiliateCodeOfOrderRule extends Rule
             return $constraints;
         }
 
-        $constraints['affiliateCode'] = RuleConstraints::string();
+        $constraints['affiliateCode'] = RuleConstraints::stringArray();
 
         return $constraints;
     }
@@ -60,7 +69,7 @@ class AffiliateCodeOfOrderRule extends Rule
     public function getConfig(): RuleConfig
     {
         return (new RuleConfig())
-            ->operatorSet(RuleConfig::OPERATOR_SET_STRING, true)
-            ->stringField('affiliateCode');
+            ->operatorSet(RuleConfig::OPERATOR_SET_STRING, true, true)
+            ->taggedField('affiliateCode');
     }
 }

--- a/src/Core/Checkout/Cart/Rule/CampaignCodeOfOrderRule.php
+++ b/src/Core/Checkout/Cart/Rule/CampaignCodeOfOrderRule.php
@@ -18,10 +18,12 @@ class CampaignCodeOfOrderRule extends Rule
 
     /**
      * @internal
+     *
+     * @param array<string> $campaignCode
      */
     public function __construct(
         protected string $operator = self::OPERATOR_EQ,
-        protected ?string $campaignCode = null
+        protected ?array $campaignCode = null
     ) {
         parent::__construct();
     }
@@ -31,6 +33,7 @@ class CampaignCodeOfOrderRule extends Rule
         if (!$scope instanceof FlowRuleScope) {
             return false;
         }
+
         if (!$this->campaignCode && $this->operator !== self::OPERATOR_EMPTY) {
             throw CartException::unsupportedValue(\gettype($this->campaignCode), self::class);
         }
@@ -38,7 +41,13 @@ class CampaignCodeOfOrderRule extends Rule
             return RuleComparison::isNegativeOperator($this->operator);
         }
 
-        return RuleComparison::string($campaignCode, $this->campaignCode ?? '', $this->operator);
+        return RuleComparison::stringArray(
+            $campaignCode,
+            $this->campaignCode !== null ? array_values(
+                array_map('mb_strtolower', $this->campaignCode)
+            ) : [],
+            $this->operator,
+        );
     }
 
     public function getConstraints(): array
@@ -51,7 +60,7 @@ class CampaignCodeOfOrderRule extends Rule
             return $constraints;
         }
 
-        $constraints['campaignCode'] = RuleConstraints::string();
+        $constraints['campaignCode'] = RuleConstraints::stringArray();
 
         return $constraints;
     }
@@ -59,7 +68,7 @@ class CampaignCodeOfOrderRule extends Rule
     public function getConfig(): RuleConfig
     {
         return (new RuleConfig())
-            ->operatorSet(RuleConfig::OPERATOR_SET_STRING, true)
-            ->stringField('campaignCode');
+            ->operatorSet(RuleConfig::OPERATOR_SET_STRING, true, true)
+            ->taggedField('campaignCode');
     }
 }

--- a/src/Core/Checkout/Customer/Rule/AffiliateCodeRule.php
+++ b/src/Core/Checkout/Customer/Rule/AffiliateCodeRule.php
@@ -18,10 +18,12 @@ class AffiliateCodeRule extends Rule
 
     /**
      * @internal
+     *
+     * @param array<string> $affiliateCode
      */
     public function __construct(
         protected string $operator = self::OPERATOR_EQ,
-        protected ?string $affiliateCode = null
+        protected ?array $affiliateCode = null
     ) {
         parent::__construct();
     }
@@ -44,7 +46,13 @@ class AffiliateCodeRule extends Rule
             return RuleComparison::isNegativeOperator($this->operator);
         }
 
-        return RuleComparison::string($affiliateCode, $this->affiliateCode ?? '', $this->operator);
+        return RuleComparison::stringArray(
+            $affiliateCode,
+            $this->affiliateCode !== null ? array_values(
+                array_map('mb_strtolower', $this->affiliateCode)
+            ) : [],
+            $this->operator,
+        );
     }
 
     public function getConstraints(): array
@@ -57,7 +65,7 @@ class AffiliateCodeRule extends Rule
             return $constraints;
         }
 
-        $constraints['affiliateCode'] = RuleConstraints::string();
+        $constraints['affiliateCode'] = RuleConstraints::stringArray();
 
         return $constraints;
     }
@@ -65,7 +73,7 @@ class AffiliateCodeRule extends Rule
     public function getConfig(): RuleConfig
     {
         return (new RuleConfig())
-            ->operatorSet(RuleConfig::OPERATOR_SET_STRING, true)
-            ->stringField('affiliateCode');
+            ->operatorSet(RuleConfig::OPERATOR_SET_STRING, true, true)
+            ->taggedField('affiliateCode');
     }
 }

--- a/src/Core/Checkout/Customer/Rule/CampaignCodeRule.php
+++ b/src/Core/Checkout/Customer/Rule/CampaignCodeRule.php
@@ -18,10 +18,12 @@ class CampaignCodeRule extends Rule
 
     /**
      * @internal
+     *
+     * @param array<string> $campaignCode
      */
     public function __construct(
         protected string $operator = self::OPERATOR_EQ,
-        protected ?string $campaignCode = null
+        protected ?array $campaignCode = null
     ) {
         parent::__construct();
     }
@@ -44,7 +46,13 @@ class CampaignCodeRule extends Rule
             return RuleComparison::isNegativeOperator($this->operator);
         }
 
-        return RuleComparison::string($campaignCode, $this->campaignCode ?? '', $this->operator);
+        return RuleComparison::stringArray(
+            $campaignCode,
+            $this->campaignCode !== null ? array_values(
+                array_map('mb_strtolower', $this->campaignCode)
+            ) : [],
+            $this->operator,
+        );
     }
 
     public function getConstraints(): array
@@ -57,7 +65,7 @@ class CampaignCodeRule extends Rule
             return $constraints;
         }
 
-        $constraints['campaignCode'] = RuleConstraints::string();
+        $constraints['campaignCode'] = RuleConstraints::stringArray();
 
         return $constraints;
     }
@@ -66,6 +74,6 @@ class CampaignCodeRule extends Rule
     {
         return (new RuleConfig())
             ->operatorSet(RuleConfig::OPERATOR_SET_STRING, true)
-            ->stringField('campaignCode');
+            ->taggedField('campaignCode');
     }
 }

--- a/src/Core/Framework/Rule/Container/ZipCodeRule.php
+++ b/src/Core/Framework/Rule/Container/ZipCodeRule.php
@@ -7,8 +7,8 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Exception\UnsupportedValueException;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleConstraints;
 use Shopware\Core\Framework\Util\FloatComparator;
-use Shopware\Core\Framework\Validation\Constraint\ArrayOfType;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
@@ -46,7 +46,7 @@ abstract class ZipCodeRule extends Rule
             return $constraints;
         }
 
-        $constraints['zipCodes'] = [new NotBlank(), new ArrayOfType('string')];
+        $constraints['zipCodes'] = RuleConstraints::stringArray();
 
         return $constraints;
     }

--- a/src/Core/Framework/Rule/RuleComparison.php
+++ b/src/Core/Framework/Rule/RuleComparison.php
@@ -60,6 +60,7 @@ class RuleComparison
         return match ($operator) {
             Rule::OPERATOR_EQ => \in_array(mb_strtolower($itemValue), $ruleValue, true),
             Rule::OPERATOR_NEQ => !\in_array(mb_strtolower($itemValue), $ruleValue, true),
+            Rule::OPERATOR_EMPTY => empty(trim($itemValue)),
             default => throw new UnsupportedOperatorException($operator, self::class),
         };
     }

--- a/src/Core/Migration/V6_6/Migration1728302885MultipleValuesForAffilateAndCampaignCodes.php
+++ b/src/Core/Migration/V6_6/Migration1728302885MultipleValuesForAffilateAndCampaignCodes.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Rule\DataAbstractionLayer\RuleIndexer;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1728302885MultipleValuesForAffilateAndCampaignCodes extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1728302885;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $ruleIds = $connection->fetchFirstColumn(<<<'SQL'
+            SELECT DISTINCT
+                `rule_id`
+            FROM
+                `rule_condition`
+            WHERE `type` IN('orderAffiliateCode', 'customerAffiliateCode', 'orderCampaignCode', 'customerCampaignCode')
+            SQL);
+
+        if (\count($ruleIds) === 0) {
+            return;
+        }
+
+        $this->convertAffilateCodeRules($connection);
+        $this->convertCampaignCodeRules($connection);
+
+        // rebuild payload of rules (as it contains the conditions serialized)
+        $connection->executeStatement('UPDATE rule SET payload = NULL WHERE id in (:rule_ids)', [
+            'rule_ids' => $ruleIds,
+        ], [
+            'rule_ids' => ArrayParameterType::BINARY,
+        ]);
+
+        $this->registerIndexer($connection, 'rule.indexer', [RuleIndexer::PAYLOAD_UPDATER]);
+    }
+
+    private function convertAffilateCodeRules(Connection $connection): void
+    {
+        $connection->executeStatement(<<<'SQL'
+            UPDATE
+                `rule_condition`
+            SET
+                `value` = JSON_SET(
+                    `value`,
+                    '$.affiliateCode',
+                    JSON_ARRAY(JSON_EXTRACT(`value`, '$.affiliateCode'))
+                )
+            WHERE
+                `type` IN('orderAffiliateCode', 'customerAffiliateCode')
+                AND JSON_VALID(`value`)
+                AND JSON_TYPE(JSON_EXTRACT(`value`, '$.affiliateCode')) = 'STRING';
+            SQL);
+    }
+
+    private function convertCampaignCodeRules(Connection $connection): void
+    {
+        $connection->executeStatement(<<<'SQL'
+            UPDATE
+                `rule_condition`
+            SET
+                `value` = JSON_SET(
+                    `value`,
+                    '$.campaignCode',
+                    JSON_ARRAY(JSON_EXTRACT(`value`, '$.campaignCode'))
+                )
+            WHERE
+                `type` IN('orderCampaignCode', 'customerCampaignCode')
+                AND JSON_VALID(`value`)
+                AND JSON_TYPE(JSON_EXTRACT(`value`, '$.campaignCode')) = 'STRING';
+            SQL);
+    }
+}

--- a/tests/integration/Core/Checkout/Customer/Rule/AffiliateCodeRuleTest.php
+++ b/tests/integration/Core/Checkout/Customer/Rule/AffiliateCodeRuleTest.php
@@ -13,7 +13,6 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Type;
 
 /**
  * @internal
@@ -71,7 +70,7 @@ class AffiliateCodeRuleTest extends TestCase
             static::assertSame(Choice::NO_SUCH_CHOICE_ERROR, $exceptions[0]['code']);
 
             static::assertSame('/0/value/affiliateCode', $exceptions[1]['source']['pointer']);
-            static::assertSame(Type::INVALID_TYPE_ERROR, $exceptions[1]['code']);
+            static::assertSame('FRAMEWORK__WRITE_CONSTRAINT_VIOLATION', $exceptions[1]['code']);
         }
     }
 }

--- a/tests/migration/Core/V6_6/Migration1728302885MultipleValuesForAffilateAndCampaignCodesTest.php
+++ b/tests/migration/Core/V6_6/Migration1728302885MultipleValuesForAffilateAndCampaignCodesTest.php
@@ -1,0 +1,212 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_6;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\IdsCollection;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_6\Migration1728302885MultipleValuesForAffilateAndCampaignCodes;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1728302885MultipleValuesForAffilateAndCampaignCodes::class)]
+class Migration1728302885MultipleValuesForAffilateAndCampaignCodesTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private Connection $connection;
+
+    private Migration1728302885MultipleValuesForAffilateAndCampaignCodes $migration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connection = KernelLifecycleManager::getConnection();
+        $this->migration = new Migration1728302885MultipleValuesForAffilateAndCampaignCodes();
+    }
+
+    public function testUpdate(): void
+    {
+        $ids = new IdsCollection();
+
+        $this->connection->insert('rule', [
+            'id' => Uuid::fromHexToBytes($ids->create('rule.1')),
+            'name' => 'testMigrateCampaignAndAffiliateCodes1',
+            'priority' => 1,
+            'payload' => 'someValue',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->connection->insert('rule', [
+            'id' => Uuid::fromHexToBytes($ids->create('rule.2')),
+            'name' => 'testMigrateCampaignAndAffiliateCodes2',
+            'priority' => 1,
+            'payload' => 'someOtherValue',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        // Affiliate codes
+        $this->connection->insert('rule_condition', [
+            'id' => Uuid::fromHexToBytes($ids->create('condition.orderAffiliateCode')),
+            'rule_id' => $ids->getBytes('rule.1'),
+            'type' => 'orderAffiliateCode',
+            'value' => '{"operator":"!=","affiliateCode":"foo"}',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->connection->insert('rule_condition', [
+            'id' => Uuid::fromHexToBytes($ids->create('condition.customerAffiliateCode')),
+            'rule_id' => $ids->getBytes('rule.2'),
+            'type' => 'customerAffiliateCode',
+            'value' => '{"operator":"=","affiliateCode":"bar"}',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->connection->insert('rule_condition', [
+            'id' => Uuid::fromHexToBytes($ids->create('condition.orderAffiliateCode.empty')),
+            'rule_id' => $ids->getBytes('rule.1'),
+            'type' => 'orderAffiliateCode',
+            'value' => '{"operator":"empty"}',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->connection->insert('rule_condition', [
+            'id' => Uuid::fromHexToBytes($ids->create('condition.customerAffiliateCode.empty')),
+            'rule_id' => $ids->getBytes('rule.1'),
+            'type' => 'customerAffiliateCode',
+            'value' => '{"operator":"empty"}',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        // Campaign codes codes
+        $this->connection->insert('rule_condition', [
+            'id' => Uuid::fromHexToBytes($ids->create('condition.orderCampaignCode')),
+            'rule_id' => $ids->getBytes('rule.2'),
+            'type' => 'orderCampaignCode',
+            'value' => '{"operator":"!=","campaignCode":"baz"}',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->connection->insert('rule_condition', [
+            'id' => Uuid::fromHexToBytes($ids->create('condition.customerCampaignCode')),
+            'rule_id' => $ids->getBytes('rule.1'),
+            'type' => 'customerCampaignCode',
+            'value' => '{"operator":"=","campaignCode":"asd"}',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->connection->insert('rule_condition', [
+            'id' => Uuid::fromHexToBytes($ids->create('condition.orderCampaignCode.empty')),
+            'rule_id' => $ids->getBytes('rule.1'),
+            'type' => 'orderCampaignCode',
+            'value' => '{"operator":"empty"}',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        $this->connection->insert('rule_condition', [
+            'id' => Uuid::fromHexToBytes($ids->create('condition.customerCampaignCode.empty')),
+            'rule_id' => $ids->getBytes('rule.2'),
+            'type' => 'customerCampaignCode',
+            'value' => '{"operator":"empty"}',
+            'created_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ]);
+
+        // Run the migration, twice
+        $this->migration->update($this->connection);
+        $this->migration->update($this->connection);
+
+        foreach ($ids->getByteList(['rule.1', 'rule.2']) as $ruleId) {
+            $rule = $this->getRule($ruleId);
+            static::assertNotFalse($rule);
+            static::assertNull($rule['payload'], 'the migrated rule payload should be empty');
+        }
+
+        $ruleCondition = $this->getRuleConditionValue($ids->getBytes('condition.orderAffiliateCode'));
+        static::assertEquals('!=', $ruleCondition['operator']);
+        static::assertCount(1, $ruleCondition['affiliateCode']);
+        static::assertContains('foo', $ruleCondition['affiliateCode']);
+
+        $ruleCondition = $this->getRuleConditionValue($ids->getBytes('condition.customerAffiliateCode'));
+        static::assertEquals('=', $ruleCondition['operator']);
+        static::assertCount(1, $ruleCondition['affiliateCode']);
+        static::assertContains('bar', $ruleCondition['affiliateCode']);
+
+        $ruleCondition = $this->getRuleConditionValue($ids->getBytes('condition.orderAffiliateCode.empty'));
+        static::assertEquals('empty', $ruleCondition['operator']);
+        static::assertArrayNotHasKey('affiliateCode', $ruleCondition);
+
+        $ruleCondition = $this->getRuleConditionValue($ids->getBytes('condition.customerAffiliateCode.empty'));
+        static::assertEquals('empty', $ruleCondition['operator']);
+        static::assertArrayNotHasKey('affiliateCode', $ruleCondition);
+
+        $ruleCondition = $this->getRuleConditionValue($ids->getBytes('condition.orderCampaignCode'));
+        static::assertEquals('!=', $ruleCondition['operator']);
+        static::assertCount(1, $ruleCondition['campaignCode']);
+        static::assertContains('baz', $ruleCondition['campaignCode']);
+
+        $ruleCondition = $this->getRuleConditionValue($ids->getBytes('condition.customerCampaignCode'));
+        static::assertEquals('=', $ruleCondition['operator']);
+        static::assertCount(1, $ruleCondition['campaignCode']);
+        static::assertContains('asd', $ruleCondition['campaignCode']);
+
+        $ruleCondition = $this->getRuleConditionValue($ids->getBytes('condition.orderCampaignCode.empty'));
+        static::assertEquals('empty', $ruleCondition['operator']);
+        static::assertArrayNotHasKey('campaignCode', $ruleCondition);
+
+        $ruleCondition = $this->getRuleConditionValue($ids->getBytes('condition.customerCampaignCode.empty'));
+        static::assertEquals('empty', $ruleCondition['operator']);
+        static::assertArrayNotHasKey('campaignCode', $ruleCondition);
+
+        $this->cleanupDatabase($ids);
+    }
+
+    /**
+     * @return array<string|int, mixed>
+     */
+    private function getRule(string $id): false|array
+    {
+        return $this->connection->fetchAssociative('SELECT * FROM rule WHERE id = :id', [
+            'id' => $id,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getRuleConditionValue(string $id): array
+    {
+        $value = $this->connection->fetchOne('SELECT `value` FROM rule_condition WHERE id = :id', [
+            'id' => $id,
+        ]);
+        static::assertIsString($value);
+
+        return json_decode((string) $value, true, 512, \JSON_THROW_ON_ERROR);
+    }
+
+    private function cleanupDatabase(IdsCollection $ids): void
+    {
+        $ruleConditionKeys = [
+            'condition.orderAffiliateCode',
+            'condition.customerAffiliateCode',
+            'condition.orderAffiliateCode.empty',
+            'condition.customerAffiliateCode.empty',
+            'condition.orderCampaignCode',
+            'condition.customerCampaignCode',
+            'condition.orderCampaignCode.empty',
+            'condition.customerCampaignCode.empty',
+        ];
+        foreach ($ids->getIdArray($ruleConditionKeys, true) as $ruleConditionIdArray) {
+            $this->connection->delete('rule_condition', $ruleConditionIdArray);
+        }
+
+        foreach ($ids->getIdArray(['rule.1', 'rule.2'], true) as $ruleIdArray) {
+            $this->connection->delete('rule', $ruleIdArray);
+        }
+    }
+}

--- a/tests/unit/Core/Checkout/Customer/Rule/CampaignCodeRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CampaignCodeRuleTest.php
@@ -44,11 +44,14 @@ class CampaignCodeRuleTest extends TestCase
         static::assertArrayHasKey('operator', $constraints, 'Constraint operator not found in Rule');
 
         static::assertEquals(RuleConstraints::stringOperators(), $constraints['operator']);
-        static::assertEquals(RuleConstraints::string(), $constraints['campaignCode']);
+        static::assertEquals(RuleConstraints::stringArray(), $constraints['campaignCode']);
     }
 
+    /**
+     * @param ?array<string> $campaignCodeConditionValue
+     */
     #[DataProvider('getMatchValues')]
-    public function testRuleMatching(?string $campaignCode, string $operator, ?string $campaignCodeConditionValue, bool $expected): void
+    public function testRuleMatching(?string $campaignCode, string $operator, ?array $campaignCodeConditionValue, bool $expected): void
     {
         $this->rule->assign([
             'operator' => $operator,
@@ -109,16 +112,22 @@ class CampaignCodeRuleTest extends TestCase
      */
     public static function getMatchValues(): \Traversable
     {
-        yield 'equal operator is matching' => ['code a', Rule::OPERATOR_EQ, 'code a', true];
-        yield 'equal operator is not matching' => ['code a', Rule::OPERATOR_EQ, 'code b', false];
-        yield 'equal operator is not match, with empty customer code ' => [null, Rule::OPERATOR_EQ, 'code a', false];
+        yield 'equal operator is matching' => ['code a', Rule::OPERATOR_EQ, ['Code a'], true];
+        yield 'equal operator is matching with multiple values' => ['code a', Rule::OPERATOR_EQ, ['Code a', 'Code b'], true];
+        yield 'equal operator is not matching' => ['code a', Rule::OPERATOR_EQ, ['Code b'], false];
+        yield 'equal operator is not matching with multiple values' => ['code a', Rule::OPERATOR_EQ, ['Code b', 'Code C'], false];
+        yield 'equal operator is not match, with empty customer code' => [null, Rule::OPERATOR_EQ, ['code a'], false];
+        yield 'equal operator is not match, with empty customer code and null code' => [null, Rule::OPERATOR_EQ, [null], false];
 
-        yield 'not equal operator is matching' => ['code a', Rule::OPERATOR_NEQ, 'code b', true];
-        yield 'not equal operator is not matching' => ['code a', Rule::OPERATOR_NEQ, 'code a', false];
-        yield 'not equal operator is matching, with empty customer code' => [null, Rule::OPERATOR_NEQ, 'code a', true];
+        yield 'not equal operator is matching' => ['code a', Rule::OPERATOR_NEQ, ['Code b'], true];
+        yield 'not equal operator is matching with multiple values' => ['code a', Rule::OPERATOR_NEQ, ['Code b', 'Code C'], true];
+        yield 'not equal operator is not matching' => ['code a', Rule::OPERATOR_NEQ, ['Code a', 'Code b'], false];
+        yield 'not equal operator is not matching with multiple values' => ['code a', Rule::OPERATOR_NEQ, ['Code a', 'Code b'], false];
+        yield 'not equal operator is matching, with empty customer code' => [null, Rule::OPERATOR_NEQ, ['Code a'], true];
+        yield 'not equal operator is matching, with empty customer code with multiple values' => [null, Rule::OPERATOR_NEQ, ['Code a', 'Code b'], true];
 
-        yield 'empty operator is matching, with empty customer code' => [null, Rule::OPERATOR_EMPTY, 'code a', true];
-        yield 'empty operator is not matching, with filled customer code' => ['code a', Rule::OPERATOR_EMPTY, 'code a', false];
+        yield 'empty operator is matching, with empty customer code' => [null, Rule::OPERATOR_EMPTY, ['Code a'], true];
+        yield 'empty operator is not matching, with filled customer code' => ['code a', Rule::OPERATOR_EMPTY, ['Code a'], false];
         yield 'empty operator is not matching, with empty rule code' => ['code a', Rule::OPERATOR_EMPTY, null, false];
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to specify more than one code in the campaign or affiliate rule, which makes the administration of these rules quite cumbersome.

### 2. What does this change do, exactly?
Allow to specify multiple values for the code rules.

### 3. Describe each step to reproduce the issue or behaviour.
Try to create a rule which matches multiple codes.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
