### PR TITLE
chore: Add `discovery` to the phpstan-type `PackageString`

### DIFF
--- a/src/Core/Framework/Log/Package.php
+++ b/src/Core/Framework/Log/Package.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Log;
 /**
  * @internal
  *
- * @phpstan-type PackageString 'buyers-experience'|'services-settings'|'inventory'|'content'|'sales-channel'|'customer-order'|'checkout'|'merchant-services'|'storefront'|'core'|'administration'|'data-services'|'innovation'
+ * @phpstan-type PackageString 'buyers-experience'|'services-settings'|'inventory'|'content'|'sales-channel'|'customer-order'|'checkout'|'merchant-services'|'storefront'|'core'|'administration'|'data-services'|'innovation'|'discovery'|'fundamentals@discovery'
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 #[Package('core')]


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the phpstan job is failing, as the type does not allow the package type `discovery`:
https://github.com/shopware/shopware/actions/runs/12659302124/job/35278127512?pr=6002#step:4:19

This type has been added in the following PR: https://github.com/shopware/shopware/pull/5946

### 2. What does this change do, exactly?
Change the type.

### 3. Describe each step to reproduce the issue or behaviour.
Run phpstan.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
