### PR TITLE
chore(ci): set shopware-version to 6.7 in major ats

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,7 +48,6 @@ jobs:
           echo "DISABLE_VUE_COMPAT=0" >> $GITHUB_ENV
           echo "REDIS_URL=redis://localhost:6379" >> $GITHUB_ENV
           echo "ADMIN_VITE=1" >> $GITHUB_ENV
-          echo "COMPOSER_ROOT_VERSION=6.7.9999999-dev" >> $GITHUB_ENV
 
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
@@ -60,6 +59,7 @@ jobs:
           install-admin: ${{ matrix.name != 'Install' }}
           install-storefront: ${{ matrix.name != 'Install' }}
           env: prod
+          composer-root-version: ${{ matrix.major == 'major' && '6.7.9999999-dev' || '.auto' }}
 
       - name: Build js
         if: ${{ matrix.name == 'Install' }}
@@ -106,7 +106,7 @@ jobs:
       - name: Run your tests
         if: ${{ !contains(github.workflow_ref, 'nightly') }}
         working-directory: tests/acceptance
-        run: npx playwright test --project=${{ matrix.name }} ${{ matrix.name == 'Install' && '--trace=on' || '' }}
+        run: npx playwright test --project=${{ matrix.name }} ${{ (matrix.name == 'Install' || matrix.major == 'major') && '--trace=on' || '' }}
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Run your tests
         if: ${{ !contains(github.workflow_ref, 'nightly') }}
         working-directory: tests/acceptance
-        run: npx playwright test --project=${{ matrix.name }} ${{ (matrix.name == 'Install' || matrix.major == 'major') && '--trace=on' || '' }}
+        run: npx playwright test --project=${{ matrix.name }} ${{ matrix.name == 'Install' && '--trace=on' || '' }}
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,6 +48,7 @@ jobs:
           echo "DISABLE_VUE_COMPAT=0" >> $GITHUB_ENV
           echo "REDIS_URL=redis://localhost:6379" >> $GITHUB_ENV
           echo "ADMIN_VITE=1" >> $GITHUB_ENV
+          echo "COMPOSER_ROOT_VERSION=6.7.9999999-dev" >> $GITHUB_ENV
 
       - name: Setup Shopware
         uses: shopware/setup-shopware@main

--- a/src/Core/Framework/DependencyInjection/CompilerPass/FrameworkMigrationReplacementCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/FrameworkMigrationReplacementCompilerPass.php
@@ -28,5 +28,8 @@ class FrameworkMigrationReplacementCompilerPass implements CompilerPassInterface
 
         $migrationSourceV6 = $container->getDefinition(MigrationSource::class . '.core.V6_7');
         $migrationSourceV6->addMethodCall('addDirectory', [$bundleRoot . '/Migration/V6_7', 'Shopware\Core\Migration\V6_7']);
+
+        $migrationSourceV6 = $container->getDefinition(MigrationSource::class . '.core.V6_8');
+        $migrationSourceV6->addMethodCall('addDirectory', [$bundleRoot . '/Migration/V6_8', 'Shopware\Core\Migration\V6_8']);
     }
 }

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -120,6 +120,12 @@ frame-ancestors 'none';
             <tag name="shopware.migration_source"/>
         </service>
 
+        <service id="Shopware\Core\Framework\Migration\MigrationSource.core.V6_8"
+                 class="Shopware\Core\Framework\Migration\MigrationSource">
+            <argument type="string">core.V6_8</argument>
+            <tag name="shopware.migration_source"/>
+        </service>
+
         <service id="Shopware\Core\Framework\Migration\MigrationSource.null"
                  class="Shopware\Core\Framework\Migration\MigrationSource">
             <argument type="string">null</argument>

--- a/tests/unit/Core/Framework/DependencyInjection/CompilerPass/FrameworkMigrationReplacementCompilerPassTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/CompilerPass/FrameworkMigrationReplacementCompilerPassTest.php
@@ -23,6 +23,7 @@ class FrameworkMigrationReplacementCompilerPassTest extends TestCase
         $container->register(MigrationSource::class . '.core.V6_5', MigrationSource::class)->setPublic(true);
         $container->register(MigrationSource::class . '.core.V6_6', MigrationSource::class)->setPublic(true);
         $container->register(MigrationSource::class . '.core.V6_7', MigrationSource::class)->setPublic(true);
+        $container->register(MigrationSource::class . '.core.V6_8', MigrationSource::class)->setPublic(true);
 
         $container->addCompilerPass(new FrameworkMigrationReplacementCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 0);
         $container->compile(false);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

We want to be able to add test for features in the ats like this https://github.com/shopware/acceptance-test-suite/pull/249#discussion_r1900639408

### 2. What does this change do, exactly?

Fake the shopware-version via `COMPOSER_ROOT_VERSION` in the major test case.

### 4. Local testing

To have the same behavior locally, you have to set the following env vars and execute migrations/setup a new shop

```
FEATURE_ALL=major
COMPOSER_ROOT_VERSION=6.7.9999999-dev
```
