### PR TITLE
feat: add custom property name to reference version field

### DIFF
--- a/changelog/_unreleased/2024-12-06-add-custom-property-name-to-reference-version-field.md
+++ b/changelog/_unreleased/2024-12-06-add-custom-property-name-to-reference-version-field.md
@@ -1,0 +1,9 @@
+---
+title: Add custom property name to reference version field
+issue:
+author: Stefan Zopfi
+author_email: stefan.z@letstalk.nl
+author_github: stefan-lt
+---
+# DAL
+* Added custom property name to the reference version field.

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -245,7 +245,7 @@ class AttributeEntityCompiler
             $field instanceof OneToMany => [$property->getName(), $field->entity, $field->ref, 'id'],
             $field instanceof ManyToMany => [$property->getName(), $field->entity, self::mappingName($entity, $field), $entity . '_id', $field->entity . '_id'],
             $field instanceof AutoIncrement, $field instanceof Version => [],
-            $field instanceof ReferenceVersion => [$field->entity, $column],
+            $field instanceof ReferenceVersion => [$field->entity, $column, $property->getName()],
             $field instanceof Serialized => [$column, $property->getName(), $field->serializer],
             default => [$column, $property->getName()],
         };

--- a/src/Core/Framework/DataAbstractionLayer/Field/ReferenceVersionField.php
+++ b/src/Core/Framework/DataAbstractionLayer/Field/ReferenceVersionField.php
@@ -33,7 +33,8 @@ class ReferenceVersionField extends FkField
 
     public function __construct(
         string $definition,
-        ?string $storageName = null
+        ?string $storageName = null,
+        ?string $propertyName = null
     ) {
         $entity = $definition;
         if (\is_subclass_of($definition, EntityDefinition::class)) {
@@ -42,9 +43,11 @@ class ReferenceVersionField extends FkField
 
         $storageName ??= $entity . '_version_id';
 
-        $propertyName = explode('_', $storageName);
-        $propertyName = array_map('ucfirst', $propertyName);
-        $propertyName = lcfirst(implode('', $propertyName));
+        if ($propertyName === null) {
+            $propertyName = explode('_', $storageName);
+            $propertyName = array_map('ucfirst', $propertyName);
+            $propertyName = lcfirst(implode('', $propertyName));
+        }
 
         parent::__construct($storageName, $propertyName, VersionDefinition::class);
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/SchemaBuilderTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Dbal/SchemaBuilderTest.php
@@ -422,7 +422,7 @@ class TestEntityWithForeignKeysDefinition extends EntityDefinition
             (new IdField('id', 'id'))->addFlags(new PrimaryKey(), new Required()),
             new VersionField(),
             new ParentFkField(self::class),
-            (new ReferenceVersionField(self::class, 'parent_version_id'))->addFlags(new Required()),
+            (new ReferenceVersionField(self::class, 'parent_version_id', 'parentVersionId'))->addFlags(new Required()),
             new FkField('association_id', 'associationId', TestAssociationDefinition::class),
             new ManyToOneAssociationField('association', 'association_id', TestAssociationDefinition::class, 'id'),
             new FkField('association_id2', 'associationId2', TestAssociationDefinition::class),


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The property name of reference version fields is always automatically set based on the storage name, the change allows for more flexibility.

### 2. What does this change do, exactly?
It allows developers to use custom property names for reference version fields.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
