### PR TITLE
chore: update PR title workflow to Conventional Commit style

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,13 @@ Please create a second pull request at https://github.com/shopware/docs
 
 
 ### 4. Please link to the relevant issues (if any).
+<!-- Examples:
+- closes #123  - closes the issue #123 when the PR is merged
+- relates #123 - relates to the issue #123
 
+In case of issue existing only on Jira, link to the Jira issue.
+- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
+-->
 
 ### 5. Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,6 @@ Please create a second pull request at https://github.com/shopware/docs
 
 ### 5. Checklist
 
-- [ ] I have rebased my changes to remove merge conflicts
 - [ ] I have written tests and verified that they fail without my change
 - [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
 - [ ] I have written or adjusted the documentation according to my changes

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,21 @@
+name: Check PR title
+# This workflow checks the PR title for semantic meaning
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Introducing workflow change after the switch to GitHub

### 2. What does this change do, exactly?
Enforces Conventional Commit PR title, in order to keep PR history intact and also have a clean history after the merge to the head branch.

### 3. Describe each step to reproduce the issue or behaviour.
- 

### 4. Please link to the relevant issues (if any).
https://github.com/shopware/docs/pull/1620 - updated contribution guides

### 5. Checklist

- [ ] ~~I have rebased my changes to remove merge conflicts~~ - this removed
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
