### PR TITLE
feat: Trigger mail.sent.error in more cases

### DIFF
--- a/changelog/_unreleased/2025-01-08-trigger-business-event-mail-error.md
+++ b/changelog/_unreleased/2025-01-08-trigger-business-event-mail-error.md
@@ -1,0 +1,8 @@
+---
+title: MailErrorEvent on MailSender exceptions
+author: Alexander Menk
+author_github: @amenk
+---
+
+# Core
+* Added additional `mail.sent.error` event in case of and exception to `\Shopware\Core\Content\Mail\Service\MailService`.


### PR DESCRIPTION
* When the mailer send method fails, before this chance nobody would notice in the business events. This is also helpful when using error monitoring plugins such as Sentry.

### 1. Why is this change necessary?

Mailer errors go unnoticed

### 2. What does this change do, exactly?

In case the send() method fails, an additional business event is logged.
This allows for example to monitor it with sentry and see it in the admin panel.

### 3. Describe each step to reproduce the issue or behaviour.

1. Make a misconfiguration in the MAILER_DSN (for example wrong password)
2. Register as new user

![mail.sent.error event received in event log ](https://github.com/user-attachments/assets/bac0a03f-37ac-4713-99da-3ab7b25d8c9b)

### 4. Please link to the relevant issues (if any).
https://github.com/FriendsOfShopware/shopware-sentry-bundle/issues/18 (External)

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.

### 6. Question to Shopware Team

Shall we `throw $e` for a better backwards compatibility or just `return null` which is more clean and the same as in the other failing cases.