### PR TITLE
Remove deprecation of AppSystemTestBehaviour

### DIFF
--- a/src/Core/Test/AppSystemTestBehaviour.php
+++ b/src/Core/Test/AppSystemTestBehaviour.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Tests\Integration\Core\Framework\App;
+namespace Shopware\Core\Test;
 
 use Psr\Log\NullLogger;
 use Shopware\Core\Framework\App\AppService;

--- a/tests/integration/Administration/Controller/NotificationControllerTest.php
+++ b/tests/integration/Administration/Controller/NotificationControllerTest.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Tests\Integration\Core\Framework\App\GuzzleTestClientBehaviour;
 
 /**

--- a/tests/integration/Core/Checkout/Cart/Facade/CartFacadeTest.php
+++ b/tests/integration/Core/Checkout/Cart/Facade/CartFacadeTest.php
@@ -33,7 +33,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\Test\TestDefaults;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/InvoiceRendererTest.php
@@ -38,7 +38,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
+++ b/tests/integration/Core/Checkout/Document/Service/DocumentGeneratorTest.php
@@ -42,7 +42,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Tests\Integration\Core\Checkout\Document\DocumentTrait;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/tests/integration/Core/Content/ProductExport/SalesChannel/ProductExportControllerTest.php
+++ b/tests/integration/Core/Content/ProductExport/SalesChannel/ProductExportControllerTest.php
@@ -18,7 +18,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Theme\ThemeService;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/tests/integration/Core/Framework/Adapter/Cache/Script/ScriptCacheInvalidationSubscriberTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/Script/ScriptCacheInvalidationSubscriberTest.php
@@ -8,7 +8,7 @@ use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/tests/integration/Core/Framework/Api/Controller/AuthControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/AuthControllerTest.php
@@ -20,7 +20,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\AdminFunctionalTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseHelper\TestUser;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\TestDefaults;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -31,7 +31,7 @@ use Shopware\Core\Kernel;
 use Shopware\Core\Maintenance\System\Service\AppUrlVerifier;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Stub\Framework\BundleFixture;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\Asset\Package;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\Asset\UrlPackage;

--- a/tests/integration/Core/Framework/Api/OAuth/ClientRepositoryTest.php
+++ b/tests/integration/Core/Framework/Api/OAuth/ClientRepositoryTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/tests/integration/Core/Framework/App/ActionButton/AppActionLoaderTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/AppActionLoaderTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/App/ActionButton/ExecutorTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/ExecutorTest.php
@@ -22,7 +22,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Random;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Tests\Integration\Core\Framework\App\GuzzleTestClientBehaviour;
 
 /**

--- a/tests/integration/Core/Framework/App/ActiveAppsLoaderTest.php
+++ b/tests/integration/Core/Framework/App/ActiveAppsLoaderTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\App;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\ActiveAppsLoader;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/App/Api/AppActionControllerTest.php
+++ b/tests/integration/Core/Framework/App/Api/AppActionControllerTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Tests\Integration\Core\Framework\App\GuzzleTestClientBehaviour;
 
 /**

--- a/tests/integration/Core/Framework/App/Api/AppCmsControllerTest.php
+++ b/tests/integration/Core/Framework/App/Api/AppCmsControllerTest.php
@@ -4,7 +4,7 @@ namespace Shopware\Tests\Integration\Core\Framework\App\Api;
 
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Tests\Integration\Core\Framework\App\GuzzleTestClientBehaviour;
 
 /**

--- a/tests/integration/Core/Framework/App/Api/AppUrlChangeControllerTest.php
+++ b/tests/integration/Core/Framework/App/Api/AppUrlChangeControllerTest.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/App/AppServiceTest.php
+++ b/tests/integration/Core/Framework/App/AppServiceTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\Finder\Finder;
 
 /**

--- a/tests/integration/Core/Framework/App/AppStateServiceTest.php
+++ b/tests/integration/Core/Framework/App/AppStateServiceTest.php
@@ -21,6 +21,7 @@ use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\Constraint\ArrayOfUuid;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\NotBlank;

--- a/tests/integration/Core/Framework/App/AppSystemTestBehaviour.php
+++ b/tests/integration/Core/Framework/App/AppSystemTestBehaviour.php
@@ -13,9 +13,6 @@ use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Shopware\Core\System\Snippet\Files\SnippetFileLoader;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * @deprecated tag:v6.7.0 - reason:becomes-internal - Will be internal in v6.7.0
- */
 trait AppSystemTestBehaviour
 {
     abstract protected static function getContainer(): ContainerInterface;

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/MoveShopPermanentlyStrategyTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/ReinstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/ReinstallAppsStrategyTest.php
@@ -16,7 +16,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**

--- a/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
+++ b/tests/integration/Core/Framework/App/AppUrlChangeResolver/UninstallAppsStrategyTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Theme\ThemeAppLifecycleHandler;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/App/Checkout/Gateway/AppCheckoutGatewayTest.php
+++ b/tests/integration/Core/Framework/App/Checkout/Gateway/AppCheckoutGatewayTest.php
@@ -19,7 +19,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Test\Integration\PaymentHandler\AsyncTestPaymentHandler;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Tests\Integration\Core\Framework\App\GuzzleTestClientBehaviour;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 

--- a/tests/integration/Core/Framework/App/Command/ActivateAppCommandTest.php
+++ b/tests/integration/Core/Framework/App/Command/ActivateAppCommandTest.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**

--- a/tests/integration/Core/Framework/App/Command/DeactivateAppCommandTest.php
+++ b/tests/integration/Core/Framework/App/Command/DeactivateAppCommandTest.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**

--- a/tests/integration/Core/Framework/App/Command/RefreshAppCommandTest.php
+++ b/tests/integration/Core/Framework/App/Command/RefreshAppCommandTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**

--- a/tests/integration/Core/Framework/App/Lifecycle/AppLoaderTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/AppLoaderTest.php
@@ -5,7 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\App\Lifecycle;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\Manifest\Manifest;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/App/Lifecycle/Registration/HandshakeFactoryTest.php
+++ b/tests/integration/Core/Framework/App/Lifecycle/Registration/HandshakeFactoryTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Kernel;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/App/ShopId/ShopIdProviderTest.php
+++ b/tests/integration/Core/Framework/App/ShopId/ShopIdProviderTest.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\App\ShopId\ShopIdProvider;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/App/Subscriber/CustomFieldProtectionSubscriberTest.php
+++ b/tests/integration/Core/Framework/App/Subscriber/CustomFieldProtectionSubscriberTest.php
@@ -16,7 +16,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetCollection;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacadeTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacadeTest.php
@@ -26,7 +26,7 @@ use Shopware\Core\Framework\Struct\ArrayStruct;
 use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\Script\Execution\TestHook;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryWriterFacadeTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Facade/RepositoryWriterFacadeTest.php
@@ -20,7 +20,7 @@ use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\Script\Execution\TestHook;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\Tax\TaxEntity;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Facade/SalesChannelRepositoryFacadeTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Facade/SalesChannelRepositoryFacadeTest.php
@@ -30,7 +30,7 @@ use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\Tax\TaxCollection;
 use Shopware\Core\Test\TestDefaults;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/Plugin/BundleConfigGeneratorTest.php
+++ b/tests/integration/Core/Framework/Plugin/BundleConfigGeneratorTest.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Plugin\BundleConfigGenerator;
 use Shopware\Core\Framework\Plugin\BundleConfigGeneratorInterface;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Theme\StorefrontPluginRegistry;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/Routing/ApiRequestContextResolverAppTest.php
+++ b/tests/integration/Core/Framework/Routing/ApiRequestContextResolverAppTest.php
@@ -15,7 +15,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 /**

--- a/tests/integration/Core/Framework/Script/Api/ScriptApiRouteTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ScriptApiRouteTest.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\AdminApiTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/tests/integration/Core/Framework/Script/Api/ScriptStoreApiRouteTest.php
+++ b/tests/integration/Core/Framework/Script/Api/ScriptStoreApiRouteTest.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Script\Api\ScriptStoreApiRoute;
 use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/tests/integration/Core/Framework/Script/Execution/ScriptExecutorTest.php
+++ b/tests/integration/Core/Framework/Script/Execution/ScriptExecutorTest.php
@@ -20,7 +20,7 @@ use Shopware\Core\Framework\Test\Script\Execution\StoppableTestHook;
 use Shopware\Core\Framework\Test\Script\Execution\TestHook;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\SalesChannelRequest;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 

--- a/tests/integration/Core/Framework/Script/Execution/ScriptLoaderTest.php
+++ b/tests/integration/Core/Framework/Script/Execution/ScriptLoaderTest.php
@@ -5,7 +5,7 @@ namespace Shopware\Tests\Integration\Core\Framework\Script\Execution;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Script\Execution\ScriptLoader;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Core/Framework/Translation/TranslatorTest.php
+++ b/tests/integration/Core/Framework/Translation/TranslatorTest.php
@@ -22,7 +22,7 @@ use Shopware\Core\System\Snippet\SnippetDefinition;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Theme\DatabaseSalesChannelThemeLoader;
 use Shopware\Storefront\Theme\ThemeService;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Tests\Integration\Core\Framework\Translation\Fixtures\UnitTest_SnippetFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/tests/integration/Core/System/CustomEntity/CustomEntityTest.php
+++ b/tests/integration/Core/System/CustomEntity/CustomEntityTest.php
@@ -65,7 +65,7 @@ use Shopware\Core\System\CustomEntity\Xml\Field\PriceField;
 use Shopware\Core\System\CustomEntity\Xml\Field\StringField;
 use Shopware\Core\System\CustomEntity\Xml\Field\TextField;
 use Shopware\Core\System\SystemConfig\Exception\XmlParsingException;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/tests/integration/Core/System/Snippet/Files/AppSnippetFileLoaderTest.php
+++ b/tests/integration/Core/System/Snippet/Files/AppSnippetFileLoaderTest.php
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\Snippet\Files\AppSnippetFileLoader;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Shopware\Core\System\Snippet\Files\SnippetFileLoader;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**

--- a/tests/integration/Core/System/SystemConfig/Facade/SystemConfigFacadeTest.php
+++ b/tests/integration/Core/System/SystemConfig/Facade/SystemConfigFacadeTest.php
@@ -22,7 +22,7 @@ use Shopware\Core\System\SystemConfig\Facade\SystemConfigFacadeHookFactory;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Storefront/Controller/ScriptControllerTest.php
+++ b/tests/integration/Storefront/Controller/ScriptControllerTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Test\Controller\StorefrontControllerTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/tests/integration/Storefront/Framework/App/AppStateServiceThemeTest.php
+++ b/tests/integration/Storefront/Framework/App/AppStateServiceThemeTest.php
@@ -17,7 +17,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Theme\Exception\ThemeAssignmentException;
 use Shopware\Storefront\Theme\ThemeService;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
 

--- a/tests/integration/Storefront/Framework/App/TemplateStateServiceTest.php
+++ b/tests/integration/Storefront/Framework/App/TemplateStateServiceTest.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
+++ b/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
@@ -17,7 +17,7 @@ use Shopware\Core\Framework\Test\IdsCollection;
 use Shopware\Core\Framework\Test\TestCaseBase\CacheTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;

--- a/tests/integration/Storefront/Framework/Cookie/AppCookieProviderTest.php
+++ b/tests/integration/Storefront/Framework/Cookie/AppCookieProviderTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Framework\Cookie\AppCookieProvider;
 use Shopware\Storefront\Framework\Cookie\CookieProviderInterface;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Storefront/Framework/Routing/StorefrontSubscriberTest.php
+++ b/tests/integration/Storefront/Framework/Routing/StorefrontSubscriberTest.php
@@ -14,7 +14,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Storefront\Event\StorefrontRenderEvent;
 use Shopware\Storefront\Framework\Routing\StorefrontSubscriber;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelEvents;
 

--- a/tests/integration/Storefront/Theme/StorefrontPluginRegistryTest.php
+++ b/tests/integration/Storefront/Theme/StorefrontPluginRegistryTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Theme\StorefrontPluginConfiguration\StorefrontPluginConfiguration;
 use Shopware\Storefront\Theme\StorefrontPluginRegistry;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 
 /**
  * @internal

--- a/tests/integration/Storefront/Theme/ThemeAppLifecycleHandlerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeAppLifecycleHandlerTest.php
@@ -13,7 +13,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Storefront\Theme\ThemeCollection;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**

--- a/tests/integration/Storefront/Theme/ThemeCompilerTest.php
+++ b/tests/integration/Storefront/Theme/ThemeCompilerTest.php
@@ -40,7 +40,7 @@ use Shopware\Storefront\Theme\Subscriber\ThemeCompilerEnrichScssVarSubscriber;
 use Shopware\Storefront\Theme\ThemeCompiler;
 use Shopware\Storefront\Theme\ThemeFileResolver;
 use Shopware\Storefront\Theme\ThemeFilesystemResolver;
-use Shopware\Tests\Integration\Core\Framework\App\AppSystemTestBehaviour;
+use Shopware\Core\Test\AppSystemTestBehaviour;
 use Shopware\Tests\Integration\Storefront\Theme\fixtures\MockThemeCompilerConcatenatedSubscriber;
 use Shopware\Tests\Integration\Storefront\Theme\fixtures\MockThemeVariablesSubscriber;
 use Shopware\Tests\Integration\Storefront\Theme\fixtures\SimplePlugin\SimplePlugin;


### PR DESCRIPTION
Hey,

Recently, I tried to secure app scripts for a customer using unit tests.

However, I couldn’t find any documentation on how this is supposed to be done.

In the end, I just created a unit test in the project that ensures the app is installed and loaded using `loadAppsFromDir`.

Therefore, the edited trait shouldn't be marked as internal with version 6.7.

Is there another way to handle this?

I also didn’t find any changelog entry regarding the deprecation.