### PR TITLE
fix: get correct path for user icon module

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/index.js
@@ -339,10 +339,10 @@ export default {
                 name: user.username,
                 tooltip: this.$tc('sw-media.sidebar.usage.tooltipFoundInUser'),
                 link: {
-                    name: 'sw.settings.user.detail',
+                    name: 'sw.users.permissions.user.detail',
                     id: user.id,
                 },
-                icon: this.getIconForModule('sw-settings-user'),
+                icon: this.getIconForModule('sw-users-permissions'),
             };
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/sw-media-quickinfo-usage.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/sw-media-quickinfo-usage.spec.js
@@ -117,7 +117,7 @@ describe('module/sw-media/components/sw-media-quickinfo-usage', () => {
             ]),
         );
 
-        register('sw-settings-user', moduleMock);
+        register('sw-users-permissions', moduleMock);
         const avatarUserMock = { username: 'abc123' };
 
         register('sw-product', moduleMock);


### PR DESCRIPTION
### 1. Why is this change necessary?
Can't get `Used in` info of media item on `User Media` folder 

![Screenshot 2024-12-25 at 16 58 56](https://github.com/user-attachments/assets/ea98e57a-74f7-47bd-9931-8918b92ef0e5)


### 2. What does this change do, exactly?
Change the correct path for the user module 

### 3. Describe each step to reproduce the issue or behaviour.
Click on a media item in the `User Media` folder to see the details.

### 4 Solution

![image](https://github.com/user-attachments/assets/f2b4f049-f94e-4d91-9705-7ce4132590cd)
