### PR TITLE
NEXT-00000 - sw-string-filter: Add types `equalsAny`, `prefix` and `suffix`

### DIFF
--- a/changelog/_unreleased/2024-10-27-add-criteria-filter-types-to-sw-string-filter.md
+++ b/changelog/_unreleased/2024-10-27-add-criteria-filter-types-to-sw-string-filter.md
@@ -1,0 +1,11 @@
+---
+title: Add criteria filter types to sw-string-filter
+issue: NEXT-00000
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Administration
+* Added criteria filter types `equalsAny`, `prefix` and `suffix` to `sw-string-filter`
+* Changed `order-number-filter` filter type to use `equalsAny` instead of `equals`
+

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/filter/sw-string-filter/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/filter/sw-string-filter/index.ts
@@ -21,17 +21,23 @@ export default Shopware.Component.wrapComponentConfig({
             required: true,
         },
         criteriaFilterType: {
-            type: String as PropType<'contains' | 'equals'>,
+            type: String as PropType<'contains' | 'equals' | 'equalsAny' | 'prefix' | 'suffix'>,
             required: false,
             default: 'contains',
             validValues: [
                 'contains',
                 'equals',
+                'equalsAny',
+                'prefix',
+                'suffix',
             ],
             validator(value: string): boolean {
                 return [
                     'contains',
                     'equals',
+                    'equalsAny',
+                    'prefix',
+                    'suffix',
                 ].includes(value);
             },
         },
@@ -43,6 +49,10 @@ export default Shopware.Component.wrapComponentConfig({
                 this.resetFilter();
 
                 return;
+            }
+
+            if (this.criteriaFilterType === 'equalsAny') {
+                newValue = newValue.split(',').map(e => e.trim());
             }
 
             const filterCriteria = [

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/index.js
@@ -147,7 +147,7 @@ export default {
                     placeholder: this.$tc('sw-order.filters.orderNumberFilter.placeholder'),
                     valueProperty: 'key',
                     labelProperty: 'key',
-                    criteriaFilterType: 'equals',
+                    criteriaFilterType: 'equalsAny',
                 },
                 'sales-channel-filter': {
                     property: 'salesChannel',


### PR DESCRIPTION
### 1. Why is this change necessary?

`sw-string-filter` does not accept `equalsAny`, `prefix` and `suffix` types. It is not possible to search for multiple order numbers

### 2. What does this change do, exactly?

It adds criteria filter types `equalsAny`, `prefix` and `suffix` to `sw-string-filter` and it changes the `order-number-filter` filter type to use `equalsAny` instead of `equals`

### 3. Describe each step to reproduce the issue or behaviour.

Try to use `sw-string-filter` with types `equalsAny`, `prefix` and `suffix`, it does break.
And it is not possible to search for more than one order number.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
