### PR TITLE
fix(admin): cannot expand flowbuilder items after scrolling down

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
@@ -152,14 +152,15 @@ $sw-tree-item-color-text: $color-darkgray-200;
     }
 
     .sw-tree-item__toggle {
-        width: 15px;
-        height: 24px;
+        display: flex;
+        align-items: center;
+        width: 100%;
+        height: 100%;
         line-height: $line-height-sm;
         text-align: center;
         position: relative;
         cursor: pointer;
         user-select: none;
-        justify-self: center;
 
         .sw-loader {
             background: none;

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-trigger/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-trigger/index.js
@@ -588,10 +588,10 @@ export default {
             }
 
             // set first item or selected event as focus
-            this.$nextTick(() => {
+            this.$nextTick().then(() => {
                 if (this.searchTerm === this.formatEventName) {
                     const currentEvent = this.eventTree.find((event) => event.id === this.eventName);
-                    this.selectedTreeItem = currentEvent || this.$refs.flowTriggerTree.treeItems[0];
+                    this.selectedTreeItem = currentEvent || this.eventTree[0];
                 }
             });
         },


### PR DESCRIPTION
Improve click area for arrow button in flow trigger component to avoid misclicks, fix nextTick method in JavaScript, and resolve issue where the first item was only selectable on the second component opening.

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
Jira issue: https://shopware.atlassian.net/browse/NEXT-40009

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
