### PR TITLE
NEXT-39787 - clear cache before start cookie acceptance test

### DIFF
--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@currents/playwright": "^1.5.11",
         "@playwright/test": "1.49.1",
-        "@shopware-ag/acceptance-test-suite": "10.2.0",
+        "@shopware-ag/acceptance-test-suite": "^10.2.2",
         "@shopware/api-client": "^0.0.0-canary-20230823113412",
         "lighthouse": "^12.2.2",
         "playwright-lighthouse": "4.0.0"
@@ -662,10 +662,9 @@
       }
     },
     "node_modules/@shopware-ag/acceptance-test-suite": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-10.2.0.tgz",
-      "integrity": "sha512-GFCW6edsmBeaMZCgUBOi+yHaLmm0N7MvuYpVIBcWp1EoNunYG6scHenNOi1DN9ZBFArLBSEpw1pU33Mbu8urfA==",
-      "license": "MIT",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-10.2.2.tgz",
+      "integrity": "sha512-sTuwXC6/XiIzGI0TiwwJhUQZmi7sYazrz+CFwpXc3r0+Q+mB0+q4RIATg9xVUEZb+3LguGKPuGnuNO9Q+/rhog==",
       "dependencies": {
         "@axe-core/playwright": "4.9.1",
         "@playwright/test": "^1.49.1",

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@currents/playwright": "^1.5.11",
     "@playwright/test": "1.49.1",
-    "@shopware-ag/acceptance-test-suite": "10.2.0",
+    "@shopware-ag/acceptance-test-suite": "^10.2.2",
     "@shopware/api-client": "^0.0.0-canary-20230823113412",
     "lighthouse": "^12.2.2",
     "playwright-lighthouse": "4.0.0"

--- a/tests/acceptance/tests/Settings/BasicConsentBannerAvailability.spec.ts
+++ b/tests/acceptance/tests/Settings/BasicConsentBannerAvailability.spec.ts
@@ -3,7 +3,10 @@ import { test } from '@fixtures/AcceptanceTest';
 test('As a shop customer, I want use a basic cookie consent banner in the storefront.', { tag: '@Settings' }, async ({
     ShopCustomer,
     StorefrontHome,
+    TestDataService,
 }) => {
+
+    await TestDataService.clearCaches();
 
     await test.step('Navigate to homepage and verify initial cookie banner visibility and content', async () => {
         await ShopCustomer.goesTo(StorefrontHome.url());


### PR DESCRIPTION
Currently, the cache was not reset before the test started.