### PR TITLE
chore: Correct command in changelog

### DIFF
--- a/UPGRADE-6.6.md
+++ b/UPGRADE-6.6.md
@@ -1,6 +1,6 @@
 # 6.6.7.0
 ## Shortened filenames with hashes for async JS built files
-When building the Storefront JS-files for production using `composer run build:storefront`, the async bundle filenames no longer contain the filepath.
+When building the Storefront JS-files for production using `composer run build:js:storefront`, the async bundle filenames no longer contain the filepath.
 Instead, only the filename is used with a chunkhash / dynamic version number. This also helps to identify which files have changed after build. Similar to the main entry file like e.g. `cms-extensions.js?1720776107`.
 
 **JS Filename before change in dist:**

--- a/changelog/release-6-6-7-0/2024-08-07-add-contenthash-for-js-plugins.md
+++ b/changelog/release-6-6-7-0/2024-08-07-add-contenthash-for-js-plugins.md
@@ -8,7 +8,7 @@ author_github: BrocksiNet
 # Storefront
 * Changed `webpack.config.js` to add a chunkhash for async JS built files (chunks) and clean up.
   * This allows you to better cache the JS files in the browser.
-  * If you want to use this feature you at least have to run `composer run build:storefront` once after the update.
+  * If you want to use this feature you at least have to run `composer run build:js:storefront` once after the update.
   * This change will also clean up the `dist` folder in plugins/apps and core. So make sure all files below 
     `/dist/storefront` can be rebuild.
 * Added webpack Plugin `FilenameToChunkNamePlugin.js` to shorten the filename and remove the path in production.
@@ -16,7 +16,7 @@ ___
 # Upgrade Information
 
 ## Shortened filenames with hashes for async JS built files
-When building the Storefront JS-files for production using `composer run build:storefront`, the async bundle filenames no longer contain the filepath.
+When building the Storefront JS-files for production using `composer run build:js:storefront`, the async bundle filenames no longer contain the filepath.
 Instead, only the filename is used with a chunkhash / dynamic version number. This also helps to identify which files have changed after build. Similar to the main entry file like e.g. `cms-extensions.js?1720776107`.
 
 **JS Filename before change in dist:**


### PR DESCRIPTION
### 1. Why is this change necessary?
There is no composer command `build:storefront` only `build:js:storefront`, and therefore while reading the UPGRADE notes I was quite confused, if the JS files need to be built differently for production, than for development (where I usually used the `build:js:storefront`).

Additionally note that in production setups usually you do not have the `composer.json` from the platform repository, but the script `bin/build-storefront.sh`. Not sure if that should also be included.

### 2. What does this change do, exactly?
Change the UPGRADE nodes and changelog to only mention the existing command.

### 3. Describe each step to reproduce the issue or behaviour.
Read the UPGRADE notes.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
