### PR TITLE
NEXT-00000 - MailService: Set 'X-Shopware-Event-Name' header to string instead of null

### DIFF
--- a/changelog/_unreleased/2024-10-15-set-event-name-header-to-type-string.md
+++ b/changelog/_unreleased/2024-10-15-set-event-name-header-to-type-string.md
@@ -1,0 +1,9 @@
+---
+title: Set 'X-Shopware-Event-Name' header to type string in MailService
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+issue: NEXT-00000
+---
+# Core
+* Changed `X-Shopware-Event-Name` header to type string in MailService

--- a/src/Core/Content/Mail/Service/MailService.php
+++ b/src/Core/Content/Mail/Service/MailService.php
@@ -204,7 +204,7 @@ class MailService extends AbstractMailService
 
         if ($this->isTestMode()) {
             $headers = $mail->getHeaders();
-            $headers->addTextHeader('X-Shopware-Event-Name', $templateData['eventName'] ?? null);
+            $headers->addTextHeader('X-Shopware-Event-Name', $templateData['eventName'] ?? '');
             $headers->addTextHeader('X-Shopware-Sales-Channel-Id', $salesChannelId);
             $headers->addTextHeader('X-Shopware-Language-Id', $context->getLanguageId());
             $mail->setHeaders($headers);


### PR DESCRIPTION
### 1. Why is this change necessary?

`In Headers.php line 122: Symfony\Component\Mime\Header\Headers::addTextHeader(): Argument #2 ($value) must be of type string, null given, called in /vendor/shopware/core/Content/Mail/Service/MailService.`

When sending mail

### 2. What does this change do, exactly?

'' instead of `null` when `$templateData['eventName']` is null


### 3. Describe each step to reproduce the issue or behaviour.

Activate staging mode, set mail sneding in staging mode to active, send mail without setting `$templateData['eventName']` to a value

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
