### PR TITLE
feat: Add robots.txt

### DIFF
--- a/changelog/_unreleased/2025-01-04-add-an-explicit-configurable-robots-txt.md
+++ b/changelog/_unreleased/2025-01-04-add-an-explicit-configurable-robots-txt.md
@@ -1,6 +1,5 @@
 ---
 title: Add an explicit configurable robots.txt
-issue: NEXT-0000
 author: Max
 author_email: max@swk-web.com
 author_github: @aragon999

--- a/changelog/_unreleased/2025-01-04-add-an-explicit-configurable-robots-txt.md
+++ b/changelog/_unreleased/2025-01-04-add-an-explicit-configurable-robots-txt.md
@@ -1,0 +1,9 @@
+---
+title: Add an explicit configurable robots.txt
+issue: NEXT-0000
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Added an explicit configurable `robots.txt` including the sitemaps

--- a/src/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilter.php
+++ b/src/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilter.php
@@ -6,7 +6,7 @@ use Shopware\Core\Framework\Log\Package;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
-#[Package('core')]
+#[Package('framework')]
 class LeadingSpacesFilter extends AbstractExtension
 {
     public function getFilters(): array

--- a/src/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilter.php
+++ b/src/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilter.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Adapter\Twig\Filter;
+
+use Shopware\Core\Framework\Log\Package;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+#[Package('core')]
+class LeadingSpacesFilter extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter(
+                'remove_leading_spaces',
+                fn (string $content): string => $this->removeLeadingSpaces($content),
+                ['is_safe' => ['all']],
+            ),
+        ];
+    }
+
+    public function removeLeadingSpaces(string $content): string
+    {
+        $contentStripped = preg_replace('/^ +/m', '', $content);
+
+        if ($contentStripped !== null) {
+            return trim($contentStripped);
+        }
+
+        return $content;
+    }
+}

--- a/src/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilter.php
+++ b/src/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilter.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
+/**
+ * @internal
+ */
 #[Package('framework')]
 class LeadingSpacesFilter extends AbstractExtension
 {

--- a/src/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilter.php
+++ b/src/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilter.php
@@ -25,7 +25,7 @@ class LeadingSpacesFilter extends AbstractExtension
 
     public function removeLeadingSpaces(string $content): string
     {
-        $contentStripped = preg_replace('/^ +/m', '', $content);
+        $contentStripped = preg_replace('/^[ \t]+/m', '', $content);
 
         if ($contentStripped !== null) {
             return trim($contentStripped);

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -399,6 +399,10 @@ frame-ancestors 'none';
             <tag name="twig.extension"/>
         </service>
 
+        <service id="Shopware\Core\Framework\Adapter\Twig\Filter\LeadingSpacesFilter" >
+            <tag name="twig.extension"/>
+        </service>
+
         <service id="Cocur\Slugify\Bridge\Twig\SlugifyExtension">
             <argument type="service" id="slugify"/>
             <tag name="twig.extension"/>

--- a/src/Core/Framework/Routing/RouteScope.php
+++ b/src/Core/Framework/Routing/RouteScope.php
@@ -8,9 +8,6 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('framework')]
 class RouteScope extends AbstractRouteScope
 {
-    /**
-     * @var array<string>
-     */
     protected array $allowedPaths = ['_wdt', '_profiler', '_error', 'robots.txt'];
 
     public function isAllowed(Request $request): bool

--- a/src/Core/Framework/Routing/RouteScope.php
+++ b/src/Core/Framework/Routing/RouteScope.php
@@ -8,7 +8,10 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('framework')]
 class RouteScope extends AbstractRouteScope
 {
-    protected array $allowedPaths = ['_wdt', '_profiler', '_error'];
+    /**
+     * @var array<string>
+     */
+    protected array $allowedPaths = ['_wdt', '_profiler', '_error', 'robots.txt'];
 
     public function isAllowed(Request $request): bool
     {

--- a/src/Core/Framework/Routing/RouteScope.php
+++ b/src/Core/Framework/Routing/RouteScope.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 #[Package('framework')]
 class RouteScope extends AbstractRouteScope
 {
-    protected array $allowedPaths = ['_wdt', '_profiler', '_error', 'robots.txt'];
+    protected array $allowedPaths = ['_wdt', '_profiler', '_error'];
 
     public function isAllowed(Request $request): bool
     {

--- a/src/Core/Migration/V6_6/Migration1728119898AddRobotsTxt.php
+++ b/src/Core/Migration/V6_6/Migration1728119898AddRobotsTxt.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1728119898AddRobotsTxt extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1728119898;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $query = 'INSERT INTO system_config SET
+                    id = :id,
+                    configuration_value = :configValue,
+                    configuration_key = :configKey,
+                    created_at = :createdAt;';
+
+        $connection->executeStatement($query, [
+            'id' => Uuid::randomBytes(),
+            'configKey' => 'core.basicInformation.robotsRules',
+            'configValue' => json_encode([
+                '_value' => <<<'TXT'
+                    Disallow: /account/
+                    Disallow: /checkout/
+                    Disallow: /widgets/
+                    Allow: /widgets/cms/
+                    Allow: /widgets/menu/offcanvas
+                    TXT,
+            ]),
+            'createdAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1728119898AddRobotsTxt.php
+++ b/src/Core/Migration/V6_7/Migration1728119898AddRobotsTxt.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Shopware\Core\Migration\V6_6;
+namespace Shopware\Core\Migration\V6_7;
 
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Defaults;
@@ -11,7 +11,7 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
-#[Package('core')]
+#[Package('framework')]
 class Migration1728119898AddRobotsTxt extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/src/Core/System/Resources/config/basicInformation.xml
+++ b/src/Core/System/Resources/config/basicInformation.xml
@@ -207,8 +207,8 @@
     </card>
 
     <card>
-        <title> robots.txt Rules</title>
-        <title lang="de-DE">robots.txt Regeln</title>
+        <title>Rules for robots.txt</title>
+        <title lang="de-DE">Regeln für robots.txt </title>
         <input-field type="textarea">
             <name>robotsRules</name>
             <label>Domain specific robots.txt Allow/Disallow rules</label>

--- a/src/Core/System/Resources/config/basicInformation.xml
+++ b/src/Core/System/Resources/config/basicInformation.xml
@@ -207,6 +207,18 @@
     </card>
 
     <card>
+        <title> robots.txt Rules</title>
+        <title lang="de-DE">robots.txt Regeln</title>
+        <input-field type="textarea">
+            <name>robotsRules</name>
+            <label>Domain specific robots.txt Allow/Disallow rules</label>
+            <label lang="de-DE">Domain spezifische robots.txt Allow/Disallow Regeln</label>
+            <helpText>Rules which will be prepended by the corresponding domain path</helpText>
+            <helpText lang="de-DE">Regeln bei denen der entsprechende Domain Pfad vorangestellt wird</helpText>
+        </input-field>
+    </card>
+
+    <card>
         <title>CAPTCHA</title>
         <title lang="de-DE">CAPTCHA</title>
 

--- a/src/Storefront/Controller/RobotsController.php
+++ b/src/Storefront/Controller/RobotsController.php
@@ -12,7 +12,7 @@ use Symfony\Component\Routing\Attribute\Route;
 /**
  * @internal
  */
-#[Route(defaults: ['_routeScope' => ['default']])]
+#[Route(defaults: ['_routeScope' => ['api'], 'auth_required' => false])]
 #[Package('framework')]
 class RobotsController extends StorefrontController
 {
@@ -21,9 +21,8 @@ class RobotsController extends StorefrontController
     }
 
     #[Route(path: '/robots.txt', name: 'frontend.robots.txt', defaults: ['_format' => 'txt', '_httpCache' => true], methods: ['GET'])]
-    public function robotsTxt(Request $request): Response
+    public function robotsTxt(Request $request, Context $context): Response
     {
-        $context = Context::createCLIContext();
         $page = $this->robotsPageLoader->load($request, $context);
 
         $response = $this->render('@Storefront/storefront/page/robots/robots.txt.twig', ['page' => $page]);

--- a/src/Storefront/Controller/RobotsController.php
+++ b/src/Storefront/Controller/RobotsController.php
@@ -13,7 +13,7 @@ use Symfony\Component\Routing\Attribute\Route;
  * @internal
  */
 #[Route(defaults: ['_routeScope' => ['default']])]
-#[Package('storefront')]
+#[Package('framework')]
 class RobotsController extends StorefrontController
 {
     public function __construct(private readonly RobotsPageLoader $robotsPageLoader)

--- a/src/Storefront/Controller/RobotsController.php
+++ b/src/Storefront/Controller/RobotsController.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Controller;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Page\Robots\RobotsPageLoader;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * @internal
+ */
+#[Route(defaults: ['_routeScope' => ['default']])]
+#[Package('storefront')]
+class RobotsController extends StorefrontController
+{
+    public function __construct(private readonly RobotsPageLoader $robotsPageLoader)
+    {
+    }
+
+    #[Route(path: '/robots.txt', name: 'frontend.robots.txt', defaults: ['_format' => 'txt', '_httpCache' => true], methods: ['GET'])]
+    public function robotsTxt(Request $request): Response
+    {
+        $context = Context::createCLIContext();
+        $page = $this->robotsPageLoader->load($request, $context);
+
+        $response = $this->render('@Storefront/storefront/page/robots/robots.txt.twig', ['page' => $page]);
+        $response->headers->set('content-type', 'text/plain; charset=utf-8');
+
+        return $response;
+    }
+}

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -334,5 +334,11 @@
             </call>
         </service>
 
+        <service id="Shopware\Storefront\Controller\RobotsController" public="true">
+            <argument type="service" id="Shopware\Storefront\Page\Robots\RobotsPageLoader"/>
+            <call method="setContainer">
+                <argument type="service" id="service_container"/>
+            </call>
+        </service>
     </services>
 </container>

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -567,5 +567,15 @@
         <service id="Shopware\Storefront\Framework\SystemCheck\Util\SalesChannelDomainProvider">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
         </service>
+
+        <service id="Shopware\Storefront\Page\Robots\RobotsPageLoader">
+            <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="sales_channel_domain.repository"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
+        </service>
+
+        <service id="Shopware\Storefront\Framework\Routing\RobotsRouteScopeWhitelist">
+            <tag name="shopware.route_scope_whitelist"/>
+        </service>
     </services>
 </container>

--- a/src/Storefront/Framework/Routing/RequestTransformer.php
+++ b/src/Storefront/Framework/Routing/RequestTransformer.php
@@ -72,16 +72,14 @@ class RequestTransformer implements RequestTransformerInterface
         SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK,
     ];
 
-    /**
-     * @var array<string>
-     */
-    private array $allowedList = [
+    private const DOES_NOT_REQUIRE_SALESCHANNEL = [
         '/_wdt/',
         '/_profiler/',
         '/_error/',
         '/payment/finalize-transaction',
         '/installer',
         '/_fragment/',
+        '/robots.txt',
     ];
 
     /**
@@ -244,7 +242,7 @@ class RequestTransformer implements RequestTransformerInterface
             }
         }
 
-        foreach ($this->allowedList as $prefix) {
+        foreach (self::DOES_NOT_REQUIRE_SALESCHANNEL as $prefix) {
             if (str_starts_with($pathInfo, $prefix)) {
                 return false;
             }

--- a/src/Storefront/Framework/Routing/RobotsRouteScopeWhitelist.php
+++ b/src/Storefront/Framework/Routing/RobotsRouteScopeWhitelist.php
@@ -6,7 +6,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Routing\RouteScopeWhitelistInterface;
 use Shopware\Storefront\Controller\RobotsController;
 
-#[Package('storefront')]
+#[Package('framework')]
 class RobotsRouteScopeWhitelist implements RouteScopeWhitelistInterface
 {
     public function applies(string $controllerClass): bool

--- a/src/Storefront/Framework/Routing/RobotsRouteScopeWhitelist.php
+++ b/src/Storefront/Framework/Routing/RobotsRouteScopeWhitelist.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\Routing;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Routing\RouteScopeWhitelistInterface;
+use Shopware\Storefront\Controller\RobotsController;
+
+#[Package('storefront')]
+class RobotsRouteScopeWhitelist implements RouteScopeWhitelistInterface
+{
+    public function applies(string $controllerClass): bool
+    {
+        return $controllerClass === RobotsController::class;
+    }
+}

--- a/src/Storefront/Page/Robots/RobotsPage.php
+++ b/src/Storefront/Page/Robots/RobotsPage.php
@@ -12,7 +12,7 @@ class RobotsPage extends Struct
     protected DomainRuleCollection $domainRules;
 
     /**
-     * @var string[]
+     * @var list<string>
      */
     protected array $sitemaps;
 

--- a/src/Storefront/Page/Robots/RobotsPage.php
+++ b/src/Storefront/Page/Robots/RobotsPage.php
@@ -6,7 +6,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Storefront\Page\Robots\Struct\DomainRuleCollection;
 
-#[Package('storefront')]
+#[Package('framework')]
 class RobotsPage extends Struct
 {
     protected DomainRuleCollection $domainRules;
@@ -27,7 +27,7 @@ class RobotsPage extends Struct
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     public function getSitemaps(): array
     {
@@ -35,7 +35,7 @@ class RobotsPage extends Struct
     }
 
     /**
-     * @param string[] $sitemaps
+     * @param list<string> $sitemaps
      */
     public function setSitemaps(array $sitemaps): void
     {

--- a/src/Storefront/Page/Robots/RobotsPage.php
+++ b/src/Storefront/Page/Robots/RobotsPage.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Robots;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+use Shopware\Storefront\Page\Robots\Struct\DomainRuleCollection;
+
+#[Package('storefront')]
+class RobotsPage extends Struct
+{
+    protected DomainRuleCollection $domainRules;
+
+    /**
+     * @var string[]
+     */
+    protected array $sitemaps;
+
+    public function getDomainRules(): DomainRuleCollection
+    {
+        return $this->domainRules;
+    }
+
+    public function setDomainRules(DomainRuleCollection $domainRules): void
+    {
+        $this->domainRules = $domainRules;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSitemaps(): array
+    {
+        return $this->sitemaps;
+    }
+
+    /**
+     * @param string[] $sitemaps
+     */
+    public function setSitemaps(array $sitemaps): void
+    {
+        $this->sitemaps = $sitemaps;
+    }
+}

--- a/src/Storefront/Page/Robots/RobotsPageLoadedEvent.php
+++ b/src/Storefront/Page/Robots/RobotsPageLoadedEvent.php
@@ -4,10 +4,11 @@ namespace Shopware\Storefront\Page\Robots;
 
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Event\NestedEvent;
+use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('storefront')]
+#[Package('framework')]
 class RobotsPageLoadedEvent extends NestedEvent implements ShopwareEvent
 {
     public function __construct(

--- a/src/Storefront/Page/Robots/RobotsPageLoadedEvent.php
+++ b/src/Storefront/Page/Robots/RobotsPageLoadedEvent.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Robots;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\NestedEvent;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\HttpFoundation\Request;
+
+#[Package('storefront')]
+class RobotsPageLoadedEvent extends NestedEvent
+{
+    public function __construct(
+        private readonly RobotsPage $page,
+        private readonly Context $context,
+        private readonly Request $request,
+    ) {
+    }
+
+    public function getPage(): RobotsPage
+    {
+        return $this->page;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+}

--- a/src/Storefront/Page/Robots/RobotsPageLoadedEvent.php
+++ b/src/Storefront/Page/Robots/RobotsPageLoadedEvent.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Request;
 
 #[Package('storefront')]
-class RobotsPageLoadedEvent extends NestedEvent
+class RobotsPageLoadedEvent extends NestedEvent implements ShopwareEvent
 {
     public function __construct(
         private readonly RobotsPage $page,

--- a/src/Storefront/Page/Robots/RobotsPageLoader.php
+++ b/src/Storefront/Page/Robots/RobotsPageLoader.php
@@ -92,7 +92,7 @@ class RobotsPageLoader
     }
 
     /**
-     * @return string[]
+     * @return list<string>
      */
     private function getSitemaps(SalesChannelDomainCollection $domains): array
     {

--- a/src/Storefront/Page/Robots/RobotsPageLoader.php
+++ b/src/Storefront/Page/Robots/RobotsPageLoader.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Robots;
+
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
+use Shopware\Core\System\SystemConfig\SystemConfigService;
+use Shopware\Storefront\Page\Robots\Struct\DomainRuleCollection;
+use Shopware\Storefront\Page\Robots\Struct\DomainRuleStruct;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+#[Package('storefront')]
+class RobotsPageLoader
+{
+    /**
+     * @internal
+     *
+     * @param EntityRepository<SalesChannelDomainCollection> $salesChannelDomainRepository
+     */
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly EntityRepository $salesChannelDomainRepository,
+        private readonly SystemConfigService $systemConfigService
+    ) {
+    }
+
+    public function load(Request $request, Context $context): RobotsPage
+    {
+        $page = new RobotsPage();
+
+        $hostname = $request->server->get('HTTP_HOST');
+
+        if (\is_string($hostname) && $hostname !== '') {
+            $domains = $this->getDomains($hostname, $context);
+
+            $page->setDomainRules($this->getDomainRules($hostname, $domains));
+            $page->setSitemaps($this->getSitemaps($domains));
+        }
+
+        $this->eventDispatcher->dispatch(
+            new RobotsPageLoadedEvent($page, $context, $request)
+        );
+
+        return $page;
+    }
+
+    /**
+     * @param non-empty-string $hostname
+     */
+    private function getDomains(string $hostname, Context $context): SalesChannelDomainCollection
+    {
+        $criteria = new Criteria();
+        $criteria
+            ->addFilter(new ContainsFilter('url', $hostname))
+            ->addFilter(new EqualsFilter('salesChannel.typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT))
+        ;
+
+        return $this->salesChannelDomainRepository->search($criteria, $context)->getEntities();
+    }
+
+    /**
+     * @param non-empty-string $hostname
+     */
+    private function getDomainRules(string $hostname, SalesChannelDomainCollection $domains): DomainRuleCollection
+    {
+        $domainRuleCollection = new DomainRuleCollection();
+
+        $seenDomainHostnames = [];
+        foreach ($domains as $domain) {
+            $domainPath = explode($hostname, $domain->getUrl(), 2);
+            $domainHostname = trim($domainPath[1] ?? '');
+
+            // Skip hostnames which are available with http and https
+            if (isset($seenDomainHostnames[$domainHostname])) {
+                continue;
+            }
+
+            $seenDomainHostnames[$domainHostname] = true;
+            $domainRules = trim($this->systemConfigService->getString('core.basicInformation.robotsRules', $domain->getSalesChannelId()));
+
+            $domainRuleCollection->add(new DomainRuleStruct($domainRules, $domainHostname));
+        }
+
+        return $domainRuleCollection;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getSitemaps(SalesChannelDomainCollection $domains): array
+    {
+        $sitemaps = [];
+
+        foreach ($domains as $domain) {
+            $sitemaps[] = $domain->getUrl() . '/sitemap.xml';
+        }
+
+        return $sitemaps;
+    }
+}

--- a/src/Storefront/Page/Robots/RobotsPageLoader.php
+++ b/src/Storefront/Page/Robots/RobotsPageLoader.php
@@ -16,7 +16,7 @@ use Shopware\Storefront\Page\Robots\Struct\DomainRuleStruct;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('storefront')]
+#[Package('framework')]
 class RobotsPageLoader
 {
     /**

--- a/src/Storefront/Page/Robots/RobotsPageLoader.php
+++ b/src/Storefront/Page/Robots/RobotsPageLoader.php
@@ -42,6 +42,9 @@ class RobotsPageLoader
 
             $page->setDomainRules($this->getDomainRules($hostname, $domains));
             $page->setSitemaps($this->getSitemaps($domains));
+        } else {
+            $page->setDomainRules(new DomainRuleCollection());
+            $page->setSitemaps([]);
         }
 
         $this->eventDispatcher->dispatch(

--- a/src/Storefront/Page/Robots/Struct/DomainRuleCollection.php
+++ b/src/Storefront/Page/Robots/Struct/DomainRuleCollection.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Robots\Struct;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Collection;
+
+/**
+ * @extends Collection<DomainRuleStruct>
+ */
+#[Package('storefront')]
+class DomainRuleCollection extends Collection
+{
+    protected function getExpectedClass(): string
+    {
+        return DomainRuleStruct::class;
+    }
+}

--- a/src/Storefront/Page/Robots/Struct/DomainRuleCollection.php
+++ b/src/Storefront/Page/Robots/Struct/DomainRuleCollection.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Struct\Collection;
 /**
  * @extends Collection<DomainRuleStruct>
  */
-#[Package('storefront')]
+#[Package('framework')]
 class DomainRuleCollection extends Collection
 {
     protected function getExpectedClass(): string

--- a/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
+++ b/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
@@ -5,7 +5,7 @@ namespace Shopware\Storefront\Page\Robots\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 
-#[Package('storefront')]
+#[Package('framework')]
 class DomainRuleStruct extends Struct
 {
     /**

--- a/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
+++ b/src/Storefront/Page/Robots/Struct/DomainRuleStruct.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Page\Robots\Struct;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\Struct;
+
+#[Package('storefront')]
+class DomainRuleStruct extends Struct
+{
+    /**
+     * @var array<array{type: string, path: string}>
+     */
+    private array $rules = [];
+
+    public function __construct(string $rules, private readonly string $basePath)
+    {
+        $this->parseRules($rules);
+    }
+
+    /**
+     * @return array<array{type: string, path: string}>
+     */
+    public function getRules(): array
+    {
+        return $this->rules;
+    }
+
+    public function getBasePath(): string
+    {
+        return $this->basePath;
+    }
+
+    private function parseRules(string $rules): void
+    {
+        $rules = explode("\n", $rules);
+
+        foreach ($rules as $rule) {
+            $rule = explode(':', $rule, 2);
+
+            $ruleType = mb_strtolower($rule[0] ?? '');
+            if (!\in_array($ruleType, ['allow', 'disallow'], true)) {
+                continue;
+            }
+
+            $path = $this->basePath . '/' . ltrim(trim($rule[1] ?? ''), '/');
+            $this->rules[] = ['type' => ucfirst($ruleType), 'path' => '/' . ltrim($path, '/')];
+        }
+    }
+}

--- a/src/Storefront/Resources/views/storefront/page/robots/robots.txt.twig
+++ b/src/Storefront/Resources/views/storefront/page/robots/robots.txt.twig
@@ -1,0 +1,44 @@
+{% block robots_txt %}{% apply remove_leading_spaces %}
+    {% block robots_txt_content %}
+        {% block robots_txt_content_user_agent %}
+            User-agent: *
+        {% endblock %}
+
+        {% if config('core.staging') %}
+            Disallow: /
+        {% else %}
+            {% block robots_txt_content_default_rules %}
+                Allow: /
+
+                {# Disallow requests with GET parameters to be indexed #}
+                Disallow: /*?
+
+                {# Allow all theme files to be indexed, including the GET requests with the cache buster #}
+                Allow: /*theme/
+
+                {# Allow all media files to be indexed, including the GET requests with the cache buster #}
+                Allow: /media/*?ts=
+            {% endblock %}
+
+            {% block robots_txt_content_domain_rules_container %}
+                {% for domainRules in page.domainRules %}
+                    {% block robots_txt_content_domain_rules %}
+                        {% for rule in domainRules.rules %}
+                            {% block robots_txt_content_domain_rules_rule %}
+                                {{ rule.type }}: {{ rule.path }}
+                            {% endblock %}
+                        {% endfor %}
+                    {% endblock %}
+                {% endfor %}
+            {% endblock %}
+
+            {% block robots_txt_content_sitemap_container %}
+                {% for sitemap in page.sitemaps %}
+                    {% block robots_txt_content_sitemap %}
+                        Sitemap: {{ sitemap }}
+                    {% endblock %}
+                {% endfor %}
+            {% endblock %}
+        {% endif %}
+    {% endblock %}
+{% endapply %}{% endblock %}

--- a/tests/integration/Storefront/Controller/RobotsControllerTest.php
+++ b/tests/integration/Storefront/Controller/RobotsControllerTest.php
@@ -3,6 +3,7 @@
 namespace Shopware\Tests\Integration\Storefront\Controller;
 
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
@@ -17,12 +18,16 @@ class RobotsControllerTest extends TestCase
 
     public function testRobotsTxt(): void
     {
+        $appUrl = EnvironmentHelper::getVariable('APP_URL');
+
         $browser = KernelLifecycleManager::createBrowser($this->getKernel());
-        $browser->request('GET', $_SERVER['APP_URL'] . '/robots.txt');
+        $browser->request('GET', $appUrl . '/robots.txt');
 
         $html = $browser->getResponse()->getContent();
 
+        $appUri = parse_url($appUrl)['path'] ?? '';
+
         static::assertIsString($html);
-        static::assertStringContainsString("User-agent: *\n\nAllow: /\n\nDisallow: /*?\n\nAllow: /*theme/\n\nAllow: /media/*?ts=\n\n\nSitemap: {$_SERVER['APP_URL']}/sitemap.xml", $html);
+        static::assertEquals("User-agent: *\n\nAllow: /\n\nDisallow: /*?\n\nAllow: /*theme/\n\nAllow: /media/*?ts=\n\nDisallow: {$appUri}/account/\nDisallow: {$appUri}/checkout/\nDisallow: {$appUri}/widgets/\nAllow: {$appUri}/widgets/cms/\nAllow: {$appUri}/widgets/menu/offcanvas\n\nSitemap: {$appUrl}/sitemap.xml", $html);
     }
 }

--- a/tests/integration/Storefront/Controller/RobotsControllerTest.php
+++ b/tests/integration/Storefront/Controller/RobotsControllerTest.php
@@ -19,6 +19,7 @@ class RobotsControllerTest extends TestCase
     public function testRobotsTxt(): void
     {
         $appUrl = EnvironmentHelper::getVariable('APP_URL');
+        static::assertIsString($appUrl);
 
         $browser = KernelLifecycleManager::createBrowser($this->getKernel());
         $browser->request('GET', $appUrl . '/robots.txt');

--- a/tests/integration/Storefront/Controller/RobotsControllerTest.php
+++ b/tests/integration/Storefront/Controller/RobotsControllerTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Integration\Storefront\Controller;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class RobotsControllerTest extends TestCase
+{
+    use IntegrationTestBehaviour;
+
+    public function testRobotsTxt(): void
+    {
+        $browser = KernelLifecycleManager::createBrowser($this->getKernel());
+        $browser->request('GET', $_SERVER['APP_URL'] . '/robots.txt');
+
+        $html = $browser->getResponse()->getContent();
+
+        static::assertIsString($html);
+        static::assertStringContainsString("User-agent: *\n\nAllow: /\n\nDisallow: /*?\n\nAllow: /*theme/\n\nAllow: /media/*?ts=\n\n\nSitemap: {$_SERVER['APP_URL']}/sitemap.xml", $html);
+    }
+}

--- a/tests/integration/Storefront/Controller/RobotsControllerTest.php
+++ b/tests/integration/Storefront/Controller/RobotsControllerTest.php
@@ -29,6 +29,6 @@ class RobotsControllerTest extends TestCase
         $appUri = parse_url($appUrl)['path'] ?? '';
 
         static::assertIsString($html);
-        static::assertEquals("User-agent: *\n\nAllow: /\n\nDisallow: /*?\n\nAllow: /*theme/\n\nAllow: /media/*?ts=\n\nDisallow: {$appUri}/account/\nDisallow: {$appUri}/checkout/\nDisallow: {$appUri}/widgets/\nAllow: {$appUri}/widgets/cms/\nAllow: {$appUri}/widgets/menu/offcanvas\n\nSitemap: {$appUrl}/sitemap.xml", $html);
+        static::assertSame("User-agent: *\n\nAllow: /\n\nDisallow: /*?\n\nAllow: /*theme/\n\nAllow: /media/*?ts=\n\nDisallow: {$appUri}/account/\nDisallow: {$appUri}/checkout/\nDisallow: {$appUri}/widgets/\nAllow: {$appUri}/widgets/cms/\nAllow: {$appUri}/widgets/menu/offcanvas\n\nSitemap: {$appUrl}/sitemap.xml", $html);
     }
 }

--- a/tests/migration/Core/V6_7/Migration1728119898AddRobotsTxtTest.php
+++ b/tests/migration/Core/V6_7/Migration1728119898AddRobotsTxtTest.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\V6_7\Migration1728119898AddRobotsTxt;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1728119898AddRobotsTxt::class)]
+class Migration1728119898AddRobotsTxtTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testMigration(): void
+    {
+        $connection = self::getContainer()->get(Connection::class);
+
+        $connection->delete('system_config', ['configuration_key' => 'core.basicInformation.robotsRules']);
+
+        $migration = new Migration1728119898AddRobotsTxt();
+        $migration->update($connection);
+        $migration->update($connection);
+
+        $robotsRules = $connection->fetchOne(
+            'SELECT configuration_value FROM system_config WHERE configuration_key = :key',
+            ['key' => 'core.basicInformation.robotsRules']
+        );
+
+        static::assertIsString($robotsRules);
+
+        $robotsRules = json_decode($robotsRules, true);
+        static::assertIsArray($robotsRules);
+        static::assertArrayHasKey('_value', $robotsRules);
+        static::assertEquals(
+            <<<'TXT'
+                Disallow: /account/
+                Disallow: /checkout/
+                Disallow: /widgets/
+                Allow: /widgets/cms/
+                Allow: /widgets/menu/offcanvas
+                TXT,
+            $robotsRules['_value']
+        );
+    }
+}

--- a/tests/migration/Core/V6_7/Migration1728119898AddRobotsTxtTest.php
+++ b/tests/migration/Core/V6_7/Migration1728119898AddRobotsTxtTest.php
@@ -38,7 +38,7 @@ class Migration1728119898AddRobotsTxtTest extends TestCase
         $robotsRules = json_decode($robotsRules, true);
         static::assertIsArray($robotsRules);
         static::assertArrayHasKey('_value', $robotsRules);
-        static::assertEquals(
+        static::assertSame(
             <<<'TXT'
                 Disallow: /account/
                 Disallow: /checkout/

--- a/tests/unit/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilterTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilterTest.php
@@ -19,9 +19,12 @@ class LeadingSpacesFilterTest extends TestCase
     public function testRemoveLeadingSpacesFilter(string $input, string $expected): void
     {
         $filter = new LeadingSpacesFilter();
-        static::assertEquals($expected, $filter->removeLeadingSpaces($input));
+        static::assertSame($expected, $filter->removeLeadingSpaces($input));
     }
 
+    /**
+     * @return array<array{string, string}>
+     */
     public static function removeLeadingSpacesProvider(): array
     {
         return [

--- a/tests/unit/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilterTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Filter/LeadingSpacesFilterTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig\Filter;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\Twig\Filter\LeadingSpacesFilter;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(LeadingSpacesFilter::class)]
+class LeadingSpacesFilterTest extends TestCase
+{
+    #[DataProvider('removeLeadingSpacesProvider')]
+    public function testRemoveLeadingSpacesFilter(string $input, string $expected): void
+    {
+        $filter = new LeadingSpacesFilter();
+        static::assertEquals($expected, $filter->removeLeadingSpaces($input));
+    }
+
+    public static function removeLeadingSpacesProvider(): array
+    {
+        return [
+            'single line with leading spaces' => [
+                ' test',
+                'test',
+            ],
+            'single line with leading and trailing spaces' => [
+                ' test ',
+                'test',
+            ],
+            'multiple leading spaces' => [
+                '     test',
+                'test',
+            ],
+            'multiline with leading spaces' => [
+                "  line1\n   line2\n    line3  ",
+                "line1\nline2\nline3",
+            ],
+            'multiline with mixed spaces and empty lines' => [
+                "  line1\n\n   line2\n     line3",
+                "line1\n\nline2\nline3",
+            ],
+            'multiline with tabs and spaces' => [
+                "\tline1\n  line2\n\t  line3",
+                "line1\nline2\nline3",
+            ],
+            'empty string' => [
+                '',
+                '',
+            ],
+            'only spaces' => [
+                '   ',
+                '',
+            ],
+        ];
+    }
+}

--- a/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
@@ -7,18 +7,15 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
-use Shopware\Storefront\Page\Robots\RobotsPage;
 use Shopware\Storefront\Page\Robots\RobotsPageLoadedEvent;
 use Shopware\Storefront\Page\Robots\RobotsPageLoader;
-use Shopware\Storefront\Page\Robots\Struct\DomainRuleCollection;
 use Shopware\Storefront\Page\Robots\Struct\DomainRuleStruct;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,8 +27,14 @@ use Symfony\Component\HttpFoundation\Request;
 class RobotsPageLoaderTest extends TestCase
 {
     private MockObject&EventDispatcherInterface $eventDispatcher;
+
+    /**
+     * @var StaticEntityRepository<SalesChannelDomainCollection>
+     */
     private StaticEntityRepository $salesChannelDomainRepository;
+
     private StaticSystemConfigService $systemConfigService;
+
     private RobotsPageLoader $robotsPageLoader;
 
     protected function setUp(): void
@@ -52,15 +55,13 @@ class RobotsPageLoaderTest extends TestCase
         $request = new Request();
         $context = Context::createDefaultContext();
 
-        $this->eventDispatcher->expects(static::once())
+        $this->eventDispatcher->expects($this->once())
             ->method('dispatch')
             ->with(static::isInstanceOf(RobotsPageLoadedEvent::class));
 
         $page = $this->robotsPageLoader->load($request, $context);
 
-        static::assertInstanceOf(RobotsPage::class, $page);
         static::assertEmpty($page->getSitemaps());
-        static::assertInstanceOf(DomainRuleCollection::class, $page->getDomainRules());
         static::assertCount(0, $page->getDomainRules());
     }
 
@@ -93,13 +94,12 @@ class RobotsPageLoaderTest extends TestCase
             $salesChannelId
         );
 
-        $this->eventDispatcher->expects(static::once())
+        $this->eventDispatcher->expects($this->once())
             ->method('dispatch')
             ->with(static::isInstanceOf(RobotsPageLoadedEvent::class));
 
         $page = $this->robotsPageLoader->load($request, $context);
 
-        static::assertInstanceOf(RobotsPage::class, $page);
         static::assertCount(1, $page->getSitemaps());
         static::assertEquals(['https://example.com/sitemap.xml'], $page->getSitemaps());
         static::assertCount(1, $page->getDomainRules());
@@ -113,7 +113,7 @@ class RobotsPageLoaderTest extends TestCase
             ['type' => 'Allow', 'path' => '/widgets/cms/'],
             ['type' => 'Allow', 'path' => '/widgets/menu/offcanvas'],
         ], $domainRule->getRules());
-        static::assertEquals('', $domainRule->getBasePath());
+        static::assertSame('', $domainRule->getBasePath());
     }
 
     public function testLoadWithMultipleDomains(): void
@@ -166,7 +166,7 @@ class RobotsPageLoaderTest extends TestCase
 
         $firstDomainRule = $domainRules->get(0);
         static::assertInstanceOf(DomainRuleStruct::class, $firstDomainRule);
-        static::assertEquals('', $firstDomainRule->getBasePath());
+        static::assertSame('', $firstDomainRule->getBasePath());
         static::assertCount(5, $firstDomainRule->getRules());
         static::assertEquals(
             [
@@ -181,7 +181,7 @@ class RobotsPageLoaderTest extends TestCase
 
         $secondDomainRule = $domainRules->get(1);
         static::assertInstanceOf(DomainRuleStruct::class, $secondDomainRule);
-        static::assertEquals('/en', $secondDomainRule->getBasePath());
+        static::assertSame('/en', $secondDomainRule->getBasePath());
         static::assertCount(3, $secondDomainRule->getRules());
 
         static::assertEquals(

--- a/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
@@ -1,0 +1,196 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Page\Robots;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
+use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
+use Shopware\Storefront\Page\Robots\RobotsPage;
+use Shopware\Storefront\Page\Robots\RobotsPageLoadedEvent;
+use Shopware\Storefront\Page\Robots\RobotsPageLoader;
+use Shopware\Storefront\Page\Robots\Struct\DomainRuleCollection;
+use Shopware\Storefront\Page\Robots\Struct\DomainRuleStruct;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @internal
+ */
+#[CoversClass(RobotsPageLoader::class)]
+class RobotsPageLoaderTest extends TestCase
+{
+    private MockObject&EventDispatcherInterface $eventDispatcher;
+    private StaticEntityRepository $salesChannelDomainRepository;
+    private StaticSystemConfigService $systemConfigService;
+    private RobotsPageLoader $robotsPageLoader;
+
+    protected function setUp(): void
+    {
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->salesChannelDomainRepository = new StaticEntityRepository([]);
+        $this->systemConfigService = new StaticSystemConfigService();
+
+        $this->robotsPageLoader = new RobotsPageLoader(
+            $this->eventDispatcher,
+            $this->salesChannelDomainRepository,
+            $this->systemConfigService
+        );
+    }
+
+    public function testLoadWithEmptyHostname(): void
+    {
+        $request = new Request();
+        $context = Context::createDefaultContext();
+
+        $this->eventDispatcher->expects(static::once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(RobotsPageLoadedEvent::class));
+
+        $page = $this->robotsPageLoader->load($request, $context);
+
+        static::assertInstanceOf(RobotsPage::class, $page);
+        static::assertEmpty($page->getSitemaps());
+        static::assertInstanceOf(DomainRuleCollection::class, $page->getDomainRules());
+        static::assertCount(0, $page->getDomainRules());
+    }
+
+    public function testLoadWithValidHostname(): void
+    {
+        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'example.com']);
+        $context = Context::createDefaultContext();
+        $salesChannelId = 'test-sales-channel-id';
+
+        $domain = new SalesChannelDomainEntity();
+        $domain->setId('test-domain-id');
+        $domain->setUrl('https://example.com');
+        $domain->setSalesChannelId($salesChannelId);
+
+        $criteria = new Criteria();
+        $criteria->addFilter(new ContainsFilter('url', 'example.com'));
+        $criteria->addFilter(new EqualsFilter('salesChannel.typeId', Defaults::SALES_CHANNEL_TYPE_STOREFRONT));
+
+        $this->salesChannelDomainRepository->addSearch(new SalesChannelDomainCollection([$domain]));
+
+        $this->robotsPageLoader = new RobotsPageLoader(
+            $this->eventDispatcher,
+            $this->salesChannelDomainRepository,
+            $this->systemConfigService
+        );
+
+        $this->systemConfigService->set(
+            'core.basicInformation.robotsRules',
+            "Disallow: /account/\nDisallow: /checkout/\nDisallow: /widgets/\nAllow: /widgets/cms/\nAllow: /widgets/menu/offcanvas",
+            $salesChannelId
+        );
+
+        $this->eventDispatcher->expects(static::once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(RobotsPageLoadedEvent::class));
+
+        $page = $this->robotsPageLoader->load($request, $context);
+
+        static::assertInstanceOf(RobotsPage::class, $page);
+        static::assertCount(1, $page->getSitemaps());
+        static::assertEquals(['https://example.com/sitemap.xml'], $page->getSitemaps());
+        static::assertCount(1, $page->getDomainRules());
+
+        $domainRule = $page->getDomainRules()->first();
+        static::assertInstanceOf(DomainRuleStruct::class, $domainRule);
+        static::assertEquals([
+            ['type' => 'Disallow', 'path' => '/account/'],
+            ['type' => 'Disallow', 'path' => '/checkout/'],
+            ['type' => 'Disallow', 'path' => '/widgets/'],
+            ['type' => 'Allow', 'path' => '/widgets/cms/'],
+            ['type' => 'Allow', 'path' => '/widgets/menu/offcanvas'],
+        ], $domainRule->getRules());
+        static::assertEquals('', $domainRule->getBasePath());
+    }
+
+    public function testLoadWithMultipleDomains(): void
+    {
+        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'example.com']);
+        $context = Context::createDefaultContext();
+        $salesChannelId1 = 'test-sales-channel-id-1';
+        $salesChannelId2 = 'test-sales-channel-id-2';
+
+        $domain1 = new SalesChannelDomainEntity();
+        $domain1->setId('test-domain-id-1');
+        $domain1->setUrl('https://example.com');
+        $domain1->setSalesChannelId($salesChannelId1);
+
+        $domain2 = new SalesChannelDomainEntity();
+        $domain2->setId('test-domain-id-2');
+        $domain2->setUrl('https://example.com/en');
+        $domain2->setSalesChannelId($salesChannelId2);
+
+        $this->salesChannelDomainRepository->addSearch(new SalesChannelDomainCollection([$domain1, $domain2]));
+
+        $this->robotsPageLoader = new RobotsPageLoader(
+            $this->eventDispatcher,
+            $this->salesChannelDomainRepository,
+            $this->systemConfigService
+        );
+
+        $this->systemConfigService->set(
+            'core.basicInformation.robotsRules',
+            "Disallow: /account/\nDisallow: /checkout/\nDisallow: /widgets/\nAllow: /widgets/cms/\nAllow: /widgets/menu/offcanvas",
+            $salesChannelId1
+        );
+        $this->systemConfigService->set(
+            'core.basicInformation.robotsRules',
+            "Disallow: /private/\nDisallow: /admin/\nAllow: /widgets/cms/",
+            $salesChannelId2
+        );
+
+        $page = $this->robotsPageLoader->load($request, $context);
+
+        static::assertCount(2, $page->getSitemaps());
+        static::assertEquals(
+            ['https://example.com/sitemap.xml', 'https://example.com/en/sitemap.xml'],
+            $page->getSitemaps()
+        );
+        static::assertCount(2, $page->getDomainRules());
+        $domainRules = $page->getDomainRules();
+
+        static::assertCount(2, $domainRules);
+
+        $firstDomainRule = $domainRules->get(0);
+        static::assertInstanceOf(DomainRuleStruct::class, $firstDomainRule);
+        static::assertEquals('', $firstDomainRule->getBasePath());
+        static::assertCount(5, $firstDomainRule->getRules());
+        static::assertEquals(
+            [
+                ['type' => 'Disallow', 'path' => '/account/'],
+                ['type' => 'Disallow', 'path' => '/checkout/'],
+                ['type' => 'Disallow', 'path' => '/widgets/'],
+                ['type' => 'Allow', 'path' => '/widgets/cms/'],
+                ['type' => 'Allow', 'path' => '/widgets/menu/offcanvas'],
+            ],
+            $firstDomainRule->getRules()
+        );
+
+        $secondDomainRule = $domainRules->get(1);
+        static::assertInstanceOf(DomainRuleStruct::class, $secondDomainRule);
+        static::assertEquals('/en', $secondDomainRule->getBasePath());
+        static::assertCount(3, $secondDomainRule->getRules());
+
+        static::assertEquals(
+            [
+                ['type' => 'Disallow', 'path' => '/en/private/'],
+                ['type' => 'Disallow', 'path' => '/en/admin/'],
+                ['type' => 'Allow', 'path' => '/en/widgets/cms/'],
+            ],
+            $secondDomainRule->getRules()
+        );
+    }
+}

--- a/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
@@ -133,6 +133,11 @@ class RobotsPageLoaderTest extends TestCase
         $domain2->setUrl('https://example.com/en');
         $domain2->setSalesChannelId($salesChannelId2);
 
+        $domain3 = new SalesChannelDomainEntity();
+        $domain3->setId('test-domain-id-3');
+        $domain3->setUrl('http://example.com/en');
+        $domain3->setSalesChannelId($salesChannelId2);
+
         $this->salesChannelDomainRepository->addSearch(new SalesChannelDomainCollection([$domain1, $domain2]));
 
         $this->robotsPageLoader = new RobotsPageLoader(

--- a/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
+++ b/tests/unit/Storefront/Page/Robots/RobotsPageLoaderTest.php
@@ -67,7 +67,7 @@ class RobotsPageLoaderTest extends TestCase
 
     public function testLoadWithValidHostname(): void
     {
-        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'example.com']);
+        $request = new Request(server: ['HTTP_HOST' => 'example.com']);
         $context = Context::createDefaultContext();
         $salesChannelId = 'test-sales-channel-id';
 
@@ -118,7 +118,7 @@ class RobotsPageLoaderTest extends TestCase
 
     public function testLoadWithMultipleDomains(): void
     {
-        $request = new Request([], [], [], [], [], ['HTTP_HOST' => 'example.com']);
+        $request = new Request(server: ['HTTP_HOST' => 'example.com']);
         $context = Context::createDefaultContext();
         $salesChannelId1 = 'test-sales-channel-id-1';
         $salesChannelId2 = 'test-sales-channel-id-2';

--- a/tests/unit/Storefront/Page/Robots/Struct/DomainRuleStructTest.php
+++ b/tests/unit/Storefront/Page/Robots/Struct/DomainRuleStructTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Storefront\Page\Robots\Struct;
+
+use Shopware\Storefront\Page\Robots\Struct\DomainRuleStruct;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+#[CoversClass(DomainRuleStruct::class)]
+class DomainRuleStructTest extends TestCase
+{
+    #[DataProvider('getTestCases')]
+    public function testParsesDomainRulesCorrectly(string $ruleString, string $basePath, array $expectedRules): void
+    {
+        $domainRuleStruct = new DomainRuleStruct($ruleString, $basePath);
+
+        static::assertEquals($basePath, $domainRuleStruct->getBasePath());
+        static::assertEquals($expectedRules, $domainRuleStruct->getRules());
+    }
+
+    public static function getTestCases(): array
+    {
+        return [
+            'empty string' => [
+                '',
+                '/en',
+                [],
+            ],
+            'single disallow rule' => [
+                "Disallow: /private/",
+                '',
+                [
+                    ['type' => 'Disallow', 'path' => '/private/'],
+                ],
+            ],
+            'single disallow with slash base path' => [
+                "Disallow: /private/",
+                '/',
+                [
+                    ['type' => 'Disallow', 'path' => '/private/'],
+                ],
+            ],
+            'single disallow rule with base path' => [
+                "Disallow: /private/",
+                '/en',
+                [
+                    ['type' => 'Disallow', 'path' => '/en/private/'],
+                ],
+            ],
+            'single allow rule' => [
+                "Allow: /widgets/cms/",
+                '',
+                [
+                    ['type' => 'Allow', 'path' => '/widgets/cms/'],
+                ],
+            ],
+            'single allow rule with base path' => [
+                "Allow: /widgets/cms/",
+                '/en',
+                [
+                    ['type' => 'Allow', 'path' => '/en/widgets/cms/'],
+                ],
+            ],
+            'multiple disallow rules with base path' => [
+                "Disallow: /private/\nDisallow: /admin/",
+                '/en',
+                [
+                    ['type' => 'Disallow', 'path' => '/en/private/'],
+                    ['type' => 'Disallow', 'path' => '/en/admin/'],
+                ],
+            ],
+            'multiple allow rules with base path' => [
+                "Allow: /widgets/cms/\nAllow: /widgets/menu/",
+                '/en',
+                [
+                    ['type' => 'Allow', 'path' => '/en/widgets/cms/'],
+                    ['type' => 'Allow', 'path' => '/en/widgets/menu/'],
+                ],
+            ],
+            'multiple rules' => [
+                "Disallow: /private/\nDisallow: /admin/\nAllow: /widgets/cms/\nAllow: /widgets/menu/",
+                '/',
+                [
+                    ['type' => 'Disallow', 'path' => '/private/'],
+                    ['type' => 'Disallow', 'path' => '/admin/'],
+                    ['type' => 'Allow', 'path' => '/widgets/cms/'],
+                    ['type' => 'Allow', 'path' => '/widgets/menu/'],
+                ],
+            ],
+            'multiple rules with base path' => [
+                "Disallow: /private/\nDisallow: /admin/\nAllow: /widgets/cms/\nAllow: /widgets/menu/",
+                '/en',
+                [
+                    ['type' => 'Disallow', 'path' => '/en/private/'],
+                    ['type' => 'Disallow', 'path' => '/en/admin/'],
+                    ['type' => 'Allow', 'path' => '/en/widgets/cms/'],
+                    ['type' => 'Allow', 'path' => '/en/widgets/menu/'],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/unit/Storefront/Page/Robots/Struct/DomainRuleStructTest.php
+++ b/tests/unit/Storefront/Page/Robots/Struct/DomainRuleStructTest.php
@@ -2,23 +2,32 @@
 
 namespace Shopware\Tests\Unit\Storefront\Page\Robots\Struct;
 
-use Shopware\Storefront\Page\Robots\Struct\DomainRuleStruct;
-use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Storefront\Page\Robots\Struct\DomainRuleStruct;
 
+/**
+ * @internal
+ */
 #[CoversClass(DomainRuleStruct::class)]
 class DomainRuleStructTest extends TestCase
 {
+    /**
+     * @param list<array{type: string, path: string}> $expectedRules
+     */
     #[DataProvider('getTestCases')]
     public function testParsesDomainRulesCorrectly(string $ruleString, string $basePath, array $expectedRules): void
     {
         $domainRuleStruct = new DomainRuleStruct($ruleString, $basePath);
 
-        static::assertEquals($basePath, $domainRuleStruct->getBasePath());
-        static::assertEquals($expectedRules, $domainRuleStruct->getRules());
+        static::assertSame($basePath, $domainRuleStruct->getBasePath());
+        static::assertSame($expectedRules, $domainRuleStruct->getRules());
     }
 
+    /**
+     * @return array<array{string, string, list<array{type: string, path: string}>}>
+     */
     public static function getTestCases(): array
     {
         return [
@@ -28,35 +37,35 @@ class DomainRuleStructTest extends TestCase
                 [],
             ],
             'single disallow rule' => [
-                "Disallow: /private/",
+                'Disallow: /private/',
                 '',
                 [
                     ['type' => 'Disallow', 'path' => '/private/'],
                 ],
             ],
             'single disallow with slash base path' => [
-                "Disallow: /private/",
+                'Disallow: /private/',
                 '/',
                 [
                     ['type' => 'Disallow', 'path' => '/private/'],
                 ],
             ],
             'single disallow rule with base path' => [
-                "Disallow: /private/",
+                'Disallow: /private/',
                 '/en',
                 [
                     ['type' => 'Disallow', 'path' => '/en/private/'],
                 ],
             ],
             'single allow rule' => [
-                "Allow: /widgets/cms/",
+                'Allow: /widgets/cms/',
                 '',
                 [
                     ['type' => 'Allow', 'path' => '/widgets/cms/'],
                 ],
             ],
             'single allow rule with base path' => [
-                "Allow: /widgets/cms/",
+                'Allow: /widgets/cms/',
                 '/en',
                 [
                     ['type' => 'Allow', 'path' => '/en/widgets/cms/'],


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently there is no `robots.txt` present. That is in particular a problem for the not found sitemaps of subshops, which are on the same domain, but in a virtual "subfolder".

This feature is currently implemented as a frosh plugin: https://github.com/FriendsOfShopware/FroshRobotsTxt but I think this belongs in the Shopware core. Furthermore the following issue is fixed in this implementation: https://github.com/FriendsOfShopware/FroshRobotsTxt/issues/3

### 2. What does this change do, exactly?
Add a `robots.txt`.

When the PR is accepted in that form, I can add tests as well.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
https://feedback.shopware.com/forums/942607-shopware-6-product-feedback-ideas/suggestions/45788116-robots-txt-optimization

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
