### PR TITLE
refactor: Cleanup internals of ProductSliderCmsElementResolver

### DIFF
--- a/changelog/_unreleased/2024-11-23-cleanup-internals-of-productslidercmselementresolver.md
+++ b/changelog/_unreleased/2024-11-23-cleanup-internals-of-productslidercmselementresolver.md
@@ -1,0 +1,9 @@
+---
+title: Cleanup internals of ProductSliderCmsElementResolver
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed the internals of `Shopware\Core\Content\Product\Cms\ProductSliderCmsElementResolver` for better readability and simplified code

--- a/tests/unit/Core/Content/Product/Cms/ProductSliderCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductSliderCmsElementResolverTest.php
@@ -46,6 +46,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\CustomField\Aggregate\CustomFieldSet\CustomFieldSetDefinition;
 use Shopware\Core\System\DeliveryTime\DeliveryTimeDefinition;
@@ -309,9 +310,10 @@ class ProductSliderCmsElementResolverTest extends TestCase
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('product.categories.id', $category->getUniqueIdentifier()));
-        $criteria->addAssociation('cover');
-        $criteria->addAssociation('options.group');
-        $criteria->addAssociation('manufacturer');
+        if (!Feature::isActive('v6.7.0.0')) {
+            $criteria->addAssociation('options.group');
+            $criteria->addAssociation('manufacturer');
+        }
 
         static::assertNotNull($collection);
         static::assertEquals($criteria, $collection->all()[ProductDefinition::class]['product-slider-entity-fallback_id']);
@@ -349,9 +351,10 @@ class ProductSliderCmsElementResolverTest extends TestCase
 
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('product.parent.id', $product->getUniqueIdentifier()));
-        $criteria->addAssociation('cover');
-        $criteria->addAssociation('options.group');
-        $criteria->addAssociation('manufacturer');
+        if (!Feature::isActive('v6.7.0.0')) {
+            $criteria->addAssociation('options.group');
+            $criteria->addAssociation('manufacturer');
+        }
 
         static::assertNotNull($collection);
         static::assertEquals($criteria, $collection->all()[ProductDefinition::class]['product-slider-entity-fallback_id']);


### PR DESCRIPTION
### 1. Why is this change necessary?
While looking at the recent changes, I noticed that the code of the `ProductSliderCmsElementResolver` is quite confusing.

### 2. What does this change do, exactly?
Cleanup the internals of the `ProductSliderCmsElementResolver`.

### 3. Describe each step to reproduce the issue or behaviour.
Look at the code.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
