### PR TITLE
NEXT-38513 - Improve checkout accessibility

### DIFF
--- a/changelog/_unreleased/2024-11-28-improved-checkout-for-a11y.md
+++ b/changelog/_unreleased/2024-11-28-improved-checkout-for-a11y.md
@@ -1,0 +1,48 @@
+---
+title: Improved Checkout accessibility
+issue: NEXT-38513
+---
+# Core
+* Changed `Shopware\Core\Checkout\Payment\PaymentMethodCollection` to not re-sort selected payment method.
+* Changed `Shopware\Core\Checkout\Shipping\ShippingMethodCollection` to not re-sort selected shipping method.
+___
+# Storefront
+* Changed `Resources/views/storefront/component/payment/payment-form.html.twig` to list all payment methods instead of only 5.
+* Changed `Resources/views/storefront/component/payment/payment-method.html.twig` to show the payment method description only for selected payment method.
+* Changed `Resources/views/storefront/component/shipping/shipping-form.html.twig` to list all shipping methods instead of only 5.
+* Changed `Resources/views/storefront/component/shipping/shipping-method.html.twig` to show the shipping method description only for selected shipping method.
+* Deprecated `Resources/views/storefront/component/payment/payment-fields.html.twig` to remove collapse logic, payment method list is now in `Resources/views/storefront/component/payment/payment-form.html.twig`
+* Deprecated `Resources/views/storefront/component/shipping/shipping-fields.html.twig` to remove collapse logic, payment method list is now in `Resources/views/storefront/component/shipping/shipping-form.html.twig`
+* Deprecated blocks for rename:
+  * `page_checkout_change_payment_form` to `component_payment_form`
+  * `page_checkout_change_payment_form_element` to `component_payment_form_element`
+  * `page_checkout_change_payment_form_redirect` to `component_payment_form_redirect`
+  * `page_checkout_change_payment_form_fields` to `component_payment_form_list`
+  * `page_checkout_change_shipping_form` to `component_shipping_form`
+  * `page_checkout_change_shipping_form_element` to `component_shipping_form_element`
+  * `page_checkout_change_shipping_form_redirect` to `component_shipping_form_redirect`
+  * `page_checkout_change_shipping_form_fields` to `component_shipping_form_list`
+* Deprecated blocks for removal:
+  * `component_shipping_methods`
+  * `component_shipping_method`
+  * `component_shipping_method_collapse`
+  * `component_shipping_method_collapse_trigger`
+  * `component_shipping_method_collapse_trigger_label`
+  * `component_shipping_method_collapse_trigger_icon`
+  * `component_payment_methods`
+  * `component_payment_method`
+  * `component_payment_method_collapse`
+  * `component_payment_method_collapse_trigger`
+  * `component_payment_method_collapse_trigger_label`
+  * `component_payment_method_collapse_trigger_icon`
+* Deprecated plugin `CollapseCheckoutConfirmMethodsPlugin`
+* Deprecated CSS classes `confirm-checkout-collapse-trigger` and `icon-confirm-checkout-chevron`
+___
+# Next Major Version Changes
+## Payment & shipping method display in Shopware 6.7
+The payment and shipping method selection in the checkout in the Storefront has been improved for accessibility.
+There are now all methods listed instead of only 5, which makes the `CollapseCheckoutConfirmMethodsPlugin` unnecessary and will be removed.
+Also, the payment and shipping method descriptions are now only shown for the selected method.
+To clean up the collapse logic, the following templates will be removed:
+* `Resources/views/storefront/component/payment/payment-fields.html.twig`, integrated into `Resources/views/storefront/component/payment/payment-form.html.twig`
+* `Resources/views/storefront/component/shipping/shipping-fields.html.twig`, integrated into `Resources/views/storefront/component/shipping/shipping-form.html.twig`

--- a/src/Core/Checkout/Payment/PaymentMethodCollection.php
+++ b/src/Core/Checkout/Payment/PaymentMethodCollection.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Checkout\Payment;
 
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -46,7 +47,8 @@ class PaymentMethodCollection extends EntityCollection
     public function sortPaymentMethodsByPreference(SalesChannelContext $context): void
     {
         $ids = array_merge(
-            [$context->getPaymentMethod()->getId(), $context->getSalesChannel()->getPaymentMethodId()],
+            !Feature::isActive('ACCESSIBILITY_TWEAKS') ? [$context->getPaymentMethod()->getId()] : [],
+            [$context->getSalesChannel()->getPaymentMethodId()],
             $this->getIds()
         );
 

--- a/src/Core/Checkout/Shipping/ShippingMethodCollection.php
+++ b/src/Core/Checkout/Shipping/ShippingMethodCollection.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Shipping;
 
 use Shopware\Core\Checkout\Shipping\Aggregate\ShippingMethodPrice\ShippingMethodPriceCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -61,7 +62,8 @@ class ShippingMethodCollection extends EntityCollection
     public function sortShippingMethodsByPreference(SalesChannelContext $context): void
     {
         $ids = array_merge(
-            [$context->getShippingMethod()->getId(), $context->getSalesChannel()->getShippingMethodId()],
+            !Feature::isActive('ACCESSIBILITY_TWEAKS') ? [$context->getShippingMethod()->getId()] : [],
+            [$context->getSalesChannel()->getShippingMethodId()],
             $this->getIds()
         );
 

--- a/src/Storefront/Resources/app/storefront/src/main.js
+++ b/src/Storefront/Resources/app/storefront/src/main.js
@@ -53,7 +53,9 @@ PluginManager.register('AccountGuestAbortButton', () => import('src/plugin/heade
 PluginManager.register('OffCanvasCart', () => import('src/plugin/offcanvas-cart/offcanvas-cart.plugin'), '[data-off-canvas-cart]');
 PluginManager.register('AddToCart', () => import('src/plugin/add-to-cart/add-to-cart.plugin'), '[data-add-to-cart]');
 PluginManager.register('CollapseFooterColumns', () => import('src/plugin/collapse/collapse-footer-columns.plugin'), '[data-collapse-footer-columns]');
-PluginManager.register('CollapseCheckoutConfirmMethods', () => import('src/plugin/collapse/collapse-checkout-confirm-methods.plugin'), '[data-collapse-checkout-confirm-methods]');
+if (!Feature.isActive('v6.7.0.0')) {
+    PluginManager.register('CollapseCheckoutConfirmMethods', () => import('src/plugin/collapse/collapse-checkout-confirm-methods.plugin'), '[data-collapse-checkout-confirm-methods]');
+}
 if (Feature.isActive('v6.7.0.0')) {
     PluginManager.register('Navbar', () => import('src/plugin/navbar/navbar.plugin'), '[data-navbar]');
 } else {

--- a/src/Storefront/Resources/app/storefront/src/plugin/collapse/collapse-checkout-confirm-methods.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/collapse/collapse-checkout-confirm-methods.plugin.js
@@ -1,6 +1,9 @@
 import Plugin from 'src/plugin-system/plugin.class';
 import DomAccess from 'src/helper/dom-access.helper';
 
+/**
+ * @deprecated tag:v6.7.0 - will be removed without placement
+ */
 export default class CollapseCheckoutConfirmMethodsPlugin extends Plugin {
 
     static options = {

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_confirm.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_confirm.scss
@@ -66,19 +66,22 @@
     }
 }
 
-.confirm-checkout-collapse-trigger {
-    text-underline: $link-color;
+// @deprecated tag:v6.7.0 - Remove the following styles
+@if not feature('ACCESSIBILITY_TWEAKS') {
+    .confirm-checkout-collapse-trigger {
+        text-underline: $link-color;
 
-    &:hover {
-        cursor: pointer;
-    }
+        &:hover {
+            cursor: pointer;
+        }
 
-    .icon-confirm-checkout-chevron {
-        height: 1.375rem;
+        .icon-confirm-checkout-chevron {
+            height: 1.375rem;
 
-        > svg {
-            color: $link-color;
-            transition: transform 0.2s ease-in-out;
+            > svg {
+                color: $link-color;
+                transition: transform 0.2s ease-in-out;
+            }
         }
     }
 }

--- a/src/Storefront/Resources/views/storefront/component/payment/payment-fields.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/payment/payment-fields.html.twig
@@ -1,15 +1,20 @@
+{# @deprecated tag:v6.7.0 - template will be removed, the list is now rendered in `component/payment/payment-form.html.twig` #}
 {% set collapseTriggerLabels = {
     collapseTriggerMoreLabel: 'checkout.collapseTriggerMore'|trans|sw_sanitize,
     collapseTriggerLessLabel: 'checkout.collapseTriggerLess'|trans|sw_sanitize
 } %}
 
+{# @deprecated tag:v6.7.0 - payment method list is moved to `component/payment/payment-form.html.twig` #}
 {% block component_payment_methods %}
     <div class="payment-methods">
+
+        {# @deprecated tag:v6.7.0 - payment method list is moved to `component/payment/payment-form.html.twig` #}
         {% block component_payment_method %}
             {% for payment in page.paymentMethods[:visiblePaymentMethodsLimit] %}
                 {% sw_include '@Storefront/storefront/component/payment/payment-method.html.twig' %}
             {% endfor %}
 
+            {# @deprecated tag:v6.7.0 - block will be removed, all payment methods will be shown for accessibility #}
             {% block component_payment_method_collapse %}
                 {% if page.paymentMethods|length > visiblePaymentMethodsLimit and visiblePaymentMethodsLimit is not same as(null) %}
                     <div class="collapse">
@@ -18,17 +23,20 @@
                         {% endfor %}
                     </div>
 
+                    {# @deprecated tag:v6.7.0 - block will be removed, all payment methods will be shown for accessibility #}
                     {% block component_payment_method_collapse_trigger %}
                         <button class="btn btn-link confirm-checkout-collapse-trigger"
                                 type="button"
                                 data-collapse-checkout-confirm-methods="true"
                                 data-collapse-checkout-confirm-methods-options="{{ collapseTriggerLabels|json_encode }}">
                             <span class="confirm-checkout-collapse-trigger-label">
+                                {# @deprecated tag:v6.7.0 - block will be removed, all payment methods will be shown for accessibility #}
                                 {% block component_payment_method_collapse_trigger_label %}
                                     {{ collapseTriggerLabels.collapseTriggerMoreLabel }}
                                 {% endblock %}
                             </span>
 
+                            {# @deprecated tag:v6.7.0 - block will be removed, all payment methods will be shown for accessibility #}
                             {% block component_payment_method_collapse_trigger_icon %}
                                 {% sw_icon 'arrow-down' style {
                                     class: 'confirm-checkout-chevron',

--- a/src/Storefront/Resources/views/storefront/component/payment/payment-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/payment/payment-form.html.twig
@@ -1,8 +1,12 @@
+{% block component_payment_form %}
+{# @deprecated tag:v6.7.0 - Block `page_checkout_change_payment_form` will be renamed to `component_payment_form` #}
 {% block page_checkout_change_payment_form %}
     {% set formAjaxSubmitOptions = {
         changeTriggerSelectors: ['.payment-method-input']
     } %}
 
+    {% block component_payment_form_element %}
+    {# @deprecated tag:v6.7.0 - Block `page_checkout_change_payment_form_element` will be renamed to `component_payment_form_element` #}
     {% block page_checkout_change_payment_form_element %}
         <form id="changePaymentForm"
               name="changePaymentForm"
@@ -10,17 +14,35 @@
               data-form-auto-submit="true"
               data-form-auto-submit-options="{{ formAjaxSubmitOptions|json_encode }}"
               method="post">
+            {% block component_payment_form_redirect %}
+            {# @deprecated tag:v6.7.0 - Block `page_checkout_change_payment_form_redirect` will be renamed to `component_payment_form_redirect` #}
             {% block page_checkout_change_payment_form_redirect %}
                 <input type="hidden" name="redirectTo" value="{{ redirect }}">
                 <input type="hidden" name="redirectParameters" value="{{ redirectParameters }}">
             {% endblock %}
-
-            {% block page_checkout_change_payment_form_fields %}
-                {% sw_include '@Storefront/storefront/component/payment/payment-fields.html.twig' with {
-                    visiblePaymentMethodsLimit: 5,
-                    selectedPaymentMethodId: context.paymentMethod.id
-                } %}
             {% endblock %}
+
+            {% if feature('ACCESSIBILITY_TWEAKS') %}
+                {% block component_payment_form_list %}
+                    <div class="payment-methods">
+                        {% for payment in page.paymentMethods %}
+                            {% block component_payment_form_method %}
+                                {% sw_include '@Storefront/storefront/component/payment/payment-method.html.twig' %}
+                            {% endblock %}
+                        {% endfor %}
+                    </div>
+                {% endblock %}
+            {% else %}
+                {# @deprecated tag:v6.7.0 - Block `page_checkout_change_payment_form_fields` will be replaced with `component_payment_form_list` #}
+                {% block page_checkout_change_payment_form_fields %}
+                    {% sw_include '@Storefront/storefront/component/payment/payment-fields.html.twig' with {
+                        visiblePaymentMethodsLimit: 5,
+                        selectedPaymentMethodId: context.paymentMethod.id
+                    } %}
+                {% endblock %}
+            {% endif %}
         </form>
     {% endblock %}
+    {% endblock %}
+{% endblock %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/payment/payment-method.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/payment/payment-method.html.twig
@@ -1,3 +1,7 @@
+{% if selectedPaymentMethodId is not defined %}
+    {% set selectedPaymentMethodId = context.paymentMethod.id %}
+{% endif %}
+
 <div class="payment-method">
     {% block component_payment_method_field %}
         <div class="payment-form-group form-group">
@@ -43,11 +47,11 @@
                                         <strong>{{ paymentName }}</strong>
                                     {% endblock %}
 
-                                    {% if payment.translated.description %}
+                                    {% if payment.translated.description and (payment.id is same as(selectedPaymentMethodId) or not feature('ACCESSIBILITY_TWEAKS')) %}
                                         {% set paymentDescription = payment.translated.description|raw %}
                                         {% set paymentDescriptionTitle = payment.translated.description|striptags|raw %}
 
-                                        {% if not payment.id is same as(selectedPaymentMethodId) %}
+                                        {% if not payment.id is same as(selectedPaymentMethodId) and not feature('ACCESSIBILITY_TWEAKS') %}
                                             {% set paymentDescription = (paymentDescription|length > 75 ? paymentDescription[:75] ~ ' ...' : paymentDescription) %}
                                         {% endif %}
 

--- a/src/Storefront/Resources/views/storefront/component/shipping/shipping-fields.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/shipping/shipping-fields.html.twig
@@ -1,15 +1,20 @@
+{# @deprecated tag:v6.7.0 - template will be removed, the list is now rendered in `component/payment/payment-form.html.twig` #}
 {% set collapseTriggerLabels = {
     collapseTriggerMoreLabel: 'checkout.collapseTriggerMore'|trans|sw_sanitize,
     collapseTriggerLessLabel: 'checkout.collapseTriggerLess'|trans|sw_sanitize
 } %}
 
+{# @deprecated tag:v6.7.0 - shipping method list is moved to `component/shipping/shipping-form.html.twig` #}
 {% block component_shipping_methods %}
     <div class="shipping-methods">
+
+        {# @deprecated tag:v6.7.0 - shipping method list is moved to `component/shipping/shipping-form.html.twig` #}
         {% block component_shipping_method %}
             {% for shipping in page.shippingMethods[:visibleShippingMethodsLimit] %}
                 {% sw_include '@Storefront/storefront/component/shipping/shipping-method.html.twig' %}
             {% endfor %}
 
+            {# @deprecated tag:v6.7.0 - block will be removed, all shipping methods will be shown for accessibility #}
             {% block component_shipping_method_collapse %}
                 {% if page.shippingMethods|length > visibleShippingMethodsLimit and visibleShippingMethodsLimit is not same as(null) %}
                     <div class="collapse">
@@ -18,17 +23,20 @@
                         {% endfor %}
                     </div>
 
+                    {# @deprecated tag:v6.7.0 - block will be removed, all shipping methods will be shown for accessibility #}
                     {% block component_shipping_method_collapse_trigger %}
                         <button class="btn btn-link confirm-checkout-collapse-trigger"
                                 type="button"
                                 data-collapse-checkout-confirm-methods="true"
                                 data-collapse-checkout-confirm-methods-options="{{ collapseTriggerLabels|json_encode }}">
                             <span class="confirm-checkout-collapse-trigger-label">
+                                {# @deprecated tag:v6.7.0 - block will be removed, all shipping methods will be shown for accessibility #}
                                 {% block component_shipping_method_collapse_trigger_label %}
                                     {{ collapseTriggerLabels.collapseTriggerMoreLabel }}
                                 {% endblock %}
                             </span>
 
+                            {# @deprecated tag:v6.7.0 - block will be removed, all shipping methods will be shown for accessibility #}
                             {% block component_shipping_method_collapse_trigger_icon %}
                                 {% sw_icon 'arrow-down' style {
                                     class: 'confirm-checkout-chevron',

--- a/src/Storefront/Resources/views/storefront/component/shipping/shipping-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/shipping/shipping-form.html.twig
@@ -1,8 +1,12 @@
+{% block component_shipping_form %}
+{# @deprecated tag:v6.7.0 - Block `page_checkout_change_shipping_form` will be renamed to `component_shipping_form` #}
 {% block page_checkout_change_shipping_form %}
     {% set formAjaxSubmitOptions = {
         changeTriggerSelectors: ['.shipping-method-input']
     } %}
 
+    {% block component_shipping_form_element %}
+    {# @deprecated tag:v6.7.0 - Block `page_checkout_change_shipping_form_element` will be renamed to `component_shipping_form_element` #}
     {% block page_checkout_change_shipping_form_element %}
         <form id="changeShippingForm"
               name="changeShippingForm"
@@ -10,16 +14,34 @@
               data-form-auto-submit="true"
               data-form-auto-submit-options="{{ formAjaxSubmitOptions|json_encode }}"
               method="post">
+            {% block component_shipping_form_redirect %}
+            {# @deprecated tag:v6.7.0 - Block `page_checkout_change_shipping_form_redirect` will be renamed to `component_shipping_form_redirect` #}
             {% block page_checkout_change_shipping_form_redirect %}
                 <input type="hidden" name="redirectTo" value="{{ redirect }}">
                 <input type="hidden" name="redirectParameters" value="{{ redirectParameters }}">
             {% endblock %}
-
-            {% block page_checkout_change_shipping_form_fields %}
-                {% sw_include '@Storefront/storefront/component/shipping/shipping-fields.html.twig' with {
-                    visibleShippingMethodsLimit: 5
-                } %}
             {% endblock %}
+
+            {% if feature('ACCESSIBILITY_TWEAKS') %}
+                {% block component_shipping_form_list %}
+                    <div class="shipping-methods">
+                        {% for shipping in page.shippingMethods %}
+                            {% block component_shipping_form_method %}
+                                {% sw_include '@Storefront/storefront/component/shipping/shipping-method.html.twig' %}
+                            {% endblock %}
+                        {% endfor %}
+                    </div>
+                {% endblock %}
+            {% else %}
+                {# @deprecated tag:v6.7.0 - Block `page_checkout_change_shipping_form_fields` will be replaced with `component_payment_form_list` #}
+                {% block page_checkout_change_shipping_form_fields %}
+                    {% sw_include '@Storefront/storefront/component/shipping/shipping-fields.html.twig' with {
+                        visibleShippingMethodsLimit: 5
+                    } %}
+                {% endblock %}
+            {% endif %}
         </form>
     {% endblock %}
+    {% endblock %}
+{% endblock %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/shipping/shipping-method.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/shipping/shipping-method.html.twig
@@ -1,3 +1,7 @@
+{% if selectedShippingMethodId is not defined %}
+    {% set selectedShippingMethodId = context.shippingMethod.id %}
+{% endif %}
+
 <div class="shipping-method">
     {% block component_shipping_method_field %}
         <div class="shipping-form-group form-group">
@@ -8,7 +12,7 @@
                                id="shippingMethod{{ shipping.id }}"
                                name="shippingMethodId"
                                value="{{ shipping.id }}"
-                               {% if shipping.id is same as(context.shippingMethod.id) %}checked="checked"{% endif %}
+                               {% if shipping.id is same as(selectedShippingMethodId) %}checked="checked"{% endif %}
                                class="form-check-input shipping-method-input"
                                data-focus-id="{{ shipping.id }}">
                     {% endblock %}
@@ -35,10 +39,10 @@
                             {% block component_shipping_method_description %}
                                 <div class="shipping-method-description">
                                     <strong>{{ shipping.translated.name }}</strong>
-                                    {% if shipping.translated.description %}
+                                    {% if shipping.translated.description and (shipping.id is same as(selectedShippingMethodId) or not feature('ACCESSIBILITY_TWEAKS')) %}
                                         {% set shippingDescription = shipping.translated.description|raw %}
 
-                                        {% if not shipping.id is same as(context.shippingMethod.id) %}
+                                        {% if not shipping.id is same as(selectedShippingMethodId) and not feature('ACCESSIBILITY_TWEAKS') %}
                                             {% set shippingDescription = (shippingDescription|length > 75 ? shippingDescription[:75] ~ ' ...' : shippingDescription) %}
                                         {% endif %}
 

--- a/tests/integration/Core/Checkout/Payment/SalesChannel/PaymentMethodRouteTest.php
+++ b/tests/integration/Core/Checkout/Payment/SalesChannel/PaymentMethodRouteTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Checkout\Payment\Hook\PaymentMethodRouteHook;
 use Shopware\Core\Checkout\Payment\SalesChannel\PaymentMethodRoute;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -74,8 +75,13 @@ class PaymentMethodRouteTest extends TestCase
         static::assertArrayHasKey(PaymentMethodRouteHook::HOOK_NAME, $traces);
     }
 
+    /**
+     * @deprecated tag:v6.7.0 - will be removed due to behavior change
+     */
     public function testSorting(): void
     {
+        Feature::skipTestIfActive('ACCESSIBILITY_TWEAKS', $this);
+
         $paymentMethodRoute = static::getContainer()->get(PaymentMethodRoute::class);
 
         $request = new Request();

--- a/tests/integration/Core/Checkout/Shipping/SalesChannel/ShippingMethodRouteTest.php
+++ b/tests/integration/Core/Checkout/Shipping/SalesChannel/ShippingMethodRouteTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Checkout\Shipping\SalesChannel\ShippingMethodRoute;
 use Shopware\Core\Checkout\Shipping\SalesChannel\SortedShippingMethodRoute;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Script\Debugging\ScriptTraces;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
@@ -150,7 +151,12 @@ class ShippingMethodRouteTest extends TestCase
         $ids = array_column($response['elements'], 'id');
 
         static::assertEquals(
+            Feature::isActive('ACCESSIBILITY_TWEAKS') ?
             [
+                $this->ids->get('shipping'),    // position  1 (sales-channel default)
+                $this->ids->get('shipping3'),   // position -3
+                $this->ids->get('shipping2'),   // position  5 (selected method)
+            ] : [
                 $this->ids->get('shipping2'),   // position  5 (selected method)
                 $this->ids->get('shipping'),    // position  1 (sales-channel default)
                 $this->ids->get('shipping3'),   // position -3
@@ -159,8 +165,13 @@ class ShippingMethodRouteTest extends TestCase
         );
     }
 
+    /**
+     * @deprecated tag:v6.7.0 - will be removed due to behavior change
+     */
     public function testSorting(): void
     {
+        Feature::skipTestIfActive('ACCESSIBILITY_TWEAKS', $this);
+
         $shippingMethodRoute = static::getContainer()->get(ShippingMethodRoute::class);
 
         $request = new Request();


### PR DESCRIPTION
### Changes for payment and shipping methods

No more putting the selected method first, only the sales channel default
No more "see more" toggle, just show all of them (merchants rarely have many methods for a single customer / country)
To save space in case merchants have many methods, we only show the description for the currently selected method

### Before
<img width="461" alt="Screenshot_2024-11-28_at_21 17 03" src="https://github.com/user-attachments/assets/1b4eeb72-305f-4022-a471-d833564a999e" />


### After
<img width="454" alt="Screenshot_2024-11-28_at_21 17 19" src="https://github.com/user-attachments/assets/21819061-ce20-4aa1-abea-8edb58bf5466" />
