### PR TITLE
NEXT-0000: Remove @internal state from Defaults.php

### DIFF
--- a/changelog/_unreleased/2024-10-16-defaults-no-more-internal.md
+++ b/changelog/_unreleased/2024-10-16-defaults-no-more-internal.md
@@ -1,0 +1,9 @@
+---
+title: Defaults no more internal
+issue: 
+author: Oliver Skroblin
+author_email: oliver@goblin-coders.de
+author_github: OliverSkroblin
+---
+# Core
+* Removed `@internal` flag from `\Shopware\Core\Defaults`

--- a/src/Core/Defaults.php
+++ b/src/Core/Defaults.php
@@ -5,7 +5,6 @@ namespace Shopware\Core;
 use Shopware\Core\Framework\Log\Package;
 
 /**
- * @internal
  * System wide defaults that are fixed for performance measures
  */
 #[Package('core')]

--- a/tests/unit/Core/DefaultsTest.php
+++ b/tests/unit/Core/DefaultsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Shopware\Tests\Unit\Core;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+
+class DefaultsTest extends TestCase
+{
+    public function testValues(): void
+    {
+        static::assertEquals('2fbb5fe2e29a4d70aa5854ce7ce3e20b', Defaults::LANGUAGE_SYSTEM);
+        static::assertEquals('0fa91ce3e96a4bc2be4bd9ce752c3425', Defaults::LIVE_VERSION);
+        static::assertEquals('b7d2554b0ce847cd82f3ac9bd1c0dfca', Defaults::CURRENCY);
+        static::assertEquals('f183ee5650cf4bdb8a774337575067a6', Defaults::SALES_CHANNEL_TYPE_API);
+        static::assertEquals('8a243080f92e4c719546314b577cf82b', Defaults::SALES_CHANNEL_TYPE_STOREFRONT);
+        static::assertEquals('ed535e5722134ac1aa6524f73e26881b', Defaults::SALES_CHANNEL_TYPE_PRODUCT_COMPARISON);
+        static::assertEquals('Y-m-d H:i:s.v', Defaults::STORAGE_DATE_TIME_FORMAT);
+        static::assertEquals('Y-m-d', Defaults::STORAGE_DATE_FORMAT);
+        static::assertEquals('7a6d253a67204037966f42b0119704d5', Defaults::CMS_PRODUCT_DETAIL_PAGE);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Defaults.php contains important values for all projects outside. Therefore the class should not be marked as @internal.

