### PR TITLE
Added twig extension which allows to trigger twig profiles

### DIFF
--- a/changelog/_unreleased/2024-10-24-added-twig-profiling-extension.md
+++ b/changelog/_unreleased/2024-10-24-added-twig-profiling-extension.md
@@ -1,0 +1,10 @@
+---
+title: Added twig profiling extension
+issue: 
+author: Oliver Skroblin
+author_email: oliver@goblin-coders.de
+author_github: OliverSkroblin
+---
+# Core
+* Added `{% profile #name# %}` and `{% endprofile %}` twig nodes to start and stop the profiles within twig rendering
+* Added new `{{ profiler_start }}` and `{{ profiler_stop }}` twig functions to start and stop the profiles within twig rendering 

--- a/src/Core/Profiling/DependencyInjection/services.xml
+++ b/src/Core/Profiling/DependencyInjection/services.xml
@@ -49,6 +49,11 @@
             />
         </service>
 
+        <service id="Shopware\Core\Profiling\Twig\ProfilerExtension">
+            <tag name="twig.extension"/>
+            <argument type="service" id="slugify"/>
+        </service>
+
         <service id="Shopware\Core\Profiling\Twig\DoctrineExtension" public="false">
             <tag name="twig.extension" />
         </service>

--- a/src/Core/Profiling/Twig/ProfileNode.php
+++ b/src/Core/Profiling/Twig/ProfileNode.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Shopware\Core\Profiling\Twig;
+
+use Twig\Compiler;
+use Twig\Node\Node;
+use Twig\Attribute\YieldReady;
+
+#[YieldReady]
+class ProfileNode extends Node
+{
+    public function __construct($name, Node $body, $line, $tag = null)
+    {
+        parent::__construct(['body' => $body], ['name' => $name], $line, $tag);
+    }
+
+    public function compile(Compiler $compiler)
+    {
+        $profileName = $this->getAttribute('name');
+
+        $compiler
+            ->addDebugInfo($this)
+            ->write("\Shopware\Core\Profiling\Profiler::start('{$profileName}', 'sw-template', []);\n")
+            ->subcompile($this->getNode('body'))
+            ->write("\Shopware\Core\Profiling\Profiler::stop('{$profileName}');\n")
+        ;
+    }
+}

--- a/src/Core/Profiling/Twig/ProfileTokenParser.php
+++ b/src/Core/Profiling/Twig/ProfileTokenParser.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Shopware\Core\Profiling\Twig;
+
+use Twig\Token;
+use Twig\TokenParser\AbstractTokenParser;
+
+class ProfileTokenParser extends AbstractTokenParser
+{
+    public function parse(Token $token)
+    {
+        $stream = $this->parser->getStream();
+
+        $profileName = $stream->expect(Token::NAME_TYPE)->getValue();
+
+        $stream->expect(Token::BLOCK_END_TYPE);
+
+        $body = $this->parser->subparse([$this, 'decideProfileEnd'], true);
+
+        $stream->expect(Token::BLOCK_END_TYPE);
+
+        return new ProfileNode($profileName, $body, $token->getLine(), $this->getTag());
+    }
+
+    public function decideProfileEnd(Token $token)
+    {
+        return $token->test('endprofile');
+    }
+
+    public function getTag()
+    {
+        return 'profile';
+    }
+}

--- a/src/Core/Profiling/Twig/ProfilerExtension.php
+++ b/src/Core/Profiling/Twig/ProfilerExtension.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Profiling\Twig;
+
+use Cocur\Slugify\Slugify;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Profiling\Profiler;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+#[Package('core')]
+class ProfilerExtension extends AbstractExtension
+{
+    public function __construct(private readonly Slugify $slugify)
+    {
+    }
+
+    public function getTokenParsers(): array
+    {
+        return [new ProfileTokenParser()];
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('profiler_start', $this->start(...)),
+            new TwigFunction('profiler_stop', $this->stop(...)),
+        ];
+    }
+
+    public function start(?string $title, string $category = 'sw-template'): void
+    {
+        if ($title === null) {
+            return;
+        }
+        Profiler::start(title: $this->slugify($title), category: $category, tags: []);
+    }
+
+    public function stop(?string $title): void
+    {
+        if ($title === null) {
+            return;
+        }
+        Profiler::stop(title: $this->slugify($title));
+    }
+
+    private function slugify(string $title): string
+    {
+        return strtolower($this->slugify->slugify($title));
+    }
+}

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -1,136 +1,148 @@
-{# Set variable to "true" to enable HMR (hot page reloading) mode #}
-{% set isHMRMode = app.request.headers.get('hot-reload-mode') and app.environment == 'dev' %}
+{% profile base %}
+    {# Set variable to "true" to enable HMR (hot page reloading) mode #}
+    {% set isHMRMode = app.request.headers.get('hot-reload-mode') and app.environment == 'dev' %}
 
-{% block base_doctype %}
-<!DOCTYPE html>
-{% endblock %}
-
-{% block base_html %}
-<html lang="{{ page.header.activeLanguage.translationCode.code }}"
-      itemscope="itemscope"
-      itemtype="https://schema.org/WebPage">
-{% endblock %}
-
-{% block base_head %}
-    {% sw_include '@Storefront/storefront/layout/meta.html.twig' %}
-{% endblock %}
-
-{% block base_body %}
-    <body class="{% block base_body_classes %}is-ctl-{% if controllerName is not empty %}{{ controllerName|lower }}{% endif %} is-act-{% if controllerAction is not empty %}{{ controllerAction|lower }}{% endif %}{% endblock %}">
-
-    {% block base_body_skip_to_content %}
-        <div class="skip-to-content bg-primary-subtle text-primary-emphasis visually-hidden-focusable overflow-hidden">
-            <div class="container d-flex justify-content-center">
-                <a href="#content-main" class="skip-to-content-link d-inline-flex text-decoration-underline m-1 p-2 fw-bold gap-2">
-                    {{ 'general.skipToContentLink'|trans|sw_sanitize }}
-                </a>
-            </div>
-        </div>
+    {% block base_doctype %}
+    <!DOCTYPE html>
     {% endblock %}
 
-    {% block base_body_inner %}
-        {% block base_noscript %}
-            <noscript class="noscript-main">
-                {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
-                    type: 'info',
-                    content: 'general.noscriptNotice'|trans|sw_sanitize,
-                    iconCache: false
-                } %}
-            </noscript>
-        {% endblock %}
+    {% block base_html %}
+    <html lang="{{ page.header.activeLanguage.translationCode.code }}"
+          itemscope="itemscope"
+          itemtype="https://schema.org/WebPage">
+    {% endblock %}
 
-        {% block base_header %}
-            {% sw_include '@Storefront/storefront/utilities/staging-info.html.twig' %}
+    {% block base_head %}
+        {% sw_include '@Storefront/storefront/layout/meta.html.twig' %}
+    {% endblock %}
 
-            <header class="header-main">
-                {% block base_header_inner %}
-                    <div class="container">
-                        {% sw_include '@Storefront/storefront/layout/header/header.html.twig' %}
-                    </div>
-                {% endblock %}
-            </header>
-        {% endblock %}
+    {% block base_body %}
+        <body class="{% block base_body_classes %}is-ctl-{% if controllerName is not empty %}{{ controllerName|lower }}{% endif %} is-act-{% if controllerAction is not empty %}{{ controllerAction|lower }}{% endif %}{% endblock %}">
 
-        {% block base_navigation %}
-            {% if feature('v6.7.0.0') %}
-                <div class="nav-main d-none d-lg-block">
-                    {% block base_navbar_inner %}
-                        {% sw_include '@Storefront/storefront/layout/navbar/navbar.html.twig' %}
-                    {% endblock %}
+        {% block base_body_skip_to_content %}
+            <div class="skip-to-content bg-primary-subtle text-primary-emphasis visually-hidden-focusable overflow-hidden">
+                <div class="container d-flex justify-content-center">
+                    <a href="#content-main" class="skip-to-content-link d-inline-flex text-decoration-underline m-1 p-2 fw-bold gap-2">
+                        {{ 'general.skipToContentLink'|trans|sw_sanitize }}
+                    </a>
                 </div>
-            {% else %}
-                {# @deprecated tag:v6.7.0 - This template will be removed, use src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig #}
-                <div class="nav-main">
-                    {% block base_navigation_inner %}
-                        {% sw_include '@Storefront/storefront/layout/navigation/navigation.html.twig' %}
-                    {% endblock %}
-                </div>
-            {% endif %}
+            </div>
         {% endblock %}
 
-        {% block base_offcanvas_navigation %}
-            {% if page.header.navigation %}
-                <div class="d-none js-navigation-offcanvas-initial-content{% if context.salesChannel.navigationCategoryId == page.header.navigation.active.id %} is-root{% endif %}">
-                    {% block base_offcanvas_navigation_inner %}
-                        {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/navigation.html.twig' with { navigation: page.header.navigation } %}
-                    {% endblock %}
-                </div>
-            {% endif %}
-        {% endblock %}
+        {% block base_body_inner %}
+            {% block base_noscript %}
+                <noscript class="noscript-main">
+                    {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
+                        type: 'info',
+                        content: 'general.noscriptNotice'|trans|sw_sanitize,
+                        iconCache: false
+                    } %}
+                </noscript>
+            {% endblock %}
 
-        {% block base_main %}
-            <main class="content-main" id="content-main">
-                {% block base_flashbags %}
-                    <div class="flashbags container">
-                        {% for type, messages in app.flashes %}
-                            {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: type, list: messages } %}
-                        {% endfor %}
-                    </div>
-                {% endblock %}
+            {% profile base_header %}
+                {% block base_header %}
+                    {% sw_include '@Storefront/storefront/utilities/staging-info.html.twig' %}
 
-                {% block base_main_inner %}
-                    <div class="container">
-                        {% block base_main_container %}
-                            <div class="container-main">
-                                {% block base_breadcrumb %}
-                                    {% sw_include '@Storefront/storefront/layout/breadcrumb.html.twig' with {
-                                        context: context,
-                                        themeIconConfig: themeIconConfig,
-                                        category: page.product.seoCategory
-                                    } only %}
-                                {% endblock %}
-
-                                {% block base_content %}{% endblock %}
+                    <header class="header-main">
+                        {% block base_header_inner %}
+                            <div class="container">
+                                {% sw_include '@Storefront/storefront/layout/header/header.html.twig' %}
                             </div>
                         {% endblock %}
-                    </div>
+                    </header>
                 {% endblock %}
-            </main>
+            {% endprofile %}
+
+            {% profile base_navigation %}
+                {% block base_navigation %}
+                    {% if feature('v6.7.0.0') %}
+                        <div class="nav-main d-none d-lg-block">
+                            {% block base_navbar_inner %}
+                                {% sw_include '@Storefront/storefront/layout/navbar/navbar.html.twig' %}
+                            {% endblock %}
+                        </div>
+                    {% else %}
+                        {# @deprecated tag:v6.7.0 - This template will be removed, use src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig #}
+                        <div class="nav-main">
+                            {% block base_navigation_inner %}
+                                {% sw_include '@Storefront/storefront/layout/navigation/navigation.html.twig' %}
+                            {% endblock %}
+                        </div>
+                    {% endif %}
+                {% endblock %}
+            {% endprofile %}
+
+            {% profile base_offcanvas_navigation %}
+                {% block base_offcanvas_navigation %}
+                    {% if page.header.navigation %}
+                        <div class="d-none js-navigation-offcanvas-initial-content{% if context.salesChannel.navigationCategoryId == page.header.navigation.active.id %} is-root{% endif %}">
+                            {% block base_offcanvas_navigation_inner %}
+                                {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/navigation.html.twig' with { navigation: page.header.navigation } %}
+                            {% endblock %}
+                        </div>
+                    {% endif %}
+                {% endblock %}
+            {% endprofile %}
+
+            {% profile base_main %}
+                {% block base_main %}
+                    <main class="content-main" id="content-main">
+                        {% block base_flashbags %}
+                            <div class="flashbags container">
+                                {% for type, messages in app.flashes %}
+                                    {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with { type: type, list: messages } %}
+                                {% endfor %}
+                            </div>
+                        {% endblock %}
+
+                        {% block base_main_inner %}
+                            <div class="container">
+                                {% block base_main_container %}
+                                    <div class="container-main">
+                                        {% block base_breadcrumb %}
+                                            {% sw_include '@Storefront/storefront/layout/breadcrumb.html.twig' with {
+                                                context: context,
+                                                themeIconConfig: themeIconConfig,
+                                                category: page.product.seoCategory
+                                            } only %}
+                                        {% endblock %}
+
+                                        {% block base_content %}{% endblock %}
+                                    </div>
+                                {% endblock %}
+                            </div>
+                        {% endblock %}
+                    </main>
+                {% endblock %}
+            {% endprofile %}
+
+            {% profile base_footer %}
+                {% block base_footer %}
+                    <footer class="footer-main">
+                        {% block base_footer_inner %}
+                            {% sw_include '@Storefront/storefront/layout/footer/footer.html.twig' %}
+                        {% endblock %}
+                    </footer>
+                {% endblock %}
+            {% endprofile %}
         {% endblock %}
 
-        {% block base_footer %}
-            <footer class="footer-main">
-                {% block base_footer_inner %}
-                    {% sw_include '@Storefront/storefront/layout/footer/footer.html.twig' %}
-                {% endblock %}
-            </footer>
+        {% block base_scroll_up %}
+            {% sw_include '@Storefront/storefront/layout/scroll-up.html.twig' %}
         {% endblock %}
-    {% endblock %}
 
-    {% block base_scroll_up %}
-        {% sw_include '@Storefront/storefront/layout/scroll-up.html.twig' %}
-    {% endblock %}
+        {% block base_cookie_permission %}
+            {% sw_include '@Storefront/storefront/layout/cookie/cookie-permission.html.twig' %}
+        {% endblock %}
 
-    {% block base_cookie_permission %}
-        {% sw_include '@Storefront/storefront/layout/cookie/cookie-permission.html.twig' %}
-    {% endblock %}
+        {% block base_pseudo_modal %}
+            {% sw_include '@Storefront/storefront/component/pseudo-modal.html.twig' %}
+        {% endblock %}
 
-    {% block base_pseudo_modal %}
-        {% sw_include '@Storefront/storefront/component/pseudo-modal.html.twig' %}
+        {% block base_body_script %}
+        {% endblock %}
+        </body>
     {% endblock %}
-
-    {% block base_body_script %}
-    {% endblock %}
-    </body>
-{% endblock %}
-</html>
+    </html>
+{% endprofile %}

--- a/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
@@ -1,118 +1,122 @@
-{% block component_filter_panel %}
-    {% block component_filter_panel_header %}
-        <div class="filter-panel-offcanvas-header">
-            <div class="filter-panel-offcanvas-only filter-panel-offcanvas-title">{{ "listing.filterTitleText"|trans }}</div>
+{% profile component_filter_panel %}
+    {% block component_filter_panel %}
+        {% block component_filter_panel_header %}
+            <div class="filter-panel-offcanvas-header">
+                <div class="filter-panel-offcanvas-only filter-panel-offcanvas-title">{{ "listing.filterTitleText"|trans }}</div>
 
-            <button type="button" class="btn-close filter-panel-offcanvas-only filter-panel-offcanvas-close js-offcanvas-close" aria-label="{{ 'listing.filterClose'|trans|striptags }}">
-            </button>
-        </div>
-    {% endblock %}
+                <button type="button" class="btn-close filter-panel-offcanvas-only filter-panel-offcanvas-close js-offcanvas-close" aria-label="{{ 'listing.filterClose'|trans|striptags }}">
+                </button>
+            </div>
+        {% endblock %}
 
-    {# @var listing \Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult #}
-    {% block component_filter_panel_element %}
-        <div class="filter-panel{% if sidebar %} is--sidebar{% endif %}" aria-label="{{ 'listing.filterTitleText'|trans|sw_sanitize }}">
-            {% block component_filter_panel_items_container %}
-                <div class="filter-panel-items-container" role="list">
-                    {% block component_filter_panel_items %}
+        {# @var listing \Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult #}
+        {% block component_filter_panel_element %}
+            <div class="filter-panel{% if sidebar %} is--sidebar{% endif %}" aria-label="{{ 'listing.filterTitleText'|trans|sw_sanitize }}">
+                {% block component_filter_panel_items_container %}
+                    <div class="filter-panel-items-container" role="list">
+                        {% block component_filter_panel_items %}
 
-                        {% block component_filter_panel_item_manufacturer %}
-                            {# @var manufacturers \Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult #}
-                            {% set manufacturers = listing.aggregations.get('manufacturer') %}
-                            {% if not manufacturers.entities is empty %}
-                                {% set manufacturersSorted = manufacturers.entities|sort((a, b) => a.translated.name|lower <=> b.translated.name|lower) %}
+                            {% block component_filter_panel_item_manufacturer %}
+                                {# @var manufacturers \Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult #}
+                                {% set manufacturers = listing.aggregations.get('manufacturer') %}
+                                {% if not manufacturers.entities is empty %}
+                                    {% set manufacturersSorted = manufacturers.entities|sort((a, b) => a.translated.name|lower <=> b.translated.name|lower) %}
 
-                                {% sw_include '@Storefront/storefront/component/listing/filter/filter-multi-select.html.twig' with {
-                                    elements: manufacturersSorted,
-                                    sidebar: sidebar,
-                                    name: 'manufacturer',
-                                    displayName: 'listing.filterManufacturerDisplayName'|trans|sw_sanitize,
-                                    ariaLabel: 'listing.filterByManufacturerAriaLabel'|trans|sw_sanitize
-                                } %}
-                            {% endif %}
-                        {% endblock %}
-
-                        {% block component_filter_panel_item_properties %}
-                            {# @var properties \Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult #}
-                            {% set properties = listing.aggregations.get('properties') %}
-
-                            {% if not properties.entities is empty %}
-                                {% for property in properties.entities %}
-                                    {% sw_include '@Storefront/storefront/component/listing/filter/filter-property-select.html.twig' with {
-                                        elements: property.options,
+                                    {% sw_include '@Storefront/storefront/component/listing/filter/filter-multi-select.html.twig' with {
+                                        elements: manufacturersSorted,
                                         sidebar: sidebar,
-                                        name: 'properties',
-                                        displayName: property.translated.name,
-                                        displayType: property.displayType,
-                                        pluginSelector: 'filter-property-select',
-                                        propertyName: property.translated.name,
-                                        ariaLabel: 'listing.filterByAriaLabel'|trans({'%name%': property.translated.name})|sw_sanitize
+                                        name: 'manufacturer',
+                                        displayName: 'listing.filterManufacturerDisplayName'|trans|sw_sanitize,
+                                        ariaLabel: 'listing.filterByManufacturerAriaLabel'|trans|sw_sanitize
                                     } %}
-                                {% endfor %}
-                            {% endif %}
+                                {% endif %}
+                            {% endblock %}
+
+                            {% profile component_filter_panel_properties %}
+                                {% block component_filter_panel_item_properties %}
+                                    {# @var properties \Shopware\Core\Framework\DataAbstractionLayer\Search\AggregationResult\Metric\EntityResult #}
+                                    {% set properties = listing.aggregations.get('properties') %}
+
+                                    {% if not properties.entities is empty %}
+                                        {% for property in properties.entities %}
+                                            {% sw_include '@Storefront/storefront/component/listing/filter/filter-property-select.html.twig' with {
+                                                elements: property.options,
+                                                sidebar: sidebar,
+                                                name: 'properties',
+                                                displayName: property.translated.name,
+                                                displayType: property.displayType,
+                                                pluginSelector: 'filter-property-select',
+                                                propertyName: property.translated.name,
+                                                ariaLabel: 'listing.filterByAriaLabel'|trans({'%name%': property.translated.name})|sw_sanitize
+                                            } %}
+                                        {% endfor %}
+                                    {% endif %}
+                                {% endblock %}
+                            {% endprofile %}
+
+                            {% block component_filter_panel_item_price %}
+                                {% set price = listing.aggregations.get('price') %}
+
+                                {% if price.min !== null and price.max !== null %}
+                                    {% sw_include '@Storefront/storefront/component/listing/filter/filter-range.html.twig' with {
+                                        sidebar: sidebar,
+                                        name: 'price',
+                                        minKey: 'min-price',
+                                        maxKey: 'max-price',
+                                        lowerBound: 0,
+                                        displayName: 'listing.filterPriceDisplayName'|trans|sw_sanitize,
+                                        minInputValue: 0,
+                                        maxInputValue: price.max,
+                                        ariaLabel: 'listing.filterByPriceAriaLabel'|trans|sw_sanitize
+                                    } %}
+                                {% endif %}
+                            {% endblock %}
+
+                            {% block component_filter_panel_item_rating_select %}
+                                {% set rating = listing.aggregations.get('rating') %}
+
+                                {% if rating.max > 0 %}
+                                    {% sw_include '@Storefront/storefront/component/listing/filter/filter-rating-select.html.twig' with {
+                                        sidebar: sidebar,
+                                        name: 'rating',
+                                        pluginSelector: 'filter-rating-select',
+                                        displayName: 'listing.filterRatingDisplayName'|trans|sw_sanitize,
+                                        ariaLabel: 'listing.filterByRatingAriaLabel'|trans|sw_sanitize
+                                    } %}
+                                {% endif %}
+                            {% endblock %}
+
+                            {% block component_filter_panel_item_shipping_free %}
+                                {% set shippingFree = listing.aggregations.get('shipping-free') %}
+
+                                {% if shippingFree.max > 0 %}
+                                    {% sw_include '@Storefront/storefront/component/listing/filter/filter-boolean.html.twig' with {
+                                        name: 'shipping-free',
+                                        displayName: 'listing.filterFreeShippingDisplayName'|trans|sw_sanitize,
+                                        altText: 'listing.filterFreeShippingAltText'|trans|sw_sanitize,
+                                        altTextActive: 'listing.filterFreeShippingAltTextActive'|trans|sw_sanitize,
+                                    } %}
+                                {% endif %}
+                            {% endblock %}
                         {% endblock %}
-
-                        {% block component_filter_panel_item_price %}
-                            {% set price = listing.aggregations.get('price') %}
-
-                            {% if price.min !== null and price.max !== null %}
-                                {% sw_include '@Storefront/storefront/component/listing/filter/filter-range.html.twig' with {
-                                    sidebar: sidebar,
-                                    name: 'price',
-                                    minKey: 'min-price',
-                                    maxKey: 'max-price',
-                                    lowerBound: 0,
-                                    displayName: 'listing.filterPriceDisplayName'|trans|sw_sanitize,
-                                    minInputValue: 0,
-                                    maxInputValue: price.max,
-                                    ariaLabel: 'listing.filterByPriceAriaLabel'|trans|sw_sanitize
-                                } %}
-                            {% endif %}
-                        {% endblock %}
-
-                        {% block component_filter_panel_item_rating_select %}
-                            {% set rating = listing.aggregations.get('rating') %}
-
-                            {% if rating.max > 0 %}
-                                {% sw_include '@Storefront/storefront/component/listing/filter/filter-rating-select.html.twig' with {
-                                    sidebar: sidebar,
-                                    name: 'rating',
-                                    pluginSelector: 'filter-rating-select',
-                                    displayName: 'listing.filterRatingDisplayName'|trans|sw_sanitize,
-                                    ariaLabel: 'listing.filterByRatingAriaLabel'|trans|sw_sanitize
-                                } %}
-                            {% endif %}
-                        {% endblock %}
-
-                        {% block component_filter_panel_item_shipping_free %}
-                            {% set shippingFree = listing.aggregations.get('shipping-free') %}
-
-                            {% if shippingFree.max > 0 %}
-                                {% sw_include '@Storefront/storefront/component/listing/filter/filter-boolean.html.twig' with {
-                                    name: 'shipping-free',
-                                    displayName: 'listing.filterFreeShippingDisplayName'|trans|sw_sanitize,
-                                    altText: 'listing.filterFreeShippingAltText'|trans|sw_sanitize,
-                                    altTextActive: 'listing.filterFreeShippingAltTextActive'|trans|sw_sanitize,
-                                } %}
-                            {% endif %}
-                        {% endblock %}
-                    {% endblock %}
-                </div>
-            {% endblock %}
-
-            {% block component_filter_panel_active_container %}
-                <div class="filter-panel-active-container">
-                    {% block component_filter_panel_active_container_inner %}{% endblock %}
-                </div>
-            {% endblock %}
-
-            {# Aria live region to tell the screen reader how many product results are shown after a filter was selected or deselected. #}
-            {% block component_filter_panel_aria_live %}
-                {% if ariaLiveUpdates %}
-                    <div class="filter-panel-aria-live visually-hidden" aria-live="polite" aria-atomic="true">
-                        {# The live region content is generated by the `ListingPlugin` #}
                     </div>
-                {% endif %}
-            {% endblock %}
-        </div>
-     {% endblock %}
-{% endblock %}
+                {% endblock %}
+
+                {% block component_filter_panel_active_container %}
+                    <div class="filter-panel-active-container">
+                        {% block component_filter_panel_active_container_inner %}{% endblock %}
+                    </div>
+                {% endblock %}
+
+                {# Aria live region to tell the screen reader how many product results are shown after a filter was selected or deselected. #}
+                {% block component_filter_panel_aria_live %}
+                    {% if ariaLiveUpdates %}
+                        <div class="filter-panel-aria-live visually-hidden" aria-live="polite" aria-atomic="true">
+                            {# The live region content is generated by the `ListingPlugin` #}
+                        </div>
+                    {% endif %}
+                {% endblock %}
+            </div>
+         {% endblock %}
+    {% endblock %}
+{% endprofile %}

--- a/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
@@ -1,137 +1,141 @@
-{# @deprecated tag:v6.7.0 - variable `currentPage` will be removed #}
-{% if not feature('v6.7.0.0') %}
-    {% set currentPage = searchResult.page %}
-{% endif %}
+{% profile product_listing %}
+    {# @deprecated tag:v6.7.0 - variable `currentPage` will be removed #}
+    {% if not feature('v6.7.0.0') %}
+        {% set currentPage = searchResult.page %}
+    {% endif %}
 
-{# @deprecated tag:v6.7.0 - variable `paginationConfig` will not be json encoded #}
-{% if feature('v6.7.0.0') %}
-    {% set paginationConfig = { page: searchResult.page } %}
-{% else %}
-    {% set paginationConfig = { page: searchResult.page }|json_encode %}
-{% endif %}
+    {# @deprecated tag:v6.7.0 - variable `paginationConfig` will not be json encoded #}
+    {% if feature('v6.7.0.0') %}
+        {% set paginationConfig = { page: searchResult.page } %}
+    {% else %}
+        {% set paginationConfig = { page: searchResult.page }|json_encode %}
+    {% endif %}
 
 
-{% if disableEmptyFilter is not defined %}
-    {% set disableEmptyFilter = config('core.listing.disableEmptyFilterOptions') %}
-{% endif %}
+    {% if disableEmptyFilter is not defined %}
+        {% set disableEmptyFilter = config('core.listing.disableEmptyFilterOptions') %}
+    {% endif %}
 
-{% set listingPagination = {
-    sidebar: sidebar,
-    params: params,
-    dataUrl: dataUrl,
-    filterUrl: filterUrl,
-    disableEmptyFilter: disableEmptyFilter,
-    ariaLiveUpdates: ariaLiveUpdates,
-    snippets: {
-        resetAllButtonText: 'listing.filterPanelResetAll'|trans|sw_sanitize,
-        resetAllFiltersAriaLabel: 'listing.filterResetAllAriaLabel'|trans|sw_sanitize,
-        removeFilterAriaLabel: 'listing.filterRemoveAriaLabel'|trans|sw_sanitize
-    }
-} %}
+    {% set listingPagination = {
+        sidebar: sidebar,
+        params: params,
+        dataUrl: dataUrl,
+        filterUrl: filterUrl,
+        disableEmptyFilter: disableEmptyFilter,
+        ariaLiveUpdates: ariaLiveUpdates,
+        snippets: {
+            resetAllButtonText: 'listing.filterPanelResetAll'|trans|sw_sanitize,
+            resetAllFiltersAriaLabel: 'listing.filterResetAllAriaLabel'|trans|sw_sanitize,
+            removeFilterAriaLabel: 'listing.filterRemoveAriaLabel'|trans|sw_sanitize
+        }
+    } %}
 
-{% block product_listing %}
-    <div class="cms-element-product-listing-wrapper"
-         data-listing-pagination="true"
-        {% if feature('v6.7.0.0') %}
-         data-listing-pagination-options="{{ paginationConfig|json_encode }}"
-        {% else %}
-         {# ludtwig-ignore html-string-quotation #}
-         data-listing-pagination-options='{{ paginationConfig }}'
-        {% endif %}
-         data-listing="true"
-         data-listing-options="{{ listingPagination|json_encode }}">
-        {% block element_product_listing_wrapper_content %}
-            <div class="cms-element-product-listing">
-                {% if searchResult.total > 0 %}
-                    {% block element_product_listing_pagination_nav_actions %}
-                        <div class="cms-element-product-listing-actions row justify-content-between">
-                            <div class="col-md-auto">
-                                {% block element_product_listing_pagination_nav_top %}
-                                    {# @deprecated tag:v6.7.0 - variable `criteria` will be removed #}
-                                    {% if feature('v6.7.0.0') %}
-                                        {% sw_include '@Storefront/storefront/component/pagination.html.twig' with {
-                                            entities: searchResult,
-                                            fallbackUrl: paginationFallbackUrl,
-                                            paginationLocation: 'top',
-                                        } %}
-                                    {% else %}
-                                        {% sw_include '@Storefront/storefront/component/pagination.html.twig' with {
-                                            entities: searchResult,
-                                            criteria: searchResult.criteria,
-                                            paginationLocation: feature('ACCESSIBILITY_TWEAKS') ? 'top' : null,
-                                        } %}
-                                    {% endif %}
-                                {% endblock %}
-                            </div>
-
-                            <div class="col-md-auto">
-                                {% block element_product_listing_sorting %}
-                                    {% sw_include '@Storefront/storefront/component/sorting.html.twig' with {
-                                        current: searchResult.sorting,
-                                        sortings: searchResult.availableSortings
-                                    } %}
-                                {% endblock %}
-                            </div>
-                        </div>
-                    {% endblock %}
-                {% endif %}
-
-                {% block element_product_listing_row %}
-                    {% set ariaLiveText %}{% apply spaceless %}
-                        {% if searchResult.total > searchResult.limit %}
-                            {{ 'listing.filterPanelAriaLivePaginated'|trans({'%count%': searchResult.entities.elements|length, '%total%': searchResult.total})|sw_sanitize }}
-                        {% else %}
-                            {{ 'listing.filterPanelAriaLive'|trans({'%count%': searchResult.total})|sw_sanitize }}
-                        {% endif %}
-                    {% endapply %}{% endset %}
-
-                    <div class="row cms-listing-row js-listing-wrapper" data-aria-live-text="{{ ariaLiveText }}"{% if searchResult.total > 0 %} role="list"{% endif %}>
-                        {% if searchResult.total > 0 %}
-                            {% block element_product_listing_col %}
-                                {% for product in searchResult %}
-                                    <div class="cms-listing-col {{ listingColumns }}" role="listitem">
-                                        {% block element_product_listing_box %}
-                                            {% sw_include '@Storefront/storefront/component/product/card/box.html.twig' with {
-                                                layout: boxLayout,
-                                                displayMode: displayMode
+    {% block product_listing %}
+        <div class="cms-element-product-listing-wrapper"
+             data-listing-pagination="true"
+            {% if feature('v6.7.0.0') %}
+             data-listing-pagination-options="{{ paginationConfig|json_encode }}"
+            {% else %}
+             {# ludtwig-ignore html-string-quotation #}
+             data-listing-pagination-options='{{ paginationConfig }}'
+            {% endif %}
+             data-listing="true"
+             data-listing-options="{{ listingPagination|json_encode }}">
+            {% block element_product_listing_wrapper_content %}
+                <div class="cms-element-product-listing">
+                    {% if searchResult.total > 0 %}
+                        {% block element_product_listing_pagination_nav_actions %}
+                            <div class="cms-element-product-listing-actions row justify-content-between">
+                                <div class="col-md-auto">
+                                    {% block element_product_listing_pagination_nav_top %}
+                                        {# @deprecated tag:v6.7.0 - variable `criteria` will be removed #}
+                                        {% if feature('v6.7.0.0') %}
+                                            {% sw_include '@Storefront/storefront/component/pagination.html.twig' with {
+                                                entities: searchResult,
+                                                fallbackUrl: paginationFallbackUrl,
+                                                paginationLocation: 'top',
                                             } %}
-                                        {% endblock %}
-                                    </div>
-                                {% endfor %}
-                            {% endblock %}
-                        {% else %}
-                            {% block element_product_listing_col_empty %}
-                                <div class="cms-listing-col col-12">
-                                    {% block element_product_listing_col_empty_alert %}
-                                        {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
-                                            type: 'info',
-                                            content: 'listing.emptyResultMessage'|trans|sw_sanitize
+                                        {% else %}
+                                            {% sw_include '@Storefront/storefront/component/pagination.html.twig' with {
+                                                entities: searchResult,
+                                                criteria: searchResult.criteria,
+                                                paginationLocation: feature('ACCESSIBILITY_TWEAKS') ? 'top' : null,
+                                            } %}
+                                        {% endif %}
+                                    {% endblock %}
+                                </div>
+
+                                <div class="col-md-auto">
+                                    {% block element_product_listing_sorting %}
+                                        {% sw_include '@Storefront/storefront/component/sorting.html.twig' with {
+                                            current: searchResult.sorting,
+                                            sortings: searchResult.availableSortings
                                         } %}
                                     {% endblock %}
                                 </div>
-                            {% endblock %}
-                        {% endif %}
-                    </div>
-                {% endblock %}
+                            </div>
+                        {% endblock %}
+                    {% endif %}
 
-                {% if searchResult.total > searchResult.limit %}
-                    {% block element_product_listing_pagination_nav_bottom %}
-                        {# @deprecated tag:v6.7.0 - variable `criteria` will be removed #}
-                        {% if feature('v6.7.0.0') %}
-                            {% sw_include '@Storefront/storefront/component/pagination.html.twig' with {
-                                entities: searchResult,
-                                paginationLocation: 'bottom',
-                            } %}
-                        {% else %}
-                            {% sw_include '@Storefront/storefront/component/pagination.html.twig' with {
-                                entities: searchResult,
-                                criteria: searchResult.criteria,
-                                paginationLocation: 'bottom',
-                            } %}
-                        {% endif %}
+                    {% block element_product_listing_row %}
+                        {% set ariaLiveText %}{% apply spaceless %}
+                            {% if searchResult.total > searchResult.limit %}
+                                {{ 'listing.filterPanelAriaLivePaginated'|trans({'%count%': searchResult.entities.elements|length, '%total%': searchResult.total})|sw_sanitize }}
+                            {% else %}
+                                {{ 'listing.filterPanelAriaLive'|trans({'%count%': searchResult.total})|sw_sanitize }}
+                            {% endif %}
+                        {% endapply %}{% endset %}
+
+                        <div class="row cms-listing-row js-listing-wrapper" data-aria-live-text="{{ ariaLiveText }}"{% if searchResult.total > 0 %} role="list"{% endif %}>
+                            {% if searchResult.total > 0 %}
+                                {% profile product_boxes %}
+                                    {% block element_product_listing_col %}
+                                        {% for product in searchResult %}
+                                            <div class="cms-listing-col {{ listingColumns }}" role="listitem">
+                                                {% block element_product_listing_box %}
+                                                    {% sw_include '@Storefront/storefront/component/product/card/box.html.twig' with {
+                                                        layout: boxLayout,
+                                                        displayMode: displayMode
+                                                    } %}
+                                                {% endblock %}
+                                            </div>
+                                        {% endfor %}
+                                    {% endblock %}
+                                {% endprofile %}
+                            {% else %}
+                                {% block element_product_listing_col_empty %}
+                                    <div class="cms-listing-col col-12">
+                                        {% block element_product_listing_col_empty_alert %}
+                                            {% sw_include '@Storefront/storefront/utilities/alert.html.twig' with {
+                                                type: 'info',
+                                                content: 'listing.emptyResultMessage'|trans|sw_sanitize
+                                            } %}
+                                        {% endblock %}
+                                    </div>
+                                {% endblock %}
+                            {% endif %}
+                        </div>
                     {% endblock %}
-                {% endif %}
-            </div>
-        {% endblock %}
-    </div>
-{% endblock %}
+
+                    {% if searchResult.total > searchResult.limit %}
+                        {% block element_product_listing_pagination_nav_bottom %}
+                            {# @deprecated tag:v6.7.0 - variable `criteria` will be removed #}
+                            {% if feature('v6.7.0.0') %}
+                                {% sw_include '@Storefront/storefront/component/pagination.html.twig' with {
+                                    entities: searchResult,
+                                    paginationLocation: 'bottom',
+                                } %}
+                            {% else %}
+                                {% sw_include '@Storefront/storefront/component/pagination.html.twig' with {
+                                    entities: searchResult,
+                                    criteria: searchResult.criteria,
+                                    paginationLocation: 'bottom',
+                                } %}
+                            {% endif %}
+                        {% endblock %}
+                    {% endif %}
+                </div>
+            {% endblock %}
+        </div>
+    {% endblock %}
+{% endprofile %}

--- a/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
@@ -1,59 +1,61 @@
-{% block layout_breadcrumb_inner %}
-    {% if category %}
-        {% set breadcrumbCategories = sw_breadcrumb_full(category, context.context) %}
-        {% set categoryId = category.id %}
+{% profile layout_breadcrumb %}
+    {% block layout_breadcrumb_inner %}
+        {% if category %}
+            {% set breadcrumbCategories = sw_breadcrumb_full(category, context.context) %}
+            {% set categoryId = category.id %}
 
-        {% set breadcrumbKeys = breadcrumbCategories|keys %}
+            {% set breadcrumbKeys = breadcrumbCategories|keys %}
 
-        {% if breadcrumbCategories|length > 0 %}
-            <nav aria-label="breadcrumb">
-                {% block layout_breadcrumb_list %}
-                    <ol class="breadcrumb"
-                        itemscope
-                        itemtype="https://schema.org/BreadcrumbList">
-                        {% for breadcrumbCategory in breadcrumbCategories %}
-                            {% set key = breadcrumbCategory.id %}
-                            {% set name = breadcrumbCategory.translated.name %}
+            {% if breadcrumbCategories|length > 0 %}
+                <nav aria-label="breadcrumb">
+                    {% block layout_breadcrumb_list %}
+                        <ol class="breadcrumb"
+                            itemscope
+                            itemtype="https://schema.org/BreadcrumbList">
+                            {% for breadcrumbCategory in breadcrumbCategories %}
+                                {% set key = breadcrumbCategory.id %}
+                                {% set name = breadcrumbCategory.translated.name %}
 
-                            {% block layout_breadcrumb_list_item %}
-                                <li class="breadcrumb-item"
-                                    {% if key is same as(categoryId) %}aria-current="page"{% endif %}
-                                    itemprop="itemListElement"
-                                    itemscope
-                                    itemtype="https://schema.org/ListItem">
-                                    {% if breadcrumbCategory.type == 'folder' %}
-                                        <div itemprop="item">
-                                            <div itemprop="name">{{ name }}</div>
+                                {% block layout_breadcrumb_list_item %}
+                                    <li class="breadcrumb-item"
+                                        {% if key is same as(categoryId) %}aria-current="page"{% endif %}
+                                        itemprop="itemListElement"
+                                        itemscope
+                                        itemtype="https://schema.org/ListItem">
+                                        {% if breadcrumbCategory.type == 'folder' %}
+                                            <div itemprop="item">
+                                                <div itemprop="name">{{ name }}</div>
+                                            </div>
+                                        {% else %}
+                                            <a href="{{ category_url(breadcrumbCategory) }}"
+                                               class="breadcrumb-link {% if key is same as(categoryId) %} is-active{% endif %}"
+                                               title="{{ name }}"
+                                               {% if category_linknewtab(breadcrumbCategory) %}target="_blank"{% endif %}
+                                               itemprop="item">
+                                                <link itemprop="url"
+                                                      href="{{ category_url(breadcrumbCategory) }}">
+                                                <span class="breadcrumb-title" itemprop="name">{{ name }}</span>
+                                            </a>
+                                        {% endif %}
+                                        <meta itemprop="position" content="{{ loop.index }}">
+                                    </li>
+                                {% endblock %}
+
+                                {% block layout_breadcrumb_placeholder %}
+                                    {% if key != breadcrumbKeys|last %}
+                                        <div
+                                            class="breadcrumb-placeholder"
+                                            aria-hidden="true"
+                                        >
+                                            {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid'} %}
                                         </div>
-                                    {% else %}
-                                        <a href="{{ category_url(breadcrumbCategory) }}"
-                                           class="breadcrumb-link {% if key is same as(categoryId) %} is-active{% endif %}"
-                                           title="{{ name }}"
-                                           {% if category_linknewtab(breadcrumbCategory) %}target="_blank"{% endif %}
-                                           itemprop="item">
-                                            <link itemprop="url"
-                                                  href="{{ category_url(breadcrumbCategory) }}">
-                                            <span class="breadcrumb-title" itemprop="name">{{ name }}</span>
-                                        </a>
                                     {% endif %}
-                                    <meta itemprop="position" content="{{ loop.index }}">
-                                </li>
-                            {% endblock %}
-
-                            {% block layout_breadcrumb_placeholder %}
-                                {% if key != breadcrumbKeys|last %}
-                                    <div
-                                        class="breadcrumb-placeholder"
-                                        aria-hidden="true"
-                                    >
-                                        {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid'} %}
-                                    </div>
-                                {% endif %}
-                            {% endblock %}
-                        {% endfor %}
-                    </ol>
-                {% endblock %}
-            </nav>
+                                {% endblock %}
+                            {% endfor %}
+                        </ol>
+                    {% endblock %}
+                </nav>
+            {% endif %}
         {% endif %}
-    {% endif %}
-{% endblock %}
+    {% endblock %}
+{% endprofile %}

--- a/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/header.html.twig
@@ -1,17 +1,22 @@
 {% block layout_header %}
-    {% block layout_top_bar %}
-        {% sw_include '@Storefront/storefront/layout/header/top-bar.html.twig' %}
-    {% endblock %}
+    {% profile layout_top_bar %}
+        {% block layout_top_bar %}
+            {% sw_include '@Storefront/storefront/layout/header/top-bar.html.twig' %}
+        {% endblock %}
+    {% endprofile %}
 
     {% block layout_header_navigation %}
         <div class="row align-items-center header-row">
-            {% block layout_header_logo %}
-                <div class="col-12 col-lg-auto header-logo-col">
-                    {% sw_include '@Storefront/storefront/layout/header/logo.html.twig' %}
-                </div>
-            {% endblock %}
+            {% profile layout_header_logo %}
+                {% block layout_header_logo %}
+                    <div class="col-12 col-lg-auto header-logo-col">
+                        {% sw_include '@Storefront/storefront/layout/header/logo.html.twig' %}
+                    </div>
+                {% endblock %}
+            {% endprofile %}
 
-            {% block layout_header_search %}
+            {% profile layout_header_search %}
+                {% block layout_header_search %}
                 <div class="col-12 order-2 col-sm order-sm-1 header-search-col">
                     <div class="row">
                         <div class="col-sm-auto d-none d-sm-block d-lg-none">
@@ -38,84 +43,95 @@
                     </div>
                 </div>
             {% endblock %}
+            {% endprofile %}
 
             {% block layout_header_actions %}
                 <div class="col-12 order-1 col-sm-auto order-sm-2 header-actions-col">
                     <div class="row g-0">
-                        {% block layout_header_navigation_toggle %}
-                            <div class="col d-sm-none">
-                                <div class="menu-button">
-                                    {% block layout_header_navigation_toggle_button %}
-                                        <button
-                                            class="btn nav-main-toggle-btn header-actions-btn"
-                                            type="button"
-                                            data-off-canvas-menu="true"
-                                            aria-label="{{ 'general.menuLink'|trans|striptags }}"
-                                        >
-                                            {% block layout_header_navigation_toggle_button_icon %}
-                                                {% sw_icon 'stack' %}
-                                            {% endblock %}
-                                        </button>
-                                    {% endblock %}
+                        {% profile layout_header_navigation_toggle %}
+                            {% block layout_header_navigation_toggle %}
+                                <div class="col d-sm-none">
+                                    <div class="menu-button">
+                                        {% block layout_header_navigation_toggle_button %}
+                                            <button
+                                                class="btn nav-main-toggle-btn header-actions-btn"
+                                                type="button"
+                                                data-off-canvas-menu="true"
+                                                aria-label="{{ 'general.menuLink'|trans|striptags }}"
+                                            >
+                                                {% block layout_header_navigation_toggle_button_icon %}
+                                                    {% sw_icon 'stack' %}
+                                                {% endblock %}
+                                            </button>
+                                        {% endblock %}
+                                    </div>
                                 </div>
-                            </div>
-                        {% endblock %}
+                            {% endblock %}
+                        {% endprofile %}
 
-                        {% block layout_header_search_toggle %}
-                            <div class="col-auto d-sm-none">
-                                <div class="search-toggle">
-                                    <button class="btn header-actions-btn search-toggle-btn js-search-toggle-btn collapsed"
-                                            type="button"
-                                            data-bs-toggle="collapse"
-                                            data-bs-target="#searchCollapse"
-                                            aria-expanded="false"
-                                            aria-controls="searchCollapse"
-                                            aria-label="{{ 'header.searchButton'|trans|striptags }}">
-                                        {% sw_icon 'search' %}
-                                    </button>
+                        {% profile layout_header_search_toggle %}
+                            {% block layout_header_search_toggle %}
+                                <div class="col-auto d-sm-none">
+                                    <div class="search-toggle">
+                                        <button class="btn header-actions-btn search-toggle-btn js-search-toggle-btn collapsed"
+                                                type="button"
+                                                data-bs-toggle="collapse"
+                                                data-bs-target="#searchCollapse"
+                                                aria-expanded="false"
+                                                aria-controls="searchCollapse"
+                                                aria-label="{{ 'header.searchButton'|trans|striptags }}">
+                                            {% sw_icon 'search' %}
+                                        </button>
+                                    </div>
                                 </div>
-                            </div>
-                        {% endblock %}
+                            {% endblock %}
+                        {% endprofile %}
 
                         {% if config('core.cart.wishlistEnabled') %}
-                            {% block layout_header_actions_wishlist %}
+                            {% profile layout_header_actions_wishlist %}
+                                {% block layout_header_actions_wishlist %}
+                                    <div class="col-auto">
+                                        <div class="header-wishlist">
+                                            <a class="btn header-wishlist-btn header-actions-btn"
+                                               href="{{ path('frontend.wishlist.page') }}"
+                                               title="{{ 'header.wishlist'|trans|striptags }}"
+                                               aria-label="{{ 'header.wishlist'|trans|striptags }}">
+                                                {% sw_include '@Storefront/storefront/layout/header/actions/wishlist-widget.html.twig' %}
+                                            </a>
+                                        </div>
+                                    </div>
+                                {% endblock %}
+                            {% endprofile %}
+                        {% endif %}
+
+                        {% profile layout_header_actions_account %}
+                            {% block layout_header_actions_account %}
                                 <div class="col-auto">
-                                    <div class="header-wishlist">
-                                        <a class="btn header-wishlist-btn header-actions-btn"
-                                           href="{{ path('frontend.wishlist.page') }}"
-                                           title="{{ 'header.wishlist'|trans|striptags }}"
-                                           aria-label="{{ 'header.wishlist'|trans|striptags }}">
-                                            {% sw_include '@Storefront/storefront/layout/header/actions/wishlist-widget.html.twig' %}
+                                    <div class="account-menu">
+                                        {% sw_include '@Storefront/storefront/layout/header/actions/account-widget.html.twig' %}
+                                    </div>
+                                </div>
+                            {% endblock %}
+                        {% endprofile %}
+
+                        {% profile layout_header_actions_cart %}
+                            {% block layout_header_actions_cart %}
+                                <div class="col-auto">
+                                    <div
+                                        class="header-cart"
+                                        data-off-canvas-cart="true"
+                                    >
+                                        <a class="btn header-cart-btn header-actions-btn"
+                                           href="{{ path('frontend.checkout.cart.page') }}"
+                                           data-cart-widget="true"
+                                           title="{{ 'checkout.cartTitle'|trans|striptags }}"
+                                           aria-label="{{ 'checkout.cartTitle'|trans|striptags }}">
+                                            {% sw_include '@Storefront/storefront/layout/header/actions/cart-widget.html.twig' %}
                                         </a>
                                     </div>
                                 </div>
                             {% endblock %}
-                        {% endif %}
-
-                        {% block layout_header_actions_account %}
-                            <div class="col-auto">
-                                <div class="account-menu">
-                                    {% sw_include '@Storefront/storefront/layout/header/actions/account-widget.html.twig' %}
-                                </div>
-                            </div>
-                        {% endblock %}
-
-                        {% block layout_header_actions_cart %}
-                            <div class="col-auto">
-                                <div
-                                    class="header-cart"
-                                    data-off-canvas-cart="true"
-                                >
-                                    <a class="btn header-cart-btn header-actions-btn"
-                                       href="{{ path('frontend.checkout.cart.page') }}"
-                                       data-cart-widget="true"
-                                       title="{{ 'checkout.cartTitle'|trans|striptags }}"
-                                       aria-label="{{ 'checkout.cartTitle'|trans|striptags }}">
-                                        {% sw_include '@Storefront/storefront/layout/header/actions/cart-widget.html.twig' %}
-                                    </a>
-                                </div>
-                            </div>
-                        {% endblock %}
+                        {% endprofile %}
                     </div>
                 </div>
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/sidebar/category-navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/sidebar/category-navigation.html.twig
@@ -42,7 +42,7 @@
                                     <span class="category-navigation-link">{{ item.category.translated.name }}</span>
                                 {% endblock %}
                             {% else %}
-                                {% block layout_navigation_categories_link %}                        
+                                {% block layout_navigation_categories_link %}
                                     <a class="category-navigation-link{% if item.category.id is same as(activeResult.id) %} is-active{% endif %}"
                                         href="{{ category_url(item.category) }}"
                                         {% if category_linknewtab(item.category) %}target="_blank"{% endif %}>

--- a/src/Storefront/Resources/views/storefront/page/content/detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/detail.html.twig
@@ -1,50 +1,51 @@
-{# @var cmsPage \Shopware\Core\Content\Cms\CmsPageEntity #}
+{% profile page_content_sections_inner %}
+    {# @var cmsPage \Shopware\Core\Content\Cms\CmsPageEntity #}
+    {# @var landingPage \Shopware\Core\Content\LandingPage\LandingPageEntity #}
+    {% block page_content_sections_inner %}
+        <div class="cms-sections">
+            {% for section in cmsPage.sections %}
+                {% set sectionBgColor = section.backgroundColor %}
+                {% set sectionBgImg = section.backgroundMedia|sw_encode_media_url %}
+                {% set sectionBgImgMode = section.backgroundMediaMode %}
 
-{# @var landingPage \Shopware\Core\Content\LandingPage\LandingPageEntity #}
-{% block page_content_sections_inner %}
-    <div class="cms-sections">
-        {% for section in cmsPage.sections %}
-            {% set sectionBgColor = section.backgroundColor %}
-            {% set sectionBgImg = section.backgroundMedia|sw_encode_media_url %}
-            {% set sectionBgImgMode = section.backgroundMediaMode %}
+                {% set sectionClasses = [section.cssClass, 'pos-' ~ section.position, 'cms-section-' ~ section.type] %}
 
-            {% set sectionClasses = [section.cssClass, 'pos-' ~ section.position, 'cms-section-' ~ section.type] %}
+                {% if sectionBgImg %}
+                    {% set sectionClasses = ['bg-image']|merge(sectionClasses) %}
+                {% endif %}
 
-            {% if sectionBgImg %}
-                {% set sectionClasses = ['bg-image']|merge(sectionClasses) %}
-            {% endif %}
+                {% if sectionBgColor %}
+                    {% set sectionClasses = ['bg-color']|merge(sectionClasses) %}
+                {% endif %}
 
-            {% if sectionBgColor %}
-                {% set sectionClasses = ['bg-color']|merge(sectionClasses) %}
-            {% endif %}
+                {% if section.visibility is null %}
+                    {% set visibility = {
+                        mobile: true,
+                        tablet: true,
+                        desktop: true
+                    } %}
+                {% else %}
+                    {% set visibility = section.visibility %}
+                {% endif %}
 
-            {% if section.visibility is null %}
-                {% set visibility = {
-                    mobile: true,
-                    tablet: true,
-                    desktop: true
-                } %}
-            {% else %}
-                {% set visibility = section.visibility %}
-            {% endif %}
+                {% if not visibility.mobile %}
+                    {% set sectionClasses = ['hidden-mobile']|merge(sectionClasses) %}
+                {% endif %}
+                {% if not visibility.tablet %}
+                    {% set sectionClasses = ['hidden-tablet']|merge(sectionClasses) %}
+                {% endif %}
+                {% if not visibility.desktop %}
+                    {% set sectionClasses = ['hidden-desktop']|merge(sectionClasses) %}
+                {% endif %}
 
-            {% if not visibility.mobile %}
-                {% set sectionClasses = ['hidden-mobile']|merge(sectionClasses) %}
-            {% endif %}
-            {% if not visibility.tablet %}
-                {% set sectionClasses = ['hidden-tablet']|merge(sectionClasses) %}
-            {% endif %}
-            {% if not visibility.desktop %}
-                {% set sectionClasses = ['hidden-desktop']|merge(sectionClasses) %}
-            {% endif %}
+                {% block page_content_section %}
+                    <div class="cms-section {{ sectionClasses|join(' ') }}"
+                         style="{% if sectionBgColor %}background-color: {{ sectionBgColor }};{% endif %}{% if sectionBgImg %}background-image: url({{ sectionBgImg }});background-size: {{ section.backgroundMediaMode }};{% endif %}">
 
-            {% block page_content_section %}
-                <div class="cms-section {{ sectionClasses|join(' ') }}"
-                     style="{% if sectionBgColor %}background-color: {{ sectionBgColor }};{% endif %}{% if sectionBgImg %}background-image: url({{ sectionBgImg }});background-size: {{ section.backgroundMediaMode }};{% endif %}">
-
-                    {% sw_include '@Storefront/storefront/section/cms-section-' ~ section.type ~ '.html.twig' %}
-                </div>
-            {% endblock %}
-        {% endfor %}
-    </div>
-{% endblock %}
+                        {% sw_include '@Storefront/storefront/section/cms-section-' ~ section.type ~ '.html.twig' %}
+                    </div>
+                {% endblock %}
+            {% endfor %}
+        </div>
+    {% endblock %}
+{% endprofile %}

--- a/src/Storefront/Resources/views/storefront/section/cms-section-block-container.html.twig
+++ b/src/Storefront/Resources/views/storefront/section/cms-section-block-container.html.twig
@@ -68,7 +68,11 @@
                  style="{% if padding %}padding: {{ padding }};{% endif %}">
                 {% block section_content_block_row %}
                     <div class="cms-block-container-row row cms-row {{ sidebarClasses }}">
+                        {{ profiler_start('cms_block_' ~ block.name) }}
+
                         {% sw_include '@Storefront/storefront/block/cms-block-' ~ block.type ~ '.html.twig' ignore missing %}
+
+                        {{ profiler_stop('cms_block_' ~ block.name) }}
                     </div>
                 {% endblock %}
             </div>

--- a/src/Storefront/Resources/views/storefront/section/cms-section-default.html.twig
+++ b/src/Storefront/Resources/views/storefront/section/cms-section-default.html.twig
@@ -4,7 +4,11 @@
     <div class="cms-section-default {{ layout }}">
         {% for block in section.blocks %}
             {% block section_default_content_block %}
+                {{ profiler_start('cms_block_' ~ block.name) }}
+
                 {% sw_include '@Storefront/storefront/section/cms-section-block-container.html.twig' %}
+
+                {{ profiler_stop('cms_block_' ~ block.name) }}
             {% endblock %}
         {% endfor %}
     </div>

--- a/src/Storefront/Resources/views/storefront/section/cms-section-sidebar.html.twig
+++ b/src/Storefront/Resources/views/storefront/section/cms-section-sidebar.html.twig
@@ -13,7 +13,11 @@
 
                 {% for block in sidebarBlocks %}
                     {% block section_sidebar_content_block %}
+                        {{ profiler_start('cms_block_' ~ block.name) }}
+
                         {% sw_include '@Storefront/storefront/section/cms-section-block-container.html.twig' %}
+
+                        {{ profiler_stop('cms_block_' ~ block.name) }}
                     {% endblock %}
                 {% endfor %}
             </div>
@@ -24,7 +28,11 @@
 
                 {% for block in mainContentBlocks %}
                     {% block section_main_content_block %}
+                        {{ profiler_start('cms_block_' ~ block.name) }}
+
                         {% sw_include '@Storefront/storefront/section/cms-section-block-container.html.twig' %}
+
+                        {{ profiler_stop('cms_block_' ~ block.name) }}
                     {% endblock %}
                 {% endfor %}
             </div>


### PR DESCRIPTION
Since the YIELD change in Twig, the different blocks are no longer displayed in the various profilers, making it difficult to track which parts are consuming significant rendering time. That's why I implemented this function, which triggers the already existing profiler extension from Shopware and forwards this debug information to the configured profiler integrations.

## Symfony profiler bar
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/138dd0eb-0147-4008-93b6-9f9b23ae25f5">


## Tideways
<img width="836" alt="image" src="https://github.com/user-attachments/assets/a78fd550-deee-4a26-a8a6-a21b3b1e226e">
