### PR TITLE
refactor: Use the collection instead of array during creation of breadcrumbs for the experimental store API

### DIFF
--- a/src/Core/Content/Breadcrumb/SalesChannel/BreadcrumbRoute.php
+++ b/src/Core/Content/Breadcrumb/SalesChannel/BreadcrumbRoute.php
@@ -38,29 +38,24 @@ class BreadcrumbRoute extends AbstractBreadcrumbRoute
         $id = $request->get('id', '');
         $type = $request->get('type', 'product');
         if ($type === 'category') {
-            $categories = $this->getCategories($id, $salesChannelContext);
+            $breadcrumb = $this->getCategories($id, $salesChannelContext);
         } else {
-            $categories = $this->tryToGetCategoriesFromProductOrCategory(
+            $breadcrumb = $this->tryToGetCategoriesFromProductOrCategory(
                 $id,
                 $request->get('referrerCategoryId', ''),
                 $salesChannelContext
             );
         }
 
-        $breadcrumb = new BreadcrumbCollection($categories);
-
         return new BreadcrumbRouteResponse($breadcrumb);
     }
 
-    /**
-     * @return array<int, Breadcrumb>
-     */
-    private function getCategories(string $id, SalesChannelContext $salesChannelContext): array
+    private function getCategories(string $id, SalesChannelContext $salesChannelContext): BreadcrumbCollection
     {
         $category = $this->breadcrumbBuilder->loadCategory($id, $salesChannelContext->getContext());
 
         if ($category === null) {
-            return [];
+            return new BreadcrumbCollection();
         }
 
         return $this->breadcrumbBuilder->getCategoryBreadcrumbUrls(
@@ -72,10 +67,8 @@ class BreadcrumbRoute extends AbstractBreadcrumbRoute
 
     /**
      * Simple helper function to retry with category type if product is not found
-     *
-     * @return array<int, Breadcrumb>
      */
-    private function tryToGetCategoriesFromProductOrCategory(string $id, string $referrerCategoryId, SalesChannelContext $salesChannelContext): array
+    private function tryToGetCategoriesFromProductOrCategory(string $id, string $referrerCategoryId, SalesChannelContext $salesChannelContext): BreadcrumbCollection
     {
         try {
             $categories = $this->breadcrumbBuilder->getProductBreadcrumbUrls($id, $referrerCategoryId, $salesChannelContext);

--- a/src/Core/Content/Breadcrumb/Struct/Breadcrumb.php
+++ b/src/Core/Content/Breadcrumb/Struct/Breadcrumb.php
@@ -13,7 +13,7 @@ class Breadcrumb extends Struct
 {
     /**
      * @param array<string, mixed> $translated
-     * @param array<int, array<string, string>> $seoUrls
+     * @param list<array<string, string>> $seoUrls
      */
     public function __construct(
         public string $name,

--- a/src/Core/Content/Breadcrumb/Struct/BreadcrumbCollection.php
+++ b/src/Core/Content/Breadcrumb/Struct/BreadcrumbCollection.php
@@ -3,37 +3,23 @@
 namespace Shopware\Core\Content\Breadcrumb\Struct;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Struct\Struct;
+use Shopware\Core\Framework\Struct\Collection;
 
 /**
  * @experimental stableVersion:v6.7.0 feature:BREADCRUMB_STORE_API
+ *
+ * @extends Collection<Breadcrumb>
  */
 #[Package('inventory')]
-class BreadcrumbCollection extends Struct
+class BreadcrumbCollection extends Collection
 {
-    /**
-     * @param array<int, Breadcrumb> $breadcrumbs
-     */
-    public function __construct(
-        public array $breadcrumbs
-    ) {
-    }
-
-    public function getBreadcrumb(int $index): ?Breadcrumb
-    {
-        return $this->breadcrumbs[$index] ?? null;
-    }
-
-    /**
-     * @return array<int, Breadcrumb>
-     */
-    public function getBreadcrumbs(): array
-    {
-        return $this->breadcrumbs;
-    }
-
     public function getApiAlias(): string
     {
         return 'breadcrumb_collection';
+    }
+
+    protected function getExpectedClass(): string
+    {
+        return Breadcrumb::class;
     }
 }

--- a/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
+++ b/src/Core/Content/Category/Service/CategoryBreadcrumbBuilder.php
@@ -6,16 +6,17 @@ use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Content\Breadcrumb\BreadcrumbException;
 use Shopware\Core\Content\Breadcrumb\Struct\Breadcrumb;
+use Shopware\Core\Content\Breadcrumb\Struct\BreadcrumbCollection;
 use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductCollection;
 use Shopware\Core\Content\Product\SalesChannel\SalesChannelProductEntity;
 use Shopware\Core\Content\Seo\MainCategory\MainCategoryEntity;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\AndFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter;
@@ -39,6 +40,9 @@ class CategoryBreadcrumbBuilder
 {
     /**
      * @internal
+     *
+     * @param EntityRepository<CategoryCollection> $categoryRepository
+     * @param SalesChannelRepository<SalesChannelProductCollection> $productRepository
      */
     public function __construct(
         private readonly EntityRepository $categoryRepository,
@@ -47,10 +51,7 @@ class CategoryBreadcrumbBuilder
     ) {
     }
 
-    /**
-     * @return array<int, Breadcrumb>
-     */
-    public function getProductBreadcrumbUrls(string $productId, string $referrerCategoryId, SalesChannelContext $salesChannelContext): array
+    public function getProductBreadcrumbUrls(string $productId, string $referrerCategoryId, SalesChannelContext $salesChannelContext): BreadcrumbCollection
     {
         $product = $this->loadProduct($productId, $salesChannelContext);
         $category = $this->getCategoryForProduct($referrerCategoryId, $product, $salesChannelContext);
@@ -84,7 +85,6 @@ class CategoryBreadcrumbBuilder
     public function getProductSeoCategory(ProductEntity $product, SalesChannelContext $context): ?CategoryEntity
     {
         $category = $this->getMainCategory($product, $context);
-
         if ($category !== null) {
             return $category;
         }
@@ -110,28 +110,21 @@ class CategoryBreadcrumbBuilder
 
         $criteria->addFilter($this->getSalesChannelFilter($context->getSalesChannel()));
 
-        $categories = $this->categoryRepository->search($criteria, $context->getContext());
-
+        $categories = $this->categoryRepository->search($criteria, $context->getContext())->getEntities();
         if ($categories->count() > 0) {
-            /** @var CategoryEntity|null $category */
-            $category = $categories->first();
-
-            return $category;
+            return $categories->first();
         }
 
         return null;
     }
 
-    /**
-     * @return array<int, Breadcrumb>
-     */
-    public function getCategoryBreadcrumbUrls(CategoryEntity $category, Context $context, SalesChannelEntity $salesChannel): array
+    public function getCategoryBreadcrumbUrls(CategoryEntity $category, Context $context, SalesChannelEntity $salesChannel): BreadcrumbCollection
     {
         $seoBreadcrumb = $this->build($category, $salesChannel);
         $categoryIds = array_keys($seoBreadcrumb ?? []);
 
         if (empty($categoryIds)) {
-            return [];
+            return new BreadcrumbCollection();
         }
 
         $categories = $this->loadCategories($categoryIds, $context, $salesChannel);
@@ -141,7 +134,7 @@ class CategoryBreadcrumbBuilder
     }
 
     /**
-     * @return array<mixed>|null
+     * @return array<string, string>|null
      */
     public function build(CategoryEntity $category, ?SalesChannelEntity $salesChannel = null, ?string $navigationCategoryId = null): ?array
     {
@@ -229,7 +222,6 @@ class CategoryBreadcrumbBuilder
 
         $firstCategory = $categories->first();
 
-        /** @var CategoryEntity|null $entity */
         $entity = $firstCategory instanceof MainCategoryEntity ? $firstCategory->getCategory() : $firstCategory;
 
         return $product->getCategoryIds() !== null && $entity !== null && \in_array($entity->getId(), $product->getCategoryIds(), true) ? $entity : null;
@@ -263,10 +255,8 @@ class CategoryBreadcrumbBuilder
         $criteria = new Criteria($categoryIds);
         $criteria->setTitle('breadcrumb::categories::data');
         $criteria->addFilter($this->getSalesChannelFilter($salesChannel));
-        /** @var EntitySearchResult<CategoryCollection> $searchResult */
-        $searchResult = $this->categoryRepository->search($criteria, $context);
 
-        return $searchResult->getEntities();
+        return $this->categoryRepository->search($criteria, $context)->getEntities();
     }
 
     /**
@@ -299,10 +289,8 @@ class CategoryBreadcrumbBuilder
 
     /**
      * @param array<int, array<string, string|mixed>> $seoUrls
-     *
-     * @return array<int, Breadcrumb>
      */
-    private function convertCategoriesToBreadcrumbUrls(CategoryCollection $categories, array $seoUrls): array
+    private function convertCategoriesToBreadcrumbUrls(CategoryCollection $categories, array $seoUrls): BreadcrumbCollection
     {
         $seoBreadcrumbCollection = [];
         foreach ($categories as $category) {
@@ -336,7 +324,7 @@ class CategoryBreadcrumbBuilder
             $seoBreadcrumbCollection[$categoryId] = $categoryBreadcrumb;
         }
 
-        return array_values($seoBreadcrumbCollection);
+        return new BreadcrumbCollection(array_values($seoBreadcrumbCollection));
     }
 
     /**

--- a/tests/unit/Core/Content/Breadcrumb/SalesChannel/BreadcrumbRouteTest.php
+++ b/tests/unit/Core/Content/Breadcrumb/SalesChannel/BreadcrumbRouteTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Breadcrumb\SalesChannel\BreadcrumbRoute;
 use Shopware\Core\Content\Breadcrumb\Struct\Breadcrumb;
+use Shopware\Core\Content\Breadcrumb\Struct\BreadcrumbCollection;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
@@ -44,27 +45,24 @@ class BreadcrumbRouteTest extends TestCase
         $categoryEntity->setType('category');
 
         $request = new Request(['id' => '1', 'type' => 'category']);
-        $this->breadcrumbBuilder->method('getCategoryBreadcrumbUrls')->willReturn([new Breadcrumb('Home', '/')]);
+        $this->breadcrumbBuilder->method('getCategoryBreadcrumbUrls')->willReturn(new BreadcrumbCollection([new Breadcrumb('Home', '/')]));
         $this->breadcrumbBuilder->method('loadCategory')->willReturn($categoryEntity);
 
-        $response = $this->breadcrumbRoute->load($request, $this->context);
-        $firstBreadcrumb = $response->getBreadcrumbCollection()->getBreadcrumb(0);
+        $collection = $this->breadcrumbRoute->load($request, $this->context)->getBreadcrumbCollection();
+        static::assertCount(1, $collection);
+        $firstBreadcrumb = $collection->first();
+        static::assertNotNull($firstBreadcrumb);
 
-        static::assertCount(1, $response->getBreadcrumbCollection()->getBreadcrumbs());
-        if ($firstBreadcrumb === null) {
-            static::fail('Breadcrumb is null');
-        }
         static::assertSame('Home', $firstBreadcrumb->name);
     }
 
     public function testLoadCategoryBreadcrumbReturnsCorrectBreadcrumbNullCategory(): void
     {
         $request = new Request(['id' => '1', 'type' => 'category']);
-        $this->breadcrumbBuilder->method('getCategoryBreadcrumbUrls')->willReturn([new Breadcrumb('Home', '/')]);
+        $this->breadcrumbBuilder->method('getCategoryBreadcrumbUrls')->willReturn(new BreadcrumbCollection([new Breadcrumb('Home', '/')]));
 
         $response = $this->breadcrumbRoute->load($request, $this->context);
-        $firstBreadcrumb = $response->getBreadcrumbCollection()->getBreadcrumb(0);
-        static::assertNull($response->getBreadcrumbCollection()->getBreadcrumb(0));
+        static::assertNull($response->getBreadcrumbCollection()->first());
     }
 
     public function testGetDecoratedThrowsException(): void
@@ -76,15 +74,13 @@ class BreadcrumbRouteTest extends TestCase
     public function testLoadProductBreadcrumbReturnsCorrectBreadcrumb(): void
     {
         $request = new Request(['id' => '1', 'type' => 'product']);
-        $this->breadcrumbBuilder->method('getProductBreadcrumbUrls')->willReturn([new Breadcrumb('Product', 'product')]);
+        $this->breadcrumbBuilder->method('getProductBreadcrumbUrls')->willReturn(new BreadcrumbCollection([new Breadcrumb('Product', 'product')]));
 
-        $response = $this->breadcrumbRoute->load($request, $this->context);
-        $firstBreadcrumb = $response->getBreadcrumbCollection()->getBreadcrumb(0);
+        $collection = $this->breadcrumbRoute->load($request, $this->context)->getBreadcrumbCollection();
+        static::assertCount(1, $collection);
+        $firstBreadcrumb = $collection->first();
+        static::assertNotNull($firstBreadcrumb);
 
-        static::assertCount(1, $response->getBreadcrumbCollection()->getBreadcrumbs());
-        if ($firstBreadcrumb === null) {
-            static::fail('Breadcrumb is null');
-        }
         static::assertSame('Product', $firstBreadcrumb->name);
     }
 
@@ -97,16 +93,13 @@ class BreadcrumbRouteTest extends TestCase
 
         $request = new Request(['id' => '1', 'type' => 'product']);
         $this->breadcrumbBuilder->method('getProductBreadcrumbUrls')->willThrowException(new ProductNotFoundException('1'));
-        $this->breadcrumbBuilder->method('getCategoryBreadcrumbUrls')->willReturn([new Breadcrumb('Category', 'category')]);
+        $this->breadcrumbBuilder->method('getCategoryBreadcrumbUrls')->willReturn(new BreadcrumbCollection([new Breadcrumb('Category', 'category')]));
         $this->breadcrumbBuilder->method('loadCategory')->willReturn($categoryEntity);
 
-        $response = $this->breadcrumbRoute->load($request, $this->context);
-        $firstBreadcrumb = $response->getBreadcrumbCollection()->getBreadcrumb(0);
-
-        static::assertCount(1, $response->getBreadcrumbCollection()->getBreadcrumbs());
-        if ($firstBreadcrumb === null) {
-            static::fail('Breadcrumb is null');
-        }
+        $collection = $this->breadcrumbRoute->load($request, $this->context)->getBreadcrumbCollection();
+        static::assertCount(1, $collection);
+        $firstBreadcrumb = $collection->first();
+        static::assertNotNull($firstBreadcrumb);
         static::assertSame('Category', $firstBreadcrumb->name);
     }
 
@@ -114,11 +107,10 @@ class BreadcrumbRouteTest extends TestCase
     {
         $request = new Request(['id' => '1', 'type' => 'product']);
         $this->breadcrumbBuilder->method('getProductBreadcrumbUrls')->willThrowException(new ProductNotFoundException('1'));
-        $this->breadcrumbBuilder->method('getCategoryBreadcrumbUrls')->willReturn([new Breadcrumb('Category', 'category')]);
+        $this->breadcrumbBuilder->method('getCategoryBreadcrumbUrls')->willReturn(new BreadcrumbCollection([new Breadcrumb('Category', 'category')]));
 
         $response = $this->breadcrumbRoute->load($request, $this->context);
-        $firstBreadcrumb = $response->getBreadcrumbCollection()->getBreadcrumb(0);
-        static::assertNull($response->getBreadcrumbCollection()->getBreadcrumb(0));
+        static::assertNull($response->getBreadcrumbCollection()->first());
     }
 
     public function testLoadBreadcrumbWithInvalidType(): void
@@ -126,6 +118,6 @@ class BreadcrumbRouteTest extends TestCase
         $request = new Request(['id' => '1', 'type' => 'invalid']);
         $response = $this->breadcrumbRoute->load($request, $this->context);
 
-        static::assertCount(0, $response->getBreadcrumbCollection()->getBreadcrumbs());
+        static::assertCount(0, $response->getBreadcrumbCollection());
     }
 }

--- a/tests/unit/Core/Content/Breadcrumb/Struct/BreadcrumbCollectionTest.php
+++ b/tests/unit/Core/Content/Breadcrumb/Struct/BreadcrumbCollectionTest.php
@@ -25,9 +25,7 @@ class BreadcrumbCollectionTest extends TestCase
             2 => $breadcrumb2,
         ];
 
-        $breadcrumbCollection = new BreadcrumbCollection($breadcrumbsCollection);
-
-        $result = $breadcrumbCollection->getBreadcrumb(0);
+        $result = (new BreadcrumbCollection($breadcrumbsCollection))->first();
 
         static::assertSame($breadcrumb0, $result);
     }
@@ -41,7 +39,7 @@ class BreadcrumbCollectionTest extends TestCase
 
         $breadcrumbCollection = new BreadcrumbCollection($breadcrumbsCollection);
 
-        static::assertNull($breadcrumbCollection->getBreadcrumb(1));
+        static::assertNull($breadcrumbCollection->getAt(1));
     }
 
     public function testGetBreadcrumbsReturnsAllBreadcrumbs(): void
@@ -54,18 +52,14 @@ class BreadcrumbCollectionTest extends TestCase
             1 => $breadcrumb1,
         ];
 
-        $breadcrumbCollection = new BreadcrumbCollection($breadcrumbsCollection);
-
-        $result = $breadcrumbCollection->getBreadcrumbs();
+        $result = (new BreadcrumbCollection($breadcrumbsCollection))->getElements();
 
         static::assertSame($breadcrumbsCollection, $result);
     }
 
     public function testGetApiAliasReturnsCorrectAlias(): void
     {
-        $breadcrumbCollection = new BreadcrumbCollection([]);
-
-        $result = $breadcrumbCollection->getApiAlias();
+        $result = (new BreadcrumbCollection([]))->getApiAlias();
 
         static::assertSame('breadcrumb_collection', $result);
     }

--- a/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
+++ b/tests/unit/Core/Content/Category/Service/CategoryBreadcrumbBuilderTest.php
@@ -156,10 +156,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c01', $this->salesChannelContext->getContext());
-        if ($category === null) {
-            static::fail('Category is null');
-        }
-        $result = $categoryBreadcrumbBuilder->getCategoryBreadcrumbUrls($category, $this->salesChannelContext->getContext(), $this->salesChannelContext->getSalesChannel());
+        static::assertNotNull($category);
+        $result = $categoryBreadcrumbBuilder->getCategoryBreadcrumbUrls($category, $this->salesChannelContext->getContext(), $this->salesChannelContext->getSalesChannel())->getElements();
         $firstBreadcrumb = $result[0];
 
         static::assertArrayHasKey('0', $result);
@@ -192,10 +190,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c02', $this->salesChannelContext->getContext());
-        if ($category === null) {
-            static::fail('Category is null');
-        }
-        $result = $categoryBreadcrumbBuilder->getCategoryBreadcrumbUrls($category, $this->salesChannelContext->getContext(), $this->salesChannelContext->getSalesChannel());
+        static::assertNotNull($category);
+        $result = $categoryBreadcrumbBuilder->getCategoryBreadcrumbUrls($category, $this->salesChannelContext->getContext(), $this->salesChannelContext->getSalesChannel())->getElements();
         $firstBreadcrumb = $result[0];
 
         static::assertArrayHasKey('0', $result);
@@ -228,10 +224,8 @@ class CategoryBreadcrumbBuilderTest extends TestCase
         );
 
         $category = $categoryBreadcrumbBuilder->loadCategory('019192b9cd82711482744d7b456b6c03', $this->salesChannelContext->getContext());
-        if ($category === null) {
-            static::fail('Category is null');
-        }
-        $result = $categoryBreadcrumbBuilder->getCategoryBreadcrumbUrls($category, $this->salesChannelContext->getContext(), $this->salesChannelContext->getSalesChannel());
+        static::assertNotNull($category);
+        $result = $categoryBreadcrumbBuilder->getCategoryBreadcrumbUrls($category, $this->salesChannelContext->getContext(), $this->salesChannelContext->getSalesChannel())->getElements();
         $firstBreadcrumb = $result[0];
 
         static::assertArrayHasKey('0', $result);
@@ -264,7 +258,7 @@ class CategoryBreadcrumbBuilderTest extends TestCase
             $this->getConnectionMock()
         );
 
-        $result = $categoryBreadcrumbBuilder->getProductBreadcrumbUrls($product->getId(), '', $this->salesChannelContext);
+        $result = $categoryBreadcrumbBuilder->getProductBreadcrumbUrls($product->getId(), '', $this->salesChannelContext)->getElements();
         $firstBreadcrumb = $result[0];
 
         static::assertArrayHasKey('0', $result);


### PR DESCRIPTION
### 1. Why is this change necessary?

For proper type hinting instead of an array


### 2. What does this change do, exactly?

Returning a collection instead of an array while creating breadcrumbs for the store API

### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-39744

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
