### PR TITLE
NEXT-00000 - Reuse product slider stream associations and fields from collect criteria

### DIFF
--- a/changelog/_unreleased/2024-11-18-reuse-product-slider-stream-associations-and-fields-from-collect-criteria.md
+++ b/changelog/_unreleased/2024-11-18-reuse-product-slider-stream-associations-and-fields-from-collect-criteria.md
@@ -1,0 +1,9 @@
+---
+title: Reuse product slider stream associations and fields from collect criteria
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Core
+* Changed `ProductSliderCmsElementResolver` to reuse associations and fields from the criteria object created in `collect` method when fetching final products from product stream in `fetchProductsByIds`.


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Using a product stream in a product slider configuration, criteria data of the cms element resolver like `associations` is lost even though it can be extended via decorators inside the `collect` method. Generally, the associations are limited to `options.group` and cannot be extended easily.

### 2. What does this change do, exactly?
* Changed `ProductSliderCmsElementResolver` to reuse the criteria object created in `collect` method when fetching final products from product stream in `fetchProductsByIds`.

### 3. Describe each step to reproduce the issue or behaviour.
Add a product slider cms element resolver decorator and extend the `collect` method to add the `media` association for example. The media association will be loaded for manually selected products, but it will not for product streams.

### 4. Please link to the relevant issues (if any).
#4757
#5137 

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
