### PR TITLE
Fix symfony scheduler bridge

### DIFF
--- a/changelog/_unreleased/2024-11-12-fix-symfony-scheduler-bridge-for-tasks-with-long-interval.md
+++ b/changelog/_unreleased/2024-11-12-fix-symfony-scheduler-bridge-for-tasks-with-long-interval.md
@@ -1,0 +1,10 @@
+---
+title: Fix symfony scheduler bridge for tasks with long interval
+issue: NEXT-00000
+author: Felix Schneider
+author_github: @schneider-felix
+---
+# Core
+* Changed `ScheduleProvider` to be stateful to ensure scheduled tasks with long
+ intervals are executed even if the message worker was restarted in the meantime
+* Changed `ScheduleProvider` to use a lock to ensure multiple workers can run in parallel

--- a/src/Core/Framework/DependencyInjection/scheduled-task.xml
+++ b/src/Core/Framework/DependencyInjection/scheduled-task.xml
@@ -24,6 +24,8 @@
         <service id="Shopware\Core\Framework\MessageQueue\ScheduledTask\SymfonyBridge\ScheduleProvider">
             <argument type="tagged" tag="shopware.scheduled.task" />
             <argument type="service" id="Doctrine\DBAL\Connection"/>
+            <argument type="service" id="cache.object"/>
+            <argument type="service" id="lock.factory"/>
 
             <tag name="scheduler.schedule_provider">
                 <attribute name="name">shopware</attribute>

--- a/tests/unit/Core/Framework/MessageQueue/ScheduledTask/SymfonyBridge/ScheduleProviderTest.php
+++ b/tests/unit/Core/Framework/MessageQueue/ScheduledTask/SymfonyBridge/ScheduleProviderTest.php
@@ -8,7 +8,10 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTask;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskDefinition;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\SymfonyBridge\ScheduleProvider;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Symfony\Component\Clock\MockClock;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
 use Symfony\Component\Scheduler\Generator\MessageGenerator;
 
 /**
@@ -24,7 +27,12 @@ class ScheduleProviderTest extends TestCase
             new TestTask2(),
         ];
 
-        $scheduleProvider = new ScheduleProvider($tasks, $this->createMock(Connection::class));
+        $scheduleProvider = new ScheduleProvider(
+            $tasks,
+            $this->createMock(Connection::class),
+            new ArrayAdapter(),
+            new LockFactory(new InMemoryStore()),
+        );
 
         $mockClock = new MockClock();
         $generator = new MessageGenerator($scheduleProvider, 'foo', $mockClock);
@@ -69,7 +77,12 @@ class ScheduleProviderTest extends TestCase
             ]
         );
 
-        $scheduleProvider = new ScheduleProvider($tasks, $connection);
+        $scheduleProvider = new ScheduleProvider(
+            $tasks,
+            $connection,
+            new ArrayAdapter(),
+            new LockFactory(new InMemoryStore()),
+        );
 
         $mockClock = new MockClock();
         $generator = new MessageGenerator($scheduleProvider, 'foo', $mockClock);


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently the recommended way to run a message worker is with a command like this:

```
bin/console messenger:consume scheduler_shopware --time-limit=60
```

However with the way the `ScheduleProvider.php` is currently working, all timers will be reset, when the message worker is restarted. Therefore, a job running only every 3600 seconds would never be executed. 

Sadly, the corresponding Symfony docs are not very clear about this. 

### 2. What does this change do, exactly?

Making the Schedule `stateful` will ensure Symfony writes the last execution time to the cache. Thereby it can pick up where it left off, when the worker was killed. 

I was thinking about introducing a separate cache pool for the scheduled tasks because object cache is deprecated and you might want to specify different settings (like cache ttl) for your scheduled tasks cache. Let me know how you would like this to be handled. 

There is still one major difference in behaviour, when compared to the `scheduled-task:run` command. Symfony Scheduler will queue the message as many times as it would have run if the messenger wasn't stopped. See the following example for clarification: 

Messenger is stopped for 5 minutes.
Job A has an interval of 60 seconds.

**Scenario A: Tasks are scheduled by `scheduled-task:run`**
After restarting, the command will notice that the task is overdue and dispatch **ONE** message.

**Scenario B: Tasks are scheduled by `messenger:consume scheduler_shopware`**
After restarting, the transport will notice that the task was last run 5 minutes ago. It will calculate `300s / 60s = 5` and therefore dispatch 5 messages. 

---

I also added a lock to the schedule to ensure it is handled correctly when multiple workers are running.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a scheduled task (set the interval to 60s for example)
2. Create the corresponding handler. It could for example look like this:
```php
#[AsMessageHandler(handles: ExampleTask::class)]
class ExampleTaskHandler extends ScheduledTaskHandler
{

    public function run(): void
    {
        dump("RUNNING TASK");
    }
}
```
3. Run `bin/console messenger:consume scheduler_shopware --time-limit=30` (make sure the time limit is shorter than your interval)
4. Notice that even after running this command multiple times, the `RUNNING TASK` debug output will never be printed.

> [!IMPORTANT]
> Make sure to test in prod mode, because the caches are deactivated in dev mode. 

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
