### PR TITLE
chore: update README.md to fix build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-[![Build Status](https://github.com/shopware/shopware/actions/workflows/02-unit.yml/badge.svg)](https://github.com/shopware/shopware/actions/workflows/02-unit.yml)
+[![Build Status](https://github.com/shopware/shopware/actions/workflows/integration.yml/badge.svg)](https://github.com/shopware/shopware/actions/workflows/integration.yml)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/shopware/platform/badges/quality-score.png)](https://scrutinizer-ci.com/g/shopware/platform/)
 [![Latest Stable Version](https://poser.pugx.org/shopware/platform/v/stable)](https://packagist.org/packages/shopware/platform)
 [![Total Downloads](https://poser.pugx.org/shopware/platform/downloads)](https://packagist.org/packages/shopware/platform)


### PR DESCRIPTION
### 1. Why is this change necessary?

build status badge is broken since refactoring 
in aug https://github.com/shopware/shopware/commit/3b2d3bb2928e7343b4f0f34a5abc34b32451fa60

### 2. What does this change do, exactly?

fix it
