### PR TITLE
fix: Allow to set default search result sorting

### DIFF
--- a/changelog/_unreleased/2024-12-27-set-default-search-result-sorting.md
+++ b/changelog/_unreleased/2024-12-27-set-default-search-result-sorting.md
@@ -1,0 +1,10 @@
+---
+title: Set default search result sorting
+issue: NEXT-39006
+---
+# Core
+* Changed `prepare` method in `Shopware\Core\Content\Product\SalesChannel\Listing\Processor\SortingListingProcessor` to use the default search result sorting for search and suggestion queries.
+* Added `Shopware\Core\Migration\V6_6\Migration1735112885AddDefaultSearchResultSorting` to set the default search result sorting
+___
+# Administration
+* Changed `sw-settings-listing` module to add a new setting for default sorting of search results.

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing/index.js
@@ -28,6 +28,7 @@ export default {
             isLoading: false,
             isSaveSuccessful: false,
             productSortingOptions: [],
+            searchResultSortingOptions: [],
             sortingOptionsGridLimit: 10,
             sortingOptionsGridPage: 1,
             modalVisible: false,
@@ -63,6 +64,14 @@ export default {
             criteria.addSorting(Criteria.sort('priority', 'DESC'));
 
             criteria.addFilter(Criteria.equals('locked', false));
+
+            return criteria;
+        },
+
+        searchResultSortingOptionCriteria() {
+            const criteria = new Criteria(this.sortingOptionsGridPage, this.sortingOptionsGridLimit);
+
+            criteria.addSorting(Criteria.sort('priority', 'DESC'));
 
             return criteria;
         },
@@ -133,6 +142,7 @@ export default {
 
         createdComponent() {
             this.fetchProductSortingOptions();
+            this.fetchSearchResultSortingOptions();
             this.fetchCustomFields();
         },
 
@@ -141,6 +151,16 @@ export default {
 
             this.productSortingOptionRepository.search(this.productSortingsOptionsCriteria).then((response) => {
                 this.productSortingOptions = response;
+
+                this.isProductSortingOptionsCardLoading = false;
+            });
+        },
+
+        fetchSearchResultSortingOptions() {
+            this.isProductSortingOptionsCardLoading = true;
+
+            this.productSortingOptionRepository.search(this.searchResultSortingOptionCriteria).then((response) => {
+                this.searchResultSortingOptions = response;
 
                 this.isProductSortingOptionsCardLoading = false;
             });
@@ -173,12 +193,15 @@ export default {
 
                     const saveProductSortingOptions = this.saveProductSortingOptions();
 
+                    const saveSearchResultSortingOptions = this.saveSearchResultSortingOptions();
+
                     const saveSalesChannelVisibilityConfig =
                         this.$refs.defaultSalesChannelCard.saveSalesChannelVisibilityConfig();
 
                     return Promise.all([
                         saveSalesChannelConfig,
                         saveProductSortingOptions,
+                        saveSearchResultSortingOptions,
                         saveSalesChannelVisibilityConfig,
                     ]);
                 })
@@ -204,6 +227,10 @@ export default {
 
         saveProductSortingOptions() {
             return this.productSortingOptionRepository.saveAll(this.productSortingOptions);
+        },
+
+        saveSearchResultSortingOptions() {
+            return this.productSortingOptionRepository.saveAll(this.searchResultSortingOptions);
         },
 
         onDeleteProductSorting(item) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing/sw-settings-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing/sw-settings-listing.html.twig
@@ -119,6 +119,31 @@
                             </template>
                         </sw-inherit-wrapper>
                         {% endblock %}
+
+                        {% block sw_settings_listing_content_card_view_system_config_default_search_result_sorting_select %}
+                        <sw-inherit-wrapper
+                            v-if="config && index === 0"
+                            v-model:value="config['core.listing.defaultSearchResultSorting']"
+                            :label="$tc('sw-settings-listing.general.labelDefaultSearchResultSorting')"
+                            :has-parent="isNotDefaultSalesChannel"
+                            :inherited-value="inheritance['core.listing.defaultSearchResultSorting']"
+                            required
+                        >
+                            <template #content="{ isInherited, currentValue, updateCurrentValue }">
+                                <sw-single-select
+                                    class="sw-settings-listing-index__default-search-result-sorting-select"
+                                    :placeholder="$tc('sw-settings-listing.general.placeholderDefaultSearchResultSorting')"
+                                    :disabled="isInherited"
+                                    :value="currentValue"
+                                    :options="searchResultSortingOptions"
+                                    :error="hasDefaultSortingError ? salesChannelDefaultSortingError : null"
+                                    label-property="label"
+                                    value-property="id"
+                                    @update:value="updateCurrentValue"
+                                />
+                            </template>
+                        </sw-inherit-wrapper>
+                        {% endblock %}
                     </template>
 
                 </sw-system-config>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/snippet/de-DE.json
@@ -8,7 +8,9 @@
       "messageSaveSuccess": "Konfiguration gespeichert.",
       "messageSaveError": "Die Konfiguration konnte nicht gelöscht werden. \"{message}\"",
       "labelDefaultSorting": "Standard-Sortierung",
+      "labelDefaultSearchResultSorting": "Standard-Sortierung der Suchergebnisse",
       "placeholderDefaultSorting": "Wähle eine Standard-Sortierung ...",
+      "placeholderDefaultSearchResultSorting": "Wählen Sie eine Standardsortierung der Suchergebnisse...",
       "productSortingCriteriaGrid": {
         "header": {
           "name": "Name",

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/snippet/en-GB.json
@@ -8,7 +8,9 @@
       "messageSaveSuccess": "Configuration saved.",
       "messageSaveError": "Configuration could not be saved due to: \"{message}\"",
       "labelDefaultSorting": "Default sorting",
+      "labelDefaultSearchResultSorting": "Default search result sorting",
       "placeholderDefaultSorting": "Select a default sorting...",
+      "placeholderDefaultSearchResultSorting": "Select a default search result sorting...",
       "productSortingCriteriaGrid": {
         "header": {
           "name": "Name",

--- a/src/Core/Content/Product/SalesChannel/Listing/Processor/SortingListingProcessor.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/Processor/SortingListingProcessor.php
@@ -41,7 +41,8 @@ class SortingListingProcessor extends AbstractListingProcessor
     public function prepare(Request $request, Criteria $criteria, SalesChannelContext $context): void
     {
         if (!$request->get('order')) {
-            $request->request->set('order', $this->getSystemDefaultSortingKey($context));
+            $key = $request->query->has('search') ? 'core.listing.defaultSearchResultSorting' : 'core.listing.defaultSorting';
+            $request->request->set('order', $this->getDefaultSortingKey($key, $context));
         }
 
         /** @var ProductSortingCollection $sortings */
@@ -138,16 +139,9 @@ class SortingListingProcessor extends AbstractListingProcessor
         return $sortings;
     }
 
-    private function getSystemDefaultSortingKey(SalesChannelContext $context): ?string
+    private function getDefaultSortingKey(string $key, SalesChannelContext $context): ?string
     {
-        $id = $this->systemConfigService->getString(
-            'core.listing.defaultSorting',
-            $context->getSalesChannelId()
-        );
-
-        if (empty($id)) {
-            return null;
-        }
+        $id = $this->systemConfigService->getString($key, $context->getSalesChannelId());
 
         if (!Uuid::isValid($id)) {
             return $id;

--- a/src/Core/Content/Product/SalesChannel/Search/ResolvedCriteriaProductSearchRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Search/ResolvedCriteriaProductSearchRoute.php
@@ -42,10 +42,6 @@ class ResolvedCriteriaProductSearchRoute extends AbstractProductSearchRoute
     #[Route(path: '/store-api/search', name: 'store-api.search', methods: ['POST'], defaults: ['_entity' => 'product'])]
     public function load(Request $request, SalesChannelContext $context, Criteria $criteria): ProductSearchRouteResponse
     {
-        if (!$request->get('order')) {
-            $request->request->set('order', self::DEFAULT_SEARCH_SORT);
-        }
-
         $criteria->addState(self::STATE);
 
         $criteria = $this->criteriaBuilder->handleRequest(

--- a/src/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRoute.php
@@ -8,7 +8,6 @@ use Shopware\Core\Content\Product\Events\ProductSuggestResultEvent;
 use Shopware\Core\Content\Product\ProductEvents;
 use Shopware\Core\Content\Product\SalesChannel\Listing\Processor\CompositeListingProcessor;
 use Shopware\Core\Content\Product\SalesChannel\ProductAvailableFilter;
-use Shopware\Core\Content\Product\SalesChannel\Search\ResolvedCriteriaProductSearchRoute;
 use Shopware\Core\Content\Product\SearchKeyword\ProductSearchBuilderInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
@@ -43,10 +42,6 @@ class ResolvedCriteriaProductSuggestRoute extends AbstractProductSuggestRoute
     {
         if (!$request->get('search')) {
             throw RoutingException::missingRequestParameter('search');
-        }
-
-        if (!$request->get('order')) {
-            $request->request->set('order', ResolvedCriteriaProductSearchRoute::DEFAULT_SEARCH_SORT);
         }
 
         $criteria->addState(ProductSuggestRoute::STATE);

--- a/src/Core/Migration/V6_6/Migration1735112885AddDefaultSearchResultSorting.php
+++ b/src/Core/Migration/V6_6/Migration1735112885AddDefaultSearchResultSorting.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1735112885AddDefaultSearchResultSorting extends MigrationStep
+{
+    private const CONFIG_KEY = 'core.listing.defaultSearchResultSorting';
+
+    public function getCreationTimestamp(): int
+    {
+        return 1735112885;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $configPresent = $connection->fetchOne('SELECT 1 FROM `system_config` WHERE `configuration_key` = ?', [self::CONFIG_KEY]);
+
+        if ($configPresent !== false) {
+            return;
+        }
+
+        $productSortingId = $connection->fetchOne('SELECT id FROM `product_sorting` WHERE `url_key` = ?', ['score']);
+        $connection->insert('system_config', [
+            'id' => Uuid::randomBytes(),
+            'configuration_key' => self::CONFIG_KEY,
+            'configuration_value' => \sprintf('{"_value": "%s"}', Uuid::fromBytesToHex($productSortingId)),
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+}

--- a/tests/migration/Core/V6_6/Migration1735112885AddDefaultSearchResultSortingTest.php
+++ b/tests/migration/Core/V6_6/Migration1735112885AddDefaultSearchResultSortingTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_6;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_6\Migration1735112885AddDefaultSearchResultSorting;
+use Shopware\Tests\Migration\MigrationTestTrait;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1735112885AddDefaultSearchResultSorting::class)]
+class Migration1735112885AddDefaultSearchResultSortingTest extends TestCase
+{
+    use MigrationTestTrait;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+        $this->connection->delete('system_config', ['configuration_key' => 'core.listing.defaultSearchResultSorting']);
+    }
+
+    public function testMigration(): void
+    {
+        static::assertEmpty($this->getConfig());
+
+        $migration = new Migration1735112885AddDefaultSearchResultSorting();
+        $migration->update($this->connection);
+
+        $record = $this->getConfig();
+
+        static::assertArrayHasKey('configuration_key', $record);
+        static::assertArrayHasKey('configuration_value', $record);
+        static::assertSame('core.listing.defaultSearchResultSorting', $record['configuration_key']);
+
+        $value = \sprintf('{"_value": "%s"}', Uuid::randomHex());
+        $this->connection->update('system_config', ['configuration_value' => $value], ['configuration_key' => 'core.listing.defaultSearchResultSorting']);
+
+        $migration->update($this->connection);
+
+        $record = $this->getConfig();
+
+        static::assertArrayHasKey('configuration_key', $record);
+        static::assertArrayHasKey('configuration_value', $record);
+        static::assertSame('core.listing.defaultSearchResultSorting', $record['configuration_key']);
+        static::assertSame($value, $record['configuration_value']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getConfig(): array
+    {
+        return $this->connection->fetchAssociative(
+            'SELECT * FROM system_config WHERE configuration_key = \'core.listing.defaultSearchResultSorting\''
+        ) ?: [];
+    }
+}


### PR DESCRIPTION
### Description

Expected behaviour:

When a Default Sorting option is selected in the Shopware Backend (e.g., Price Ascending), this sorting should apply consistently to both the Category page and the Search Results page.
The Default Sorting setting in Shopware should affect both pages equally, ensuring the same sorting is displayed on the Search Results and Category pages.

Actual behaviour:

The Default Sorting option is only applied to the Category page.
The selected sorting is not applied to the Search Results page, where a different logic seems to be used (set to "score/Top Results" by default).
Merchants are experiencing issues with this behavior, as they expect the selected default sorting to apply to both the Category and Search Results pages.

From our point of view you'd need to adapt your "Default Search Sort" setting as it is configurable within the SW-Backend but never used because within the code they have it set to score/Top Results.

How to reproduce:

Go to Shopware Settings → Products → Default Sorting.
Change the Default Sorting to any option different from the preselected one (e.g., Price Ascending).
Go to the Storefront and submit a search.
On the Search Results page, compare the displayed sorting with the Default Sorting set in the Shopware settings.
Navigate to any Category page with products.
Compare the sorting of products on the Category page with the Default Sorting set in the Shopware settings.![Image](https://github.com/user-attachments/assets/57503926-9e4f-4587-9792-f9ce5373c130)
![Image](https://github.com/user-attachments/assets/79a1ad8f-9daa-4434-947e-ef49825461ac)

### Solution


https://github.com/user-attachments/assets/5b1f8854-4784-42fa-9d93-2e3276a0ada9






