### PR TITLE
fix(ci): use a unique run ID when publishing currents reports fo…

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -96,7 +96,12 @@ jobs:
       - name: Run your tests with reporting
         if: ${{ contains(github.workflow_ref, 'nightly') }}
         working-directory: tests/acceptance
-        run: npx pwc --project-id ${{ secrets.CURRENTS_PROJECT_ID }} --key ${{ secrets.CURRENTS_RECORD_KEY }} -- --project ${{ matrix.name }} --trace=on
+        run: |-
+          npx pwc \
+            --ci-build-id "${{ format('{0}-{1}-{2}', github.repository, github.run_id, github.run_attempt) }}${{ matrix.major }}" \
+            --project-id ${{ secrets.CURRENTS_PROJECT_ID }} \
+            --key ${{ secrets.CURRENTS_RECORD_KEY }} \
+            -- --project ${{ matrix.name }} --trace=on
 
       - name: Run your tests
         if: ${{ !contains(github.workflow_ref, 'nightly') }}


### PR DESCRIPTION
…r major testing

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

We currently overwrite the regular currents report with the major report or vice-versa, depending on which job finishes first.

### 2. What does this change do, exactly?

It uses a `major` suffix for the [Build ID](https://docs.currents.dev/guides/ci-build-id#what-is-ci-build-id), when publishing reports during the major integration test. This allows us to separate distinct jobs (major flag, no major flag) of the same workflow run and playwright suite.

### TODO

- [x] Revert bcc4cff4965cd816e6bd2920dbb359e1db240805 prior to merging
