### PR TITLE
feat: Add rule for requested customer group

### DIFF
--- a/changelog/_unreleased/2024-10-24-add-rule-for-requested-customer-group.md
+++ b/changelog/_unreleased/2024-10-24-add-rule-for-requested-customer-group.md
@@ -1,0 +1,14 @@
+---
+title: Add rule for requested customer group
+issue: NEXT-00000
+author: Robin Homberg
+author_email: robin.homberg@flagbit.de
+author_github: @robin-homberg
+---
+# Administration
+* Changed `src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.ts` to make CustomerRequestedGroupRule available in Administration
+* Changed administration snippets to add translations for CustomerRequestedGroupRule
+___
+# Core
+* Added `src/Core/Checkout/Customer/Rule/CustomerRequestedGroupRule.php` to create new Rule conditions using customers requestedCustomerGroup
+* Changed `src/Core/Checkout/DependencyInjection/rule.xml` to register CustomerRequestedGroupRule

--- a/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.ts
+++ b/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.ts
@@ -84,6 +84,12 @@ Application.addServiceProviderDecorator('ruleConditionDataProviderService', (rul
         scopes: ['checkout'],
         group: 'customer',
     });
+    ruleConditionService.addCondition('customerRequestedCustomerGroup', {
+        component: 'sw-condition-generic',
+        label: 'global.sw-condition.condition.customerRequestedGroupRule',
+        scopes: ['checkout'],
+        group: 'customer',
+    });
     ruleConditionService.addCondition('customerTag', {
         component: 'sw-condition-generic',
         label: 'global.sw-condition.condition.customerTagRule',

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -661,6 +661,7 @@
         "billingStateRule": "Rechnungsadresse: Bundesland",
         "billingZipCodeRule": "Rechnungsadresse: Postleitzahl",
         "customerGroupRule": "Kundengruppe",
+        "customerRequestedGroupRule": "Angefragte Kundengruppe",
         "customerTagRule": "Kunde mit Tag",
         "customerNumberRule": "Kundennummer",
         "differentAddressesRule": "Kunde mit abweichender Lieferadresse",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -661,6 +661,7 @@
         "billingStateRule": "Billing address: State",
         "billingZipCodeRule": "Billing address: Postal code",
         "customerGroupRule": "Customer group",
+        "customerRequestedGroupRule": "Requested customer group",
         "customerTagRule": "Customer with tag",
         "customerNumberRule": "Customer number",
         "differentAddressesRule": "Customer with deviating shipping address",

--- a/src/Core/Checkout/Customer/Rule/CustomerRequestedGroupRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerRequestedGroupRule.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Customer\Rule;
+
+use Shopware\Core\Checkout\CheckoutRuleScope;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupDefinition;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleComparison;
+use Shopware\Core\Framework\Rule\RuleConfig;
+use Shopware\Core\Framework\Rule\RuleConstraints;
+use Shopware\Core\Framework\Rule\RuleScope;
+
+#[Package('services-settings')]
+class CustomerRequestedGroupRule extends Rule
+{
+    final public const RULE_NAME = 'customerRequestedCustomerGroup';
+
+    /**
+     * @internal
+     *
+     * @param list<string>|null $customerGroupIds
+     */
+    public function __construct(
+        protected string $operator = self::OPERATOR_EQ,
+        protected ?array $customerGroupIds = null
+    ) {
+        parent::__construct();
+    }
+
+    public function match(RuleScope $scope): bool
+    {
+        if (!$scope instanceof CheckoutRuleScope) {
+            return false;
+        }
+
+        if (!$customer = $scope->getSalesChannelContext()->getCustomer()) {
+            return RuleComparison::isNegativeOperator($this->operator);
+        }
+
+        $requestedCustomerGroupId = $customer->getRequestedGroupId();
+
+        if ($requestedCustomerGroupId === null) {
+            return RuleComparison::isNegativeOperator($this->operator);
+        }
+
+        return RuleComparison::uuids([$requestedCustomerGroupId], $this->customerGroupIds, $this->operator);
+    }
+
+    public function getConstraints(): array
+    {
+        $constraints = [
+            'operator' => RuleConstraints::uuidOperators(),
+        ];
+
+        if ($this->operator === self::OPERATOR_EMPTY) {
+            return $constraints;
+        }
+
+        $constraints['customerGroupIds'] = RuleConstraints::uuids();
+
+        return $constraints;
+    }
+
+    public function getConfig(): RuleConfig
+    {
+        return (new RuleConfig())
+            ->operatorSet(RuleConfig::OPERATOR_SET_STRING, true, true)
+            ->entitySelectField('customerGroupIds', CustomerGroupDefinition::ENTITY_NAME, true);
+    }
+}

--- a/src/Core/Checkout/DependencyInjection/rule.xml
+++ b/src/Core/Checkout/DependencyInjection/rule.xml
@@ -92,6 +92,10 @@
             <tag name="shopware.rule.definition"/>
         </service>
 
+        <service id="Shopware\Core\Checkout\Customer\Rule\CustomerRequestedGroupRule">
+            <tag name="shopware.rule.definition"/>
+        </service>
+
         <service id="Shopware\Core\Checkout\Customer\Rule\CustomerTagRule">
             <tag name="shopware.rule.definition"/>
         </service>

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerRequestedGroupRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerRequestedGroupRuleTest.php
@@ -1,0 +1,143 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Customer\Rule;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\CheckoutRuleScope;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupDefinition;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\Rule\CustomerRequestedGroupRule;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleConfig;
+use Shopware\Core\Framework\Rule\RuleConstraints;
+use Shopware\Core\Framework\Rule\RuleScope;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @internal
+ */
+#[Package('services-settings')]
+#[CoversClass(CustomerRequestedGroupRule::class)]
+#[Group('rules')]
+class CustomerRequestedGroupRuleTest extends TestCase
+{
+    private CustomerRequestedGroupRule $rule;
+
+    protected function setUp(): void
+    {
+        $this->rule = new CustomerRequestedGroupRule();
+    }
+
+    public function testName(): void
+    {
+        static::assertSame('customerRequestedCustomerGroup', $this->rule->getName());
+    }
+
+    public function testGetConstraints(): void
+    {
+        $constraints = $this->rule->getConstraints();
+
+        static::assertArrayHasKey('operator', $constraints, 'Constraint operator not found in Rule');
+        static::assertArrayHasKey('customerGroupIds', $constraints, 'Constraint customerGroupIds not found in Rule');
+        static::assertEquals(RuleConstraints::uuidOperators(), $constraints['operator']);
+        static::assertEquals(RuleConstraints::uuids(), $constraints['customerGroupIds']);
+    }
+
+    public function testGetConstraintsOperatorEmpty(): void
+    {
+        $rule = new CustomerRequestedGroupRule(Rule::OPERATOR_EMPTY);
+        $constraints = $rule->getConstraints();
+
+        static::assertArrayHasKey('operator', $constraints, 'Constraint operator not found in Rule');
+        static::assertArrayNotHasKey('customerGroupIds', $constraints, 'Constraint customerGroupIds found in Rule');
+        static::assertEquals(RuleConstraints::uuidOperators(), $constraints['operator']);
+    }
+
+    public function testGetConfig(): void
+    {
+        $config = $this->rule->getConfig();
+        static::assertEquals([
+            'operatorSet' => [
+                'operators' => [
+                    ...RuleConfig::OPERATOR_SET_STRING,
+                    Rule::OPERATOR_EMPTY,
+                ],
+                'isMatchAny' => true,
+            ],
+            'fields' => [
+                'customerGroupIds' => [
+                    'name' => 'customerGroupIds',
+                    'type' => 'multi-entity-id-select',
+                    'config' => [
+                        'entity' => CustomerGroupDefinition::ENTITY_NAME,
+                    ],
+                ],
+            ],
+        ], $config->getData());
+    }
+
+    /**
+     * @param array<string> $customerGroupIds
+     *
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
+    #[DataProvider('getMatchValues')]
+    public function testCustomerRequestedGroupRuleMatching(bool $expected, bool $loggedIn, ?string $requestedGroupId, array $customerGroupIds, string $operator): void
+    {
+        $customer = null;
+
+        if ($loggedIn) {
+            $customer = new CustomerEntity();
+
+            if ($requestedGroupId !== null) {
+                $customerGroup = new CustomerGroupEntity();
+                $customerGroup->setId($requestedGroupId);
+                $customer->setRequestedGroup($customerGroup);
+                $customer->setRequestedGroupId($requestedGroupId);
+            }
+        }
+
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('getCustomer')->willReturn($customer);
+        $scope = new CheckoutRuleScope($context);
+
+        $this->rule->assign(['customerGroupIds' => $customerGroupIds, 'operator' => $operator]);
+
+        static::assertSame($expected, $this->rule->match($scope));
+    }
+
+    public function testInvalidScopeIsFalse(): void
+    {
+        $invalidScope = $this->createMock(RuleScope::class);
+        $this->rule->assign(['customerGroupIds' => [Uuid::randomHex()], 'operator' => Rule::OPERATOR_EQ]);
+        static::assertFalse($this->rule->match($invalidScope));
+    }
+
+    /**
+     * @return \Traversable<string, array<bool|string|array<string>|null>>
+     */
+    public static function getMatchValues(): \Traversable
+    {
+        $id = Uuid::randomHex();
+
+        yield 'operator_one_of / no match' => [false, true, $id, [Uuid::randomHex()], Rule::OPERATOR_EQ];
+        yield 'operator_one_of / one match' => [true, true, $id, [$id, Uuid::randomHex()], Rule::OPERATOR_EQ];
+        yield 'operator_one_of / empty' => [false, true, null, [$id, Uuid::randomHex()], Rule::OPERATOR_EQ];
+        yield 'operator_one_of / not logged in' => [false, false, null, [$id], Rule::OPERATOR_EQ];
+
+        yield 'operator_none_of / no match' => [true, true, $id, [Uuid::randomHex()], Rule::OPERATOR_NEQ];
+        yield 'operator_none_of / one match' => [false, true, $id, [$id, Uuid::randomHex()], Rule::OPERATOR_NEQ];
+        yield 'operator_none_of / empty' => [true, true, null, [$id, Uuid::randomHex()], Rule::OPERATOR_NEQ];
+        yield 'operator_none_of / not logged in' => [true, false, null, [$id], Rule::OPERATOR_NEQ];
+
+        yield 'operator_empty / empty' => [true, true, null, null, Rule::OPERATOR_EMPTY];
+        yield 'operator_empty / not empty' => [false, true, $id, null, Rule::OPERATOR_EMPTY];
+        yield 'operator_empty / not logged in' => [true, false, null, null, Rule::OPERATOR_EMPTY];
+    }
+}

--- a/tests/unit/Core/Checkout/Customer/Rule/CustomerRequestedGroupRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/CustomerRequestedGroupRuleTest.php
@@ -136,8 +136,8 @@ class CustomerRequestedGroupRuleTest extends TestCase
         yield 'operator_none_of / empty' => [true, true, null, [$id, Uuid::randomHex()], Rule::OPERATOR_NEQ];
         yield 'operator_none_of / not logged in' => [true, false, null, [$id], Rule::OPERATOR_NEQ];
 
-        yield 'operator_empty / empty' => [true, true, null, null, Rule::OPERATOR_EMPTY];
-        yield 'operator_empty / not empty' => [false, true, $id, null, Rule::OPERATOR_EMPTY];
-        yield 'operator_empty / not logged in' => [true, false, null, null, Rule::OPERATOR_EMPTY];
+        yield 'operator_empty / empty' => [true, true, null, [], Rule::OPERATOR_EMPTY];
+        yield 'operator_empty / not empty' => [false, true, $id, [], Rule::OPERATOR_EMPTY];
+        yield 'operator_empty / not logged in' => [true, false, null, [], Rule::OPERATOR_EMPTY];
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Having the option to use `requested_customer_group` from the current customer in rule conditions, makes it e.g. possible to create Flows to subscribe on customers registering for a specific customer group. But might be useful for other things as well.

### 2. What does this change do, exactly?
Makes `requested_customer_group` from the customer available in rule conditions.

### 3. Describe each step to reproduce the issue or behaviour.
--

### 4. Please link to the relevant issues (if any).
--

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
