### PR TITLE
Allow to specify entity collection for attributed entities

### DIFF
--- a/changelog/_unreleased/2024-10-22-allow-to-override-entity-collection-class-for-attributed-entities.md
+++ b/changelog/_unreleased/2024-10-22-allow-to-override-entity-collection-class-for-attributed-entities.md
@@ -1,0 +1,9 @@
+---
+title: Allow to override entity collection class for attributed entities
+issue:
+author: Nicky Gerritsen
+author_email: nicky@letstalk.nl
+author_github: nickygerritsen
+---
+# Core
+* Added support for specifying the entity collection class on attributed entities.

--- a/src/Core/Framework/DataAbstractionLayer/Attribute/Entity.php
+++ b/src/Core/Framework/DataAbstractionLayer/Attribute/Entity.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Attribute;
 
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('core')]
@@ -16,7 +17,8 @@ class Entity
     public function __construct(
         public string $name,
         public ?string $parent = null,
-        public ?string $since = null
+        public ?string $since = null,
+        public ?string $collectionClass = EntityCollection::class,
     ) {
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -136,6 +136,7 @@ class AttributeEntityCompiler
             'parent' => $instance->parent,
             'entity_class' => $class,
             'entity_name' => $instance->name,
+            'collection_class' => $instance->collectionClass,
             'fields' => $fields,
         ];
 

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityDefinition.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityDefinition.php
@@ -33,6 +33,11 @@ class AttributeEntityDefinition extends EntityDefinition
         return $this->meta['entity_name'];
     }
 
+    public function getCollectionClass(): string
+    {
+        return $this->meta['collection_class'];
+    }
+
     protected function getParentDefinitionClass(): ?string
     {
         return $this->meta['parent'] ?? null;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\AttributeEntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\AttributeMappingDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\AttributeTranslationDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldType\DateInterval;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
@@ -28,6 +29,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Core\Test\TestDefaults;
 use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\AttributeEntity;
+use Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture\AttributeEntityCollection;
 
 /**
  * @internal
@@ -71,7 +73,9 @@ class AttributeEntityIntegrationTest extends TestCase
         static::assertTrue(static::getContainer()->has('attribute_entity_translation.definition'));
 
         static::assertInstanceOf(AttributeEntityDefinition::class, static::getContainer()->get('attribute_entity.definition'));
+        static::assertSame(AttributeEntityCollection::class, static::getContainer()->get('attribute_entity.definition')->getCollectionClass());
         static::assertInstanceOf(AttributeEntityDefinition::class, static::getContainer()->get('attribute_entity_agg.definition'));
+        static::assertSame(EntityCollection::class, static::getContainer()->get('attribute_entity_agg.definition')->getCollectionClass());
         static::assertInstanceOf(AttributeMappingDefinition::class, static::getContainer()->get('attribute_entity_currency.definition'));
         static::assertInstanceOf(AttributeTranslationDefinition::class, static::getContainer()->get('attribute_entity_translation.definition'));
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntity.php
@@ -32,7 +32,7 @@ use Shopware\Core\System\StateMachine\Aggregation\StateMachineState\StateMachine
 /**
  * @internal
  */
-#[Entity('attribute_entity', since: '6.6.3.0')]
+#[Entity('attribute_entity', since: '6.6.3.0', collectionClass: AttributeEntityCollection::class)]
 class AttributeEntity extends EntityStruct
 {
     use EntityCustomFieldsTrait;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntityCollection.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntityCollection.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+/**
+ * @internal
+ *
+ * @extends EntityCollection<AttributeEntity>
+ */
+class AttributeEntityCollection extends EntityCollection
+{
+    protected function getExpectedClass(): string
+    {
+        return AttributeEntity::class;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Sometimes you want a custom entity collection for you entities, but this was not possible yet for attributed entities.

### 2. What does this change do, exactly?

It adds a parameter to specify the entity collection for attributed entities, defaulting to `EntityCollection`.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
