### PR TITLE
NEXT-39778 - allow sending email synchronously

### DIFF
--- a/src/Core/Content/DependencyInjection/mail_template.xml
+++ b/src/Core/Content/DependencyInjection/mail_template.xml
@@ -52,10 +52,11 @@
         </service>
 
         <service id="Shopware\Core\Content\Mail\Service\MailSender" public="true">
-            <argument type="service" id="messenger.default_bus"/>
+            <argument type="service" id="mailer.transports"/>
             <argument type="service" id="shopware.filesystem.private"/>
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument>%shopware.mail.max_body_length%</argument>
+            <argument type="abstract" id="message bus"/>
         </service>
 
         <service id="Shopware\Core\Content\Mail\Service\MailFactory" public="true">

--- a/src/Core/Content/Mail/MailException.php
+++ b/src/Core/Content/Mail/MailException.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Core\Content\Mail;
 
+use Shopware\Core\Content\MailTemplate\Exception\MailTransportFailedException;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
@@ -17,6 +19,8 @@ class MailException extends HttpException
     final public const MAIL_BODY_TOO_LONG = 'MAIL__MAIL_BODY_TOO_LONG';
 
     final public const MAIL_TEMPLATE_NOT_FOUND = 'MAIL_TEMPLATE_NOT_FOUND';
+
+    final public const MAIL_TRANSPORT_FAILED = 'CONTENT__MAIL_TRANSPORT_FAILED';
 
     /**
      * @param string[] $validOptions
@@ -58,6 +62,20 @@ class MailException extends HttpException
             self::MAIL_TEMPLATE_NOT_FOUND,
             'Mail template with id {id} not found',
             ['id' => $mailTemplateId]
+        );
+    }
+
+    public static function mailTransportFailedException(?\Throwable $e = null): self|MailTransportFailedException
+    {
+        if (!Feature::isActive('v6.7.0.0')) {
+            return new MailTransportFailedException([], $e);
+        }
+
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::MAIL_TRANSPORT_FAILED,
+            'Failed sending mail with Error: {{ errorMessage }}',
+            ['errorMessage' => $e ? $e->getMessage() : 'Unknown error']
         );
     }
 }

--- a/src/Core/Content/Mail/MailerConfigurationCompilerPass.php
+++ b/src/Core/Content/Mail/MailerConfigurationCompilerPass.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\Mail;
 
 use Shopware\Core\Content\Mail\Service\MailerTransportLoader;
+use Shopware\Core\Content\Mail\Service\MailSender;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,5 +26,10 @@ class MailerConfigurationCompilerPass implements CompilerPassInterface
             new Reference(MailerTransportLoader::class),
             'fromStrings',
         ]);
+
+        $mailer = $container->getDefinition(MailSender::class);
+        // use the same mailer from symfony/mailer configuration. matching: https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue.html#sending-mails-over-the-message-queue
+        $originalMailer = $container->getDefinition('mailer.mailer');
+        $mailer->replaceArgument(4, $originalMailer->getArgument(1));
     }
 }

--- a/src/Core/Content/MailTemplate/Exception/MailTransportFailedException.php
+++ b/src/Core/Content/MailTemplate/Exception/MailTransportFailedException.php
@@ -2,10 +2,14 @@
 
 namespace Shopware\Core\Content\MailTemplate\Exception;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @deprecated tag:v6.7.0 - Will be removed in v6.7.0.0. Use MailException::mailTransportFailedException instead
+ */
 #[Package('buyers-experience')]
 class MailTransportFailedException extends ShopwareHttpException
 {
@@ -13,6 +17,11 @@ class MailTransportFailedException extends ShopwareHttpException
         array $failedRecipients,
         ?\Throwable $e = null
     ) {
+        Feature::triggerDeprecationOrThrow(
+            'v6.7.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.7.0.0', 'MailException::mailTransportFailedException')
+        );
+
         parent::__construct(
             'Failed sending mail to following recipients: {{ recipients }} with Error: {{ errorMessage }}',
             ['recipients' => $failedRecipients, 'recipientsString' => implode(', ', $failedRecipients), 'errorMessage' => $e ? $e->getMessage() : 'Unknown error'],
@@ -22,11 +31,21 @@ class MailTransportFailedException extends ShopwareHttpException
 
     public function getErrorCode(): string
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.7.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.7.0.0', 'MailException::mailTransportFailedException')
+        );
+
         return 'CONTENT__MAIL_TRANSPORT_FAILED';
     }
 
     public function getStatusCode(): int
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.7.0.0',
+            Feature::deprecatedClassMessage(self::class, 'v6.7.0.0', 'MailException::mailTransportFailedException')
+        );
+
         return Response::HTTP_BAD_REQUEST;
     }
 }


### PR DESCRIPTION
Reintroduce the previous behavior of being able to either send via the message bus, or sync. 