### PR TITLE
Add extension point for ProductListingLoader loadPreviews (Fixes #5395)

### DIFF
--- a/changelog/_unreleased/2024-11-06-add-extension-point-for-productlistingloader-loadpreviews.md
+++ b/changelog/_unreleased/2024-11-06-add-extension-point-for-productlistingloader-loadpreviews.md
@@ -1,0 +1,9 @@
+---
+title: Add extension point for ProductListingLoader loadPreviews
+issue: NEXT-39433
+author: Rune Laenen
+author_email: rune@laenen.me
+author_github: @runelaenen
+---
+# Core
+* Added extension point in `\Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingLoader::resolvePreviews`

--- a/src/Core/Content/Product/Extension/LoadPreviewExtension.php
+++ b/src/Core/Content/Product/Extension/LoadPreviewExtension.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\Extension;
+
+use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @extends Extension<array>
+ */
+#[Package('inventory')]
+final class LoadPreviewExtension extends Extension
+{
+    public const NAME = 'listing-loader.load-previews';
+
+    /**
+     * @internal shopware owns the __constructor, but the properties are public API
+     */
+    public function __construct(
+        /**
+         * @public
+         *
+         * @description The array should contain a list of product ids.
+         */
+        public readonly array $ids,
+        /**
+         * @public
+         *
+         * @description Allows you to access to the current customer/sales-channel context
+         */
+        public readonly SalesChannelContext $context
+    ) {
+    }
+}

--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingLoader.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Product\Events\ProductListingPreviewCriteriaEvent;
 use Shopware\Core\Content\Product\Events\ProductListingResolvePreviewEvent;
+use Shopware\Core\Content\Product\Extension\LoadPreviewExtension;
 use Shopware\Core\Content\Product\Extension\ResolveListingExtension;
 use Shopware\Core\Content\Product\Extension\ResolveListingIdsExtension;
 use Shopware\Core\Content\Product\ProductCollection;
@@ -287,7 +288,11 @@ class ProductListingLoader
 
         $hasOptionFilter = $this->hasOptionFilter($criteria);
         if (!$hasOptionFilter) {
-            $mapping = $this->loadPreviews($keys, $context);
+            $mapping = $this->extensions->publish(
+                name: LoadPreviewExtension::NAME,
+                extension: new LoadPreviewExtension($keys, $context),
+                function: $this->loadPreviews(...)
+            );
         }
 
         $event = new ProductListingResolvePreviewEvent($context, $criteria, $mapping, $hasOptionFilter);

--- a/tests/unit/Core/Content/Product/SalesChannel/Listing/LoadPreviewExtensionTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Listing/LoadPreviewExtensionTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel\Listing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Product\Extension\LoadPreviewExtension;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Tests\Examples\ProductListingCriteriaExtensionExample;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * @internal
+ */
+#[CoversClass(LoadPreviewExtension::class)]
+class LoadPreviewExtensionTest extends TestCase
+{
+    public function testLoadPreviewExample(): void
+    {
+        $example = new ProductListingCriteriaExtensionExample();
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($example);
+
+        $extension = new LoadPreviewExtension(
+            ['5441aebfd9d048338476f88ba7f07c76'],
+            $this->createMock(SalesChannelContext::class)
+        );
+
+        $result = (new ExtensionDispatcher($dispatcher))->publish(
+            name: LoadPreviewExtension::NAME,
+            extension: $extension,
+            function: function (array $ids, SalesChannelContext $context): array {
+                return array_combine($ids, $ids);
+            }
+        );
+
+        static::assertIsArray($result);
+        static::assertEquals(['5441aebfd9d048338476f88ba7f07c76' => '5441aebfd9d048338476f88ba7f07c76'], $result);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
https://github.com/shopware/shopware/issues/5395

### 2. What does this change do, exactly?
Adds an extension point in the ProductListingLoader

### 3. Describe each step to reproduce the issue or behaviour.
/

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/5395

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
