### PR TITLE
NEXT-3743 - Fix inadequate entity definition resolving in Elasticsearch filter parsing that show when filtering for a translated field of a related entity is executed in Shopware 6.5

### DIFF
--- a/changelog/_unreleased/2024-12-04-fixed-elasticsearch-filter-parsing-of-translated-fields-in-product-related-entities.md
+++ b/changelog/_unreleased/2024-12-04-fixed-elasticsearch-filter-parsing-of-translated-fields-in-product-related-entities.md
@@ -1,0 +1,12 @@
+---
+title: Fixed Elasticsearch Filter parsing of translated fields in product-related entities
+issue: NEXT-37804
+author: Martin Bens
+author_email: martin.bens@it-bens.de
+author_github: @spigandromeda
+---
+# Core
+
+* Backported the `getAssociatedDefinition` method of the `EntityDefinitionQueryHelper` from NEXT-34674
+* Added `v6.6.6.0` feature variance to the `testFilterParsing` method of the `CriteriaParserTest`
+* Changed `Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser` to resolve related definitions before parsing a value while parsing a filter

--- a/changelog/_unreleased/2024-12-04-fixed-elasticsearch-filter-parsing-of-translated-fields-in-product-related-entities.md
+++ b/changelog/_unreleased/2024-12-04-fixed-elasticsearch-filter-parsing-of-translated-fields-in-product-related-entities.md
@@ -7,6 +7,6 @@ author_github: @spigandromeda
 ---
 # Core
 
-* Backported the `getAssociatedDefinition` method of the `EntityDefinitionQueryHelper` from NEXT-34674
+* Added the `getAssociatedDefinition` method of the `EntityDefinitionQueryHelper` from NEXT-34674
 * Added `v6.6.6.0` feature variance to the `testFilterParsing` method of the `CriteriaParserTest`
 * Changed `Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser` to resolve related definitions before parsing a value while parsing a filter

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
@@ -136,6 +136,34 @@ class EntityDefinitionQueryHelper
     }
 
     /**
+     * Resolves the definition of the provided field name.
+     * For e.g:
+     * `product.name` => returns ProductDefinition
+     * `product.unit.shortCode` => returns UnitDefinition
+     */
+    public static function getAssociatedDefinition(EntityDefinition $rootDefinition, string $field): EntityDefinition
+    {
+        $fields = self::getFieldsOfAccessor($rootDefinition, $field, false);
+
+        array_pop($fields);
+        $field = array_pop($fields);
+
+        if ($field === null) {
+            return $rootDefinition;
+        }
+
+        if ($field instanceof ManyToManyAssociationField) {
+            return $field->getToManyReferenceDefinition();
+        }
+
+        if ($field instanceof AssociationField) {
+            return $field->getReferenceDefinition();
+        }
+
+        return $rootDefinition;
+    }
+
+    /**
      * Returns the field instance of the provided fieldName.
      *
      * @example

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -981,6 +981,7 @@ class CriteriaParser
     private function parseValue(EntityDefinition $definition, SingleFieldFilter $filter, mixed $value): mixed
     {
         $field = $this->getField($definition, $filter->getField());
+        $definition = EntityDefinitionQueryHelper::getAssociatedDefinition($definition, $filter->getField());
 
         if ($field instanceof TranslatedField) {
             $field = EntityDefinitionQueryHelper::getTranslatedField($definition, $field);

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelperTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelperTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Dbal;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\Aggregate\CategoryTranslation\CategoryTranslationDefinition;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductCategory\ProductCategoryDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition;
+use Shopware\Core\Content\Product\Aggregate\ProductTranslation\ProductTranslationDefinition;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * @internal
+ *
+ * @covers \Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper
+ */
+#[Package('core')]
+class EntityDefinitionQueryHelperTest extends TestCase
+{
+    /**
+     * @dataProvider provideGetAssociatedDefinition
+     */
+    public function testGetAssociatedDefinition(string $accessor, string $expectedEntity): void
+    {
+        $definition = $this->getRegistry()->getByEntityName('product');
+
+        static::assertEquals(
+            $expectedEntity,
+            EntityDefinitionQueryHelper::getAssociatedDefinition($definition, $accessor)->getEntityName()
+        );
+    }
+
+    public static function provideGetAssociatedDefinition(): \Generator
+    {
+        yield 'no root' => ['name', 'product'];
+        yield 'with root' => ['categories.name', 'category'];
+        yield 'many to many' => ['product.categories.name', 'category'];
+        yield 'many to one' => ['product.manufacturer.name', 'product_manufacturer'];
+        yield 'nested' => ['product.categories.translated.customFields.test', 'category'];
+    }
+
+    private function getRegistry(): DefinitionInstanceRegistry
+    {
+        return new StaticDefinitionInstanceRegistry(
+            [
+                ProductDefinition::class,
+                ProductCategoryDefinition::class,
+                CategoryTranslationDefinition::class,
+                CategoryDefinition::class,
+                ProductManufacturerDefinition::class,
+                ProductTranslationDefinition::class,
+            ],
+            $this->createMock(ValidatorInterface::class),
+            $this->createMock(EntityWriteGatewayInterface::class)
+        );
+    }
+}

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
@@ -32,6 +32,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\System\CustomField\CustomFieldService;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Elasticsearch\ElasticsearchException;
@@ -47,6 +48,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class CriteriaParserTest extends TestCase
 {
     private const SECOND_LANGUAGE = 'd5da80fc94874ea988eac8abdea44e0a';
+
+    use EnvTestBehaviour;
 
     public function testAggregationWithSorting(): void
     {
@@ -925,6 +928,10 @@ class CriteriaParserTest extends TestCase
 
         // Unset the 'source' key before comparison.
         unset($sortedFilterArray['script']['script']['inline']);
+
+        if (!Feature::isActive('v6.6.0.0')) {
+            unset($sortedFilterArray['script']['script']['id']);
+        }
 
         static::assertEquals($expectedFilter, $sortedFilterArray);
     }

--- a/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
+++ b/tests/unit/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParserTest.php
@@ -34,6 +34,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterfa
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\System\CustomField\CustomFieldService;
+use Shopware\Core\System\Unit\Aggregate\UnitTranslation\UnitTranslationDefinition;
+use Shopware\Core\System\Unit\UnitDefinition;
 use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Shopware\Elasticsearch\Framework\DataAbstractionLayer\CriteriaParser;
@@ -47,9 +49,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  */
 class CriteriaParserTest extends TestCase
 {
-    private const SECOND_LANGUAGE = 'd5da80fc94874ea988eac8abdea44e0a';
-
     use EnvTestBehaviour;
+    private const SECOND_LANGUAGE = 'd5da80fc94874ea988eac8abdea44e0a';
 
     public function testAggregationWithSorting(): void
     {
@@ -1097,12 +1098,37 @@ class CriteriaParserTest extends TestCase
                 ],
             ],
         ];
+
+        yield $featureFlagKeyPrefix . 'translated property of related entity with a name that doesn\'t exist in the product definition' => [
+            new EqualsFilter('unit.shortCode', 'value'),
+            [
+                'nested' => [
+                    'path' => 'unit',
+                    'query' => [
+                        'multi_match' => [
+                            'query' => 'value',
+                            'fields' => [
+                                'unit.shortCode.2fbb5fe2e29a4d70aa5854ce7ce3e20b',
+                            ],
+                            'type' => 'best_fields',
+                        ],
+                    ],
+                ],
+            ],
+            $enable6660FeatureFlag
+        ];
     }
 
     public function getDefinition(): EntityDefinition
     {
         $instanceRegistry = new StaticDefinitionInstanceRegistry(
-            [ProductDefinition::class, ProductManufacturerDefinition::class, ProductTranslationDefinition::class],
+            [
+                ProductDefinition::class,
+                ProductManufacturerDefinition::class,
+                UnitDefinition::class,
+                ProductTranslationDefinition::class,
+                UnitTranslationDefinition::class,
+            ],
             $this->createMock(ValidatorInterface::class),
             $this->createMock(EntityWriteGatewayInterface::class)
         );


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If a filter is applied on an Elasticsearch query that uses a translated field of an entity that is related to the product entity, a `RuntimeException` is thrown in the `getTranslatedField`method of the `EntityDefinitionQueryHelper`.

The filter parsing uses the `getField` method of the `EntityDefinitionQueryHelper` to get the field even if the field name contains relations. The same is not done for the definition itself. As the root definition is passed to the value parsing this would mostly lead to a null return of the `getField` method, which is unexpected behavoir. However, if the field is `TranslatedField, the `getTranslatedField` method is called. This method only searches for the field in the fields of the passed translation (without deeper resolving). The field won't be found an an execption is thrown indicating that the property is missing.

### 2. What does this change do, exactly?

This change introduces a private `getDefinition` method in the `CriteriaParser` to resolve the definition over it's relations to a definition that actually contains the field. This method is called in the `parseEqualsAnyFilter` method, the `parseEqualsFilter` method and the `parseRangeFilter` method. The original definition will still be used for the query creation. If the field does not exist in the resolved entity, an exception is still thrown.

### 3. Describe each step to reproduce the issue or behaviour.

The bug only occurs on translated fields of entities that are related to the product entity. One example is the `shortCode` field in the unit entity. The exception will be thrown if a filter (equals, equals any or range) is applied to this field.

### 4. Please link to the relevant issues (if any).

https://github.com/shopware/shopware/issues/3743

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

### 6. Related PR

There is closed (an merged) PR for this changes implemented in SW 6.6. This is a backport of this changes to SW 6.5. https://github.com/shopware/shopware/pull/5739
