### PR TITLE
feat: Add generated schema folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ Thumbs.db
 /vendor/*
 /composer.lock
 
+# Generated database schema files
+/schema
+
 # Symfony-CLI
 php.ini
 .php-version


### PR DESCRIPTION
### 1. Why is this change necessary?
Once you run the `dal:create:schema` a folder `schema` is generated in the root folder of Shopware. But the problem is, that the generated SQL files should not be commited, and hence one always has them uncommited in the root folder.

### 2. What does this change do, exactly?
Ignore the `/schema` folder in the `.gitignore`.

### 3. Describe each step to reproduce the issue or behaviour.
Generate the schema using `dal:create:schema` and look at `git status`.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
