### PR TITLE
fix: set correctly collate and charset for generated migrations

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -772,4 +772,14 @@ class DataAbstractionLayerException extends HttpException
             ['association' => $association, 'entityDefinition' => $entityDefinition]
         );
     }
+
+    public static function versionFieldNotFound(string $field): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::FIELD_NOT_FOUND,
+            'Field "{{ field }}" is missing a reference version field',
+            ['field' => $field]
+        );
+    }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/SchemaBuilder.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/SchemaBuilder.php
@@ -159,6 +159,8 @@ class SchemaBuilder
     public function buildSchemaOfDefinition(EntityDefinition $definition): Table
     {
         $table = (new Schema())->createTable($definition->getEntityName());
+        $table->addOption('charset', 'utf8mb4');
+        $table->addOption('collate', 'utf8mb4_unicode_ci');
 
         /** @var Field $field */
         foreach ($definition->getFields() as $field) {
@@ -304,6 +306,10 @@ class SchemaBuilder
                 if ($field instanceof ParentAssociationField) {
                     $columns[] = 'version_id';
                 } else {
+                    if ($versionField === null) {
+                        throw DataAbstractionLayerException::versionFieldNotFound($field->getPropertyName());
+                    }
+
                     /** @var ReferenceVersionField $versionField */
                     $columns[] = $versionField->getStorageName();
                 }


### PR DESCRIPTION
### 1. Why is this change necessary?

wanted to generate a migration for my created definition and run into several problems

### 2. What does this change do, exactly?

- Table charset is wrong
- when you forgot a reference version field it crashes with getStorageName on null


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
