### PR TITLE
fix: dont set session time zone when it's disabled

### DIFF
--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -352,6 +352,9 @@ class Kernel extends HttpKernel
 
     protected function initializeDatabaseConnectionVariables(): void
     {
+        /**
+         * @deprecated tag:v6.7.0 - remove if-clause, we have already SQL_SET_DEFAULT_SESSION_VARIABLES which is documented does the same
+         */
         $shopwareSkipConnectionVariables = EnvironmentHelper::getVariable('SHOPWARE_SKIP_CONNECTION_VARIABLES', false);
 
         if ($shopwareSkipConnectionVariables) {
@@ -368,7 +371,7 @@ class Kernel extends HttpKernel
              * @deprecated tag:v6.7.0 - remove if clause and enforce timezone setting
              */
             $timeZoneSupportEnabled = (bool) EnvironmentHelper::getVariable('SHOPWARE_DBAL_TIMEZONE_SUPPORT_ENABLED', Feature::isActive('v6.7.0.0'));
-            if ($timeZoneSupportEnabled) {
+            if ($timeZoneSupportEnabled && $setSessionVariables) {
                 $connectionVariables[] = 'SET @@session.time_zone = "+00:00"';
             }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

since 6.7 flag is enabled it makes an session.timezone sql query even when that is disabled

### 2. What does this change do, exactly?

don't do time zone query when disabled


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
