### PR TITLE
Added extension point for pdf renderer

### DIFF
--- a/changelog/_unreleased/2024-10-30-added-pdf-renderer-extension.md
+++ b/changelog/_unreleased/2024-10-30-added-pdf-renderer-extension.md
@@ -1,0 +1,10 @@
+---
+title: Added pdf renderer extension
+issue: 
+author: Oliver Skroblin
+author_email: oliver@goblin-coders.de
+author_github: OliverSkroblin
+---
+
+# Core
+* Added `PdfRendererExtension` inside the `PdfRenderer` class.

--- a/src/Core/Checkout/DependencyInjection/document.xml
+++ b/src/Core/Checkout/DependencyInjection/document.xml
@@ -111,6 +111,7 @@
 
         <service id="Shopware\Core\Checkout\Document\Service\PdfRenderer">
             <argument>%shopware.dompdf.options%</argument>
+            <argument type="service" id="Shopware\Core\Framework\Extensions\ExtensionDispatcher"/>
         </service>
 
         <service id="Shopware\Core\Checkout\Document\Service\DocumentGenerator">

--- a/src/Core/Checkout/Document/Extension/PdfRendererExtension.php
+++ b/src/Core/Checkout/Document/Extension/PdfRendererExtension.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Document\Extension;
+
+use Shopware\Core\Checkout\Document\Renderer\RenderedDocument;
+use Shopware\Core\Framework\Extensions\Extension;
+
+/**
+ * @experimental stableVersion:v6.7.0 feature:EXTENSION_SYSTEM
+ *
+ * @extends Extension<string>
+ */
+final class PdfRendererExtension extends Extension
+{
+    public const NAME = 'pdf-renderer';
+
+    /**
+     * @internal shopware owns the __constructor, but the properties are public API
+     */
+    public function __construct(public readonly RenderedDocument $document) {}
+}

--- a/tests/unit/Core/Checkout/Document/Service/DocumentGeneratorTest.php
+++ b/tests/unit/Core/Checkout/Document/Service/DocumentGeneratorTest.php
@@ -16,8 +16,10 @@ use Shopware\Core\Checkout\Document\Service\PdfRenderer;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Content\Media\MediaService;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * @internal
@@ -56,7 +58,7 @@ class DocumentGeneratorTest extends TestCase
         $registry = new DocumentRendererRegistry([$mockRenderer]);
         $generator = new DocumentGenerator(
             $registry,
-            new PdfRenderer([]),
+            new PdfRenderer([], new ExtensionDispatcher(new EventDispatcher())),
             $this->createMock(MediaService::class),
             new StaticEntityRepository([]),
             $this->createMock(Connection::class),


### PR DESCRIPTION
In some cases, you may want to handle the PDF rendering yourself or perform additional actions on the rendered PDF before it’s written to the file system.

Of course, you could intervene after the entire PDF rendering process, but in this case, you would need to interfere more deeply in the overall process, as you would have to read the PDF back from the system and write it again, which is not trivial.