### PR TITLE
fix: make cache hash deterministic

### DIFF
--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -341,6 +341,8 @@ class Kernel extends HttpKernel
             $plugins[$plugin['name']] = $plugin['version'];
         }
 
+        asort($plugins);
+
         return Hasher::hash([
             $this->cacheId,
             (string) $this->shopwareVersionRevision,


### PR DESCRIPTION
### 1. Why is this change necessary?

The cache-id can differ when the plugins are returned in another order. 

### 2. What does this change do, exactly?

sort the array before generating the hash


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have rebased my changes to remove merge conflicts
- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
