### PR TITLE
Fix loading data for one to many grid

### DIFF
--- a/changelog/_unreleased/2024-12-16-fix-loading-data-for-one-to-many-grid-component.md
+++ b/changelog/_unreleased/2024-12-16-fix-loading-data-for-one-to-many-grid-component.md
@@ -1,0 +1,12 @@
+---
+title: Fix loading data for one to many grid component
+issue: NEXT-00000
+author: Le Nguyen
+author_email: l.nguyen@shopware.com
+author_github: @nguyenquocdaile
+---
+# Administration
+* Added `watch` property to watching the data changed of props collection in the `sw-one-to-many-grid` component.
+* Changed `deleteItems` method to fix loading data when delete all items of last page in the `sw-one-to-many-grid` component.
+* Deprecated `intial` data to fix typo use `initial` instead in the `sw-one-to-many-grid` component.
+* Changed `applyResult` method to check correct condition when apply result in the `sw-one-to-many-grid` component.

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-one-to-many-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-one-to-many-grid/index.js
@@ -63,8 +63,23 @@ Component.extend('sw-one-to-many-grid', 'sw-data-grid', {
             page: 1,
             limit: 25,
             total: 0,
+            /**
+             * @deprecated tag:v6.7.0 - Will be removed because wrong typo, use `initial` instead
+             */
             intial: true,
+            initial: true,
         };
+    },
+
+    watch: {
+        collection: {
+            handler() {
+                if (!this.initial) {
+                    this.load();
+                }
+            },
+            deep: true,
+        },
     },
 
     methods: {
@@ -74,7 +89,11 @@ Component.extend('sw-one-to-many-grid', 'sw-data-grid', {
             // assign collection as records for the sw-data-grid
             this.applyResult(this.collection);
 
+            /**
+             * @deprecated tag:v6.7.0 - Will be removed this.intial assignment
+             */
             this.intial = false;
+            this.initial = false;
 
             // local mode means, the records are loaded with the parent record
             if (this.localMode) {
@@ -92,7 +111,7 @@ Component.extend('sw-one-to-many-grid', 'sw-data-grid', {
             );
 
             // records contains a pre loaded offset
-            if (this.records.length > 0) {
+            if (Array.isArray(this.records) && this.records.length > 0) {
                 return Promise.resolve();
             }
 
@@ -102,7 +121,7 @@ Component.extend('sw-one-to-many-grid', 'sw-data-grid', {
         applyResult(result) {
             this.result = result;
 
-            if (!this.dataSource || !this.intial) {
+            if (!this.collection || !this.initial) {
                 this.records = result;
             }
 
@@ -138,6 +157,11 @@ Component.extend('sw-one-to-many-grid', 'sw-data-grid', {
         },
 
         load() {
+            // If in local mode, return early since data is loaded with parent
+            if (this.localMode) {
+                return Promise.resolve();
+            }
+
             return this.repository.search(this.result.criteria, this.result.context).then((response) => {
                 this.applyResult(response);
                 this.$emit('load-finish');
@@ -182,7 +206,8 @@ Component.extend('sw-one-to-many-grid', 'sw-data-grid', {
             return this.repository
                 .syncDeleted(selectedIds, this.result.context)
                 .then(() => {
-                    return this.deleteItemsFinish();
+                    this.resetSelection();
+                    this.load();
                 })
                 .catch(() => {
                     return this.deleteItemsFinish();

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-one-to-many-grid/sw-one-to-many-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-one-to-many-grid/sw-one-to-many-grid.spec.js
@@ -71,6 +71,19 @@ describe('app/component/entity/sw-one-to-many-grid', () => {
     it('should enable the context menu delete item', async () => {
         const wrapper = await createWrapper();
 
+        await wrapper.setData({
+            records: [
+                {
+                    name: 'name',
+                    shortCode: 'shortCode',
+                },
+                {
+                    name: 'name',
+                    shortCode: 'shortCode',
+                },
+            ],
+        });
+
         const firstRow = wrapper.find('.sw-data-grid__row--1');
         const firstRowActions = firstRow.find('.sw-data-grid__cell--actions');
         const firstRowActionDelete = firstRowActions.find('.sw-one-to-many-grid__delete-action');
@@ -84,6 +97,19 @@ describe('app/component/entity/sw-one-to-many-grid', () => {
 
         await wrapper.setProps({
             allowDelete: false,
+        });
+
+        await wrapper.setData({
+            records: [
+                {
+                    name: 'name',
+                    shortCode: 'shortCode',
+                },
+                {
+                    name: 'name',
+                    shortCode: 'shortCode',
+                },
+            ],
         });
 
         const firstRow = wrapper.find('.sw-data-grid__row--1');

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-individual-codes-behavior/sw-promotion-v2-individual-codes-behavior.html.twig
@@ -62,7 +62,6 @@
                 class="sw-promotion-v2-individual-codes-behavior__grid"
                 :is-loading="isGridLoading"
                 :collection="promotion.individualCodes"
-                :data-source="promotionRepository"
                 :columns="codeColumns"
                 :local-mode="false"
                 sort-by="code"


### PR DESCRIPTION
### 1. Why is this change necessary?
Some issues with sw-one-to-many-grid

- Add more code doesn't change the pagination page
- Deletes all the items on the last page and doesn't load data again
- Generate code doesn't load data again

### 2. What does this change do, exactly?
Fix some issues mentioned above

### 3. Describe each step to reproduce the issue or behavior.
https://github.com/user-attachments/assets/d578711f-cf77-4744-b517-bec5c5777ce8

### 4. Video work after my fix

https://github.com/user-attachments/assets/d8c0e605-ee35-455b-8750-a81a294dc055
