### PR TITLE
Prevent triggering license violations from loopback address (127.0.0.1)

### DIFF
--- a/changelog/_unreleased/2024-11-20-prevent-license-violation-from-loopback-address.md
+++ b/changelog/_unreleased/2024-11-20-prevent-license-violation-from-loopback-address.md
@@ -1,0 +1,9 @@
+---
+title: Prevent license violation from loopback address
+issue: NEXT-00000
+author: Felix Schneider
+author_email: felix@wirduzen.de
+author_github: @schneider-felix
+___
+# Administration
+* Changed `license-violation.service.js` to prevent license violation from loopback address

--- a/src/Administration/Resources/app/administration/src/app/service/license-violation.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/service/license-violation.service.spec.js
@@ -21,6 +21,7 @@ describe('app/service/license-violation.service.js', () => {
 
     beforeEach(async () => {
         jest.clearAllMocks();
+        delete window.location;
     });
 
     it('should be an object', async () => {
@@ -218,5 +219,17 @@ describe('app/service/license-violation.service.js', () => {
         expect(cacheApiServiceMock.clear).not.toHaveBeenCalled();
         expect(extensionApiServiceMock.uninstallExtension).not.toHaveBeenCalled();
         expect(extensionApiServiceMock.removeExtension).toHaveBeenCalled();
+    });
+
+    it('should not trigger license violation for loopback', async () => {
+        window.location = new URL('http://127.0.0.1');
+
+        const res = await licenseViolationService.checkForLicenseViolations();
+
+        expect(res).toEqual({
+            warnings: [],
+            violations: [],
+            other: [],
+        });
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/service/license-violations.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/license-violations.service.js
@@ -34,7 +34,17 @@ export default function createLicenseViolationsService(storeService) {
     };
 
     function checkForLicenseViolations() {
-        const topLevelDomain = window.location.hostname.split('.').pop();
+        const hostname = window.location.hostname;
+
+        if (hostname === '[::1]' || hostname === '127.0.0.1') {
+            return Promise.resolve({
+                warnings: [],
+                violations: [],
+                other: [],
+            });
+        }
+
+        const hostnameParts = hostname.split('.').pop();
         const allowlistDomains = [
             'localhost',
             'test',
@@ -47,7 +57,7 @@ export default function createLicenseViolationsService(storeService) {
         ];
 
         // if the user is on a allowlisted domain
-        if (allowlistDomains.includes(topLevelDomain)) {
+        if (allowlistDomains.includes(hostnameParts)) {
             return Promise.resolve({
                 warnings: [],
                 violations: [],


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently when developing locally, the admin will trigger a license violation when connecting using a loopback address like 127.0.0.1 / [::1]. An E-Mail will then be sent to the customer informing them about a license violation. This does obviously not make sense at all. 

### 2. What does this change do, exactly?

Just check for 127.0.0.1 and [::1]

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
