### PR TITLE
fix: schema for the customer accountType distinction

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Customer.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Customer.json
@@ -6,10 +6,17 @@
         "schemas": {
             "Customer": {
                 "type": "object",
+                "required": [
+                    "apiAlias",
+                    "activeBillingAddress",
+                    "activeShippingAddress"
+                ],
                 "properties": {
                     "apiAlias": {
                         "type": "string",
-                        "enum": ["customer"]
+                        "enum": [
+                            "customer"
+                        ]
                     },
                     "activeBillingAddress": {
                         "$ref": "#/components/schemas/CustomerAddress"
@@ -18,7 +25,46 @@
                         "$ref": "#/components/schemas/CustomerAddress"
                     }
                 },
-                "required": ["apiAlias", "activeBillingAddress", "activeShippingAddress"]
+                "oneOf": [
+                    {
+                        "required": [
+                            "accountType"
+                        ],
+                        "properties": {
+                            "accountType": {
+                                "type": "string",
+                                "enum": [
+                                    "private"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "required": [
+                            "accountType",
+                            "vatIds",
+                            "company"
+                        ],
+                        "properties": {
+                            "accountType": {
+                                "type": "string",
+                                "enum": [
+                                    "business"
+                                ]
+                            },
+                            "vatIds": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "minItems": 1
+                            },
+                            "company": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
             }
         }
     }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/account.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/account.json
@@ -57,6 +57,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
+                                "type": "object",
                                 "required": [
                                     "salutationId",
                                     "firstName",
@@ -79,10 +80,6 @@
                                         "description": "Customer last name. Value will be reused for shipping and billing address if not provided explicitly.",
                                         "type": "string"
                                     },
-                                    "company": {
-                                        "description": "Company of the customer. Only required when `accountType` is `business`.",
-                                        "type": "string"
-                                    },
                                     "birthdayDay": {
                                         "description": "Birthday day",
                                         "type": "integer"
@@ -96,7 +93,54 @@
                                         "type": "integer"
                                     }
                                 },
-                                "type": "object"
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "accountType": {
+                                                "description": "Type of the customer account. Default value is 'private'.",
+                                                "type": "string",
+                                                "enum": [
+                                                    "private"
+                                                ],
+                                                "default": "private"
+                                            },
+                                            "company": {
+                                                "type": "null"
+                                            },
+                                            "vatIds": {
+                                                "type": "null"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "required": [
+                                            "accountType",
+                                            "company",
+                                            "vatIds"
+                                        ],
+                                        "properties": {
+                                            "accountType": {
+                                                "description": "Type of the customer account. Can be `private` or `business`.",
+                                                "type": "string",
+                                                "enum": [
+                                                    "business"
+                                                ]
+                                            },
+                                            "company": {
+                                                "description": "Company of the customer. Only required when `accountType` is `business`.",
+                                                "type": "string"
+                                            },
+                                            "vatIds": {
+                                                "description": "VAT IDs of the customer's company. Only valid when `accountType` is `business`.",
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "minItems": 1
+                                            }
+                                        }
+                                    }
+                                ]
                             }
                         }
                     }
@@ -497,7 +541,6 @@
                                         {
                                             "$ref": "#/components/schemas/CustomerAddress"
                                         },
-
                                         {
                                             "$ref": "#/components/schemas/CustomerAddressRead"
                                         }
@@ -773,11 +816,6 @@
                                     "shippingAddress": {
                                         "$ref": "#/components/schemas/CustomerAddress"
                                     },
-                                    "accountType": {
-                                        "description": "Account type of the customer which can be either `private` or `business`.",
-                                        "type": "string",
-                                        "default": "private"
-                                    },
                                     "guest": {
                                         "description": "If set, will create a guest customer. Guest customers can re-use an email address and don't need a password.",
                                         "type": "boolean",
@@ -817,6 +855,54 @@
                                     "acceptedDataProtection",
                                     "storefrontUrl",
                                     "billingAddress"
+                                ],
+                                "oneOf": [
+                                    {
+                                        "properties": {
+                                            "accountType": {
+                                                "description": "Type of the customer account. Default value is 'private'.",
+                                                "type": "string",
+                                                "enum": [
+                                                    "private"
+                                                ],
+                                                "default": "private"
+                                            },
+                                            "company": {
+                                                "type": "null"
+                                            },
+                                            "vatIds": {
+                                                "type": "null"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "required": [
+                                            "accountType",
+                                            "company",
+                                            "vatIds"
+                                        ],
+                                        "properties": {
+                                            "accountType": {
+                                                "description": "Type of the customer account. Can be `private` or `business`.",
+                                                "type": "string",
+                                                "enum": [
+                                                    "business"
+                                                ]
+                                            },
+                                            "company": {
+                                                "description": "Company of the customer. Only required when `accountType` is `business`.",
+                                                "type": "string"
+                                            },
+                                            "vatIds": {
+                                                "description": "VAT IDs of the customer's company. Only valid when `accountType` is `business`.",
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "minItems": 1
+                                            }
+                                        }
+                                    }
                                 ],
                                 "type": "object"
                             }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
related to https://github.com/shopware/frontends/pull/1477

missing and improper definition of the schema

### 2. What does this change do, exactly?

- defines one of two cases - for `private` accountType there are no `company` and `vatIds` definitions. For the `business` account type these two are appearing in the schema 

### 3. Describe each step to reproduce the issue or behaviour.

generation of the openAPI schema json file

### 4. Please link to the relevant issues (if any).

not a breaking change, not a functional change, no need for the changelog either

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
