### PR TITLE
NEXT-00000 - Fix return type of method getOrderCustomers

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -37,5 +37,9 @@ return [
         'The parameter $languageIdChain of \\\\Shopware\\\\Elasticsearch\\\\TokenQueryBuilder#build\(\) changed from array to array|Shopware\\\\Core\\\\Framework\\\\Context',
         'Parameter 3 of Shopware\\\\Elasticsearch\\\\TokenQueryBuilder#build\(\) changed name from languageIdChain to context',
         'Parameter context was added to Method build\(\) of class Shopware\\\\Elasticsearch\\\\TokenQueryBuilder',
+
+        // The return type was incorrect and led to an error. It is not a breaking change if it's already breaking.
+        'The return type of Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderCollection#getOrderCustomers(\) changed from Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerCollection to the non-covariant Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerCollection',
+        'The return type of Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderCollection#getOrderCustomers(\) changed from Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerCollection to Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerCollection',
     ],
 ];

--- a/changelog/_unreleased/2024-11-11-fix-return-type-of-method-getOrderCustomers.md
+++ b/changelog/_unreleased/2024-11-11-fix-return-type-of-method-getOrderCustomers.md
@@ -1,0 +1,9 @@
+---
+title: Fix return type of method getOrderCustomers
+issue: NEXT-00000
+author: Moritz Müller
+author_email: moritz@momocode.de
+author_github: @momocode-de
+---
+# Core
+* Changed method `getOrderCustomers` in `Shopware\Core\Checkout\Order\OrderCollection` class to return a `OrderCustomerCollection` instead of `CustomerCollection`

--- a/src/Core/Checkout/Order/OrderCollection.php
+++ b/src/Core/Checkout/Order/OrderCollection.php
@@ -2,8 +2,8 @@
 
 namespace Shopware\Core\Checkout\Order;
 
-use Shopware\Core\Checkout\Customer\CustomerCollection;
 use Shopware\Core\Checkout\Order\Aggregate\OrderAddress\OrderAddressCollection;
+use Shopware\Core\Checkout\Order\Aggregate\OrderCustomer\OrderCustomerCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Currency\CurrencyCollection;
@@ -41,9 +41,9 @@ class OrderCollection extends EntityCollection
         return $this->filter(fn (OrderEntity $order) => $order->getSalesChannelId() === $id);
     }
 
-    public function getOrderCustomers(): CustomerCollection
+    public function getOrderCustomers(): OrderCustomerCollection
     {
-        return new CustomerCollection(
+        return new OrderCustomerCollection(
             $this->fmap(fn (OrderEntity $order) => $order->getOrderCustomer())
         );
     }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The function `getOrderCustomers` has so far returned a `CustomerCollection`. However, an `OrderCustomerCollection` would be correct, otherwise this error would occur:

![image](https://github.com/user-attachments/assets/1fbd542c-8736-4c3a-91b5-abfb8e26dcbd)

### 2. What does this change do, exactly?

An `OrderCustomerCollection` is now returned instead of an `CustomerCollection`.

### 3. Describe each step to reproduce the issue or behaviour.

If I see it correctly, the function `getOrderCustomers` is not used anywhere in the core. If I use it in a plugin, I get the error shown above.

### 4. Please link to the relevant issues (if any).

x

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
