### PR TITLE
feat: Add document renderer order criteria events

### DIFF
--- a/changelog/_unreleased/2024-11-25-add-events-for-order-loading-when-creating-documents.md
+++ b/changelog/_unreleased/2024-11-25-add-events-for-order-loading-when-creating-documents.md
@@ -1,9 +1,8 @@
 ---
 title: Add events for order loading when creating documents
-issue: NEXT-0000
 author: Max
 author_email: max@swk-web.com
 author_github: @aragon999
 ---
 # Core
-* Added events `Shopware\Core\Checkout\Document\Event\{CreditNoteOrderCriteriaEvent,DeliveryNoteOrderCriteriaEvent,InvoiceOrderCriteriaEvent,StornoOrderCriteriaEvent}` to modify the criteria when loading the order for the respective documents
+* Added events `{credit_note,delivery_note,invoice,storno}.document.criteria` to modify the criteria when loading the order for the respective documents

--- a/changelog/_unreleased/2024-11-25-add-events-for-order-loading-when-creating-documents.md
+++ b/changelog/_unreleased/2024-11-25-add-events-for-order-loading-when-creating-documents.md
@@ -1,0 +1,9 @@
+---
+title: Add events for order loading when creating documents
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Added events `Shopware\Core\Checkout\Document\Event\{CreditNoteOrderCriteriaEvent,DeliveryNoteOrderCriteriaEvent,InvoiceOrderCriteriaEvent,StornoOrderCriteriaEvent}` to modify the criteria when loading the order for the respective documents

--- a/src/Core/Checkout/Document/DocumentEvents.php
+++ b/src/Core/Checkout/Document/DocumentEvents.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Document;
+
+use Shopware\Core\Checkout\Document\Renderer\CreditNoteRenderer;
+use Shopware\Core\Checkout\Document\Renderer\DeliveryNoteRenderer;
+use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
+use Shopware\Core\Checkout\Document\Renderer\StornoRenderer;
+
+#[Package('after-sales')]
+class DocumentEvents
+{
+    public const CREDIT_NOTE_ORDER_CRITERIA_EVENT = CreditNoteRenderer::TYPE . '.document.criteria';
+    public const DELIVERY_ORDER_CRITERIA_EVENT = DeliveryNoteRenderer::TYPE . '.document.criteria';
+    public const INVOICE_ORDER_CRITERIA_EVENT = InvoiceRenderer::TYPE . '.document.criteria';
+    public const STORNO_ORDER_CRITERIA_EVENT = StornoRenderer::TYPE . '.document.criteria';
+}

--- a/src/Core/Checkout/Document/DocumentEvents.php
+++ b/src/Core/Checkout/Document/DocumentEvents.php
@@ -6,6 +6,7 @@ use Shopware\Core\Checkout\Document\Renderer\CreditNoteRenderer;
 use Shopware\Core\Checkout\Document\Renderer\DeliveryNoteRenderer;
 use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
 use Shopware\Core\Checkout\Document\Renderer\StornoRenderer;
+use Shopware\Core\Framework\Log\Package;
 
 #[Package('after-sales')]
 class DocumentEvents

--- a/src/Core/Checkout/Document/Event/DocumentOrderCriteriaEvent.php
+++ b/src/Core/Checkout/Document/Event/DocumentOrderCriteriaEvent.php
@@ -17,11 +17,6 @@ use Symfony\Contracts\EventDispatcher\Event;
 #[Package('after-sales')]
 final class DocumentOrderCriteriaEvent extends Event implements GenericEvent
 {
-    public const CREDIT_NOTE_ORDER_CRITERIA_EVENT = CreditNoteRenderer::TYPE . '.document.criteria';
-    public const DELIVERY_ORDER_CRITERIA_EVENT = DeliveryNoteRenderer::TYPE . '.document.criteria';
-    public const INVOICE_ORDER_CRITERIA_EVENT = InvoiceRenderer::TYPE . '.document.criteria';
-    public const STORNO_ORDER_CRITERIA_EVENT = StornoRenderer::TYPE . '.document.criteria';
-
     private readonly string $name;
 
     /**

--- a/src/Core/Checkout/Document/Event/DocumentOrderCriteriaEvent.php
+++ b/src/Core/Checkout/Document/Event/DocumentOrderCriteriaEvent.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Checkout\Document\Event;
+
+use Shopware\Core\Checkout\Document\Renderer\CreditNoteRenderer;
+use Shopware\Core\Checkout\Document\Renderer\DeliveryNoteRenderer;
+use Shopware\Core\Checkout\Document\Renderer\DocumentRendererConfig;
+use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
+use Shopware\Core\Checkout\Document\Renderer\StornoRenderer;
+use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\GenericEvent;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('after-sales')]
+final class DocumentOrderCriteriaEvent extends Event implements GenericEvent
+{
+    public const CREDIT_NOTE_ORDER_CRITERIA_EVENT = CreditNoteRenderer::TYPE . '.document.criteria';
+    public const DELIVERY_ORDER_CRITERIA_EVENT = DeliveryNoteRenderer::TYPE . '.document.criteria';
+    public const INVOICE_ORDER_CRITERIA_EVENT = InvoiceRenderer::TYPE . '.document.criteria';
+    public const STORNO_ORDER_CRITERIA_EVENT = StornoRenderer::TYPE . '.document.criteria';
+
+    private readonly string $name;
+
+    /**
+     * @param array<string, DocumentGenerateOperation> $operations
+     */
+    public function __construct(
+        private readonly Criteria $criteria,
+        private readonly Context $context,
+        private readonly array $operations,
+        private readonly DocumentRendererConfig $documentRendererConfig,
+        string $documentType,
+    ) {
+        $this->name = $documentType . '.document.criteria';
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getCriteria(): Criteria
+    {
+        return $this->criteria;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    /**
+     * @return array<string, DocumentGenerateOperation> $operations
+     */
+    public function getOperations(): array
+    {
+        return $this->operations;
+    }
+
+    public function getDocumentRendererConfig(): DocumentRendererConfig
+    {
+        return $this->documentRendererConfig;
+    }
+}

--- a/src/Core/Checkout/Document/Event/DocumentOrderCriteriaEvent.php
+++ b/src/Core/Checkout/Document/Event/DocumentOrderCriteriaEvent.php
@@ -2,11 +2,7 @@
 
 namespace Shopware\Core\Checkout\Document\Event;
 
-use Shopware\Core\Checkout\Document\Renderer\CreditNoteRenderer;
-use Shopware\Core\Checkout\Document\Renderer\DeliveryNoteRenderer;
 use Shopware\Core\Checkout\Document\Renderer\DocumentRendererConfig;
-use Shopware\Core\Checkout\Document\Renderer\InvoiceRenderer;
-use Shopware\Core\Checkout\Document\Renderer\StornoRenderer;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;

--- a/src/Core/Checkout/Document/Event/DocumentOrderEvent.php
+++ b/src/Core/Checkout/Document/Event/DocumentOrderEvent.php
@@ -22,7 +22,7 @@ abstract class DocumentOrderEvent extends Event
     }
 
     /**
-     * @return DocumentGenerateOperation[]
+     * @return array<string, DocumentGenerateOperation> $operations
      */
     public function getOperations(): array
     {

--- a/src/Core/Checkout/Document/Renderer/CreditNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/CreditNoteRenderer.php
@@ -7,6 +7,7 @@ use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Document\DocumentException;
 use Shopware\Core\Checkout\Document\Event\CreditNoteOrdersEvent;
+use Shopware\Core\Checkout\Document\Event\DocumentOrderCriteriaEvent;
 use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\DocumentFileRendererRegistry;
 use Shopware\Core\Checkout\Document\Service\ReferenceInvoiceLoader;
@@ -20,7 +21,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -66,20 +66,19 @@ final class CreditNoteRenderer extends AbstractDocumentRenderer
 
         $orders = new OrderCollection();
 
-        /** @var DocumentGenerateOperation $operation */
         foreach ($operations as $operation) {
             try {
                 $orderId = $operation->getOrderId();
                 $invoice = $this->referenceInvoiceLoader->load($orderId, $operation->getReferencedDocumentId(), $rendererConfig->deepLinkCode);
 
                 if (empty($invoice)) {
-                    throw DocumentException::generationError('Can not generate credit note document because no invoice document exists. OrderId: ' . $operation->getOrderId());
+                    throw DocumentException::generationError('Can not generate credit note document because no invoice document exists. OrderId: ' . $orderId);
                 }
 
                 $documentRefer = json_decode($invoice['config'], true, 512, \JSON_THROW_ON_ERROR);
                 $referenceInvoiceNumbers[$orderId] = $invoice['documentNumber'] ?? $documentRefer['documentNumber'];
 
-                $order = $this->getOrder($orderId, $invoice['orderVersionId'], $context, $rendererConfig->deepLinkCode);
+                $order = $this->getOrder($operation, $invoice['orderVersionId'], $context, $rendererConfig);
 
                 $orders->add($order);
                 $operation->setReferencedDocumentId($invoice['id']);
@@ -151,7 +150,6 @@ final class CreditNoteRenderer extends AbstractDocumentRenderer
 
                 $price = $this->calculatePrice($creditItems, $order);
 
-                /** @var LanguageEntity|null $language */
                 $language = $order->getLanguage();
                 if ($language === null) {
                     throw DocumentException::generationError('Can not generate credit note document because no language exists. OrderId: ' . $operation->getOrderId());
@@ -189,35 +187,52 @@ final class CreditNoteRenderer extends AbstractDocumentRenderer
         throw new DecorationPatternException(self::class);
     }
 
-    private function getOrder(string $orderId, string $versionId, Context $context, string $deepLinkCode = ''): OrderEntity
+    private function getOrder(DocumentGenerateOperation $operation, string $versionId, Context $context, DocumentRendererConfig $rendererConfig): OrderEntity
     {
-        ['language_id' => $languageId] = $this->getOrdersLanguageId([$orderId], $versionId, $this->connection)[0];
+        ['language_id' => $languageId] = $this->getOrdersLanguageId([$operation->getOrderId()], $versionId, $this->connection)[0];
+        $languageIdChain = array_values(
+            array_unique(
+                array_filter([$languageId, ...$context->getLanguageIdChain()])
+            )
+        );
 
-        // Get the correct order with versioning from reference invoice
-        $versionContext = $context->createWithVersionId($versionId)->assign([
-            'languageIdChain' => \array_values(\array_unique(\array_filter([$languageId, ...$context->getLanguageIdChain()]))),
-        ]);
+        // First try to load the order with the version from the reference invoice
+        $order = $this->loadOrder($operation, $versionId, $context, $languageIdChain, $rendererConfig)
+            ?? $this->loadOrder($operation, Defaults::LIVE_VERSION, $context, $languageIdChain, $rendererConfig);
 
-        $criteria = OrderDocumentCriteriaFactory::create([$orderId], $deepLinkCode, self::TYPE)
-            ->addFilter(new EqualsFilter('lineItems.type', LineItem::CREDIT_LINE_ITEM_TYPE));
-
-        $order = $this->orderRepository->search($criteria, $versionContext)->getEntities()->first();
-        if ($order) {
-            return $order;
-        }
-
-        $versionContext = $context->createWithVersionId(Defaults::LIVE_VERSION)->assign([
-            'languageIdChain' => \array_values(\array_unique(\array_filter([$languageId, ...$context->getLanguageIdChain()]))),
-        ]);
-
-        $criteria = OrderDocumentCriteriaFactory::create([$orderId], $deepLinkCode, self::TYPE);
-
-        $order = $this->orderRepository->search($criteria, $versionContext)->getEntities()->first();
-        if (!$order) {
-            throw DocumentException::orderNotFound($orderId);
+        if ($order === null) {
+            throw DocumentException::orderNotFound($operation->getOrderId());
         }
 
         return $order;
+    }
+
+    /**
+     * @param list<string> $languageIdChain
+     */
+    private function loadOrder(
+        DocumentGenerateOperation $operation,
+        string $versionId,
+        Context $context,
+        array $languageIdChain,
+        DocumentRendererConfig $rendererConfig,
+    ): ?OrderEntity {
+        $versionContext = $context->createWithVersionId($versionId)->assign([
+            'languageIdChain' => $languageIdChain,
+        ]);
+
+        $criteria = OrderDocumentCriteriaFactory::create([$operation->getOrderId()], $rendererConfig->deepLinkCode, self::TYPE)
+            ->addFilter(new EqualsFilter('lineItems.type', LineItem::CREDIT_LINE_ITEM_TYPE));
+
+        $this->eventDispatcher->dispatch(new DocumentOrderCriteriaEvent(
+            $criteria,
+            $context,
+            [$operation->getOrderId() => $operation],
+            $rendererConfig,
+            self::TYPE
+        ));
+
+        return $this->orderRepository->search($criteria, $versionContext)->getEntities()->first();
     }
 
     private function getNumber(Context $context, OrderEntity $order, DocumentGenerateOperation $operation): string

--- a/src/Core/Checkout/Document/Renderer/CreditNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/CreditNoteRenderer.php
@@ -221,8 +221,10 @@ final class CreditNoteRenderer extends AbstractDocumentRenderer
             'languageIdChain' => $languageIdChain,
         ]);
 
-        $criteria = OrderDocumentCriteriaFactory::create([$operation->getOrderId()], $rendererConfig->deepLinkCode, self::TYPE)
-            ->addFilter(new EqualsFilter('lineItems.type', LineItem::CREDIT_LINE_ITEM_TYPE));
+        $criteria = OrderDocumentCriteriaFactory::create([$operation->getOrderId()], $rendererConfig->deepLinkCode, self::TYPE);
+        $criteria->getAssociation('lineItems')->addFilter(
+            new EqualsFilter('type', LineItem::CREDIT_LINE_ITEM_TYPE)
+        );
 
         $this->eventDispatcher->dispatch(new DocumentOrderCriteriaEvent(
             $criteria,

--- a/src/Core/Checkout/Document/Renderer/DeliveryNoteRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/DeliveryNoteRenderer.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Checkout\Document\Renderer;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\Document\DocumentException;
 use Shopware\Core\Checkout\Document\Event\DeliveryNoteOrdersEvent;
+use Shopware\Core\Checkout\Document\Event\DocumentOrderCriteriaEvent;
 use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\DocumentFileRendererRegistry;
 use Shopware\Core\Checkout\Document\Struct\DocumentGenerateOperation;
@@ -15,7 +16,6 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -66,7 +66,13 @@ final class DeliveryNoteRenderer extends AbstractDocumentRenderer
                 'languageIdChain' => \array_values(\array_unique(\array_filter([$languageId, ...$languageIdChain]))),
             ]);
 
-            // TODO: future implementation (only fetch required data and associations)
+            $this->eventDispatcher->dispatch(new DocumentOrderCriteriaEvent(
+                $criteria,
+                $context,
+                $operations,
+                $rendererConfig,
+                self::TYPE,
+            ));
 
             $orders = $this->orderRepository->search($criteria, $context)->getEntities();
 
@@ -119,7 +125,6 @@ final class DeliveryNoteRenderer extends AbstractDocumentRenderer
                         $deliveries = $order->getDeliveries()->first();
                     }
 
-                    /** @var LanguageEntity|null $language */
                     $language = $order->getLanguage();
                     if ($language === null) {
                         throw DocumentException::generationError('Can not generate credit note document because no language exists. OrderId: ' . $operation->getOrderId());

--- a/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
+++ b/src/Core/Checkout/Document/Renderer/InvoiceRenderer.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Document\Renderer;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\Document\DocumentException;
+use Shopware\Core\Checkout\Document\Event\DocumentOrderCriteriaEvent;
 use Shopware\Core\Checkout\Document\Event\InvoiceOrdersEvent;
 use Shopware\Core\Checkout\Document\Service\DocumentConfigLoader;
 use Shopware\Core\Checkout\Document\Service\DocumentFileRendererRegistry;
@@ -15,7 +16,6 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
-use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\System\NumberRange\ValueGenerator\NumberRangeValueGeneratorInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
@@ -67,7 +67,13 @@ final class InvoiceRenderer extends AbstractDocumentRenderer
                 'languageIdChain' => \array_values(\array_unique(\array_filter([$languageId, ...$languageIdChain]))),
             ]);
 
-            // TODO: future implementation (only fetch required data and associations)
+            $this->eventDispatcher->dispatch(new DocumentOrderCriteriaEvent(
+                $criteria,
+                $context,
+                $operations,
+                $rendererConfig,
+                self::TYPE,
+            ));
 
             $orders = $this->orderRepository->search($criteria, $context)->getEntities();
 
@@ -119,7 +125,6 @@ final class InvoiceRenderer extends AbstractDocumentRenderer
                         continue;
                     }
 
-                    /** @var LanguageEntity|null $language */
                     $language = $order->getLanguage();
                     if ($language === null) {
                         throw DocumentException::generationError('Can not generate credit note document because no language exists. OrderId: ' . $operation->getOrderId());

--- a/tests/integration/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php
+++ b/tests/integration/Core/Checkout/Document/Renderer/CreditNoteRendererTest.php
@@ -321,7 +321,6 @@ class CreditNoteRendererTest extends TestCase
             new DocumentRendererConfig()
         );
 
-        static::assertEquals($operationCreditNote->getOrderVersionId(), Defaults::LIVE_VERSION);
         static::assertTrue($this->orderVersionExists($orderId, $operationCreditNote->getOrderVersionId()));
     }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to modify the criteria objects, when creating documents, i.e. one needs to load the data afterwards in the next event.

### 2. What does this change do, exactly?
Add events to modify the criteria objects.

### 3. Describe each step to reproduce the issue or behaviour.
Extend the documents.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
