### PR TITLE
perf: optimize product export performance by optimizing seo url replace

### DIFF
--- a/changelog/_unreleased/2024-12-07-improve-product-export-performance-by-reducing-seo-url-replacement-calls.md
+++ b/changelog/_unreleased/2024-12-07-improve-product-export-performance-by-reducing-seo-url-replacement-calls.md
@@ -1,0 +1,9 @@
+---
+title: Improve product export performance by reducing seo-url replacement calls
+issue: NEXT-00000
+author: Felix Schneider
+author_email: felix@wirduzen.de
+author_github: @schneider-felix
+---
+# Core
+* Changed `ProductExportGenerator` to not replace seo-urls for each product individually but instead replace all seo-urls at once.

--- a/src/Core/Content/DependencyInjection/product_export.xml
+++ b/src/Core/Content/DependencyInjection/product_export.xml
@@ -15,7 +15,6 @@
         <service id="Shopware\Core\Content\ProductExport\Service\ProductExportRenderer">
             <argument type="service" id="Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer"/>
             <argument type="service" id="event_dispatcher"/>
-            <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface"/>
         </service>
 
         <service id="Shopware\Core\Content\ProductExport\Service\ProductExporter" public="true">

--- a/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportGenerator.php
@@ -148,7 +148,6 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
             )
         );
 
-        $body = '';
         while ($productResult = $iterator->fetch()) {
             foreach ($productResult->getEntities() as $product) {
                 $data = $productContext->getContext();
@@ -161,18 +160,19 @@ class ProductExportGenerator implements ProductExportGeneratorInterface
                     continue; // Skip variants unless they are included
                 }
 
-                $body .= $this->productExportRender->renderBody($productExport, $context, $data);
+                $content .= $this->productExportRender->renderBody($productExport, $context, $data);
             }
 
             if ($exportBehavior->batchMode()) {
                 break;
             }
         }
-        $content .= $this->seoUrlPlaceholderHandler->replace($body, $productExport->getSalesChannelDomain()->getUrl(), $context);
 
         if ($exportBehavior->generateFooter()) {
             $content .= $this->productExportRender->renderFooter($productExport, $context);
         }
+
+        $content = $this->seoUrlPlaceholderHandler->replace($content, $productExport->getSalesChannelDomain()->getUrl(), $context);
 
         $encodingEvent = $this->eventDispatcher->dispatch(
             new ProductExportChangeEncodingEvent($productExport, $content, mb_convert_encoding($content, $productExport->getEncoding()))

--- a/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
+++ b/src/Core/Content/ProductExport/Service/ProductExportRenderer.php
@@ -8,7 +8,6 @@ use Shopware\Core\Content\ProductExport\Event\ProductExportRenderFooterContextEv
 use Shopware\Core\Content\ProductExport\Event\ProductExportRenderHeaderContextEvent;
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\ProductExportException;
-use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Adapter\Twig\Exception\StringTemplateRenderingException;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Context;
@@ -25,7 +24,6 @@ class ProductExportRenderer implements ProductExportRendererInterface
     public function __construct(
         private readonly StringTemplateRenderer $templateRenderer,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler
     ) {
     }
 
@@ -47,13 +45,11 @@ class ProductExportRenderer implements ProductExportRendererInterface
         );
 
         try {
-            $content = $this->templateRenderer->render(
+            return $this->templateRenderer->render(
                 $productExport->getHeaderTemplate(),
                 $headerContext->getContext(),
                 $salesChannelContext->getContext()
             ) . \PHP_EOL;
-
-            return $this->replaceSeoUrlPlaceholder($content, $productExport, $salesChannelContext);
         } catch (StringTemplateRenderingException $exception) {
             $renderHeaderException = ProductExportException::renderHeaderException($exception->getMessage());
             $this->logException($salesChannelContext->getContext(), $renderHeaderException);
@@ -80,13 +76,11 @@ class ProductExportRenderer implements ProductExportRendererInterface
         );
 
         try {
-            $content = $this->templateRenderer->render(
+            return $this->templateRenderer->render(
                 $productExport->getFooterTemplate(),
                 $footerContext->getContext(),
                 $salesChannelContext->getContext()
             ) . \PHP_EOL;
-
-            return $this->replaceSeoUrlPlaceholder($content, $productExport, $salesChannelContext);
         } catch (StringTemplateRenderingException $exception) {
             $renderFooterException = ProductExportException::renderFooterException($exception->getMessage());
             $this->logException($salesChannelContext->getContext(), $renderFooterException);
@@ -109,13 +103,11 @@ class ProductExportRenderer implements ProductExportRendererInterface
         }
 
         try {
-            $content = $this->templateRenderer->render(
+            return $this->templateRenderer->render(
                 $bodyTemplate,
                 $data,
                 $salesChannelContext->getContext()
             ) . \PHP_EOL;
-
-            return $this->replaceSeoUrlPlaceholder($content, $productExport, $salesChannelContext);
         } catch (StringTemplateRenderingException $exception) {
             $renderProductException = ProductExportException::renderProductException($exception->getMessage());
             $this->logException($salesChannelContext->getContext(), $renderProductException);
@@ -136,17 +128,5 @@ class ProductExportRenderer implements ProductExportRendererInterface
         );
 
         $this->eventDispatcher->dispatch($loggingEvent);
-    }
-
-    private function replaceSeoUrlPlaceholder(
-        string $content,
-        ProductExportEntity $productExportEntity,
-        SalesChannelContext $salesChannelContext
-    ): string {
-        return $this->seoUrlPlaceholderHandler->replace(
-            $content,
-            $productExportEntity->getSalesChannelDomain()->getUrl(),
-            $salesChannelContext
-        );
     }
 }

--- a/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
+++ b/tests/unit/Core/Content/ProductExport/Service/ProductExportRendererTest.php
@@ -12,7 +12,6 @@ use Shopware\Core\Content\ProductExport\Event\ProductExportRenderHeaderContextEv
 use Shopware\Core\Content\ProductExport\ProductExportEntity;
 use Shopware\Core\Content\ProductExport\ProductExportException;
 use Shopware\Core\Content\ProductExport\Service\ProductExportRenderer;
-use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
 use Shopware\Core\Framework\Adapter\Twig\Exception\StringTemplateRenderingException;
 use Shopware\Core\Framework\Adapter\Twig\StringTemplateRenderer;
 use Shopware\Core\Framework\Log\Package;
@@ -63,13 +62,10 @@ class ProductExportRendererTest extends TestCase
         $environment = new Environment(new ArrayLoader());
 
         $twigRenderer = new StringTemplateRenderer($environment, sys_get_temp_dir());
-        $seoUrlPlaceholderHandler = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
-        $seoUrlPlaceholderHandler->method('replace')->with($expected, $domainUrl, $this->context)->willReturn($expected);
 
         $renderer = new ProductExportRenderer(
             $twigRenderer,
             $dispatcher,
-            $seoUrlPlaceholderHandler,
         );
 
         $rendered = $renderer->renderHeader($productExport, $this->context);
@@ -103,13 +99,9 @@ class ProductExportRendererTest extends TestCase
         $twigRenderer = $this->createMock(StringTemplateRenderer::class);
         $twigRenderer->expects(static::once())->method('render')->willThrowException(new StringTemplateRenderingException('error'));
 
-        $seoUrlPlaceholderHandler = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
-        $seoUrlPlaceholderHandler->expects(static::never())->method('replace');
-
         $renderer = new ProductExportRenderer(
             $twigRenderer,
             $dispatcher,
-            $seoUrlPlaceholderHandler,
         );
 
         static::expectException(ProductExportException::class);
@@ -143,13 +135,10 @@ class ProductExportRendererTest extends TestCase
         $environment = new Environment(new ArrayLoader());
 
         $twigRenderer = new StringTemplateRenderer($environment, sys_get_temp_dir());
-        $seoUrlPlaceholderHandler = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
-        $seoUrlPlaceholderHandler->method('replace')->with($expected, $domainUrl, $this->context)->willReturn($expected);
 
         $renderer = new ProductExportRenderer(
             $twigRenderer,
             $dispatcher,
-            $seoUrlPlaceholderHandler,
         );
 
         $rendered = $renderer->renderFooter($productExport, $this->context);
@@ -177,13 +166,10 @@ class ProductExportRendererTest extends TestCase
         $environment = new Environment(new ArrayLoader());
 
         $twigRenderer = new StringTemplateRenderer($environment, sys_get_temp_dir());
-        $seoUrlPlaceholderHandler = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
-        $seoUrlPlaceholderHandler->method('replace')->with($expected, $domainUrl, $this->context)->willReturn($expected);
 
         $renderer = new ProductExportRenderer(
             $twigRenderer,
             $dispatcher,
-            $seoUrlPlaceholderHandler,
         );
 
         $rendered = $renderer->renderBody($productExport, $this->context, $data);
@@ -217,13 +203,9 @@ class ProductExportRendererTest extends TestCase
         $twigRenderer = $this->createMock(StringTemplateRenderer::class);
         $twigRenderer->expects(static::once())->method('render')->willThrowException(new StringTemplateRenderingException('error'));
 
-        $seoUrlPlaceholderHandler = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
-        $seoUrlPlaceholderHandler->expects(static::never())->method('replace');
-
         $renderer = new ProductExportRenderer(
             $twigRenderer,
             $dispatcher,
-            $seoUrlPlaceholderHandler,
         );
 
         static::expectException(ProductExportException::class);
@@ -240,12 +222,10 @@ class ProductExportRendererTest extends TestCase
 
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $twigRenderer = $this->createMock(StringTemplateRenderer::class);
-        $seoUrlPlaceholderHandler = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
 
         $renderer = new ProductExportRenderer(
             $twigRenderer,
             $dispatcher,
-            $seoUrlPlaceholderHandler,
         );
 
         static::expectException(ProductExportException::class);
@@ -274,13 +254,9 @@ class ProductExportRendererTest extends TestCase
         $twigRenderer = $this->createMock(StringTemplateRenderer::class);
         $twigRenderer->expects(static::once())->method('render')->willThrowException(new StringTemplateRenderingException('error'));
 
-        $seoUrlPlaceholderHandler = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
-        $seoUrlPlaceholderHandler->expects(static::never())->method('replace');
-
         $renderer = new ProductExportRenderer(
             $twigRenderer,
             $dispatcher,
-            $seoUrlPlaceholderHandler,
         );
 
         static::expectException(ProductExportException::class);


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently the seo url placeholders are replaced for each product individually. The placeholders inside header and footer are also replaced separately. This harms performance by causing a lot of database queries. Reducing the number of those queries can have a big impact for large exports.

### 2. What does this change do, exactly?

Replace all seo url placeholders at once after rendering the template.
![image](https://github.com/user-attachments/assets/eed3ab30-5a30-40a1-8a75-64f8701c01d9)


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
