### PR TITLE
Enable Vite build for major testing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,6 +26,14 @@ jobs:
       BLUE_GREEN_DEPLOYMENT: 1
       COMPOSER_ROOT_VERSION: 6.6.9999999-dev
     services:
+      database:
+        image: mysql:8.0
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: shopware
+        ports:
+          - "3306:3306"
+        options: --health-cmd="mysqladmin ping"
       redis: # Redis is required since cache rework
         image: ${{ matrix.major == 'major' && 'redis:alpine' || '' }}
         ports:
@@ -40,10 +48,12 @@ jobs:
           echo "FEATURE_ALL=major" >> $GITHUB_ENV
           echo "DISABLE_VUE_COMPAT=0" >> $GITHUB_ENV
           echo "REDIS_URL=redis://localhost:6379" >> $GITHUB_ENV
+          echo "ADMIN_VITE=1" >> $GITHUB_ENV
 
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
+          mysql-version: 'skip'
           shopware-version: ${{ github.ref }}
           shopware-repository: ${{ github.repository }}
           install: ${{ matrix.name != 'Install' }} # When testing the installation routine of Shopware, don't execute the installation automatically


### PR DESCRIPTION
Enable Vite build for major testing.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

We'd like to test all relevant major changes, including the `vite` build.

### 2. What does this change do, exactly?

- Enables the new `vite` build process in the test pipeline
- Uses a database container service, instead of the mysqld built into the GHA runner image (easier for local testing)

The latter change is optional, but I think it makes sense to use a service here.

Job trace with this change and [another PR](https://github.com/shopware/setup-shopware/pull/18) to the setup-shopware action: https://github.com/shopware/shopware/actions/runs/12232768450/artifacts/2292967635

And the link to the job: https://github.com/shopware/shopware/actions/runs/12232768450/job/34118487715
