### PR TITLE
fix: Changed `ScheduledTaskEntity` to enable automatic recovery for tasks stuck in state `running`.

### DIFF
--- a/changelog/_unreleased/2024-12-18-improve-scheduled-task-recovery.md
+++ b/changelog/_unreleased/2024-12-18-improve-scheduled-task-recovery.md
@@ -1,0 +1,9 @@
+---
+title: improve-scheduled-task-recovery
+issue: NEXT-00000
+author: Julian Drauz
+author_email: julian.drauz@pickware.de
+author_github: @DrauzJu
+---
+# Core
+* Changed `ScheduledTaskEntity` to enable automatic recovery for tasks stuck in state `running`.

--- a/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskEntity.php
+++ b/src/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskEntity.php
@@ -102,10 +102,13 @@ class ScheduledTaskEntity extends Entity
 
     public function isExecutionAllowed(): bool
     {
-        // If the status is failed, skipped or queued, the execution is still allowed, so retries are possible
+        // If the status is failed, skipped or queued, the execution is still allowed, so retries are possible.
+        // To ensure idempotency, even allow execution if the task is currently running.
+        // The messenger transport must ensure no concurrent execution happens.
         return $this->status === ScheduledTaskDefinition::STATUS_QUEUED
             || $this->status === ScheduledTaskDefinition::STATUS_FAILED
-            || $this->status === ScheduledTaskDefinition::STATUS_SKIPPED;
+            || $this->status === ScheduledTaskDefinition::STATUS_SKIPPED
+            || $this->status === ScheduledTaskDefinition::STATUS_RUNNING;
     }
 
     public function setStatus(string $status): void

--- a/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
+++ b/tests/integration/Core/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandlerTest.php
@@ -90,6 +90,7 @@ class ScheduledTaskHandlerTest extends TestCase
     public static function allowedStatus(): array
     {
         return [
+            [ScheduledTaskDefinition::STATUS_RUNNING],
             [ScheduledTaskDefinition::STATUS_QUEUED],
             [ScheduledTaskDefinition::STATUS_FAILED],
         ];
@@ -265,7 +266,6 @@ class ScheduledTaskHandlerTest extends TestCase
     public static function notAllowedStatus(): array
     {
         return [
-            [ScheduledTaskDefinition::STATUS_RUNNING],
             [ScheduledTaskDefinition::STATUS_SCHEDULED],
             [ScheduledTaskDefinition::STATUS_INACTIVE],
         ];


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently, a scheduled task may be stuck in the `running` state forever.

### 2. What does this change do, exactly?

This change modifies the behavior of the ScheduledTaskHandler to allow handling messags of scheduled tasks which are in state `running`. At first sight, this introduces the risk that a message is handled twice in parallel, but it must be ensured by the messenger transport that this does not happen.

### 3. Describe each step to reproduce the issue or behaviour.

In the following scenario, a scheduled task would be stuck in the `running` state forever:

1. A queue message, which belongs to a scheduled task, is picked up by a worker. Its handler is called, which inherits from the ScheduledTaskHandler, which updates the state of the scheduled task to `running`.
2. A fatal error occurs while handling the message (e.g. a PHP segmentation fault), which leads to an instant crash of the PHP process.
3. When the queue message will be retried, the ScheduledTaskHandler early returns due to the scheduled task still being in state `running`. The message will be acked and therefore removed from the message queue.
4. The scheduled task will never be scheduled again by the TaskScheduler.

### 4. Please link to the relevant issues (if any).

None

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
