### PR TITLE
feat: Add custom pagination parameter

### DIFF
--- a/changelog/_unreleased/2025-01-07-allow-custom-pagination-parameters.md
+++ b/changelog/_unreleased/2025-01-07-allow-custom-pagination-parameters.md
@@ -1,0 +1,8 @@
+---
+title: Allow custom pagination parameters
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Added variable `pageParameter` to the `storefront/component/pagination.html.twig` template to allow for custom pagination parameters

--- a/src/Storefront/Resources/views/storefront/component/pagination.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/pagination.html.twig
@@ -17,6 +17,10 @@
         {% set href = true %}
     {% endif %}
 
+    {% if href and pageParameter is not defined %}
+        {% set pageParameter = 'p' %}
+    {% endif %}
+
     {% set searchQuery = '' %}
     {% if feature('ACCESSIBILITY_TWEAKS') and searchResult.currentFilters.search %}
         {% set searchQuery = '&search=' ~ searchResult.currentFilters.search %}
@@ -31,7 +35,7 @@
                         {# @deprecated tag:v6.7.0 - Pagination items will use anchor elements instead of radio inputs and labels. #}
                         {% if feature('ACCESSIBILITY_TWEAKS') %}
                             {% block component_pagination_first_link_element %}
-                                <a href="{{ href ? '?p=1' ~ searchQuery : '#' }}" class="page-link" data-page="1" aria-label="{{ 'general.first'|trans|striptags }}" data-focus-id="first"{% if currentPage == 1 %} tabindex="-1" aria-disabled="true"{% endif %}>
+                                <a href="{{ href ? '?' ~ pageParameter ~ '=1' ~ searchQuery : '#' }}" class="page-link" data-page="1" aria-label="{{ 'general.first'|trans|striptags }}" data-focus-id="first"{% if currentPage == 1 %} tabindex="-1" aria-disabled="true"{% endif %}>
                                     {% block component_pagination_first_link_icon %}
                                         {% sw_icon 'arrow-medium-double-left' style { size: 'fluid', pack: 'solid', ariaHidden: true } %}
                                     {% endblock %}
@@ -67,7 +71,7 @@
                         {# @deprecated tag:v6.7.0 - Pagination items will use anchor elements instead of radio inputs and labels. #}
                         {% if feature('ACCESSIBILITY_TWEAKS') %}
                             {% block component_pagination_prev_link_element %}
-                                <a href="{{ href ? '?p=' ~ (currentPage - 1) ~ searchQuery : '#' }}" class="page-link" data-page="{{ currentPage - 1 }}" aria-label="{{ 'general.pagination.prev'|trans|striptags }}" data-focus-id="prev"{% if currentPage == 1 %} tabindex="-1" aria-disabled="true"{% endif %}>
+                                <a href="{{ href ? '?' ~ pageParameter ~ '=' ~ (currentPage - 1) ~ searchQuery : '#' }}" class="page-link" data-page="{{ currentPage - 1 }}" aria-label="{{ 'general.pagination.prev'|trans|striptags }}" data-focus-id="prev"{% if currentPage == 1 %} tabindex="-1" aria-disabled="true"{% endif %}>
                                     {% block component_pagination_prev_link_icon %}
                                         {% sw_icon 'arrow-medium-left' style { size: 'fluid', pack: 'solid', ariaHidden: true } %}
                                     {% endblock %}
@@ -125,7 +129,7 @@
                                 {# @deprecated tag:v6.7.0 - Pagination items will use anchor elements instead of radio inputs and labels. #}
                                 {% if feature('ACCESSIBILITY_TWEAKS') %}
                                     {% block component_pagination_item_link_element %}
-                                        <a href="{{ href ? '?p=' ~ page ~ searchQuery : '#' }}" class="page-link" data-page="{{ page }}" data-focus-id="{{ page }}">
+                                        <a href="{{ href ? '?' ~ pageParameter ~ '=' ~ page ~ searchQuery : '#' }}" class="page-link" data-page="{{ page }}" data-focus-id="{{ page }}">
                                             {% block component_pagination_item_link_text %}
                                                 <span class="visually-hidden">{{ 'general.pagination.page'|trans|sw_sanitize }}</span> {{ page }}
                                             {% endblock %}
@@ -167,7 +171,7 @@
                         {# @deprecated tag:v6.7.0 - Pagination items will use anchor elements instead of radio inputs and labels. #}
                         {% if feature('ACCESSIBILITY_TWEAKS') %}
                             {% block component_pagination_next_link_element %}
-                                <a href="{{ href ? '?p=' ~ (currentPage + 1) ~ searchQuery : '#' }}" class="page-link" data-page="{{ currentPage + 1 }}" aria-label="{{ 'general.pagination.next'|trans|striptags }}" data-focus-id="next"{% if currentPage == totalPages %} tabindex="-1" aria-disabled="true"{% endif %}>
+                                <a href="{{ href ? '?' ~ pageParameter ~ '=' ~ (currentPage + 1) ~ searchQuery : '#' }}" class="page-link" data-page="{{ currentPage + 1 }}" aria-label="{{ 'general.pagination.next'|trans|striptags }}" data-focus-id="next"{% if currentPage == totalPages %} tabindex="-1" aria-disabled="true"{% endif %}>
                                     {% block component_pagination_next_link_icon %}
                                         {% sw_icon 'arrow-medium-right' style { size: 'fluid', pack: 'solid', ariaHidden: true } %}
                                     {% endblock %}
@@ -206,7 +210,7 @@
                         {# @deprecated tag:v6.7.0 - Pagination items will use anchor elements instead of radio inputs and labels. #}
                         {% if feature('ACCESSIBILITY_TWEAKS') %}
                             {% block component_pagination_last_link_element %}
-                                <a href="{{ href ? '?p=' ~ totalPages ~ searchQuery : '#' }}" class="page-link" data-page="{{ totalPages }}" aria-label="{{ 'general.pagination.last'|trans|striptags }}" data-focus-id="last"{% if currentPage == totalPages %} tabindex="-1" aria-disabled="true"{% endif %}>
+                                <a href="{{ href ? '?' ~ pageParameter ~ '=' ~ totalPages ~ searchQuery : '#' }}" class="page-link" data-page="{{ totalPages }}" aria-label="{{ 'general.pagination.last'|trans|striptags }}" data-focus-id="last"{% if currentPage == totalPages %} tabindex="-1" aria-disabled="true"{% endif %}>
                                     {% block component_pagination_last_link_icon %}
                                         {% sw_icon 'arrow-medium-double-right' style { size: 'fluid', pack: 'solid', ariaHidden: true } %}
                                     {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
For a plugin, we use a different pagination parameter (as we have an additional paginated element on the product listing). There we currently utilize the pagination template. 

When having the forms, we could modify the `GET` parameters with Javascript, which is still possible with links, but not really accessible (and the links initially have the wrong parameters).

### 2. What does this change do, exactly?
Add a new variable to define the parameter which is used for the pagination.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
