### PR TITLE
Add more line-item TWIG blocks

### DIFF
--- a/changelog/_unreleased/2024-10-23-add-line-item-twig-blocks.md
+++ b/changelog/_unreleased/2024-10-23-add-line-item-twig-blocks.md
@@ -1,0 +1,9 @@
+---
+title: Add more line-item TWIG blocks
+issue: 
+author: Toby Denhaerinck
+author_email: toby@vhulcan.com
+author_github: @Vhulcan
+---
+# Storefront
+* Added `component_line_item_type_X_inner`, `component_line_item_type_X_details`, `component_line_item_type_X_details_container` TWIG-blocks to line-item templates.

--- a/changelog/_unreleased/2024-10-23-add-line-item-twig-blocks.md
+++ b/changelog/_unreleased/2024-10-23-add-line-item-twig-blocks.md
@@ -6,4 +6,4 @@ author_email: toby@vhulcan.com
 author_github: @Vhulcan
 ---
 # Storefront
-* Added `component_line_item_type_X_inner`, `component_line_item_type_X_details`, `component_line_item_type_X_details_container` TWIG-blocks to line-item templates.
+* Added `component_line_item_type_product_inner`, `component_line_item_type_X_info_row`, `component_line_item_type_X_row`, `component_line_item_type_X_row_inner`, `component_line_item_type_X_details` and `component_line_item_type_X_details_container` TWIG-blocks to line-item templates.

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig
@@ -27,84 +27,89 @@
     {%- else -%}
         <div class="{{ lineItemClasses }}" role="listitem">
     {%- endif -%}
-        <div class="row line-item-row">
-            {% block component_line_item_type_container_col_info %}
-                <div class="line-item-info">
-                    <div class="row line-item-row">
+        {% block component_line_item_type_container_inner %}
+            <div class="row line-item-row">
+                {% block component_line_item_type_container_col_info %}
+                    <div class="line-item-info">
+                        {% block component_line_item_type_container_info %}
+                            <div class="row line-item-row">
+                                {% if nestingLevel < 1 %}
+                                    {% block component_line_item_type_container_image %}
+                                        <div class="col-auto line-item-info-img">
+                                            <div class="line-item-img-container">
+                                                {% block component_line_item_type_container_image_inner %}
+                                                    {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
+                                                        fallbackIcon: 'bag-product'
+                                                    } %}
+                                                {% endblock %}
+                                            </div>
+                                        </div>
+                                    {% endblock %}
+                                {% endif %}
 
-                        {% if nestingLevel < 1 %}
-                            {% block component_line_item_type_container_image %}
-                                <div class="col-auto line-item-info-img">
-                                    <div class="line-item-img-container">
-                                        {% block component_line_item_type_container_image_inner %}
-                                            {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
-                                                fallbackIcon: 'bag-product'
-                                            } %}
+                                {% block component_line_item_type_container_details %}
+                                    <div class="line-item-details">
+                                        {% block component_line_item_type_container_details_container %}
+                                            <div class="line-item-details-container">
+                                                {% block component_line_item_type_container_label %}
+                                                    {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
+                                                {% endblock %}
+                                            </div>
                                         {% endblock %}
                                     </div>
-                                </div>
-                            {% endblock %}
-                        {% endif %}
-
-                        {% block component_line_item_type_container_details %}
-                            <div class="line-item-details">
-                                <div class="line-item-details-container">
-                                    {% block component_line_item_type_container_label %}
-                                        {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
-                                    {% endblock %}
-                                </div>
+                                {% endblock %}
                             </div>
                         {% endblock %}
                     </div>
-                </div>
-            {% endblock %}
+                {% endblock %}
 
-            {% block component_line_item_type_container_col_quantity %}
-                <div class="line-item-quantity">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
-                </div>
-            {% endblock %}
-
-            {% if showTaxPrice %}
-                {% block component_line_item_type_container_col_tax_price %}
-                    <div class="line-item-tax-price">
-                        {% if context.salesChannel.taxCalculationType == 'horizontal' %}
-                            {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
-                        {% endif %}
+                {% block component_line_item_type_container_col_quantity %}
+                    <div class="line-item-quantity">
+                        {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
                     </div>
                 {% endblock %}
-            {% else %}
-                {% block component_line_item_type_container_col_unit_price %}
-                    <div class="line-item-unit-price">
-                        {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
+
+                {% if showTaxPrice %}
+                    {% block component_line_item_type_container_col_tax_price %}
+                        <div class="line-item-tax-price">
+                            {% if context.salesChannel.taxCalculationType == 'horizontal' %}
+                                {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
+                            {% endif %}
+                        </div>
+                    {% endblock %}
+                {% else %}
+                    {% block component_line_item_type_container_col_unit_price %}
+                        <div class="line-item-unit-price">
+                            {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
+                        </div>
+                    {% endblock %}
+                {% endif %}
+
+                {% block component_line_item_type_container_col_total_price %}
+                    <div class="line-item-total-price">
+                        {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                            currency: lineItem.order.currency.isoCode
+                        } %}
                     </div>
                 {% endblock %}
-            {% endif %}
 
-            {% block component_line_item_type_container_col_total_price %}
-                <div class="line-item-total-price">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                        currency: lineItem.order.currency.isoCode
-                    } %}
-                </div>
-            {% endblock %}
+                {% if showRemoveButton %}
+                    {% block component_line_item_type_container_col_remove %}
+                        <div class="line-item-remove">
+                            {% if lineItem.removable and nestingLevel < 1 %}
+                                {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
+                            {% endif %}
+                        </div>
+                    {% endblock %}
+                {% endif %}
 
-            {% if showRemoveButton %}
-                {% block component_line_item_type_container_col_remove %}
-                    <div class="line-item-remove">
-                        {% if lineItem.removable and nestingLevel < 1 %}
-                            {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
-                        {% endif %}
-                    </div>
-                {% endblock %}
-            {% endif %}
-
-            {% if lineItem.children.count > 0 %}
-                {% block component_line_item_type_container_children %}
-                    {% sw_include '@Storefront/storefront/component/line-item/element/children-wrapper.html.twig' %}
-                {% endblock %}
-            {% endif %}
-        </div>
+                {% if lineItem.children.count > 0 %}
+                    {% block component_line_item_type_container_children %}
+                        {% sw_include '@Storefront/storefront/component/line-item/element/children-wrapper.html.twig' %}
+                    {% endblock %}
+                {% endif %}
+            </div>
+        {% endblock %}
     {# @deprecated tag:v6.7.0 - Line item wrapper element will be `<li>` element instead of `<div>` #}
     {%- if not feature('ACCESSIBILITY_TWEAKS') -%}
         </div>

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig
@@ -29,85 +29,87 @@
     {%- endif -%}
         {% block component_line_item_type_container_row %}
             <div class="row line-item-row">
-                {% block component_line_item_type_container_col_info %}
-                    <div class="line-item-info">
-                        {% block component_line_item_type_container_info %}
-                            <div class="row line-item-row">
-                                {% if nestingLevel < 1 %}
-                                    {% block component_line_item_type_container_image %}
-                                        <div class="col-auto line-item-info-img">
-                                            <div class="line-item-img-container">
-                                                {% block component_line_item_type_container_image_inner %}
-                                                    {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
-                                                        fallbackIcon: 'bag-product'
-                                                    } %}
-                                                {% endblock %}
-                                            </div>
-                                        </div>
-                                    {% endblock %}
-                                {% endif %}
-
-                                {% block component_line_item_type_container_details %}
-                                    <div class="line-item-details">
-                                        {% block component_line_item_type_container_details_container %}
-                                            <div class="line-item-details-container">
-                                                {% block component_line_item_type_container_label %}
-                                                    {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
-                                                {% endblock %}
+                {% block component_line_item_type_container_row_inner %}
+                    {% block component_line_item_type_container_col_info %}
+                        <div class="line-item-info">
+                            {% block component_line_item_type_container_info_row %}
+                                <div class="row line-item-row">
+                                    {% if nestingLevel < 1 %}
+                                        {% block component_line_item_type_container_image %}
+                                            <div class="col-auto line-item-info-img">
+                                                <div class="line-item-img-container">
+                                                    {% block component_line_item_type_container_image_inner %}
+                                                        {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
+                                                            fallbackIcon: 'bag-product'
+                                                        } %}
+                                                    {% endblock %}
+                                                </div>
                                             </div>
                                         {% endblock %}
-                                    </div>
-                                {% endblock %}
+                                    {% endif %}
+
+                                    {% block component_line_item_type_container_details %}
+                                        <div class="line-item-details">
+                                            {% block component_line_item_type_container_details_container %}
+                                                <div class="line-item-details-container">
+                                                    {% block component_line_item_type_container_label %}
+                                                        {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
+                                                    {% endblock %}
+                                                </div>
+                                            {% endblock %}
+                                        </div>
+                                    {% endblock %}
+                                </div>
+                            {% endblock %}
+                        </div>
+                    {% endblock %}
+
+                    {% block component_line_item_type_container_col_quantity %}
+                        <div class="line-item-quantity">
+                            {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
+                        </div>
+                    {% endblock %}
+
+                    {% if showTaxPrice %}
+                        {% block component_line_item_type_container_col_tax_price %}
+                            <div class="line-item-tax-price">
+                                {% if context.salesChannel.taxCalculationType == 'horizontal' %}
+                                    {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
+                                {% endif %}
                             </div>
                         {% endblock %}
-                    </div>
-                {% endblock %}
+                    {% else %}
+                        {% block component_line_item_type_container_col_unit_price %}
+                            <div class="line-item-unit-price">
+                                {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
+                            </div>
+                        {% endblock %}
+                    {% endif %}
 
-                {% block component_line_item_type_container_col_quantity %}
-                    <div class="line-item-quantity">
-                        {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
-                    </div>
-                {% endblock %}
-
-                {% if showTaxPrice %}
-                    {% block component_line_item_type_container_col_tax_price %}
-                        <div class="line-item-tax-price">
-                            {% if context.salesChannel.taxCalculationType == 'horizontal' %}
-                                {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
-                            {% endif %}
+                    {% block component_line_item_type_container_col_total_price %}
+                        <div class="line-item-total-price">
+                            {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                                currency: lineItem.order.currency.isoCode
+                            } %}
                         </div>
                     {% endblock %}
-                {% else %}
-                    {% block component_line_item_type_container_col_unit_price %}
-                        <div class="line-item-unit-price">
-                            {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
-                        </div>
-                    {% endblock %}
-                {% endif %}
 
-                {% block component_line_item_type_container_col_total_price %}
-                    <div class="line-item-total-price">
-                        {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                            currency: lineItem.order.currency.isoCode
-                        } %}
-                    </div>
+                    {% if showRemoveButton %}
+                        {% block component_line_item_type_container_col_remove %}
+                            <div class="line-item-remove">
+                                {% if lineItem.removable and nestingLevel < 1 %}
+                                    {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
+                                {% endif %}
+                            </div>
+                        {% endblock %}
+                    {% endif %}
+
+                    {% if lineItem.children.count > 0 %}
+                        {% block component_line_item_type_container_children %}
+                            {% sw_include '@Storefront/storefront/component/line-item/element/children-wrapper.html.twig' %}
+                        {% endblock %}
+                    {% endif %}
                 {% endblock %}
-
-                {% if showRemoveButton %}
-                    {% block component_line_item_type_container_col_remove %}
-                        <div class="line-item-remove">
-                            {% if lineItem.removable and nestingLevel < 1 %}
-                                {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
-                            {% endif %}
-                        </div>
-                    {% endblock %}
-                {% endif %}
-
-                {% if lineItem.children.count > 0 %}
-                    {% block component_line_item_type_container_children %}
-                        {% sw_include '@Storefront/storefront/component/line-item/element/children-wrapper.html.twig' %}
-                    {% endblock %}
-                {% endif %}
             </div>
         {% endblock %}
     {# @deprecated tag:v6.7.0 - Line item wrapper element will be `<li>` element instead of `<div>` #}

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/container.html.twig
@@ -27,7 +27,7 @@
     {%- else -%}
         <div class="{{ lineItemClasses }}" role="listitem">
     {%- endif -%}
-        {% block component_line_item_type_container_inner %}
+        {% block component_line_item_type_container_row %}
             <div class="row line-item-row">
                 {% block component_line_item_type_container_col_info %}
                     <div class="line-item-info">

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig
@@ -28,30 +28,33 @@
     {%- endif -%}
         {% block component_line_item_type_discount_row %}
             <div class="row line-item-row">
-            {% block component_line_item_type_discount_col_info %}
-                <div class="line-item-info">
-                    {% block component_line_item_type_discount_info %}
-                        <div class="row line-item-row">
-                            {% if nestingLevel < 1 %}
-                                {% block component_line_item_type_discount_image %}
-                                    <div class="col-auto line-item-info-img">
-                                        <div class="line-item-img-container">
-                                            {% block component_line_item_type_discount_image_inner %}
-                                                {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
-                                                    fallbackIcon: 'marketing'
-                                                } %}
-                                            {% endblock %}
-                                        </div>
-                                    </div>
-                                {% endblock %}
-                            {% endif %}
+                {% block component_line_item_type_discount_row_inner %}
+                    {% block component_line_item_type_discount_col_info %}
+                        <div class="line-item-info">
+                            {% block component_line_item_type_discount_info_row %}
+                                <div class="row line-item-row">
+                                    {% if nestingLevel < 1 %}
+                                        {% block component_line_item_type_discount_image %}
+                                            <div class="col-auto line-item-info-img">
+                                                <div class="line-item-img-container">
+                                                    {% block component_line_item_type_discount_image_inner %}
+                                                        {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
+                                                            fallbackIcon: 'marketing'
+                                                        } %}
+                                                    {% endblock %}
+                                                </div>
+                                            </div>
+                                        {% endblock %}
+                                    {% endif %}
 
-                            {% block component_line_item_type_discount_details %}
-                                <div class="line-item-details">
-                                    {% block component_line_item_type_discount_details_container %}
-                                        <div class="line-item-details-container">
-                                            {% block component_line_item_type_discount_label %}
-                                                {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
+                                    {% block component_line_item_type_discount_details %}
+                                        <div class="line-item-details">
+                                            {% block component_line_item_type_discount_details_container %}
+                                                <div class="line-item-details-container">
+                                                    {% block component_line_item_type_discount_label %}
+                                                        {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
+                                                    {% endblock %}
+                                                </div>
                                             {% endblock %}
                                         </div>
                                     {% endblock %}
@@ -59,47 +62,46 @@
                             {% endblock %}
                         </div>
                     {% endblock %}
-                </div>
-            {% endblock %}
 
-            {% block component_line_item_type_discount_col_quantity %}
-                <div class="line-item-quantity">
-                </div>
-            {% endblock %}
+                    {% block component_line_item_type_discount_col_quantity %}
+                        <div class="line-item-quantity">
+                        </div>
+                    {% endblock %}
 
-            {% if showTaxPrice %}
-                {% block component_line_item_type_discount_col_tax_price %}
-                    <div class="line-item-tax-price">
-                        {% if context.salesChannel.taxCalculationType == 'horizontal' %}
-                            {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
-                        {% endif %}
-                    </div>
+                    {% if showTaxPrice %}
+                        {% block component_line_item_type_discount_col_tax_price %}
+                            <div class="line-item-tax-price">
+                                {% if context.salesChannel.taxCalculationType == 'horizontal' %}
+                                    {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
+                                {% endif %}
+                            </div>
+                        {% endblock %}
+                    {% else %}
+                        {% block component_line_item_type_discount_col_unit_price %}
+                            <div class="line-item-unit-price">
+                            </div>
+                        {% endblock %}
+                    {% endif %}
+
+                    {% block component_line_item_type_discount_col_total_price %}
+                        <div class="line-item-total-price">
+                            {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                                currency: lineItem.order.currency.isoCode
+                            } %}
+                        </div>
+                    {% endblock %}
+
+                    {% if showRemoveButton %}
+                        {% block component_line_item_type_discount_col_total_remove %}
+                            <div class="line-item-remove">
+                                {% if lineItem.removable and nestingLevel < 1 %}
+                                    {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
+                                {% endif %}
+                            </div>
+                        {% endblock %}
+                    {% endif %}
                 {% endblock %}
-            {% else %}
-                {% block component_line_item_type_discount_col_unit_price %}
-                    <div class="line-item-unit-price">
-                    </div>
-                {% endblock %}
-            {% endif %}
-
-            {% block component_line_item_type_discount_col_total_price %}
-                <div class="line-item-total-price">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                        currency: lineItem.order.currency.isoCode
-                    } %}
-                </div>
-            {% endblock %}
-
-            {% if showRemoveButton %}
-                {% block component_line_item_type_discount_col_total_remove %}
-                    <div class="line-item-remove">
-                        {% if lineItem.removable and nestingLevel < 1 %}
-                            {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
-                        {% endif %}
-                    </div>
-                {% endblock %}
-            {% endif %}
-        </div>
+            </div>
         {% endblock %}
     {# @deprecated tag:v6.7.0 - Line item wrapper element will be `<li>` element instead of `<div>` #}
     {%- if not feature('ACCESSIBILITY_TWEAKS') -%}

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig
@@ -26,7 +26,7 @@
     {%- else -%}
         <div class="{{ lineItemClasses }}" role="listitem">
     {%- endif -%}
-        {% block component_line_item_type_discount_inner %}
+        {% block component_line_item_type_discount_row %}
             <div class="row line-item-row">
             {% block component_line_item_type_discount_col_info %}
                 <div class="line-item-info">

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/discount.html.twig
@@ -26,35 +26,39 @@
     {%- else -%}
         <div class="{{ lineItemClasses }}" role="listitem">
     {%- endif -%}
-        <div class="row line-item-row">
+        {% block component_line_item_type_discount_inner %}
+            <div class="row line-item-row">
             {% block component_line_item_type_discount_col_info %}
                 <div class="line-item-info">
-                    <div class="row line-item-row">
-
-                        {% if nestingLevel < 1 %}
-                            {% block component_line_item_type_discount_image %}
-                                <div class="col-auto line-item-info-img">
-                                    <div class="line-item-img-container">
-                                        {% block component_line_item_type_discount_image_inner %}
-                                            {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
-                                                fallbackIcon: 'marketing'
-                                            } %}
-                                        {% endblock %}
+                    {% block component_line_item_type_discount_info %}
+                        <div class="row line-item-row">
+                            {% if nestingLevel < 1 %}
+                                {% block component_line_item_type_discount_image %}
+                                    <div class="col-auto line-item-info-img">
+                                        <div class="line-item-img-container">
+                                            {% block component_line_item_type_discount_image_inner %}
+                                                {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
+                                                    fallbackIcon: 'marketing'
+                                                } %}
+                                            {% endblock %}
+                                        </div>
                                     </div>
-                                </div>
-                            {% endblock %}
-                        {% endif %}
+                                {% endblock %}
+                            {% endif %}
 
-                        {% block component_line_item_type_discount_details %}
-                            <div class="line-item-details">
-                                <div class="line-item-details-container">
-                                    {% block component_line_item_type_discount_label %}
-                                        {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
+                            {% block component_line_item_type_discount_details %}
+                                <div class="line-item-details">
+                                    {% block component_line_item_type_discount_details_container %}
+                                        <div class="line-item-details-container">
+                                            {% block component_line_item_type_discount_label %}
+                                                {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
+                                            {% endblock %}
+                                        </div>
                                     {% endblock %}
                                 </div>
-                            </div>
-                        {% endblock %}
-                    </div>
+                            {% endblock %}
+                        </div>
+                    {% endblock %}
                 </div>
             {% endblock %}
 
@@ -96,6 +100,7 @@
                 {% endblock %}
             {% endif %}
         </div>
+        {% endblock %}
     {# @deprecated tag:v6.7.0 - Line item wrapper element will be `<li>` element instead of `<div>` #}
     {%- if not feature('ACCESSIBILITY_TWEAKS') -%}
         </div>

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig
@@ -30,7 +30,7 @@
     {%- else -%}
         <div class="{{ lineItemClasses }}" role="listitem">
     {%- endif -%}
-        {% block component_line_item_type_generic_inner %}
+        {% block component_line_item_type_generic_row %}
             <div class="row line-item-row">
                 {% block component_line_item_type_generic_col_info %}
                     <div class="line-item-info">

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig
@@ -30,120 +30,125 @@
     {%- else -%}
         <div class="{{ lineItemClasses }}" role="listitem">
     {%- endif -%}
-        <div class="row line-item-row">
-            {% block component_line_item_type_generic_col_info %}
-                <div class="line-item-info">
-                    <div class="row line-item-row">
-
-                        {% if nestingLevel < 1 %}
-                            {% block component_line_item_type_generic_image %}
-                                <div class="col-auto line-item-info-img">
-                                    <div class="line-item-img-container">
-                                        {% block component_line_item_type_generic_image_inner %}
-                                            {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' %}
-                                        {% endblock %}
-                                    </div>
-                                </div>
-                            {% endblock %}
-                        {% endif %}
-
-                        {% block component_line_item_type_generic_details %}
-                            <div class="line-item-details">
-                                <div class="line-item-details-container">
-                                    {% block component_line_item_type_generic_label %}
-                                        {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
+        {% block component_line_item_type_generic_inner %}
+            <div class="row line-item-row">
+                {% block component_line_item_type_generic_col_info %}
+                    <div class="line-item-info">
+                        {% block component_line_item_type_generic_info %}
+                            <div class="row line-item-row">
+                                {% if nestingLevel < 1 %}
+                                    {% block component_line_item_type_generic_image %}
+                                        <div class="col-auto line-item-info-img">
+                                            <div class="line-item-img-container">
+                                                {% block component_line_item_type_generic_image_inner %}
+                                                    {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' %}
+                                                {% endblock %}
+                                            </div>
+                                        </div>
                                     {% endblock %}
+                                {% endif %}
 
-                                    {% if lineItem.payload.options is not empty %}
-                                        {% block component_line_item_type_generic_variant_characteristics %}
-                                            {% sw_include '@Storefront/storefront/component/line-item/element/variant-characteristics.html.twig' %}
-                                        {% endblock %}
-                                    {% endif %}
+                                {% block component_line_item_type_generic_details %}
+                                    <div class="line-item-details">
+                                        {% block component_line_item_type_generic_details_container %}
+                                            <div class="line-item-details-container">
+                                                {% block component_line_item_type_generic_label %}
+                                                    {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
+                                                {% endblock %}
 
-                                    {% if lineItem.payload.features is not empty %}
-                                        {% block component_line_item_type_generic_features %}
-                                            {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
-                                                features: lineItem.payload.features
-                                            } %}
-                                        {% endblock %}
-                                    {% endif %}
+                                                {% if lineItem.payload.options is not empty %}
+                                                    {% block component_line_item_type_generic_variant_characteristics %}
+                                                        {% sw_include '@Storefront/storefront/component/line-item/element/variant-characteristics.html.twig' %}
+                                                    {% endblock %}
+                                                {% endif %}
 
-                                    {% if lineItem.payload.productNumber %}
-                                        {% block component_line_item_type_generic_product_number %}
-                                            <div class="line-item-product-number">
-                                                {{ 'checkout.cartItemInfoId'|trans|sw_sanitize }} {{ lineItem.payload.productNumber }}
+                                                {% if lineItem.payload.features is not empty %}
+                                                    {% block component_line_item_type_generic_features %}
+                                                        {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
+                                                            features: lineItem.payload.features
+                                                        } %}
+                                                    {% endblock %}
+                                                {% endif %}
+
+                                                {% if lineItem.payload.productNumber %}
+                                                    {% block component_line_item_type_generic_product_number %}
+                                                        <div class="line-item-product-number">
+                                                            {{ 'checkout.cartItemInfoId'|trans|sw_sanitize }} {{ lineItem.payload.productNumber }}
+                                                        </div>
+                                                    {% endblock %}
+                                                {% endif %}
+
+                                                {% if config('core.cart.showDeliveryTime') %}
+                                                    {% block component_line_item_type_generic_delivery_date %}
+                                                        {% sw_include '@Storefront/storefront/component/line-item/element/delivery-date.html.twig' %}
+                                                    {% endblock %}
+                                                {% endif %}
+
+                                                {% if config('core.cart.wishlistEnabled') %}
+                                                    {% block component_line_item_type_generic_wishlist %}
+                                                        {% sw_include '@Storefront/storefront/component/product/card/wishlist.html.twig' with {
+                                                            showText: true,
+                                                            size: 'sm',
+                                                            productId: lineItem.referencedId
+                                                        } %}
+                                                    {% endblock %}
+                                                {% endif %}
                                             </div>
                                         {% endblock %}
-                                    {% endif %}
-
-                                    {% if config('core.cart.showDeliveryTime') %}
-                                        {% block component_line_item_type_generic_delivery_date %}
-                                            {% sw_include '@Storefront/storefront/component/line-item/element/delivery-date.html.twig' %}
-                                        {% endblock %}
-                                    {% endif %}
-
-                                    {% if config('core.cart.wishlistEnabled') %}
-                                        {% block component_line_item_type_generic_wishlist %}
-                                            {% sw_include '@Storefront/storefront/component/product/card/wishlist.html.twig' with {
-                                                showText: true,
-                                                size: 'sm',
-                                                productId: lineItem.referencedId
-                                            } %}
-                                        {% endblock %}
-                                    {% endif %}
-                                </div>
+                                    </div>
+                                {% endblock %}
                             </div>
                         {% endblock %}
                     </div>
-                </div>
-            {% endblock %}
+                {% endblock %}
 
-            {% block component_line_item_type_generic_col_quantity %}
-                <div class="line-item-quantity">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
-                </div>
-            {% endblock %}
-
-            {% if showTaxPrice %}
-                {% block component_line_item_type_generic_col_tax_price %}
-                    <div class="line-item-tax-price">
-                        {% if context.salesChannel.taxCalculationType == 'horizontal' %}
-                            {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
-                        {% endif %}
+                {% block component_line_item_type_generic_col_quantity %}
+                    <div class="line-item-quantity">
+                        {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
                     </div>
                 {% endblock %}
-            {% else %}
-                {% block component_line_item_type_generic_col_unit_price %}
-                    <div class="line-item-unit-price">
-                        {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
+
+                {% if showTaxPrice %}
+                    {% block component_line_item_type_generic_col_tax_price %}
+                        <div class="line-item-tax-price">
+                            {% if context.salesChannel.taxCalculationType == 'horizontal' %}
+                                {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
+                            {% endif %}
+                        </div>
+                    {% endblock %}
+                {% else %}
+                    {% block component_line_item_type_generic_col_unit_price %}
+                        <div class="line-item-unit-price">
+                            {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
+                        </div>
+                    {% endblock %}
+                {% endif %}
+
+                {% block component_line_item_type_generic_col_total_price %}
+                    <div class="line-item-total-price">
+                        {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                            currency: lineItem.order.currency.isoCode
+                        } %}
                     </div>
                 {% endblock %}
-            {% endif %}
 
-            {% block component_line_item_type_generic_col_total_price %}
-                <div class="line-item-total-price">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                        currency: lineItem.order.currency.isoCode
-                    } %}
-                </div>
-            {% endblock %}
+                {% if showRemoveButton %}
+                    {% block component_line_item_type_generic_col_remove %}
+                        <div class="line-item-remove">
+                            {% if lineItem.removable and nestingLevel < 1 %}
+                                {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
+                            {% endif %}
+                        </div>
+                    {% endblock %}
+                {% endif %}
 
-            {% if showRemoveButton %}
-                {% block component_line_item_type_generic_col_remove %}
-                    <div class="line-item-remove">
-                        {% if lineItem.removable and nestingLevel < 1 %}
-                            {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
-                        {% endif %}
-                    </div>
-                {% endblock %}
-            {% endif %}
-
-            {% if lineItem.children.count > 0 %}
-                {% block component_line_item_type_generic_children %}
-                    {% sw_include '@Storefront/storefront/component/line-item/element/children-wrapper.html.twig' %}
-                {% endblock %}
-            {% endif %}
-        </div>
+                {% if lineItem.children.count > 0 %}
+                    {% block component_line_item_type_generic_children %}
+                        {% sw_include '@Storefront/storefront/component/line-item/element/children-wrapper.html.twig' %}
+                    {% endblock %}
+                {% endif %}
+            </div>
+        {% endblock %}
     {# @deprecated tag:v6.7.0 - Line item wrapper element will be `<li>` element instead of `<div>` #}
     {%- if not feature('ACCESSIBILITY_TWEAKS') -%}
         </div>

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/generic.html.twig
@@ -32,121 +32,123 @@
     {%- endif -%}
         {% block component_line_item_type_generic_row %}
             <div class="row line-item-row">
-                {% block component_line_item_type_generic_col_info %}
-                    <div class="line-item-info">
-                        {% block component_line_item_type_generic_info %}
-                            <div class="row line-item-row">
-                                {% if nestingLevel < 1 %}
-                                    {% block component_line_item_type_generic_image %}
-                                        <div class="col-auto line-item-info-img">
-                                            <div class="line-item-img-container">
-                                                {% block component_line_item_type_generic_image_inner %}
-                                                    {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' %}
-                                                {% endblock %}
-                                            </div>
-                                        </div>
-                                    {% endblock %}
-                                {% endif %}
-
-                                {% block component_line_item_type_generic_details %}
-                                    <div class="line-item-details">
-                                        {% block component_line_item_type_generic_details_container %}
-                                            <div class="line-item-details-container">
-                                                {% block component_line_item_type_generic_label %}
-                                                    {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
-                                                {% endblock %}
-
-                                                {% if lineItem.payload.options is not empty %}
-                                                    {% block component_line_item_type_generic_variant_characteristics %}
-                                                        {% sw_include '@Storefront/storefront/component/line-item/element/variant-characteristics.html.twig' %}
+                {% block component_line_item_type_generic_row_inner %}
+                    {% block component_line_item_type_generic_col_info %}
+                        <div class="line-item-info">
+                            {% block component_line_item_type_generic_info_row %}
+                                <div class="row line-item-row">
+                                    {% if nestingLevel < 1 %}
+                                        {% block component_line_item_type_generic_image %}
+                                            <div class="col-auto line-item-info-img">
+                                                <div class="line-item-img-container">
+                                                    {% block component_line_item_type_generic_image_inner %}
+                                                        {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' %}
                                                     {% endblock %}
-                                                {% endif %}
-
-                                                {% if lineItem.payload.features is not empty %}
-                                                    {% block component_line_item_type_generic_features %}
-                                                        {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
-                                                            features: lineItem.payload.features
-                                                        } %}
-                                                    {% endblock %}
-                                                {% endif %}
-
-                                                {% if lineItem.payload.productNumber %}
-                                                    {% block component_line_item_type_generic_product_number %}
-                                                        <div class="line-item-product-number">
-                                                            {{ 'checkout.cartItemInfoId'|trans|sw_sanitize }} {{ lineItem.payload.productNumber }}
-                                                        </div>
-                                                    {% endblock %}
-                                                {% endif %}
-
-                                                {% if config('core.cart.showDeliveryTime') %}
-                                                    {% block component_line_item_type_generic_delivery_date %}
-                                                        {% sw_include '@Storefront/storefront/component/line-item/element/delivery-date.html.twig' %}
-                                                    {% endblock %}
-                                                {% endif %}
-
-                                                {% if config('core.cart.wishlistEnabled') %}
-                                                    {% block component_line_item_type_generic_wishlist %}
-                                                        {% sw_include '@Storefront/storefront/component/product/card/wishlist.html.twig' with {
-                                                            showText: true,
-                                                            size: 'sm',
-                                                            productId: lineItem.referencedId
-                                                        } %}
-                                                    {% endblock %}
-                                                {% endif %}
+                                                </div>
                                             </div>
                                         {% endblock %}
-                                    </div>
-                                {% endblock %}
+                                    {% endif %}
+
+                                    {% block component_line_item_type_generic_details %}
+                                        <div class="line-item-details">
+                                            {% block component_line_item_type_generic_details_container %}
+                                                <div class="line-item-details-container">
+                                                    {% block component_line_item_type_generic_label %}
+                                                        {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' %}
+                                                    {% endblock %}
+
+                                                    {% if lineItem.payload.options is not empty %}
+                                                        {% block component_line_item_type_generic_variant_characteristics %}
+                                                            {% sw_include '@Storefront/storefront/component/line-item/element/variant-characteristics.html.twig' %}
+                                                        {% endblock %}
+                                                    {% endif %}
+
+                                                    {% if lineItem.payload.features is not empty %}
+                                                        {% block component_line_item_type_generic_features %}
+                                                            {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
+                                                                features: lineItem.payload.features
+                                                            } %}
+                                                        {% endblock %}
+                                                    {% endif %}
+
+                                                    {% if lineItem.payload.productNumber %}
+                                                        {% block component_line_item_type_generic_product_number %}
+                                                            <div class="line-item-product-number">
+                                                                {{ 'checkout.cartItemInfoId'|trans|sw_sanitize }} {{ lineItem.payload.productNumber }}
+                                                            </div>
+                                                        {% endblock %}
+                                                    {% endif %}
+
+                                                    {% if config('core.cart.showDeliveryTime') %}
+                                                        {% block component_line_item_type_generic_delivery_date %}
+                                                            {% sw_include '@Storefront/storefront/component/line-item/element/delivery-date.html.twig' %}
+                                                        {% endblock %}
+                                                    {% endif %}
+
+                                                    {% if config('core.cart.wishlistEnabled') %}
+                                                        {% block component_line_item_type_generic_wishlist %}
+                                                            {% sw_include '@Storefront/storefront/component/product/card/wishlist.html.twig' with {
+                                                                showText: true,
+                                                                size: 'sm',
+                                                                productId: lineItem.referencedId
+                                                            } %}
+                                                        {% endblock %}
+                                                    {% endif %}
+                                                </div>
+                                            {% endblock %}
+                                        </div>
+                                    {% endblock %}
+                                </div>
+                            {% endblock %}
+                        </div>
+                    {% endblock %}
+
+                    {% block component_line_item_type_generic_col_quantity %}
+                        <div class="line-item-quantity">
+                            {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
+                        </div>
+                    {% endblock %}
+
+                    {% if showTaxPrice %}
+                        {% block component_line_item_type_generic_col_tax_price %}
+                            <div class="line-item-tax-price">
+                                {% if context.salesChannel.taxCalculationType == 'horizontal' %}
+                                    {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
+                                {% endif %}
                             </div>
                         {% endblock %}
-                    </div>
-                {% endblock %}
+                    {% else %}
+                        {% block component_line_item_type_generic_col_unit_price %}
+                            <div class="line-item-unit-price">
+                                {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
+                            </div>
+                        {% endblock %}
+                    {% endif %}
 
-                {% block component_line_item_type_generic_col_quantity %}
-                    <div class="line-item-quantity">
-                        {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
-                    </div>
-                {% endblock %}
-
-                {% if showTaxPrice %}
-                    {% block component_line_item_type_generic_col_tax_price %}
-                        <div class="line-item-tax-price">
-                            {% if context.salesChannel.taxCalculationType == 'horizontal' %}
-                                {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
-                            {% endif %}
+                    {% block component_line_item_type_generic_col_total_price %}
+                        <div class="line-item-total-price">
+                            {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                                currency: lineItem.order.currency.isoCode
+                            } %}
                         </div>
                     {% endblock %}
-                {% else %}
-                    {% block component_line_item_type_generic_col_unit_price %}
-                        <div class="line-item-unit-price">
-                            {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
-                        </div>
-                    {% endblock %}
-                {% endif %}
 
-                {% block component_line_item_type_generic_col_total_price %}
-                    <div class="line-item-total-price">
-                        {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                            currency: lineItem.order.currency.isoCode
-                        } %}
-                    </div>
+                    {% if showRemoveButton %}
+                        {% block component_line_item_type_generic_col_remove %}
+                            <div class="line-item-remove">
+                                {% if lineItem.removable and nestingLevel < 1 %}
+                                    {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
+                                {% endif %}
+                            </div>
+                        {% endblock %}
+                    {% endif %}
+
+                    {% if lineItem.children.count > 0 %}
+                        {% block component_line_item_type_generic_children %}
+                            {% sw_include '@Storefront/storefront/component/line-item/element/children-wrapper.html.twig' %}
+                        {% endblock %}
+                    {% endif %}
                 {% endblock %}
-
-                {% if showRemoveButton %}
-                    {% block component_line_item_type_generic_col_remove %}
-                        <div class="line-item-remove">
-                            {% if lineItem.removable and nestingLevel < 1 %}
-                                {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
-                            {% endif %}
-                        </div>
-                    {% endblock %}
-                {% endif %}
-
-                {% if lineItem.children.count > 0 %}
-                    {% block component_line_item_type_generic_children %}
-                        {% sw_include '@Storefront/storefront/component/line-item/element/children-wrapper.html.twig' %}
-                    {% endblock %}
-                {% endif %}
             </div>
         {% endblock %}
     {# @deprecated tag:v6.7.0 - Line item wrapper element will be `<li>` element instead of `<div>` #}

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
@@ -26,129 +26,135 @@
     {%- else -%}
         <div class="{{ lineItemClasses }}" role="listitem">
     {%- endif -%}
-        <div class="row line-item-row">
-            {% block component_line_item_type_product_col_info %}
-                <div class="line-item-info">
-                    <div class="row line-item-row">
-                        {% set showLineItemModal = controllerAction is same as('confirmPage') %}
+        {% block component_line_item_type_product_inner %}
+            <div class="row line-item-row">
+                {% block component_line_item_type_product_col_info %}
+                    <div class="line-item-info">
+                        {% block component_line_item_type_product_info %}
+                            <div class="row line-item-row">
+                                {% set showLineItemModal = controllerAction is same as('confirmPage') %}
 
-                        {% if nestingLevel < 1 %}
-                            {% block component_line_item_type_product_image %}
-                                <div class="col-auto line-item-info-img">
-                                    <div class="line-item-img-container">
-                                        {% block component_line_item_type_product_image_inner %}
-                                            {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
-                                                lineItemLink: displayMode !== 'order' or lineItem.productId ? seoUrl('frontend.detail.page', { productId: lineItem.referencedId }) : null,
-                                                lineItemModalLink: showLineItemModal ? path('widgets.quickview.minimal', { productId: lineItem.referencedId }) : false,
-                                            } %}
+                                {% if nestingLevel < 1 %}
+                                    {% block component_line_item_type_product_image %}
+                                        <div class="col-auto line-item-info-img">
+                                            <div class="line-item-img-container">
+                                                {% block component_line_item_type_product_image_inner %}
+                                                    {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
+                                                        lineItemLink: displayMode !== 'order' or lineItem.productId ? seoUrl('frontend.detail.page', { productId: lineItem.referencedId }) : null,
+                                                        lineItemModalLink: showLineItemModal ? path('widgets.quickview.minimal', { productId: lineItem.referencedId }) : false,
+                                                    } %}
+                                                {% endblock %}
+                                            </div>
+                                        </div>
+                                    {% endblock %}
+                                {% endif %}
+
+                                {% block component_line_item_type_product_details %}
+                                    <div class="line-item-details">
+                                        {% block component_line_item_type_product_details_container %}
+                                            <div class="line-item-details-container">
+                                            {% block component_line_item_type_product_label %}
+                                                {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' with {
+                                                    lineItemLink: displayMode !== 'order' or lineItem.productId ? seoUrl('frontend.detail.page', { productId: lineItem.referencedId }) : null,
+                                                    lineItemModalLink: showLineItemModal ? path('widgets.quickview.minimal', { productId: lineItem.referencedId }) : false,
+                                                } %}
+                                            {% endblock %}
+
+                                            {% if lineItem.payload.options is not empty %}
+                                                {% block component_line_item_type_product_variant_characteristics %}
+                                                    {% sw_include '@Storefront/storefront/component/line-item/element/variant-characteristics.html.twig' %}
+                                                {% endblock %}
+                                            {% endif %}
+
+                                            {% if lineItem.payload.features is not empty %}
+                                                {% block component_line_item_type_product_features %}
+                                                    {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
+                                                        features: lineItem.payload.features
+                                                    } %}
+                                                {% endblock %}
+                                            {% endif %}
+
+                                            {% if lineItem.payload.productNumber %}
+                                                {% block component_line_item_type_product_number %}
+                                                    <div class="line-item-product-number">
+                                                        {{ 'checkout.cartItemInfoId'|trans|sw_sanitize }} {{ lineItem.payload.productNumber }}
+                                                    </div>
+                                                {% endblock %}
+                                            {% endif %}
+
+                                            {% if config('core.cart.showDeliveryTime') %}
+                                                {% block component_line_item_type_product_delivery_date %}
+                                                    {% sw_include '@Storefront/storefront/component/line-item/element/delivery-date.html.twig' %}
+                                                {% endblock %}
+                                            {% endif %}
+
+                                            {% if config('core.cart.wishlistEnabled') %}
+                                                {% block component_line_item_type_product_wishlist %}
+                                                    {% sw_include '@Storefront/storefront/component/product/card/wishlist.html.twig' with {
+                                                        showText: true,
+                                                        size: 'sm',
+                                                        productId: lineItem.referencedId
+                                                    } %}
+                                                {% endblock %}
+                                            {% endif %}
+                                        </div>
                                         {% endblock %}
                                     </div>
-                                </div>
-                            {% endblock %}
-                        {% endif %}
-
-                        {% block component_line_item_type_product_details %}
-                            <div class="line-item-details">
-                                <div class="line-item-details-container">
-                                    {% block component_line_item_type_product_label %}
-                                        {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' with {
-                                            lineItemLink: displayMode !== 'order' or lineItem.productId ? seoUrl('frontend.detail.page', { productId: lineItem.referencedId }) : null,
-                                            lineItemModalLink: showLineItemModal ? path('widgets.quickview.minimal', { productId: lineItem.referencedId }) : false,
-                                        } %}
-                                    {% endblock %}
-
-                                    {% if lineItem.payload.options is not empty %}
-                                        {% block component_line_item_type_product_variant_characteristics %}
-                                            {% sw_include '@Storefront/storefront/component/line-item/element/variant-characteristics.html.twig' %}
-                                        {% endblock %}
-                                    {% endif %}
-
-                                    {% if lineItem.payload.features is not empty %}
-                                        {% block component_line_item_type_product_features %}
-                                            {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
-                                                features: lineItem.payload.features
-                                            } %}
-                                        {% endblock %}
-                                    {% endif %}
-
-                                    {% if lineItem.payload.productNumber %}
-                                        {% block component_line_item_type_product_number %}
-                                            <div class="line-item-product-number">
-                                                {{ 'checkout.cartItemInfoId'|trans|sw_sanitize }} {{ lineItem.payload.productNumber }}
-                                            </div>
-                                        {% endblock %}
-                                    {% endif %}
-
-                                    {% if config('core.cart.showDeliveryTime') %}
-                                        {% block component_line_item_type_product_delivery_date %}
-                                            {% sw_include '@Storefront/storefront/component/line-item/element/delivery-date.html.twig' %}
-                                        {% endblock %}
-                                    {% endif %}
-
-                                    {% if config('core.cart.wishlistEnabled') %}
-                                        {% block component_line_item_type_product_wishlist %}
-                                            {% sw_include '@Storefront/storefront/component/product/card/wishlist.html.twig' with {
-                                                showText: true,
-                                                size: 'sm',
-                                                productId: lineItem.referencedId
-                                            } %}
-                                        {% endblock %}
-                                    {% endif %}
-                                </div>
+                                {% endblock %}
                             </div>
                         {% endblock %}
                     </div>
-                </div>
-            {% endblock %}
+                {% endblock %}
 
-            {% block component_line_item_type_product_col_quantity %}
-                <div class="line-item-quantity">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
-                </div>
-            {% endblock %}
-
-            {% if showTaxPrice %}
-                {% block component_line_item_type_product_col_tax_price %}
-                    <div class="line-item-tax-price">
-                        {% if context.salesChannel.taxCalculationType == 'horizontal' %}
-                            {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
-                        {% endif %}
+                {% block component_line_item_type_product_col_quantity %}
+                    <div class="line-item-quantity">
+                        {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
                     </div>
                 {% endblock %}
-            {% else %}
-                {% block component_line_item_type_product_col_unit_price %}
-                    <div class="line-item-unit-price{% if lineItem.quantity > 1 %} is-shown{% endif %}">
-                        {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
+
+                {% if showTaxPrice %}
+                    {% block component_line_item_type_product_col_tax_price %}
+                        <div class="line-item-tax-price">
+                            {% if context.salesChannel.taxCalculationType == 'horizontal' %}
+                                {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
+                            {% endif %}
+                        </div>
+                    {% endblock %}
+                {% else %}
+                    {% block component_line_item_type_product_col_unit_price %}
+                        <div class="line-item-unit-price{% if lineItem.quantity > 1 %} is-shown{% endif %}">
+                            {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
+                        </div>
+                    {% endblock %}
+                {% endif %}
+
+                {% block component_line_item_type_product_col_total_price %}
+                    <div class="line-item-total-price line-item-price">
+                        {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                            currency: lineItem.order.currency.isoCode
+                        } %}
+                    </div>
+                {% endblock %}
+
+                {% if showRemoveButton %}
+                    {% block component_line_item_type_product_col_remove %}
+                        <div class="line-item-remove">
+                            {% if lineItem.removable and nestingLevel < 1 %}
+                                {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
+                            {% endif %}
+                        </div>
+                    {% endblock %}
+                {% endif %}
+            </div>
+
+            {% if displayMode === 'order' %}
+                {% block component_line_item_type_product_downloads_table %}
+                    <div class="order-detail-content-list">
+                        {% sw_include '@Storefront/storefront/component/line-item/element/downloads.html.twig' %}
                     </div>
                 {% endblock %}
             {% endif %}
-
-            {% block component_line_item_type_product_col_total_price %}
-                <div class="line-item-total-price line-item-price">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                        currency: lineItem.order.currency.isoCode
-                    } %}
-                </div>
-            {% endblock %}
-
-            {% if showRemoveButton %}
-                {% block component_line_item_type_product_col_remove %}
-                    <div class="line-item-remove">
-                        {% if lineItem.removable and nestingLevel < 1 %}
-                            {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
-                        {% endif %}
-                    </div>
-                {% endblock %}
-            {% endif %}
-        </div>
-
-        {% if displayMode === 'order' %}
-            {% block component_line_item_type_product_downloads_table %}
-                <div class="order-detail-content-list">
-                    {% sw_include '@Storefront/storefront/component/line-item/element/downloads.html.twig' %}
-                </div>
-            {% endblock %}
-        {% endif %}
+        {% endblock %}
     {# @deprecated tag:v6.7.0 - Line item wrapper element will be `<li>` element instead of `<div>` #}
     {%- if not feature('ACCESSIBILITY_TWEAKS') -%}
         </div>

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
@@ -36,118 +36,120 @@
                                     <div class="row line-item-row">
                                         {% set showLineItemModal = controllerAction is same as('confirmPage') %}
 
-                                {% if nestingLevel < 1 %}
-                                    {% block component_line_item_type_product_image %}
-                                        <div class="col-auto line-item-info-img">
-                                            <div class="line-item-img-container">
-                                                {% block component_line_item_type_product_image_inner %}
-                                                    {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
-                                                        lineItemLink: displayMode !== 'order' or lineItem.productId ? seoUrl('frontend.detail.page', { productId: lineItem.referencedId }) : null,
-                                                        lineItemModalLink: showLineItemModal ? path('widgets.quickview.minimal', { productId: lineItem.referencedId }) : false,
-                                                    } %}
+                                        {% if nestingLevel < 1 %}
+                                            {% block component_line_item_type_product_image %}
+                                                <div class="col-auto line-item-info-img">
+                                                    <div class="line-item-img-container">
+                                                        {% block component_line_item_type_product_image_inner %}
+                                                            {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
+                                                                lineItemLink: displayMode !== 'order' or lineItem.productId ? seoUrl('frontend.detail.page', { productId: lineItem.referencedId }) : null,
+                                                                lineItemModalLink: showLineItemModal ? path('widgets.quickview.minimal', { productId: lineItem.referencedId }) : false,
+                                                            } %}
+                                                        {% endblock %}
+                                                    </div>
+                                                </div>
+                                            {% endblock %}
+                                        {% endif %}
+
+                                        {% block component_line_item_type_product_details %}
+                                            <div class="line-item-details">
+                                                {% block component_line_item_type_product_details_container %}
+                                                    <div class="line-item-details-container">
+                                                    {% block component_line_item_type_product_label %}
+                                                        {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' with {
+                                                            lineItemLink: displayMode !== 'order' or lineItem.productId ? seoUrl('frontend.detail.page', { productId: lineItem.referencedId }) : null,
+                                                            lineItemModalLink: showLineItemModal ? path('widgets.quickview.minimal', { productId: lineItem.referencedId }) : false,
+                                                        } %}
+                                                    {% endblock %}
+
+                                                    {% if lineItem.payload.options is not empty %}
+                                                        {% block component_line_item_type_product_variant_characteristics %}
+                                                            {% sw_include '@Storefront/storefront/component/line-item/element/variant-characteristics.html.twig' %}
+                                                        {% endblock %}
+                                                    {% endif %}
+
+                                                    {% if lineItem.payload.features is not empty %}
+                                                        {% block component_line_item_type_product_features %}
+                                                            {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
+                                                                features: lineItem.payload.features
+                                                            } %}
+                                                        {% endblock %}
+                                                    {% endif %}
+
+                                                    {% if lineItem.payload.productNumber %}
+                                                        {% block component_line_item_type_product_number %}
+                                                            <div class="line-item-product-number">
+                                                                {{ 'checkout.cartItemInfoId'|trans|sw_sanitize }} {{ lineItem.payload.productNumber }}
+                                                            </div>
+                                                        {% endblock %}
+                                                    {% endif %}
+
+                                                    {% if config('core.cart.showDeliveryTime') %}
+                                                        {% block component_line_item_type_product_delivery_date %}
+                                                            {% sw_include '@Storefront/storefront/component/line-item/element/delivery-date.html.twig' %}
+                                                        {% endblock %}
+                                                    {% endif %}
+
+                                                    {% if config('core.cart.wishlistEnabled') %}
+                                                        {% block component_line_item_type_product_wishlist %}
+                                                            {% sw_include '@Storefront/storefront/component/product/card/wishlist.html.twig' with {
+                                                                showText: true,
+                                                                size: 'sm',
+                                                                productId: lineItem.referencedId
+                                                            } %}
+                                                        {% endblock %}
+                                                    {% endif %}
+                                                </div>
                                                 {% endblock %}
                                             </div>
-                                        </div>
-                                    {% endblock %}
-                                {% endif %}
-
-                                {% block component_line_item_type_product_details %}
-                                    <div class="line-item-details">
-                                        {% block component_line_item_type_product_details_container %}
-                                            <div class="line-item-details-container">
-                                            {% block component_line_item_type_product_label %}
-                                                {% sw_include '@Storefront/storefront/component/line-item/element/label.html.twig' with {
-                                                    lineItemLink: displayMode !== 'order' or lineItem.productId ? seoUrl('frontend.detail.page', { productId: lineItem.referencedId }) : null,
-                                                    lineItemModalLink: showLineItemModal ? path('widgets.quickview.minimal', { productId: lineItem.referencedId }) : false,
-                                                } %}
-                                            {% endblock %}
-
-                                            {% if lineItem.payload.options is not empty %}
-                                                {% block component_line_item_type_product_variant_characteristics %}
-                                                    {% sw_include '@Storefront/storefront/component/line-item/element/variant-characteristics.html.twig' %}
-                                                {% endblock %}
-                                            {% endif %}
-
-                                            {% if lineItem.payload.features is not empty %}
-                                                {% block component_line_item_type_product_features %}
-                                                    {% sw_include '@Storefront/storefront/component/product/feature/list.html.twig' with {
-                                                        features: lineItem.payload.features
-                                                    } %}
-                                                {% endblock %}
-                                            {% endif %}
-
-                                            {% if lineItem.payload.productNumber %}
-                                                {% block component_line_item_type_product_number %}
-                                                    <div class="line-item-product-number">
-                                                        {{ 'checkout.cartItemInfoId'|trans|sw_sanitize }} {{ lineItem.payload.productNumber }}
-                                                    </div>
-                                                {% endblock %}
-                                            {% endif %}
-
-                                            {% if config('core.cart.showDeliveryTime') %}
-                                                {% block component_line_item_type_product_delivery_date %}
-                                                    {% sw_include '@Storefront/storefront/component/line-item/element/delivery-date.html.twig' %}
-                                                {% endblock %}
-                                            {% endif %}
-
-                                            {% if config('core.cart.wishlistEnabled') %}
-                                                {% block component_line_item_type_product_wishlist %}
-                                                    {% sw_include '@Storefront/storefront/component/product/card/wishlist.html.twig' with {
-                                                        showText: true,
-                                                        size: 'sm',
-                                                        productId: lineItem.referencedId
-                                                    } %}
-                                                {% endblock %}
-                                            {% endif %}
-                                        </div>
                                         {% endblock %}
                                     </div>
                                 {% endblock %}
                             </div>
                         {% endblock %}
-                    </div>
-                {% endblock %}
 
-                {% block component_line_item_type_product_col_quantity %}
-                    <div class="line-item-quantity">
-                        {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
-                    </div>
-                {% endblock %}
+                        {% block component_line_item_type_product_col_quantity %}
+                            <div class="line-item-quantity">
+                                {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
+                            </div>
+                        {% endblock %}
 
-                {% if showTaxPrice %}
-                    {% block component_line_item_type_product_col_tax_price %}
-                        <div class="line-item-tax-price">
-                            {% if context.salesChannel.taxCalculationType == 'horizontal' %}
-                                {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
-                            {% endif %}
-                        </div>
+                        {% if showTaxPrice %}
+                            {% block component_line_item_type_product_col_tax_price %}
+                                <div class="line-item-tax-price">
+                                    {% if context.salesChannel.taxCalculationType == 'horizontal' %}
+                                        {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
+                                    {% endif %}
+                                </div>
+                            {% endblock %}
+                        {% else %}
+                            {% block component_line_item_type_product_col_unit_price %}
+                                <div class="line-item-unit-price{% if lineItem.quantity > 1 %} is-shown{% endif %}">
+                                    {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
+                                </div>
+                            {% endblock %}
+                        {% endif %}
+
+                        {% block component_line_item_type_product_col_total_price %}
+                            <div class="line-item-total-price line-item-price">
+                                {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
+                                    currency: lineItem.order.currency.isoCode
+                                } %}
+                            </div>
+                        {% endblock %}
+
+                        {% if showRemoveButton %}
+                            {% block component_line_item_type_product_col_remove %}
+                                <div class="line-item-remove">
+                                    {% if lineItem.removable and nestingLevel < 1 %}
+                                        {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
+                                    {% endif %}
+                                </div>
+                            {% endblock %}
+                        {% endif %}
                     {% endblock %}
-                {% else %}
-                    {% block component_line_item_type_product_col_unit_price %}
-                        <div class="line-item-unit-price{% if lineItem.quantity > 1 %} is-shown{% endif %}">
-                            {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
-                        </div>
-                    {% endblock %}
-                {% endif %}
-
-                {% block component_line_item_type_product_col_total_price %}
-                    <div class="line-item-total-price line-item-price">
-                        {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
-                            currency: lineItem.order.currency.isoCode
-                        } %}
-                    </div>
-                {% endblock %}
-
-                {% if showRemoveButton %}
-                    {% block component_line_item_type_product_col_remove %}
-                        <div class="line-item-remove">
-                            {% if lineItem.removable and nestingLevel < 1 %}
-                                {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
-                            {% endif %}
-                        </div>
-                    {% endblock %}
-                {% endif %}
-            </div>
+                </div>
+            {% endblock %}
 
             {% if displayMode === 'order' %}
                 {% block component_line_item_type_product_downloads_table %}

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
@@ -27,12 +27,14 @@
         <div class="{{ lineItemClasses }}" role="listitem">
     {%- endif -%}
         {% block component_line_item_type_product_inner %}
-            <div class="row line-item-row">
-                {% block component_line_item_type_product_col_info %}
-                    <div class="line-item-info">
-                        {% block component_line_item_type_product_info %}
-                            <div class="row line-item-row">
-                                {% set showLineItemModal = controllerAction is same as('confirmPage') %}
+            {% block component_line_item_type_product_row %}
+                <div class="row line-item-row">
+                    {% block component_line_item_type_product_row_inner %}
+                        {% block component_line_item_type_product_col_info %}
+                            <div class="line-item-info">
+                                {% block component_line_item_type_product_info_row %}
+                                    <div class="row line-item-row">
+                                        {% set showLineItemModal = controllerAction is same as('confirmPage') %}
 
                                 {% if nestingLevel < 1 %}
                                     {% block component_line_item_type_product_image %}


### PR DESCRIPTION
### 1. Why is this change necessary?

Rows, and other elements, inside the line-item component were not wrapped in a TWIG-blocks making it very difficult to add new elements or changing the order of elements.

You usually have to override multiple and entire line-item layouts to add an element, because the last blocks are conditional.

For example if you wanted to add a text to the bottom of a line-item, you couldn't use the last block inside the row because its wrapped in an `if`-statement.
This breaks inheritance with multiple plugins overriding the same block.

Example of adding an element before this change:

```
{% block component_line_item_type_discount %}
    <div class="{{ lineItemClasses }}">
        <div class="row line-item-row">
            {% block component_line_item_type_discount_col_info %}
                {{ parent() }}
            {% endblock %}

            {% block component_line_item_type_discount_col_quantity %}
                {{ parent() }}
            {% endblock %}

            ...

            {% if showRemoveButton %}
                {% block component_line_item_type_discount_col_total_remove %}
                    {{ parent() }}
                {% endblock %}
            {% endif %}

            {# my custom element #}
            <div>...</div>
        </div>
    </div>
{% endblock %}
```

After this change:

```
{% block component_line_item_type_discount_row_inner %}
    {{ parent() }}

    {# my custom element #}
    <div>...</div>
{% endblock %}
```


### 2. What does this change do, exactly?
 
Add more TWIG blocks to line-item templates.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
