### PR TITLE
revert: "chore(ci): set DEBUG variable when debug logging is activated"

### DIFF
--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -62,7 +62,6 @@ jobs:
       CHECK_REPOSITORY: 'shopware/recipes'
       CHECK_WORKFLOW: 'nightly.yml'
       CHECK_STATUS: 'success'
-      DEBUG: ${{ runner.debug }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,7 +90,6 @@ jobs:
       GIT_AUTHOR_NAME: "shopwareBot"
       GIT_COMMITTER_EMAIL: "shopwarebot@shopware.com"
       GIT_COMMITTER_NAME: "shopwareBot"
-      DEBUG: ${{ runner.debug }}
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -159,7 +157,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # set dry run if it's not a tag
           DRY_RUN: ${{ github.ref_type != 'tag' && '1' || '' }}
-          DEBUG: ${{ runner.debug }}
         run: |
           echo DRY_RUN: "${DRY_RUN}"
           bash .github/bin/create_github_release.bash draft "${{ github.ref_name }}"
@@ -176,7 +173,6 @@ jobs:
       SBP_TOKEN: ${{ secrets[format('SBP_API_TOKEN_{0}', matrix.sbp-environment)] }}
       # set dry run if it's not a tag
       DRY_RUN: ${{ github.ref_type != 'tag' && '1' || '' }}
-      DEBUG: ${{ runner.debug }}
     continue-on-error: true
     steps:
       - name: Checkout

--- a/.github/workflows/05-publish-release.yml
+++ b/.github/workflows/05-publish-release.yml
@@ -118,7 +118,7 @@ jobs:
             -H "Content-Type: application/json" \
             https://api.github.com/repos/shopwareLabs/testenv-platform/actions/workflows/shopware.yml/dispatches \
             -d '{"ref": "trunk"}'
-
+  
   publish-sbp-release:
     if: github.repository == 'shopware/shopware'
     strategy:
@@ -129,7 +129,6 @@ jobs:
       SBP_TOKEN: ${{ secrets[format('sbp_api_token_{0}', matrix.sbp-environment)] }}
       # set dry run if it's not a tag
       DRY_RUN: ${{ github.ref_type != 'tag' && '1' || '' }}
-      DEBUG: ${{ runner.debug }}
     runs-on: ubuntu-24.04
     continue-on-error: true
     steps:

--- a/.github/workflows/saas-branch.yml
+++ b/.github/workflows/saas-branch.yml
@@ -58,7 +58,6 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.sts-shopware-private.outputs.token }}
           GITLAB_SAAS_TOKEN: ${{ secrets.GITLAB_SAAS_TOKEN }}
-          DEBUG: ${{ runner.debug }}
         shell: bash
         run: ./.github/bin/compile_deployment_info.sh deployment_env_b64 CI_B64_ENVIRONMENT >> "${GITHUB_ENV}"
       - name: Trigger SaaS Pipeline


### PR DESCRIPTION
Partly reverts shopware/shopware#5992

The `runner` context apparently is not available everywhere I've referenced it.