### PR TITLE
chore(ci): trigger release preparation workflow in nightly workflow

### DIFF
--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -12,6 +12,7 @@ jobs:
       SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION: "1"
       DATABASE_URL: mysql://root:root@127.0.0.1:3306/root
       COMPOSER_ROOT_VERSION: 6.6.9999999-dev
+      APP_URL: http://localhost:8000
     services:
       database:
         image: mysql:8.0

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -129,15 +129,15 @@ jobs:
           git -C repos/${{ matrix.package }} log -n 2
           git -C repos/${{ matrix.package }} diff @^.. | head -n 100
       - name: Create temporary branch
-        if: github.ref_type != 'tag'
+        if: github.ref_type != 'tag' && !github.ref_protected
         run: |
           bash .github/bin/split.bash branch "${{ matrix.package }}" "tmp-${{ github.sha }}"
       - name: Push
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || github.ref_protected
         run: |
           bash .github/bin/split.bash push "${{ matrix.package }}" https://git:${{ secrets.MANYREPO_SYNC_TOKEN }}@github.com/shopware "${{ github.ref_name }}"
       - name: Push temporary branch
-        if: github.ref_type != 'tag'
+        if: github.ref_type != 'tag' && !github.ref_protected
         run: |
           bash .github/bin/split.bash push "${{ matrix.package }}" https://git:${{ secrets.MANYREPO_SYNC_TOKEN }}@github.com/shopware "tmp-${{ github.sha }}"
 

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -2,6 +2,7 @@ name: Prepare release
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:
@@ -127,7 +128,6 @@ jobs:
           git -C repos/${{ matrix.package }} log -n 2
           git -C repos/${{ matrix.package }} diff @^.. | head -n 100
       - name: Push
-        if: github.ref_type == 'tag'
         run: |
           bash .github/bin/split.bash push "${{ matrix.package }}" https://git:${{ secrets.MANYREPO_SYNC_TOKEN }}@github.com/shopware "${{ github.ref_name }}"
 

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -128,9 +128,18 @@ jobs:
           cat repos/${{ matrix.package }}/composer.json
           git -C repos/${{ matrix.package }} log -n 2
           git -C repos/${{ matrix.package }} diff @^.. | head -n 100
+      - name: Create temporary branch
+        if: github.ref_type != 'tag'
+        run: |
+          bash .github/bin/split.bash branch "${{ matrix.package }}" "tmp-${{ github.sha }}"
       - name: Push
+        if: github.ref_type == 'tag'
         run: |
           bash .github/bin/split.bash push "${{ matrix.package }}" https://git:${{ secrets.MANYREPO_SYNC_TOKEN }}@github.com/shopware "${{ github.ref_name }}"
+      - name: Push temporary branch
+        if: github.ref_type != 'tag'
+        run: |
+          bash .github/bin/split.bash push "${{ matrix.package }}" https://git:${{ secrets.MANYREPO_SYNC_TOKEN }}@github.com/shopware "tmp-${{ github.sha }}"
 
   draft-release-notes:
     needs: split

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -180,4 +180,4 @@ jobs:
       - name: Create sbp release
         run: |
           echo DRY_RUN: "${DRY_RUN}"
-          bash .github/bin/sbp_release.bash create "${{ github.ref_name }}"
+          bash .github/bin/sbp_release.bash create "${{ github.ref_type == 'tag' && github.ref_name || 'v6.6.9999999.9999999-dev' }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,4 +94,7 @@ jobs:
     if: github.repository == 'shopware/shopware'
     with:
       nightly: true
-
+  prepare-release: # This will only execute dry-runs and push current trunk to the many-repos
+    uses: ./.github/workflows/05-prepare-release.yml
+    secrets: inherit
+    if: github.repository == 'shopware/shopware'


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The manyrepos `trunk` branches are currently still updated by Gitlab-CI.

### 2. What does this change do, exactly?

This PR adds this capability to the nightly workflow and also allows us to push temporary dev-branches for testing purposes.

In order to push dev-branches, we currently need to manually specify exceptions to the list of branches allowed to deploy into the `release` environment. @pweyck @mkraeml - shall we allow _all_ branches to create deployments into this environment or rather introduce another environment just for this purpose? Since all deployments need to be approved, I don't strictly see any reason against either option, WDYT?

---

Complete workflow execution: https://github.com/shopware/shopware/actions/runs/12545309026