### PR TITLE
refactor: Introduce new global Twig template data to replace usage of common header and footer objects

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -33,6 +33,8 @@ return [
         // Added new optional parameter to those classes
         'Parameter session was added to Method __construct\(\) of class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Event\\\\SalesChannelContextCreatedEvent',
         'Parameter collectionClass was added to Method __construct\(\) of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Attribute\\\\Entity',
+        'Parameter cacheDir was added to Method createTwigEnvironment\(\) of class Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlTwigFactory',
+        'Parameter serviceMenu was added to Method __construct\(\) of class Shopware\\\\Storefront\\\\Pagelet\\\\NavigationPagelet',
 
         // Changed $languageIdChain parameter to $context in TokenQueryBuilder
         'The parameter $languageIdChain of \\\\Shopware\\\\Elasticsearch\\\\TokenQueryBuilder#build\(\) changed from array to array|Shopware\\\\Core\\\\Framework\\\\Context',
@@ -45,9 +47,6 @@ return [
         // The return type was incorrect and led to an error. It is not a breaking change if it's already breaking.
         'The return type of Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderCollection#getOrderCustomers\(\) changed from Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerCollection to the non-covariant Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerCollection',
         'The return type of Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderCollection#getOrderCustomers\(\) changed from Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerCollection to Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerCollection',
-
-        // Added new optional parameter to those classes
-        'Parameter cacheDir was added to Method createTwigEnvironment\(\) of class Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlTwigFactory',
 
         // Version related const values changed for 7.2 update
         'Value of constant Symfony\\\\Component\\\\HttpKernel\\\\Kernel',

--- a/changelog/_unreleased/2025-01-07-introduce-global-template-data-for-language-and-navigation.md
+++ b/changelog/_unreleased/2025-01-07-introduce-global-template-data-for-language-and-navigation.md
@@ -17,7 +17,6 @@ ___
 * Added `minSearchLength` to the global `shopware` Twig variable, which defines the minimum search term length.
 * Added `showStagingBanner` to the global `shopware` Twig variable, which defines if the staging banner should be shown.
 * Deprecated the global `showStagingBanner` Twig variable. Use `shopware.showStagingBanner` instead.
-* Deprecated the global `themeId` Twig variable as it is unused.
 * Deprecated the usage of the `header` and `footer` properties of page Twig objects outside the dedicated header and footer templates. Use the following alternatives instead:
     * `context.currency` instead of `page.header.activeCurrency`
     * `shopware.navigation` instead of `page.header.navigation.active`
@@ -27,9 +26,8 @@ ___
 
 # Upgrade Information
 
-## Deprecation of Twig variables
+## Deprecation of Twig variable
 The global `showStagingBanner` Twig variable has been deprecated. Use `shopware.showStagingBanner` instead.
-The global `themeId` Twig variable has been deprecated as it is unused.
 
 ## New constructor parameter in FooterPagelet
 The new optional parameter `serviceMenu` of type `\Shopware\Core\Content\Category\CategoryCollection` has been added to `\Shopware\Storefront\Pagelet\Footer\FooterPagelet`.
@@ -38,9 +36,8 @@ ___
 
 # Next Major Version Changes
 
-## Removal of Twig variables
+## Removal of Twig variable
 The global `showStagingBanner` Twig variable was removed. Use `shopware.showStagingBanner` instead.
-The global `themeId` Twig variable was removed as it is unused.
 
 ## FooterPagelet changes
 The former optional parameter `serviceMenu` of type `\Shopware\Core\Content\Category\CategoryCollection` in `\Shopware\Storefront\Pagelet\Footer\FooterPagelet` is now required.

--- a/changelog/_unreleased/2025-01-07-introduce-global-template-data-for-language-and-navigation.md
+++ b/changelog/_unreleased/2025-01-07-introduce-global-template-data-for-language-and-navigation.md
@@ -5,6 +5,43 @@ author: Michael Telgmann
 author_github: @mitelg
 ---
 
+# Core
+* Deprecated `\Shopware\Core\System\SalesChannel\Exception\ContextPermissionsLockedException`. Use `\Shopware\Core\System\SalesChannel\SalesChannelException::contextPermissionsLocked` instead
+* Deprecated `\Shopware\Core\System\SalesChannel\Exception\ContextRulesLockedException`. Use `\Shopware\Core\System\SalesChannel\SalesChannelException::contextRulesLocked` instead
+* Deprecated `\Shopware\Core\System\Tax\Exception\TaxNotFoundException`. Use `\Shopware\Core\System\SalesChannel\SalesChannelException::taxNotFound` instead
+___
+
 # Storefront
+* Added new Twig function `sw_breadcrumb_full_by_id` to get the full breadcrumb for a category ID.
+* Added `\Shopware\Storefront\Framework\Twig\NavigationInfo` to the global `shopware` Twig variable, to provide the category ID of the main navigation and the current navigation path.
+* Added `minSearchLength` to the global `shopware` Twig variable, which defines the minimum search term length.
+* Added `showStagingBanner` to the global `shopware` Twig variable, which defines if the staging banner should be shown.
+* Deprecated the global `showStagingBanner` Twig variable. Use `shopware.showStagingBanner` instead.
+* Deprecated the global `themeId` Twig variable as it is unused.
 * Deprecated the usage of the `header` and `footer` properties of page Twig objects outside the dedicated header and footer templates. Use the following alternatives instead:
     * `context.currency` instead of `page.header.activeCurrency`
+    * `shopware.navigation` instead of `page.header.navigation.active`
+    * `context.saleschannel.languages.first` instead of `page.header.activeLanguage`
+* Added new optional parameter `serviceMenu` of type `\Shopware\Core\Content\Category\CategoryCollection` to `\Shopware\Storefront\Pagelet\Footer\FooterPagelet`. It will be required in the next major version.
+___
+
+# Upgrade Information
+
+## Deprecation of Twig variables
+The global `showStagingBanner` Twig variable has been deprecated. Use `shopware.showStagingBanner` instead.
+The global `themeId` Twig variable has been deprecated as it is unused.
+
+## New constructor parameter in FooterPagelet
+The new optional parameter `serviceMenu` of type `\Shopware\Core\Content\Category\CategoryCollection` has been added to `\Shopware\Storefront\Pagelet\Footer\FooterPagelet`.
+You can already add it to your implementation to prevent breaking changes, as it will be required in the next major version.
+___
+
+# Next Major Version Changes
+
+## Removal of Twig variables
+The global `showStagingBanner` Twig variable was removed. Use `shopware.showStagingBanner` instead.
+The global `themeId` Twig variable was removed as it is unused.
+
+## FooterPagelet changes
+The former optional parameter `serviceMenu` of type `\Shopware\Core\Content\Category\CategoryCollection` in `\Shopware\Storefront\Pagelet\Footer\FooterPagelet` is now required.
+Make sure to pass it to the constructor.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2171,11 +2171,6 @@ parameters:
 			path: src/Core/Framework/Changelog/Processor/ChangelogReleaseCreator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 2
-			path: src/Core/Framework/Context.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Command\\\\CreateHydratorCommand\\:\\:renderClass\\(\\) has parameter \\$calls with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Command/CreateHydratorCommand.php
@@ -3980,16 +3975,6 @@ parameters:
 			message: "#^Expected domain exception class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
 			count: 1
 			path: src/Core/System/SalesChannel/SalesChannel/StoreApiInfoController.php
-
-		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelException, got Shopware\\\\Core\\\\Checkout\\\\Cart\\\\CartException$#"
-			count: 2
-			path: src/Core/System/SalesChannel/SalesChannelContext.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 2
-			path: src/Core/System/SalesChannel/SalesChannelContext.php
 
 		-
 			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Command\\\\ValidateSnippetsCommand\\:\\:hydrateMissingSnippets\\(\\) has parameter \\$missingSnippetsArray with no value type specified in iterable type array\\.$#"

--- a/src/Core/Framework/Context.php
+++ b/src/Core/Framework/Context.php
@@ -11,8 +11,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\StateAwareTrait;
 use Shopware\Core\Framework\Struct\Struct;
-use Shopware\Core\System\SalesChannel\Exception\ContextRulesLockedException;
-use Symfony\Component\Serializer\Annotation\Ignore;
+use Symfony\Component\Serializer\Attribute\Ignore;
 
 #[Package('core')]
 class Context extends Struct
@@ -26,7 +25,7 @@ class Context extends Struct
     final public const SKIP_TRIGGER_FLOW = 'skipTriggerFlow';
 
     /**
-     * @var non-empty-array<string>
+     * @var non-empty-list<string>
      */
     protected array $languageIdChain;
 
@@ -62,13 +61,12 @@ class Context extends Struct
             $this->scope = self::SYSTEM_SCOPE;
         }
 
+        $languageIdChain = array_values(array_filter($languageIdChain));
         if (empty($languageIdChain)) {
-            throw new \InvalidArgumentException('Argument languageIdChain must not be empty');
+            throw FrameworkException::invalidArgumentException('Argument "languageIdChain" must not be empty');
         }
 
-        /** @var non-empty-array<string> $chain */
-        $chain = array_keys(array_flip(array_filter($languageIdChain)));
-        $this->languageIdChain = $chain;
+        $this->languageIdChain = $languageIdChain;
     }
 
     /**
@@ -120,7 +118,7 @@ class Context extends Struct
     }
 
     /**
-     * @return non-empty-array<string>
+     * @return non-empty-list<string>
      */
     public function getLanguageIdChain(): array
     {
@@ -150,6 +148,8 @@ class Context extends Struct
     }
 
     /**
+     * @deprecated tag:v6.7.0 - reason:return-type-change - Return type will be native
+     *
      * @template TReturn of mixed
      *
      * @param \Closure(Context): TReturn $callback
@@ -210,13 +210,15 @@ class Context extends Struct
     public function setRuleIds(array $ruleIds): void
     {
         if ($this->rulesLocked) {
-            throw new ContextRulesLockedException();
+            throw FrameworkException::contextRulesLocked();
         }
 
         $this->ruleIds = array_filter(array_values($ruleIds));
     }
 
     /**
+     * @deprecated tag:v6.7.0 - reason:return-type-change - Return type will be native
+     *
      * @template TReturn of mixed
      *
      * @param \Closure(Context): TReturn $function
@@ -234,6 +236,8 @@ class Context extends Struct
     }
 
     /**
+     * @deprecated tag:v6.7.0 - reason:return-type-change - Return type will be native
+     *
      * @template TReturn of mixed
      *
      * @param \Closure(Context): TReturn $function

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Filter/AbstractTokenFilter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Filter/AbstractTokenFilter.php
@@ -9,6 +9,8 @@ use Symfony\Contracts\Service\ResetInterface;
 #[Package('core')]
 abstract class AbstractTokenFilter implements ResetInterface
 {
+    final public const DEFAULT_MIN_SEARCH_TERM_LENGTH = 2;
+
     public function reset(): void
     {
         $this->getDecorated()->reset();

--- a/src/Core/Framework/DataAbstractionLayer/Search/Term/Filter/TokenFilter.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Term/Filter/TokenFilter.php
@@ -14,8 +14,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('core')]
 class TokenFilter extends AbstractTokenFilter
 {
-    private const DEFAULT_MIN_SEARCH_TERM_LENGTH = 2;
-
     /**
      * @var array<string, FilterConfig>
      */

--- a/src/Core/Framework/FrameworkException.php
+++ b/src/Core/Framework/FrameworkException.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Exception\ContextRulesLockedException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Exception\InvalidOptionsException;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
@@ -27,6 +28,7 @@ class FrameworkException extends HttpException
     private const EXTENSION_RESULT_NOT_SET = 'FRAMEWORK__EXTENSION_RESULT_NOT_SET';
     private const VALIDATION_FAILED = 'FRAMEWORK__VALIDATION_FAILED';
     private const CLASS_NOT_FOUND = 'FRAMEWORK__CLASS_NOT_FOUND';
+    private const CONTEXT_RULES_LOCKED = 'FRAMEWORK__CONTEXT_RULES_LOCKED';
 
     private const MISSING_OPTIONS = 'FRAMEWORK__MISSING_OPTIONS';
     private const INVALID_OPTIONS = 'FRAMEWORK__INVALID_OPTIONS';
@@ -122,6 +124,22 @@ class FrameworkException extends HttpException
             self::INVALID_COLLECTION_ELEMENT_TYPE,
             'Expected collection element of type {{ expected }} got {{ element }}',
             ['expected' => $expectedClass, 'element' => $elementClass]
+        );
+    }
+
+    /**
+     * @deprecated tag:v6.7.0 - reason:return-type-change - Will only return 'self' in the future
+     */
+    public static function contextRulesLocked(): self|ContextRulesLockedException
+    {
+        if (!Feature::isActive('v6.7.0.0')) {
+            return new ContextRulesLockedException();
+        }
+
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::CONTEXT_RULES_LOCKED,
+            'Context rules in application context already locked.'
         );
     }
 

--- a/src/Core/System/SalesChannel/BaseContext.php
+++ b/src/Core/System/SalesChannel/BaseContext.php
@@ -10,10 +10,13 @@ use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\SalesChannel\Context\LanguageInfo;
 use Shopware\Core\System\Tax\TaxCollection;
 
 /**
  * @internal Use SalesChannelContext for extensions
+ *
+ * @codeCoverageIgnore
  */
 #[Package('core')]
 class BaseContext
@@ -28,7 +31,8 @@ class BaseContext
         protected ShippingMethodEntity $shippingMethod,
         protected ShippingLocation $shippingLocation,
         private readonly CashRoundingConfig $itemRounding,
-        private readonly CashRoundingConfig $totalRounding
+        private readonly CashRoundingConfig $totalRounding,
+        private readonly LanguageInfo $languageInfo
     ) {
     }
 
@@ -77,22 +81,11 @@ class BaseContext
         return $this->context->getTaxState();
     }
 
-    public function getApiAlias(): string
-    {
-        return 'base_channel_context';
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
     public function getTotalRounding(): CashRoundingConfig
     {
         return $this->totalRounding;
     }
 
-    /**
-     * @codeCoverageIgnore
-     */
     public function getItemRounding(): CashRoundingConfig
     {
         return $this->itemRounding;
@@ -101,5 +94,15 @@ class BaseContext
     public function getCurrencyId(): string
     {
         return $this->getCurrency()->getId();
+    }
+
+    public function getLanguageInfo(): LanguageInfo
+    {
+        return $this->languageInfo;
+    }
+
+    public function getApiAlias(): string
+    {
+        return 'base_channel_context';
     }
 }

--- a/src/Core/System/SalesChannel/Context/BaseContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/BaseContextFactory.php
@@ -5,8 +5,10 @@ namespace Shopware\Core\System\SalesChannel\Context;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Checkout\Cart\Delivery\Struct\ShippingLocation;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
-use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupEntity;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerGroup\CustomerGroupCollection;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
+use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\AdminSalesChannelApiSource;
@@ -18,11 +20,17 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateCollection;
 use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateEntity;
+use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\CountryEntity;
+use Shopware\Core\System\Currency\Aggregate\CurrencyCountryRounding\CurrencyCountryRoundingCollection;
 use Shopware\Core\System\Currency\Aggregate\CurrencyCountryRounding\CurrencyCountryRoundingEntity;
+use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\SalesChannel\BaseContext;
+use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelException;
 use Shopware\Core\System\Tax\TaxCollection;
@@ -33,6 +41,17 @@ use Shopware\Core\System\Tax\TaxCollection;
 #[Package('core')]
 class BaseContextFactory extends AbstractBaseContextFactory
 {
+    /**
+     * @param EntityRepository<SalesChannelCollection> $salesChannelRepository
+     * @param EntityRepository<CurrencyCollection> $currencyRepository
+     * @param EntityRepository<CustomerGroupCollection> $customerGroupRepository
+     * @param EntityRepository<CountryCollection> $countryRepository
+     * @param EntityRepository<TaxCollection> $taxRepository
+     * @param EntityRepository<PaymentMethodCollection> $paymentMethodRepository
+     * @param EntityRepository<ShippingMethodCollection> $shippingMethodRepository
+     * @param EntityRepository<CountryStateCollection> $countryStateRepository
+     * @param EntityRepository<CurrencyCountryRoundingCollection> $currencyCountryRepository
+     */
     public function __construct(
         private readonly EntityRepository $salesChannelRepository,
         private readonly EntityRepository $currencyRepository,
@@ -58,20 +77,23 @@ class BaseContextFactory extends AbstractBaseContextFactory
         $criteria->setTitle('base-context-factory::sales-channel');
         $criteria->addAssociation('currency');
         $criteria->addAssociation('domains');
+        $criteria->getAssociation('languages')
+            ->addFilter(new EqualsFilter('id', $context->getLanguageId()))
+            ->addAssociation('translationCode')
+            ->addAssociation('locale');
 
-        $salesChannel = $this->salesChannelRepository->search($criteria, $context)->get($salesChannelId);
-
+        $salesChannel = $this->salesChannelRepository->search($criteria, $context)->getEntities()->get($salesChannelId);
         if (!$salesChannel instanceof SalesChannelEntity) {
             throw SalesChannelException::salesChannelNotFound($salesChannelId);
         }
 
         // load active currency, fallback to shop currency
-        /** @var CurrencyEntity $currency */
         $currency = $salesChannel->getCurrency();
-
         if (\array_key_exists(SalesChannelContextService::CURRENCY_ID, $options)) {
             $currencyId = $options[SalesChannelContextService::CURRENCY_ID];
-            \assert(\is_string($currencyId) && Uuid::isValid($currencyId));
+            if (!\is_string($currencyId) || !Uuid::isValid($currencyId)) {
+                throw SalesChannelException::invalidCurrencyId();
+            }
 
             $criteria = new Criteria([$currencyId]);
             $criteria->setTitle('base-context-factory::currency');
@@ -83,6 +105,10 @@ class BaseContextFactory extends AbstractBaseContextFactory
             }
         }
 
+        if ($currency === null) {
+            throw SalesChannelException::currencyNotFound($salesChannel->getCurrencyId());
+        }
+
         // load not logged in customer with default shop configuration or with provided checkout scopes
         $shippingLocation = $this->loadShippingLocation($options, $context, $salesChannel);
 
@@ -91,10 +117,10 @@ class BaseContextFactory extends AbstractBaseContextFactory
         $criteria = new Criteria([$salesChannel->getCustomerGroupId()]);
         $criteria->setTitle('base-context-factory::customer-group');
 
-        $customerGroups = $this->customerGroupRepository->search($criteria, $context);
-
-        /** @var CustomerGroupEntity $customerGroup */
-        $customerGroup = $customerGroups->get($groupId);
+        $customerGroup = $this->customerGroupRepository->search($criteria, $context)->getEntities()->get($groupId);
+        if ($customerGroup === null) {
+            throw SalesChannelException::customerGroupNotFound($groupId);
+        }
 
         // loads tax rules based on active customer and delivery address
         $taxRules = $this->getTaxRules($context);
@@ -129,7 +155,8 @@ class BaseContextFactory extends AbstractBaseContextFactory
             $shippingMethod,
             $shippingLocation,
             $itemRounding,
-            $totalRounding
+            $totalRounding,
+            $this->getLanguageInfo($salesChannel->getLanguages(), $context->getLanguageId()),
         );
     }
 
@@ -139,10 +166,7 @@ class BaseContextFactory extends AbstractBaseContextFactory
         $criteria->setTitle('base-context-factory::taxes');
         $criteria->addAssociation('rules.type');
 
-        /** @var TaxCollection $taxes */
-        $taxes = $this->taxRepository->search($criteria, $context)->getEntities();
-
-        return $taxes;
+        return $this->taxRepository->search($criteria, $context)->getEntities();
     }
 
     /**
@@ -181,10 +205,12 @@ class BaseContextFactory extends AbstractBaseContextFactory
         $criteria->addAssociation('media');
         $criteria->setTitle('base-context-factory::shipping-method');
 
-        $shippingMethods = $this->shippingMethodRepository->search($criteria, $context);
+        $shippingMethods = $this->shippingMethodRepository->search($criteria, $context)->getEntities();
 
-        /** @var ShippingMethodEntity $shippingMethod */
         $shippingMethod = $shippingMethods->get($id) ?? $shippingMethods->get($salesChannel->getShippingMethodId());
+        if ($shippingMethod === null) {
+            throw SalesChannelException::shippingMethodNotFound($id);
+        }
 
         return $shippingMethod;
     }
@@ -274,7 +300,9 @@ class BaseContextFactory extends AbstractBaseContextFactory
         // allows previewing cart calculation for a specify state for not logged in customers
         if (isset($options[SalesChannelContextService::COUNTRY_STATE_ID])) {
             $countryStateId = $options[SalesChannelContextService::COUNTRY_STATE_ID];
-            \assert(\is_string($countryStateId) && Uuid::isValid($countryStateId));
+            if (!\is_string($countryStateId) || !Uuid::isValid($countryStateId)) {
+                throw SalesChannelException::invalidCountryStateId();
+            }
 
             $criteria = new Criteria([$countryStateId]);
             $criteria->addAssociation('country');
@@ -287,14 +315,18 @@ class BaseContextFactory extends AbstractBaseContextFactory
                 throw SalesChannelException::countryStateNotFound($countryStateId);
             }
 
-            /** @var CountryEntity $country */
             $country = $state->getCountry();
+            if (!$country instanceof CountryEntity) {
+                throw SalesChannelException::countryNotFound($state->getCountryId());
+            }
 
             return new ShippingLocation($country, $state, null);
         }
 
         $countryId = $options[SalesChannelContextService::COUNTRY_ID] ?? $salesChannel->getCountryId();
-        \assert(\is_string($countryId) && Uuid::isValid($countryId));
+        if (!\is_string($countryId) || !Uuid::isValid($countryId)) {
+            throw SalesChannelException::invalidCountryId();
+        }
 
         $criteria = new Criteria([$countryId]);
         $criteria->setTitle('base-context-factory::country');
@@ -353,5 +385,21 @@ class BaseContextFactory extends AbstractBaseContextFactory
         }
 
         return [$currency->getItemRounding(), $currency->getTotalRounding()];
+    }
+
+    private function getLanguageInfo(?LanguageCollection $languages, string $currentLanguageId): LanguageInfo
+    {
+        $currentLanguage = $languages?->get($currentLanguageId);
+        if ($currentLanguage === null) {
+            throw SalesChannelException::languageNotFound($currentLanguageId);
+        }
+
+        $locale = $currentLanguage->getTranslationCode() ?? $currentLanguage->getLocale();
+        \assert($locale !== null, 'At least the localeId is required, so the fallback should never be null');
+
+        return new LanguageInfo(
+            $currentLanguage->getTranslation('name') ?? $currentLanguage->getName(),
+            $locale->getCode(),
+        );
     }
 }

--- a/src/Core/System/SalesChannel/Context/LanguageInfo.php
+++ b/src/Core/System/SalesChannel/Context/LanguageInfo.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\System\SalesChannel\Context;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[Package('core')]
+final readonly class LanguageInfo
+{
+    public function __construct(
+        public string $name,
+        public string $localeCode,
+    ) {
+    }
+}

--- a/src/Core/System/SalesChannel/Exception/ContextPermissionsLockedException.php
+++ b/src/Core/System/SalesChannel/Exception/ContextPermissionsLockedException.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @deprecated tag:v6.7.0 - reason:remove-exception - Will be removed. Use \Shopware\Core\System\SalesChannel\SalesChannelException::contextPermissionsLocked instead
+ */
 #[Package('core')]
 class ContextPermissionsLockedException extends ShopwareHttpException
 {

--- a/src/Core/System/SalesChannel/Exception/ContextRulesLockedException.php
+++ b/src/Core/System/SalesChannel/Exception/ContextRulesLockedException.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @deprecated tag:v6.7.0 - reason:remove-exception - Will be removed. Use \Shopware\Core\Framework\FrameworkException::contextRulesLocked instead
+ */
 #[Package('core')]
 class ContextRulesLockedException extends ShopwareHttpException
 {

--- a/src/Core/System/SalesChannel/SalesChannelException.php
+++ b/src/Core/System/SalesChannel/SalesChannelException.php
@@ -2,35 +2,42 @@
 
 namespace Shopware\Core\System\SalesChannel;
 
+use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Customer\Exception\CustomerNotFoundByIdException;
 use Shopware\Core\Checkout\Payment\PaymentException;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
+use Shopware\Core\System\SalesChannel\Exception\ContextPermissionsLockedException;
+use Shopware\Core\System\Tax\Exception\TaxNotFoundException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('discovery')]
 class SalesChannelException extends HttpException
 {
     final public const SALES_CHANNEL_DOES_NOT_EXISTS_EXCEPTION = 'SYSTEM__SALES_CHANNEL_DOES_NOT_EXISTS';
-
     final public const LANGUAGE_INVALID_EXCEPTION = 'SYSTEM__LANGUAGE_INVALID_EXCEPTION';
-
     final public const COUNTRY_DOES_NOT_EXISTS_EXCEPTION = 'SYSTEM__COUNTRY_DOES_NOT_EXISTS_EXCEPTION';
-
     final public const CURRENCY_DOES_NOT_EXISTS_EXCEPTION = 'SYSTEM__CURRENCY_DOES_NOT_EXISTS_EXCEPTION';
-
     final public const COUNTRY_STATE_DOES_NOT_EXISTS_EXCEPTION = 'SYSTEM__COUNTRY_STATE_DOES_NOT_EXISTS_EXCEPTION';
-
+    final public const TAX_DOES_NOT_EXISTS_EXCEPTION = 'SYSTEM__TAX_DOES_NOT_EXISTS_EXCEPTION';
+    final public const CUSTOMER_GROUP_DOES_NOT_EXISTS_EXCEPTION = 'SYSTEM__CUSTOMER_GROUP_DOES_NOT_EXISTS_EXCEPTION';
+    final public const SHIPPING_METHOD_DOES_NOT_EXISTS_EXCEPTION = 'SYSTEM__SHIPPING_METHOD_DOES_NOT_EXISTS_EXCEPTION';
     final public const SALES_CHANNEL_LANGUAGE_NOT_AVAILABLE_EXCEPTION = 'SYSTEM__SALES_CHANNEL_LANGUAGE_NOT_AVAILABLE_EXCEPTION';
-
     final public const NO_CONTEXT_DATA_EXCEPTION = 'SYSTEM__NO_CONTEXT_DATA_EXCEPTION';
-
     final public const LANGUAGE_NOT_FOUND = 'SYSTEM__LANGUAGE_NOT_FOUND';
-
     final public const SALES_CHANNEL_DOMAIN_IN_USE = 'SYSTEM__SALES_CHANNEL_DOMAIN_IN_USE';
-
     public const INVALID_TYPE = 'FRAMEWORK__INVALID_TYPE';
+    final public const CURRENCY_INVALID_EXCEPTION = 'SYSTEM__CURRENCY_INVALID_EXCEPTION';
+    final public const COUNTRY_INVALID_EXCEPTION = 'SYSTEM__COUNTRY_INVALID_EXCEPTION';
+
+    final public const COUNTRY_STATE_INVALID_EXCEPTION = 'SYSTEM__COUNTRY_STATE_INVALID_EXCEPTION';
+    final public const SALES_CHANNEL_CONTEXT_PERMISSIONS_LOCKED = 'SYSTEM__SALES_CHANNEL_CONTEXT_PERMISSIONS_LOCKED';
+    private const INVALID_UUID_MESSAGE_TEMPLATE = 'Provided %s is not a valid UUID';
 
     public static function salesChannelNotFound(string $salesChannelId): self
     {
@@ -92,7 +99,7 @@ class SalesChannelException extends HttpException
         return new self(
             Response::HTTP_PRECONDITION_FAILED,
             self::LANGUAGE_INVALID_EXCEPTION,
-            'Provided languageId is not a valid uuid',
+            \sprintf(self::INVALID_UUID_MESSAGE_TEMPLATE, 'language ID'),
         );
     }
 
@@ -140,6 +147,91 @@ class SalesChannelException extends HttpException
             Response::HTTP_INTERNAL_SERVER_ERROR,
             self::INVALID_TYPE,
             $message
+        );
+    }
+
+    public static function invalidCurrencyId(): self
+    {
+        return new self(
+            Response::HTTP_PRECONDITION_FAILED,
+            self::CURRENCY_INVALID_EXCEPTION,
+            \sprintf(self::INVALID_UUID_MESSAGE_TEMPLATE, 'currency ID'),
+        );
+    }
+
+    public static function invalidCountryId(): self
+    {
+        return new self(
+            Response::HTTP_PRECONDITION_FAILED,
+            self::COUNTRY_INVALID_EXCEPTION,
+            \sprintf(self::INVALID_UUID_MESSAGE_TEMPLATE, 'country ID'),
+        );
+    }
+
+    public static function invalidCountryStateId(): self
+    {
+        return new self(
+            Response::HTTP_PRECONDITION_FAILED,
+            self::COUNTRY_STATE_INVALID_EXCEPTION,
+            \sprintf(self::INVALID_UUID_MESSAGE_TEMPLATE, 'country state ID'),
+        );
+    }
+
+    public static function customerNotLoggedIn(): CartException
+    {
+        return CartException::customerNotLoggedIn();
+    }
+
+    /**
+     * @deprecated tag:v6.7.0 - reason:return-type-change - Will only return 'self' in the future
+     */
+    public static function contextPermissionsLocked(): self|ContextPermissionsLockedException
+    {
+        if (!Feature::isActive('v6.7.0.0')) {
+            return new ContextPermissionsLockedException();
+        }
+
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::SALES_CHANNEL_CONTEXT_PERMISSIONS_LOCKED,
+            'Context permission in SalesChannel context already locked.'
+        );
+    }
+
+    /**
+     * @deprecated tag:v6.7.0 - reason:return-type-change - Will only return 'self' in the future
+     */
+    public static function taxNotFound(string $taxId): self|TaxNotFoundException
+    {
+        if (!Feature::isActive('v6.7.0.0')) {
+            return new TaxNotFoundException($taxId);
+        }
+
+        return new self(
+            Response::HTTP_PRECONDITION_FAILED,
+            self::TAX_DOES_NOT_EXISTS_EXCEPTION,
+            self::$couldNotFindMessage,
+            ['entity' => 'tax', 'field' => 'id', 'value' => $taxId]
+        );
+    }
+
+    public static function customerGroupNotFound(string $customerGroupId): self
+    {
+        return new self(
+            Response::HTTP_NOT_FOUND,
+            self::CUSTOMER_GROUP_DOES_NOT_EXISTS_EXCEPTION,
+            self::$couldNotFindMessage,
+            ['entity' => 'customer group', 'field' => 'id', 'value' => $customerGroupId]
+        );
+    }
+
+    public static function shippingMethodNotFound(string $shippingMethodId): self
+    {
+        return new self(
+            Response::HTTP_NOT_FOUND,
+            self::SHIPPING_METHOD_DOES_NOT_EXISTS_EXCEPTION,
+            self::$couldNotFindMessage,
+            ['entity' => 'shipping method', 'field' => 'id', 'value' => $shippingMethodId]
         );
     }
 }

--- a/src/Core/System/Tax/Exception/TaxNotFoundException.php
+++ b/src/Core/System/Tax/Exception/TaxNotFoundException.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @deprecated tag:v6.7.0 - reason:remove-exception - Will be removed. Use \Shopware\Core\System\SalesChannel\SalesChannelException::taxNotFound instead
+ */
 #[Package('checkout')]
 class TaxNotFoundException extends ShopwareHttpException
 {

--- a/src/Core/Test/Generator.php
+++ b/src/Core/Test/Generator.php
@@ -32,6 +32,7 @@ use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateEntity;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\DeliveryTime\DeliveryTimeEntity;
+use Shopware\Core\System\SalesChannel\Context\LanguageInfo;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelDefinition;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -59,7 +60,8 @@ class Generator extends TestCase
         ?CustomerEntity $customer = null,
         ?string $token = null,
         ?string $domainId = null,
-        bool $createCustomer = true
+        bool $createCustomer = true,
+        ?LanguageInfo $languageInfo = null,
     ): SalesChannelContext {
         if (!$baseContext) {
             $baseContext = Context::createDefaultContext();
@@ -156,7 +158,8 @@ class Generator extends TestCase
             $customer,
             new CashRoundingConfig(2, 0.01, true),
             new CashRoundingConfig(2, 0.01, true),
-            []
+            [],
+            $languageInfo ?? new LanguageInfo('English', 'en-GB')
         );
     }
 

--- a/src/Elasticsearch/Product/StopwordTokenFilter.php
+++ b/src/Elasticsearch/Product/StopwordTokenFilter.php
@@ -12,8 +12,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 #[Package('core')]
 class StopwordTokenFilter extends AbstractTokenFilter
 {
-    private const DEFAULT_MIN_SEARCH_TERM_LENGTH = 2;
-
     /**
      * @var array<string, int>
      */

--- a/src/Storefront/DependencyInjection/services.xml
+++ b/src/Storefront/DependencyInjection/services.xml
@@ -88,6 +88,7 @@
         <service id="Shopware\Storefront\Framework\Twig\TemplateDataExtension">
             <argument type="service" id="request_stack"/>
             <argument>%shopware.staging.storefront.show_banner%</argument>
+            <argument type="service" id="Doctrine\DBAL\Connection"/>
 
             <tag name="twig.extension"/>
         </service>

--- a/src/Storefront/Framework/Twig/NavigationInfo.php
+++ b/src/Storefront/Framework/Twig/NavigationInfo.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Storefront\Framework\Twig;
+
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @codeCoverageIgnore
+ */
+#[Package('storefront')]
+final readonly class NavigationInfo
+{
+    public function __construct(
+        public string $id,
+        public string $path,
+    ) {
+    }
+}

--- a/src/Storefront/Framework/Twig/TemplateDataExtension.php
+++ b/src/Storefront/Framework/Twig/TemplateDataExtension.php
@@ -2,9 +2,15 @@
 
 namespace Shopware\Storefront\Framework\Twig;
 
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Term\Filter\AbstractTokenFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
 use Shopware\Core\SalesChannelRequest;
+use Shopware\Core\System\SalesChannel\Context\LanguageInfo;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -19,7 +25,8 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
      */
     public function __construct(
         private readonly RequestStack $requestStack,
-        private readonly bool $showStagingBanner
+        private readonly bool $showStagingBanner,
+        private readonly Connection $connection,
     ) {
     }
 
@@ -29,34 +36,52 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
     public function getGlobals(): array
     {
         $request = $this->requestStack->getCurrentRequest();
-
-        if (!$request) {
+        if (!$request instanceof Request) {
             return [];
         }
 
-        /** @var SalesChannelContext|null $context */
         $context = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT);
-
-        if (!$context) {
+        if (!$context instanceof SalesChannelContext) {
             return [];
+        }
+
+        /** @deprecated tag:v6.7.0 - Remove the if condition and the private method as the value is always set */
+        if ($context->getLanguageInfo() === null) {
+            $context->setLanguageInfo($this->getLanguageInfo($context->getContext()));
         }
 
         [$controllerName, $controllerAction] = $this->getControllerInfo($request);
 
         $themeId = $request->attributes->get(SalesChannelRequest::ATTRIBUTE_THEME_ID);
 
-        return [
+        $activeNavigationId = (string) $request->get('navigationId', $context->getSalesChannel()->getNavigationCategoryId());
+        $navigationInfo = new NavigationInfo(
+            $activeNavigationId,
+            $this->getNavigationPath($activeNavigationId),
+        );
+
+        $globalTemplateData = [
             'shopware' => [
                 'dateFormat' => \DATE_ATOM,
+                'navigation' => $navigationInfo,
+                'minSearchLength' => $this->minSearchLength($context),
+                'showStagingBanner' => $this->showStagingBanner,
             ],
-            'themeId' => $themeId,
             'controllerName' => $controllerName,
             'controllerAction' => $controllerAction,
             'context' => $context,
             'activeRoute' => $request->attributes->get('_route'),
             'formViolations' => $request->attributes->get('formViolations'),
-            'showStagingBanner' => $this->showStagingBanner,
         ];
+
+        if (!Feature::isActive('v6.7.0.0')) {
+            /** @deprecated tag:v6.7.0 - Will be removed as it is unused */
+            $globalTemplateData['themeId'] = $themeId;
+            /** @deprecated tag:v6.7.0 - Will be removed, use shopware.showStagingBanner instead */
+            $globalTemplateData['showStagingBanner'] = $this->showStagingBanner;
+        }
+
+        return $globalTemplateData;
     }
 
     /**
@@ -64,19 +89,56 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
      */
     private function getControllerInfo(Request $request): array
     {
-        $controller = $request->attributes->get('_controller');
-
-        if (!$controller) {
+        $controller = $request->attributes->getString('_controller');
+        if ($controller === '') {
             return ['', ''];
         }
 
         $matches = [];
-        preg_match('/Controller\\\\(\w+)Controller::?(\w+)$/', (string) $controller, $matches);
-
+        preg_match('/Controller\\\\(\w+)Controller::?(\w+)$/', $controller, $matches);
         if ($matches) {
             return [$matches[1], $matches[2]];
         }
 
         return ['', ''];
+    }
+
+    private function minSearchLength(SalesChannelContext $context): int
+    {
+        $query = $this->connection->createQueryBuilder();
+
+        $query->select('min_search_length')
+            ->from('product_search_config')
+            ->where('language_id = :id')
+            ->setParameter('id', Uuid::fromHexToBytes($context->getLanguageId()));
+
+        $min = (int) $query->executeQuery()->fetchOne();
+
+        return $min ?: AbstractTokenFilter::DEFAULT_MIN_SEARCH_TERM_LENGTH;
+    }
+
+    private function getNavigationPath(string $activeNavigationId): string
+    {
+        return $this->connection->fetchOne(
+            'SELECT path FROM category WHERE id = :id',
+            ['id' => Uuid::fromHexToBytes($activeNavigationId)]
+        ) ?: '';
+    }
+
+    private function getLanguageInfo(Context $context): LanguageInfo
+    {
+        $data = $this->connection->createQueryBuilder()
+            ->select(['language.name', 'locale.code as localeCode'])
+            ->from('language')
+            ->innerJoin('language', 'locale', 'locale', 'language.translation_code_id = locale.id')
+            ->where('language.id = :id')
+            ->setParameter('id', Uuid::fromHexToBytes($context->getLanguageId()))
+            ->executeQuery()
+            ->fetchAssociative() ?: [];
+
+        return new LanguageInfo(
+            $data['name'],
+            $data['localeCode'],
+        );
     }
 }

--- a/src/Storefront/Framework/Twig/TemplateDataExtension.php
+++ b/src/Storefront/Framework/Twig/TemplateDataExtension.php
@@ -67,6 +67,7 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
                 'minSearchLength' => $this->minSearchLength($context),
                 'showStagingBanner' => $this->showStagingBanner,
             ],
+            'themeId' => $themeId, /** Not used in Twig template directly, but in @see \Shopware\Storefront\Framework\Twig\Extension\ConfigExtension::getThemeId */
             'controllerName' => $controllerName,
             'controllerAction' => $controllerAction,
             'context' => $context,
@@ -75,8 +76,6 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
         ];
 
         if (!Feature::isActive('v6.7.0.0')) {
-            /** @deprecated tag:v6.7.0 - Will be removed as it is unused */
-            $globalTemplateData['themeId'] = $themeId;
             /** @deprecated tag:v6.7.0 - Will be removed, use shopware.showStagingBanner instead */
             $globalTemplateData['showStagingBanner'] = $this->showStagingBanner;
         }

--- a/src/Storefront/Pagelet/Footer/FooterPagelet.php
+++ b/src/Storefront/Pagelet/Footer/FooterPagelet.php
@@ -2,10 +2,32 @@
 
 namespace Shopware\Storefront\Pagelet\Footer;
 
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Category\Tree\Tree;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Pagelet\NavigationPagelet;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('storefront')]
 class FooterPagelet extends NavigationPagelet
 {
+    /**
+     * @deprecated tag:v6.7.0 - reason:new-optional-parameter - Parameter serviceMenu will be required
+     */
+    public function __construct(
+        ?Tree $navigation,
+        protected ?CategoryCollection $serviceMenu = null,
+    ) {
+        parent::__construct($navigation);
+    }
+
+    /**
+     * @deprecated tag:v6.7.0 - reason:return-type-change - Will only return CategoryCollection
+     */
+    public function getServiceMenu(): ?CategoryCollection
+    {
+        return $this->serviceMenu;
+    }
 }

--- a/src/Storefront/Pagelet/Footer/FooterPageletLoader.php
+++ b/src/Storefront/Pagelet/Footer/FooterPageletLoader.php
@@ -2,7 +2,9 @@
 
 namespace Shopware\Storefront\Pagelet\Footer;
 
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\Service\NavigationLoaderInterface;
+use Shopware\Core\Content\Category\Tree\TreeItem;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -34,12 +36,25 @@ class FooterPageletLoader implements FooterPageletLoaderInterface
             $tree = $this->navigationLoader->load($navigationId, $salesChannelContext, $footerId);
         }
 
-        $pagelet = new FooterPagelet($tree);
+        $pagelet = new FooterPagelet($tree, $this->getServiceMenu($salesChannelContext));
 
         $this->eventDispatcher->dispatch(
             new FooterPageletLoadedEvent($pagelet, $salesChannelContext, $request)
         );
 
         return $pagelet;
+    }
+
+    private function getServiceMenu(SalesChannelContext $context): CategoryCollection
+    {
+        $serviceId = $context->getSalesChannel()->getServiceCategoryId();
+
+        if ($serviceId === null) {
+            return new CategoryCollection();
+        }
+
+        $navigation = $this->navigationLoader->load($serviceId, $context, $serviceId, 1);
+
+        return new CategoryCollection(array_map(static fn (TreeItem $treeItem) => $treeItem->getCategory(), $navigation->getTree()));
     }
 }

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block base_html %}
-<html lang="{{ page.header.activeLanguage.translationCode.code }}"
+<html lang="{{ context.saleschannel.languages.first.translationCode.code }}"
       itemscope="itemscope"
       itemtype="https://schema.org/WebPage">
 {% endblock %}
@@ -93,7 +93,7 @@
                                     {% sw_include '@Storefront/storefront/layout/breadcrumb.html.twig' with {
                                         context: context,
                                         themeIconConfig: themeIconConfig,
-                                        category: page.product.seoCategory
+                                        categoryId: shopware.navigation.id,
                                     } only %}
                                 {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/component/review/review-login.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/review/review-login.html.twig
@@ -23,7 +23,7 @@
 
     <input type="hidden"
            name="redirectParameters"
-           value="{{ {productId: reviews.productId, id: cmsPage.id, navigationId: page.header.navigation.active.id}|json_encode }}">
+           value="{{ {productId: reviews.productId, id: cmsPage.id, navigationId: shopware.navigation.id}|json_encode }}">
 {% endblock %}
 
 {% block component_account_login_submit %}

--- a/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-form/form-types/contact-form.html.twig
@@ -134,7 +134,7 @@
                     <input type="hidden" id="{{ formPrefix }}-navigationId" name="navigationId" value="{{ page.navigationId }}">
                     <input type="hidden" id="{{ formPrefix }}-entityName" name="entityName" value="{{ page.entityName }}">
                 {% else %}
-                    <input type="hidden" id="{{ formPrefix }}-navigationId" name="navigationId" value="{{ page.header.navigation.active.id }}">
+                    <input type="hidden" id="{{ formPrefix }}-navigationId" name="navigationId" value="{{ shopware.navigation.id }}">
                 {% endif %}
 
                 <input type="hidden" id="{{ formPrefix }}-slotId" name="slotId" value="{{ element.id }}">

--- a/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/breadcrumb.html.twig
@@ -2,58 +2,59 @@
     {% if category %}
         {% set breadcrumbCategories = sw_breadcrumb_full(category, context.context) %}
         {% set categoryId = category.id %}
+    {% elseif categoryId %}
+        {% set breadcrumbCategories = sw_breadcrumb_full_by_id(categoryId, context.context) %}
+    {% else %}
+        {% return %}
+    {% endif %}
 
+    {% if breadcrumbCategories|length > 0 %}
         {% set breadcrumbKeys = breadcrumbCategories|keys %}
 
-        {% if breadcrumbCategories|length > 0 %}
-            <nav aria-label="breadcrumb">
-                {% block layout_breadcrumb_list %}
-                    <ol class="breadcrumb"
-                        itemscope
-                        itemtype="https://schema.org/BreadcrumbList">
-                        {% for breadcrumbCategory in breadcrumbCategories %}
-                            {% set key = breadcrumbCategory.id %}
-                            {% set name = breadcrumbCategory.translated.name %}
+        <nav aria-label="breadcrumb">
+            {% block layout_breadcrumb_list %}
+                <ol class="breadcrumb"
+                    itemscope
+                    itemtype="https://schema.org/BreadcrumbList">
+                    {% for breadcrumbCategory in breadcrumbCategories %}
+                        {% set key = breadcrumbCategory.id %}
+                        {% set name = breadcrumbCategory.translated.name %}
 
-                            {% block layout_breadcrumb_list_item %}
-                                <li class="breadcrumb-item"
-                                    {% if key is same as(categoryId) %}aria-current="page"{% endif %}
-                                    itemprop="itemListElement"
-                                    itemscope
-                                    itemtype="https://schema.org/ListItem">
-                                    {% if breadcrumbCategory.type == 'folder' %}
-                                        <div itemprop="item">
-                                            <div itemprop="name">{{ name }}</div>
-                                        </div>
-                                    {% else %}
-                                        <a href="{{ category_url(breadcrumbCategory) }}"
-                                           class="breadcrumb-link {% if key is same as(categoryId) %} is-active{% endif %}"
-                                           title="{{ name }}"
-                                           {% if category_linknewtab(breadcrumbCategory) %}target="_blank"{% endif %}
-                                           itemprop="item">
-                                            <link itemprop="url"
-                                                  href="{{ category_url(breadcrumbCategory) }}">
-                                            <span class="breadcrumb-title" itemprop="name">{{ name }}</span>
-                                        </a>
-                                    {% endif %}
-                                    <meta itemprop="position" content="{{ loop.index }}">
-                                </li>
-                            {% endblock %}
-
-                            {% block layout_breadcrumb_placeholder %}
-                                {% if key != breadcrumbKeys|last %}
-                                    <div
-                                        class="breadcrumb-placeholder"
-                                        aria-hidden="true"
-                                    >
-                                        {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid'} %}
+                        {% block layout_breadcrumb_list_item %}
+                            <li class="breadcrumb-item"
+                                {% if key is same as(categoryId) %}aria-current="page"{% endif %}
+                                itemprop="itemListElement"
+                                itemscope
+                                itemtype="https://schema.org/ListItem">
+                                {% if breadcrumbCategory.type == 'folder' %}
+                                    <div itemprop="item">
+                                        <div itemprop="name">{{ name }}</div>
                                     </div>
+                                {% else %}
+                                    <a href="{{ category_url(breadcrumbCategory) }}"
+                                       class="breadcrumb-link {% if key is same as(categoryId) %} is-active{% endif %}"
+                                       title="{{ name }}"
+                                       {% if category_linknewtab(breadcrumbCategory) %}target="_blank"{% endif %}
+                                       itemprop="item">
+                                        <link itemprop="url"
+                                              href="{{ category_url(breadcrumbCategory) }}">
+                                        <span class="breadcrumb-title" itemprop="name">{{ name }}</span>
+                                    </a>
                                 {% endif %}
-                            {% endblock %}
-                        {% endfor %}
-                    </ol>
-                {% endblock %}
-            </nav>
-        {% endif %}
+                                <meta itemprop="position" content="{{ loop.index }}">
+                            </li>
+                        {% endblock %}
+
+                        {% block layout_breadcrumb_placeholder %}
+                            {% if key != breadcrumbKeys|last %}
+                                <div class="breadcrumb-placeholder">
+                                    {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid', ariaHidden: true } %}
+                                </div>
+                            {% endif %}
+                        {% endblock %}
+                    {% endfor %}
+                </ol>
+            {% endblock %}
+        </nav>
     {% endif %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -1,3 +1,7 @@
+{% if not footer is defined and page is defined %}
+    {% set footer = page.footer %}
+{% endif %}
+
 {% block layout_footer_inner_container %}
     <div class="container">
         {% block layout_footer_navigation %}
@@ -56,7 +60,7 @@
                 {% endblock %}
 
                 {% block layout_footer_navigation_columns %}
-                    {% for root in page.footer.navigation.tree %}
+                    {% for root in footer.navigation.tree %}
                         {% block layout_footer_navigation_column %}
                             <div class="col-md-4 footer-column js-footer-column">
                                 {% block layout_footer_navigation_information_headline %}
@@ -188,7 +192,7 @@
                     {% block layout_footer_service_menu_content %}
                         {% apply spaceless %}
                             <ul class="footer-service-menu-list list-unstyled">
-                                {% for serviceMenuItem in page.header.serviceMenu %}
+                                {% for serviceMenuItem in footer.serviceMenu %}
                                     {% block layout_footer_service_menu_item %}
                                         <li class="footer-service-menu-item">
                                             <a class="footer-service-menu-link"

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/currency-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/currency-widget.html.twig
@@ -74,7 +74,7 @@
                             {% block layout_header_actions_currency_widget_form_redirect %}
                                 <input name="redirectTo"
                                        type="hidden"
-                                       value="{{ app.request.get('_route') }}">
+                                       value="{{ activeRoute }}">
 
                                 {% for key, value in app.request.attributes.get('_route_params') %}
                                     <input name="redirectParameters[{{ key }}]"

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/language-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/language-widget.html.twig
@@ -1,9 +1,13 @@
+{% if not header is defined and page is defined %}
+    {% set header = page.header %}
+{% endif %}
+
 {% block layout_header_actions_language_widget %}
     {% if position is empty %}
         {% set position = 'top-bar' %}
     {% endif %}
 
-    {% if page.header.languages.count > 1 %}
+    {% if header.languages.count > 1 %}
         <div class="top-bar-nav-item top-bar-language">
             {% block layout_header_actions_language_widget_form %}
                 <form method="post"
@@ -11,7 +15,7 @@
                       class="language-form"
                       data-form-auto-submit="true">
                     {% block layout_header_actions_language_widget_content %}
-                        {% set isoCode = page.header.activeLanguage.translationCode.code|lower|split('-') %}
+                        {% set isoCode = context.languageInfo.localeCode|lower|split('-') %}
                         {% set language = isoCode[0] %}
                         {% set country = isoCode[1] %}
 
@@ -22,17 +26,17 @@
                                     data-bs-toggle="dropdown"
                                     aria-haspopup="true"
                                     aria-expanded="false"
-                                    aria-label="{{ 'header.languageTrigger'|trans({ '%lang%': page.header.activeLanguage.name })|striptags }}">
+                                    aria-label="{{ 'header.languageTrigger'|trans({ '%lang%': context.languageInfo.name })|striptags }}">
                                 <span aria-hidden="true" class="top-bar-list-icon language-flag country-{{ country }} language-{{ language }}"></span>
                                 {# @deprecated tag:v6.7.0 - Toggling the text display will use Bootstrap helper classes instead of custom CSS. #}
-                                <span class="top-bar-nav-text{% if feature('ACCESSIBILITY_TWEAKS') %} d-none d-md-inline{% endif %}">{{ page.header.activeLanguage.name }}</span>
+                                <span class="top-bar-nav-text{% if feature('ACCESSIBILITY_TWEAKS') %} d-none d-md-inline{% endif %}">{{ context.languageInfo.name }}</span>
                             </button>
 
                             {% block layout_header_actions_languages_widget_form_items %}
                                 <ul class="top-bar-list dropdown-menu dropdown-menu-end"
                                     aria-label="{{ 'header.languageList'|trans|striptags }}">
-                                    {% for language in page.header.languages %}
-                                        {% set isActiveLanguage = language.id is same as(page.header.activeLanguage.id) %}
+                                    {% for language in header.languages %}
+                                        {% set isActiveLanguage = language.id is same as(context.context.languageId) %}
 
                                         {# @deprecated tag:v6.7.0 - `dropdown-item` class will be on the button as docuented by Bootstrap: https://getbootstrap.com/docs/5.3/components/dropdowns/#menu-items #}
                                         {# @deprecated tag:v6.7.0 - `item-checked` class will be removed. Bootstrap class `active` will be used instead. #}
@@ -72,7 +76,7 @@
                             {% endblock %}
                         </div>
 
-                        <input name="redirectTo" type="hidden" value="{{ app.request.get('_route') }}">
+                        <input name="redirectTo" type="hidden" value="{{ activeRoute }}">
 
                         {% for key, value in app.request.attributes.get('_route_params') %}
                             <input name="redirectParameters[{{ key }}]" type="hidden" value="{{ value }}">

--- a/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search.html.twig
@@ -1,6 +1,4 @@
-{% set searchWidgetOptions = {
-    searchWidgetMinChars: page.header.activeLanguage.productSearchConfig.minSearchLength ?: 3
-} %}
+{% set searchWidgetOptions = { searchWidgetMinChars: shopware.minSearchLength } %}
 
 {% block layout_header_search %}
     <div class="collapse"

--- a/src/Storefront/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/meta.html.twig
@@ -149,7 +149,7 @@
         {% block layout_head_javascript_router %}
             {# Register all routes that will be needed in JavaScript to the window.router object #}
             <script>
-                window.activeNavigationId = '{{ page.header.navigation.active.id }}';
+                window.activeNavigationId = '{{ shopware.navigation.id }}';
                 window.router = {
                     'frontend.cart.offcanvas': '{{ path('frontend.cart.offcanvas') }}',
                     'frontend.cookie.offcanvas': '{{ path('frontend.cookie.offcanvas') }}',
@@ -162,7 +162,7 @@
                     'frontend.country.country-data': '{{ path('frontend.country.country.data') }}',
                     'frontend.app-system.generate-token': '{{ path('frontend.app-system.generate-token', { name: 'Placeholder' }) }}',
                     };
-                window.salesChannelId = '{{ app.request.attributes.get('sw-sales-channel-id') }}';
+                window.salesChannelId = '{{ context.salesChannelId }}';
             </script>
         {% endblock %}
 

--- a/src/Storefront/Resources/views/storefront/layout/navbar/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navbar/categories.html.twig
@@ -4,9 +4,9 @@
     {% if not level %}
         {% set level = 0 %}
     {% endif %}
-    {% set activeId = page.header.navigation.active.id %}
+    {% set activeId = shopware.navigation.id %}
 
-    {% set activePath = page.header.navigation.active.path %}
+    {% set activePath = shopware.navigation.path %}
 
     <div class="{% if level == 0 %}row {% endif %}navigation-flyout-categories is-level-{{ level }}">
         {% for treeItem in navigationTree %}

--- a/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig
@@ -1,3 +1,7 @@
+{% if not header is defined and page is defined %}
+    {% set header = page.header %}
+{% endif %}
+
 {% block layout_navbar %}
     <div class="container">
         <nav class="navbar navbar-expand-lg main-navigation-menu"
@@ -26,9 +30,9 @@
                         {% endblock %}
 
                         {% block layout_navbar_menu_items %}
-                            {% set activePath = page.header.navigation.active.path %}
+                            {% set activePath = shopware.navigation.path %}
 
-                            {% for treeItem in page.header.navigation.tree %}
+                            {% for treeItem in header.navigation.tree %}
                                 {% set category = treeItem.category %}
                                 {% set name = category.translated.name %}
 
@@ -45,7 +49,7 @@
                                         </li>
                                     {% else %}
                                         <li class="nav-item {% if treeItem.children|length > 0 %}dropdown position-static pe-2{% endif %}">
-                                            <a class="nav-link dropdown-toggle main-navigation-link{% if category.id == page.header.navigation.active.id or category.id in activePath %} active{% endif %} p-2"
+                                            <a class="nav-link dropdown-toggle main-navigation-link{% if category.id == shopware.navigation.id or category.id in activePath %} active{% endif %} p-2"
                                                href="{{ category_url(category) }}"
                                                data-bs-toggle="dropdown"
                                                itemprop="url"

--- a/src/Storefront/Resources/views/storefront/layout/navigation/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/categories.html.twig
@@ -5,9 +5,9 @@
     {% if not level %}
         {% set level = 0 %}
     {% endif %}
-    {% set activeId = page.header.navigation.active.id %}
+    {% set activeId = shopware.navigation.id %}
 
-    {% set activePath = page.header.navigation.active.path %}
+    {% set activePath = shopware.navigation.path %}
 
     <div class="{% if level == 0 %}row {% endif %}navigation-flyout-categories is-level-{{ level }}">
         {% for treeItem in navigationTree %}

--- a/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
@@ -1,4 +1,8 @@
 {# @deprecated tag:v6.7.0 - This template will be removed, use src/Storefront/Resources/views/storefront/layout/navbar/navbar.html.twig #}
+{% if not header is defined and page is defined %}
+    {% set header = page.header %}
+{% endif %}
+
 {% block layout_main_navigation %}
     <div class="main-navigation"
          id="mainNavigation"
@@ -27,9 +31,9 @@
                         {% endblock %}
 
                         {% block layout_main_navigation_menu_items %}
-                            {% set activePath = page.header.navigation.active.path %}
+                            {% set activePath = shopware.navigation.path %}
 
-                            {% for treeItem in page.header.navigation.tree %}
+                            {% for treeItem in header.navigation.tree %}
                                 {% set category = treeItem.category %}
                                 {% set name = category.translated.name %}
 
@@ -45,7 +49,12 @@
                                             </div>
                                         </div>
                                     {% else %}
-                                        <a class="nav-link main-navigation-link nav-item-{{ category.id}} {% if category.id == page.header.navigation.active.id or category.id in activePath %} active{% endif %}"
+                                        {% set active = '' %}
+                                        {% if category.id == shopware.navigation.id or category.id in activePath %}
+                                            {% set active = 'active' %}
+                                        {% endif %}
+
+                                        <a class="nav-link main-navigation-link nav-item-{{ category.id}} {{ active }}"
                                            href="{{ category_url(category) }}"
                                            itemprop="url"
                                            {% if treeItem.children|length > 0 %}data-flyout-menu-trigger="{{ category.id }}"{% endif %}
@@ -80,7 +89,7 @@
                 {% if not feature('ACCESSIBILITY_TWEAKS') %}
                 {% block layout_main_navigation_menu_flyout_wrapper %}
                     {% set navigationChildrenCount = 0 %}
-                    {% for treeItem in page.header.navigation.tree %}
+                    {% for treeItem in header.navigation.tree %}
                         {% if treeItem.category.childCount > 0 %}
                             {% set navigationChildrenCount = navigationChildrenCount + 1 %}
                         {% endif %}
@@ -90,7 +99,7 @@
                         {% block layout_main_navigation_menu_flyout_container %}
                             <div class="navigation-flyouts">
                                 {% block layout_main_navigation_menu_flyouts %}
-                                    {% for treeItem in page.header.navigation.tree %}
+                                    {% for treeItem in header.navigation.tree %}
                                         {% if treeItem.children|length > 0 %}
                                             {% block layout_main_navigation_menu_flyout %}
                                                 <div class="navigation-flyout"

--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/categories.html.twig
@@ -18,7 +18,7 @@
             {% endif %}
 
             <ul class="list-unstyled navigation-offcanvas-list">
-                {% if not isRoot and page.navigation.active.type != 'folder' %}
+                {% if not isRoot and active.type != 'folder' %}
                     {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/show-active-link.html.twig' with { item: active } %}
                 {% endif %}
 

--- a/src/Storefront/Resources/views/storefront/page/content/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/content/index.html.twig
@@ -9,7 +9,7 @@
                     {% sw_include '@Storefront/storefront/layout/breadcrumb.html.twig' with {
                         context: context,
                         themeIconConfig: themeIconConfig,
-                        category: page.header.navigation.active
+                        categoryId: shopware.navigation.id,
                     } only %}
                 </div>
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/utilities/staging-info.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/staging-info.html.twig
@@ -1,5 +1,5 @@
 {% block staging_info %}
-    {% if showStagingBanner and config('core.staging') %}
+    {% if shopware.showStagingBanner and config('core.staging') %}
         <div class="storefront-staging-info bg-secondary text-white sticky-top z-index-1000 d-flex justify-content-center align-items-center p-3">
             {% sw_icon 'eye-open' style { class : 'flex-shrink-0 me-2'} %}
 

--- a/tests/unit/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtensionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Extension/BuildBreadcrumbExtensionTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig\Extension;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Category\Service\CategoryBreadcrumbBuilder;
+use Shopware\Core\Framework\Adapter\Twig\Extension\BuildBreadcrumbExtension;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+
+/**
+ * @internal
+ */
+#[CoversClass(BuildBreadcrumbExtension::class)]
+class BuildBreadcrumbExtensionTest extends TestCase
+{
+    public function testGetFunctions(): void
+    {
+        $functions = $this->getBuildBreadcrumbExtension()->getFunctions();
+
+        static::assertSame('sw_breadcrumb_full', $functions[0]->getName());
+        static::assertSame('sw_breadcrumb_full_by_id', $functions[1]->getName());
+    }
+
+    public function testGetFullBreadcrumbNoSeoBreadCrumb(): void
+    {
+        $salesChannelContext = Generator::createSalesChannelContext();
+
+        $breadCrumb = $this->getBuildBreadcrumbExtension()
+            ->getFullBreadcrumb(['context' => $salesChannelContext], new CategoryEntity(), $salesChannelContext->getContext());
+
+        static::assertSame([], $breadCrumb);
+    }
+
+    public function testGetFullBreadcrumbWithEmptySeoBreadCrumb(): void
+    {
+        $salesChannelContext = Generator::createSalesChannelContext();
+
+        $categoryBreadcrumbBuilder = $this->createMock(CategoryBreadcrumbBuilder::class);
+        $categoryBreadcrumbBuilder->method('build')->willReturn([]);
+
+        $breadCrumb = $this->getBuildBreadcrumbExtension($categoryBreadcrumbBuilder)
+            ->getFullBreadcrumb(['context' => $salesChannelContext], new CategoryEntity(), $salesChannelContext->getContext());
+
+        static::assertSame([], $breadCrumb);
+    }
+
+    public function testGetFullBreadcrumbWithSeoBreadCrumb(): void
+    {
+        $salesChannelContext = Generator::createSalesChannelContext();
+        $categoryId = Uuid::randomHex();
+        $notConsideredCategoryId = Uuid::randomHex();
+
+        $categoryBreadcrumbBuilder = $this->createMock(CategoryBreadcrumbBuilder::class);
+        $categoryBreadcrumbBuilder->method('build')->willReturn([$categoryId => 'Home', $notConsideredCategoryId => 'Not considered']);
+
+        $breadCrumb = $this->getBuildBreadcrumbExtension($categoryBreadcrumbBuilder, $categoryId)
+            ->getFullBreadcrumb(['context' => $salesChannelContext], new CategoryEntity(), $salesChannelContext->getContext());
+
+        static::assertArrayHasKey($categoryId, $breadCrumb);
+        static::assertInstanceOf(CategoryEntity::class, $breadCrumb[$categoryId]);
+        static::assertArrayNotHasKey($notConsideredCategoryId, $breadCrumb);
+    }
+
+    public function testGetFullBreadcrumbByIdWithNonExistingCategoryId(): void
+    {
+        $salesChannelContext = Generator::createSalesChannelContext();
+
+        $breadCrumb = $this->getBuildBreadcrumbExtension()
+            ->getFullBreadcrumbById(['context' => $salesChannelContext], Uuid::randomHex(), $salesChannelContext->getContext());
+
+        static::assertSame([], $breadCrumb);
+    }
+
+    public function testGetFullBreadcrumbById(): void
+    {
+        $salesChannelContext = Generator::createSalesChannelContext();
+        $categoryId = Uuid::randomHex();
+        $notConsideredCategoryId = Uuid::randomHex();
+
+        $categoryBreadcrumbBuilder = $this->createMock(CategoryBreadcrumbBuilder::class);
+        $categoryBreadcrumbBuilder->method('build')->willReturn([$categoryId => 'Home', $notConsideredCategoryId => 'Not considered']);
+
+        $breadCrumb = $this->getBuildBreadcrumbExtension($categoryBreadcrumbBuilder, $categoryId)
+            ->getFullBreadcrumbById(['context' => $salesChannelContext], $categoryId, $salesChannelContext->getContext());
+
+        static::assertArrayHasKey($categoryId, $breadCrumb);
+        static::assertInstanceOf(CategoryEntity::class, $breadCrumb[$categoryId]);
+        static::assertArrayNotHasKey($notConsideredCategoryId, $breadCrumb);
+    }
+
+    private function getBuildBreadcrumbExtension(?CategoryBreadcrumbBuilder $categoryBreadcrumbBuilder = null, ?string $categoryId = null): BuildBreadcrumbExtension
+    {
+        $categoryBreadcrumbBuilder ??= $this->createMock(CategoryBreadcrumbBuilder::class);
+
+        $categories = new CategoryCollection();
+        if ($categoryId !== null) {
+            $category = new CategoryEntity();
+            $category->setUniqueIdentifier($categoryId);
+            $categories->add($category);
+        }
+
+        $entitySearchResult = new EntitySearchResult(
+            CategoryDefinition::ENTITY_NAME,
+            1,
+            $categories,
+            null,
+            new Criteria(),
+            Context::createDefaultContext(),
+        );
+
+        /** @var StaticEntityRepository<CategoryCollection> $categoryRepository */
+        $categoryRepository = new StaticEntityRepository([
+            $entitySearchResult, clone $entitySearchResult,
+        ]);
+
+        return new BuildBreadcrumbExtension($categoryBreadcrumbBuilder, $categoryRepository);
+    }
+}

--- a/tests/unit/Core/Framework/Adapter/Twig/Extension/TemplateDataExtensionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Extension/TemplateDataExtensionTest.php
@@ -77,6 +77,9 @@ class TemplateDataExtensionTest extends TestCase
         static::assertArrayHasKey('showStagingBanner', $globals['shopware']);
         static::assertTrue($globals['shopware']['showStagingBanner']);
 
+        static::assertArrayHasKey('themeId', $globals);
+        static::assertSame($themeId, $globals['themeId']);
+
         static::assertArrayHasKey('controllerName', $globals);
         static::assertSame('Navigation', $globals['controllerName']);
         static::assertArrayHasKey('controllerAction', $globals);

--- a/tests/unit/Core/Framework/Adapter/Twig/Extension/TemplateDataExtensionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Extension/TemplateDataExtensionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig\Extension;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\SalesChannelRequest;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\Doctrine\FakeConnection;
+use Shopware\Storefront\Controller\NavigationController;
+use Shopware\Storefront\Framework\Twig\NavigationInfo;
+use Shopware\Storefront\Framework\Twig\TemplateDataExtension;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @internal
+ */
+#[CoversClass(TemplateDataExtension::class)]
+class TemplateDataExtensionTest extends TestCase
+{
+    public function testGetGlobalsWithoutRequest(): void
+    {
+        $globals = (new TemplateDataExtension(
+            new RequestStack(),
+            true,
+            new FakeConnection([])
+        ))->getGlobals();
+
+        static::assertSame([], $globals);
+    }
+
+    public function testGetGlobalsWithoutSalesChannelContextInRequest(): void
+    {
+        $globals = (new TemplateDataExtension(
+            new RequestStack([new Request()]),
+            true,
+            new FakeConnection([])
+        ))->getGlobals();
+
+        static::assertSame([], $globals);
+    }
+
+    public function testGetGlobals(): void
+    {
+        $salesChannelContext = Generator::createSalesChannelContext();
+        $activeRoute = 'frontend.home.page';
+        $controller = NavigationController::class;
+        $themeId = Uuid::randomHex();
+        $expectedMinSearchLength = 3;
+
+        $request = new Request(attributes: [
+            PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT => $salesChannelContext,
+            '_route' => $activeRoute,
+            '_controller' => $controller . '::index',
+            SalesChannelRequest::ATTRIBUTE_THEME_ID => $themeId,
+        ]);
+
+        $globals = (new TemplateDataExtension(
+            new RequestStack([$request]),
+            true,
+            new FakeConnection([['minSearchLength' => (string) $expectedMinSearchLength]])
+        ))->getGlobals();
+
+        static::assertArrayHasKey('shopware', $globals);
+        static::assertArrayHasKey('dateFormat', $globals['shopware']);
+        static::assertSame('Y-m-d\TH:i:sP', $globals['shopware']['dateFormat']);
+        static::assertArrayHasKey('navigation', $globals['shopware']);
+        static::assertInstanceOf(NavigationInfo::class, $globals['shopware']['navigation']);
+        static::assertSame($salesChannelContext->getSalesChannel()->getNavigationCategoryId(), $globals['shopware']['navigation']->id);
+        static::assertArrayHasKey('minSearchLength', $globals['shopware']);
+        static::assertSame($expectedMinSearchLength, $globals['shopware']['minSearchLength']);
+        static::assertArrayHasKey('showStagingBanner', $globals['shopware']);
+        static::assertTrue($globals['shopware']['showStagingBanner']);
+
+        static::assertArrayHasKey('controllerName', $globals);
+        static::assertSame('Navigation', $globals['controllerName']);
+        static::assertArrayHasKey('controllerAction', $globals);
+        static::assertSame('index', $globals['controllerAction']);
+
+        static::assertArrayHasKey('context', $globals);
+        static::assertSame($salesChannelContext, $globals['context']);
+
+        static::assertArrayHasKey('activeRoute', $globals);
+        static::assertSame($activeRoute, $globals['activeRoute']);
+
+        static::assertArrayHasKey('formViolations', $globals);
+        static::assertNull($globals['formViolations']);
+    }
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\SalesChannel\Context\LanguageInfo;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\Tax\TaxCollection;
@@ -157,7 +158,8 @@ class DummyContext extends SalesChannelContext
             new CustomerEntity(),
             new CashRoundingConfig(2, 0.01, true),
             new CashRoundingConfig(2, 0.01, true),
-            []
+            [],
+            new LanguageInfo('English', 'en-GB'),
         );
     }
 

--- a/tests/unit/Core/System/SalesChannel/Context/BaseContextFactoryTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/BaseContextFactoryTest.php
@@ -24,6 +24,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateCollection;
 use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateDefinition;
+use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateEntity;
 use Shopware\Core\System\Country\CountryCollection;
 use Shopware\Core\System\Country\CountryDefinition;
 use Shopware\Core\System\Country\CountryEntity;
@@ -32,6 +33,9 @@ use Shopware\Core\System\Currency\Aggregate\CurrencyCountryRounding\CurrencyCoun
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Currency\CurrencyDefinition;
 use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\Language\LanguageEntity;
+use Shopware\Core\System\Locale\LocaleEntity;
 use Shopware\Core\System\SalesChannel\Context\BaseContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
@@ -66,14 +70,23 @@ class BaseContextFactoryTest extends TestCase
             $this->expectExceptionMessage($exceptionMessage);
         }
 
+        /** @var StaticEntityRepository<CurrencyCollection> $currencyRepository */
         $currencyRepository = new StaticEntityRepository([new CurrencyCollection($entitySearchResult[CurrencyDefinition::ENTITY_NAME] ?? [])]);
+        /** @var StaticEntityRepository<CustomerGroupCollection> $customerGroupRepository */
         $customerGroupRepository = new StaticEntityRepository([new CustomerGroupCollection($entitySearchResult[CustomerGroupDefinition::ENTITY_NAME] ?? [])]);
+        /** @var StaticEntityRepository<CountryCollection> $countryRepository */
         $countryRepository = new StaticEntityRepository([new CountryCollection($entitySearchResult[CountryDefinition::ENTITY_NAME] ?? [])]);
+        /** @var StaticEntityRepository<TaxCollection> $taxRepository */
         $taxRepository = new StaticEntityRepository([new TaxCollection($entitySearchResult[TaxDefinition::ENTITY_NAME] ?? [])]);
+        /** @var StaticEntityRepository<PaymentMethodCollection> $paymentMethodRepository */
         $paymentMethodRepository = new StaticEntityRepository([new PaymentMethodCollection($entitySearchResult[PaymentMethodDefinition::ENTITY_NAME] ?? [])]);
+        /** @var StaticEntityRepository<ShippingMethodCollection> $shippingMethodRepository */
         $shippingMethodRepository = new StaticEntityRepository([new ShippingMethodCollection($entitySearchResult[ShippingMethodDefinition::ENTITY_NAME] ?? [])]);
+        /** @var StaticEntityRepository<SalesChannelCollection> $salesChannelRepository */
         $salesChannelRepository = new StaticEntityRepository([new SalesChannelCollection($entitySearchResult[SalesChannelDefinition::ENTITY_NAME] ?? [])]);
+        /** @var StaticEntityRepository<CountryStateCollection> $countryStateRepository */
         $countryStateRepository = new StaticEntityRepository([new CountryStateCollection($entitySearchResult[CountryStateDefinition::ENTITY_NAME] ?? [])]);
+        /** @var StaticEntityRepository<CurrencyCountryRoundingCollection> $currencyCountryRepository */
         $currencyCountryRepository = new StaticEntityRepository([new CurrencyCountryRoundingCollection($entitySearchResult[CurrencyCountryRoundingDefinition::ENTITY_NAME] ?? [])]);
 
         $connection = $this->createMock(Connection::class);
@@ -124,12 +137,25 @@ class BaseContextFactoryTest extends TestCase
         $currencyId = Uuid::randomHex();
         $countryStateId = Uuid::randomHex();
         $countryId = Uuid::randomHex();
+        $anotherLanguageId = Uuid::randomHex();
+
+        $locale = new LocaleEntity();
+        $locale->setCode('en-GB');
+
+        $language = new LanguageEntity();
+        $language->setId(Defaults::LANGUAGE_SYSTEM);
+        $language->setUniqueIdentifier(Defaults::LANGUAGE_SYSTEM);
+        $language->setName('English');
+        $language->setLocale($locale);
+        $language->setTranslationCode($locale);
 
         $salesChannelEntity = new SalesChannelEntity();
         $salesChannelEntity->setUniqueIdentifier(TestDefaults::SALES_CHANNEL);
         $salesChannelEntity->setCustomerGroupId($customerGroupId);
         $salesChannelEntity->setPaymentMethodId($paymentMethodId);
         $salesChannelEntity->setShippingMethodId($shippingMethodId);
+        $salesChannelEntity->setLanguages(new LanguageCollection([$language]));
+        $salesChannelEntity->setCurrencyId(Defaults::CURRENCY);
 
         $currency = new CurrencyEntity();
         $rounding = new CashRoundingConfig(1, 1, true);
@@ -142,6 +168,10 @@ class BaseContextFactoryTest extends TestCase
         $country = new CountryEntity();
         $country->setUniqueIdentifier($countryId);
         $country->setId($countryId);
+
+        $countryState = new CountryStateEntity();
+        $countryState->setUniqueIdentifier($countryStateId);
+        $countryState->setCountryId($countryId);
 
         $paymentMethod = new PaymentMethodEntity();
         $paymentMethod->setUniqueIdentifier($paymentMethodId);
@@ -184,7 +214,7 @@ class BaseContextFactoryTest extends TestCase
             ],
             'fetchParentLanguageResult' => false,
             'entitySearchResult' => [],
-            'exceptionMessage' => 'Provided languageId is not a valid uuid',
+            'exceptionMessage' => 'Provided language ID is not a valid UUID',
         ];
 
         yield 'language id not found' => [
@@ -215,6 +245,26 @@ class BaseContextFactoryTest extends TestCase
             'exceptionMessage' => \sprintf('Sales channel with id "%s" not found or not valid!.', TestDefaults::SALES_CHANNEL),
         ];
 
+        yield 'currency id is not uuid' => [
+            'options' => [
+                SalesChannelContextService::LANGUAGE_ID => Defaults::LANGUAGE_SYSTEM,
+                SalesChannelContextService::CURRENCY_ID => 'not-an-uuid',
+            ],
+            'fetchDataResult' => [
+                'sales_channel_default_language_id' => Uuid::randomBytes(),
+                'sales_channel_currency_factor' => 1,
+                'sales_channel_currency_id' => Uuid::randomBytes(),
+                'sales_channel_language_ids' => Defaults::LANGUAGE_SYSTEM,
+            ],
+            'fetchParentLanguageResult' => false,
+            'entitySearchResult' => [
+                SalesChannelDefinition::ENTITY_NAME => [
+                    TestDefaults::SALES_CHANNEL => $salesChannelEntity,
+                ],
+            ],
+            'exceptionMessage' => 'Provided currency ID is not a valid UUID',
+        ];
+
         yield 'currency not found' => [
             'options' => [
                 SalesChannelContextService::LANGUAGE_ID => Defaults::LANGUAGE_SYSTEM,
@@ -233,6 +283,76 @@ class BaseContextFactoryTest extends TestCase
                 ],
             ],
             'exceptionMessage' => 'Could not find currency with id "3ebb5fe2e29a4d70aa5854ce7ce3e20b"',
+        ];
+
+        yield 'currency not set in options and not in sales channel' => [
+            'options' => [
+                SalesChannelContextService::LANGUAGE_ID => Defaults::LANGUAGE_SYSTEM,
+            ],
+            'fetchDataResult' => [
+                'sales_channel_default_language_id' => Uuid::randomBytes(),
+                'sales_channel_currency_factor' => 1,
+                'sales_channel_currency_id' => Uuid::randomBytes(),
+                'sales_channel_language_ids' => Defaults::LANGUAGE_SYSTEM,
+            ],
+            'fetchParentLanguageResult' => false,
+            'entitySearchResult' => [
+                SalesChannelDefinition::ENTITY_NAME => [
+                    TestDefaults::SALES_CHANNEL => $salesChannelEntity,
+                ],
+            ],
+            'exceptionMessage' => 'Could not find currency with id "b7d2554b0ce847cd82f3ac9bd1c0dfca"',
+        ];
+
+        yield 'customer group not found' => [
+            'options' => [
+                SalesChannelContextService::LANGUAGE_ID => Defaults::LANGUAGE_SYSTEM,
+                SalesChannelContextService::CURRENCY_ID => $currencyId,
+                SalesChannelContextService::COUNTRY_ID => $countryId,
+            ],
+            'fetchDataResult' => [
+                'sales_channel_default_language_id' => Uuid::randomBytes(),
+                'sales_channel_currency_factor' => 1,
+                'sales_channel_currency_id' => Uuid::randomBytes(),
+                'sales_channel_language_ids' => Defaults::LANGUAGE_SYSTEM,
+            ],
+            'fetchParentLanguageResult' => false,
+            'entitySearchResult' => [
+                SalesChannelDefinition::ENTITY_NAME => [
+                    TestDefaults::SALES_CHANNEL => $salesChannelEntity,
+                ],
+                CurrencyDefinition::ENTITY_NAME => [
+                    $currencyId => $currency,
+                ],
+                CountryDefinition::ENTITY_NAME => [
+                    $countryId => $country,
+                ],
+            ],
+            'exceptionMessage' => \sprintf('Could not find customer group with id "%s"', $customerGroupId),
+        ];
+
+        yield 'country state id is not uuid' => [
+            'options' => [
+                SalesChannelContextService::LANGUAGE_ID => Defaults::LANGUAGE_SYSTEM,
+                SalesChannelContextService::CURRENCY_ID => $currencyId,
+                SalesChannelContextService::COUNTRY_STATE_ID => 'not-an-uuid',
+            ],
+            'fetchDataResult' => [
+                'sales_channel_default_language_id' => Uuid::randomBytes(),
+                'sales_channel_currency_factor' => 1,
+                'sales_channel_currency_id' => Uuid::randomBytes(),
+                'sales_channel_language_ids' => Defaults::LANGUAGE_SYSTEM,
+            ],
+            'fetchParentLanguageResult' => false,
+            'entitySearchResult' => [
+                SalesChannelDefinition::ENTITY_NAME => [
+                    TestDefaults::SALES_CHANNEL => $salesChannelEntity,
+                ],
+                CurrencyDefinition::ENTITY_NAME => [
+                    $currencyId => $currency,
+                ],
+            ],
+            'exceptionMessage' => 'Provided country state ID is not a valid UUID',
         ];
 
         yield 'country state not found' => [
@@ -257,6 +377,57 @@ class BaseContextFactoryTest extends TestCase
                 ],
             ],
             'exceptionMessage' => \sprintf('Could not find country state with id "%s"', $countryStateId),
+        ];
+
+        yield 'country not found if country state ID is given' => [
+            'options' => [
+                SalesChannelContextService::LANGUAGE_ID => Defaults::LANGUAGE_SYSTEM,
+                SalesChannelContextService::CURRENCY_ID => $currencyId,
+                SalesChannelContextService::COUNTRY_STATE_ID => $countryStateId,
+            ],
+            'fetchDataResult' => [
+                'sales_channel_default_language_id' => Uuid::randomBytes(),
+                'sales_channel_currency_factor' => 1,
+                'sales_channel_currency_id' => Uuid::randomBytes(),
+                'sales_channel_language_ids' => Defaults::LANGUAGE_SYSTEM,
+            ],
+            'fetchParentLanguageResult' => false,
+            'entitySearchResult' => [
+                SalesChannelDefinition::ENTITY_NAME => [
+                    TestDefaults::SALES_CHANNEL => $salesChannelEntity,
+                ],
+                CurrencyDefinition::ENTITY_NAME => [
+                    $currencyId => $currency,
+                ],
+                CountryStateDefinition::ENTITY_NAME => [
+                    $countryStateId => $countryState,
+                ],
+            ],
+            'exceptionMessage' => \sprintf('Could not find country with id "%s"', $countryId),
+        ];
+
+        yield 'country id is not uuid' => [
+            'options' => [
+                SalesChannelContextService::LANGUAGE_ID => Defaults::LANGUAGE_SYSTEM,
+                SalesChannelContextService::CURRENCY_ID => $currencyId,
+                SalesChannelContextService::COUNTRY_ID => 'not-an-uuid',
+            ],
+            'fetchDataResult' => [
+                'sales_channel_default_language_id' => Uuid::randomBytes(),
+                'sales_channel_currency_factor' => 1,
+                'sales_channel_currency_id' => Uuid::randomBytes(),
+                'sales_channel_language_ids' => Defaults::LANGUAGE_SYSTEM,
+            ],
+            'fetchParentLanguageResult' => false,
+            'entitySearchResult' => [
+                SalesChannelDefinition::ENTITY_NAME => [
+                    TestDefaults::SALES_CHANNEL => $salesChannelEntity,
+                ],
+                CurrencyDefinition::ENTITY_NAME => [
+                    $currencyId => $currency,
+                ],
+            ],
+            'exceptionMessage' => 'Provided country ID is not a valid UUID',
         ];
 
         yield 'country not found' => [
@@ -306,8 +477,80 @@ class BaseContextFactoryTest extends TestCase
                 CountryDefinition::ENTITY_NAME => [
                     $countryId => $country,
                 ],
+                CustomerGroupDefinition::ENTITY_NAME => [
+                    $customerGroupId => $customerGroup,
+                ],
             ],
             'exceptionMessage' => \sprintf('Could not find payment method with id "%s"', $paymentMethodId),
+        ];
+
+        yield 'shipping method not found' => [
+            'options' => [
+                SalesChannelContextService::LANGUAGE_ID => Defaults::LANGUAGE_SYSTEM,
+                SalesChannelContextService::CURRENCY_ID => $currencyId,
+                SalesChannelContextService::COUNTRY_ID => $countryId,
+            ],
+            'fetchDataResult' => [
+                'sales_channel_default_language_id' => Uuid::randomBytes(),
+                'sales_channel_currency_factor' => 1,
+                'sales_channel_currency_id' => Uuid::randomBytes(),
+                'sales_channel_language_ids' => Defaults::LANGUAGE_SYSTEM,
+            ],
+            'fetchParentLanguageResult' => false,
+            'entitySearchResult' => [
+                SalesChannelDefinition::ENTITY_NAME => [
+                    TestDefaults::SALES_CHANNEL => $salesChannelEntity,
+                ],
+                CurrencyDefinition::ENTITY_NAME => [
+                    $currencyId => $currency,
+                ],
+                CountryDefinition::ENTITY_NAME => [
+                    $countryId => $country,
+                ],
+                PaymentMethodDefinition::ENTITY_NAME => [
+                    $paymentMethodId => $paymentMethod,
+                ],
+                CustomerGroupDefinition::ENTITY_NAME => [
+                    $customerGroupId => $customerGroup,
+                ],
+            ],
+            'exceptionMessage' => \sprintf('Could not find shipping method with id "%s"', $shippingMethodId),
+        ];
+
+        yield 'missing sales channel language' => [
+            'options' => [
+                SalesChannelContextService::LANGUAGE_ID => $anotherLanguageId,
+                SalesChannelContextService::CURRENCY_ID => $currencyId,
+                SalesChannelContextService::COUNTRY_ID => $countryId,
+            ],
+            'fetchDataResult' => [
+                'sales_channel_default_language_id' => Uuid::randomBytes(),
+                'sales_channel_currency_factor' => 1,
+                'sales_channel_currency_id' => Uuid::randomBytes(),
+                'sales_channel_language_ids' => Defaults::LANGUAGE_SYSTEM . ',' . $anotherLanguageId,
+            ],
+            'fetchParentLanguageResult' => Defaults::LANGUAGE_SYSTEM,
+            'entitySearchResult' => [
+                SalesChannelDefinition::ENTITY_NAME => [
+                    TestDefaults::SALES_CHANNEL => $salesChannelEntity,
+                ],
+                CurrencyDefinition::ENTITY_NAME => [
+                    $currencyId => $currency,
+                ],
+                CountryDefinition::ENTITY_NAME => [
+                    $countryId => $country,
+                ],
+                PaymentMethodDefinition::ENTITY_NAME => [
+                    $paymentMethodId => $paymentMethod,
+                ],
+                ShippingMethodDefinition::ENTITY_NAME => [
+                    $shippingMethodId => $shippingMethod,
+                ],
+                CustomerGroupDefinition::ENTITY_NAME => [
+                    $customerGroupId => $customerGroup,
+                ],
+            ],
+            'exceptionMessage' => \sprintf('Could not find language with id "%s"', $anotherLanguageId),
         ];
 
         yield 'create base context successfully' => [

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextFactoryTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextFactoryTest.php
@@ -30,6 +30,7 @@ use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\SalesChannel\BaseContext;
 use Shopware\Core\System\SalesChannel\Context\AbstractBaseContextFactory;
+use Shopware\Core\System\SalesChannel\Context\LanguageInfo;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -83,8 +84,10 @@ class SalesChannelContextFactoryTest extends TestCase
             new ShippingLocation($country, null, null),
             new CashRoundingConfig(2, 0.01, true),
             new CashRoundingConfig(2, 0.01, true),
+            new LanguageInfo('English', 'en-GB'),
         );
 
+        /** @var StaticEntityRepository<PaymentMethodCollection> $paymentMethodRepository */
         $paymentMethodRepository = new StaticEntityRepository(
             [
                 static function (Criteria $criteria, Context $context) use ($baseContext) {
@@ -107,6 +110,7 @@ class SalesChannelContextFactoryTest extends TestCase
             new PaymentMethodDefinition(),
         );
 
+        /** @var StaticEntityRepository<CustomerCollection> $customerRepository */
         $customerRepository = new StaticEntityRepository(
             [
                 static function (Criteria $criteria, Context $context) use ($customer) {
@@ -123,6 +127,7 @@ class SalesChannelContextFactoryTest extends TestCase
             new CustomerDefinition(),
         );
 
+        /** @var StaticEntityRepository<CustomerAddressCollection> $addressRepository */
         $addressRepository = new StaticEntityRepository(
             [
                 static function (Criteria $criteria, Context $context) use ($addresses) {

--- a/tests/unit/Core/System/SalesChannel/SalesChannelExceptionTest.php
+++ b/tests/unit/Core/System/SalesChannel/SalesChannelExceptionTest.php
@@ -48,7 +48,7 @@ class SalesChannelExceptionTest extends TestCase
             'exception' => SalesChannelException::invalidLanguageId(),
             'statusCode' => Response::HTTP_PRECONDITION_FAILED,
             'errorCode' => SalesChannelException::LANGUAGE_INVALID_EXCEPTION,
-            'message' => 'Provided languageId is not a valid uuid',
+            'message' => 'Provided language ID is not a valid UUID',
         ];
 
         yield SalesChannelException::NO_CONTEXT_DATA_EXCEPTION => [


### PR DESCRIPTION
### 1. Why is this change necessary?

To be more independent on loading several templates (especially common templates like the header and the footer) some data should not be taken from the page objects. Instead globally available data should be used. Some are already present, like the currency in the context object; some need to be added new.

### 2. What does this change do, exactly?

* Added new LanguageInfo to the SalesChannelContext
* Added new NavigationInfo to global template data

### 4. Please link to the relevant issues (if any).

- Jira issue: https://shopware.atlassian.net/browse/NEXT-39744

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
