### PR TITLE
fix: Do not use deprecated method in Twig rendering

### DIFF
--- a/changelog/_unreleased/2024-11-06-do-not-use-deprecated-method-in-twig-rendering-which-can-lead-to-a-memory-limit-overflow.md
+++ b/changelog/_unreleased/2024-11-06-do-not-use-deprecated-method-in-twig-rendering-which-can-lead-to-a-memory-limit-overflow.md
@@ -1,0 +1,9 @@
+---
+title: Do not use deprecated method in Twig rendering which can lead to a memory limit overflow
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed `Shopware\Storefront\Theme\ThemeConfigValueAccessor::get` to not use the deprecated method `Shopware\Storefront\Theme\ThemeConfigValueAccessor::buildName` as the trace in Twig rendering can become quite large which can easily lead to a memory limit overflow in `Symfony\Component\ErrorHandler\ErrorHandler::cleanTrace`, as the stack traces in Twig rendering can become quite large

--- a/src/Storefront/Theme/ThemeConfigValueAccessor.php
+++ b/src/Storefront/Theme/ThemeConfigValueAccessor.php
@@ -60,7 +60,7 @@ class ThemeConfigValueAccessor
         if (!Feature::isActive('cache_rework')) {
             if ($this->fineGrainedCache) {
                 foreach (array_keys($this->keys) as $trace) {
-                    $this->traces[$trace][self::buildName($key)] = true;
+                    $this->traces[$trace]['theme.' . $key] = true;
                 }
             } else {
                 foreach (array_keys($this->keys) as $trace) {


### PR DESCRIPTION
### 1. Why is this change necessary?
We have overwritten the template `@Storefront/storefront/component/product/card/badges.html.twig` with the following content:
```twig
{% block component_product_badges_new %}
    {{ parent() }}

    {% if product.extensions.swkwebProductSetListingPrice and config('SwkwebProductSet.config.swkwebProductSetProductBoxBadge') %}
        {% block swkweb_product_set_product_card_badge  %}
            <div>
                <span class="badge bg-success">{{ 'swkweb-product-set.product.box.badge'|trans }}</span>
            </div>
        {% endblock %}
    {% endif %}
{% endblock %}
```

If we run into the `if` condition `config(...)` several times on a page, the memory limit of 512MB is easily overflown:
```
PHP Fatal error:  Allowed memory size of 536870912 bytes exhausted (tried to allocate 20480 bytes) in /srv/http/sw/platform/vendor/symfony/error-handler/ErrorHandler.php on line 732
```

While debugging, I found that the deprecation is causing the overflow, see the following trace:
![image](https://github.com/user-attachments/assets/b2f82c92-7c42-4efe-bbe0-2a76b0fd207c)

### 2. What does this change do, exactly?
Remove triggering the deprecation, by inlining the key generation, with the change the "offending" memory consumers are gone:
![image](https://github.com/user-attachments/assets/b3bebfa9-66f9-48bd-aaf3-2a3841fb8ca5)

It would be quite nice, if we could get a fixing patch release for this change, as we received a number of bug reports for this already, although I missed the deadline for the `6.6.8.1` release.

### 3. Describe each step to reproduce the issue or behaviour.
Have a template, which is calling the `config()` method in the theme, and do it quite often in a deeply nested template and try to render the page without cache. 

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
