### PR TITLE
NEXT-00000 - Fix wrong invalid class

### DIFF
--- a/changelog/_unreleased/2024-10-16-only-add-invalid-class-when-field-violation-is-present.md
+++ b/changelog/_unreleased/2024-10-16-only-add-invalid-class-when-field-violation-is-present.md
@@ -1,0 +1,10 @@
+---
+title: Only add invalid class when field violation is present
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Storefront
+* Only add invalid class when field violation is present

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-input.html.twig
@@ -14,7 +14,7 @@
                    value="{{ data.get( fieldName ) }}"
                    placeholder="{{ placeholder|trans }}"
                    {% if required %}required="required"{% endif %}
-                   class="form-control{% if formViolations.getViolations( '/' ~ fieldName ) %} is-invalid{% endif %}">
+                   class="form-control{% if formViolations.getViolations( '/' ~ fieldName ) is not empty %} is-invalid{% endif %}">
 
             {% if formViolations.getViolations( '/' ~ fieldName ) is not empty %}
                 {% sw_include '@Storefront/storefront/utilities/form-violation.html.twig' with {

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-textarea.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-components/cms-element-form-textarea.html.twig
@@ -13,7 +13,7 @@
                           placeholder="{{ placeholder|trans }}"
                           {% if rows %}rows="{{ rows }}"{% endif %}
                           {% if required %}required="required"{% endif %}
-                          class="form-control{% if formViolations.getViolations( '/' ~ fieldName ) %} is-invalid{% endif %}">
+                          class="form-control{% if formViolations.getViolations( '/' ~ fieldName ) is not empty %} is-invalid{% endif %}">
                     {{ data.get(fieldName) }}
                 </textarea>
             {% endapply %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
For the CMS input form element and the CMS textarea form element, the `is-invalid` class is added when its form violations returns true. The problem is that this will return a `Symfony\Component\Validator\ConstraintViolationList`, this will incorrectly pass our check and the class will be added when it should not be. 

### 2. What does this change do, exactly?
This change will only add the `is-invalid` class when the `ConstraintViolationList` is empty. 

### 3. Describe each step to reproduce the issue or behaviour.
1. Create a form using the CMS form element textarea or input
2. Submit this form but make it fail because another element gives a violation
3. See that the CMS form element has the `is-invalid` class even though this element does not have a violation

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
