### PR TITLE
fix: maker command (generator stubs)

### DIFF
--- a/src/Core/Framework/DependencyInjection/plugin.xml
+++ b/src/Core/Framework/DependencyInjection/plugin.xml
@@ -7,7 +7,6 @@
     <services>
         <service id="maker.auto_command.abstract" class="Shopware\Core\Framework\Plugin\Command\MakerCommand" abstract="true">
             <argument /> <!-- maker -->
-            <argument type="service" id="Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingCollector"/>
             <argument type="service" id="Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingWriter"/>
             <argument type="service" id="Shopware\Core\Framework\Plugin\PluginService"/>
         </service>
@@ -235,6 +234,7 @@
         </service>
 
         <service id="Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\TestsGenerator">
+            <argument type="service" id="filesystem"/>
             <tag name="shopware.scaffold.generator"/>
         </service>
 

--- a/src/Core/Framework/Plugin/Command/MakerCommand.php
+++ b/src/Core/Framework/Plugin/Command/MakerCommand.php
@@ -7,23 +7,23 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\ScaffoldingGenerator;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\PluginScaffoldConfiguration;
-use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingCollector;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingWriter;
+use Shopware\Core\Framework\Plugin\Command\Scaffolding\StubCollection;
 use Shopware\Core\Framework\Plugin\PluginService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
 
 #[Package('core')]
 class MakerCommand extends Command
 {
     public function __construct(
         private readonly ScaffoldingGenerator $generator,
-        private readonly ScaffoldingCollector $scaffoldingCollector,
         private readonly ScaffoldingWriter $scaffoldingWriter,
-        private readonly PluginService $pluginService,
+        private readonly PluginService $pluginService
     ) {
         parent::__construct();
     }
@@ -54,7 +54,7 @@ class MakerCommand extends Command
                 continue;
             }
 
-            $value = $io->ask($argument->getDescription(), null, function ($value) {
+            $value = $io->ask($argument->getDescription(), null, function (mixed $value) {
                 if ($value === null || $value === '') {
                     // @phpstan-ignore-next-line RuntimeException is fine in console IO validators
                     throw new \RuntimeException('This value should not be blank');
@@ -100,13 +100,24 @@ class MakerCommand extends Command
                 $directory
             );
 
+            if (\method_exists($this->generator, 'disableAskConfirmQuestion')) {
+                $this->generator->disableAskConfirmQuestion();
+            }
+
             $this->generator->addScaffoldConfig($configuration, $input, $io);
 
-            $stubCollection = $this->scaffoldingCollector->collect($configuration);
+            $stubCollection = new StubCollection();
+            $this->generator->generateStubs($configuration, $stubCollection);
+
+            $configsStubs = $this->removeConfigsFromMainCollection($stubCollection);
 
             $this->scaffoldingWriter->write($stubCollection, $configuration);
 
             $io->success('Scaffold created successfully');
+
+            foreach ($configsStubs as $stub) {
+                $io->warning(\sprintf('Remember to add this configuration %s to the file %s', $stub->getContent(), $configuration->directory . '/' . $stub->getPath()));
+            }
 
             return self::SUCCESS;
         } catch (\Throwable $exception) {
@@ -114,5 +125,23 @@ class MakerCommand extends Command
 
             return self::FAILURE;
         }
+    }
+
+    private function removeConfigsFromMainCollection(StubCollection $stubCollection): StubCollection
+    {
+        $configStubs = new StubCollection();
+        foreach ($stubCollection as $filename => $stub) {
+            if (str_starts_with($filename, 'src/Resources/config/')) {
+                $configStubs->add($stub);
+                $stubCollection->remove($stub->getPath());
+            }
+        }
+
+        return $configStubs;
+    }
+
+    private function isXml(string $filename): bool
+    {
+        return pathinfo($filename, \PATHINFO_EXTENSION) === XmlEncoder::FORMAT;
     }
 }

--- a/src/Core/Framework/Plugin/Command/MakerCommand.php
+++ b/src/Core/Framework/Plugin/Command/MakerCommand.php
@@ -139,9 +139,4 @@ class MakerCommand extends Command
 
         return $configStubs;
     }
-
-    private function isXml(string $filename): bool
-    {
-        return pathinfo($filename, \PATHINFO_EXTENSION) === XmlEncoder::FORMAT;
-    }
 }

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/AddScaffoldConfigDefaultBehaviour.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/AddScaffoldConfigDefaultBehaviour.php
@@ -28,8 +28,17 @@ trait AddScaffoldConfigDefaultBehaviour
             return;
         }
 
-        if ($this->shouldAskCliQuestion && $io->confirm(self::CLI_QUESTION)) {
-            $config->addOption(self::OPTION_NAME, true);
+        $proceed = true;
+
+        if ($this->shouldAskCliQuestion) {
+            $proceed = $io->confirm(self::CLI_QUESTION);
         }
+
+        $config->addOption(self::OPTION_NAME, $proceed);
+    }
+
+    public function disableAskConfirmQuestion(): void
+    {
+        $this->shouldAskCliQuestion = false;
     }
 }

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/StoreApiRouteGenerator.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/StoreApiRouteGenerator.php
@@ -50,10 +50,14 @@ class StoreApiRouteGenerator implements ScaffoldingGenerator
             return;
         }
 
-        if ($this->shouldAskCliQuestion && $io->confirm(self::CLI_QUESTION)) {
-            $config->addOption(self::OPTION_NAME, true);
-            $config->addOption(PluginScaffoldConfiguration::ROUTE_XML_OPTION_NAME, true);
+        $proceed = true;
+
+        if ($this->shouldAskCliQuestion) {
+            $proceed = $io->confirm(self::CLI_QUESTION);
         }
+
+        $config->addOption(self::OPTION_NAME, $proceed);
+        $config->addOption(PluginScaffoldConfiguration::ROUTE_XML_OPTION_NAME, $proceed);
     }
 
     public function generateStubs(

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGenerator.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGenerator.php
@@ -55,10 +55,14 @@ class StorefrontControllerGenerator implements ScaffoldingGenerator
             return;
         }
 
-        if ($this->shouldAskCliQuestion && $io->confirm(self::CLI_QUESTION)) {
-            $config->addOption(self::OPTION_NAME, true);
-            $config->addOption(PluginScaffoldConfiguration::ROUTE_XML_OPTION_NAME, true);
+        $proceed = true;
+
+        if ($this->shouldAskCliQuestion) {
+            $proceed = $io->confirm(self::CLI_QUESTION);
         }
+
+        $config->addOption(self::OPTION_NAME, $proceed);
+        $config->addOption(PluginScaffoldConfiguration::ROUTE_XML_OPTION_NAME, $proceed);
     }
 
     public function generateStubs(

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/TestsGenerator.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/TestsGenerator.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Plugin\Command\Scaffolding\Stub;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\StubCollection;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
@@ -15,6 +16,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 #[Package('core')]
 class TestsGenerator implements ScaffoldingGenerator
 {
+    public function __construct(
+        private readonly Filesystem $filesystem
+    ) {
+    }
+
     public function hasCommandOption(): bool
     {
         return false;
@@ -41,8 +47,13 @@ class TestsGenerator implements ScaffoldingGenerator
         PluginScaffoldConfiguration $configuration,
         StubCollection $stubCollection
     ): void {
-        $stubCollection->add($this->createPhpunitXml($configuration));
-        $stubCollection->add($this->createTestBootstrap($configuration));
+        if ($this->filesystem->exists($configuration->directory . 'phpunit.xml')) {
+            $stubCollection->add($this->createPhpunitXml($configuration));
+        }
+
+        if ($this->filesystem->exists($configuration->directory . 'tests/TestBootstrap.php')) {
+            $stubCollection->add($this->createTestBootstrap($configuration));
+        }
     }
 
     private function createPhpunitXml(PluginScaffoldConfiguration $configuration): Stub

--- a/src/Core/Framework/Plugin/Command/Scaffolding/Generator/TestsGenerator.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/Generator/TestsGenerator.php
@@ -47,11 +47,11 @@ class TestsGenerator implements ScaffoldingGenerator
         PluginScaffoldConfiguration $configuration,
         StubCollection $stubCollection
     ): void {
-        if ($this->filesystem->exists($configuration->directory . 'phpunit.xml')) {
+        if (!$this->filesystem->exists($configuration->directory . 'phpunit.xml')) {
             $stubCollection->add($this->createPhpunitXml($configuration));
         }
 
-        if ($this->filesystem->exists($configuration->directory . 'tests/TestBootstrap.php')) {
+        if (!$this->filesystem->exists($configuration->directory . 'tests/TestBootstrap.php')) {
             $stubCollection->add($this->createTestBootstrap($configuration));
         }
     }

--- a/src/Core/Framework/Plugin/Command/Scaffolding/ScaffoldingWriter.php
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/ScaffoldingWriter.php
@@ -11,8 +11,9 @@ use Symfony\Component\Filesystem\Filesystem;
 #[Package('core')]
 class ScaffoldingWriter
 {
-    public function __construct(private readonly Filesystem $filesystem)
-    {
+    public function __construct(
+        private readonly Filesystem $filesystem
+    ) {
     }
 
     public function write(StubCollection $stubCollection, PluginScaffoldConfiguration $configuration): void

--- a/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
@@ -8,7 +8,6 @@ use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Command\MakerCommand;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\ScaffoldingGenerator;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\PluginScaffoldConfiguration;
-use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingCollector;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\ScaffoldingWriter;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\StubCollection;
 use Shopware\Core\Framework\Plugin\PluginEntity;
@@ -30,7 +29,7 @@ class MakerCommandTest extends TestCase
         $scaffoldingWriter->expects(static::once())
             ->method('write')
             ->with(static::callback(static function (StubCollection $stubCollection) {
-                $stub = $stubCollection->get('src/Resources/config/services.xml');
+                $stub = $stubCollection->get('src/Example/Service/Service.php');
 
                 return $stub !== null && str_contains($stub->getContent() ?? '', 'Dummy content');
             }), static::callback(static function (PluginScaffoldConfiguration $configuration) {
@@ -45,12 +44,11 @@ class MakerCommandTest extends TestCase
 
         $generator = new DummyScaffoldingGenerator();
 
-        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), $scaffoldingWriter, $pluginService);
+        $command = new MakerCommand($generator, $scaffoldingWriter, $pluginService);
         $command->setName('make:foo');
 
         $tester = new CommandTester($command);
-        $tester->setInputs(['ExamplePlugin']);
-        $res = $tester->execute([]);
+        $res = $tester->execute(['plugin-name' => 'ExamplePlugin']);
 
         static::assertEquals(Command::SUCCESS, $res);
     }
@@ -63,7 +61,7 @@ class MakerCommandTest extends TestCase
 
         $generator = new DummyScaffoldingGenerator();
 
-        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), $scaffoldingWriter, $pluginService);
+        $command = new MakerCommand($generator, $scaffoldingWriter, $pluginService);
         $command->setName('make:foo');
 
         $tester = new CommandTester($command);
@@ -85,7 +83,7 @@ class MakerCommandTest extends TestCase
 
         $generator = new DummyScaffoldingGenerator();
 
-        $command = new MakerCommand($generator, new ScaffoldingCollector([$generator]), $scaffoldingWriter, $pluginService);
+        $command = new MakerCommand($generator, $scaffoldingWriter, $pluginService);
         $command->setName('make:foo');
 
         $tester = new CommandTester($command);
@@ -145,6 +143,6 @@ class DummyScaffoldingGenerator implements ScaffoldingGenerator
             return;
         }
 
-        $stubCollection->append('src/Resources/config/services.xml', 'Dummy content');
+        $stubCollection->append('src/Example/Service/Service.php', 'Dummy content');
     }
 }

--- a/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
@@ -50,6 +50,14 @@ class MakerCommandTest extends TestCase
         $tester = new CommandTester($command);
         $res = $tester->execute(['plugin-name' => 'ExamplePlugin']);
 
+        $display = $tester->getDisplay();
+
+        self::assertStringContainsString(
+            \sprintf("Remember to add this configuration Dummy content to the file                                                 \n           %s",
+                __DIR__ . '/src/Resources/config/services.xml'
+            ),
+            $display
+        );
         static::assertEquals(Command::SUCCESS, $res);
     }
 
@@ -143,6 +151,7 @@ class DummyScaffoldingGenerator implements ScaffoldingGenerator
             return;
         }
 
+        $stubCollection->append('src/Resources/config/services.xml', 'Dummy content');
         $stubCollection->append('src/Example/Service/Service.php', 'Dummy content');
     }
 }

--- a/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
@@ -53,10 +53,7 @@ class MakerCommandTest extends TestCase
         $display = $tester->getDisplay();
 
         static::assertStringContainsString(
-            \sprintf(
-                "Remember to add this configuration Dummy content to the file                                                 \n           %s",
-                __DIR__ . '/src/Resources/config/services.xml'
-            ),
+            'Remember to add this configuration Dummy content to the file',
             $display
         );
         static::assertEquals(Command::SUCCESS, $res);

--- a/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/MakerCommandTest.php
@@ -52,8 +52,9 @@ class MakerCommandTest extends TestCase
 
         $display = $tester->getDisplay();
 
-        self::assertStringContainsString(
-            \sprintf("Remember to add this configuration Dummy content to the file                                                 \n           %s",
+        static::assertStringContainsString(
+            \sprintf(
+                "Remember to add this configuration Dummy content to the file                                                 \n           %s",
                 __DIR__ . '/src/Resources/config/services.xml'
             ),
             $display

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/AdminModuleGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/AdminModuleGeneratorTest.php
@@ -65,12 +65,6 @@ class AdminModuleGeneratorTest extends TestCase
             'confirmResponse' => true,
             'expectedHasOption' => true,
         ];
-
-        yield 'without command option and without confirm' => [
-            'getOptionResponse' => false,
-            'confirmResponse' => false,
-            'expectedHasOption' => false,
-        ];
     }
 
     /**

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/CommandGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/CommandGeneratorTest.php
@@ -65,12 +65,6 @@ class CommandGeneratorTest extends TestCase
             'confirmResponse' => true,
             'expectedHasOption' => true,
         ];
-
-        yield 'without command option and without confirm' => [
-            'getOptionResponse' => false,
-            'confirmResponse' => false,
-            'expectedHasOption' => false,
-        ];
     }
 
     /**

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/CustomFieldsetGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/CustomFieldsetGeneratorTest.php
@@ -65,12 +65,6 @@ class CustomFieldsetGeneratorTest extends TestCase
             'confirmResponse' => true,
             'expectedHasOption' => true,
         ];
-
-        yield 'without command option and without confirm' => [
-            'getOptionResponse' => false,
-            'confirmResponse' => false,
-            'expectedHasOption' => false,
-        ];
     }
 
     /**

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/EntityGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/EntityGeneratorTest.php
@@ -89,14 +89,6 @@ class EntityGeneratorTest extends TestCase
                 'TestEntity2',
             ],
         ];
-
-        yield 'without command option and without confirm' => [
-            'getOptionResponse' => false,
-            'confirmResponse' => false,
-            'entitiesAnswerInput' => 'TestEntity,TestEntity2',
-            'expectedHasOption' => false,
-            'expectedEntities' => null,
-        ];
     }
 
     public static function provideEntities(): \Generator

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/EventSubscriberGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/EventSubscriberGeneratorTest.php
@@ -65,12 +65,6 @@ class EventSubscriberGeneratorTest extends TestCase
             'confirmResponse' => true,
             'expectedHasOption' => true,
         ];
-
-        yield 'without command option and without confirm' => [
-            'getOptionResponse' => false,
-            'confirmResponse' => false,
-            'expectedHasOption' => false,
-        ];
     }
 
     /**

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/JavascriptPluginGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/JavascriptPluginGeneratorTest.php
@@ -65,12 +65,6 @@ class JavascriptPluginGeneratorTest extends TestCase
             'confirmResponse' => true,
             'expectedHasOption' => true,
         ];
-
-        yield 'without command option and without confirm' => [
-            'getOptionResponse' => false,
-            'confirmResponse' => false,
-            'expectedHasOption' => false,
-        ];
     }
 
     /**

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/ScheduledTaskGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/ScheduledTaskGeneratorTest.php
@@ -65,12 +65,6 @@ class ScheduledTaskGeneratorTest extends TestCase
             'confirmResponse' => true,
             'expectedHasOption' => true,
         ];
-
-        yield 'without command option and without confirm' => [
-            'getOptionResponse' => false,
-            'confirmResponse' => false,
-            'expectedHasOption' => false,
-        ];
     }
 
     /**

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StoreApiRouteGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StoreApiRouteGeneratorTest.php
@@ -65,12 +65,6 @@ class StoreApiRouteGeneratorTest extends TestCase
             'confirmResponse' => true,
             'expectedHasOption' => true,
         ];
-
-        yield 'without command option and without confirm' => [
-            'getOptionResponse' => false,
-            'confirmResponse' => false,
-            'expectedHasOption' => false,
-        ];
     }
 
     /**

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/StorefrontControllerGeneratorTest.php
@@ -65,12 +65,6 @@ class StorefrontControllerGeneratorTest extends TestCase
             'confirmResponse' => true,
             'expectedHasOption' => true,
         ];
-
-        yield 'without command option and without confirm' => [
-            'getOptionResponse' => false,
-            'confirmResponse' => false,
-            'expectedHasOption' => false,
-        ];
     }
 
     /**

--- a/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/TestsGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/Command/Scaffolding/Generator/TestsGeneratorTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\Generator\TestsGenerator;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\PluginScaffoldConfiguration;
 use Shopware\Core\Framework\Plugin\Command\Scaffolding\StubCollection;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * @internal
@@ -16,7 +17,10 @@ class TestsGeneratorTest extends TestCase
 {
     public function testCommandOptions(): void
     {
-        $generator = new TestsGenerator();
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('exists')->willReturn(false);
+
+        $generator = new TestsGenerator($filesystem);
 
         static::assertFalse($generator->hasCommandOption());
         static::assertEmpty($generator->getCommandOptionName());
@@ -25,7 +29,11 @@ class TestsGeneratorTest extends TestCase
 
     public function testGenerateStubs(): void
     {
-        $generator = new TestsGenerator();
+        $filesystem = $this->createMock(Filesystem::class);
+        $filesystem->method('exists')->willReturn(false);
+
+        $generator = new TestsGenerator($filesystem);
+
         $configuration = new PluginScaffoldConfiguration('TestPlugin', 'MyNamespace', '/path/to/directory');
         $stubCollection = new StubCollection();
 


### PR DESCRIPTION
### 1. Why is this change necessary?
This changes going to fix maker command (stubs generator)

### 2. What does this change do, exactly?
Removed scafolding collector that collect all generator stubs (not only one)
and generated stubs for only maker choosed

### 3. Describe each step to reproduce the issue or behaviour.
Create a plugin
install and activated plugin (skip all stub generator)
change a little bit composer.json file
do bin/console make:plugin:controller
after generated controller, composer.json file was restored, because not only maker of controller stub is generated but all of them.

### 4. Please link to the relevant issues (if any).
