### PR TITLE
Fix/google ads always shown

### DIFF
--- a/changelog/_unreleased/2024-10-21-only-show-google-ads-cookie-notice-if-google-analytics-is-enabled.md
+++ b/changelog/_unreleased/2024-10-21-only-show-google-ads-cookie-notice-if-google-analytics-is-enabled.md
@@ -1,0 +1,9 @@
+---
+title: Only show Google Ads cookie notice if Google Analytics is enabled
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed `Shopware\Storefront\Controller\CookieController` to only display Google Ads cookie if Google Analytics is enabled

--- a/tests/unit/Storefront/Controller/CookieControllerTest.php
+++ b/tests/unit/Storefront/Controller/CookieControllerTest.php
@@ -22,6 +22,8 @@ class CookieControllerTest extends TestCase
     public function testResponseDoesNotIncludeGoogleAnalyticsCookieByDefault(): void
     {
         $salesChannelContext = Generator::createSalesChannelContext();
+
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([])]);
 
         $controller = new CookieControllerTestClass(
@@ -44,6 +46,8 @@ class CookieControllerTest extends TestCase
         $analytics = new SalesChannelAnalyticsEntity();
         $analytics->setId($analyticsId);
         $analytics->setActive(true);
+
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([$analytics])]);
 
         $controller = new CookieControllerTestClass(
@@ -66,6 +70,8 @@ class CookieControllerTest extends TestCase
         $analytics = new SalesChannelAnalyticsEntity();
         $analytics->setId($analyticsId);
         $analytics->setActive(false);
+
+        /** @var StaticEntityRepository<SalesChannelAnalyticsCollection> $repository */
         $repository = new StaticEntityRepository([new SalesChannelAnalyticsCollection([$analytics])]);
 
         $controller = new CookieControllerTestClass(
@@ -87,12 +93,13 @@ class CookieControllerTest extends TestCase
     {
         $googleAnalyticsCookie = array_filter($cookieGroups, static function (array $cookieGroup) {
             return \count(array_filter($cookieGroup['entries'], static function (array $cookie) {
-                return $cookie['cookie'] === 'google-analytics-enabled';
+                return \in_array($cookie['cookie'], ['google-analytics-enabled', 'google-ads-enabled'], true);
             })) > 0;
         });
 
         if ($expected) {
             static::assertNotEmpty($googleAnalyticsCookie);
+            static::assertCount(2, $googleAnalyticsCookie);
         } else {
             static::assertEmpty($googleAnalyticsCookie);
         }


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the Google Ads Cookie notice is always shown, even if, one does not utilize this feature.

### 2. What does this change do, exactly?
Filter the cookie based on the Google Analytics setting.

Note, I am not sure if other plugins now rely on the feature, since it is always dispatched in the storefront. If that would be the case, it might be a breaking change.

### 3. Describe each step to reproduce the issue or behaviour.
Create a shop and configure the cookies, and be confused why you should consent to Google Ads, even though you do not use Google Ads.

### 4. Please link to the relevant issues (if any).
The following issue mentions this problem, but also other things: https://github.com/shopware/shopware/issues/5070

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
