### PR TITLE
Fix exception in ElasticsearchIndexer

### DIFF
--- a/changelog/_unreleased/2024-11-13-fix-exception-in-elasticsearch-indexer.md
+++ b/changelog/_unreleased/2024-11-13-fix-exception-in-elasticsearch-indexer.md
@@ -1,8 +1,8 @@
 ---
 title: Fix exception thrown by the logic of the ElasticsearchIndexer
 issue: NEXT-00000
-author: Tommy Meier
-author_github: @tyurderi
+author: Net Inventors GmbH
+author_github: @NetInventors
 ---
 # Core
 * Changed method `handleIndexingMessage` in `src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php` to fix a thrown exception

--- a/changelog/_unreleased/2024-11-13-fix-exception-in-elasticsearch-indexer.md
+++ b/changelog/_unreleased/2024-11-13-fix-exception-in-elasticsearch-indexer.md
@@ -1,0 +1,8 @@
+---
+title: Fix exception thrown by the logic of the ElasticsearchIndexer
+issue: NEXT-00000
+author: Tommy Meier
+author_github: @tyurderi
+---
+# Core
+* Changed method `handleIndexingMessage` in `src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php` to fix a thrown exception

--- a/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+++ b/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
@@ -289,7 +289,7 @@ class ElasticsearchIndexer
         foreach ($toRemove as $id) {
             $documents[] = ['delete' => ['_id' => $id]];
         }
-        
+
         if ($documents === []) {
             return;
         }

--- a/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+++ b/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
@@ -289,6 +289,10 @@ class ElasticsearchIndexer
         foreach ($toRemove as $id) {
             $documents[] = ['delete' => ['_id' => $id]];
         }
+        
+        if ([] === $documents) {
+            return;
+        }
 
         $arguments = [
             'index' => $index,

--- a/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
+++ b/src/Elasticsearch/Framework/Indexing/ElasticsearchIndexer.php
@@ -290,7 +290,7 @@ class ElasticsearchIndexer
             $documents[] = ['delete' => ['_id' => $id]];
         }
         
-        if ([] === $documents) {
+        if ($documents === []) {
             return;
         }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When updating the **same** `order_line_item` in the **same** request **multiple** times, it throws the following exception:

![image (9)](https://github.com/user-attachments/assets/22e3c25a-6600-4187-aa70-012cf6949595)

The root cause is that the method `\Shopware\Core\Content\Product\Stock\OrderStockSubscriber::beforeWriteOrderItems` will not find any changeset for the second update of the entity, which is not yet catched in the ElasticsearchIndexer class.

### 2. What does this change do, exactly?
It adds a condition that checks if the array `$documents` is empty and stops further handling of the indexing message to prevent creating an empty request body, which results in the exception at a later point.

### 3. Describe each step to reproduce the issue or behaviour.
At first, you need to have your Shopware instance set up with elasticsearch. We encounted the problem within our plugin NetiNextEasyCoupon but there is some code that reproduces the issue. It is only an example to reproduce the behavior, we are not updating the same order_line_item with the same data twice.

```php
$changes = [
    'id' => '019325bed02073519c5232a942d3b106',
    'referencedId' => '019169ccaf517030ae85a115ccee1444',
    'productId' => '019169ccaf517030ae85a115ccee1444',
    'payload' => [
        'productNumber' => 'SW10005',
    ]
];

$this->orderLineItemRepository->update([ $changes ], $context);
$this->orderLineItemRepository->update([ $changes ], $context);
```

Make sure to replace the IDs in the payload with valid values of an order_line_item row.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
