### PR TITLE
fix: Price field overrides

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-price-field/index.js
@@ -160,21 +160,6 @@ Component.register('sw-price-field', {
         };
     },
 
-    setup() {
-        const onPriceGrossChangeDebounce = debounce(function onPriceGrossChangeDebounce() {
-            this.onPriceGrossChange(this.priceForCurrency.gross);
-        }, 300);
-
-        const onPriceNetChangeDebounce = debounce(function onPriceNetChangeDebounce() {
-            this.onPriceNetChange(this.priceForCurrency.net);
-        }, 300);
-
-        return {
-            onPriceGrossChangeDebounce,
-            onPriceNetChangeDebounce,
-        };
-    },
-
     computed: {
         calculatePriceApiService() {
             return Application.getContainer('factory').apiService.getByName('calculate-price');
@@ -302,8 +287,13 @@ Component.register('sw-price-field', {
 
         onEndsWithDecimalSeparator(value) {
             if (value) {
-                this.onPriceGrossChangeDebounce.cancel();
-                this.onPriceNetChangeDebounce.cancel();
+                // cancel might not be a function if debounce is not active
+                if (this.onPriceGrossChangeDebounce.cancel) {
+                    this.onPriceGrossChangeDebounce.cancel();
+                }
+                if (this.onPriceNetChangeDebounce.cancel) {
+                    this.onPriceNetChangeDebounce.cancel();
+                }
             }
         },
 
@@ -426,5 +416,13 @@ Component.register('sw-price-field', {
         onCloseModal() {
             this.showModal = false;
         },
+
+        onPriceGrossChangeDebounce: debounce(function onPriceGrossChange() {
+            this.onPriceGrossChange(this.priceForCurrency.gross);
+        }, 300),
+
+        onPriceNetChangeDebounce: debounce(function onPriceNetChange() {
+            this.onPriceNetChange(this.priceForCurrency.net);
+        }, 300),
     },
 });


### PR DESCRIPTION
Actual behaviour:

Overriding the `sw-price-field` Vue-component makes the price field not recalculate the corresponding gross/net price correctly.
This is because the `sw-price-field` uses the `setup()` Hook to define two methods (`onPriceGrossChangeDebounce` & `onPriceNetChangeDebounce`).
However, when overriding a component, the setup() Hook of the original component is completely overriden (even if the overriding component does not define a setup() Hook and thus the two methods are undefined when they are try to be called.

Expected behaviour:

Overriding the `sw-price-field` component should not cause the recalculation of the prices to fail.

How to reproduce:

Create a Vue-component that overrides `sw-price-field` (can be empty).

The prices are now not calculated correctly (`TypeError: this.onPriceGrossChangeDebounce is not a function`)