### PR TITLE
feat: add controller specific route event

### DIFF
--- a/src/Core/Framework/Routing/RouteEventSubscriber.php
+++ b/src/Core/Framework/Routing/RouteEventSubscriber.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\Routing;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Event\StorefrontRenderEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -27,6 +28,7 @@ class RouteEventSubscriber implements EventSubscriberInterface
     {
         $events = [
             KernelEvents::REQUEST => ['request', -10],
+            KernelEvents::CONTROLLER => ['controller', -10],
             KernelEvents::RESPONSE => ['response', -10],
         ];
 
@@ -67,6 +69,17 @@ class RouteEventSubscriber implements EventSubscriberInterface
         }
 
         $name = $request->attributes->get('_route') . '.response';
+        $this->dispatcher->dispatch($event, $name);
+    }
+
+    public function controller(ControllerEvent $event): void
+    {
+        $request = $event->getRequest();
+        if (!$request->attributes->has('_route')) {
+            return;
+        }
+
+        $name = $request->attributes->get('_route') . '.controller';
         $this->dispatcher->dispatch($event, $name);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Easier listing on controller events for routes like request and response


### 2. What does this change do, exactly?

Example replace the home page

```
class TestSubscriber implements EventSubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [
            'frontend.home.page.controller' => 'onFrontendHomePage',
        ];
    }

    public function onFrontendHomePage(ControllerEvent $event): void
    {
        $event->setController(fn() => new Response('Hello World!'));
    }
}
```

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
