### PR TITLE
Fix incorrect measures & packaging field types in product bulk edit

### DIFF
--- a/changelog/_unreleased/2024-10-30-fix-multiple-field-types-in-product-bulk-edit.md
+++ b/changelog/_unreleased/2024-10-30-fix-multiple-field-types-in-product-bulk-edit.md
@@ -1,0 +1,9 @@
+---
+title: Fix multiple field types in product bulk edit
+issue: NEXT-00000
+author: Tim Theisinger
+author_email: tim.theisinger@pickware.de
+---
+
+# Administration
+* Changed the type of the fields `width`, `height`, `length`, `weight`, `purchaseUnit` and `referenceUnit` from `int` to `float` in `src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js`  

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/index.js
@@ -619,7 +619,7 @@ export default {
             return [
                 {
                     name: 'width',
-                    type: 'int',
+                    type: 'float',
                     canInherit: this.isChild,
                     config: {
                         componentName: 'sw-number-field',
@@ -633,7 +633,7 @@ export default {
                 },
                 {
                     name: 'height',
-                    type: 'int',
+                    type: 'float',
                     canInherit: this.isChild,
                     config: {
                         componentName: 'sw-number-field',
@@ -647,7 +647,7 @@ export default {
                 },
                 {
                     name: 'length',
-                    type: 'int',
+                    type: 'float',
                     canInherit: this.isChild,
                     config: {
                         componentName: 'sw-number-field',
@@ -661,7 +661,7 @@ export default {
                 },
                 {
                     name: 'weight',
-                    type: 'int',
+                    type: 'float',
                     canInherit: this.isChild,
                     config: {
                         componentName: 'sw-number-field',
@@ -675,7 +675,7 @@ export default {
                 },
                 {
                     name: 'purchaseUnit',
-                    type: 'int',
+                    type: 'float',
                     canInherit: this.isChild,
                     config: {
                         componentName: 'sw-number-field',
@@ -723,7 +723,7 @@ export default {
                 },
                 {
                     name: 'referenceUnit',
-                    type: 'int',
+                    type: 'float',
                     canInherit: this.isChild,
                     config: {
                         componentName: 'sw-number-field',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, it's not possible to type decimal numbers into the `width`, `height`, `length`, `weight`, `purchaseUnit` and `referenceUnit` inputs in the measures and packaging section when bulk editing products, even though all of these are internally floats.

### 2. What does this change do, exactly?
It fixes the presumably  typos in the configuration of these fields.

### 3. Describe each step to reproduce the issue or behaviour.
1. Start a product bulk edit
2. Go to the measures and packaging section
3. Try to input a decimal number into any of the above mentioned fields

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.