### PR TITLE
fix: remove message queue error notifications in admin

### DIFF
--- a/changelog/_unreleased/2025-01-07-remove-message-queue-error-notification-in-admin.md
+++ b/changelog/_unreleased/2025-01-07-remove-message-queue-error-notification-in-admin.md
@@ -1,0 +1,9 @@
+---
+title: Remove message queue error notification in admin
+issue: NEXT-35021
+author: Jannis Leifeld
+author_email: j.leifeld@shopware.com
+author_github: @Jannis Leifeld
+---
+# Administration
+* Changed message queue errors notifications in administration to console log errors to prevent showing unreadable error messages for the user

--- a/src/Administration/Resources/app/administration/src/core/worker/admin-notification-worker.js
+++ b/src/Administration/Resources/app/administration/src/core/worker/admin-notification-worker.js
@@ -45,7 +45,7 @@ export default class AdminNotificationWorker {
                 }
             })
             .catch((error) => {
-                this.createNotification('error', error.message);
+                console.error('Error while fetching notifications', error);
             });
 
         this._notiticationTimeoutId = setTimeout(() => {

--- a/src/Administration/Resources/app/administration/src/core/worker/admin-notification-worker.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/worker/admin-notification-worker.spec.js
@@ -1,0 +1,24 @@
+import AdminNotificationWorker from 'src/core/worker/admin-notification-worker';
+
+describe('src/core/worker/admin-notification-worker', () => {
+
+    it('should log an error when the notification fetching fails', async () => {
+        const notificationService = {
+            fetchNotifications: jest.fn().mockRejectedValue(new Error('Unexpected error')),
+        };
+        const userConfigService = {
+            upsert: jest.fn(),
+        };
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        Shopware.Service().register('notificationsService', () => notificationService);
+        Shopware.Service().register('userConfigService', () => userConfigService);
+
+        const adminNotificationWorker = new AdminNotificationWorker();
+        adminNotificationWorker.loadNotifications();
+
+        await flushPromises();
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith('Error while fetching notifications', new Error('Unexpected error'));
+    });
+});

--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -230,7 +230,6 @@ const missingTests = [
     'src/core/service/utils/object.utils.ts',
     'src/core/service/utils/sort.utils.ts',
     'src/core/service/validation.service.js',
-    'src/core/worker/admin-notification-worker.js',
     'src/core/worker/worker-notification-listener.js',
     'src/core/worker/admin-worker.worker.js',
     'src/core/worker/admin-worker.shared-worker.js',


### PR DESCRIPTION
### 1. Why is this change necessary?

If the message queue is broken the administration get's spammed with unreadable error notifications.

### 2. What does this change do, exactly?

It replaces the creation of error messages with console errors. The errors are still saved by the backend in the logs.