### PR TITLE
chore(ci): rename deployment environment, discern branch and tag depl…

### DIFF
--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -74,7 +74,7 @@ jobs:
   split:
     needs: build
     runs-on: ubuntu-24.04
-    environment: release
+    environment: ${{ format('manyrepos ({0})', github.ref_type) }}
     # we use this image to get an older git version, which does not suffer from a performance regression
     container: alpine:3.19
     if: github.repository == 'shopware/shopware'


### PR DESCRIPTION
…oyments

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

For the nightly workflow to automatically update the `trunk` references in all many repos, we need to allow branch deployments to these.

### 2. What does this change do, exactly?

It discerns tag and branch deployments by setting the corresponding environment. For branch deployments, no approval is necessary; when deploying tags, it is.

I've already created the [environments](https://github.com/shopware/shopware/settings/environments) accordingly. Once this is merged, we can remove the existing `release` environment.