### PR TITLE
fix: dont emit deprecations for production environments, fixes #5668

### DIFF
--- a/src/Core/Framework/Feature.php
+++ b/src/Core/Framework/Feature.php
@@ -17,6 +17,11 @@ class Feature
     final public const ALL_MAJOR = 'major';
 
     /**
+     * @internal
+     */
+    public static bool $emitDeprecations = true;
+
+    /**
      * @var array<bool>
      */
     private static array $silent = [];
@@ -230,7 +235,7 @@ class Feature
 
     public static function triggerDeprecationOrThrow(string $majorFlag, string $message): void
     {
-        if (!empty(self::$silent[$majorFlag])) {
+        if (!self::$emitDeprecations || !empty(self::$silent[$majorFlag])) {
             return;
         }
 

--- a/src/Core/Framework/Framework.php
+++ b/src/Core/Framework/Framework.php
@@ -158,5 +158,6 @@ class Framework extends Bundle
 
         CacheValueCompressor::$compress = $this->container->getParameter('shopware.cache.cache_compression');
         CacheValueCompressor::$compressMethod = $this->container->getParameter('shopware.cache.cache_compression_method');
+        Feature::$emitDeprecations = $this->container->getParameter('kernel.debug');
     }
 }

--- a/tests/unit/Core/Framework/FrameworkTest.php
+++ b/tests/unit/Core/Framework/FrameworkTest.php
@@ -37,6 +37,7 @@ class FrameworkTest extends TestCase
         $container->setParameter('kernel.cache_dir', '/tmp');
         $container->setParameter('shopware.cache.cache_compression', true);
         $container->setParameter('shopware.cache.cache_compression_method', 'gzip');
+        $container->setParameter('kernel.debug', true);
         $framework = new Framework();
         $framework->setContainer($container);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

Memory Limit is full due too many deprecations are fired in production.


### 2. What does this change do, exactly?

When APP_ENV=prod, don't emit any deprecations


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
