### PR TITLE
fix: truncate long custom field descriptions in rulebuilder

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-custom-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-custom-field/index.js
@@ -4,6 +4,7 @@ import './sw-condition-line-item-custom-field.scss';
 const { Component, Mixin } = Shopware;
 const { mapPropertyErrors } = Component.getComponentHelper();
 const { Criteria } = Shopware.Data;
+const { Filter } = Shopware;
 
 /**
  * @package services-settings
@@ -120,6 +121,10 @@ Component.extend('sw-condition-line-item-custom-field', 'sw-condition-base-line-
                 this.conditionValueOperatorError ||
                 this.conditionValueRenderedFieldValueError
             );
+        },
+
+        truncateFilter() {
+            return Filter.getByName('truncate');
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-custom-field/sw-condition-line-item-custom-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-custom-field/sw-condition-line-item-custom-field.html.twig
@@ -31,7 +31,7 @@
                 <template #description>
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_condition_line_item_custom_field_field_description %}
-                    {{ getInlineSnippet(item.customFieldSet.config.label) || item.customFieldSet.name }}
+                    {{ truncateFilter((getInlineSnippet(item.customFieldSet.config.label) || item.customFieldSet.name), 20) }}
                     {% endblock %}
                 </template>
             </sw-select-result>

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-custom-field/sw-condition-line-item-custom-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-line-item-custom-field/sw-condition-line-item-custom-field.spec.js
@@ -241,4 +241,18 @@ describe('components/rule/condition-type/sw-condition-line-item-custom-field', (
 
         expect(wrapper.vm.renderedFieldValue).toBe('test123');
     });
+
+    it('should truncate custom field description', async () => {
+        mockCustomFields.at(0).customFieldSet.config.label = 'Product migration custom fields (attributes)';
+
+        const testWrapper = await createWrapper();
+        await flushPromises();
+
+        await testWrapper.find('.sw-entity-single-select .sw-select__selection').trigger('click');
+        await flushPromises();
+
+        const description = document.body.querySelector('.sw-select-result__result-item-description').textContent;
+        expect(description).toHaveLength(20);
+        expect(description.endsWith('...')).toBe(true);
+    });
 });


### PR DESCRIPTION
Related Jira issue: https://shopware.atlassian.net/browse/NEXT-40101

Issue:
The name of the custom field is no longer displayed in the popup if the name of the custom field set is too long.

Solution:
Limit the name of the custom field set to 20 characters and remove overflow:hidden