### PR TITLE
feat: consider bulk entity extension for autoconfiguration

### DIFF
--- a/src/Core/Framework/DependencyInjection/CompilerPass/AutoconfigureCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/AutoconfigureCompilerPass.php
@@ -24,6 +24,7 @@ use Shopware\Core\Content\Seo\SeoUrlRoute\SeoUrlRouteInterface;
 use Shopware\Core\Content\Sitemap\Provider\AbstractUrlProvider;
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AdapterFactoryInterface;
 use Shopware\Core\Framework\Adapter\Twig\NamespaceHierarchy\TemplateNamespaceHierarchyBuilderInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\BulkEntityExtension;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\ExceptionHandlerInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityExtension;
@@ -60,6 +61,10 @@ class AutoconfigureCompilerPass implements CompilerPassInterface
         $container
             ->registerForAutoconfiguration(EntityExtension::class)
             ->addTag('shopware.entity.extension');
+
+        $container
+            ->registerForAutoconfiguration(BulkEntityExtension::class)
+            ->addTag('shopware.bulk.entity.extension');
 
         $container
             ->registerForAutoconfiguration(CartProcessorInterface::class)


### PR DESCRIPTION
### 1. Why is this change necessary?

when autowire and autoconfigure is turned on for my plugin the bulk entity extensions are not considered

### 2. What does this change do, exactly?

configure it


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
