### PR TITLE
Fix inadequate entity definition resolving in Elasticsearch filter parsing that show when filtering for a translated field of a related entity is executed

### DIFF
--- a/changelog/_unreleased/2024-12-01-fixed-elasticsearch-filter-parsing-of-translated-fields-in-product-related-entities.md
+++ b/changelog/_unreleased/2024-12-01-fixed-elasticsearch-filter-parsing-of-translated-fields-in-product-related-entities.md
@@ -1,0 +1,9 @@
+---
+title: Fixed Elasticsearch Filter parsing of translated fields in product-related entities
+issue: NEXT-00000
+author: Martin Bens
+author_email: martin.bens@it-bens.de
+author_github: @spigandromeda
+---
+# Elasticsearch
+* Changed `Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser` to resolve related definitions before parsing a value while parsing a filter

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -35,6 +35,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\DateTimeField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FloatField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToManyAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\PriceField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Aggregation;
@@ -555,6 +556,9 @@ class CriteriaParser
 
             $field = $this->getField($definition, $fieldName);
 
+            $originalDefinition = $definition;
+            $definition = $this->getDefinition($definition, $fieldName);
+
             if ($filter->getValue() === null) {
                 $query = new BoolQuery();
 
@@ -566,7 +570,7 @@ class CriteriaParser
                     $query->add(new ExistsQuery($fieldName), BoolQuery::MUST_NOT);
                 }
 
-                return $this->createNestedQuery($query, $definition, $filter->getField());
+                return $this->createNestedQuery($query, $originalDefinition, $filter->getField());
             }
 
             $value = $this->parseValue($definition, $filter, $filter->getValue());
@@ -584,7 +588,7 @@ class CriteriaParser
                 ]);
             }
 
-            return $this->createNestedQuery($query, $definition, $filter->getField());
+            return $this->createNestedQuery($query, $originalDefinition, $filter->getField());
         }
 
         $fieldName = $this->buildAccessor($definition, $filter->getField(), $context);
@@ -596,16 +600,22 @@ class CriteriaParser
             return $this->createNestedQuery($query, $definition, $filter->getField());
         }
 
+        $originalDefinition = $definition;
+        $definition = $this->getDefinition($definition, $fieldName);
+
         $value = $this->parseValue($definition, $filter, $filter->getValue());
 
         $query = new TermQuery($fieldName, $value);
 
-        return $this->createNestedQuery($query, $definition, $filter->getField());
+        return $this->createNestedQuery($query, $originalDefinition, $filter->getField());
     }
 
     private function parseEqualsAnyFilter(EqualsAnyFilter $filter, EntityDefinition $definition, Context $context): BuilderInterface
     {
         $fieldName = $this->buildAccessor($definition, $filter->getField(), $context);
+
+        $originalDefinition = $definition;
+        $definition = $this->getDefinition($definition, $fieldName);
 
         if ($this->keyValueStorage->get(ElasticsearchIndexer::ENABLE_MULTILINGUAL_INDEX_KEY, false)) {
             $field = $this->getField($definition, $fieldName);
@@ -624,7 +634,7 @@ class CriteriaParser
 
             return $this->createNestedQuery(
                 $query,
-                $definition,
+                $originalDefinition,
                 $filter->getField()
             );
         }
@@ -633,7 +643,7 @@ class CriteriaParser
 
         return $this->createNestedQuery(
             new TermsQuery($fieldName, $value),
-            $definition,
+            $originalDefinition,
             $filter->getField()
         );
     }
@@ -771,6 +781,9 @@ class CriteriaParser
 
         $accessor = $this->buildAccessor($definition, $filter->getField(), $context);
 
+        $originalDefinition = $definition;
+        $definition = $this->getDefinition($definition, $filter->getField());
+
         if ($this->keyValueStorage->get(ElasticsearchIndexer::ENABLE_MULTILINGUAL_INDEX_KEY, false)) {
             $field = $this->getField($definition, $filter->getField());
 
@@ -787,14 +800,14 @@ class CriteriaParser
 
             return $this->createNestedQuery(
                 $query,
-                $definition,
+                $originalDefinition,
                 $filter->getField()
             );
         }
 
         return $this->createNestedQuery(
             new RangeQuery($accessor, $this->parseValue($definition, $filter, $filter->getParameters())),
-            $definition,
+            $originalDefinition,
             $filter->getField()
         );
     }
@@ -940,6 +953,46 @@ class CriteriaParser
         }
 
         return $query;
+    }
+
+    private function getDefinition(EntityDefinition $definition, string $fieldName): EntityDefinition
+    {
+        $root = $definition->getEntityName();
+
+        $parts = explode('.', $fieldName);
+        if ($root === $parts[0]) {
+            array_shift($parts);
+        }
+
+        $prefix = $root . '.';
+
+        if (mb_strpos($fieldName, $prefix) === 0) {
+            $fieldName = mb_substr($fieldName, mb_strlen($prefix));
+        }
+
+        $fields = $definition->getFields();
+
+        $isAssociation = mb_strpos($fieldName, '.') !== false;
+
+        if (!$isAssociation && $fields->has($fieldName)) {
+            return $definition;
+        }
+
+        $associationKey = explode('.', $fieldName);
+        $associationKey = array_shift($associationKey);
+
+        $field = $fields->get($associationKey);
+
+        if (!$field instanceof AssociationField) {
+            return $definition;
+        }
+
+        $referenceDefinition = $field->getReferenceDefinition();
+        if ($field instanceof ManyToManyAssociationField) {
+            $referenceDefinition = $field->getToManyReferenceDefinition();
+        }
+
+        return $this->getDefinition($referenceDefinition, $fieldName);
     }
 
     private function getField(EntityDefinition $definition, string $fieldName): ?Field

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
@@ -33,6 +33,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\System\CustomField\CustomFieldService;
+use Shopware\Core\System\Unit\Aggregate\UnitTranslation\UnitTranslationDefinition;
+use Shopware\Core\System\Unit\UnitDefinition;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser;
@@ -1090,12 +1092,36 @@ class CriteriaParserTest extends TestCase
                 ],
             ],
         ];
+
+        yield 'translated property of related entity with a name that doesn\'t exist in the product definition' => [
+            new EqualsFilter('unit.shortCode', 'value'),
+            [
+                'nested' => [
+                    'path' => 'unit',
+                    'query' => [
+                        'multi_match' => [
+                            'query' => 'value',
+                            'fields' => [
+                                'unit.shortCode.2fbb5fe2e29a4d70aa5854ce7ce3e20b',
+                            ],
+                            'type' => 'best_fields',
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 
     public function getDefinition(): EntityDefinition
     {
         $instanceRegistry = new StaticDefinitionInstanceRegistry(
-            [ProductDefinition::class, ProductManufacturerDefinition::class, ProductTranslationDefinition::class],
+            [
+                ProductDefinition::class,
+                ProductManufacturerDefinition::class,
+                UnitDefinition::class,
+                ProductTranslationDefinition::class,
+                UnitTranslationDefinition::class,
+            ],
             $this->createMock(ValidatorInterface::class),
             $this->createMock(EntityWriteGatewayInterface::class)
         );


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If a filter is applied on an Elasticsearch query that uses a translated field of an entity that is related to the product entity, a `RuntimeException` is thrown in the `getTranslatedField`method of the `EntityDefinitionQueryHelper`.

The filter parsing uses the `getField` method of the `EntityDefinitionQueryHelper` to get the field even if the field name contains relations. The same is not done for the definition itself. As the root definition is passed to the value parsing this would mostly lead to a null return of the `getField` method, which is unexpected behavoir. However, if the field is `TranslatedField, the `getTranslatedField` method is called. This method only searches for the field in the fields of the passed translation (without deeper resolving). The field won't be found an an execption is thrown indicating that the property is missing.

### 2. What does this change do, exactly?

This change introduces a private `getDefinition` method in the `CriteriaParser` to resolve the definition over it's relations to a definition that actually contains the field. This method is called in the `parseEqualsAnyFilter` method, the `parseEqualsFilter` method and the `parseRangeFilter` method. The original definition will still be used for the query creation. If the field does not exist in the resolved entity, an exception is still thrown.

### 3. Describe each step to reproduce the issue or behaviour.

The bug only occurs on translated fields of entities that are related to the product entity. One example is the `shortCode` field in the unit entity. The exception will be thrown if a filter (equals, equals any or range) is applied to this field.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
