### PR TITLE
fix(storefront): update review language property according to schema.org

### DIFF
--- a/changelog/_unreleased/2024-11-09-review-schema-preoprty-change.md
+++ b/changelog/_unreleased/2024-11-09-review-schema-preoprty-change.md
@@ -1,0 +1,9 @@
+---
+title: Change outdated language property to inLanguage on Review schema
+issue: NEXT-000000
+author: Alex Jank
+author_email: alex@nuonic.de
+author_github: @jankal
+---
+# Storefront
+* Changed the `language` property of the `Review` schema type to `inLanguage` as per https://schema.org/inLanguage

--- a/src/Storefront/Resources/views/storefront/component/review/review-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review-item.html.twig
@@ -15,7 +15,7 @@
 
         {% block component_review_item_meta_lang %}
             {% if review.language %}
-                <meta itemprop="language" content="{{ review.language.translationCode.code }}">
+                <meta itemprop="inLanguage" content="{{ review.language.translationCode.code }}">
             {% endif %}
         {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/page/product-detail/review/review-item.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/review/review-item.html.twig
@@ -17,7 +17,7 @@
             <meta itemprop="name" content="{{ review.title }}">
 
             {% if review.language %}
-                <meta itemprop="language" content="{{ review.language.translationCode.code }}">
+                <meta itemprop="inLanguage" content="{{ review.language.translationCode.code }}">
             {% endif %}
         {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
According to https://schema.org/inLanguage the previous `language` property changed to the new `inLanguage` property.

### 2. What does this change do, exactly?
Rename the field in the schema meta information in review-item.html.twig

### 3. Describe each step to reproduce the issue or behaviour.
Run the previous version through https://validator.schema.org/ and get an error like this:
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/d235932c-2c52-4356-a24b-727df733d5ed">

### 4. Please link to the relevant issues (if any).
none

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
