### PR TITLE
chore: Remove remaining Vue2 compatibility code

### DIFF
--- a/changelog/_unreleased/2024-11-22-removed-unneeded-vue2-compatibility-code.md
+++ b/changelog/_unreleased/2024-11-22-removed-unneeded-vue2-compatibility-code.md
@@ -1,0 +1,9 @@
+---
+title: Removed unneeded Vue2 compatibility code
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Removed unneeded Vue2 compatibility code from the `sw-highlight-text` component and the `app-cms` service

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-highlight-text/index.js
@@ -18,16 +18,7 @@ Component.register('sw-highlight-text', {
 
     compatConfig: Shopware.compatConfig,
 
-    render(createElement) {
-        // Vue2 syntax
-        if (typeof createElement === 'function') {
-            return createElement('div', {
-                class: 'sw-highlight-text',
-                domProps: { innerHTML: this.searchAndReplace() },
-            });
-        }
-
-        // Vue3 syntax
+    render() {
         return h('div', {
             class: 'sw-highlight-text',
             innerHTML: this.searchAndReplace(),

--- a/src/Administration/Resources/app/administration/src/app/service/app-cms.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/app-cms.service.js
@@ -138,7 +138,7 @@ export default class AppCmsService {
             name: componentName,
             compatConfig: Shopware.compatConfig,
 
-            render(createElement) {
+            render() {
                 const slotEntries = Object.entries(block.slots);
                 const hasPositions = slotEntries.every((entries) => !!entries[1].position);
 
@@ -146,21 +146,7 @@ export default class AppCmsService {
                     slotEntries.sort((a, b) => a[1].position - b[1].position);
                 }
 
-                // Vue2 syntax
-                if (typeof createElement === 'function') {
-                    const children = slotEntries.map(([slotName]) => this.$scopedSlots[slotName]());
-
-                    return createElement(
-                        'div',
-                        {
-                            class: componentName,
-                        },
-                        children,
-                    );
-                }
-
-                // Vue3 syntax
-                const children = slotEntries.map(([slotName]) => this.$slots[slotName]());
+                const children = slotEntries.map(([slotName]) => this.$slots[slotName]);
 
                 return h(
                     'div',


### PR DESCRIPTION
### 1. Why is this change necessary?
The code is not needed anymore and probably it was forgotten to remove this code in the Shopware 6.6.0.0 release.

### 2. What does this change do, exactly?
Remove the code.

I was not sure, if the `compatConfig` is still needed, or if it would be a break to remove this as well. I can adjust the PR if needed.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
