### PR TITLE
feat: introduce env variable to skip cache invalidation on asset:install

### DIFF
--- a/src/Core/Framework/Plugin/Util/AssetService.php
+++ b/src/Core/Framework/Plugin/Util/AssetService.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Plugin\Util;
 
 use League\Flysystem\FilesystemOperator;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatch;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInput;
@@ -147,7 +148,9 @@ class AssetService
         $manifest[$bundleOrAppName] = $localBundleManifest;
         $this->writeManifest($manifest);
 
-        $this->cacheInvalidator->invalidate(['asset-metaData'], true);
+        if (!EnvironmentHelper::getVariable('SHOPWARE_SKIP_ASSET_INSTALL_CACHE_INVALIDATION', false)) {
+            $this->cacheInvalidator->invalidate(['asset-metaData'], true);
+        }
     }
 
     /**

--- a/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/Util/AssetServiceTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\Plugin\Exception\PluginNotFoundException;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
 use Shopware\Core\Framework\Plugin\Util\AssetService;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
 use Shopware\Core\Framework\Util\Filesystem as ThemeFilesystem;
 use Shopware\Core\Test\Stub\App\StaticSourceResolver;
 use Shopware\Core\Test\Stub\Framework\Util\StaticFilesystem;
@@ -30,6 +31,8 @@ use Symfony\Component\HttpKernel\KernelInterface;
 #[CoversClass(AssetService::class)]
 class AssetServiceTest extends TestCase
 {
+    use EnvTestBehaviour;
+
     public function testCopyAssetsFromBundlePluginDoesNotExists(): void
     {
         $kernelMock = $this->createMock(KernelInterface::class);
@@ -62,12 +65,49 @@ class AssetServiceTest extends TestCase
             ->willReturn($this->getBundle());
 
         $filesystem = new Filesystem(new MemoryFilesystemAdapter());
+
+        $cacheInvalidator = $this->createMock(CacheInvalidator::class);
+        $cacheInvalidator->expects(static::exactly(2))->method('invalidate');
+
         $assetService = new AssetService(
             $filesystem,
             $filesystem,
             $kernel,
             new StaticKernelPluginLoader($this->createMock(ClassLoader::class)),
-            $this->createMock(CacheInvalidator::class),
+            $cacheInvalidator,
+            new StaticSourceResolver(),
+            new ParameterBag(['shopware.filesystem.asset.type' => 's3'])
+        );
+
+        $assetService->copyAssetsFromBundle('ExampleBundle');
+
+        static::assertTrue($filesystem->has('bundles/example'));
+        static::assertTrue($filesystem->has('bundles/example/test.txt'));
+        static::assertSame('TEST', trim($filesystem->read('bundles/example/test.txt')));
+        static::assertTrue($filesystem->has('bundles/featurea'));
+    }
+
+    public function testCopyAssetsFromBundlePluginWithoutInvalidation(): void
+    {
+        $this->setEnvVars(['SHOPWARE_SKIP_ASSET_INSTALL_CACHE_INVALIDATION' => '1']);
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel
+            ->method('getBundle')
+            ->with('ExampleBundle')
+            ->willReturn($this->getBundle());
+
+        $filesystem = new Filesystem(new MemoryFilesystemAdapter());
+
+        $cacheInvalidator = $this->createMock(CacheInvalidator::class);
+        $cacheInvalidator->expects(static::never())->method('invalidate');
+
+        $assetService = new AssetService(
+            $filesystem,
+            $filesystem,
+            $kernel,
+            new StaticKernelPluginLoader($this->createMock(ClassLoader::class)),
+            $cacheInvalidator,
             new StaticSourceResolver(),
             new ParameterBag(['shopware.filesystem.asset.type' => 's3'])
         );


### PR DESCRIPTION
### 1. Why is this change necessary?

Users are worried as they see stuff like in their PaaS projects:

```
W: 07:21:53 WARNING   [cache] Failed to delete key "asset-metaData\x01tags\x01": Redis connection failed: Connection refused ["key" => "asset-metaData\x01tags\x01","exception" => Symfony\Component\Cache\Exception\InvalidArgumentException { …},"cache-adapter" => "Symfony\Component\Cache\Adapter\RedisAdapter"]
```


### 2. What does this change do, exactly?

Added a env to disable cache invalidation, on build phase where we have to access to the Redis server


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
