### PR TITLE
chore(ci): only require the recipe repo status check during release preparation

### DIFF
--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -62,6 +62,7 @@ jobs:
       CHECK_REPOSITORY: 'shopware/recipes'
       CHECK_WORKFLOW: 'nightly.yml'
       CHECK_STATUS: 'success'
+      DEBUG: ${{ runner.debug }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,6 +91,7 @@ jobs:
       GIT_AUTHOR_NAME: "shopwareBot"
       GIT_COMMITTER_EMAIL: "shopwarebot@shopware.com"
       GIT_COMMITTER_NAME: "shopwareBot"
+      DEBUG: ${{ runner.debug }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -157,6 +159,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # set dry run if it's not a tag
           DRY_RUN: ${{ github.ref_type != 'tag' && '1' || '' }}
+          DEBUG: ${{ runner.debug }}
         run: |
           echo DRY_RUN: "${DRY_RUN}"
           bash .github/bin/create_github_release.bash draft "${{ github.ref_name }}"
@@ -173,6 +176,7 @@ jobs:
       SBP_TOKEN: ${{ secrets[format('SBP_API_TOKEN_{0}', matrix.sbp-environment)] }}
       # set dry run if it's not a tag
       DRY_RUN: ${{ github.ref_type != 'tag' && '1' || '' }}
+      DEBUG: ${{ runner.debug }}
     continue-on-error: true
     steps:
       - name: Checkout

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -56,7 +56,7 @@ jobs:
 
   check-recipe:
     runs-on: ubuntu-24.04
-    if: github.repository == 'shopware/shopware'
+    if: github.repository == 'shopware/shopware' && github.ref_type == 'tag'
     env:
       GH_TOKEN: ${{ github.token }}
       CHECK_REPOSITORY: 'shopware/recipes'

--- a/.github/workflows/05-publish-release.yml
+++ b/.github/workflows/05-publish-release.yml
@@ -118,7 +118,7 @@ jobs:
             -H "Content-Type: application/json" \
             https://api.github.com/repos/shopwareLabs/testenv-platform/actions/workflows/shopware.yml/dispatches \
             -d '{"ref": "trunk"}'
-  
+
   publish-sbp-release:
     if: github.repository == 'shopware/shopware'
     strategy:
@@ -129,6 +129,7 @@ jobs:
       SBP_TOKEN: ${{ secrets[format('sbp_api_token_{0}', matrix.sbp-environment)] }}
       # set dry run if it's not a tag
       DRY_RUN: ${{ github.ref_type != 'tag' && '1' || '' }}
+      DEBUG: ${{ runner.debug }}
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:

--- a/.github/workflows/saas-branch.yml
+++ b/.github/workflows/saas-branch.yml
@@ -58,6 +58,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.sts-shopware-private.outputs.token }}
           GITLAB_SAAS_TOKEN: ${{ secrets.GITLAB_SAAS_TOKEN }}
+          DEBUG: ${{ runner.debug }}
         shell: bash
         run: ./.github/bin/compile_deployment_info.sh deployment_env_b64 CI_B64_ENVIRONMENT >> "${GITHUB_ENV}"
       - name: Trigger SaaS Pipeline


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The recipe check job fails during our nightly builds, because the schedules of this repository and the recipes repository aren't aligned.

Since this job should serve as a warning sign during release preparation, we don't actually need to execute it regularly.

### 2. What does this change do, exactly?

Instead of trying to align the schedules of the nightlies or similar (introducing more failure points), I'd propose skipping this job _except_ when preparing a release, so when running for a tag.
