### PR TITLE
fix gallery slider image height while loading

### DIFF
--- a/changelog/_unreleased/2024-10-25-fix-gallery-slider-image-height-while-loading.md
+++ b/changelog/_unreleased/2024-10-25-fix-gallery-slider-image-height-while-loading.md
@@ -1,0 +1,12 @@
+---
+title: fix gallery slider image height while loading
+issue: NEXT-00000
+author: Carlo Cecco
+author_email: 6672778+luminalpark@users.noreply.github.com
+author_github: @luminalpark
+---
+# Storefront
+* Changed `storefront/src/scss/component/_gallery-slider.scss` : fix height of gallery slider image while loading. In layouts with large images, the height of the gallery slider image was not set correctly, causing a jump in height when the image was loaded.
+  * Added `height: auto` to `.gallery-slider-image` to allow the image to show entirely without a jump in height (was limited to a fixed height of 430px).
+  * Added `.gallery-slider-item-container` display none to hide the image until it is loaded. This applies to all images except the first one.
+  * Added `.gallery-slider-thumbnails-col.is-underneath` display none to hide the thumbnails until the image is loaded (only when the thumbnails are shown underneath the image).

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_gallery-slider.scss
@@ -19,8 +19,18 @@ based on "base-slider" component and "tiny-slider" (https://github.com/ganlanyua
     margin-bottom: $spacer;
 
     &.is-loading {
-        height: 430px;
+        height: auto;
         overflow: hidden;
+
+        .gallery-slider-item-container {
+            &:not(:first-child) {
+                display: none;
+            }
+        }
+
+        .gallery-slider-thumbnails-col.is-underneath{
+            display: none;
+        }
     }
 
     &.is-single-image {


### PR DESCRIPTION
### 1. Why is this change necessary?
In layouts with large images, the height of the gallery slider image is restricted to 430px during slider plugin init,  causing a jump in height when the slider finish initialization and removes `.is-loading` class

### 2. What does this change do, exactly?
* Added `height: auto` to `.gallery-slider-image` to allow the image to show entirely without a jump in height (was limited to a fixed height of 430px).
  * Added `.gallery-slider-item-container` display none to hide the image until it is loaded. This applies to all images except the first one.
  * Added `.gallery-slider-thumbnails-col.is-underneath` display none to hide the thumbnails until the image is loaded (only when the thumbnails are shown underneath the image).

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
