### PR TITLE
fix: listen to the correct error after cancellation

### DIFF
--- a/changelog/_unreleased/2025-01-06-fix-removal-of-cancelled-extensions.md
+++ b/changelog/_unreleased/2025-01-06-fix-removal-of-cancelled-extensions.md
@@ -1,0 +1,8 @@
+---
+title: Fix deletion of extensions with cancelled licenses
+issue: NEXT-39821
+author: Albert Scherman
+author_github: @bird87za
+---
+# Core
+* Changed the way deletion of extensions with cancelled licenses is handled. The cancellation flow now looks for the correct error type and proceeds as intended.

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-base/index.js
@@ -323,10 +323,10 @@ export default {
             }
         },
 
-        async closeModalAndRemoveExtension() {
+        async closeModalAndRemoveExtension(removeData) {
             // we close the modal in the called methods before updating the listing
             if (this.extension.storeLicense === null || this.extension.storeLicense.variant !== 'rent') {
-                await this.removeExtension();
+                await this.removeExtension(removeData);
                 this.showRemovalModal = false;
 
                 return;
@@ -387,12 +387,16 @@ export default {
             Utils.debug.warn(this._name, 'No implementation of installAndActivateExtension found');
         },
 
-        async removeExtension() {
+        async removeExtension(removeData) {
             try {
                 this.showRemovalModal = false;
                 this.isLoading = true;
 
-                await this.shopwareExtensionService.removeExtension(this.extension.name, this.extension.type);
+                await this.shopwareExtensionService.removeExtension(
+                    this.extension.name,
+                    this.extension.type,
+                    removeData,
+                );
                 this.extension.active = false;
             } catch (e) {
                 this.showStoreError(e);

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/index.js
@@ -27,6 +27,7 @@ export default {
             showRatingModal: false,
             showExtensionInstallationFailedModal: false,
             installationFailedError: null,
+            removePluginData: false,
         };
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-card-bought/sw-extension-card-bought.spec.js
@@ -375,10 +375,6 @@ describe('src/module/sw-extension/component/sw-extension-card-bought', () => {
     });
 
     it('should not try to cancel the extension subscription on remove attempt when it already has an expiry date', async () => {
-        httpClient.delete.mockImplementation(() => {
-            return Promise.resolve();
-        });
-
         const cancelLicenceSpy = jest.spyOn(extensionStoreActionService, 'cancelLicense');
         const removeExtensionSpy = jest.spyOn(extensionStoreActionService, 'removeExtension');
 
@@ -415,7 +411,6 @@ describe('src/module/sw-extension/component/sw-extension-card-bought', () => {
         expect(wrapper.find('.sw-extension-removal-modal').exists()).toBe(false);
         expect(cancelLicenceSpy).toHaveBeenCalledTimes(0);
         expect(removeExtensionSpy).toHaveBeenCalledTimes(1);
-        expect(httpClient.delete).toHaveBeenCalledTimes(1);
     });
 
     it('should try to cancel the extension subscription on remove attempt when it has no expiry date', async () => {
@@ -460,7 +455,7 @@ describe('src/module/sw-extension/component/sw-extension-card-bought', () => {
         expect(wrapper.find('.sw-extension-removal-modal').exists()).toBe(false);
         expect(cancelLicenceSpy).toHaveBeenCalledTimes(1);
         expect(removeExtensionSpy).toHaveBeenCalledTimes(1);
-        expect(httpClient.delete).toHaveBeenCalledTimes(2);
+        expect(httpClient.delete).toHaveBeenCalledTimes(1);
     });
 
     it('should display error on install and download attempt when app subscription is expired', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/index.js
@@ -30,6 +30,12 @@ export default {
         },
     },
 
+    data() {
+        return {
+            removePluginData: false,
+        };
+    },
+
     computed: {
         title() {
             return this.isLicensed

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/sw-extension-removal-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/sw-extension-removal-modal.html.twig
@@ -18,6 +18,14 @@
         <p class="sw-extension-removal-modal__bold-paragraph">
             {{ alert }}
         </p>
+
+        <p>
+            <sw-switch-field
+                v-model:value="removePluginData"
+                :label="$tc('sw-extension-store.component.sw-extension-uninstall-modal.labelRemovePluginData')"
+                :help-text="$tc('sw-extension-store.component.sw-extension-uninstall-modal.helpTextRemovePluginData')"
+            />
+        </p>
         {% endblock %}
     </template>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/sw-extension-removal-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-removal-modal/sw-extension-removal-modal.spec.js
@@ -10,6 +10,7 @@ async function createWrapper(propsData = {}) {
             },
             stubs: {
                 'sw-button': true,
+                'sw-switch-field': true,
             },
         },
         props: {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-self-maintained-extension-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-self-maintained-extension-card/index.js
@@ -107,12 +107,16 @@ export default {
             }
         },
 
-        async removeExtension() {
+        async removeExtension(removeData) {
             try {
                 this.showRemovalModal = false;
                 this.isLoading = true;
 
-                await this.shopwareExtensionService.removeExtension(this.extension.name, this.extension.type);
+                await this.shopwareExtensionService.removeExtension(
+                    this.extension.name,
+                    this.extension.type,
+                    removeData,
+                );
                 this.extension.active = false;
                 await this.clearCacheAndReloadPage();
             } catch (e) {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/extension-store-action.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/extension-store-action.service.ts
@@ -173,8 +173,13 @@ export default class ExtensionStoreActionService extends ApiService {
         );
     }
 
-    public removeExtension(technicalName: string, type: ExtensionType): Promise<AxiosResponse<void>> {
-        return this.httpClient.delete(`_action/${this.getApiBasePath()}/remove/${type}/${technicalName}`, {
+    public removeExtension(
+        technicalName: string,
+        type: ExtensionType,
+        removeData: boolean,
+    ): Promise<AxiosResponse<void>> {
+        return this.httpClient.post(`_action/${this.getApiBasePath()}/remove/${type}/${technicalName}`,
+            { keepUserData: !removeData },{
             headers: this.storeHeaders(),
             version: 3,
         });

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.spec.js
@@ -124,6 +124,7 @@ describe('src/module/sw-extension/service/shopware-extension.service', () => {
                 [
                     'someExtension',
                     'app',
+                    true,
                 ],
             ],
         ])('delegates %s correctly', async (lifecycleMethod, parameters) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/service/shopware-extension.service.ts
@@ -73,8 +73,8 @@ export default class ShopwareExtensionService {
         await this.updateExtensionData();
     }
 
-    public async removeExtension(extensionName: string, type: ExtensionType): Promise<void> {
-        await this.extensionStoreActionService.removeExtension(extensionName, type);
+    public async removeExtension(extensionName: string, type: ExtensionType, removeData: boolean): Promise<void> {
+        await this.extensionStoreActionService.removeExtension(extensionName, type, removeData);
 
         await this.updateExtensionData();
     }

--- a/src/Core/Framework/Store/Api/ExtensionStoreActionsController.php
+++ b/src/Core/Framework/Store/Api/ExtensionStoreActionsController.php
@@ -119,12 +119,17 @@ class ExtensionStoreActionsController extends AbstractController
         return new Response('', Response::HTTP_NO_CONTENT);
     }
 
-    #[Route(path: '/api/_action/extension/remove/{type}/{technicalName}', name: 'api.extension.remove', methods: ['DELETE'])]
-    public function removeExtension(string $type, string $technicalName, Context $context): Response
+    #[Route(path: '/api/_action/extension/remove/{type}/{technicalName}', name: 'api.extension.remove', methods: ['POST'])]
+    public function removeExtension(string $type, string $technicalName, Request $request, Context $context): Response
     {
         $this->checkExtensionManagementAllowed();
 
-        $this->extensionLifecycleService->remove($type, $technicalName, $context);
+        $this->extensionLifecycleService->remove(
+            $type,
+            $technicalName,
+            $request->request->getBoolean('keepUserData'),
+            $context
+        );
 
         return new Response('', Response::HTTP_NO_CONTENT);
     }

--- a/src/Core/Framework/Store/Services/AbstractExtensionLifecycle.php
+++ b/src/Core/Framework/Store/Services/AbstractExtensionLifecycle.php
@@ -21,7 +21,7 @@ abstract class AbstractExtensionLifecycle
 
     abstract public function deactivate(string $type, string $technicalName, Context $context): void;
 
-    abstract public function remove(string $type, string $technicalName, Context $context): void;
+    abstract public function remove(string $type, string $technicalName, bool $keepUserData, Context $context): void;
 
     abstract protected function getDecorated(): AbstractExtensionLifecycle;
 }

--- a/src/Core/Framework/Store/Services/AbstractStoreAppLifecycleService.php
+++ b/src/Core/Framework/Store/Services/AbstractStoreAppLifecycleService.php
@@ -15,9 +15,9 @@ abstract class AbstractStoreAppLifecycleService
 
     abstract public function uninstallExtension(string $technicalName, Context $context, bool $keepUserData = false): void;
 
-    abstract public function removeExtensionAndCancelSubscription(int $licenseId, string $technicalName, string $id, Context $context): void;
+    abstract public function removeExtensionAndCancelSubscription(int $licenseId, string $technicalName, string $id, bool $keepUserData, Context $context): void;
 
-    abstract public function deleteExtension(string $technicalName): void;
+    abstract public function deleteExtension(string $technicalName, bool $keepUserData, Context $context): void;
 
     abstract public function activateExtension(string $technicalName, Context $context): void;
 

--- a/src/Core/Framework/Store/Services/ExtensionLifecycleService.php
+++ b/src/Core/Framework/Store/Services/ExtensionLifecycleService.php
@@ -83,7 +83,7 @@ class ExtensionLifecycleService extends AbstractExtensionLifecycle
         $this->storeAppLifecycleService->deactivateExtension($technicalName, $context);
     }
 
-    public function remove(string $type, string $technicalName, Context $context): void
+    public function remove(string $type, string $technicalName, bool $keepUserData, Context $context): void
     {
         if ($type === 'plugin') {
             $plugin = $this->pluginService->getPluginByName($technicalName, $context);
@@ -92,7 +92,7 @@ class ExtensionLifecycleService extends AbstractExtensionLifecycle
             return;
         }
 
-        $this->storeAppLifecycleService->deleteExtension($technicalName);
+        $this->storeAppLifecycleService->deleteExtension($technicalName, $keepUserData, $context);
     }
 
     protected function getDecorated(): AbstractExtensionLifecycle

--- a/src/Core/Framework/Store/Services/StoreAppLifecycleService.php
+++ b/src/Core/Framework/Store/Services/StoreAppLifecycleService.php
@@ -61,17 +61,18 @@ class StoreAppLifecycleService extends AbstractStoreAppLifecycleService
         $this->appLifecycle->delete($technicalName, ['id' => $app->getId(), 'roleId' => $app->getAclRoleId()], $context, $keepUserData);
     }
 
-    public function removeExtensionAndCancelSubscription(int $licenseId, string $technicalName, string $id, Context $context): void
+    public function removeExtensionAndCancelSubscription(int $licenseId, string $technicalName, string $id, bool $keepUserData, Context $context): void
     {
         $this->validateExtensionCanBeRemoved($technicalName, $id, $context);
         $app = $this->getAppById($id, $context);
         $this->storeClient->cancelSubscription($licenseId, $context);
         $this->appLifecycle->delete($technicalName, ['id' => $id, 'roleId' => $app->getAclRoleId()], $context);
-        $this->deleteExtension($technicalName);
+        $this->deleteExtension($technicalName, $keepUserData, $context);
     }
 
-    public function deleteExtension(string $technicalName): void
+    public function deleteExtension(string $technicalName, bool $keepUserData, Context $context): void
     {
+        $this->uninstallExtension($technicalName, $context, $keepUserData);
         $this->appLoader->deleteApp($technicalName);
     }
 

--- a/src/Core/Framework/Store/Services/StoreClient.php
+++ b/src/Core/Framework/Store/Services/StoreClient.php
@@ -34,6 +34,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 #[Package('checkout')]
 class StoreClient
 {
+    public const EXTENSION_LICENSE_IS_ALREADY_CANCELLED = 'ShopwarePlatformException-61';
     private const PLUGIN_LICENSE_VIOLATION_EXTENSION_KEY = 'licenseViolation';
 
     public function __construct(
@@ -351,7 +352,7 @@ class StoreClient
                 $error = \json_decode((string) $e->getResponse()->getBody(), true, flags: \JSON_THROW_ON_ERROR);
 
                 // It's okay when its already canceled
-                if (isset($error['type']) && $error['type'] === 'EXTENSION_LICENSE_IS_ALREADY_CANCELLED') {
+                if (isset($error['code']) && $error['code'] === self::EXTENSION_LICENSE_IS_ALREADY_CANCELLED) {
                     return;
                 }
             }

--- a/tests/integration/Core/Framework/Store/Services/ExtensionLifecycleServiceTest.php
+++ b/tests/integration/Core/Framework/Store/Services/ExtensionLifecycleServiceTest.php
@@ -104,7 +104,7 @@ class ExtensionLifecycleServiceTest extends TestCase
         $this->installApp(__DIR__ . '/../_fixtures/TestApp');
 
         $this->lifecycleService->uninstall('app', 'TestApp', false, $this->context);
-        $this->lifecycleService->remove('app', 'TestApp', $this->context);
+        $this->lifecycleService->remove('app', 'TestApp', false, $this->context);
 
         $apps = $this->appRepository->search(new Criteria(), $this->context)->getEntities();
 
@@ -312,7 +312,7 @@ class ExtensionLifecycleServiceTest extends TestCase
 
         rename($oldName, $newName);
 
-        $this->lifecycleService->remove('app', 'TestAppTheme', Context::createDefaultContext());
+        $this->lifecycleService->remove('app', 'TestAppTheme', true, Context::createDefaultContext());
 
         static::assertFileDoesNotExist($newName);
     }

--- a/tests/integration/Core/Framework/Store/Services/StoreClientTest.php
+++ b/tests/integration/Core/Framework/Store/Services/StoreClientTest.php
@@ -208,4 +208,23 @@ class StoreClientTest extends TestCase
 
         static::assertSame([], $returnedUserInfo);
     }
+
+    public function testCancelExtensionAlreadyCancelled(): void
+    {
+        $errorInfo = [
+            'success' => false,
+            'code' => StoreClient::EXTENSION_LICENSE_IS_ALREADY_CANCELLED,
+            'title' => 'Error',
+            'description' => 'The license is already cancelled',
+        ];
+        $this->getStoreRequestHandler()->append(new Response(400, [], \json_encode($errorInfo, \JSON_THROW_ON_ERROR)));
+
+        $this->storeClient->cancelSubscription(123, $this->storeContext);
+
+        $lastRequest = $this->getStoreRequestHandler()->getLastRequest();
+        static::assertInstanceOf(RequestInterface::class, $lastRequest);
+
+        static::assertEquals('/swplatform/pluginlicenses/123/cancel', $lastRequest->getUri()->getPath());
+        static::assertEquals('POST', $lastRequest->getMethod());
+    }
 }

--- a/tests/unit/Core/Framework/Store/Api/ExtensionStoreActionsControllerTest.php
+++ b/tests/unit/Core/Framework/Store/Api/ExtensionStoreActionsControllerTest.php
@@ -230,7 +230,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
 
         static::assertEquals(
             Response::HTTP_NO_CONTENT,
-            $controller->removeExtension('plugin', 'test', Context::createDefaultContext())->getStatusCode()
+            $controller->removeExtension('plugin', 'test', new Request(), Context::createDefaultContext())->getStatusCode()
         );
     }
 
@@ -340,7 +340,7 @@ class ExtensionStoreActionsControllerTest extends TestCase
         }
 
         try {
-            $controller->removeExtension('plugin', 'test', $context);
+            $controller->removeExtension('plugin', 'test', new Request(), $context);
         } catch (StoreException $e) {
             static::assertEquals(StoreException::EXTENSION_RUNTIME_EXTENSION_MANAGEMENT_NOT_ALLOWED, $e->getErrorCode());
         }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently when a subscription is cancelled and an extension is removed from the shop, an exception occurs. This exception prevents the user from removing the extension.

### 2. What does this change do, exactly?
It looks at the correct error code to see if it's the expected licence already cancelled exception. If it is, it continues with the removal process. If it's not, it throws the error. This change also completely removes the extension, keeping the user data.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
Jira issue: https://shopware.atlassian.net/browse/NEXT-39821

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
