### PR TITLE
Fix mobile tiny slider behavior

### DIFF
--- a/changelog/_unreleased/2024-10-15-Fix-Mobile-Tiny-Slider-Behavior.md
+++ b/changelog/_unreleased/2024-10-15-Fix-Mobile-Tiny-Slider-Behavior.md
@@ -1,0 +1,9 @@
+---
+title: Fix Mobile Tiny Slider Behavior
+issue: NEXT-0000
+author: Ada Wiberg
+author_email: wiberg@mothership.de
+author_github: @qway
+---
+# Storefront
+* Added new section to tiny-slider+2.9.4.patch to fix a minification issue that broke mobile touch sliding

--- a/src/Storefront/Resources/app/storefront/patches/tiny-slider+2.9.4.patch
+++ b/src/Storefront/Resources/app/storefront/patches/tiny-slider+2.9.4.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/tiny-slider/dist/tiny-slider.js b/node_modules/tiny-slider/dist/tiny-slider.js
-index 1b5d912..d9c52b6 100644
+index 1b5d912..ba572a1 100644
 --- a/node_modules/tiny-slider/dist/tiny-slider.js
 +++ b/node_modules/tiny-slider/dist/tiny-slider.js
 @@ -563,7 +563,8 @@ var tns = function (options) {
@@ -92,3 +92,21 @@ index 1b5d912..d9c52b6 100644
          addClass(navCurrent, navActiveClass);
          navCurrentIndexCached = navCurrentIndex;
        }
+@@ -3483,14 +3492,14 @@ var tns = function (options) {
+ 
+       if (!horizontal || fixedWidth || autoWidth) {
+         x += dist;
+-        x += 'px';
++        var xFormatted = x + 'px';
+       } else {
+         var percentageX = TRANSFORM ? dist * items * 100 / ((viewport + gutter) * slideCountNew) : dist * 100 / (viewport + gutter);
+         x += percentageX;
+-        x += '%';
++        var xFormatted = x + '%';
+       }
+ 
+-      container.style[transformAttr] = transformPrefix + x + transformPostfix;
++      container.style[transformAttr] = transformPrefix + xFormatted + transformPostfix;
+     }
+   }
+ 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

In nearly any store the slider behaves incorrectly when swiping on mobile. See the two attached videos for an explanation.

Before the fix(both smooth touch slide and backwards slide are broken):

https://github.com/user-attachments/assets/225b6e75-da6d-48aa-b2d3-e66f97d19371

After the fix:

https://github.com/user-attachments/assets/3f903372-f72f-426c-a793-d2f10705bfa3

#### Why does this happen?

The terser minifier accidentally inlines a line which changes an addition into a string concatenation, which creates unexpected behavior in the frontend

### 2. What does this change do, exactly?

By introducing an additional intermediate variable through the already existing `tiny-slider+2.9.4.patch` we can keep the same minifier settings but remove the string concatenation issue.

### 3. Describe each step to reproduce the issue or behaviour.

- On a fresh install with demo products, use the Slider in mobile view with touch navigation



### 4. Please link to the relevant issues (if any).

- https://github.com/shopware/shopware/issues/4702
- https://github.com/shopware/shopware/issues/4357
- https://github.com/shopware/shopware/issues/3905

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
