### PR TITLE
chore(ci): fix permissions for checkout

### DIFF
--- a/.github/workflows/saas-branch.yml
+++ b/.github/workflows/saas-branch.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   id-token: write
+  contents: read
 
 jobs:
   create_deployment_branches:


### PR DESCRIPTION
We need to add `contents: read` because we override the defaults. This is necessary, because the repo where this is executed is private