### PR TITLE
Fix payment method active toggle

### DIFF
--- a/changelog/_unreleased/2024-11-27-fix-payment-method-active-toggle.md
+++ b/changelog/_unreleased/2024-11-27-fix-payment-method-active-toggle.md
@@ -1,0 +1,9 @@
+---
+title: Fix payment method active toggle
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `setPaymentMethodActive` method in `sw-payment-card` component to receive the switch field active state and prevent emitting `set-payment-active` event if the active state is unchanged.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-payment-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-payment-card/index.js
@@ -28,7 +28,11 @@ export default {
     },
 
     methods: {
-        async setPaymentMethodActive(active) {
+        setPaymentMethodActive(active) {
+            if (this.paymentMethod.active === active) {
+                return;
+            }
+
             this.paymentMethod.active = active;
 
             this.$emit('set-payment-active', this.paymentMethod);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-payment-card/sw-payment-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-payment-card/sw-payment-card.html.twig
@@ -42,7 +42,7 @@
             :value="paymentMethod.active"
             :disabled="!acl.can('payment.editor') || undefined"
             :label="$tc('sw-settings-payment.overview.activeToggle')"
-            @update:value="setPaymentMethodActive(!paymentMethod.active)"
+            @update:value="setPaymentMethodActive"
         />
         {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-payment-card/sw-payment-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/component/sw-payment-card/sw-payment-card.spec.js
@@ -72,4 +72,27 @@ describe('module/sw-settings-payment/component/sw-payment-card', () => {
         const activeToggle = wrapper.find('sw-switch-field-stub');
         expect(activeToggle.attributes().disabled).toBeFalsy();
     });
+
+    it('should correctly emit set-payment-active event', async () => {
+        const wrapper = await createWrapper(['payment.editor']);
+        await wrapper.vm.$nextTick();
+
+        const activeToggle = wrapper.findComponent('sw-switch-field-stub');
+        await activeToggle.vm.$emit('update:value', false);
+
+        const expectedPaymentMethod = {
+            id: '5e6f7g8h',
+            translated: {
+                name: 'Test settings-payment 2',
+            },
+            active: false,
+        };
+
+        expect(wrapper.emitted('set-payment-active')).toHaveLength(1);
+        expect(wrapper.emitted('set-payment-active')[0]).toEqual([expectedPaymentMethod]);
+
+        await activeToggle.vm.$emit('update:value', false);
+
+        expect(wrapper.emitted('set-payment-active')).toHaveLength(1);
+    });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Activating or deactivating a payment method results into two notifications having the wrong/opposing notification message (on activation the notification says it was deactivated and vice versa).

![Screenshot 2024-11-27 002411](https://github.com/user-attachments/assets/9f13ce76-bd6c-48e8-af85-ac693867f788)

### 2. What does this change do, exactly?
* Changed `setPaymentMethodActive` method in `sw-payment-card` component to receive the switch field active state and prevent emitting `set-payment-active` event if the active state is unchanged.

### 3. Describe each step to reproduce the issue or behaviour.
Go to settings > payment methods. Activate or deactivate any payment method.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
