### PR TITLE
fix: foreign Key Constraint Violation on Save & Publish

### DIFF
--- a/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
+++ b/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
@@ -8,9 +8,12 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * @internal
+ *
  * Handles cleanup of CMS entities (`cms_slot`) referencing deleted parent entities (`cms_block`) during a version merge.
+ * This solution addresses a specific corner case for CMS entities. If a similar issue arises with other entities,
+ * consider generalizing this approach.
  */
-#[Package('buyers-experience')]
+#[Package('discovery')]
 class CmsVersionMergeSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array

--- a/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
+++ b/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Cms\Subscriber;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Event\BeforeVersionMergeEvent;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+#[Package('buyers-experience')]
+class CmsVersionMergeSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            BeforeVersionMergeEvent::class => 'onBeforeVersionMerge',
+        ];
+    }
+
+    public function onBeforeVersionMerge(BeforeVersionMergeEvent $event): void
+    {
+        $writes = &$event->getWrites();
+
+        if (empty($writes['delete']['cms_block'])) {
+            return;
+        }
+
+        $deletedBlocks = [];
+        foreach ($writes['delete']['cms_block'] as $deletedBlock) {
+            $blockId = $deletedBlock['id'] ?? null;
+            $blockVersionId = $deletedBlock['versionId'] ?? null;
+
+            if ($blockId && $blockVersionId) {
+                $deletedBlocks[$blockId][$blockVersionId] = true;
+            }
+        }
+
+        foreach (['insert', 'update'] as $operation) {
+            if (!empty($writes[$operation]['cms_slot'])) {
+                $writes[$operation]['cms_slot'] = array_filter($writes[$operation]['cms_slot'], function ($slot) use ($deletedBlocks) {
+                    $blockId = $slot['blockId'] ?? null;
+                    $blockVersionId = $slot['cmsBlockVersionId'] ?? null;
+
+                    return empty($deletedBlocks[$blockId][$blockVersionId]);
+                });
+            }
+        }
+    }
+}

--- a/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
+++ b/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Event\BeforeVersionMergeEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * @internal
+ */
 #[Package('buyers-experience')]
 class CmsVersionMergeSubscriber implements EventSubscriberInterface
 {
@@ -36,12 +39,12 @@ class CmsVersionMergeSubscriber implements EventSubscriberInterface
 
         foreach (['insert', 'update'] as $operation) {
             if (!empty($writes[$operation]['cms_slot'])) {
-                $writes[$operation]['cms_slot'] = array_filter($writes[$operation]['cms_slot'], function ($slot) use ($deletedBlocks) {
+                $writes[$operation]['cms_slot'] = array_values(array_filter($writes[$operation]['cms_slot'], function ($slot) use ($deletedBlocks) {
                     $blockId = $slot['blockId'] ?? null;
                     $blockVersionId = $slot['cmsBlockVersionId'] ?? null;
 
                     return empty($deletedBlocks[$blockId][$blockVersionId]);
-                });
+                }));
             }
         }
     }

--- a/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
+++ b/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
@@ -8,6 +8,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * @internal
+ * Handles cleanup of CMS entities (`cms_slot`) referencing deleted parent entities (`cms_block`) during a version merge.
  */
 #[Package('buyers-experience')]
 class CmsVersionMergeSubscriber implements EventSubscriberInterface
@@ -21,7 +22,7 @@ class CmsVersionMergeSubscriber implements EventSubscriberInterface
 
     public function onBeforeVersionMerge(BeforeVersionMergeEvent $event): void
     {
-        $writes = &$event->getWrites();
+        $writes = $event->writes;
 
         if (empty($writes['delete']['cms_block'])) {
             return;
@@ -37,6 +38,8 @@ class CmsVersionMergeSubscriber implements EventSubscriberInterface
 
             $writes[$operation]['cms_slot'] = $this->filterSlots($writes[$operation]['cms_slot'], $deletedBlocks);
         }
+
+        $event->writes = $writes;
     }
 
     /**

--- a/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
+++ b/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
@@ -27,28 +27,52 @@ class CmsVersionMergeSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $deletedBlocks = [];
-        foreach ($writes['delete']['cms_block'] as $deletedBlock) {
+        $deletedBlocks = $this->mapDeletedBlocks($writes['delete']['cms_block']);
+
+        // Filter slots based on deleted blocks
+        foreach (['insert', 'update'] as $operation) {
+            if (empty($writes[$operation]['cms_slot'])) {
+                continue;
+            }
+
+            $writes[$operation]['cms_slot'] = $this->filterSlots($writes[$operation]['cms_slot'], $deletedBlocks);
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $deletedBlocks
+     * @return array<string, array<string, bool>>
+     */
+    private function mapDeletedBlocks(array $deletedBlocks): array
+    {
+        $mapped = [];
+        foreach ($deletedBlocks as $deletedBlock) {
             $blockId = $deletedBlock['id'] ?? null;
             $blockVersionId = $deletedBlock['versionId'] ?? null;
 
             if ($blockId && $blockVersionId) {
-                $deletedBlocks[$blockId][$blockVersionId] = true;
+                $mapped[$blockId][$blockVersionId] = true;
             }
         }
 
-        foreach (['insert', 'update'] as $operation) {
-            if (!empty($writes[$operation]['cms_slot'])) {
-                $writes[$operation]['cms_slot'] = array_values(array_filter(
-                    $writes[$operation]['cms_slot'],
-                    function ($slot) use ($deletedBlocks) {
-                        $blockId = $slot['blockId'] ?? null;
-                        $blockVersionId = $slot['cmsBlockVersionId'] ?? null;
+        return $mapped;
+    }
 
-                        return empty($deletedBlocks[$blockId][$blockVersionId]);
-                    }
-                ));
+    /**
+     * @param array<int, array<string, mixed>> $slots
+     * @param array<string, array<string, bool>> $deletedBlocks
+     * @return array<int, array<string, mixed>>
+     */
+    private function filterSlots(array $slots, array $deletedBlocks): array
+    {
+        return array_values(array_filter(
+            $slots,
+            static function (array $slot) use ($deletedBlocks): bool {
+                $blockId = $slot['blockId'] ?? null;
+                $blockVersionId = $slot['cmsBlockVersionId'] ?? null;
+
+                return empty($deletedBlocks[$blockId][$blockVersionId]);
             }
-        }
+        ));
     }
 }

--- a/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
+++ b/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
@@ -39,12 +39,15 @@ class CmsVersionMergeSubscriber implements EventSubscriberInterface
 
         foreach (['insert', 'update'] as $operation) {
             if (!empty($writes[$operation]['cms_slot'])) {
-                $writes[$operation]['cms_slot'] = array_values(array_filter($writes[$operation]['cms_slot'], function ($slot) use ($deletedBlocks) {
-                    $blockId = $slot['blockId'] ?? null;
-                    $blockVersionId = $slot['cmsBlockVersionId'] ?? null;
+                $writes[$operation]['cms_slot'] = array_values(array_filter(
+                    $writes[$operation]['cms_slot'],
+                    function ($slot) use ($deletedBlocks) {
+                        $blockId = $slot['blockId'] ?? null;
+                        $blockVersionId = $slot['cmsBlockVersionId'] ?? null;
 
-                    return empty($deletedBlocks[$blockId][$blockVersionId]);
-                }));
+                        return empty($deletedBlocks[$blockId][$blockVersionId]);
+                    }
+                ));
             }
         }
     }

--- a/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
+++ b/src/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriber.php
@@ -41,14 +41,15 @@ class CmsVersionMergeSubscriber implements EventSubscriberInterface
 
     /**
      * @param array<int, array<string, mixed>> $deletedBlocks
+     *
      * @return array<string, array<string, bool>>
      */
     private function mapDeletedBlocks(array $deletedBlocks): array
     {
         $mapped = [];
         foreach ($deletedBlocks as $deletedBlock) {
-            $blockId = $deletedBlock['id'] ?? null;
-            $blockVersionId = $deletedBlock['versionId'] ?? null;
+            $blockId = isset($deletedBlock['id']) ? (string) $deletedBlock['id'] : null;
+            $blockVersionId = isset($deletedBlock['versionId']) ? (string) $deletedBlock['versionId'] : null;
 
             if ($blockId && $blockVersionId) {
                 $mapped[$blockId][$blockVersionId] = true;
@@ -61,6 +62,7 @@ class CmsVersionMergeSubscriber implements EventSubscriberInterface
     /**
      * @param array<int, array<string, mixed>> $slots
      * @param array<string, array<string, bool>> $deletedBlocks
+     *
      * @return array<int, array<string, mixed>>
      */
     private function filterSlots(array $slots, array $deletedBlocks): array

--- a/src/Core/Content/DependencyInjection/cms.xml
+++ b/src/Core/Content/DependencyInjection/cms.xml
@@ -83,5 +83,9 @@
             <argument type="service" id="Shopware\Core\Content\Media\MediaUrlPlaceholderHandlerInterface"/>
             <tag name="kernel.event_subscriber"/>
         </service>
+
+        <service id="Shopware\Core\Content\Cms\Subscriber\CmsVersionMergeSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
     </services>
 </container>

--- a/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
@@ -5,24 +5,24 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Event;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @phpstan-type WriteOperation array<string, array<int, mixed>>
+ * @phpstan-type Writes array{
+ *     insert: WriteOperation,
+ *     update: WriteOperation,
+ *     delete: WriteOperation
+ * }
+ */
 #[Package('core')]
 class BeforeVersionMergeEvent extends Event
 {
     /**
-     * @var array{
-     *     insert: array<string, array<int, mixed>>,
-     *     update: array<string, array<int, mixed>>,
-     *     delete: array<string, array<int, mixed>>
-     * }
+     * @var Writes
      */
     private array $writes;
 
     /**
-     * @param array{
-     *     insert: array<string, array<int, mixed>>,
-     *     update: array<string, array<int, mixed>>,
-     *     delete: array<string, array<int, mixed>>
-     * } $writes
+     * @param Writes $writes
      */
     public function __construct(array &$writes)
     {
@@ -30,11 +30,7 @@ class BeforeVersionMergeEvent extends Event
     }
 
     /**
-     * @return array{
-     *     insert: array<string, array<int, mixed>>,
-     *     update: array<string, array<int, mixed>>,
-     *     delete: array<string, array<int, mixed>>
-     * }
+     * @return Writes
      */
     public function &getWrites(): array
     {

--- a/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class BeforeVersionMergeEvent extends Event
+{
+    private array $writes;
+
+    public function __construct(array &$writes)
+    {
+        $this->writes = &$writes;
+    }
+
+    public function &getWrites(): array
+    {
+        return $this->writes;
+    }
+}

--- a/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
@@ -9,12 +9,20 @@ use Symfony\Contracts\EventDispatcher\Event;
 class BeforeVersionMergeEvent extends Event
 {
     /**
-     * @var array<string, array<string, mixed>>
+     * @var array{
+     *     insert: array<string, array<int, mixed>>,
+     *     update: array<string, array<int, mixed>>,
+     *     delete: array<string, array<int, mixed>>
+     * }
      */
     private array $writes;
 
     /**
-     * @param array<string, array<string, mixed>> $writes
+     * @param array{
+     *     insert: array<string, array<int, mixed>>,
+     *     update: array<string, array<int, mixed>>,
+     *     delete: array<string, array<int, mixed>>
+     * } $writes
      */
     public function __construct(array &$writes)
     {
@@ -22,7 +30,11 @@ class BeforeVersionMergeEvent extends Event
     }
 
     /**
-     * @return array<string, array<string, mixed>>
+     * @return array{
+     *     insert: array<string, array<int, mixed>>,
+     *     update: array<string, array<int, mixed>>,
+     *     delete: array<string, array<int, mixed>>
+     * }
      */
     public function &getWrites(): array
     {

--- a/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
@@ -6,6 +6,12 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
+ * @internal
+ *
+ * This event is dispatched during the version merge process and solves specific CMS entities problem.
+ * It allows listeners to manipulate the writes array before they are applied.
+ * If a similar issue arises for other entities, this approach should be revisited and generalized at a more abstract level
+ *
  * @phpstan-type WriteOperation array<string, array<int, mixed>>
  * @phpstan-type Writes array{
  *     insert: WriteOperation,
@@ -17,23 +23,20 @@ use Symfony\Contracts\EventDispatcher\Event;
 class BeforeVersionMergeEvent extends Event
 {
     /**
-     * @var Writes
-     */
-    private array $writes;
-
-    /**
      * @param Writes $writes
      */
-    public function __construct(array &$writes)
+    public function __construct(public array $writes)
     {
-        $this->writes = &$writes;
     }
 
     /**
      * @return Writes
      */
-    public function &getWrites(): array
+    public function filterWrites(callable $callback): array
     {
-        return $this->writes;
+        $filtered = array_filter($this->writes, $callback);
+
+        /** @var Writes $filtered */
+        return $filtered;
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
@@ -2,17 +2,28 @@
 
 namespace Shopware\Core\Framework\DataAbstractionLayer\Event;
 
+use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+#[Package('core')]
 class BeforeVersionMergeEvent extends Event
 {
+    /**
+     * @var array<string, array<string, mixed>>
+     */
     private array $writes;
 
+    /**
+     * @param array<string, array<string, mixed>> $writes
+     */
     public function __construct(array &$writes)
     {
         $this->writes = &$writes;
     }
 
+    /**
+     * @return array<string, array<string, mixed>>
+     */
     public function &getWrites(): array
     {
         return $this->writes;

--- a/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
+++ b/src/Core/Framework/DataAbstractionLayer/Event/BeforeVersionMergeEvent.php
@@ -8,9 +8,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 /**
  * @internal
  *
- * This event is dispatched during the version merge process and solves specific CMS entities problem.
- * It allows listeners to manipulate the writes array before they are applied.
- * If a similar issue arises for other entities, this approach should be revisited and generalized at a more abstract level
+ * This event is dispatched during the version merge process and allows listeners to manipulate the writes array before they are applied.
  *
  * @phpstan-type WriteOperation array<string, array<int, mixed>>
  * @phpstan-type Writes array{

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -788,15 +788,15 @@ class VersionManager
     {
         $operations = [];
 
-        foreach (array_filter($writes['insert']) as $entity => $payload) {
+        foreach (array_filter($writes['insert'] ?? []) as $entity => $payload) {
             $operations[] = new SyncOperation('insert-' . $entity, $entity, 'upsert', $payload);
         }
 
-        foreach (array_filter($writes['update']) as $entity => $payload) {
+        foreach (array_filter($writes['update'] ?? []) as $entity => $payload) {
             $operations[] = new SyncOperation('update-' . $entity, $entity, 'upsert', $payload);
         }
 
-        foreach (array_filter($writes['delete']) as $entity => $payload) {
+        foreach (array_filter($writes['delete'] ?? []) as $entity => $payload) {
             $operations[] = new SyncOperation('delete-' . $entity, $entity, 'delete', $payload);
         }
 

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -772,7 +772,48 @@ class VersionManager
             $writes['delete']['version_commit'][] = ['id' => $commit->getId()];
         }
 
+        $this->cleanupSlotsReferencingDeletedBlocks($writes);
+
         return $writes;
+    }
+
+    /**
+     * @param array{insert:array<string, array<int, mixed>>, update:array<string, array<int, mixed>>, delete:array<string, array<int, mixed>>} $writes
+     */
+    private function cleanupSlotsReferencingDeletedBlocks(array &$writes): void
+    {
+        if (empty($writes['delete']['cms_block'])) {
+            return;
+        }
+
+        // Map deleted blocks
+        $deletedBlocks = [];
+        foreach ($writes['delete']['cms_block'] as $deletedBlock) {
+            $blockId = $deletedBlock['id'] ?? null;
+            $blockVersionId = $deletedBlock['versionId'] ?? Defaults::LIVE_VERSION;
+            if ($blockId) {
+                if (!isset($deletedBlocks[$blockId])) {
+                    $deletedBlocks[$blockId] = [];
+                }
+                $deletedBlocks[$blockId][$blockVersionId] = true;
+            }
+        }
+
+        foreach (['insert', 'update'] as $operation) {
+            if (!empty($writes[$operation]['cms_slot'])) {
+                $writes[$operation]['cms_slot'] = array_filter($writes[$operation]['cms_slot'], function ($slot) use ($deletedBlocks) {
+                    $blockId = $slot['blockId'] ?? null;
+                    $blockVersionId = $slot['cmsBlockVersionId'] ?? Defaults::LIVE_VERSION;
+
+                    if (!$blockId) {
+                        return true;
+                    }
+
+                    // If blockId and versionId are deleted, remove slot
+                    return empty($deletedBlocks[$blockId][$blockVersionId]);
+                });
+            }
+        }
     }
 
     /**
@@ -782,13 +823,26 @@ class VersionManager
     {
         $operations = [];
         foreach ($writes['insert'] as $entity => $payload) {
+            if (empty($payload)) {
+                continue;
+            }
             $operations[] = new SyncOperation('insert-' . $entity, $entity, 'upsert', $payload);
         }
         foreach ($writes['update'] as $entity => $payload) {
+            if (empty($payload)) {
+                continue;
+            }
             $operations[] = new SyncOperation('update-' . $entity, $entity, 'upsert', $payload);
         }
         foreach ($writes['delete'] as $entity => $payload) {
+            if (empty($payload)) {
+                continue;
+            }
             $operations[] = new SyncOperation('delete-' . $entity, $entity, 'delete', $payload);
+        }
+
+        if (empty($operations)) {
+            return new WriteResult([], [], []);
         }
 
         return $this->entityWriter->sync($operations, $liveContext);

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -6,6 +6,7 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
 use Shopware\Core\Framework\Api\Sync\SyncOperation;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\BeforeVersionMergeEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\AssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\ChildrenAssociationField;
@@ -179,6 +180,8 @@ class VersionManager
 
         // group all payloads by their action (insert, update, delete) and by their entity name
         $writes = $this->buildWrites($commits);
+
+        $this->eventDispatcher->dispatch(new BeforeVersionMergeEvent($writes));
 
         // execute writes and get access to the write result to dispatch events later on
         $result = $this->executeWrites($writes, $liveContext);
@@ -772,48 +775,7 @@ class VersionManager
             $writes['delete']['version_commit'][] = ['id' => $commit->getId()];
         }
 
-        $this->cleanupSlotsReferencingDeletedBlocks($writes);
-
         return $writes;
-    }
-
-    /**
-     * @param array{insert:array<string, array<int, mixed>>, update:array<string, array<int, mixed>>, delete:array<string, array<int, mixed>>} $writes
-     */
-    private function cleanupSlotsReferencingDeletedBlocks(array &$writes): void
-    {
-        if (empty($writes['delete']['cms_block'])) {
-            return;
-        }
-
-        // Map deleted blocks
-        $deletedBlocks = [];
-        foreach ($writes['delete']['cms_block'] as $deletedBlock) {
-            $blockId = $deletedBlock['id'] ?? null;
-            $blockVersionId = $deletedBlock['versionId'] ?? Defaults::LIVE_VERSION;
-            if ($blockId) {
-                if (!isset($deletedBlocks[$blockId])) {
-                    $deletedBlocks[$blockId] = [];
-                }
-                $deletedBlocks[$blockId][$blockVersionId] = true;
-            }
-        }
-
-        foreach (['insert', 'update'] as $operation) {
-            if (!empty($writes[$operation]['cms_slot'])) {
-                $writes[$operation]['cms_slot'] = array_filter($writes[$operation]['cms_slot'], function ($slot) use ($deletedBlocks) {
-                    $blockId = $slot['blockId'] ?? null;
-                    $blockVersionId = $slot['cmsBlockVersionId'] ?? Defaults::LIVE_VERSION;
-
-                    if (!$blockId) {
-                        return true;
-                    }
-
-                    // If blockId and versionId are deleted, remove slot
-                    return empty($deletedBlocks[$blockId][$blockVersionId]);
-                });
-            }
-        }
     }
 
     /**

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -181,7 +181,10 @@ class VersionManager
         // group all payloads by their action (insert, update, delete) and by their entity name
         $writes = $this->buildWrites($commits);
 
-        $this->eventDispatcher->dispatch(new BeforeVersionMergeEvent($writes));
+        $this->eventDispatcher->dispatch($event = new BeforeVersionMergeEvent($writes));
+        $writes = $event->filterWrites(static function ($operation) {
+            return !empty($operation);
+        });
 
         // execute writes and get access to the write result to dispatch events later on
         $result = $this->executeWrites($writes, $liveContext);
@@ -784,22 +787,16 @@ class VersionManager
     private function executeWrites(array $writes, WriteContext $liveContext): WriteResult
     {
         $operations = [];
-        foreach ($writes['insert'] as $entity => $payload) {
-            if (empty($payload)) {
-                continue;
-            }
+
+        foreach (array_filter($writes['insert']) as $entity => $payload) {
             $operations[] = new SyncOperation('insert-' . $entity, $entity, 'upsert', $payload);
         }
-        foreach ($writes['update'] as $entity => $payload) {
-            if (empty($payload)) {
-                continue;
-            }
+
+        foreach (array_filter($writes['update']) as $entity => $payload) {
             $operations[] = new SyncOperation('update-' . $entity, $entity, 'upsert', $payload);
         }
-        foreach ($writes['delete'] as $entity => $payload) {
-            if (empty($payload)) {
-                continue;
-            }
+
+        foreach (array_filter($writes['delete']) as $entity => $payload) {
             $operations[] = new SyncOperation('delete-' . $entity, $entity, 'delete', $payload);
         }
 

--- a/tests/unit/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriberTest.php
+++ b/tests/unit/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriberTest.php
@@ -45,7 +45,7 @@ class CmsVersionMergeSubscriberTest extends TestCase
 
         $subscriber->onBeforeVersionMerge($event);
 
-        static::assertEquals($expectedWrites, $event->getWrites());
+        static::assertEquals($expectedWrites, $event->writes);
     }
 
     public static function versionMergeEventDataProvider(): \Generator

--- a/tests/unit/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriberTest.php
+++ b/tests/unit/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriberTest.php
@@ -25,8 +25,16 @@ class CmsVersionMergeSubscriberTest extends TestCase
     }
 
     /**
-     * @param array<string, array<string, mixed>> $writes
-     * @param array<string, array<string, mixed>> $expectedWrites
+     * @param array{
+     *      insert: array<string, array<int, mixed>>,
+     *      update: array<string, array<int, mixed>>,
+     *      delete: array<string, array<int, mixed>>
+     *  } $writes
+     * @param array{
+     *      insert: array<string, array<int, mixed>>,
+     *      update: array<string, array<int, mixed>>,
+     *      delete: array<string, array<int, mixed>>
+     *  } $expectedWrites
      */
     #[DataProvider('versionMergeEventDataProvider')]
     public function testOnVersionMerge(array $writes, array $expectedWrites): void

--- a/tests/unit/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriberTest.php
+++ b/tests/unit/Core/Content/Cms/Subscriber/CmsVersionMergeSubscriberTest.php
@@ -1,0 +1,102 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Cms\Subscriber\CmsVersionMergeSubscriber;
+use Shopware\Core\Framework\DataAbstractionLayer\Event\BeforeVersionMergeEvent;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[CoversClass(CmsVersionMergeSubscriber::class)]
+class CmsVersionMergeSubscriberTest extends TestCase
+{
+    public function testGetSubscribedEvents(): void
+    {
+        $expectedEvents = [
+            BeforeVersionMergeEvent::class => 'onBeforeVersionMerge',
+        ];
+
+        static::assertEquals($expectedEvents, CmsVersionMergeSubscriber::getSubscribedEvents());
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $writes
+     * @param array<string, array<string, mixed>> $expectedWrites
+     */
+    #[DataProvider('versionMergeEventDataProvider')]
+    public function testOnVersionMerge(array $writes, array $expectedWrites): void
+    {
+        $subscriber = new CmsVersionMergeSubscriber();
+
+        $event = new BeforeVersionMergeEvent($writes);
+
+        $subscriber->onBeforeVersionMerge($event);
+
+        static::assertEquals($expectedWrites, $event->getWrites());
+    }
+
+    public static function versionMergeEventDataProvider(): \Generator
+    {
+        $blockId1 = Uuid::randomHex();
+        $blockId2 = Uuid::randomHex();
+        $slotId1 = Uuid::randomHex();
+        $slotId2 = Uuid::randomHex();
+        $versionId1 = Uuid::randomHex();
+        $versionId2 = Uuid::randomHex();
+
+        yield 'No cms_block deletions, writes remain unchanged' => [
+            'writes' => [
+                'insert' => ['cms_slot' => [['id' => $slotId1, 'blockId' => $blockId1, 'cmsBlockVersionId' => $versionId1]]],
+                'delete' => [],
+            ],
+            'expectedWrites' => [
+                'insert' => ['cms_slot' => [['id' => $slotId1, 'blockId' => $blockId1, 'cmsBlockVersionId' => $versionId1]]],
+                'delete' => [],
+            ],
+        ];
+
+        yield 'Slots referencing deleted blocks are removed' => [
+            'writes' => [
+                'insert' => ['cms_slot' => [
+                    ['id' => $slotId1, 'blockId' => $blockId1, 'cmsBlockVersionId' => $versionId1],
+                    ['id' => $slotId2, 'blockId' => $blockId2, 'cmsBlockVersionId' => $versionId2],
+                ]],
+                'delete' => ['cms_block' => [
+                    ['id' => $blockId1, 'versionId' => $versionId1],
+                ]],
+            ],
+            'expectedWrites' => [
+                'insert' => ['cms_slot' => [
+                    ['id' => $slotId2, 'blockId' => $blockId2, 'cmsBlockVersionId' => $versionId2],
+                ]],
+                'delete' => ['cms_block' => [
+                    ['id' => $blockId1, 'versionId' => $versionId1],
+                ]],
+            ],
+        ];
+
+        yield 'Slots remain if block deletion does not match version' => [
+            'writes' => [
+                'insert' => ['cms_slot' => [
+                    ['id' => $slotId1, 'blockId' => $blockId1, 'cmsBlockVersionId' => $versionId1],
+                ]],
+                'delete' => ['cms_block' => [
+                    ['id' => $blockId1, 'versionId' => $versionId2],
+                ]],
+            ],
+            'expectedWrites' => [
+                'insert' => ['cms_slot' => [
+                    ['id' => $slotId1, 'blockId' => $blockId1, 'cmsBlockVersionId' => $versionId1],
+                ]],
+                'delete' => ['cms_block' => [
+                    ['id' => $blockId1, 'versionId' => $versionId2],
+                ]],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
When merging versioned data we end up with a set of inserts , updates and delete operations that describe how to transform the draft into live.However , multiple commits might introduce conflict changes like cms_block insert/update in one commit , then delete in another and cms_slot may reference cms_block that no longer exists. If these conflicts aren't resolved befor sync operation , we get foreign key constrain issue.

### 2. What does this change do, exactly?
Collect all actions , this gives a list of inserts/updates/deletes
Cleanup invalid references (get deleted cms blocks and remove any cms slot action that refere to those deleted blocks)


Jira issue: https://shopware.atlassian.net/browse/NEXT-40023