### PR TITLE
Improve theme configuration load inside ThemeScript component

### DIFF
--- a/changelog/_unreleased/2024-10-15-theme-script-with-configuration-load-improved.md
+++ b/changelog/_unreleased/2024-10-15-theme-script-with-configuration-load-improved.md
@@ -6,4 +6,4 @@ author_email: raffaele.carelle@gmail.com
 author_github: @raffaelecarelle
 ---
 # Storefront
-* Use `AbstractConfigLoader` component inside `ThemeScript` to load theme configuration
+* Changed `ThemeScript` component to use `AbstractConfigLoader`  to load theme configuration

--- a/changelog/_unreleased/2024-10-15-theme-script-with-configuration-load-improved.md
+++ b/changelog/_unreleased/2024-10-15-theme-script-with-configuration-load-improved.md
@@ -1,0 +1,9 @@
+---
+title: Use AbstractConfigLoader component to load configuration inside ThemeScript component
+issue: NEXT-00000
+author: Raffaele Carelle
+author_email: raffaele.carelle@gmail.com
+author_github: @raffaelecarelle
+---
+# Storefront
+* Use `AbstractConfigLoader` component inside `ThemeScript` to load theme configuration

--- a/changelog/_unreleased/2024-10-15-theme-script-with-configuration-load-improved.md
+++ b/changelog/_unreleased/2024-10-15-theme-script-with-configuration-load-improved.md
@@ -6,4 +6,4 @@ author_email: raffaele.carelle@gmail.com
 author_github: @raffaelecarelle
 ---
 # Storefront
-* Changed `ThemeScript` component to use `AbstractConfigLoader`  to load theme configuration
+* Changed `Shopware\Storefront\Theme\ThemeScripts` component to use `Shopware\Storefront\Theme\ConfigLoader\AbstractConfigLoader`  to load theme configuration

--- a/src/Storefront/DependencyInjection/theme.xml
+++ b/src/Storefront/DependencyInjection/theme.xml
@@ -66,6 +66,7 @@
             <argument type="service" id="request_stack"/>
             <argument type="service" id="Shopware\Storefront\Theme\AbstractThemePathBuilder"/>
             <argument type="service" id="cache.object"/>
+            <argument type="service" id="Shopware\Storefront\Theme\ConfigLoader\DatabaseConfigLoader"/>
         </service>
 
         <service id="Shopware\Storefront\Theme\ThemeService">

--- a/src/Storefront/Theme/ThemeScripts.php
+++ b/src/Storefront/Theme/ThemeScripts.php
@@ -5,6 +5,7 @@ namespace Shopware\Storefront\Theme;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Theme\ConfigLoader\AbstractConfigLoader;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -50,11 +51,13 @@ readonly class ThemeScripts
         }
 
         $salesChannelId = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID);
-        $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT);
         $path = $this->themePathBuilder->assemblePath($salesChannelId, $themeId);
 
-        return $this->cache->get('theme_scripts_' . $path, function (ItemInterface $item) use ($themeId, $context) {
-            $themeConfig = $this->configLoader->load($themeId, $context);
+        /** @var SalesChannelContext $salesChannelContext */
+        $salesChannelContext = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
+
+        return $this->cache->get('theme_scripts_' . $path, function (ItemInterface $item) use ($themeId, $salesChannelContext) {
+            $themeConfig = $this->configLoader->load($themeId, $salesChannelContext->getContext());
 
             $resolvedFiles = $this->themeFileResolver->resolveFiles(
                 $themeConfig,

--- a/src/Storefront/Theme/ThemeScripts.php
+++ b/src/Storefront/Theme/ThemeScripts.php
@@ -53,8 +53,11 @@ readonly class ThemeScripts
         $salesChannelId = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID);
         $path = $this->themePathBuilder->assemblePath($salesChannelId, $themeId);
 
-        /** @var SalesChannelContext $salesChannelContext */
         $salesChannelContext = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
+
+        if (!$salesChannelContext instanceof SalesChannelContext) {
+            return [];
+        }
 
         return $this->cache->get('theme_scripts_' . $path, function (ItemInterface $item) use ($themeId, $salesChannelContext) {
             $themeConfig = $this->configLoader->load($themeId, $salesChannelContext->getContext());

--- a/tests/unit/Storefront/Theme/ThemeScriptsTest.php
+++ b/tests/unit/Storefront/Theme/ThemeScriptsTest.php
@@ -4,8 +4,10 @@ namespace Shopware\Tests\Unit\Storefront\Theme;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
+use Shopware\Storefront\Theme\ConfigLoader\AbstractConfigLoader;
 use Shopware\Storefront\Theme\MD5ThemePathBuilder;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\File as StorefrontPluginConfigurationFile;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\FileCollection;
@@ -31,7 +33,8 @@ class ThemeScriptsTest extends TestCase
             $this->createMock(ThemeFileResolver::class),
             $this->createMock(RequestStack::class),
             new MD5ThemePathBuilder(),
-            new ArrayAdapter()
+            new ArrayAdapter(),
+            $this->createMock(AbstractConfigLoader::class)
         );
 
         static::assertEquals([], $themeScripts->getThemeScripts());
@@ -48,6 +51,7 @@ class ThemeScriptsTest extends TestCase
             $requestStack,
             new MD5ThemePathBuilder(),
             new ArrayAdapter(),
+            $this->createMock(AbstractConfigLoader::class)
         );
 
         static::assertEquals([], $themeScripts->getThemeScripts());
@@ -69,6 +73,7 @@ class ThemeScriptsTest extends TestCase
             $requestStack,
             new MD5ThemePathBuilder(),
             new ArrayAdapter(),
+            $this->createMock(AbstractConfigLoader::class)
         );
 
         static::assertEquals([], $themeScripts->getThemeScripts());
@@ -81,6 +86,8 @@ class ThemeScriptsTest extends TestCase
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, 'Storefront');
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_ID, 'Storefront');
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_NAME, 'Storefront');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT, Context::createCLIContext());
+
         $requestStack->push($request);
 
         $pluginRegistry = $this->createMock(StorefrontPluginRegistry::class);
@@ -104,6 +111,7 @@ class ThemeScriptsTest extends TestCase
             $requestStack,
             new MD5ThemePathBuilder(),
             new ArrayAdapter(),
+            $this->createMock(AbstractConfigLoader::class)
         );
 
         static::assertEquals(['js/foo/foo.js'], $themeScripts->getThemeScripts());
@@ -119,6 +127,8 @@ class ThemeScriptsTest extends TestCase
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_ID, 'Storefront');
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_NAME, null);
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_BASE_NAME, 'Storefront');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT, Context::createCLIContext());
+
         $requestStack->push($request);
 
         $pluginRegistry = $this->createMock(StorefrontPluginRegistry::class);
@@ -141,6 +151,7 @@ class ThemeScriptsTest extends TestCase
             $requestStack,
             new MD5ThemePathBuilder(),
             new ArrayAdapter(),
+            $this->createMock(AbstractConfigLoader::class)
         );
 
         static::assertEquals(['js/foo/foo.js'], $themeScripts->getThemeScripts());

--- a/tests/unit/Storefront/Theme/ThemeScriptsTest.php
+++ b/tests/unit/Storefront/Theme/ThemeScriptsTest.php
@@ -128,8 +128,8 @@ class ThemeScriptsTest extends TestCase
         $request = new Request();
         // for some reason db themes the theme name is null
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, 'Storefront');
-        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_ID, 'Storefront');
-        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_NAME, null);
+        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_ID, 'ChildId');
+        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_NAME, 'ChildName');
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_BASE_NAME, 'Storefront');
         $request->attributes->set(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT, Context::createCLIContext());
 

--- a/tests/unit/Storefront/Theme/ThemeScriptsTest.php
+++ b/tests/unit/Storefront/Theme/ThemeScriptsTest.php
@@ -87,9 +87,10 @@ class ThemeScriptsTest extends TestCase
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, 'Storefront');
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_ID, 'Storefront');
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_NAME, 'Storefront');
-        $request->attributes->set(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT, Context::createCLIContext());
+
         $salesChannelContext = $this->createMock(SalesChannelContext::class);
         $salesChannelContext->method('getContext')->willReturn(Context::createCLIContext());
+
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
 
         $requestStack->push($request);

--- a/tests/unit/Storefront/Theme/ThemeScriptsTest.php
+++ b/tests/unit/Storefront/Theme/ThemeScriptsTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
-use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Theme\ConfigLoader\AbstractConfigLoader;
 use Shopware\Storefront\Theme\MD5ThemePathBuilder;

--- a/tests/unit/Storefront/Theme/ThemeScriptsTest.php
+++ b/tests/unit/Storefront/Theme/ThemeScriptsTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Theme\ConfigLoader\AbstractConfigLoader;
 use Shopware\Storefront\Theme\MD5ThemePathBuilder;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\File as StorefrontPluginConfigurationFile;
@@ -87,6 +88,9 @@ class ThemeScriptsTest extends TestCase
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_ID, 'Storefront');
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_NAME, 'Storefront');
         $request->attributes->set(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT, Context::createCLIContext());
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getContext')->willReturn(Context::createCLIContext());
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
 
         $requestStack->push($request);
 
@@ -128,6 +132,10 @@ class ThemeScriptsTest extends TestCase
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_NAME, null);
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_BASE_NAME, 'Storefront');
         $request->attributes->set(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT, Context::createCLIContext());
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getContext')->willReturn(Context::createCLIContext());
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
 
         $requestStack->push($request);
 

--- a/tests/unit/Storefront/Theme/ThemeScriptsTest.php
+++ b/tests/unit/Storefront/Theme/ThemeScriptsTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Theme\ConfigLoader\AbstractConfigLoader;
 use Shopware\Storefront\Theme\MD5ThemePathBuilder;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\File as StorefrontPluginConfigurationFile;
@@ -88,9 +89,7 @@ class ThemeScriptsTest extends TestCase
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_ID, 'Storefront');
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_NAME, 'Storefront');
 
-        $salesChannelContext = $this->createMock(SalesChannelContext::class);
-        $salesChannelContext->method('getContext')->willReturn(Context::createCLIContext());
-
+        $salesChannelContext = Generator::createSalesChannelContext();
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
 
         $requestStack->push($request);
@@ -134,8 +133,7 @@ class ThemeScriptsTest extends TestCase
         $request->attributes->set(SalesChannelRequest::ATTRIBUTE_THEME_BASE_NAME, 'Storefront');
         $request->attributes->set(PlatformRequest::ATTRIBUTE_CONTEXT_OBJECT, Context::createCLIContext());
 
-        $salesChannelContext = $this->createMock(SalesChannelContext::class);
-        $salesChannelContext->method('getContext')->willReturn(Context::createCLIContext());
+        $salesChannelContext = Generator::createSalesChannelContext();
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
 
         $requestStack->push($request);


### PR DESCRIPTION
### 1. Why is this change necessary?
This changes fix use case which child theme script doesn't not load correctly

### 2. What does this change do, exactly?
Use AbstractConfigLoader component to load configuration

### 3. Describe each step to reproduce the issue or behaviour.
Create a custom theme
create a child theme of custom theme created above
create sales channel with child theme associated.

Now in the storefront scripts js doesn't load correctly (es. menu doesn't open or dropdowns don't work properly)

With styles/css there aren't issues