### PR TITLE
fix: styling issues for categories page

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.html.twig
@@ -40,12 +40,14 @@
         @click="collapseItem"
         @keydown.enter="collapseItem"
     >
-        <sw-icon
+        <mt-icon
+            size="24px"
             :name="`regular-chevron-${expandChevronDirection}-xxs`"
             class="sw-sidebar-collapse__expand-button"
             :class="expandButtonClass"
         />
-        <sw-icon
+        <mt-icon
+            size="16px"
             name="regular-chevron-down-xxs"
             class="sw-sidebar-collapse__collapse-button"
             :class="collapseButtonClass"

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.scss
@@ -24,7 +24,7 @@ $sw-sidebar-collapse-font-size-title: $font-size-s;
     .sw-sidebar-collapse__indicator {
         cursor: pointer;
 
-        .sw-icon {
+        .mt-icon {
             margin-right: 25px;
 
             &.is--hidden {

--- a/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/sidebar/sw-sidebar-collapse/sw-sidebar-collapse.spec.js
@@ -10,11 +10,11 @@ async function createWrapper() {
     return mount(await wrapTestComponent('sw-sidebar-collapse', { sync: true }), {
         global: {
             stubs: {
-                'sw-icon': {
+                'mt-icon': {
                     props: [
                         'name',
                     ],
-                    template: '<span class="sw-icon">{{ name }}</span>',
+                    template: '<span class="mt-icon">{{ name }}</span>',
                 },
                 'sw-collapse': true,
             },

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.html.twig
@@ -44,7 +44,10 @@
 
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_tree_item_element_toggle_icon %}
-            <sw-icon :name="opened ? 'regular-chevron-down-xxs' : 'regular-chevron-right-xxs'" />
+            <mt-icon
+                size="24px"
+                :name="opened ? 'regular-chevron-down-xxs' : 'regular-chevron-right-xxs'"
+            />
             {% endblock %}
         </div>
         {% endblock %}
@@ -85,7 +88,7 @@
                 v-else
                 class="sw-tree-item__icon"
             >
-                <sw-icon name="regular-circle-xxs" />
+                <mt-icon name="regular-circle-xxs" />
             </div>
         </slot>
         {% endblock %}
@@ -146,9 +149,9 @@
 
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_tree_items_active_state %}
-            <sw-icon
+            <mt-icon
                 v-if="shouldShowActiveState"
-                size="6"
+                size="6px"
                 :color="getActiveIconColor(item)"
                 name="solid-circle-xxxs"
             />
@@ -353,9 +356,9 @@
 
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_tree_items_transition_active_state %}
-                    <sw-icon
+                    <mt-icon
                         v-if="shouldShowActiveState"
-                        size="6"
+                        size="6px"
                         :color="getActiveIconColor(item)"
                         name="solid-circle-xxxs"
                     />

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.html.twig
@@ -70,15 +70,15 @@
                 v-if="item.childCount > 0"
                 class="sw-tree-item__icon"
             >
-                <sw-icon
+                <mt-icon
                     v-if="opened"
                     name="regular-folder-open"
-                    small
+                    size="16px"
                 />
-                <sw-icon
+                <mt-icon
                     v-else
                     name="regular-folder"
-                    small
+                    size="16px"
                 />
             </div>
             <div

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree-item/sw-tree-item.scss
@@ -252,6 +252,18 @@ $sw-tree-item-color-text: $color-darkgray-200;
             @include size(8px);
         }
     }
+
+    .sw-tree-detail__edit-tree-item {
+        .mt-field {
+            margin-bottom: 0;
+        }
+    }
+
+    .mt-field--checkbox__container {
+        .mt-field--checkbox {
+            margin-bottom: 0;
+        }
+    }
 }
 
 .sw-tree-item__element {

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-base/sw-landing-page-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-base/sw-landing-page-detail-base.html.twig
@@ -75,12 +75,13 @@
         :title="$tc('sw-landing-page.base.seo.title')"
         :is-loading="isLoading"
     >
-        <sw-alert
+        <mt-banner
             v-if="!isLayoutSet"
-            variant="warning"
+            variant="attention"
+            :title="$tc('sw-landing-page.base.seo.notification.noLayoutAssigned')"
         >
             {{ $tc('sw-landing-page.base.seo.notification.noLayoutAssigned') }}
-        </sw-alert>
+        </mt-banner>
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_landing_page_detail_base_seo_form %}

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-base/sw-landing-page-detail-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-base/sw-landing-page-detail-base.spec.js
@@ -60,7 +60,7 @@ async function createWrapper(state = {}) {
                     props: ['disabled'],
                 },
                 'sw-entity-multi-select': true,
-                'sw-alert': true,
+                'mt-banner': true,
                 'sw-textarea-field': true,
                 'sw-custom-field-set-renderer': true,
             },


### PR DESCRIPTION
### 1. Why is this change necessary?
Some UI issues found in 6.7 if use meteor component library

1.  Icon is too big, text not align, sidebar collapse icon not hidden

![Screenshot 2025-01-10 at 15 10 28](https://github.com/user-attachments/assets/7a624c91-0aae-4c65-9908-10b9d6e320d5)

2. mt-alert with variant "warning" will change to mt-banner with variant "attentions"

![Screenshot 2025-01-10 at 15 11 13](https://github.com/user-attachments/assets/3e4468ae-e22b-4048-aa03-503f4635a42a)
