### PR TITLE
feat: add functionality for plugin checksums

### DIFF
--- a/src/Core/Framework/DependencyInjection/plugin.xml
+++ b/src/Core/Framework/DependencyInjection/plugin.xml
@@ -134,6 +134,24 @@
             <tag name="console.command"/>
         </service>
 
+        <service id="Shopware\Core\Framework\Plugin\Command\Lifecycle\PluginChecksumCreateCommand">
+            <argument type="service" id="plugin.repository"/>
+            <argument type="service" id="Shopware\Core\Framework\Plugin\Command\Lifecycle\PluginFileHashService"/>
+
+            <tag name="console.command"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Plugin\Command\Lifecycle\PluginChecksumCheckCommand">
+            <argument type="service" id="plugin.repository"/>
+            <argument type="service" id="Shopware\Core\Framework\Plugin\Command\Lifecycle\PluginFileHashService"/>
+
+            <tag name="console.command"/>
+        </service>
+
+        <service id="Shopware\Core\Framework\Plugin\Command\Lifecycle\PluginFileHashService">
+            <argument>%kernel.project_dir%</argument>
+        </service>
+
         <service id="Shopware\Core\Framework\Plugin\Command\Lifecycle\PluginUpdateCommand">
             <argument type="service" id="Shopware\Core\Framework\Plugin\PluginLifecycleService"/>
             <argument type="service" id="plugin.repository"/>

--- a/src/Core/Framework/DependencyInjection/store.xml
+++ b/src/Core/Framework/DependencyInjection/store.xml
@@ -121,11 +121,17 @@
             <argument type="service" id="Shopware\Core\System\Locale\LanguageLocaleCodeProvider"/>
         </service>
 
+        <service id="Shopware\Core\Framework\Store\Services\ExtensionChecksumLoader">
+            <argument type="service" id="plugin.repository"/>
+            <argument type="service" id="Shopware\Core\Framework\Plugin\Command\Lifecycle\PluginFileHashService"/>
+        </service>
+
         <service id="Shopware\Core\Framework\Store\Services\AbstractExtensionDataProvider" class="Shopware\Core\Framework\Store\Services\ExtensionDataProvider">
             <argument type="service" id="Shopware\Core\Framework\Store\Services\ExtensionLoader"/>
             <argument type="service" id="app.repository"/>
             <argument type="service" id="plugin.repository"/>
             <argument type="service" id="Shopware\Core\Framework\Store\Services\ExtensionListingLoader"/>
+            <argument type="service" id="Shopware\Core\Framework\Store\Services\ExtensionChecksumLoader"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
 

--- a/src/Core/Framework/Plugin/Command/Lifecycle/PluginChecksumCheckCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/PluginChecksumCheckCommand.php
@@ -1,0 +1,134 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Command\Lifecycle;
+
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginCollection;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'plugin:checksum:check',
+    description: 'Check the integrity of plugin files',
+)]
+#[Package('core')]
+class PluginChecksumCheckCommand extends Command
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly EntityRepository $pluginRepository,
+        private readonly PluginFileHashService $pluginFileHashService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('plugin', InputArgument::OPTIONAL, 'Plugin name');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+
+        $plugins = $this->getPlugins((string) $input->getArgument('plugin'), $io);
+        if ($plugins->count() === 0) {
+            $io->error('No plugins found');
+
+            return self::FAILURE;
+        }
+
+        $success = true;
+        foreach ($plugins as $plugin) {
+            $io->info('Checking plugin: ' . $plugin->getName());
+
+            $pluginChecksumCheckResult = $this->pluginFileHashService->checkPluginForChanges($plugin);
+            if ($pluginChecksumCheckResult->isFileMissing()) {
+                $io->info(\sprintf('Plugin "%s" checksum file for not found', $plugin->getName()));
+
+                continue;
+            }
+
+            if ($pluginChecksumCheckResult->isWrongVersion()) {
+                $io->error(\sprintf('Checksum file for plugin "%s" was generated for different version', $plugin->getName()));
+
+                continue;
+            }
+
+            if ($pluginChecksumCheckResult->getNewFiles() === []
+                && $pluginChecksumCheckResult->getChangedFiles() === []
+                && $pluginChecksumCheckResult->getMissingFiles() === []
+            ) {
+                $io->success(\sprintf('Plugin "%s" has no detected file-changes.', $plugin->getName()));
+
+                continue;
+            }
+
+            $success = false;
+
+            $io->error(\sprintf('Plugin "%s" has changed code.', $plugin->getName()));
+            $this->outputFileChanges($io, 'New files detected:', $pluginChecksumCheckResult->getNewFiles());
+            $this->outputFileChanges($io, 'Changed files detected:', $pluginChecksumCheckResult->getChangedFiles());
+            $this->outputFileChanges($io, 'Missing files detected:', $pluginChecksumCheckResult->getMissingFiles());
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function getPlugins(string $pluginName, ShopwareStyle $io): PluginCollection
+    {
+        $context = Context::createCLIContext();
+
+        if (!$pluginName) {
+            $io->info('Checking all plugins');
+
+            /** @var PluginCollection $plugins */
+            $plugins = $this->pluginRepository->search(new Criteria(), $context)->getEntities();
+
+            return $plugins;
+        }
+
+        $plugins = new PluginCollection();
+
+        $plugin = $this->getPlugin($pluginName, $context);
+        if ($plugin instanceof PluginEntity) {
+            $plugins->add($plugin);
+        }
+
+        return $plugins;
+    }
+
+    private function getPlugin(string $pluginName, Context $context): ?Entity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $pluginName));
+
+        return $this->pluginRepository->search($criteria, $context)->first();
+    }
+
+    /**
+     * @param string[] $files
+     */
+    private function outputFileChanges(ShopwareStyle $io, string $text, array $files): void
+    {
+        if ($files) {
+            $io->warning($text);
+            $io->listing($files);
+        }
+    }
+}

--- a/src/Core/Framework/Plugin/Command/Lifecycle/PluginChecksumCheckResult.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/PluginChecksumCheckResult.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Command\Lifecycle;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+#[Package('core')]
+class PluginChecksumCheckResult extends Struct
+{
+    /**
+     * @param string[] $newFiles
+     * @param string[] $changedFiles
+     * @param string[] $missingFiles
+     */
+    public function __construct(
+        protected bool $fileMissing = false,
+        protected bool $wrongVersion = false,
+        protected array $newFiles = [],
+        protected array $changedFiles = [],
+        protected array $missingFiles = [],
+    ) {
+    }
+
+    public function isFileMissing(): bool
+    {
+        return $this->fileMissing;
+    }
+
+    public function isWrongVersion(): bool
+    {
+        return $this->wrongVersion;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNewFiles(): array
+    {
+        return $this->newFiles;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getChangedFiles(): array
+    {
+        return $this->changedFiles;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMissingFiles(): array
+    {
+        return $this->missingFiles;
+    }
+}

--- a/src/Core/Framework/Plugin/Command/Lifecycle/PluginChecksumCreateCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/PluginChecksumCreateCommand.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Command\Lifecycle;
+
+use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'plugin:checksum:create',
+    description: 'Creates a list of files and their checksum for a plugin',
+)]
+#[Package('core')]
+class PluginChecksumCreateCommand extends Command
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly EntityRepository $pluginRepository,
+        private readonly PluginFileHashService $pluginFileHashService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('plugin', InputArgument::REQUIRED, 'Plugin name');
+        $this->addOption('file-extensions', null, InputOption::VALUE_OPTIONAL, 'Comma-separated list of file extensions to include in the checksum (example: "*.php,*.twig")', '*.php,*.twig');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new ShopwareStyle($input, $output);
+        $context = Context::createCLIContext();
+
+        $pluginName = (string) $input->getArgument('plugin');
+        $plugin = $this->getPlugin($pluginName, $context);
+
+        if (!$plugin instanceof PluginEntity) {
+            $io->error(\sprintf('Plugin "%s" not found', $pluginName));
+
+            return self::FAILURE;
+        }
+
+        $fileExtensions = \explode(',', (string) $input->getOption('file-extensions'));
+        if ($fileExtensions === []) {
+            $io->error('No valid file extensions provided');
+
+            return self::FAILURE;
+        }
+
+        $checksumFilePath = $this->pluginFileHashService->getChecksumFilePathForPlugin($plugin);
+        if (!$checksumFilePath) {
+            $io->error(\sprintf('Plugin "%s" checksum file path could not be identified', $plugin->getName()));
+
+            return self::FAILURE;
+        }
+
+        $checksumStruct = $this->pluginFileHashService->getChecksumData($plugin, $fileExtensions);
+
+        $io->info(\sprintf('Writing %s checksums for plugin "%s" to file %s', \count($checksumStruct->getHashes()), $plugin->getName(), $checksumFilePath));
+
+        file_put_contents($checksumFilePath, \json_encode($checksumStruct->jsonSerialize(), \JSON_THROW_ON_ERROR));
+
+        return self::SUCCESS;
+    }
+
+    private function getPlugin(string $pluginName, Context $context): ?Entity
+    {
+        $criteria = new Criteria();
+        $criteria->addFilter(new EqualsFilter('name', $pluginName));
+
+        return $this->pluginRepository->search($criteria, $context)->first();
+    }
+}

--- a/src/Core/Framework/Plugin/Command/Lifecycle/PluginChecksumStruct.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/PluginChecksumStruct.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Command\Lifecycle;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+#[Package('core')]
+class PluginChecksumStruct extends Struct
+{
+    protected string $algorithm;
+
+    /**
+     * @var array<string>
+     */
+    protected array $fileExtensions;
+
+    /**
+     * @var array<string>
+     */
+    protected array $hashes;
+
+    protected string $pluginVersion;
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return (new self())->assign($data);
+    }
+
+    public function getAlgorithm(): string
+    {
+        return $this->algorithm;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getFileExtensions(): array
+    {
+        return $this->fileExtensions;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getHashes(): array
+    {
+        return $this->hashes;
+    }
+
+    public function getPluginVersion(): string
+    {
+        return $this->pluginVersion;
+    }
+}

--- a/src/Core/Framework/Plugin/Command/Lifecycle/PluginFileHashService.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/PluginFileHashService.php
@@ -1,0 +1,122 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Command\Lifecycle;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Core\Framework\Util\Hasher;
+use Symfony\Component\Finder\Finder;
+
+#[Package('core')]
+class PluginFileHashService
+{
+    public const CHECKSUM_FILE = 'checksums.json';
+
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly string $rootDir,
+    ) {
+    }
+
+    public function getChecksumFilePathForPlugin(PluginEntity $plugin): string
+    {
+        return "$this->rootDir/{$plugin->getPath()}" . self::CHECKSUM_FILE;
+    }
+
+    /**
+     * @param string[] $fileExtensions
+     */
+    public function getChecksumData(PluginEntity $plugin, array $fileExtensions): PluginChecksumStruct
+    {
+        return PluginChecksumStruct::fromArray([
+            'algorithm' => Hasher::ALGO,
+            'fileExtensions' => $fileExtensions,
+            'hashes' => $this->getHashes($plugin, $fileExtensions),
+            'pluginVersion' => $plugin->getVersion(),
+        ]);
+    }
+
+    public function checkPluginForChanges(PluginEntity $plugin): PluginChecksumCheckResult
+    {
+        $checksumFilePath = $this->getChecksumFilePathForPlugin($plugin);
+        if (!is_file($checksumFilePath)) {
+            return new PluginChecksumCheckResult(fileMissing: true);
+        }
+
+        $checksumFileContent = (string) file_get_contents($checksumFilePath);
+        $checksumFileData = PluginChecksumStruct::fromArray(json_decode($checksumFileContent, true, 512, \JSON_THROW_ON_ERROR));
+
+        $extensions = $checksumFileData->getFileExtensions();
+        $checksumPluginVersion = $checksumFileData->getPluginVersion();
+
+        if ($plugin->getVersion() !== $checksumPluginVersion) {
+            return new PluginChecksumCheckResult(wrongVersion: true);
+        }
+
+        $currentHashes = $this->getHashes($plugin, $extensions, $checksumFileData->getAlgorithm());
+        $previouslyHashedFiles = $checksumFileData->getHashes();
+
+        $newFiles = array_diff_key($currentHashes, $previouslyHashedFiles);
+        $missingFiles = array_diff_key($previouslyHashedFiles, $currentHashes);
+        $manipulatedFiles = array_diff(array_diff_key($previouslyHashedFiles, $missingFiles, $newFiles), $currentHashes);
+
+        return new PluginChecksumCheckResult(
+            newFiles: array_keys($newFiles),
+            changedFiles: array_keys($manipulatedFiles),
+            missingFiles: array_keys($missingFiles),
+        );
+    }
+
+    /**
+     * @param string[] $extensions
+     *
+     * @return array<string, string>
+     */
+    private function getHashes(PluginEntity $plugin, array $extensions, ?string $algorithm = null): array
+    {
+        $algorithm = $algorithm ?? Hasher::ALGO;
+        $pluginPath = $plugin->getPath();
+        if ($pluginPath === null) {
+            return [];
+        }
+
+        $directories = $this->getDirectories($plugin);
+
+        $finder = new Finder();
+        $finder->in($directories)->files()->name($extensions);
+
+        $hashes = [];
+        foreach ($finder as $file) {
+            $absoluteFilePath = $file->getRealPath();
+            if (!\is_string($absoluteFilePath) || !$absoluteFilePath) {
+                continue;
+            }
+
+            $relativePath = (string) str_replace($this->rootDir . '/' . $pluginPath, '', $absoluteFilePath);
+
+            $hashes[$relativePath] = Hasher::hashFile($absoluteFilePath, $algorithm);
+        }
+
+        return $hashes;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getDirectories(PluginEntity $plugin): array
+    {
+        $directories = [];
+
+        $autoload = $plugin->getAutoload();
+        $psr4 = $autoload['psr-4'] ?? [];
+        foreach ($psr4 as $path) {
+            if (\is_string($path) && $path !== '') {
+                $directories[] = "$this->rootDir/{$plugin->getPath()}$path";
+            }
+        }
+
+        return array_unique($directories);
+    }
+}

--- a/src/Core/Framework/Store/Services/ExtensionChecksumLoader.php
+++ b/src/Core/Framework/Store/Services/ExtensionChecksumLoader.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Store\Services;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Command\Lifecycle\PluginFileHashService;
+use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Core\Framework\Store\Struct\ExtensionCollection;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+readonly class ExtensionChecksumLoader
+{
+    public function __construct(
+        private EntityRepository $pluginRepository,
+        private PluginFileHashService $pluginFileHashService,
+    ) {
+    }
+
+    public function load(ExtensionCollection $localCollection, Context $context): ExtensionCollection
+    {
+        $this->addChecksumInformation($localCollection, $context);
+
+        return $localCollection;
+    }
+
+    private function addChecksumInformation(ExtensionCollection $localCollection, Context $context): void
+    {
+        foreach ($localCollection as $extension) {
+            $criteria = new Criteria();
+            $criteria->addFilter(new EqualsFilter('name', $extension->getName()));
+            $plugin = $this->pluginRepository->search($criteria, $context)->first();
+            if (!$plugin instanceof PluginEntity) {
+                continue;
+            }
+
+            $pluginChecksumCheckResult = $this->pluginFileHashService->checkPluginForChanges($plugin);
+
+            $extension->setChecksumFileMissing($pluginChecksumCheckResult->isFileMissing());
+            $extension->setChecksumFileWrongVersion($pluginChecksumCheckResult->isWrongVersion());
+            $extension->setNewFiles($pluginChecksumCheckResult->getNewFiles());
+            $extension->setChangedFiles($pluginChecksumCheckResult->getChangedFiles());
+            $extension->setMissingFiles($pluginChecksumCheckResult->getMissingFiles());
+        }
+    }
+}

--- a/src/Core/Framework/Store/Services/ExtensionDataProvider.php
+++ b/src/Core/Framework/Store/Services/ExtensionDataProvider.php
@@ -29,6 +29,7 @@ class ExtensionDataProvider extends AbstractExtensionDataProvider
         private readonly EntityRepository $appRepository,
         private readonly EntityRepository $pluginRepository,
         private readonly ExtensionListingLoader $extensionListingLoader,
+        private readonly ExtensionChecksumLoader $extensionChecksumLoader,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
@@ -50,6 +51,8 @@ class ExtensionDataProvider extends AbstractExtensionDataProvider
         $pluginCollection = $this->extensionLoader->loadFromPluginCollection($context, $installedPlugins);
 
         $extensions = $this->extensionLoader->loadFromAppCollection($context, $installedApps)->merge($pluginCollection);
+
+        $extensions = $this->extensionChecksumLoader->load($extensions, $context);
 
         if ($loadCloudExtensions) {
             $extensions = $this->extensionListingLoader->load($extensions, $context);

--- a/src/Core/Framework/Store/Struct/ExtensionStruct.php
+++ b/src/Core/Framework/Store/Struct/ExtensionStruct.php
@@ -154,6 +154,25 @@ class ExtensionStruct extends Struct
 
     protected bool $managedByComposer = false;
 
+    protected bool $checksumFileMissing = false;
+
+    protected bool $checksumFileWrongVersion = false;
+
+    /**
+     * @var array<string>
+     */
+    protected array $newFiles = [];
+
+    /**
+     * @var array<string>
+     */
+    protected array $missingFiles = [];
+
+    /**
+     * @var array<string>
+     */
+    protected array $changedFiles = [];
+
     /**
      * @param array<string, mixed> $data
      *
@@ -602,5 +621,73 @@ class ExtensionStruct extends Struct
     public function setStoreUrl(string $storeUrl): void
     {
         $this->storeUrl = $storeUrl;
+    }
+
+    public function isChecksumFileMissing(): bool
+    {
+        return $this->checksumFileMissing;
+    }
+
+    public function setChecksumFileMissing(bool $checksumFileMissing): void
+    {
+        $this->checksumFileMissing = $checksumFileMissing;
+    }
+
+    public function isChecksumFileWrongVersion(): bool
+    {
+        return $this->checksumFileWrongVersion;
+    }
+
+    public function setChecksumFileWrongVersion(bool $checksumFileWrongVersion): void
+    {
+        $this->checksumFileWrongVersion = $checksumFileWrongVersion;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getNewFiles(): array
+    {
+        return $this->newFiles;
+    }
+
+    /**
+     * @param array<string> $newFiles
+     */
+    public function setNewFiles(array $newFiles): void
+    {
+        $this->newFiles = $newFiles;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getMissingFiles(): array
+    {
+        return $this->missingFiles;
+    }
+
+    /**
+     * @param array<string> $missingFiles
+     */
+    public function setMissingFiles(array $missingFiles): void
+    {
+        $this->missingFiles = $missingFiles;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getChangedFiles(): array
+    {
+        return $this->changedFiles;
+    }
+
+    /**
+     * @param array<string> $changedFiles
+     */
+    public function setChangedFiles(array $changedFiles): void
+    {
+        $this->changedFiles = $changedFiles;
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Plugin developers have no way to see if their plugin code has been modified other than checking each file. This functionality was included in Shopware 5.

### 2. What does this change do, exactly?

It adds 2 commands and a modal in the administration that allows the creation and checking of a checksum.

### 3. Describe each step to reproduce the issue or behavior.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
