### PR TITLE
Identify themes installed via plugin by technical name

### DIFF
--- a/changelog/_unreleased/2024-12-04-identify-themes-installed-via-plugin-by-technical-name.md
+++ b/changelog/_unreleased/2024-12-04-identify-themes-installed-via-plugin-by-technical-name.md
@@ -1,0 +1,9 @@
+---
+title: Identify themes installed via plugin by technical name
+issue: NEXT-00000
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Storefront
+* Changed `sw-theme-list-item`, `sw-theme-manager-detail` and `sw-theme-manager-list` administration components to identify themes installed via plugin by its technical name instead of the parent theme id.

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-list-item/sw-theme-list-item.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/component/sw-theme-list-item/sw-theme-list-item.html.twig
@@ -21,7 +21,7 @@
             <div class="sw-theme-list-item__info">
                 <div v-if="theme" class="sw-theme-list-item__status" :class="componentClasses"></div>
                 <div class="sw-theme-list-item__title" v-if="theme" @click="onThemeClick">{{ theme.name }}</div>
-                <sw-icon v-if="theme && !theme.parentThemeId"
+                <sw-icon v-if="theme && theme.technicalName"
                          class="sw-theme-list-item__locked"
                          name="regular-lock"
                          v-tooltip="lockToolTip"

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-detail/sw-theme-manager-detail.html.twig
@@ -217,7 +217,7 @@
                                                 {% block sw_theme_manager_detail_context_button_option_create %}
                                                     <sw-context-menu-item
                                                         @click="onDuplicateTheme(theme)"
-                                                        v-if="!theme.parentThemeId"
+                                                        v-if="theme.technicalName"
                                                         :disabled="!acl.can('theme.creator')">
                                                         {{ $tc('sw-theme-manager.actions.duplicate') }}
                                                     </sw-context-menu-item>
@@ -235,7 +235,7 @@
 
                                                 {% block sw_theme_manager_detail_context_button_option_delete %}
                                                     <sw-context-menu-item
-                                                        v-if="theme.parentThemeId"
+                                                        v-if="!theme.technicalName"
                                                         :disabled="!acl.can('theme.deleter') || theme.salesChannels.length > 0"
                                                         v-tooltip.right="deleteDisabledToolTip"
                                                         class="sw-theme-manager-detail__option-delete"

--- a/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-list/sw-theme-manager-list.html.twig
+++ b/src/Storefront/Resources/app/administration/src/modules/sw-theme-manager/page/sw-theme-manager-list/sw-theme-manager-list.html.twig
@@ -87,7 +87,7 @@
                                                                 <sw-icon
                                                                     name="regular-lock"
                                                                     class="sw-theme-list__icon-lock"
-                                                                    v-if="!item.parentThemeId"
+                                                                    v-if="item.technicalName"
                                                                     v-tooltip="lockToolTip"
                                                                     size="14">
                                                                 </sw-icon>
@@ -135,7 +135,7 @@
                                                                         :disabled="item.salesChannels.length > 0 || !acl.can('theme.deleter')"
                                                                         v-tooltip="deleteDisabledToolTip(item)"
                                                                         @click="onDeleteTheme(item)"
-                                                                        v-if="item.parentThemeId">
+                                                                        v-if="!item.technicalName">
 
                                                                         {{ $tc('sw-theme-manager.themeListItem.delete') }}
                                                                     </sw-context-menu-item>
@@ -143,7 +143,7 @@
 
                                                                 {% block sw_theme_list_listing_list_data_grid_actions_create %}
                                                                     <sw-context-menu-item
-                                                                        v-if="!item.parentThemeId"
+                                                                        v-if="item.technicalName"
                                                                         class="sw-theme-list-item__option-duplicate"
                                                                         @click="onDuplicateTheme(item)"
                                                                         :disabled="!acl.can('theme.creator')">
@@ -219,7 +219,7 @@
 
                                                                     {% block sw_theme_list_listing_list_item_option_create %}
                                                                         <sw-context-menu-item
-                                                                            v-if="!theme.parentThemeId"
+                                                                            v-if="theme.technicalName"
                                                                             class="sw-theme-list-item__option-duplicate"
                                                                             @click="onDuplicateTheme(theme)"
                                                                             :disabled="!acl.can('theme.creator')">
@@ -229,7 +229,7 @@
 
                                                                     {% block sw_theme_list_listing_list_item_option_delete %}
                                                                         <sw-context-menu-item
-                                                                            v-if="theme.parentThemeId"
+                                                                            v-if="!theme.technicalName"
                                                                             class="sw-theme-list-item__option-delete"
                                                                             variant="danger"
                                                                             :disabled="theme.salesChannels.length > 0 || !acl.can('theme.deleter')"


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, if you install a theme plugin which is a child theme of another installed theme, the child theme seems like a duplicated theme in the administration because there is no lock sign, duplication is not available and deletion is possible.

### 2. What does this change do, exactly?
* Changed `sw-theme-list-item`, `sw-theme-manager-detail` and `sw-theme-manager-list` administration components to identify themes installed via plugin by its technical name instead of the parent theme id.

### 3. Describe each step to reproduce the issue or behaviour.
Install a child theme plugin > go to Content > Themes in the Administration

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
