### PR TITLE
Make web installer command timeout configurable through environment variable

### DIFF
--- a/changelog/_unreleased/2024-10-26-Add-configurable-installer-timeout.md
+++ b/changelog/_unreleased/2024-10-26-Add-configurable-installer-timeout.md
@@ -1,0 +1,39 @@
+---
+title: Add configurable installer timeout
+issue: NEXT-XXXXX
+author: Marc Christenfeldt
+author_email: marc.christenfeldt@gmx.de
+author_github: marcbln
+discussion: https://forum.shopware.com/t/shopware-update-bricht-wegen-zu-langer-laufzeit-ab/104013/11
+---
+
+# Core
+
+* Added new environment variable `SHOPWARE_INSTALLER_TIMEOUT` to configure the command timeout in the web installer
+* Added constant `DEFAULT_TIMEOUT` in `StreamedCommandResponseGenerator` to define the default timeout value of 900 seconds
+* Changed timeout handling in `StreamedCommandResponseGenerator` to support configurable timeout values from environment
+
+# Upgrade Information
+
+## Environment Configuration
+
+The web installer now supports configurable command timeouts through the environment variable `SHOPWARE_INSTALLER_TIMEOUT`. This value should be provided in seconds.
+
+### Default Behavior
+If the environment variable is not set, the installer will use the default timeout of 900 seconds (15 minutes).
+
+### Configuration Examples
+```bash
+# Set timeout to 30 minutes
+export SHOPWARE_INSTALLER_TIMEOUT=1800
+
+# Set timeout to 1 hour
+export SHOPWARE_INSTALLER_TIMEOUT=3600
+```
+
+### Validation
+The provided timeout value must be:
+- A numeric value
+- Non-negative
+
+If these conditions are not met, the installer will fall back to the default timeout of 900 seconds.

--- a/src/WebInstaller/README.md
+++ b/src/WebInstaller/README.md
@@ -90,3 +90,14 @@ you have to use that version for the next version variable.
 
 Then run the updater regularly with `php shopware-installer.phar.php`,
 it will use the forced version and don't try to determine a version anymore.
+
+### Configurable Installer Timeout
+
+The installer timeout can be configured using the `SHOPWARE_INSTALLER_TIMEOUT` environment variable (in seconds). 
+Default is 900 seconds (15 minutes). Invalid values fall back to default.
+
+Example:
+```bash
+export SHOPWARE_INSTALLER_TIMEOUT=1200  # 20 minutes
+```
+

--- a/src/WebInstaller/Services/StreamedCommandResponseGenerator.php
+++ b/src/WebInstaller/Services/StreamedCommandResponseGenerator.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Shopware\WebInstaller\Services;
 
+use Composer\Util\Platform;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Process\Process;
@@ -13,6 +14,8 @@ use Symfony\Component\Process\Process;
 #[Package('core')]
 class StreamedCommandResponseGenerator
 {
+    public const DEFAULT_TIMEOUT = 900.0; // 15 minutes
+
     /**
      * @param array<string> $params
      * @param callable(Process): void $finish
@@ -21,7 +24,15 @@ class StreamedCommandResponseGenerator
     {
         $process = new Process($params);
         $process->setEnv(['COMPOSER_HOME' => sys_get_temp_dir() . '/composer']);
-        $process->setTimeout(900);
+
+        // Read process timeout from environment or use default value
+        $timeout = Platform::getEnv('SHOPWARE_INSTALLER_TIMEOUT');
+        if (empty($timeout) || !is_numeric($timeout) || $timeout < 0) {
+            $timeout = self::DEFAULT_TIMEOUT;
+        } else {
+            $timeout = (float) $timeout;
+        }
+        $process->setTimeout($timeout);
 
         $process->start();
 

--- a/src/WebInstaller/Tests/Services/StreamedCommandResponseGeneratorTest.php
+++ b/src/WebInstaller/Tests/Services/StreamedCommandResponseGeneratorTest.php
@@ -43,4 +43,92 @@ class StreamedCommandResponseGeneratorTest extends TestCase
 
         static::assertSame('foo' . \PHP_EOL . '{"success":true}', $content);
     }
+
+    public function testCustomTimeoutFromEnv(): void
+    {
+        $customTimeout = 333.0;
+        putenv('SHOPWARE_INSTALLER_TIMEOUT=' . $customTimeout);
+
+        $generator = new StreamedCommandResponseGenerator();
+
+        $theFinishedProcess = null;
+        $response = $generator->runJson(['echo', 'foo'], function (Process $process) use (&$theFinishedProcess): void {
+            $theFinishedProcess = $process;
+        });
+
+        ob_start();
+        $response->sendContent();
+        ob_end_clean();
+
+        self::assertNotNull($theFinishedProcess);
+        static::assertSame((float)$customTimeout, $theFinishedProcess->getTimeout());
+
+        // Cleanup
+        putenv('SHOPWARE_INSTALLER_TIMEOUT');
+    }
+
+    public function testDefaultTimeout(): void
+    {
+        // Ensure no timeout is set in environment
+        putenv('SHOPWARE_INSTALLER_TIMEOUT');
+
+        $generator = new StreamedCommandResponseGenerator();
+
+        $theFinishedProcess = null;
+        $response = $generator->runJson(['echo', 'foo'], function (Process $process) use (&$theFinishedProcess): void {
+            $theFinishedProcess = $process;
+        });
+
+        ob_start();
+        $response->sendContent();
+        ob_end_clean();
+
+        self::assertNotNull($theFinishedProcess);
+        static::assertSame(StreamedCommandResponseGenerator::DEFAULT_TIMEOUT, $theFinishedProcess->getTimeout());
+    }
+
+    public function testNonNumericTimeoutUsesDefault(): void
+    {
+        putenv('SHOPWARE_INSTALLER_TIMEOUT=not-a-number');
+
+        $generator = new StreamedCommandResponseGenerator();
+
+        $theFinishedProcess = null;
+        $response = $generator->runJson(['echo', 'foo'], function (Process $process) use (&$theFinishedProcess): void {
+            $theFinishedProcess = $process;
+        });
+
+
+        ob_start();
+        $response->sendContent();
+        ob_end_clean();
+
+        self::assertNotNull($theFinishedProcess);
+        static::assertSame(StreamedCommandResponseGenerator::DEFAULT_TIMEOUT, $theFinishedProcess->getTimeout());
+
+        // Cleanup
+        putenv('SHOPWARE_INSTALLER_TIMEOUT');
+    }
+
+    public function testNegativeTimeoutUsesDefault(): void
+    {
+        putenv('SHOPWARE_INSTALLER_TIMEOUT=-42.5');
+
+        $generator = new StreamedCommandResponseGenerator();
+
+        $theFinishedProcess = null;
+        $response = $generator->runJson(['echo', 'foo'], function (Process $process) use (&$theFinishedProcess): void {
+            $theFinishedProcess = $process;
+        });
+
+        ob_start();
+        $response->sendContent();
+        ob_end_clean();
+
+        self::assertNotNull($theFinishedProcess);
+        static::assertSame(StreamedCommandResponseGenerator::DEFAULT_TIMEOUT, $theFinishedProcess->getTimeout());
+
+        // Cleanup
+        putenv('SHOPWARE_INSTALLER_TIMEOUT');
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The current web installer uses a hard-coded timeout value of 900 seconds (15 minutes) for running commands. This can be problematic in environments where longer timeouts are needed or where administrators want to customize the timeout duration based on their specific requirements.

### 2. What does this change do, exactly?
This change introduces environment variable configuration for the command timeout in Shopware's web installer. Specifically:
- Adds a constant `DEFAULT_TIMEOUT` set to 900.0 seconds (15 minutes)
- Introduces support for a new environment variable `SHOPWARE_INSTALLER_TIMEOUT`
- Reads the timeout value from the environment variable if set
- Validates that the timeout value is numeric and non-negative
- Falls back to the default timeout if the environment variable is:
  - Not set
  - Not numeric
  - Negative

### 3. Describe each step to reproduce the issue or behaviour.
To test the new functionality:
1. Set the environment variable: `export SHOPWARE_INSTALLER_TIMEOUT=1800`
2. Run the web installer
3. The installer commands will now use the custom timeout of 1800 seconds

To verify default behavior:
1. Ensure SHOPWARE_INSTALLER_TIMEOUT is not set
2. Run the web installer
3. Commands will use the default 900 second timeout

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
  - Added comprehensive tests covering:
    - Custom timeout from environment variable
    - Default timeout behavior
    - Non-numeric timeout handling
    - Negative timeout handling
- [x] I have created a changelog file
- [x] all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.