### PR TITLE
NEXT-39319 - fix: prevent current date output in product schema when release date is unset

### DIFF
--- a/changelog/_unreleased/2024-11-03-fix-release-date-schema-issue.md
+++ b/changelog/_unreleased/2024-11-03-fix-release-date-schema-issue.md
@@ -1,0 +1,11 @@
+---
+title: Fix issue with defaulting release date to current day in product schema
+issue: NEXT-38490
+author: Stefan Pilz
+author_email: shopware@stefanpilz.ltd
+author_github: @StefanPilzLtd
+---
+
+# Storefront
+* Added a conditional check in `buy-widget.html.twig` to ensure the release date only appears if explicitly set.
+* Prevented the schema from defaulting to the current date when no release date is provided.

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget.html.twig
@@ -52,8 +52,10 @@
             {% endblock %}
 
             {% block buy_widget_rich_snippets_release_date %}
-                <meta itemprop="releaseDate"
-                      content="{{ product.releaseDate|format_date(pattern='Y-MM-dd') }}">
+                {% if product.releaseDate %}
+                    <meta itemprop="releaseDate"
+                          content="{{ product.releaseDate|format_date(pattern='Y-MM-dd') }}">
+                {% endif %}
             {% endblock %}
         {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
This update is necessary to fix a bug in the product schema markup where the current date was always displayed as the release date if no specific "release date" was set for a product. This behavior could mislead users and search engines, affecting the accuracy of the structured data used for indexing.

### 2. What does this change do, exactly?
The fix adds a conditional check to ensure that the "release date" is only displayed in the schema definition if it is explicitly set. If no release date is defined, no date will be output instead of incorrectly defaulting to the current date. This change modifies the buy-widget.html.twig template file and improves the accuracy of schema data.

### 3. Describe each step to reproduce the issue or behaviour.

- Open the Shopware frontend and navigate to a product without a defined "release date."
- Inspect the HTML schema markup on the product page.
- Observe that the current date is displayed as the releaseDate in the schema, despite no release date being set for the product.
- This issue occurs because the template does not check for the existence of a release date before outputting it in the schema data.

### 4. Please link to the relevant issues (if any).
GitHub Issue: [shopware/shopware#5324](https://github.com/shopware/shopware/issues/5324)

### 5. Checklist

- [X ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X ] I have read the contribution requirements and fulfill them.
