### PR TITLE
fix: call feature check once in ExtensionRegistry

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/ExtensionRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/ExtensionRegistry.php
@@ -16,6 +16,8 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegis
 #[Package('core')]
 class ExtensionRegistry
 {
+    private bool $is67;
+
     /**
      * @internal
      *
@@ -26,6 +28,7 @@ class ExtensionRegistry
         private readonly iterable $extensions,
         private readonly iterable $bulks
     ) {
+        $this->is67 = Feature::isActive('v6.7.0.0');
     }
 
     public function configureExtensions(DefinitionInstanceRegistry $registry, SalesChannelDefinitionInstanceRegistry $salesChannelRegistry): void
@@ -115,7 +118,7 @@ class ExtensionRegistry
 
     private function getInstance(DefinitionInstanceRegistry $registry, EntityExtension $extension): EntityDefinition
     {
-        if (Feature::isActive('v6.7.0.0')) {
+        if ($this->is67) {
             $entity = $extension->getEntityName();
 
             return $registry->getByEntityName($entity);


### PR DESCRIPTION
### 1. Why is this change necessary?

The feature check is happening over ~174 times when commercial is installed and increases which more plugins much more on every request

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
