### PR TITLE
chore(ci): add check job to consolidate required checks

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -460,3 +460,24 @@ jobs:
       - name: Run blue-green check
         if: ${{ !contains(github.workflow_ref, 'nightly') }}
         run: php .gitlab/bin/blue-green-check.php # TODO: Move script to .github after migration
+
+  # this allows us to specifiy just one required job/check
+  # this is not practical with matrix jobs directly, because you've to specify all permutations
+  check:
+    if: always()
+    needs:
+    - acceptance
+    - phpunit
+    - win-checkout
+    - code-ql
+    - acceptance-update
+    - blue-green-66-67
+
+    runs-on: Ubuntu-latest
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        # allowed-failures: docs, linters
+        # allowed-skips: non-voting-flaky-job
+        jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
### 1. Why is this change necessary?

Merges do not required all jobs to have succeeded


### 2. What does this change do, exactly?

We use the `re-actors/alls-green@release/v1` action to check all required jobs have succeeded. Only this job is then added as a required check in the protected branch settings.