### PR TITLE
[NEXT-0000] Avoid resetting customFields

### DIFF
--- a/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
+++ b/src/Core/Content/Newsletter/SalesChannel/NewsletterSubscribeRoute.php
@@ -153,6 +153,11 @@ class NewsletterSubscribeRoute extends AbstractNewsletterSubscribeRoute
                 NewsletterRecipientDefinition::ENTITY_NAME,
                 $dataBag->get('customFields')
             );
+
+            if (empty($data['customFields'])) {
+                // Avoid resetting customFields if empty
+                unset($data['customFields']);
+            }
         }
 
         $this->newsletterRecipientRepository->upsert([$data], $context->getContext());


### PR DESCRIPTION
Follow up on: https://github.com/shopware/shopware/pull/4487

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To ensure customFields arne't reset/deleted if the recipient sign-up for newsletter multiple times.


### 2. What does this change do, exactly?
Removes "customFields" if empty.

### 3. Describe each step to reproduce the issue or behaviour.
Register as a newsletter_recipient (With customFields), register again _(Same email etc.)_ but this time without customfields.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
