### PR TITLE
fix: reset the selectedIds for the app actions buttons correctly on c…

### DIFF
--- a/changelog/_unreleased/2025-01-07-fix-app-action-visibility-behavior.md
+++ b/changelog/_unreleased/2025-01-07-fix-app-action-visibility-behavior.md
@@ -1,0 +1,9 @@
+---
+title: Fix app-action visibility behavior
+issue: NEXT-40053
+author: Jannis Leifeld
+author_email: j.leifeld@shopware.com
+author_github: @Jannis Leifeld
+---
+# Administration
+* Added reset of selectedIds in the app action button to fix visbility issue of the app-action button in listings

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/index.js
@@ -128,8 +128,11 @@ Component.register('sw-app-actions', {
 
     created() {
         // Reset the selectedIds when the component is created to avoid
-        // that the actions are executed on the wrong entities
-        Shopware.State.commit('shopwareApps/setSelectedIds', []);
+        // that the actions are executed on the wrong entities.
+        // Only reset when a entity exists
+        if (this.entity) {
+            Shopware.State.commit('shopwareApps/setSelectedIds', []);
+        }
     },
 
     methods: {

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/index.js
@@ -126,6 +126,12 @@ Component.register('sw-app-actions', {
         },
     },
 
+    created() {
+        // Reset the selectedIds when the component is created to avoid
+        // that the actions are executed on the wrong entities
+        Shopware.State.commit('shopwareApps/setSelectedIds', []);
+    },
+
     methods: {
         async runAction(action) {
             const entityIdList = { ids: this.params };

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/sw-app-actions.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/sw-app-actions.spec.js
@@ -133,6 +133,10 @@ describe('sw-app-actions', () => {
     it('creates an sw-app-action-button per action', async () => {
         wrapper = await createWrapper(router);
 
+        Shopware.State.commit('shopwareApps/setSelectedIds', [
+            Shopware.Utils.createId(),
+        ]);
+
         router.push({ name: 'sw.product.detail' });
         await flushPromises();
 
@@ -145,6 +149,16 @@ describe('sw-app-actions', () => {
         expect(actionButtons).toHaveLength(2);
         expect(actionButtons.at(0).props('action')).toEqual(actionButtonData[0]);
         expect(actionButtons.at(1).props('action')).toEqual(actionButtonData[1]);
+    });
+
+    it('should reset the selectedIds on creation', async () => {
+        expect(Shopware.State.get('shopwareApps').selectedIds).toEqual([
+            expect.any(String),
+        ]);
+
+        wrapper = await createWrapper(router);
+
+        expect(Shopware.State.get('shopwareApps').selectedIds).toEqual([]);
     });
 
     it('is not rendered if action buttons is empty', async () => {
@@ -191,6 +205,10 @@ describe('sw-app-actions', () => {
     it('calls appActionButtonService.runAction if triggered by context menu button', async () => {
         wrapper = await createWrapper(router);
 
+        Shopware.State.commit('shopwareApps/setSelectedIds', [
+            Shopware.Utils.createId(),
+        ]);
+
         router.push({ name: 'sw.product.detail' });
         await flushPromises();
 
@@ -228,6 +246,10 @@ describe('sw-app-actions', () => {
         wrapper = await createWrapper(router);
         wrapper.vm.createNotification = jest.fn();
 
+        Shopware.State.commit('shopwareApps/setSelectedIds', [
+            Shopware.Utils.createId(),
+        ]);
+
         router.push({ name: 'sw.product.detail' });
         await flushPromises();
 
@@ -258,6 +280,10 @@ describe('sw-app-actions', () => {
             },
         };
         wrapper = await createWrapper(router, openModalResponseData);
+
+        Shopware.State.commit('shopwareApps/setSelectedIds', [
+            Shopware.Utils.createId(),
+        ]);
 
         router.push({ name: 'sw.product.detail' });
         await flushPromises();

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/sw-app-actions.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-actions/sw-app-actions.spec.js
@@ -151,14 +151,30 @@ describe('sw-app-actions', () => {
         expect(actionButtons.at(1).props('action')).toEqual(actionButtonData[1]);
     });
 
-    it('should reset the selectedIds on creation', async () => {
+    it('should reset the selectedIds on creation when entity exists', async () => {
+        expect(Shopware.State.get('shopwareApps').selectedIds).toEqual([
+            expect.any(String),
+        ]);
+
+        router.push({ name: 'sw.product.detail' });
+        await flushPromises();
+
+        wrapper = await createWrapper(router);
+
+        expect(Shopware.State.get('shopwareApps').selectedIds).toEqual([]);
+    });
+
+    it('should not reset the selectedIds on creation when entity exists', async () => {
         expect(Shopware.State.get('shopwareApps').selectedIds).toEqual([
             expect.any(String),
         ]);
 
         wrapper = await createWrapper(router);
+        await flushPromises();
 
-        expect(Shopware.State.get('shopwareApps').selectedIds).toEqual([]);
+        expect(Shopware.State.get('shopwareApps').selectedIds).toEqual([
+            expect.any(String),
+        ]);
     });
 
     it('is not rendered if action buttons is empty', async () => {


### PR DESCRIPTION
### 1. Why is this change necessary?

Fixes this issue: https://github.com/shopware/shopware/issues/5825

### 2. What does this change do, exactly?

The `selectedIds` doesn't get resetted correctly when switching listings. This leads to issues that the app-action button is visible even when nothing is selected in the current listing. And if you click then on the button the "old" id's from the selection of the other listing are sent together with the wrong entity.

### 3. Describe each step to reproduce the issue or behaviour.

For Visibility Issue:

1. Install the minimal test app from the issue: https://github.com/shopware/shopware/issues/5825
2. Navigate to the promotion listing
3. Observe that the action button is not visible
4. Navigate to any other listing (e.g., orders)
5. Select any item in that listing
6. Return to the promotion listing
7. Observe that the action button is now visible

For Data Integrity Issue:

1. Navigate to order listing
2. Select an order (note its ID)
3. Navigate to promotion listing
4. Click the action button
5. Check the request sent to the endpoint - it will contain the order ID instead of the promotion ID

#### Expected behavior (after the PR fix):
Visibility issue:

In step 7 the action button should not be visible. It should only be visible when the user selects something.

For Data Integrity Issue:

In step 4 the button should not be visible. Therefore it is not possible to sent the request to the endpoint.

