### PR TITLE
fix: move mail variable update to system scope

### DIFF
--- a/changelog/_unreleased/2024-12-06-move-mail-variable-update-to-system-scope.md
+++ b/changelog/_unreleased/2024-12-06-move-mail-variable-update-to-system-scope.md
@@ -1,0 +1,9 @@
+---
+title: Move mail variable update to system scope
+issue: NEXT-00000
+author: Felix Schneider
+author_email: felix@wirduzen.de
+author_github: @schneider-felix
+---
+# Core
+* Changed mail variable update to run in system scope to prevent ACL issues

--- a/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
+++ b/src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
@@ -225,10 +225,12 @@ class SendMailAction extends FlowAction implements DelayableAction
             return;
         }
 
-        $this->mailTemplateTypeRepository->update([[
-            'id' => $mailTemplate->getMailTemplateTypeId(),
-            'templateData' => $templateData,
-        ]], $context);
+        $context->scope(Context::SYSTEM_SCOPE, function (Context $context) use ($mailTemplate, $templateData): void {
+            $this->mailTemplateTypeRepository->update([[
+                'id' => $mailTemplate->getMailTemplateTypeId(),
+                'templateData' => $templateData,
+            ]], $context);
+        });
     }
 
     private function getMailTemplate(string $id, Context $context): ?MailTemplateEntity


### PR DESCRIPTION
### 1. Why is this change necessary?

Previously the send mail action would fail if the user doesn't have persissions for the mail templates. 

### 2. What does this change do, exactly?

Surround the mail variable update with system scope to ignore acl permissions.

### 3. Describe each step to reproduce the issue or behaviour.

Send an E-Mail for example by changing the state of an order as a user who doesn't have permissions to mail templates.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
