### PR TITLE
fix: sending mail in test mode

### DIFF
--- a/changelog/_unreleased/2024-11-27-fix-sending-mail-in-test-mode.md
+++ b/changelog/_unreleased/2024-11-27-fix-sending-mail-in-test-mode.md
@@ -1,0 +1,9 @@
+---
+title: Fix sending mail in test mode
+issue: NEXT-00000
+author: Moritz Müller
+author_email: moritz@momocode.de
+author_github: @momocode-de
+---
+# Core
+* Changed method `send` in `Shopware\Core\Content\Mail\Service\MailService` class so that no CRITICAL error occurs if no salesChannelId is available and you are in test mode

--- a/src/Core/Content/Mail/Service/MailService.php
+++ b/src/Core/Content/Mail/Service/MailService.php
@@ -81,7 +81,7 @@ class MailService extends AbstractMailService
         $salesChannel = null;
         $containsValidSalesChannel = $this->templateDataContainsSalesChannel($templateData);
 
-        if (($salesChannelId !== null && !$containsValidSalesChannel) || $this->isTestMode($data)) {
+        if ($salesChannelId !== null && (!$containsValidSalesChannel || $this->isTestMode($data))) {
             $criteria = $this->getSalesChannelDomainCriteria($salesChannelId, $context);
 
             $salesChannel = $this->salesChannelRepository->search($criteria, $context)->getEntities()->get($salesChannelId);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If you are in test mode (staging mode) and, for example, send a mail using a console command and the mail data does not contain a “salesChannelId”, the following error occurs:

```
Shopware\Core\Content\Mail\Service\MailService::getSalesChannelDomainCriteria(): Argument #1 ($salesChannelId) must be of type string, null given, called in /.../shopware/core/Content/Mail/Service/MailService.php on  
   line 85
```

The problem is the arrangement in the if. If you are in the if branch, the `$salesChannelId` must never be `null` because the ID is required for the functions used there. However, this is not always the case due to the `|| $this->isTestMode($data)`.

### 2. What does this change do, exactly?

The arrangement in the if is corrected so that it is always ensured that the `$salesChannelId` is not `null`.

### 3. Describe each step to reproduce the issue or behaviour.

- Activate the test mode with `bin/console system:setup:staging`
- Write a command that sends a mail without “salesChannelId” in the data.
- Execute the command


### 4. Please link to the relevant issues (if any).

x

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
