### PR TITLE
refactor: Get current currency from context in template files

### DIFF
--- a/changelog/_unreleased/2025-01-07-introduce-global-template-data-for-language-and-navigation.md
+++ b/changelog/_unreleased/2025-01-07-introduce-global-template-data-for-language-and-navigation.md
@@ -1,0 +1,10 @@
+---
+title: Introduce global template data for language and navigation
+issue: NEXT-39744
+author: Michael Telgmann
+author_github: @mitelg
+---
+
+# Storefront
+* Deprecated the usage of the `header` and `footer` properties of page Twig objects outside the dedicated header and footer templates. Use the following alternatives instead:
+    * `context.currency` instead of `page.header.activeCurrency`

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
@@ -34,7 +34,7 @@
                                             itemtype="https://schema.org/Offer">
                                             {% block buy_widget_price_block_table_body_cell_quantity %}
                                                 <th scope="row" class="product-block-prices-cell product-block-prices-cell-thin">
-                                                    <meta itemprop="priceCurrency" content="{{ page.header.activeCurrency.translated.shortName }}">
+                                                    <meta itemprop="priceCurrency" content="{{ context.currency.translated.shortName }}">
                                                     <meta itemprop="price" content="{{ price.unitPrice }}">
 
                                                     {% if loop.last %}

--- a/src/Storefront/Resources/views/storefront/component/listing/filter/filter-range.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter/filter-range.html.twig
@@ -25,7 +25,7 @@
 {% endif %}
 
 {% if unit is not defined %}
-    {% set unit = page.header.activeCurrency.symbol %}
+    {% set unit = context.currency.symbol %}
 {% endif %}
 
 {% if minInputValue is not defined %}

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/currency-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/currency-widget.html.twig
@@ -1,9 +1,13 @@
+{% if not header is defined and page is defined %}
+    {% set header = page.header %}
+{% endif %}
+
 {% block layout_header_actions_currency_widget %}
     {% if position is empty %}
         {% set position = 'top-bar' %}
     {% endif %}
 
-    {% if page.header.currencies.count > 1 %}
+    {% if header.currencies.count > 1 %}
         <div class="top-bar-nav-item top-bar-currency">
             {% block layout_header_actions_currency_widget_form %}
                 <form method="post"
@@ -19,11 +23,11 @@
                                         data-bs-toggle="dropdown"
                                         aria-haspopup="true"
                                         aria-expanded="false"
-                                        aria-label="{{ 'header.currencyTrigger'|trans({ '%currency%': page.header.activeCurrency.translated.name })|striptags }}">
+                                        aria-label="{{ 'header.currencyTrigger'|trans({ '%currency%': context.currency.translated.name })|striptags }}">
                                     {% block layout_header_actions_currency_widget_dropdown_toggle_name %}
-                                        <span aria-hidden="true">{{ page.header.activeCurrency.symbol }}</span>
+                                        <span aria-hidden="true">{{ context.currency.translated.symbol }}</span>
                                         {# @deprecated tag:v6.7.0 - Toggling the text display will use Bootstrap helper classes instead of custom CSS. #}
-                                        <span class="top-bar-nav-text{% if feature('ACCESSIBILITY_TWEAKS') %} d-none d-md-inline{% endif %}">{{ page.header.activeCurrency.translated.name }}</span>
+                                        <span class="top-bar-nav-text{% if feature('ACCESSIBILITY_TWEAKS') %} d-none d-md-inline{% endif %}">{{ context.currency.translated.name }}</span>
                                     {% endblock %}
                                 </button>
                             {% endblock %}
@@ -31,8 +35,8 @@
                             {% block layout_header_actions_currency_widget_form_items %}
                                 <ul class="top-bar-list dropdown-menu dropdown-menu-end"
                                     aria-label="{{ 'header.currencyList'|trans|striptags }}">
-                                    {% for currency in page.header.currencies %}
-                                        {% set isActiveCurrency = currency.id is same as(page.header.activeCurrency.id) %}
+                                    {% for currency in header.currencies %}
+                                        {% set isActiveCurrency = currency.id is same as(context.currency.id) %}
 
                                         {% block layout_header_actions_currency_widget_form_items_element %}
                                             {# @deprecated tag:v6.7.0 - `dropdown-item` class will be on the button as docuented by Bootstrap: https://getbootstrap.com/docs/5.3/components/dropdowns/#menu-items #}

--- a/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/buy-widget-price.html.twig
@@ -38,7 +38,7 @@
                                                 itemtype="https://schema.org/Offer">
                                                 {% block page_product_detail_price_block_table_body_cell_quantity %}
                                                     <th scope="row" class="product-block-prices-cell product-block-prices-cell-thin">
-                                                        <meta itemprop="priceCurrency" content="{{ page.header.activeCurrency.translated.shortName }}">
+                                                        <meta itemprop="priceCurrency" content="{{ context.currency.translated.shortName }}">
                                                         <meta itemprop="price" content="{{ price.unitPrice }}">
 
                                                         {% if loop.last %}


### PR DESCRIPTION
### 1. Why is this change necessary?

To be more independent on loading several templates (especially common templates like the header and the footer) some data should not be taken from the page objects. Instead globally available data should be used. Some are already present, like the currency in the context object; some need to be added new.

### 2. What does this change do, exactly?

Get current currency from context in template files

### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-39744

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
