### PR TITLE
Remove @internal flag from ids collection

### DIFF
--- a/changelog/_unreleased/2024-10-19-remove-internal-from-ids-collection.md
+++ b/changelog/_unreleased/2024-10-19-remove-internal-from-ids-collection.md
@@ -1,0 +1,9 @@
+---
+title: Remove internal from ids collection
+issue: 
+author: Oliver Skroblin
+author_email: oliver@goblin-coders.de
+author_github: OliverSkroblin
+---
+# Core
+* Removed @internal flag from `\Shopware\Core\Framework\Test\IdsCollection`

--- a/src/Core/Framework/Test/IdsCollection.php
+++ b/src/Core/Framework/Test/IdsCollection.php
@@ -5,9 +5,6 @@ namespace Shopware\Core\Framework\Test;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 
-/**
- * @internal
- */
 #[Package('core')]
 class IdsCollection
 {

--- a/tests/unit/Core/Framework/Test/IdsCollectionTest.php
+++ b/tests/unit/Core/Framework/Test/IdsCollectionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Shopware\Tests\Unit\Core\Framework\Test;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\IdsCollection;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class IdsCollectionTest extends TestCase
+{
+    public function testIdsCollection(): void
+    {
+        $ids = new IdsCollection();
+        $id = $ids->create('test');
+
+        $ids->set('foo', $id);
+
+        static::assertEquals($id, $ids->get('foo'));
+        static::assertIsString($id);
+        static::assertEquals($id, $ids->get('test'));
+        static::assertEquals([$id], array_values($ids->getList(['test'])));
+        static::assertEquals([['id' => $id]], $ids->getIdArray(['test']));
+        static::assertEquals(Uuid::fromHexToBytes($id), $ids->getBytes('test'));
+        static::assertEquals([['id' => $id]], $ids->getIdArray(['test']));
+    }
+}


### PR DESCRIPTION
The `ids` collection is an important helper for unit testing. It is also located in the `src/Core/Framework/Test` namespace, which serves as a "framework" for unit tests, both for Shopware and plugins (internal and external).

Therefore, this class should not be marked as @internal.