### PR TITLE
chore: Remove Pickware copyright notice from ManyToOneAssociationFieldResolverTest

### DIFF
--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolverTest.php
@@ -1,13 +1,4 @@
-<?php
-/*
- * Copyright (c) Pickware GmbH. All rights reserved.
- * This file is part of software that is released under a proprietary license.
- * You must not copy, modify, distribute, make publicly available, or execute
- * its contents or parts thereof without express permission by the copyright
- * holder, unless otherwise permitted by law.
- */
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer\Dbal\FieldResolver;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

As Shopware is open source, including a restrictive copyright notice in one of it's tests should be avoided.


### 2. What does this change do, exactly?

Removes a copyright notice of Pickware Gmbh, erroneously added in https://github.com/shopware/shopware/pull/3065.


### 3. Describe each step to reproduce the issue or behaviour.

N/A


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

N/A

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
