### PR TITLE
Open correct image in PDP Zoom modal

### DIFF
--- a/changelog/_unreleased/2024-11-07-open-correct-image-in-pdp-zoom-modal.md
+++ b/changelog/_unreleased/2024-11-07-open-correct-image-in-pdp-zoom-modal.md
@@ -1,0 +1,9 @@
+---
+title: Open correct image in PDP Zoom modal
+issue: NEXT-39450
+author: Rune Laenen
+author_email: rune@laenen.me
+author_github: @runelaenen
+---
+# Storefront
+* Changed the logic of focussing the correct slide in case the slider is already initialized to use same logic as when the slider is first opened.

--- a/src/Storefront/Resources/app/storefront/src/plugin/zoom-modal/zoom-modal.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/zoom-modal/zoom-modal.plugin.js
@@ -303,9 +303,8 @@ export default class ZoomModalPlugin extends Plugin {
         const galleryImages =  modal.querySelectorAll(this.options.imgGallerySelector);
 
         if (this.gallerySliderPlugin && this.gallerySliderPlugin._slider) {
-
-            this.gallerySliderPlugin._slider.goTo(parentSliderIndex + 1);
-            window.focusHandler.setFocus(galleryImages.item(parentSliderIndex + 1));
+            this.gallerySliderPlugin._slider.goTo(parentSliderIndex);
+            window.focusHandler.setFocus(galleryImages.item(parentSliderIndex));
 
             return;
         }
@@ -333,6 +332,7 @@ export default class ZoomModalPlugin extends Plugin {
             },
         }).then(() => {
             this.gallerySliderPlugin = window.PluginManager.getPluginInstanceFromElement(slider, 'GallerySlider');
+            this.gallerySliderPlugin._slider.goTo(parentSliderIndex);
             window.focusHandler.setFocus(galleryImages.item(parentSliderIndex));
 
             this.$emitter.publish('initSlider');


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes https://github.com/shopware/shopware/issues/5410

### 2. What does this change do, exactly?
Use the same logic to assign the focus as is currently already used on the first loading of the modal.

### 3. Describe each step to reproduce the issue or behaviour.
https://github.com/shopware/shopware/issues/5410

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/5410

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
