### PR TITLE
fix: Migrate important file_exists usages

### DIFF
--- a/changelog/_unreleased/2025-05-18-change-file_exists-to-is_dir.md
+++ b/changelog/_unreleased/2025-05-18-change-file_exists-to-is_dir.md
@@ -1,0 +1,11 @@
+---
+title: Change file_exists to is_dir
+issue: NEXT-40109
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+
+# Core
+
+* Changed `file_exists` to `is_dir` in `TwigLoaderConfigCompilerPass` and `ComposerPluginLoader` to slightly improve performance when checking for the existence of a directory.

--- a/changelog/_unreleased/2025-05-18-change-file_exists-to-is_dir.md
+++ b/changelog/_unreleased/2025-05-18-change-file_exists-to-is_dir.md
@@ -1,6 +1,6 @@
 ---
 title: Change file_exists to is_dir
-issue: NEXT-40109
+issue: https://github.com/shopware/shopware/issues/5913
 author: tinect
 author_email: s.koenig@tinect.de
 author_github: tinect

--- a/src/Core/Framework/DependencyInjection/CompilerPass/TwigLoaderConfigCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/TwigLoaderConfigCompilerPass.php
@@ -26,19 +26,20 @@ class TwigLoaderConfigCompilerPass implements CompilerPassInterface
         }
 
         foreach ($bundlesMetadata as $name => $bundle) {
-            $viewDirectory = $bundle['path'] . '/Resources/views';
             $resourcesDirectory = $bundle['path'] . '/Resources';
+            $viewDirectory = $resourcesDirectory . '/views';
+            $distDirectory = $resourcesDirectory . '/app/storefront/dist';
 
-            if (file_exists($viewDirectory)) {
+            if (\is_dir($viewDirectory)) {
                 $fileSystemLoader->addMethodCall('addPath', [$viewDirectory]);
                 $fileSystemLoader->addMethodCall('addPath', [$viewDirectory, $name]);
             }
 
-            if (file_exists($viewDirectory . '/../app/storefront/dist')) {
-                $fileSystemLoader->addMethodCall('addPath', [$viewDirectory . '/../app/storefront/dist', $name]);
+            if (\is_dir($distDirectory)) {
+                $fileSystemLoader->addMethodCall('addPath', [$distDirectory, $name]);
             }
 
-            if (file_exists($resourcesDirectory)) {
+            if (\is_dir($resourcesDirectory)) {
                 $fileSystemLoader->addMethodCall('addPath', [$resourcesDirectory, $name]);
             }
         }
@@ -68,19 +69,20 @@ class TwigLoaderConfigCompilerPass implements CompilerPassInterface
 
         foreach ($apps as $app) {
             \assert(\is_string($app['path']));
-            $viewDirectory = \sprintf('%s/%s/Resources/views', $projectDir, $app['path']);
             $resourcesDirectory = \sprintf('%s/%s/Resources', $projectDir, $app['path']);
+            $viewDirectory = $resourcesDirectory . '/views';
+            $distDirectory = $resourcesDirectory . '/app/storefront/dist';
 
-            if (file_exists($viewDirectory)) {
+            if (\is_dir($viewDirectory)) {
                 $fileSystemLoader->addMethodCall('addPath', [$viewDirectory]);
                 $fileSystemLoader->addMethodCall('addPath', [$viewDirectory, $app['name']]);
             }
 
-            if (file_exists($viewDirectory . '/../app/storefront/dist')) {
-                $fileSystemLoader->addMethodCall('addPath', [$viewDirectory . '/../app/storefront/dist', $app['name']]);
+            if (\is_dir($distDirectory)) {
+                $fileSystemLoader->addMethodCall('addPath', [$distDirectory, $app['name']]);
             }
 
-            if (file_exists($resourcesDirectory)) {
+            if (\is_dir($resourcesDirectory)) {
                 $fileSystemLoader->addMethodCall('addPath', [$resourcesDirectory, $app['name']]);
             }
         }

--- a/src/Core/Framework/Plugin/KernelPluginLoader/ComposerPluginLoader.php
+++ b/src/Core/Framework/Plugin/KernelPluginLoader/ComposerPluginLoader.php
@@ -33,7 +33,7 @@ class ComposerPluginLoader extends KernelPluginLoader
             $path = InstalledVersions::getInstallPath($composerName);
             $composerJsonPath = $path . '/composer.json';
 
-            if (!\file_exists($composerJsonPath)) {
+            if (!\is_file($composerJsonPath)) {
                 continue;
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?
see #5913

this might be the most important change https://github.com/shopware/shopware/pull/5916/commits/36800b83db3232a202ba84ca397752a04d00ecef


### 2. What does this change do, exactly?
see #5913

### 3. Describe each step to reproduce the issue or behaviour.
see #5913

### 4. Please link to the relevant issues (if any).
fixes #5913

### 5. Checklist

- [x] I have rebased my changes to remove merge conflicts
- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
