### PR TITLE
NEXT-38817 - add frame-ancestors to default Content-Security-Policy Header

### DIFF
--- a/changelog/_unreleased/2024-10-18-add-frame-ancestors-to-default-content-security-policy-header.md
+++ b/changelog/_unreleased/2024-10-18-add-frame-ancestors-to-default-content-security-policy-header.md
@@ -1,0 +1,9 @@
+---
+title: Add frame-ancestors to default Content-Security-Policy Header
+issue: NEXT-38817
+author: Florian Liebig
+author_email: hello@florian-liebig.de
+author_github: @florianliebig
+---
+# Core
+* Added `frame-ancestors 'none';` to default Content-Security-Policy Header in services.xml

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -22,11 +22,13 @@
 object-src 'none';
 script-src 'none';
 base-uri 'self';
+frame-ancestors 'none';
             </parameter>
             <parameter key="administration">
 object-src 'none';
 script-src 'strict-dynamic' 'nonce-%%nonce%%' 'unsafe-inline' 'unsafe-eval' https: http:;
 base-uri 'self';
+frame-ancestors 'none';
             </parameter>
             <parameter key="storefront"/>
             <parameter key="installer"/>


### PR DESCRIPTION
### 1. Why is this change necessary?

X-Frame-Options is deprecated
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options

### 2. What does this change do, exactly?

Instead of this header, use the frame-ancestors directive in a Content-Security-Policy header.


### 3. Describe each step to reproduce the issue or behaviour.

Access administration, check response headers of initial html.

⚠️ X-Frame-Options is still present as this won't break anything. If desired, I can mark it depcreated or remove it totally.


### 4. Please link to the relevant issues (if any).

https://github.com/shopware/shopware/issues/5059


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
