### PR TITLE
feat: Add force cache invalidate header

### DIFF
--- a/changelog/_unreleased/2025-01-08-add-force-cache-invalidate-header.md
+++ b/changelog/_unreleased/2025-01-08-add-force-cache-invalidate-header.md
@@ -1,0 +1,33 @@
+---
+title: Add force cache invalidate header
+issue: NEXT-31006
+---
+# Core
+* Added `\Shopware\Core\PlatformRequest::HEADER_FORCE_CACHE_INVALIDATE` const: 'sw-force-cache-invalidate'
+* Changed `\Shopware\Core\Framework\Adapter\Cache\CacheInvalidator::invalidate` to force the immediate Cache invalidation if the `PlatformRequest::HEADER_FORCE_CACHE_INVALIDATE` header is set
+___
+# Next Major Version Changes
+## Delayed Cache Invalidation
+In the next major version, the cache invalidation will be delayed by default. This means that the cache will be invalidated in regular intervals and not immediately.
+As this feature is now active by default the previous `shopware.cache.invalidation.delay` configuration is removed.
+
+The default interval is 5 min, this can be changed by adjusting the run interval of the `shopware.invalidate_cache` scheduled task.
+
+If you sent an API request with critical information, where the cache should be invalidated immediately, you can set the `sw-force-cache-invalidate` header on your request.
+```
+POST /api/product
+sw-force-cache-invalidate: 1
+```
+
+To clear manually clear all the stale caches you can either run the `cache:clear:delayed` command or use the `/api/_action/cache-delayed` api endpoint.
+```
+bin/console cache:clear:delayed
+```
+```
+DELETE /api/_action/cache-delayed
+```
+
+For debugging there is the `cache:watch:delayed` command available, to watch the cache tags that are stored in the delayed cache invalidation queue.
+```
+bin/console cache:watch:delayed
+```

--- a/changelog/_unreleased/2025-01-08-add-force-cache-invalidate-header.md
+++ b/changelog/_unreleased/2025-01-08-add-force-cache-invalidate-header.md
@@ -9,6 +9,7 @@ ___
 # Next Major Version Changes
 ## Delayed Cache Invalidation
 In the next major version, the cache invalidation will be delayed by default. This means that the cache will be invalidated in regular intervals and not immediately.
+This will lead to better cache hit rates and way less (duplicated) cache invalidations, which will improve efficiency and scalability of the system.
 As this feature is now active by default the previous `shopware.cache.invalidation.delay` configuration is removed.
 
 The default interval is 5 min, this can be changed by adjusting the run interval of the `shopware.invalidate_cache` scheduled task.
@@ -19,7 +20,7 @@ POST /api/product
 sw-force-cache-invalidate: 1
 ```
 
-To clear manually clear all the stale caches you can either run the `cache:clear:delayed` command or use the `/api/_action/cache-delayed` api endpoint.
+To manually clear all the stale caches you can either run the `cache:clear:delayed` command or use the `/api/_action/cache-delayed` API endpoint.
 ```
 bin/console cache:clear:delayed
 ```

--- a/src/Core/Framework/Adapter/Cache/CacheInvalidator.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidator.php
@@ -7,7 +7,9 @@ use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Adapter\Cache\InvalidatorStorage\AbstractInvalidatorStorage;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\PlatformRequest;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -27,6 +29,7 @@ class CacheInvalidator
         private readonly AbstractInvalidatorStorage $cache,
         private readonly EventDispatcherInterface $dispatcher,
         private readonly LoggerInterface $logger,
+        private readonly RequestStack $requestStack,
         private readonly string $environment
     ) {
     }
@@ -43,9 +46,7 @@ class CacheInvalidator
         }
 
         if (Feature::isActive('cache_rework')) {
-            $force = $force || $this->environment !== 'prod';
-
-            if ($force) {
+            if ($force || $this->shouldForceInvalidate()) {
                 $this->purge($tags);
 
                 return;
@@ -99,5 +100,11 @@ class CacheInvalidator
         }
 
         $this->dispatcher->dispatch(new InvalidateCacheEvent($keys));
+    }
+
+    private function shouldForceInvalidate(): bool
+    {
+        return $this->environment !== 'prod'
+            || $this->requestStack->getMainRequest()?->headers->get(PlatformRequest::HEADER_FORCE_CACHE_INVALIDATE) === '1';
     }
 }

--- a/src/Core/Framework/Adapter/Cache/CacheInvalidator.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidator.php
@@ -30,7 +30,6 @@ class CacheInvalidator
         private readonly EventDispatcherInterface $dispatcher,
         private readonly LoggerInterface $logger,
         private readonly RequestStack $requestStack,
-        private readonly string $environment
     ) {
     }
 
@@ -104,7 +103,6 @@ class CacheInvalidator
 
     private function shouldForceInvalidate(): bool
     {
-        return $this->environment !== 'prod'
-            || $this->requestStack->getMainRequest()?->headers->get(PlatformRequest::HEADER_FORCE_CACHE_INVALIDATE) === '1';
+        return $this->requestStack->getMainRequest()?->headers->get(PlatformRequest::HEADER_FORCE_CACHE_INVALIDATE) === '1';
     }
 }

--- a/src/Core/Framework/DependencyInjection/cache.xml
+++ b/src/Core/Framework/DependencyInjection/cache.xml
@@ -54,6 +54,7 @@
             <argument type="service" id="Shopware\Core\Framework\Adapter\Cache\InvalidatorStorage\AbstractInvalidatorStorage"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Psr\Log\LoggerInterface"/>
+            <argument type="service" id="request_stack"/>
             <argument>%kernel.environment%</argument>
         </service>
 

--- a/src/Core/Framework/DependencyInjection/cache.xml
+++ b/src/Core/Framework/DependencyInjection/cache.xml
@@ -55,7 +55,6 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Psr\Log\LoggerInterface"/>
             <argument type="service" id="request_stack"/>
-            <argument>%kernel.environment%</argument>
         </service>
 
         <service id="Shopware\Core\Framework\Adapter\Cache\InvalidateCacheTask">

--- a/src/Core/PlatformRequest.php
+++ b/src/Core/PlatformRequest.php
@@ -27,6 +27,7 @@ final class PlatformRequest
 
     public const HEADER_INDEXING_BEHAVIOR = 'indexing-behavior';
     public const HEADER_INDEXING_SKIP = 'indexing-skip';
+    public const HEADER_FORCE_CACHE_INVALIDATE = 'sw-force-cache-invalidate';
 
     /**
      * API Expectation headers to check requirements are fulfilled

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
@@ -159,7 +159,7 @@ class CacheInvalidatorTest extends TestCase
     #[DataProvider('dataProviderInvalidation')]
     #[DisabledFeatures(['cache_rework'])]
     /**
-     * @deprecated tag:v6.7.0.0 - can be removed as it tests only deprecated functionality
+     * @deprecated tag:v6.7.0 - can be removed as it tests only deprecated functionality
      */
     public function testInvalidation(bool $enableDelay, bool $directInvalidate, bool $backgroundInvalidate, bool $force): void
     {

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
@@ -44,7 +44,6 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
-            'test'
         );
 
         $invalidator->invalidate([]);
@@ -70,36 +69,9 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
-            'prod'
         );
 
         $invalidator->invalidate(['foo'], true);
-    }
-
-    public function testInvalidationIsImplicitlyForcedOnNonProdEnvs(): void
-    {
-        $tagAwareAdapter = $this->createMock(TagAwareAdapterInterface::class);
-        $tagAwareAdapter
-            ->expects(static::once())
-            ->method('invalidateTags')
-            ->with(['foo']);
-
-        $redisInvalidatorStorage = $this->createMock(RedisInvalidatorStorage::class);
-        $redisInvalidatorStorage
-            ->expects(static::never())
-            ->method('store');
-
-        $invalidator = new CacheInvalidator(
-            0,
-            [$tagAwareAdapter],
-            $redisInvalidatorStorage,
-            new EventDispatcher(),
-            new NullLogger(),
-            new RequestStack([new Request()]),
-            'dev'
-        );
-
-        $invalidator->invalidate(['foo']);
     }
 
     public function testInvalidationIsImplicitlyForcedWhenRequestHeaderIsSet(): void
@@ -125,7 +97,6 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([$request]),
-            'prod'
         );
 
         $invalidator->invalidate(['foo']);
@@ -150,7 +121,6 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
-            'prod'
         );
 
         $invalidator->invalidate(['foo']);
@@ -183,7 +153,6 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
-            'prod'
         );
 
         $invalidator->invalidate(['foo'], $force);
@@ -242,7 +211,6 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
-            'test'
         );
 
         $invalidator->invalidateExpired();
@@ -271,7 +239,6 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
-            'test'
         );
 
         $invalidator->invalidateExpired();

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
@@ -9,9 +9,12 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Shopware\Core\Framework\Adapter\Cache\CacheInvalidator;
 use Shopware\Core\Framework\Adapter\Cache\InvalidatorStorage\RedisInvalidatorStorage;
-use Shopware\Core\Framework\Feature;
+use Shopware\Core\PlatformRequest;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @internal
@@ -40,6 +43,7 @@ class CacheInvalidatorTest extends TestCase
             $redisInvalidatorStorage,
             new EventDispatcher(),
             new NullLogger(),
+            new RequestStack([new Request()]),
             'test'
         );
 
@@ -48,7 +52,6 @@ class CacheInvalidatorTest extends TestCase
 
     public function testForceInvalidation(): void
     {
-        Feature::skipTestIfActive('v6.7.0.0', $this);
         $tagAwareAdapter = $this->createMock(TagAwareAdapterInterface::class);
         $tagAwareAdapter
             ->expects(static::once())
@@ -66,10 +69,66 @@ class CacheInvalidatorTest extends TestCase
             $redisInvalidatorStorage,
             new EventDispatcher(),
             new NullLogger(),
+            new RequestStack([new Request()]),
             'prod'
         );
 
         $invalidator->invalidate(['foo'], true);
+    }
+
+    public function testInvalidationIsImplicitlyForcedOnNonProdEnvs(): void
+    {
+        $tagAwareAdapter = $this->createMock(TagAwareAdapterInterface::class);
+        $tagAwareAdapter
+            ->expects(static::once())
+            ->method('invalidateTags')
+            ->with(['foo']);
+
+        $redisInvalidatorStorage = $this->createMock(RedisInvalidatorStorage::class);
+        $redisInvalidatorStorage
+            ->expects(static::never())
+            ->method('store');
+
+        $invalidator = new CacheInvalidator(
+            0,
+            [$tagAwareAdapter],
+            $redisInvalidatorStorage,
+            new EventDispatcher(),
+            new NullLogger(),
+            new RequestStack([new Request()]),
+            'dev'
+        );
+
+        $invalidator->invalidate(['foo']);
+    }
+
+    public function testInvalidationIsImplicitlyForcedWhenRequestHeaderIsSet(): void
+    {
+        $tagAwareAdapter = $this->createMock(TagAwareAdapterInterface::class);
+        $tagAwareAdapter
+            ->expects(static::once())
+            ->method('invalidateTags')
+            ->with(['foo']);
+
+        $redisInvalidatorStorage = $this->createMock(RedisInvalidatorStorage::class);
+        $redisInvalidatorStorage
+            ->expects(static::never())
+            ->method('store');
+
+        $request = new Request();
+        $request->headers->set(PlatformRequest::HEADER_FORCE_CACHE_INVALIDATE, '1');
+
+        $invalidator = new CacheInvalidator(
+            0,
+            [$tagAwareAdapter],
+            $redisInvalidatorStorage,
+            new EventDispatcher(),
+            new NullLogger(),
+            new RequestStack([$request]),
+            'prod'
+        );
+
+        $invalidator->invalidate(['foo']);
     }
 
     public function testStoreInvalidation(): void
@@ -90,6 +149,7 @@ class CacheInvalidatorTest extends TestCase
             $redisInvalidatorStorage,
             new EventDispatcher(),
             new NullLogger(),
+            new RequestStack([new Request()]),
             'prod'
         );
 
@@ -97,9 +157,12 @@ class CacheInvalidatorTest extends TestCase
     }
 
     #[DataProvider('dataProviderInvalidation')]
+    #[DisabledFeatures(['cache_rework'])]
+    /**
+     * @deprecated tag:v6.7.0.0 - can be removed as it tests only deprecated functionality
+     */
     public function testInvalidation(bool $enableDelay, bool $directInvalidate, bool $backgroundInvalidate, bool $force): void
     {
-        Feature::skipTestIfActive('v6.7.0.0', $this);
         $tagAwareAdapter = $this->createMock(TagAwareAdapterInterface::class);
         $tagAwareAdapter
             ->expects($directInvalidate ? static::once() : static::never())
@@ -119,6 +182,7 @@ class CacheInvalidatorTest extends TestCase
             $redisInvalidatorStorage,
             new EventDispatcher(),
             new NullLogger(),
+            new RequestStack([new Request()]),
             'prod'
         );
 
@@ -177,6 +241,7 @@ class CacheInvalidatorTest extends TestCase
             $redisInvalidatorStorage,
             new EventDispatcher(),
             new NullLogger(),
+            new RequestStack([new Request()]),
             'test'
         );
 
@@ -205,6 +270,7 @@ class CacheInvalidatorTest extends TestCase
             $redisInvalidatorStorage,
             new EventDispatcher(),
             new NullLogger(),
+            new RequestStack([new Request()]),
             'test'
         );
 


### PR DESCRIPTION
Jira Ticket: NEXT-31006


If you sent an API request with critical information, where the cache should be invalidated immediately, you can set the `sw-force-cache-invalidate` header on your request.