### PR TITLE
Fix styling input groups

### DIFF
--- a/changelog/_unreleased/2024-10-21-fix-styling-input-groups.md
+++ b/changelog/_unreleased/2024-10-21-fix-styling-input-groups.md
@@ -1,0 +1,10 @@
+---
+title: Fix styling input groups
+issue: NEXT-00000
+author: Wanne Van Camp
+author_email: wanne.vancamp@meteor.be
+author_github: @wannevancamp
+---
+# Storefront
+* Changed `src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig` to apply correct styling to `page_checkout_cart_add_product_input_group` and `page_checkout_cart_add_promotion_input_group`
+* Changed `src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig` to apply correct styling to `component_offcanvas_cart_actions_promotion_input_group`

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart.html.twig
@@ -103,14 +103,13 @@
                                                    value="frontend.cart.offcanvas">
                                         {% endblock %}
 
+                                        {% block component_offcanvas_cart_actions_promotion_label %}
+                                            <label class="visually-hidden" for="addPromotionOffcanvasCartInput">
+                                                {{ 'checkout.addPromotionLabel'|trans|sw_sanitize }}
+                                            </label>
+                                        {% endblock %}
                                         {% block component_offcanvas_cart_actions_promotion_input_group %}
                                             <div class="input-group">
-                                                {% block component_offcanvas_cart_actions_promotion_label %}
-                                                    <label class="visually-hidden" for="addPromotionOffcanvasCartInput">
-                                                        {{ 'checkout.addPromotionLabel'|trans|sw_sanitize }}
-                                                    </label>
-                                                {% endblock %}
-
                                                 {% block component_offcanvas_cart_actions_promotion_input %}
                                                     <input type="text"
                                                            name="code"

--- a/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/cart/index.html.twig
@@ -81,14 +81,13 @@
                                        value="frontend.checkout.cart.page">
                             {% endblock %}
 
+                            {% block page_checkout_cart_add_product_label %}
+                                <label class="visually-hidden" for="addProductInput">
+                                    {{ 'checkout.addProductLabel'|trans|sw_sanitize }}
+                                </label>
+                            {% endblock %}
                             {% block page_checkout_cart_add_product_input_group %}
                                 <div class="input-group">
-                                    {% block page_checkout_cart_add_product_label %}
-                                        <label class="visually-hidden" for="addProductInput">
-                                            {{ 'checkout.addProductLabel'|trans|sw_sanitize }}
-                                        </label>
-                                    {% endblock %}
-
                                     {% block page_checkout_cart_add_product_input %}
                                         <input type="text"
                                                name="number"
@@ -221,14 +220,13 @@
                            value="frontend.checkout.cart.page">
                 {% endblock %}
 
+                {% block page_checkout_cart_add_promotion_label %}
+                    <label class="visually-hidden" for="addPromotionInput">
+                        {{ 'checkout.addPromotionLabel'|trans|sw_sanitize }}
+                    </label>
+                {% endblock %}
                 {% block page_checkout_cart_add_promotion_input_group %}
                     <div class="input-group checkout-aside-add-code mt-3">
-                        {% block page_checkout_cart_add_promotion_label %}
-                            <label class="visually-hidden" for="addPromotionInput">
-                                {{ 'checkout.addPromotionLabel'|trans|sw_sanitize }}
-                            </label>
-                        {% endblock %}
-
                         {% block page_checkout_cart_add_promotion_input %}
                             <input type="text"
                                    name="code"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When the Bootstrap `--bs-border-radius` variable is set, the top-left and bottom-left border-radius of input fields are set to 0. The first element in a Bootstrap input group receives the border-radius. Currently, a hidden label is the first element inside the input group, but it should be placed outside of it. Once the hidden label is moved outside the input group, the correct styling will apply.

![image](https://github.com/user-attachments/assets/b58e1249-914d-4cae-b830-f3179d2b1bc8)

Currently:
![image](https://github.com/user-attachments/assets/124bec59-b0a1-404d-b568-f1b4b542d57e)

After change:
![image](https://github.com/user-attachments/assets/ad9e832a-383f-40a2-a9fc-93cf1459668a)


### 2. What does this change do, exactly?
Rearrange input-groups to apply correct default Bootstrap styling

### 3. Describe each step to reproduce the issue or behaviour.
1. Apply `--bs-border-radius` higher than 0
2. The top-left and bottom-left border-radius are set to 0

### 4. Please link to the relevant issues (if any).
/

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
