### PR TITLE
Enable jest disabled compat

### DIFF
--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - src/Administration/Resources/app/administration/**/*
+      - .github/workflows/admin.yml
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -43,6 +43,11 @@ jobs:
   admin:
     runs-on: ubuntu-24.04
     name: "Jest Admin"
+    strategy:
+      matrix:
+        test-type:
+          - unit
+          - unit:disabled-compat
     env:
       APP_ENV: prod
       DATABASE_URL: mysql://root:root@database:3306/root
@@ -58,9 +63,8 @@ jobs:
           install-admin: true
           shopware-version: ${{ github.ref }}
           shopware-repository: ${{ github.repository }}
-      # idea: Only run tests that have changed or the tests for files that have changed
-      - name: Run Jest Admin
-        run: npm --prefix src/Administration/Resources/app/administration run unit -- --silent
+      - name: Run Jest Admin ${{ matrix.test-type }}
+        run: npm --prefix src/Administration/Resources/app/administration run ${{ matrix.test-type }} -- --silent
 
   license-check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -10,6 +10,7 @@ on:
       - src/Elasticsearch/**/*
       - src/Storefront/DependencyInjection/*
       - src/**/snippet/**/*.json
+      - .github/workflows/php.yml
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - src/Storefront/Resources/app/storefront/**/*
+      - .github/workflows/storefront.yml
   workflow_dispatch:
   workflow_call:
 


### PR DESCRIPTION
Transitioning from gitlab the Jest step with disabled compat mode was left out. This still needs to run until the next major version is released.