### PR TITLE
fix: fix memory leak in tooltip directive

### DIFF
--- a/changelog/_unreleased/2025-01-08-fix-memory-leak-in-tooltip-directive.md
+++ b/changelog/_unreleased/2025-01-08-fix-memory-leak-in-tooltip-directive.md
@@ -1,0 +1,9 @@
+---
+title: Fix memory leak in tooltip directive
+issue: NEXT-39896
+author: Jannis Leifeld
+author_email: j.leifeld@shopware.com
+author_github: @Jannis Leifeld
+---
+# Administration
+* Added the removal of the tooltip in the registry on unmount to prevent memory leaks.

--- a/src/Administration/Resources/app/administration/src/app/directive/tooltip.directive.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/directive/tooltip.directive.spec.js
@@ -4,7 +4,7 @@
 
 import { shallowMount } from '@vue/test-utils';
 
-import 'src/app/directive/tooltip.directive';
+import { tooltipRegistry } from 'src/app/directive/tooltip.directive';
 
 jest.useFakeTimers();
 
@@ -66,6 +66,20 @@ describe('directives/tooltip', () => {
         tooltips = document.body.getElementsByClassName('sw-tooltip');
         // Tooltip gets rendered
         expect(tooltips).toHaveLength(0);
+    });
+
+    it('should remove the tooltip from the registry after unmount to prevent memory leak', async () => {
+        const wrapper = await createWrapper('a tooltip');
+        await flushPromises();
+
+        // Tooltip is in the registry
+        expect(tooltipRegistry.size).toBe(1);
+
+        // Unmount the wrapper
+        wrapper.unmount();
+
+        // Tooltip is removed from the registry
+        expect(tooltipRegistry.size).toBe(0);
     });
 
     it('should not be created when target element gets deleted before creation of tooltip', async () => {

--- a/src/Administration/Resources/app/administration/src/app/directive/tooltip.directive.ts
+++ b/src/Administration/Resources/app/administration/src/app/directive/tooltip.directive.ts
@@ -12,8 +12,12 @@ const availableTooltipPlacements: Placements[] = [
     'left',
 ];
 
-// eslint-disable-next-line no-use-before-define
-const tooltipRegistry = new Map<string, Tooltip>();
+/**
+ * @private
+ */
+// eslint-disable-next-line max-len
+// eslint-disable-next-line no-use-before-define,import/prefer-default-export,sw-deprecation-rules/private-feature-declarations
+export const tooltipRegistry = new Map<string, Tooltip>();
 
 /**
  * @private
@@ -516,6 +520,10 @@ Shopware.Directive.register('tooltip', {
             const tooltip = tooltipRegistry.get(el.getAttribute('tooltip-id')!);
             tooltip!.hideTooltip();
         }
+
+
+        // Remove the tooltip from the registry
+        tooltipRegistry.delete(el.getAttribute('tooltip-id')!);
     },
 
     updated: (el: HTMLElement, binding) => {

--- a/src/Administration/Resources/app/administration/src/meta/baseline.ts
+++ b/src/Administration/Resources/app/administration/src/meta/baseline.ts
@@ -115,7 +115,6 @@ const missingTests = [
     'src/app/decorator/index.js',
     'src/app/directive/index.ts',
     'src/app/directive/popover.directive.ts',
-    'src/app/directive/tooltip.directive.ts',
     'src/app/filter/index.ts',
     'src/app/init/directive.init.ts',
     'src/app/init/index.ts',


### PR DESCRIPTION
### 1. Why is this change necessary?

When refreshing or switching between pages with tooltips on them, the memory usage grows indefinitely. This is because the tooltip directive has a tooltip registry from the tooltips are never removed. Since the values in this Map are DOM Elements, a lot of memory is kept around. 

### 2. What does this change do, exactly?

Remove the tooltip after unmounting the component