### PR TITLE
fix: media folder creation not possible with enter key

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-base-item/sw-media-base-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-base-item/sw-media-base-item.html.twig
@@ -6,7 +6,7 @@
     role="button"
     tabindex="0"
     @click="handleItemClick"
-    @keydown.enter="handleItemClick"
+    @keydown.enter.self="handleItemClick"
 >
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-folder-item/sw-media-folder-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-folder-item/sw-media-folder-item.html.twig
@@ -64,7 +64,7 @@
             name="media-item-name"
             @blur="onBlur($event, item, endInlineEdit)"
             @click.stop
-            @keydown.enter.stop
+            @keydown.enter="onBlur($event, item, endInlineEdit)"
             @keyup.esc="endInlineEdit"
         />
         <div

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-media-item/sw-media-media-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-media-item/sw-media-media-item.html.twig
@@ -29,7 +29,7 @@
             @blur="onBlur($event, item, endInlineEdit)"
             @keyup.esc="endInlineEdit"
             @click.stop
-            @keydown.enter.stop
+            @keydown.enter="endInlineEdit"
         />
         <div
             v-else


### PR DESCRIPTION
### Description

I have tried to create a new folder under Media. I can name the new folder. However, when I want to confirm with the Enter key, the folder disappears and I am still in the “Media” parent folder, but without any content being displayed. I can't upload anything in this “folder” either. 

However, if I click somewhere else instead of pressing Enter, the folder is created correctly and if I then go to this folder, I can also upload files.

Steps to reproduce: 
1. Create New Folder
2. Name the Folder
3. Press Enter

Expected result: Folder is created upon pressing the Enter key
Actual result: Folder is not created and media can't be uploaded

### Solution

https://github.com/user-attachments/assets/875c382d-1d93-4ff4-b024-90f88d1f39f4
