### PR TITLE
chore: Update releases.json

### DIFF
--- a/releases.json
+++ b/releases.json
@@ -1,242 +1,92 @@
 [
   {
-    "version": "6.4.0.0",
+    "version": "6.4",
     "release_date": "2021-05-04",
     "extended_eol": false,
-    "security_eol": "2025-02-01"
+    "security_eol": "2025-05-14"
   },
   {
-    "version": "6.4.1.0",
-    "release_date": "2021-06-07",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.2.0",
-    "release_date": "2021-07-07",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.3.0",
-    "release_date": "2021-08-02",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.4.0",
-    "release_date": "2021-09-06",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.5.0",
-    "release_date": "2021-10-04",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.6.0",
-    "release_date": "2021-11-03",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.7.0",
-    "release_date": "2021-12-09",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.8.0",
-    "release_date": "2022-02-09",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.9.0",
-    "release_date": "2022-03-14",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.10.0",
-    "release_date": "2022-04-05",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.11.0",
-    "release_date": "2022-05-04",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.12.0",
-    "release_date": "2022-06-13",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.13.0",
-    "release_date": "2022-07-04",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.14.0",
-    "release_date": "2022-08-01",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.15.0",
-    "release_date": "2022-09-19",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.16.0",
-    "release_date": "2022-10-04",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.17.0",
-    "release_date": "2022-11-07",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.18.0",
-    "release_date": "2022-12-08",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.19.0",
-    "release_date": "2023-02-07",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.4.20.0",
-    "release_date": "2023-02-22",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.5.0.0",
+    "version": "6.5",
     "release_date": "2023-05-03",
     "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.5.1.0",
-    "release_date": "2023-05-24",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.5.2.0",
-    "release_date": "2023-06-12",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.5.3.0",
-    "release_date": "2023-07-03",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.5.4.0",
-    "release_date": "2023-08-07",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.5.5.0",
-    "release_date": "2023-09-04",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.5.6.0",
-    "release_date": "2023-10-04",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
-  },
-  {
-    "version": "6.5.7.0",
-    "release_date": "2023-11-20",
-    "extended_eol": false,
-    "security_eol": "2025-02-01"
+    "security_eol": "2025-05-14"
   },
   {
     "version": "6.5.8.0",
     "release_date": "2024-01-15",
-    "extended_eol": "2025-02-01",
-    "security_eol": "2026-02-01"
+    "extended_eol": "2025-05-14",
+    "security_eol": "2026-02-28"
   },
   {
     "version": "6.6.0.0",
     "release_date": "2024-03-21",
     "extended_eol": false,
-    "security_eol": "2026-02-01"
+    "security_eol": "2026-02-28"
   },
   {
     "version": "6.6.1.0",
     "release_date": "2024-04-09",
     "extended_eol": false,
-    "security_eol": "2026-02-01"
+    "security_eol": "2026-02-28"
   },
   {
     "version": "6.6.2.0",
     "release_date": "2024-05-06",
     "extended_eol": false,
-    "security_eol": "2026-02-01"
+    "security_eol": "2026-02-28"
   },
   {
     "version": "6.6.3.0",
     "release_date": "2024-06-04",
     "extended_eol": false,
-    "security_eol": "2026-02-01"
+    "security_eol": "2026-02-28"
   },
   {
     "version": "6.6.4.0",
     "release_date": "2024-07-01",
     "extended_eol": false,
-    "security_eol": "2026-02-01"
+    "security_eol": "2026-02-28"
   },
   {
     "version": "6.6.5.0",
     "release_date": "2024-08-06",
     "extended_eol": false,
-    "security_eol": "2026-02-01"
+    "security_eol": "2026-02-28"
   },
   {
     "version": "6.6.6.0",
     "release_date": "2024-09-03",
     "extended_eol": false,
-    "security_eol": "2026-02-01"
+    "security_eol": "2026-02-28"
   },
   {
     "version": "6.6.7.0",
     "release_date": "2024-10-14",
     "extended_eol": false,
-    "security_eol": "2026-02-01"
+    "security_eol": "2026-02-28"
   },
   {
     "version": "6.6.8.0",
     "release_date": "2024-11-06",
     "extended_eol": false,
-    "security_eol": "2026-02-01"
+    "security_eol": "2026-02-28"
   },
   {
     "version": "6.6.9.0",
     "release_date": "2024-12-03",
     "extended_eol": false,
-    "security_eol": "2026-02-01"
+    "security_eol": "2026-02-28"
+  },
+  {
+    "version": "6.6.10.0",
+    "release_date": "2025-02-03",
+    "extended_eol": "2026-02-28",
+    "security_eol": "2027-02-28"
+  },
+  {
+    "version": "6.7.0.0",
+    "release_date": "2025-05-14",
+    "extended_eol": false,
+    "security_eol": "2027-02-28"
   }
 ]


### PR DESCRIPTION
I updated the release overview to include the last minor release in 6.6 and the 6.7 major release. In addition I cleaned up the older versions a bit to shrink down the calendar. I also updated the corresponding end of life dates.
