### PR TITLE
NEXT-00000 Add created-at colum to manually generated coupon codes

### DIFF
--- a/changelog/_unreleased/2024-12-11-add-created-at-column-to-coupon-codes.md
+++ b/changelog/_unreleased/2024-12-11-add-created-at-column-to-coupon-codes.md
@@ -1,0 +1,9 @@
+---
+title: Allow duplicate promotion
+issue: NEXT-00000
+author: Alexander Menk
+author_email: a.menk@imi.de
+author_github: amenk
+---
+# Administration
+* Added column created at in the list of manually generated coupon codes

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/index.js
@@ -82,11 +82,19 @@ export default {
                     property: 'payload.customerName',
                     label: this.$tc('sw-promotion-v2.detail.base.codes.individual.columnCustomer'),
                 },
+                {
+                    property: 'createdAt',
+                    label: this.$tc('sw-promotion-v2.detail.base.codes.individual.columnCreatedAt'),
+                },
             ];
         },
 
         assetFilter() {
             return Shopware.Filter.getByName('asset');
+        },
+
+        dateFilter() {
+            return Shopware.Filter.getByName('date');
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.html.twig
@@ -122,6 +122,12 @@
                 </template>
                 {% endblock %}
 
+                {% block sw_promotion_v2_individual_codes_behavior_grid_created_at %}
+                <template #column-createdAt="{ item }">
+                    {{ dateFilter(item.createdAt, { hour: '2-digit', minute: '2-digit' }) }}
+                </template>
+                {% endblock %}
+
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_promotion_v2_individual_codes_behavior_grid_actions %}
                 <template #actions="{ item }">

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/de-DE.json
@@ -71,6 +71,7 @@
                         "columnCode": "Code",
                         "columnRedeemed": "Eingelöst",
                         "columnCustomer": "Kunde",
+                        "columnCreatedAt": "Erzeugt am",
                         "textDeleteConfirm": "Möchtest Du den Aktionscode \"{code}\" wirklich löschen? | Möchtest Du diese {count} Aktionscodes wirklich löschen?",
                         "openCustomer": "Kunde öffnen",
                         "routingError": "Der Kunde \"{name}\" konnte nicht gefunden werden.",

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/snippet/en-GB.json
@@ -71,6 +71,7 @@
                         "columnCode": "Code",
                         "columnRedeemed": "Redeemed",
                         "columnCustomer": "Customer",
+                        "columnCreatedAt": "Generated at",
                         "textDeleteConfirm": "Are you sure you want to delete the code \"{code}\"? | Are you sure cou want to delete these {count} codes?",
                         "openCustomer": "Open customer",
                         "routingError": "The customer \"{name}\" has not been found.",


### PR DESCRIPTION
### 1. Why is this change necessary?

As a shop owner I generate some new codes and want to pass them on to the customer. But I have no chance to see which codes I just generated.

### 2. What does this change do, exactly?

Adds a column "created at" to the coupon codes

![Demo](https://github.com/user-attachments/assets/4d57114e-c73f-4921-854f-f3d7b043b191)



### 3. Describe each step to reproduce the issue or behaviour.

* Generate codes
* See them in the list

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

### 6. Todos

- [x] Add translations
- [?] Tests necessary?
