### PR TITLE
Read sales-channel while forward to route

### DIFF
--- a/src/Storefront/Framework/Routing/RequestTransformer.php
+++ b/src/Storefront/Framework/Routing/RequestTransformer.php
@@ -264,6 +264,15 @@ class RequestTransformer implements RequestTransformerInterface
             return null;
         }
 
+        if ($request->attributes->get('sw-domain-id') !== null) {
+            $id = $request->attributes->get('sw-domain-id');
+            foreach ($domains as $url => $data) {
+                if ($data['id'] === $id) {
+                    return $data;
+                }
+            }
+        }
+
         // domain urls and request uri should be in same format, all with trailing slash
         $requestUrl = rtrim($this->getSchemeAndHttpHost($request) . $request->getBasePath() . $request->getPathInfo(), '/') . '/';
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

If a request is forwarded to another route, the sales-channel is matched on the domain only. This is not working when using languages in the path.  

### 2. What does this change do, exactly?

If the request already contains information about the sales-channel, this is further used and not rematched only on the domain info.

### 3. Describe each step to reproduce the issue or behaviour.

Use a sales channel on e.g. https://example.com. Configure domains for another language e.g. on https://example.com/nl.

Call a route at the sales channel using the other language that is forwarding on exception, e.g. when creating in checkout an account with an already registered email address or a search without params, e.g. https://example.com/nl/search.

The router is forwarding, but is changing to the sales channel with default language.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
