### PR TITLE
fix: can't create customer with different addresses

### DIFF
--- a/changelog/_unreleased/2024-12-04-fix-can-t-create-customer-with-different-addresses.md
+++ b/changelog/_unreleased/2024-12-04-fix-can-t-create-customer-with-different-addresses.md
@@ -1,0 +1,6 @@
+---
+title: Fix can't create customer with different addresses
+issue: NEXT-39853
+---
+# Administration
+* Changed the computed `isSameBilling` property from the `sw-order-new-customer-modal` component to skip call twice.

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-new-customer-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-new-customer-modal/index.js
@@ -95,6 +95,10 @@ export default {
             },
 
             set(newValue) {
+                if (newValue === this.isSameBilling) {
+                    return;
+                }
+
                 if (newValue === true) {
                     this.customer.defaultShippingAddressId = this.customer.defaultBillingAddressId;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-new-customer-modal/sw-order-new-customer-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-new-customer-modal/sw-order-new-customer-modal.spec.js
@@ -265,11 +265,28 @@ describe('src/module/sw-order/component/sw-order-new-customer-modal', () => {
             },
         });
 
+        wrapper.vm.isSameBilling = true;
         wrapper.vm.isSameBilling = false;
 
         expect(wrapper.vm.customer.defaultShippingAddressId).toBe('new-shipping-address-id');
         expect(wrapper.vm.customer.addresses.has('new-shipping-address-id')).toBe(true);
         expect(wrapper.vm.defaultSalutationId).toBe('salutationId');
         expect(wrapper.vm.customer.addresses.get('new-shipping-address-id').salutationId).toBe('salutationId');
+    });
+
+    it('should does not change defaultShippingAddressId if newValue is the same as isSameBilling', async () => {
+        await wrapper.setData({
+            customer: {
+                ...wrapper.vm.customer,
+                defaultBillingAddressId: 'billing-address-id',
+                defaultShippingAddressId: 'billing-address-id',
+                isNew: jest.fn(() => false),
+            },
+        });
+
+        const originalShippingAddressId = wrapper.vm.customer.defaultShippingAddressId;
+        wrapper.vm.isSameBilling = true;
+
+        expect(wrapper.vm.customer.defaultShippingAddressId).toBe(originalShippingAddressId);
     });
 });


### PR DESCRIPTION
### Description

Cannot create new customer with different billing and shipping address

Jira issue: https://shopware.atlassian.net/browse/NEXT-39853

##### Actual behaviour:

An error occurs when trying to create a new customer with a different billing and shipping address from the order overview

##### Expected behaviour:

Create a new customer with different billing and shipping address

How to reproduce:

1. Go to Orders
2. Create new order
3. From modal Create new customer
4. Complete customer information with different billing and shipping address


https://github.com/user-attachments/assets/14572868-37d9-4547-a458-6ad71a1d0fcd

