### PR TITLE
fix: Select fields lazy loading

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-category-tree-field/sw-category-tree-field.html.twig
@@ -93,7 +93,6 @@
                 popover-class="sw-category-tree-field__results_popover"
                 :z-index="1100"
                 :resize-width="true"
-                :popover-config-extension="{ stopScrollPropagation: true }"
             >
 
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result-list/sw-select-result-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-result-list/sw-select-result-list.html.twig
@@ -6,7 +6,6 @@
         :popover-class="popoverClass"
         :z-index="1100"
         :resize-width="popoverResizeWidth"
-        :popover-config-extension="{ stopScrollPropagation: true }"
     >
         <div
             ref="popoverContent"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-toolbar/index.js
@@ -74,6 +74,7 @@ Component.register('sw-text-editor-toolbar', {
             rightButtons: [],
             tableEdit: false,
             scrollEventHandler: undefined,
+            preventReposition: false,
         };
     },
 
@@ -217,7 +218,7 @@ Component.register('sw-text-editor-toolbar', {
         },
 
         setToolbarPosition() {
-            if (!this.selection) {
+            if (!this.selection || this.preventReposition) {
                 return;
             }
 
@@ -229,7 +230,10 @@ Component.register('sw-text-editor-toolbar', {
             this.setSelectionRange();
             const boundary = this.range?.getBoundingClientRect?.();
 
-            if (!boundary) {
+            const selectionLost =
+                !boundary || boundary.top <= 0 || boundary.left <= 0 || boundary.width <= 0 || boundary.height <= 0;
+
+            if (selectionLost) {
                 return;
             }
 
@@ -315,6 +319,9 @@ Component.register('sw-text-editor-toolbar', {
         },
 
         onButtonClick(button, parent = null) {
+            // Whenever a button is clicked, we can allow the toolbar to reposition because the link menu is closed
+            this.preventReposition = false;
+
             if (button.type === 'link') {
                 this.handleTextStyleChangeLink(button);
                 return;
@@ -462,6 +469,14 @@ Component.register('sw-text-editor-toolbar', {
         },
 
         onToggleMenu(event, button) {
+            // Whenever the link menu is opened, we need to prevent the toolbar from repositioning
+            // The link menu has multiple problems:
+            // 1. It is a popover and not a dropdown
+            // 2. It is not a child of the toolbar, so the toolbar does not know when it is opened
+            // 3. Repositioning the the toolbar while the link menu is opened causes
+            // all popovers to close and the toolbar to disappear
+            this.preventReposition = button.type === 'link';
+
             this.keepSelection();
 
             this.buttonConfig.forEach((item) => {

--- a/src/Administration/Resources/app/administration/src/app/directive/popover.directive.ts
+++ b/src/Administration/Resources/app/administration/src/app/directive/popover.directive.ts
@@ -30,6 +30,7 @@ interface PopoverConfig {
     targetSelector: string;
     resizeWidth: boolean;
     style: Record<string, string>;
+    /* @deprecated tag:v6.7.0 - Will be removed */
     stopScrollPropagation?: boolean;
 }
 
@@ -38,6 +39,7 @@ const defaultConfig: PopoverConfig = {
     targetSelector: '',
     resizeWidth: false,
     style: {},
+    /* @deprecated tag:v6.7.0 - Will be removed */
     stopScrollPropagation: false,
 };
 
@@ -181,7 +183,7 @@ function stopVirtualScrolling() {
     window.removeEventListener('scroll', virtualScrollingHandler, true);
 }
 
-function virtualScrollingHandler(event: Event) {
+function virtualScrollingHandler() {
     if (virtualScrollingElements.size <= 0) {
         stopVirtualScrolling();
         return;
@@ -189,9 +191,6 @@ function virtualScrollingHandler(event: Event) {
 
     virtualScrollingElements.forEach((entry) => {
         setElementPosition(entry.el, entry.ref, entry.config);
-        if (entry.config.stopScrollPropagation) {
-            event.stopPropagation();
-        }
     });
 }
 


### PR DESCRIPTION
Unfortunately commit `411c4ef118c762eb3fafa5c0adb1f9a357cd43e4` introduced a bug to all our select fields. It aimed to fix a bug in the CMS where scrolling with the link menu open would close all popovers and seemingly the text editor toolbar.

To fix both issues in the extended support version we decided to disable the toolbar repositioning whenever the link menu is opened. Additionally we marked the `stopScrollPropagation` of the popover directive interface as deprecated as this broke the lazy loading of the select fields.