### PR TITLE
Remove duplicate gad_source from ignored parameter list

### DIFF
--- a/changelog/_unreleased/2024-10-30-remove-duplicate-gad_source-from-ignored-parameter-list.md
+++ b/changelog/_unreleased/2024-10-30-remove-duplicate-gad_source-from-ignored-parameter-list.md
@@ -1,0 +1,9 @@
+---
+title: Changed `shopware.http_cache.ignored_url_parameters` by removing duplicate `gad_source` parameter
+issue: NEXT-38521
+author: Wanne Van Camp
+author_email: wanne.vancamp@meteor.be
+author_github: wannevancamp
+---
+# Core
+* Changed `shopware.http_cache.ignored_url_parameters` by removing duplicate `gad_source` parameter

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -93,7 +93,7 @@ shopware:
             - 'gdffi'
             - '_ke'  # Klaviyo
             - '_kx'
-            - 'redirect_log_mongo_id'
+            - 'redirect_log_mongo_id' # MongoDB
             - 'redirect_mongo_id'
             - 'sb_referer_host'
             - 'mkwid' # Marin

--- a/src/Core/Framework/Resources/config/packages/shopware.yaml
+++ b/src/Core/Framework/Resources/config/packages/shopware.yaml
@@ -56,7 +56,6 @@ shopware:
             - 'utm_medium'
             - 'utm_campaign'
             - 'utm_content'
-            - 'gad_source'
             - 'cx'
             - 'ie'
             - 'cof'


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Parameter `gad_source` in `shopware.http_cache.ignored_url_parameters` is declared twice.


### 2. What does this change do, exactly?
Remove duplicate

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
