### PR TITLE
NEXT-00000 - Allow activating staging mode via console with no interaction

### DIFF
--- a/changelog/_unreleased/2024-11-06-add-force-option-command-system-setup-staging.md
+++ b/changelog/_unreleased/2024-11-06-add-force-option-command-system-setup-staging.md
@@ -1,0 +1,9 @@
+---
+title: Added --force option to command `bin/console system:setup:staging`
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+issue: NEXT-00000
+---
+# Core
+* Added `--force` option to command `bin/console system:setup:staging` to allow activating staging mode without confirm

--- a/changelog/_unreleased/2024-11-06-allow-activating-staging-mode-with-no-interaction.md
+++ b/changelog/_unreleased/2024-11-06-allow-activating-staging-mode-with-no-interaction.md
@@ -1,9 +1,0 @@
----
-title: Allow activating staging mode via console with no interaction
-author: Marcus Müller
-author_email: 25648755+M-arcus@users.noreply.github.com
-author_github: @M-arcus
-issue: NEXT-00000
----
-# Core
-* Changed command `bin/console system:setup:staging` confirm default to true to allow activating staging mode with no interaction

--- a/changelog/_unreleased/2024-11-06-allow-activating-staging-mode-with-no-interaction.md
+++ b/changelog/_unreleased/2024-11-06-allow-activating-staging-mode-with-no-interaction.md
@@ -1,0 +1,9 @@
+---
+title: Allow activating staging mode via console with no interaction
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+issue: NEXT-00000
+---
+# Core
+* Changed command `bin/console system:setup:staging` confirm default to true to allow activating staging mode with no interaction

--- a/src/Core/Maintenance/Staging/Command/SystemSetupStagingCommand.php
+++ b/src/Core/Maintenance/Staging/Command/SystemSetupStagingCommand.php
@@ -34,7 +34,7 @@ class SystemSetupStagingCommand extends Command
     {
         $io = new ShopwareStyle($input, $output);
 
-        if (!$io->confirm('This command will install the Shopware 6 system in staging mode. It will overwrite existing data in this database, make sure you use a staging database and have a backup', false)) {
+        if (!$io->confirm('This command will install the Shopware 6 system in staging mode. It will overwrite existing data in this database, make sure you use a staging database and have a backup')) {
             return self::FAILURE;
         }
 

--- a/src/Core/Maintenance/Staging/Command/SystemSetupStagingCommand.php
+++ b/src/Core/Maintenance/Staging/Command/SystemSetupStagingCommand.php
@@ -11,6 +11,7 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -30,11 +31,16 @@ class SystemSetupStagingCommand extends Command
         parent::__construct();
     }
 
+    protected function configure(): void
+    {
+        $this->addOption('force', 'f', InputOption::VALUE_NONE, 'Force setup of staging system');
+    }
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new ShopwareStyle($input, $output);
 
-        if (!$io->confirm('This command will install the Shopware 6 system in staging mode. It will overwrite existing data in this database, make sure you use a staging database and have a backup')) {
+        if (!$input->getOption('force') && !$io->confirm('This command will install the Shopware 6 system in staging mode. It will overwrite existing data in this database, make sure you use a staging database and have a backup', false)) {
             return self::FAILURE;
         }
 

--- a/tests/unit/Core/Maintenance/Staging/Command/SystemSetupStagingCommandTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Command/SystemSetupStagingCommandTest.php
@@ -56,7 +56,7 @@ class SystemSetupStagingCommandTest extends TestCase
         static::assertInstanceOf(SetupStagingEvent::class, $event);
     }
 
-    public function testRunNoInteraction(): void
+    public function testRunNoInteractionWithForce(): void
     {
         $configService = new StaticSystemConfigService();
         $eventDispatcher = new CollectingEventDispatcher();
@@ -67,8 +67,7 @@ class SystemSetupStagingCommandTest extends TestCase
         );
 
         $tester = new CommandTester($command);
-        $tester->setInputs(['yes']);
-        $tester->execute([], ['interactive' => false]);
+        $tester->execute(['--force' => null], ['interactive' => false]);
         $tester->assertCommandIsSuccessful();
 
         static::assertTrue($configService->get('core.staging'));
@@ -77,5 +76,18 @@ class SystemSetupStagingCommandTest extends TestCase
         $event = $eventDispatcher->getEvents()[0];
 
         static::assertInstanceOf(SetupStagingEvent::class, $event);
+    }
+
+    public function testRunNoInteractionWithoutForce(): void
+    {
+        $command = new SystemSetupStagingCommand(
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(SystemConfigService::class)
+        );
+
+        $tester = new CommandTester($command);
+
+        $tester->execute([], ['interactive' => false]);
+        static::assertSame(Command::FAILURE, $tester->getStatusCode());
     }
 }

--- a/tests/unit/Core/Maintenance/Staging/Command/SystemSetupStagingCommandTest.php
+++ b/tests/unit/Core/Maintenance/Staging/Command/SystemSetupStagingCommandTest.php
@@ -55,4 +55,27 @@ class SystemSetupStagingCommandTest extends TestCase
 
         static::assertInstanceOf(SetupStagingEvent::class, $event);
     }
+
+    public function testRunNoInteraction(): void
+    {
+        $configService = new StaticSystemConfigService();
+        $eventDispatcher = new CollectingEventDispatcher();
+
+        $command = new SystemSetupStagingCommand(
+            $eventDispatcher,
+            $configService
+        );
+
+        $tester = new CommandTester($command);
+        $tester->setInputs(['yes']);
+        $tester->execute([], ['interactive' => false]);
+        $tester->assertCommandIsSuccessful();
+
+        static::assertTrue($configService->get('core.staging'));
+        static::assertCount(1, $eventDispatcher->getEvents());
+
+        $event = $eventDispatcher->getEvents()[0];
+
+        static::assertInstanceOf(SetupStagingEvent::class, $event);
+    }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently, it is not possible to activate staging mode via CLI command `system:setup:staging` with the `--no-interaction` option.

### 2. What does this change do, exactly?

It changes the default of the confirm-question to true, to allow activating staging mode via CLI command `system:setup:staging` with the `--no-interaction` option.

### 3. Describe each step to reproduce the issue or behavior.

Follow the documentation here: https://developer.shopware.com/docs/guides/hosting/configurations/shopware/staging.html#activate-the-staging-mode, with the `--no-interaction` option

### 4. Please link to the relevant issues (if any).

There aren't any.

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
