### PR TITLE
feat: removed sizes from the meta apple-touch-icon

### DIFF
--- a/changelog/_unreleased/2024-10-24-removed-sites-from-apple-touch-icon.md
+++ b/changelog/_unreleased/2024-10-24-removed-sites-from-apple-touch-icon.md
@@ -1,0 +1,17 @@
+---
+title: Removed sites from apple-touch-icon
+issue: NEXT-39257
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Administration
+
+* Changed the meta apple-touch-icon to have no sizes attribute because there is none
+
+___
+# Storefront
+
+* Changed the meta apple-touch-icon to have no sizes attribute because there is none
+

--- a/src/Administration/Resources/views/administration/layout/base.html.twig
+++ b/src/Administration/Resources/views/administration/layout/base.html.twig
@@ -11,7 +11,7 @@
     {% endblock %}
 
     {% block administration_favicons %}
-        <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('static/img/favicon/apple-touch-icon.png', '@Administration') }}">
+        <link rel="apple-touch-icon" href="{{ asset('static/img/favicon/apple-touch-icon.png', '@Administration') }}">
         <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('static/img/favicon/favicon-16x16.png', '@Administration') }}">
         <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('static/img/favicon/favicon-32x32.png', '@Administration') }}" id="dynamic-favicon">
         <link rel="icon" type="image/png" sizes="192x192" href="{{ asset('static/img/favicon/android-chrome-192x192.png', '@Administration') }}">

--- a/src/Storefront/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/meta.html.twig
@@ -91,7 +91,6 @@
         {% block layout_head_apple %}
             {% if theme_config('sw-logo-share') %}
             <link rel="apple-touch-icon"
-                  sizes="180x180"
                   href="{{ theme_config('sw-logo-share') }}">
             {% endif %}
         {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
see #5281
see https://webhint.io/docs/user-guide/hints/hint-apple-touch-icons/#:~:text=When%20using%20one%20image%2C%20there%20is%20no%20need%20to%20use%20the

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.
see #5281

### 4. Please link to the relevant issues (if any).
#5281

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
