### PR TITLE
feat: lazy create custom entity repositories to improve application s…

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityRepository.php
@@ -25,6 +25,7 @@ use Shopware\Core\Framework\Uuid\Exception\InvalidUuidException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Profiling\Profiler;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\VarExporter\LazyGhostTrait;
 
 /**
  * @final
@@ -34,6 +35,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 #[Package('core')]
 class EntityRepository
 {
+    use LazyGhostTrait;
+
     /**
      * @internal
      */

--- a/src/Core/System/CustomEntity/CustomEntityRegistrar.php
+++ b/src/Core/System/CustomEntity/CustomEntityRegistrar.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\System\CustomEntity;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityLoadedEventFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Read\EntityReaderInterface;
@@ -56,7 +57,7 @@ class CustomEntityRegistrar
             $definitions[] = $definition;
 
             $this->container->set($definition->getEntityName(), $definition);
-            $this->container->set($definition->getEntityName() . '.repository', $this->createRepository($definition));
+            $this->container->set($definition->getEntityName() . '.repository', self::createRepository($this->container, $definition));
             $registry->register($definition, $definition->getEntityName());
         }
 
@@ -66,16 +67,18 @@ class CustomEntityRegistrar
         }
     }
 
-    private function createRepository(DynamicEntityDefinition $definition): EntityRepository
+    public static function createRepository(ContainerInterface $container, EntityDefinition $definition): EntityRepository
     {
-        return new EntityRepository(
-            $definition,
-            $this->container->get(EntityReaderInterface::class),
-            $this->container->get(VersionManager::class),
-            $this->container->get(EntitySearcherInterface::class),
-            $this->container->get(EntityAggregatorInterface::class),
-            $this->container->get('event_dispatcher'),
-            $this->container->get(EntityLoadedEventFactory::class)
-        );
+        return EntityRepository::createLazyGhost(function (EntityRepository $instance) use ($definition, $container): void {
+            $instance->__construct(
+                $definition,
+                $container->get(EntityReaderInterface::class),
+                $container->get(VersionManager::class),
+                $container->get(EntitySearcherInterface::class),
+                $container->get(EntityAggregatorInterface::class),
+                $container->get('event_dispatcher'),
+                $container->get(EntityLoadedEventFactory::class)
+            );
+        });
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Custom Entity slows down the application startup process
<img width="429" alt="grafik" src="https://github.com/user-attachments/assets/15d9f30b-d947-41f8-8427-8f0c9e40e780" />

### 2. What does this change do, exactly?

Place Ghost objects as Entity Repositories and instialize it lazyily when they are required

<img width="413" alt="grafik" src="https://github.com/user-attachments/assets/2bb4087d-d464-48fe-8eaf-39eefc5b7868" />


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
