### PR TITLE
feat: configuration for meta tag "robots"

### DIFF
--- a/changelog/_unreleased/2024-11-08-add-configuration-for-meta-tag-robots.md
+++ b/changelog/_unreleased/2024-11-08-add-configuration-for-meta-tag-robots.md
@@ -1,0 +1,12 @@
+---
+title: Add configuration for meta tag "robots"
+issue: NEXT-000000
+author: Vincent Neubauer
+author_email: v.neubauer@vonmaehlen.com
+author_github: @dallyger
+---
+# Administration
+* Added text field "Robots Meta Tag" to Settings > Basic information
+___
+# Storefront
+* Render `<meta name="robots" ...>` based on Settings > Basic information > Robots Meta Tag.

--- a/changelog/_unreleased/2024-11-08-add-configuration-for-meta-tag-robots.md
+++ b/changelog/_unreleased/2024-11-08-add-configuration-for-meta-tag-robots.md
@@ -1,12 +1,26 @@
 ---
 title: Add configuration for meta tag "robots"
-issue: NEXT-000000
 author: Vincent Neubauer
 author_email: v.neubauer@vonmaehlen.com
 author_github: @dallyger
 ---
+
 # Administration
-* Added text field "Robots Meta Tag" to Settings > Basic information
+
+* Added new configuration for "Robots Meta Tag" to Settings > Basic information
+
 ___
+
 # Storefront
-* Render `<meta name="robots" ...>` based on Settings > Basic information > Robots Meta Tag.
+
+* Changed rendering of robots meta tag to consider new setting.
+
+___
+
+# Upgrade Information
+
+## New robots meta tag configuration
+
+The new configuration option "Robots Meta Tag" has been added to the administration under Settings > Basic information.
+This allows you to set the content of the robots meta tag rendered in the storefront (`<meta name="robots" ...>`).
+

--- a/src/Core/System/Resources/config/basicInformation.xml
+++ b/src/Core/System/Resources/config/basicInformation.xml
@@ -231,4 +231,18 @@
         </component>
     </card>
 
+    <card>
+        <title>Meta</title>
+        <input-field type="text">
+            <name>metaRobots</name>
+            <label>Robots Meta Tag</label>
+            <label lang="de-DE">Robots Meta Tag</label>
+            <helpText>This option affects the default content attribute of the "robots" meta tag. CMS pages can override this value. Some pages like the cart will always set "noindex,follow".</helpText>
+            <helpText lang="de-DE">Diese Option betrifft den Standardwert des "robots" Meta Tag. CMS Seiten können diesen Wert überschreiben. Einige Seiten, wie der Warenkorb, nutzen immer "noindex,follow".</helpText>
+            <defaultValue>index,follow</defaultValue>
+            <placeholder>index,follow</placeholder>
+            <placeholder lang="de-DE">index,follow</placeholder>
+        </input-field>
+    </card>
+
 </config>

--- a/src/Storefront/Page/GenericPageLoader.php
+++ b/src/Storefront/Page/GenericPageLoader.php
@@ -29,7 +29,7 @@ class GenericPageLoader implements GenericPageLoaderInterface
 
             $page->setMetaInformation((new MetaInformation())->assign([
                 'revisit' => '15 days',
-                'robots' => 'index,follow',
+                'robots' => $this->systemConfigService->getString('core.basicInformation.metaRobots', $context->getSalesChannel()->getId()) ?: 'index,follow',
                 'xmlLang' => $request->attributes->get(SalesChannelRequest::ATTRIBUTE_DOMAIN_LOCALE) ?? '',
                 'metaTitle' => $this->systemConfigService->getString('core.basicInformation.shopName', $context->getSalesChannelId()),
             ]));


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently, there is no way to notify crawlers, that they should not index the site / a storefront.


### 2. What does this change do, exactly?

Add configuration option at Settings > Basic information to define the default content of meta tag "robots".

Using the hard coded value as a fallback on a null-ish value, because updating an existing project will not auto-load the defaultValue into DB and people may save an empty value, thinking it would fall back to the default/previous behaviour.

Initially, I thought to add the configuration option to "Settings > SEO", but that configuration does not support saving settings for an individual sales channel.

I've checked for test files, I could append. However, there seems to be none for the GenericPageLoader::class. Checked other `*PageLoader::class` files to check if I could copy and adapt them. But they're a lot of work to adapt. Therefore, I've skipped the tests. If you could point me to an existing test file to use, I will check if I can add a test for this change. But right now, that seems to be a huge waste of time and resources with very little benefit (because nothing else seems to be tested from that class).

### 3. Describe each step to reproduce the issue or behaviour.

Setup Shopware

### 4. Please link to the relevant issues (if any).

None

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
