### PR TITLE
NEXT-28108 - fix colorpicker overlapping in theme manager

### DIFF
--- a/changelog/_unreleased/2024-10-20-fix-colorpicker-overlapping-issue.md
+++ b/changelog/_unreleased/2024-10-20-fix-colorpicker-overlapping-issue.md
@@ -1,0 +1,9 @@
+---
+title: Fix colorpicker overlapping issue
+issue: NEXT-28108
+author: Florian Liebig
+author_email: hello@florian-liebig.de
+author_github: @florianliebig
+# Administration
+* Added zIndex to `sw-colorpicker` in `sw-theme-manager-detail.html.twig`
+* Added z-index to `.sw-page__head-area` to avoid further overlapping

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-page/sw-page.scss
@@ -29,6 +29,7 @@ $sw-page-search-bar-z-index: $z-index-sw-page-search-bar;
         align-items: center;
         background: $sw-page-smart-bar-background-color;
         border-bottom: 2px solid $sw-page-smart-bar-border-color;
+        z-index: 200;
     }
 
     .sw-page__search-bar {

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -356,6 +356,7 @@
                                                                                     :helpText="!field.helpText ? null : field.helpText"
                                                                                     :disabled="isInherited || !acl.can('theme.editor') || themeConfig[fieldName].editable === false"
                                                                                     :value="currentValue"
+                                                                                    zIndex="100"
                                                                                     @update:value="updateCurrentValue"
                                                                                 />
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The colorpicker has an inproper z-index leading other text elements to overlap it in the theme-manager.

### 2. What does this change do, exactly?

- Introduces zIndex on the sw-colorpicker in the theme manager
- Increases header z-index to avoid additional overlapping of the colorpicker over the header bar

Made sure there are no other overlapping now with the header bar (see gif / video)

### 3. Describe each step to reproduce the issue or behaviour.

Install standard storefront theme
Go to theme manager
Open a colorpicker element
Scroll / Check overlapping

![colorpicker](https://github.com/user-attachments/assets/c7815aa2-10b1-4608-beaf-df5d61a72747)

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/shopware/issues/4848

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
