### PR TITLE
NEXT-00000 - Sitemap: Add option to exclude hidden products from sitemap

### DIFF
--- a/changelog/_unreleased/2024-10-27-add-option-to-exclude-hidden-products-from-sitemap.md
+++ b/changelog/_unreleased/2024-10-27-add-option-to-exclude-hidden-products-from-sitemap.md
@@ -1,0 +1,9 @@
+---
+title: Add criteria filter types to sw-string-filter
+issue: NEXT-00000
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Added option to exclude hidden products from sitemap

--- a/changelog/_unreleased/2024-10-27-add-option-to-exclude-hidden-products-from-sitemap.md
+++ b/changelog/_unreleased/2024-10-27-add-option-to-exclude-hidden-products-from-sitemap.md
@@ -1,5 +1,5 @@
 ---
-title: Add criteria filter types to sw-string-filter
+title: Add option to exclude hidden products from sitemap
 issue: NEXT-00000
 author: Marcus Müller
 author_email: 25648755+M-arcus@users.noreply.github.com

--- a/src/Core/Migration/V6_6/Migration1730059142AddNewSitemapConfigForExcludingHiddenProducts.php
+++ b/src/Core/Migration/V6_6/Migration1730059142AddNewSitemapConfigForExcludingHiddenProducts.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1730059142AddNewSitemapConfigForExcludingHiddenProducts extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1730059142;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $query = 'INSERT IGNORE INTO system_config SET
+                    id = :id,
+                    configuration_value = :configValue,
+                    configuration_key = :configKey,
+                    created_at = :createdAt;';
+
+        $connection->executeStatement($query, [
+            'id' => Uuid::randomBytes(),
+            'configKey' => 'core.sitemap.excludeLinkedProducts',
+            'configValue' => '{"_value": false}',
+            'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+    }
+}

--- a/src/Core/System/Resources/config/sitemap.xml
+++ b/src/Core/System/Resources/config/sitemap.xml
@@ -52,5 +52,13 @@
             </helpText>
         </input-field>
 
+        <input-field type="bool">
+            <name>excludeLinkedProducts</name>
+            <label>Exclude hidden products from sitemap</label>
+            <label lang="de-DE">Versteckte Produkte von der Sitemap ausschließen</label>
+            <helpText>Products, that are hidden in listings and search, will be excluded from the sitemap</helpText>
+            <helpText lang="de-DE">Produkte, die in den Listen und in der Suche versteckt sind, werden von der Sitemap ausgeschlossen</helpText>
+        </input-field>
+
     </card>
 </config>


### PR DESCRIPTION
### 1. Why is this change necessary?

There is no option to exclude products from the sitemap that are hidden from search and listing.

### 2. What does this change do, exactly?

It adds an option to exclude products from the sitemap that are hidden from search and listing.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
