### PR TITLE
fix: Immediately invalidate critical caches

### DIFF
--- a/changelog/_unreleased/2024-12-19-immedietly-invalidate-critical-caches.md
+++ b/changelog/_unreleased/2024-12-19-immedietly-invalidate-critical-caches.md
@@ -1,0 +1,11 @@
+---
+title: Immediately invalidate critical caches
+issue: NEXT-40112
+---
+# Core
+* Changed `\Shopware\Core\Framework\Adapter\Cache\CacheInvalidationSubscriber` to force the immediate invalidation of the following caches:
+  * `\Shopware\Core\System\StateMachine\Loader\InitialStateIdLoader`
+  * `\Shopware\Core\System\SystemConfig\CachedSystemConfigLoader`
+  * `\Shopware\Core\Checkout\Cart\CachedRuleLoader`
+  * `\Shopware\Core\System\SalesChannel\Context\CachedSalesChannelContextFactory`
+  * `\Shopware\Core\System\SalesChannel\Context\CachedBaseContextFactory`

--- a/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidationSubscriber.php
@@ -93,7 +93,7 @@ class CacheInvalidationSubscriber
             return;
         }
 
-        $this->cacheInvalidator->invalidate([InitialStateIdLoader::CACHE_KEY]);
+        $this->cacheInvalidator->invalidate([InitialStateIdLoader::CACHE_KEY], true);
     }
 
     public function invalidateSitemap(SitemapGeneratedEvent $event): void
@@ -105,16 +105,18 @@ class CacheInvalidationSubscriber
 
     public function invalidateConfig(): void
     {
-        // invalidates the complete cached config
-        $this->cacheInvalidator->invalidate([
-            CachedSystemConfigLoader::CACHE_TAG,
-        ]);
+        // invalidates the complete cached config immediately
+        $this->cacheInvalidator->invalidate([CachedSystemConfigLoader::CACHE_TAG], true);
     }
 
     public function invalidateConfigKey(SystemConfigChangedHook $event): void
     {
         if (Feature::isActive('cache_rework')) {
-            $this->cacheInvalidator->invalidate(['global.system.config', CachedSystemConfigLoader::CACHE_TAG]);
+            // invalidates the complete cached config immediately
+            $this->cacheInvalidator->invalidate([CachedSystemConfigLoader::CACHE_TAG], true);
+
+            // global system config tag is used in all http caches that access system config, that should be invalidated delayed
+            $this->cacheInvalidator->invalidate(['global.system.config']);
 
             return;
         }
@@ -183,8 +185,8 @@ class CacheInvalidationSubscriber
 
     public function invalidateRules(): void
     {
-        // invalidates the rule loader each time a rule changed or a plugin install state changed
-        $this->cacheInvalidator->invalidate([CachedRuleLoader::CACHE_KEY]);
+        // immediately invalidates the rule loader each time a rule changed or a plugin install state changed
+        $this->cacheInvalidator->invalidate([CachedRuleLoader::CACHE_KEY], true);
     }
 
     public function invalidateCmsPageIds(EntityWrittenContainerEvent $event): void
@@ -464,7 +466,8 @@ class CacheInvalidationSubscriber
             return;
         }
 
-        $this->cacheInvalidator->invalidate($keys);
+        // immediately invalidates the context cache
+        $this->cacheInvalidator->invalidate($keys, true);
     }
 
     public function invalidateManufacturerFilters(EntityWrittenContainerEvent $event): void

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidationSubscriberTest.php
@@ -58,7 +58,7 @@ class CacheInvalidationSubscriberTest extends TestCase
                     'context-factory-' . $salesChannelId,
                     'base-context-factory-' . $salesChannelId,
                 ],
-                false
+                true
             );
 
         $subscriber = new CacheInvalidationSubscriber(


### PR DESCRIPTION
We will use delayed cache invalidation by default starting with 6.7, however some critical object caches should be invalidated immediately as stale reads could be critical

Related Jira issue: https://shopware.atlassian.net/browse/NEXT-40112
