### PR TITLE
Removed abstract declaration from StoreApiResponse class

### DIFF
--- a/changelog/_unreleased/2024-10-19-allow-generic-store-api-response.md
+++ b/changelog/_unreleased/2024-10-19-allow-generic-store-api-response.md
@@ -1,0 +1,9 @@
+---
+title: Allow generic store api response
+issue: 
+author: Oliver Skroblin
+author_email: oliver@goblin-coders.de
+author_github: OliverSkroblin
+---
+# Core
+* Removed `abstract` declaration from `\Shopware\Core\System\SalesChannel\StoreApiResponse` which allows to use the class as a generic response object for store api responses. 

--- a/src/Core/System/SalesChannel/StoreApiResponse.php
+++ b/src/Core/System/SalesChannel/StoreApiResponse.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Struct\VariablesAccessTrait;
 use Symfony\Component\HttpFoundation\Response;
 
 #[Package('core')]
-abstract class StoreApiResponse extends Response
+class StoreApiResponse extends Response
 {
     // allows the cache key finder to get access of all returned data to build the cache tags
     use VariablesAccessTrait;


### PR DESCRIPTION
In many projects, I've seen teams create generic response classes because they don't need type hints, as the routes are only called via HTTP and never via PHP.

On the other hand, some projects end up with dozens of "empty" response classes lying around.

It would be beneficial if the base class could be used directly for such cases, instead of reinventing the wheel in every project.

The response `api_alias` is already determined based on the internal data objects anyway.