### PR TITLE
fix: payment status cannot be exported

### DIFF
--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/FieldSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/FieldSerializer.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Content\ImportExport\DataAbstractionLayer\Serializer\Field;
 
 use Shopware\Core\Checkout\Order\Aggregate\OrderDelivery\OrderDeliveryDefinition;
+use Shopware\Core\Checkout\Order\Aggregate\OrderTransaction\OrderTransactionDefinition;
 use Shopware\Core\Content\ImportExport\ImportExportException;
 use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Defaults;
@@ -58,7 +59,7 @@ class FieldSerializer extends AbstractFieldSerializer
         }
 
         if ($field instanceof AssociationField) {
-            if ($value === null || !\in_array($field->getReferenceClass(), [OrderDeliveryDefinition::class], true)) {
+            if ($value === null || !\in_array($field->getReferenceClass(), [OrderDeliveryDefinition::class, OrderTransactionDefinition::class], true)) {
                 return;
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
Payment status in import/export can't be exported.

### 2. What does this change do, exactly?
Adds the OrderTransactionDefinition Class to the FieldSerializer.php

### 3. Describe each step to reproduce the issue or behaviour.
Create an export with `transactions.stateMachineState.translations.DEFAULT.name` 
This Value is then empty 

### 4. Please link to the relevant issues (if any).
Jira issue: https://shopware.atlassian.net/browse/NEXT-39679

### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
