### PR TITLE
fix(storefront): replace semantically invalid `h1` tags

### DIFF
--- a/changelog/_unreleased/2024-11-19-replace-multiple-invalid-h1-tags-with-h2-tags.md
+++ b/changelog/_unreleased/2024-11-19-replace-multiple-invalid-h1-tags-with-h2-tags.md
@@ -1,0 +1,9 @@
+---
+title: Replace multiple, invalid H1 tags with H2 tags
+issue: 0000
+author: Zuza Gronska
+author_email: zgronska@gmail.com
+author_github: @Zuza Gronska
+---
+# Storefront
+* In `component/account/login.html.twig` and `component/account/register.html.twig`, replaced `cardTitle` `h1` element with a `h2` element.

--- a/src/Storefront/Resources/views/storefront/component/account/login.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/account/login.html.twig
@@ -3,9 +3,9 @@
         <div class="card-body">
             {% block component_account_login_header %}
                 {% if cardTitle %}
-                    <h1 class="card-title">
+                    <h2 class="card-title">
                         {{ cardTitle }}
-                    </h1>
+                    </h2>
                 {% endif %}
             {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/component/account/register.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/account/register.html.twig
@@ -3,9 +3,9 @@
         <div class="card-body">
             {% block component_account_register_header %}
                 {% if cardTitle %}
-                    <h1 class="card-title">
+                    <h2 class="card-title">
                         {{ cardTitle }}
-                    </h1>
+                    </h2>
                 {% endif %}
             {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
According to [best practices](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements#avoid_using_multiple_h1_elements_on_one_page), a page should have only one `h1` element.
Both `.card-title`s  in login and register card components are `h1`s. In consequence:
- on the login/register page (`/account/login`) there are two `h1`s ("I'm a customer already!", "I'm a new customer!"),
- on the checkout register page (`checkout/register`) there are two `h1`s ("Shipping information", "Your personal details").
This structure is semantically invalid according to aformentioned best practices.

### 2. What does this change do, exactly?
This change replaces the `h1` tags with `h2` tags, which can coexist on the same level.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
