### PR TITLE
NEXT-39170 - Fix testing settings to be persisted on local emailAgent

### DIFF
--- a/changelog/_unreleased/2024-10-21-fix-mailer-settings-persisting-old-data.md
+++ b/changelog/_unreleased/2024-10-21-fix-mailer-settings-persisting-old-data.md
@@ -1,0 +1,8 @@
+---
+title: Fix Mailer Settings persisting old data
+issue: NEXT-39170
+author: Florian Liebig
+author_email: hello@florian-liebig.de
+author_github: @florianliebig
+# Administration
+* Changed `sw-mailer-settings` to reset most mailer settings when choosing emailAgent `local`

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/index.js
@@ -114,6 +114,17 @@ export default {
                 return;
             }
 
+            // Reset mailerSettings as local would take over certain values
+            if (this.mailerSettings['core.mailerSettings.emailAgent'] === 'local') {
+                this.mailerSettings['core.mailerSettings.host'] = null;
+                this.mailerSettings['core.mailerSettings.port'] = null;
+                this.mailerSettings['core.mailerSettings.username'] = null;
+                this.mailerSettings['core.mailerSettings.password'] = null;
+                this.mailerSettings['core.mailerSettings.encryption'] = null;
+                this.mailerSettings['core.mailerSettings.senderAddress'] = null;
+                this.mailerSettings['core.mailerSettings.deliveryAddress'] = null;
+            }
+
             await this.systemConfigApiService.saveValues(this.mailerSettings);
             this.isLoading = false;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.spec.js
@@ -148,4 +148,39 @@ describe('src/module/sw-settings-mailer/page/sw-settings-mailer', () => {
 
         expect(wrapper.vm.smtpPortError).toBeNull();
     });
+
+    it('should reset mailer settings when submitting as emailAgent local', async () => {
+        const wrapper = await new CreateSettingsMailer();
+
+        await wrapper.setData({
+            mailerSettings: {
+                'core.mailerSettings.emailAgent': 'local',
+                'core.mailerSettings.host': 'smtp.shopware.com',
+                'core.mailerSettings.port': 465,
+                'core.mailerSettings.username': 'smtp',
+                'core.mailerSettings.password': 'smtp',
+                'core.mailerSettings.encryption': 'ssl',
+                'core.mailerSettings.authenticationMethod': 'login',
+                'core.mailerSettings.senderAddress': 'test@example.com',
+                'core.mailerSettings.deliveryAddress': 'info@test.de',
+            }
+        });
+
+        const spySaveValues = jest.spyOn(wrapper.vm.systemConfigApiService, 'saveValues');
+
+        wrapper.vm.saveMailerSettings();
+
+        expect(spySaveValues).toHaveBeenCalledWith({
+            'core.mailerSettings.emailAgent': 'local',
+            'core.mailerSettings.host': null,
+            'core.mailerSettings.port': null,
+            'core.mailerSettings.username': null,
+            'core.mailerSettings.password': null,
+            'core.mailerSettings.encryption': null,
+            'core.mailerSettings.authenticationMethod': 'login',
+            'core.mailerSettings.senderAddress': null,
+            'core.mailerSettings.deliveryAddress': null,
+            'core.mailerSettings.disableDelivery': false
+        });
+    })
 });


### PR DESCRIPTION
### 1. Why is this change necessary?

When changing Mailer Settings E-Mail agent to "local" from "smtp" many settings are preserved, even though they are not visible. Especially for `deliveryAddress` settings this can lead to side-effects as you do not expect this to be set anymore. As described in https://github.com/shopware/shopware/issues/5207

![CleanShot 2024-10-21 at 20 52 45@2x](https://github.com/user-attachments/assets/cb4a353d-5dd4-4e80-a575-b0dd2d44b923)


### 2. What does this change do, exactly?

When choosing "local" as `emailAgent` all other settings are set to its default value again in the vue component. Leading the settings service to remove those again.

### 3. Describe each step to reproduce the issue or behaviour.

http://localhost:8080/#/sw/settings/mailer/index
Save settings with agent "smtp"
Check database `system_config` with key containing `core.mailerSettings`
Change to agent "local" and safe again
Recheck database settings -> most are still there, even if not used for local agent


### 4. Please link to the relevant issues (if any).

https://github.com/shopware/shopware/issues/5207

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
