### PR TITLE
refactor: Proper redirection of non logged-in customers when accessing checkout routes

### DIFF
--- a/changelog/_unreleased/2024-10-10-proper-redirection-of-non-logged-in-customers-when-accessing-checkout-routes.md
+++ b/changelog/_unreleased/2024-10-10-proper-redirection-of-non-logged-in-customers-when-accessing-checkout-routes.md
@@ -1,0 +1,9 @@
+---
+title: Proper redirection of non logged-in customers when accessing checkout routes
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed the routes `frontend.checkout.confirm.page`, `frontend.checkout.finish.page` and `frontend.checkout.finish.order` to redirect non logged-in customers to the login/registration page and afterwards back to the previous page

--- a/tests/unit/Storefront/Controller/CheckoutControllerTest.php
+++ b/tests/unit/Storefront/Controller/CheckoutControllerTest.php
@@ -186,18 +186,6 @@ class CheckoutControllerTest extends TestCase
         static::assertEquals($cart, $response->getObject());
     }
 
-    public function testConfirmPageNoCustomer(): void
-    {
-        $context = $this->createMock(SalesChannelContext::class);
-        $context->method('getCustomer')->willReturn(null);
-
-        $response = $this->controller->confirmPage(new Request(), $context);
-
-        static::assertInstanceOf(RedirectResponse::class, $response);
-        static::assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
-        static::assertEquals('frontend.checkout.register.page', $response->getTargetUrl());
-    }
-
     public function testConfirmPageEmptyCart(): void
     {
         $context = $this->createMock(SalesChannelContext::class);
@@ -292,18 +280,6 @@ class CheckoutControllerTest extends TestCase
         static::assertEmpty($response->getContent());
     }
 
-    public function testFinishPageNoCustomer(): void
-    {
-        $context = $this->createMock(SalesChannelContext::class);
-        $context->method('getCustomer')->willReturn(null);
-
-        $response = $this->controller->finishPage(new Request(), $context, new RequestDataBag());
-
-        static::assertInstanceOf(RedirectResponse::class, $response);
-        static::assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
-        static::assertEquals('frontend.checkout.register.page', $response->getTargetUrl());
-    }
-
     public function testFinishPageOrderNotFound(): void
     {
         $context = $this->createMock(SalesChannelContext::class);
@@ -380,18 +356,6 @@ class CheckoutControllerTest extends TestCase
 
         static::assertEquals(Response::HTTP_OK, $response->getStatusCode());
         static::assertEmpty($response->getContent());
-    }
-
-    public function testOrderNoCustomer(): void
-    {
-        $context = $this->createMock(SalesChannelContext::class);
-        $context->method('getCustomer')->willReturn(null);
-
-        $response = $this->controller->order(new RequestDataBag(), $context, new Request());
-
-        static::assertInstanceOf(RedirectResponse::class, $response);
-        static::assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
-        static::assertEquals('frontend.checkout.register.page', $response->getTargetUrl());
     }
 
     public function testOrder(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the users are always redirected to the cart when they are not logged in and try to access for example the `checkout/confirm` page.

### 2. What does this change do, exactly?
Change the routes to required logged in users, which does proper redirection.

### 3. Describe each step to reproduce the issue or behaviour.
Try to access `http://shop.tld/checkout/confirm` as not logged in user.

### 4. Please link to the relevant issues (if any).
\

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
