### PR TITLE
refactor: Unify duplicate cache constants

### DIFF
--- a/changelog/_unreleased/2024-11-26-unify-cache-state-and-cookie-constants.md
+++ b/changelog/_unreleased/2024-11-26-unify-cache-state-and-cookie-constants.md
@@ -1,0 +1,10 @@
+---
+title: Unify cache state and cookie constants
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Deprecated duplicate constants `Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber::{STATE_LOGGED_IN,STATE_CART_FILLED}` use `Shopware\Core\Framework\Adapter\Cache\CacheStateSubscriber::{STATE_LOGGED_IN,STATE_CART_FILLED}` instead
+* Deprecated duplicate constants `Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber::{CURRENCY_COOKIE,CONTEXT_CACHE_COOKIE,SYSTEM_STATE_COOKIE,INVALIDATION_STATES_HEADER}` use `Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator::{CURRENCY_COOKIE,CONTEXT_CACHE_COOKIE,SYSTEM_STATE_COOKIE,INVALIDATION_STATES_HEADER}` instead

--- a/src/Core/Framework/Adapter/Cache/Http/CacheControlListener.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheControlListener.php
@@ -31,7 +31,7 @@ readonly class CacheControlListener
 
         // We don't want that the client will cache the website, if no reverse proxy is configured
         $response->headers->remove('cache-control');
-        $response->headers->remove(CacheResponseSubscriber::INVALIDATION_STATES_HEADER);
+        $response->headers->remove(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER);
         $response->setPrivate();
 
         if ($noStore) {

--- a/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriber.php
@@ -30,17 +30,31 @@ use Symfony\Component\HttpKernel\KernelEvents;
 #[Package('core')]
 class CacheResponseSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @deprecated tag:v6.7.0 - Will be removed, use CacheStateSubscriber::STATE_LOGGED_IN instead
+     */
     final public const STATE_LOGGED_IN = CacheStateSubscriber::STATE_LOGGED_IN;
+    /**
+     * @deprecated tag:v6.7.0 - Will be removed, use CacheStateSubscriber::STATE_CART_FILLED instead
+     */
     final public const STATE_CART_FILLED = CacheStateSubscriber::STATE_CART_FILLED;
 
-    final public const CURRENCY_COOKIE = 'sw-currency';
-    final public const CONTEXT_CACHE_COOKIE = HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE;
-
-    final public const SYSTEM_STATE_COOKIE = 'sw-states';
     /**
-     * @deprecated tag:v6.7.0 - Will be removed
+     * @deprecated tag:v6.7.0 - Will be removed, use HttpCacheKeyGenerator::CURRENCY_COOKIE instead
      */
-    final public const INVALIDATION_STATES_HEADER = 'sw-invalidation-states';
+    final public const CURRENCY_COOKIE = HttpCacheKeyGenerator::CURRENCY_COOKIE;
+    /**
+     * @deprecated tag:v6.7.0 - Will be removed, use HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE instead
+     */
+    final public const CONTEXT_CACHE_COOKIE = HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE;
+    /**
+     * @deprecated tag:v6.7.0 - Will be removed, use HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE instead
+     */
+    final public const SYSTEM_STATE_COOKIE = HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE;
+    /**
+     * @deprecated tag:v6.7.0 - Will be removed, use HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER instead
+     */
+    final public const INVALIDATION_STATES_HEADER = HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER;
 
     /**
      * @param array<string> $cookies
@@ -121,15 +135,15 @@ class CacheResponseSubscriber implements EventSubscriberInterface
         if ($context->getCustomer() || $cart->getLineItems()->count() > 0) {
             $newValue = $this->buildCacheHash($request, $context);
 
-            if ($request->cookies->get(self::CONTEXT_CACHE_COOKIE, '') !== $newValue) {
-                $cookie = Cookie::create(self::CONTEXT_CACHE_COOKIE, $newValue);
+            if ($request->cookies->get(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE, '') !== $newValue) {
+                $cookie = Cookie::create(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE, $newValue);
                 $cookie->setSecureDefault($request->isSecure());
 
                 $response->headers->setCookie($cookie);
             }
-        } elseif ($request->cookies->has(self::CONTEXT_CACHE_COOKIE)) {
-            $response->headers->removeCookie(self::CONTEXT_CACHE_COOKIE);
-            $response->headers->clearCookie(self::CONTEXT_CACHE_COOKIE);
+        } elseif ($request->cookies->has(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE)) {
+            $response->headers->removeCookie(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE);
+            $response->headers->clearCookie(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE);
         }
 
         /** @var bool|array{maxAge?: int, states?: list<string>}|null $cache */
@@ -150,7 +164,7 @@ class CacheResponseSubscriber implements EventSubscriberInterface
 
         $response->setSharedMaxAge($maxAge);
         $response->headers->set(
-            self::INVALIDATION_STATES_HEADER,
+            HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER,
             implode(',', $cache['states'] ?? [])
         );
 
@@ -255,9 +269,9 @@ class CacheResponseSubscriber implements EventSubscriberInterface
         $states = $this->getSystemStates($request, $context, $cart);
 
         if (empty($states)) {
-            if ($request->cookies->has(self::SYSTEM_STATE_COOKIE)) {
-                $response->headers->removeCookie(self::SYSTEM_STATE_COOKIE);
-                $response->headers->clearCookie(self::SYSTEM_STATE_COOKIE);
+            if ($request->cookies->has(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE)) {
+                $response->headers->removeCookie(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE);
+                $response->headers->clearCookie(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE);
             }
 
             return [];
@@ -265,8 +279,8 @@ class CacheResponseSubscriber implements EventSubscriberInterface
 
         $newStates = implode(',', $states);
 
-        if ($request->cookies->get(self::SYSTEM_STATE_COOKIE) !== $newStates) {
-            $cookie = Cookie::create(self::SYSTEM_STATE_COOKIE, $newStates);
+        if ($request->cookies->get(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE) !== $newStates) {
+            $cookie = Cookie::create(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE, $newStates);
             $cookie->setSecureDefault($request->isSecure());
 
             $response->headers->setCookie($cookie);
@@ -281,14 +295,14 @@ class CacheResponseSubscriber implements EventSubscriberInterface
     private function getSystemStates(Request $request, SalesChannelContext $context, Cart $cart): array
     {
         $states = [];
-        $swStates = (string) $request->cookies->get(self::SYSTEM_STATE_COOKIE);
+        $swStates = (string) $request->cookies->get(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE);
         if ($swStates !== '') {
             $states = array_flip(explode(',', $swStates));
         }
 
-        $states = $this->switchState($states, self::STATE_LOGGED_IN, $context->getCustomer() !== null);
+        $states = $this->switchState($states, CacheStateSubscriber::STATE_LOGGED_IN, $context->getCustomer() !== null);
 
-        $states = $this->switchState($states, self::STATE_CART_FILLED, $cart->getLineItems()->count() > 0);
+        $states = $this->switchState($states, CacheStateSubscriber::STATE_CART_FILLED, $cart->getLineItems()->count() > 0);
 
         return array_keys($states);
     }
@@ -319,7 +333,7 @@ class CacheResponseSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $cookie = Cookie::create(self::CURRENCY_COOKIE, $currencyId);
+        $cookie = Cookie::create(HttpCacheKeyGenerator::CURRENCY_COOKIE, $currencyId);
         $cookie->setSecureDefault($request->isSecure());
 
         $response->headers->setCookie($cookie);

--- a/src/Core/Framework/Adapter/Cache/ReverseProxy/ReverseProxyCache.php
+++ b/src/Core/Framework/Adapter/Cache/ReverseProxy/ReverseProxyCache.php
@@ -4,8 +4,8 @@ namespace Shopware\Core\Framework\Adapter\Cache\ReverseProxy;
 
 use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
-use Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber;
 use Shopware\Core\Framework\Adapter\Cache\Http\CacheStore;
+use Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator;
 use Shopware\Core\Framework\Adapter\Cache\InvalidateCacheEvent;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
@@ -63,10 +63,10 @@ class ReverseProxyCache implements StoreInterface
             $response->headers->remove(CacheStore::TAG_HEADER);
         }
 
-        $states = $response->headers->get(CacheResponseSubscriber::INVALIDATION_STATES_HEADER, '');
+        $states = $response->headers->get(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER, '');
         $states = array_unique(array_filter(array_merge(explode(',', $states), $this->states)));
 
-        $response->headers->set(CacheResponseSubscriber::INVALIDATION_STATES_HEADER, \implode(',', $states));
+        $response->headers->set(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER, \implode(',', $states));
 
         $this->gateway->tag(\array_values($tags), $request->getPathInfo(), $response);
 

--- a/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
+++ b/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
@@ -8,8 +8,8 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
-use Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber;
 use Shopware\Core\Framework\Adapter\Cache\Http\CacheStore;
+use Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator;
 use Shopware\Core\Framework\Adapter\Kernel\HttpCacheKernel;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Routing\RequestTransformerInterface;
@@ -94,7 +94,7 @@ class HttpCacheIntegrationTest extends TestCase
         static::assertIsString($appUrl);
 
         $request = $this->createRequest($appUrl);
-        $request->cookies->set(CacheResponseSubscriber::CONTEXT_CACHE_COOKIE, 'a');
+        $request->cookies->set(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE, 'a');
 
         $response = $kernel->handle($request);
         static::assertEquals('GET /: miss, store', $response->headers->get('x-symfony-cache'));
@@ -102,7 +102,7 @@ class HttpCacheIntegrationTest extends TestCase
         $response = $kernel->handle($request);
         static::assertEquals('GET /: fresh', $response->headers->get('x-symfony-cache'));
 
-        $request->cookies->set(CacheResponseSubscriber::CONTEXT_CACHE_COOKIE, 'b');
+        $request->cookies->set(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE, 'b');
 
         $response = $kernel->handle($request);
         static::assertEquals('GET /: miss, store', $response->headers->get('x-symfony-cache'));
@@ -211,7 +211,7 @@ class HttpCacheIntegrationTest extends TestCase
 
         $this->addEventListener($this->getContainer()->get('event_dispatcher'), KernelEvents::RESPONSE, function (ResponseEvent $event): void {
             static::assertEquals(5, $event->getResponse()->getMaxAge());
-            static::assertEquals('logged-in', $event->getResponse()->headers->get(CacheResponseSubscriber::INVALIDATION_STATES_HEADER));
+            static::assertEquals('logged-in', $event->getResponse()->headers->get(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
         }, -1501);
 
         $response = $kernel->handle($request);

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheControlListenerTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheControlListenerTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Cache\Http\CacheControlListener;
-use Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber;
+use Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator;
 use Shopware\Core\Framework\Event\BeforeSendResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,7 +21,7 @@ class CacheControlListenerTest extends TestCase
     public function testResponseHeaders(bool $reverseProxyEnabled, ?string $beforeHeader, string $afterHeader): void
     {
         $response = new Response();
-        $response->headers->set(CacheResponseSubscriber::INVALIDATION_STATES_HEADER, 'foo');
+        $response->headers->set(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER, 'foo');
 
         if ($beforeHeader) {
             $response->headers->set('cache-control', $beforeHeader);
@@ -34,7 +34,7 @@ class CacheControlListenerTest extends TestCase
         static::assertSame($afterHeader, $response->headers->get('cache-control'));
 
         if (!$reverseProxyEnabled) {
-            static::assertFalse($response->headers->has(CacheResponseSubscriber::INVALIDATION_STATES_HEADER));
+            static::assertFalse($response->headers->has(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
         }
     }
 

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheResponseSubscriberTest.php
@@ -13,6 +13,7 @@ use Shopware\Core\Checkout\Customer\Event\CustomerLoginEvent;
 use Shopware\Core\Checkout\Customer\Event\CustomerLogoutEvent;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber;
+use Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator;
 use Shopware\Core\Framework\Routing\MaintenanceModeResolver;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
@@ -210,7 +211,7 @@ class CacheResponseSubscriberTest extends TestCase
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $salesChannelContext);
 
         if ($hasCookie === false) {
-            $request->cookies->set(CacheResponseSubscriber::CONTEXT_CACHE_COOKIE, 'foo');
+            $request->cookies->set(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE, 'foo');
         }
 
         $response = new Response();
@@ -227,7 +228,7 @@ class CacheResponseSubscriberTest extends TestCase
         if ($hasCookie) {
             static::assertTrue($response->headers->has('set-cookie'));
 
-            $cookies = array_filter($response->headers->getCookies(), fn (Cookie $cookie) => $cookie->getName() === CacheResponseSubscriber::CONTEXT_CACHE_COOKIE);
+            $cookies = array_filter($response->headers->getCookies(), fn (Cookie $cookie) => $cookie->getName() === HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE);
 
             static::assertCount(1, $cookies);
             /** @var Cookie $cookie */
@@ -437,7 +438,7 @@ class CacheResponseSubscriberTest extends TestCase
 
         $request = new Request();
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $this->createMock(SalesChannelContext::class));
-        $request->cookies->set(CacheResponseSubscriber::SYSTEM_STATE_COOKIE, 'cart-filled');
+        $request->cookies->set(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE, 'cart-filled');
 
         $response = new Response();
         $subscriber->setResponseCache(new ResponseEvent(
@@ -535,8 +536,8 @@ class CacheResponseSubscriberTest extends TestCase
         $salesChannelContext->assign(['customer' => null]);
 
         $salesChannelRequest = new Request([], [], [PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT => $salesChannelContext]);
-        $salesChannelRequest->cookies->set(CacheResponseSubscriber::CONTEXT_CACHE_COOKIE, 'foo');
-        $salesChannelRequest->cookies->set(CacheResponseSubscriber::SYSTEM_STATE_COOKIE, 'logged-in');
+        $salesChannelRequest->cookies->set(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE, 'foo');
+        $salesChannelRequest->cookies->set(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE, 'logged-in');
 
         $maintenanceRequest = clone $salesChannelRequest;
         $maintenanceRequest->attributes->set(SalesChannelRequest::ATTRIBUTE_SALES_CHANNEL_MAINTENANCE, true);
@@ -572,7 +573,7 @@ class CacheResponseSubscriberTest extends TestCase
             'states' => ['cart-filled'],
         ]);
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $this->createMock(SalesChannelContext::class));
-        $request->cookies->set(CacheResponseSubscriber::SYSTEM_STATE_COOKIE, 'cart-filled');
+        $request->cookies->set(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE, 'cart-filled');
 
         $response = new Response();
         $subscriber->setResponseCache(new ResponseEvent(
@@ -584,7 +585,7 @@ class CacheResponseSubscriberTest extends TestCase
 
         $cookies = $response->headers->getCookies();
         static::assertCount(1, $cookies);
-        static::assertSame(CacheResponseSubscriber::CONTEXT_CACHE_COOKIE, $cookies[0]->getName());
+        static::assertSame(HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE, $cookies[0]->getName());
         static::assertSame(0, $cookies[0]->getExpiresTime(), 'the cookie should be an session cookie');
 
         // still not cached
@@ -608,7 +609,7 @@ class CacheResponseSubscriberTest extends TestCase
         $request = new Request();
         $request->attributes->set(PlatformRequest::ATTRIBUTE_HTTP_CACHE, true);
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $this->createMock(SalesChannelContext::class));
-        $request->cookies->set(CacheResponseSubscriber::SYSTEM_STATE_COOKIE, 'cart-filled');
+        $request->cookies->set(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE, 'cart-filled');
 
         $response = new Response();
         $subscriber->setResponseCache(new ResponseEvent(
@@ -637,36 +638,36 @@ class CacheResponseSubscriberTest extends TestCase
             'route' => 'no.login',
             'requestMethod' => Request::METHOD_POST,
             'cookiesAmount' => 1,
-            'cookieName' => CacheResponseSubscriber::SYSTEM_STATE_COOKIE,
+            'cookieName' => HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE,
             'assertCountErrorMessage' => 'There should be 1 cookies set now!',
-            'assertEqualsErrorMessage' => 'CacheResponseSubscriber::SYSTEM_STATE_COOKIE should be set as 1. cookie',
+            'assertEqualsErrorMessage' => 'HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE should be set as 1. cookie',
         ];
 
         yield 'Set cache on login via post' => [
             'route' => 'frontend.account.login',
             'requestMethod' => Request::METHOD_POST,
             'cookiesAmount' => 2,
-            'cookieName' => CacheResponseSubscriber::CONTEXT_CACHE_COOKIE,
+            'cookieName' => HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE,
             'assertCountErrorMessage' => 'There should be 2 cookies set now!',
-            'assertEqualsErrorMessage' => 'CacheResponseSubscriber::CONTEXT_CACHE_COOKIE should be set as 2. cookie',
+            'assertEqualsErrorMessage' => 'HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE should be set as 2. cookie',
         ];
 
         yield 'Set cache on no_login via get' => [
             'route' => 'anything',
             'requestMethod' => Request::METHOD_GET,
             'cookiesAmount' => 2,
-            'cookieName' => CacheResponseSubscriber::CONTEXT_CACHE_COOKIE,
+            'cookieName' => HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE,
             'assertCountErrorMessage' => 'There should be 2 cookies set now!',
-            'assertEqualsErrorMessage' => 'CacheResponseSubscriber::CONTEXT_CACHE_COOKIE should be set as 2. cookie',
+            'assertEqualsErrorMessage' => 'HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE should be set as 2. cookie',
         ];
 
         yield 'Set cache on login via get' => [
             'route' => 'frontend.account.login',
             'requestMethod' => Request::METHOD_GET,
             'cookiesAmount' => 2,
-            'cookieName' => CacheResponseSubscriber::CONTEXT_CACHE_COOKIE,
+            'cookieName' => HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE,
             'assertCountErrorMessage' => 'There should be 2 cookies set now!',
-            'assertEqualsErrorMessage' => 'CacheResponseSubscriber::CONTEXT_CACHE_COOKIE should be set as 2. cookie',
+            'assertEqualsErrorMessage' => 'HttpCacheKeyGenerator::CONTEXT_CACHE_COOKIE should be set as 2. cookie',
         ];
     }
 

--- a/tests/unit/Core/Framework/Adapter/Cache/Http/CacheStateValidatorTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/Http/CacheStateValidatorTest.php
@@ -6,8 +6,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber;
 use Shopware\Core\Framework\Adapter\Cache\Http\CacheStateValidator;
+use Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -43,7 +43,7 @@ class CacheStateValidatorTest extends TestCase
     private static function createRequest(string ...$states): Request
     {
         $request = new Request();
-        $request->cookies->set(CacheResponseSubscriber::SYSTEM_STATE_COOKIE, implode(',', $states));
+        $request->cookies->set(HttpCacheKeyGenerator::SYSTEM_STATE_COOKIE, implode(',', $states));
 
         return $request;
     }
@@ -51,7 +51,7 @@ class CacheStateValidatorTest extends TestCase
     private static function createResponse(string ...$states): Response
     {
         $response = new Response();
-        $response->headers->set(CacheResponseSubscriber::INVALIDATION_STATES_HEADER, implode(',', $states));
+        $response->headers->set(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER, implode(',', $states));
 
         return $response;
     }

--- a/tests/unit/Core/Framework/Adapter/Cache/ReverseProxy/ReverseProxyCacheTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/ReverseProxy/ReverseProxyCacheTest.php
@@ -5,10 +5,11 @@ namespace Shopware\Tests\Unit\Core\Framework\Adapter\Cache\ReverseProxy;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Cache\AbstractCacheTracer;
+use Shopware\Core\Framework\Adapter\Cache\CacheStateSubscriber;
 use Shopware\Core\Framework\Adapter\Cache\CacheTagCollector;
 use Shopware\Core\Framework\Adapter\Cache\CacheTracer;
-use Shopware\Core\Framework\Adapter\Cache\Http\CacheResponseSubscriber;
 use Shopware\Core\Framework\Adapter\Cache\Http\CacheStore;
+use Shopware\Core\Framework\Adapter\Cache\Http\HttpCacheKeyGenerator;
 use Shopware\Core\Framework\Adapter\Cache\InvalidateCacheEvent;
 use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\AbstractReverseProxyGateway;
 use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\ReverseProxyCache;
@@ -76,15 +77,15 @@ class ReverseProxyCacheTest extends TestCase
 
     public function testWriteAddsGlobalStates(): void
     {
-        $store = new ReverseProxyCache($this->createMock(AbstractReverseProxyGateway::class), $this->createMock(CacheTracer::class), [CacheResponseSubscriber::STATE_LOGGED_IN], new CacheTagCollector($this->createMock(RequestStack::class)));
+        $store = new ReverseProxyCache($this->createMock(AbstractReverseProxyGateway::class), $this->createMock(CacheTracer::class), [CacheStateSubscriber::STATE_LOGGED_IN], new CacheTagCollector($this->createMock(RequestStack::class)));
 
         $request = new Request();
         $request->attributes->set(RequestTransformer::ORIGINAL_REQUEST_URI, '/foo');
         $response = new Response();
         $store->write($request, $response);
 
-        static::assertTrue($response->headers->has(CacheResponseSubscriber::INVALIDATION_STATES_HEADER));
-        static::assertSame($response->headers->get(CacheResponseSubscriber::INVALIDATION_STATES_HEADER), CacheResponseSubscriber::STATE_LOGGED_IN);
+        static::assertTrue($response->headers->has(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER));
+        static::assertSame($response->headers->get(HttpCacheKeyGenerator::INVALIDATION_STATES_HEADER), CacheStateSubscriber::STATE_LOGGED_IN);
     }
 
     public function testPurge(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
The constants of the `CacheResponseSubscriber` are duplicated from other places.

### 2. What does this change do, exactly?
Unify the constants, to make it easier to search for constants and not wonder which one should use.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
