### PR TITLE
fix: replace mt-alert component to mt-banner meteor component with variant attention

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-replace/sw-media-modal-replace.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-replace/sw-media-modal-replace.html.twig
@@ -19,13 +19,13 @@
         variant="regular"
     />
 
-    <sw-alert
+    <mt-banner
         v-if="newFileExtension"
         class="sw-media-modal-replace__file-extension-warning"
-        variant="warning"
+        variant="attention"
     >
         {{ $tc('global.sw-media-modal-replace.warningFileExtension', 0, { extension: newFileExtension }) }}
-    </sw-alert>
+    </mt-banner>
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_media_modal_replace_modal_footer %}

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-confirm/sw-bulk-edit-save-modal-confirm.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-confirm/sw-bulk-edit-save-modal-confirm.html.twig
@@ -25,22 +25,22 @@
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_bulk_edit_save_modal_confirm_trigger_flows_alert %}
-        <sw-alert
+        <mt-banner
             v-show="isFlowTriggered"
             class="sw-bulk-edit-save-modal-confirm__trigger-flows-alert"
         >
             <p>{{ $tc('sw-bulk-edit.modal.confirm.alertTitle') }}</p>
             <span>{{ triggeredFlows.join(', ') }}</span>
-        </sw-alert>
+        </mt-banner>
         {% endblock %}
     </div>
     {% endblock %}
 
-    <sw-alert
-        variant="warning"
+    <mt-banner
+        variant="attention"
         class="sw-bulk-edit-save-modal__warning"
     >
         {{ $tc('sw-bulk-edit.modal.warningText') }}
-    </sw-alert>
+    </mt-banner>
 </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-confirm/sw-bulk-edit-save-modal-confirm.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-confirm/sw-bulk-edit-save-modal-confirm.scss
@@ -9,7 +9,7 @@
         margin-right: 0;
     }
 
-    &__trigger-flows-alert.sw-alert {
+    &__trigger-flows-alert.mt-banner {
         font-size: $font-size-xs;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-process/sw-bulk-edit-save-modal-process.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-process/sw-bulk-edit-save-modal-process.html.twig
@@ -53,12 +53,12 @@
         {{ $tc('sw-bulk-edit.modal.process.helpText') }}
     </p>
 
-    <sw-alert
-        variant="warning"
+    <mt-banner
+        variant="attention"
         class="sw-bulk-edit-save-modal__warning"
     >
         {{ $tc('sw-bulk-edit.modal.warningText') }}
-    </sw-alert>
+    </mt-banner>
     {% endblock %}
 </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-process/sw-bulk-edit-save-modal-process.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-save-modal-process/sw-bulk-edit-save-modal-process.spec.js
@@ -12,7 +12,7 @@ async function createWrapper() {
         {
             global: {
                 stubs: {
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-loader': true,
                     'sw-label': true,
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/sw-bulk-edit-customer.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-customer/sw-bulk-edit-customer.spec.js
@@ -71,7 +71,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-customer', () => {
                     'sw-notification-center': true,
                     'sw-icon': true,
                     'sw-help-text': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-label': true,
                     'sw-tabs': await wrapTestComponent('sw-tabs'),
                     'sw-tabs-deprecated': await wrapTestComponent('sw-tabs-deprecated', { sync: true }),

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.html.twig
@@ -52,9 +52,9 @@
                 class="sw-bulk-edit-order__restricted-fields"
                 position-identifier="sw-bulk-edit-order-restricted-fields"
             >
-                <sw-alert
+                <mt-banner
                     :title="$tc('sw-bulk-edit.order.alertRestrictedFields.title')"
-                    variant="warning"
+                    variant="attention"
                 >
                     <span v-html="$tc('sw-bulk-edit.order.alertRestrictedFields.message')"></span>
                     <ul>
@@ -65,7 +65,7 @@
                             {{ $tc(`sw-bulk-edit.order.alertRestrictedFields.${restrictedField}`) }}
                         </li>
                     </ul>
-                </sw-alert>
+                </mt-banner>
             </sw-card>
 
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.scss
@@ -22,7 +22,7 @@
         padding: 24px 32px 0 24px;
     }
 
-    &__restricted-fields .sw-alert {
+    &__restricted-fields .mt-banner {
         margin: 0 auto;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-order/sw-bulk-edit-order.spec.js
@@ -81,7 +81,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-order', () => {
                     'sw-help-center': true,
                     'sw-icon': true,
                     'sw-help-text': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-label': true,
                     'sw-tabs': await wrapTestComponent('sw-tabs'),
                     'sw-tabs-deprecated': await wrapTestComponent('sw-tabs-deprecated', { sync: true }),

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.html.twig
@@ -84,20 +84,9 @@
             >
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_bulk_edit_product_content_inheritance_alert %}
-                <sw-alert variant="info">
-                    <template #customIcon>
-                        <div class="sw-bulk-edit-product__inheritance-icon">
-                            <sw-icon
-                                name="regular-link"
-                                color="#7363e5"
-                                size="16"
-                            />
-                        </div>
-                    </template>
-                    <template #default>
-                        {{ $tc('sw-bulk-edit.product.alertInheritance.message') }}
-                    </template>
-                </sw-alert>
+                <mt-banner variant="inherited">
+                    {{ $tc('sw-bulk-edit.product.alertInheritance.message') }}
+                </mt-banner>
                 {% endblock %}
             </sw-card>
             {% endblock %}
@@ -107,9 +96,9 @@
                 class="sw-bulk-edit-product__restricted-fields"
                 position-identifier="sw-bulk-edit-product-restricted-fields"
             >
-                <sw-alert
+                <mt-banner
                     :title="$tc('sw-bulk-edit.product.alertRestrictedFields.title')"
-                    variant="warning"
+                    variant="attention"
                 >
                     <span v-html="$tc('sw-bulk-edit.product.alertRestrictedFields.message')"></span>
                     <ul>
@@ -120,7 +109,7 @@
                             {{ $tc(`sw-bulk-edit.product.alertRestrictedFields.${restrictedField}`) }}
                         </li>
                     </ul>
-                </sw-alert>
+                </mt-banner>
             </sw-card>
 
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.scss
@@ -123,40 +123,7 @@
         border: 0;
     }
 
-    &__inheritance .sw-alert {
-        display: grid;
-        grid-template-columns: 60px 1fr;
-        margin: 0 auto;
-        border: 1px solid $color-module-purple-900;
-        background: $color-module-purple-50;
-        font-size: $font-size-xs;
-
-        .sw-alert__actions:empty {
-            display: none;
-        }
-
-        .sw-alert__icon {
-            position: unset;
-            margin-top: 28px;
-            margin-left: 26px;
-        }
-    }
-
-    &__inheritance .sw-alert__body {
-        padding-left: 0;
-    }
-
-    &__inheritance-icon {
-        position: relative;
-    }
-
-    &__inheritance-icon .sw-icon {
-        position: absolute;
-        top: 30px;
-        right: 10px;
-    }
-
-    &__restricted-fields .sw-alert {
+    &__restricted-fields .mt-banner {
         margin: 0 auto;
     }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/page/sw-bulk-edit-product/sw-bulk-edit-product.spec.js
@@ -133,7 +133,7 @@ describe('src/module/sw-bulk-edit/page/sw-bulk-edit-product', () => {
                     'sw-tabs': await wrapTestComponent('sw-tabs'),
                     'sw-tabs-deprecated': await wrapTestComponent('sw-tabs-deprecated', { sync: true }),
                     'sw-tabs-item': await wrapTestComponent('sw-tabs-item'),
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-label': true,
                     'sw-extension-component-section': true,
                     'sw-inheritance-switch': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/html/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/html/config/config.spec.js
@@ -16,7 +16,7 @@ async function createWrapper() {
                 },
                 stubs: {
                     'sw-code-editor': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                 },
             },
             props: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/html/config/sw-cms-el-config-html.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/html/config/sw-cms-el-config-html.html.twig
@@ -6,7 +6,7 @@
         @blur="onBlur"
     />
 
-    <sw-alert variant="warning">
+    <mt-banner variant="attention">
         {{ $tc('sw-cms.elements.html.config.warning') }}
-    </sw-alert>
+    </mt-banner>
 </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/html/config/sw-cms-el-config-html.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/html/config/sw-cms-el-config-html.scss
@@ -9,7 +9,7 @@
         }
     }
 
-    .sw-alert {
+    .mt-banner {
         margin-bottom: 0;
 
         .sw-icon {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.html.twig
@@ -164,12 +164,12 @@
                         v-if="page.locked"
                         class="sw-cms-detail__page-notification"
                     >
-                        <sw-alert
+                        <mt-banner
                             class="sw-cms-detail__page-notification-alert"
                             variant="info"
                         >
                             {{ $tc('sw-cms.detail.label.lockedNotification') }}
-                        </sw-alert>
+                        </mt-banner>
                     </div>
                     {% endblock %}
 
@@ -195,9 +195,9 @@
                         v-if="hasPageErrors"
                         class="sw-cms-detail__page-notification"
                     >
-                        <sw-alert
+                        <mt-banner
                             class="sw-cms-detail__page-notification-alert is--error"
-                            variant="error"
+                            variant="attention"
                         >
                             {{ $tc('sw-cms.detail.notification.errorCollectionText') }}
                             <li
@@ -206,7 +206,7 @@
                             >
                                 {{ error.detail }}
                             </li>
-                        </sw-alert>
+                        </mt-banner>
                     </div>
                     {% endblock %}
 
@@ -216,9 +216,9 @@
                         v-if="validationWarnings.length > 0"
                         class="sw-cms-detail__page-notification"
                     >
-                        <sw-alert
+                        <mt-banner
                             class="sw-cms-detail__page-notification-alert is--warning"
-                            variant="warning"
+                            variant="attention"
                         >
                             {{ $tc('sw-cms.detail.notification.warningCollectionText') }}
                             <li
@@ -227,7 +227,7 @@
                             >
                                 {{ warning }}
                             </li>
-                        </sw-alert>
+                        </mt-banner>
                     </div>
                     {% endblock %}
 
@@ -237,12 +237,12 @@
                         v-if="page.locked"
                         class="sw-cms-detail__page-notification is--info"
                     >
-                        <sw-alert
+                        <mt-banner
                             class="sw-cms-detail__page-notification-alert"
                             variant="info"
                         >
                             {{ $tc('sw-cms.detail.label.lockedNotification') }}
-                        </sw-alert>
+                        </mt-banner>
                     </div>
                     {% endblock %}
                     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
@@ -34,7 +34,7 @@ async function createWrapper(versionId = '0fa91ce3e96a4bc2be4bd9ce752c3425') {
                     `,
                     },
                     'sw-cms-toolbar': await wrapTestComponent('sw-cms-toolbar'),
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-language-switch': true,
                     'sw-router-link': true,
                     'sw-icon': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
@@ -77,7 +77,7 @@ async function createWrapper(
                     'sw-skeleton': true,
                     'sw-empty-state': true,
                     'sw-sorting-select': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-modal': {
                         template: `
                         <div class="sw-modal-stub">

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-config/sw-extension-config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-config/sw-extension-config.spec.js
@@ -35,7 +35,7 @@ describe('src/module/sw-extension/page/sw-extension-config.spec', () => {
                     'sw-icon': true,
                     'sw-tabs': true,
                     'sw-sales-channel-switch': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-form-field-renderer': true,
                     'sw-inherit-wrapper': true,
                     'sw-card': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.html.twig
@@ -8,38 +8,34 @@
         v-else
         class="sw-extension-my-extensions-listing__listing-grid"
     >
-        <sw-alert
+        <mt-banner
             v-if="!isAppUrlReachable"
             class="sw-extension-my-extensions-listing__app-url-warning"
-            variant="warning"
+            variant="attention"
             :title="$tc('sw-app.component.sw-app-wrong-app-url-modal.title')"
         >
 
-            <template #default>
-                <div>
-                    {{ $tc('sw-app.component.sw-app-wrong-app-url-modal.explanation') }}
-                </div>
-                <div>
-                    {{ $tc('sw-app.component.sw-app-wrong-app-url-modal.textGetSupport') }}
-                </div>
-            </template>
+            <div>
+                {{ $tc('sw-app.component.sw-app-wrong-app-url-modal.explanation') }}
+            </div>
+            <div>
+                {{ $tc('sw-app.component.sw-app-wrong-app-url-modal.textGetSupport') }}
+            </div>
 
-            <template #actions>
-                <sw-button
-                    class="sw-app-wrong-app-url-modal__content-link-button"
-                    variant="ghost"
-                    :link="$tc('sw-app.component.sw-app-wrong-app-url-modal.linkToDocsArticle')"
-                >
-                    {{ $tc('sw-app.component.sw-app-wrong-app-url-modal.labelLearnMoreButton') }}
-                </sw-button>
-            </template>
+            <mt-button
+                class="sw-app-wrong-app-url-modal__content-link-button"
+                ghost
+                :link="$tc('sw-app.component.sw-app-wrong-app-url-modal.linkToDocsArticle')"
+            >
+                {{ $tc('sw-app.component.sw-app-wrong-app-url-modal.labelLearnMoreButton') }}
+            </mt-button>
 
-        </sw-alert>
+        </mt-banner>
 
-        <sw-alert
+        <mt-banner
             v-if="extensionManagementDisabled"
             class="sw-extension-my-extensions-listing__runtime-extension-warning"
-            variant="warning"
+            variant="attention"
             :title="$tc('sw-extension-store.component.sw-extension-my-extensions-listing.alertExtensionManagement.title')"
         >
             <template #default>
@@ -55,7 +51,7 @@
                     {{ $tc('sw-app.component.sw-app-wrong-app-url-modal.labelLearnMoreButton') }}
                 </sw-external-link>
             </template>
-        </sw-alert>
+        </mt-banner>
 
         {% block sw_extension_my_extensions_list_empty_state %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.scss
@@ -28,13 +28,17 @@
         .sw-extension-my-extensions-listing__app-url-warning {
             max-width: 960px;
             margin-bottom: 32px;
+
+            .sw-app-wrong-app-url-modal__content-link-button .mt-button__content {
+                display: inline-block;
+            }
         }
 
         .sw-extension-my-extensions-listing__runtime-extension-warning {
             max-width: 960px;
             margin-bottom: 32px;
 
-            .sw-alert__actions {
+            .mt-banner__actions {
                 padding: 16px;
             }
         }

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.spec.js
@@ -69,12 +69,9 @@ async function createWrapper() {
                     'sw-select-field': await wrapTestComponent('sw-select-field', { sync: true }),
                     'sw-select-field-deprecated': await wrapTestComponent('sw-select-field-deprecated', { sync: true }),
                     'sw-block-field': await wrapTestComponent('sw-block-field', { sync: true }),
-                    'sw-alert': await wrapTestComponent('sw-alert', {
-                        sync: true,
-                    }),
+                    'mt-banner': true,
                     'sw-skeleton': true,
                     'sw-external-link': true,
-                    'sw-alert-deprecated': true,
                     'sw-inheritance-switch': true,
                     'sw-ai-copilot-badge': true,
                     'sw-help-text': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-detail/sw-flow-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-detail/sw-flow-detail.html.twig
@@ -74,13 +74,13 @@
                 {% block sw_flow_tabs_header_extension %}{% endblock %}
             </sw-tabs>
             {% endblock %}
-            <sw-alert
+            <mt-banner
                 v-if="isTemplate"
-                variant="warning"
+                variant="attention"
                 class="sw-flow-detail__warning"
             >
                 {{ $tc('sw-flow.flowNotification.messageWarningSave') }}
-            </sw-alert>
+            </mt-banner>
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_flow_tabs_content %}
             <template v-if="isLoading">

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-detail/sw-flow-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-detail/sw-flow-detail.spec.js
@@ -206,7 +206,7 @@ async function createWrapper(query = {}, config = {}, flowId = null, saveSuccess
                     }),
                     'sw-button-deprecated': await wrapTestComponent('sw-button-deprecated', { sync: true }),
                     'sw-skeleton': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-flow-leave-page-modal': true,
                     'sw-tabs': {
                         template: `

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-flow/sw-flow-detail-flow.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-flow/sw-flow-detail-flow.html.twig
@@ -8,9 +8,9 @@
         :class="{'sw-flow-detail-flow-template': isTemplate }"
         :style="flowContainerStyle"
     >
-        <sw-alert
+        <mt-banner
             v-if="isUnknownTrigger"
-            variant="warning"
+            variant="attention"
             class="sw-flow-detail-flow__warning-unknow-trigger"
         >
             <p>{{ $tc('sw-flow.flowNotification.messageUnknownTriggerWarning') }}</p>
@@ -20,15 +20,15 @@
                 <li>{{ $tc('sw-flow.flowNotification.textGuide2') }}</li>
                 <li>{{ $tc('sw-flow.flowNotification.textGuide3') }}</li>
             </ul>
-        </sw-alert>
+        </mt-banner>
 
-        <sw-alert
+        <mt-banner
             v-if="!isLoading && !isUnknownTrigger && showActionWarning "
-            variant="warning"
+            variant="attention"
             class="sw-flow-detail-flow__warning-box"
         >
             {{ $tc('sw-flow.detail.warningText') }}
-        </sw-alert>
+        </mt-banner>
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_flow_detail_trigger_card %}
         <div class="sw-flow-detail-flow__trigger-card">

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-flow/sw-flow-detail-flow.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-flow/sw-flow-detail-flow.scss
@@ -18,7 +18,7 @@
         }
     }
 
-    &__warning-box.sw-alert {
+    &__warning-box.mt-banner {
         margin-bottom: 40px;
     }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-flow/sw-flow-detail-flow.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-flow/sw-flow-detail-flow.spec.js
@@ -125,7 +125,7 @@ async function createWrapper(privileges = []) {
                         class="sw-flow-trigger" />
                 `,
                 },
-                'sw-alert': true,
+                'mt-banner': true,
             },
             provide: {
                 repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-general/sw-flow-detail-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-general/sw-flow-detail-general.html.twig
@@ -3,9 +3,9 @@
 <div class="sw-flow-detail-general">
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_flow_detail_general_information %}
-    <sw-alert
+    <mt-banner
         v-if="isUnknownTrigger"
-        variant="warning"
+        variant="attention"
         class="sw-flow-detail-general__warning-unknow-trigger"
     >
         <p>{{ $tc('sw-flow.flowNotification.messageUnknownTriggerWarning') }}</p>
@@ -15,7 +15,7 @@
             <li>{{ $tc('sw-flow.flowNotification.textGuide2') }}</li>
             <li>{{ $tc('sw-flow.flowNotification.textGuide3') }}</li>
         </ul>
-    </sw-alert>
+    </mt-banner>
 
     <sw-card
         class="sw-flow-detail-general__general-card"

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-general/sw-flow-detail-general.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-general/sw-flow-detail-general.spec.js
@@ -46,7 +46,7 @@ async function createWrapper(privileges = [], query = {}) {
                         template: '<div><slot></slot></div>',
                     },
                     'sw-switch-field': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                 },
             },
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list/sw-flow-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list/sw-flow-list.html.twig
@@ -124,9 +124,9 @@
                 >
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_flow_list_grid_action_modal_confirm_delete_text %}
-                    <sw-alert variant="warning">
+                    <mt-banner variant="attention">
                         {{ deleteWarningMessage() }}
-                    </sw-alert>
+                    </mt-banner>
                     {% endblock %}
 
                     <template #modal-footer>
@@ -154,9 +154,9 @@
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_flow_list_grid_bulk_modal_delete_confirm_text %}
             <template #bulk-modal-delete-confirm-text="{ selectionCount }">
-                <sw-alert variant="warning">
+                <mt-banner variant="attention">
                     {{ bulkDeleteWarningMessage(selectionCount) }}
-                </sw-alert>
+                </mt-banner>
             </template>
             {% endblock %}
         </sw-entity-listing>

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list/sw-flow-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list/sw-flow-list.spec.js
@@ -67,7 +67,7 @@ async function createWrapper(privileges = [], hasSnippetFromApp = false, customF
                 'sw-context-menu-item': await wrapTestComponent('sw-context-menu-item'),
                 'sw-empty-state': true,
                 'sw-search-bar': true,
-                'sw-alert': true,
+                'mt-banner': true,
                 'sw-extension-component-section': true,
                 'sw-ai-copilot-badge': true,
                 'sw-context-button': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal/sw-import-export-edit-profile-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal/sw-import-export-edit-profile-modal.html.twig
@@ -11,12 +11,12 @@
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_import_export_edit_profile_modal_alert %}
-        <sw-alert
+        <mt-banner
             v-if="profile.systemDefault"
             variant="info"
         >
             {{ $tc('sw-import-export.profile.systemDefaultInfoText') }}
-        </sw-alert>
+        </mt-banner>
         {% endblock %}
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal/sw-import-export-edit-profile-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal/sw-import-export-edit-profile-modal.spec.js
@@ -60,7 +60,7 @@ async function createWrapper(
                     'sw-tabs': true,
                     'sw-tabs-item': true,
                     'sw-modal': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-import-export-edit-profile-general': true,
                     'sw-import-export-edit-profile-field-indicators': true,
                     'sw-import-export-edit-profile-import-settings': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-exporter/sw-import-export-exporter.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-exporter/sw-import-export-exporter.html.twig
@@ -36,8 +36,8 @@
     <template v-if="showProductVariantsInfo">
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_import_export_exporter_product_variants_warning %}
-        <sw-alert
-            variant="warning"
+        <mt-banner
+            variant="attention"
             class="sw-import-export-exporter__variants-warning"
         >
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
@@ -63,7 +63,7 @@
                 </a>
             </p>
             {% endblock %}
-        </sw-alert>
+        </mt-banner>
         {% endblock %}
     </template>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-exporter/sw-import-export-exporter.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-exporter/sw-import-export-exporter.spec.js
@@ -72,16 +72,13 @@ describe('components/sw-import-export-exporter', () => {
                         'sw-highlight-text': await wrapTestComponent('sw-highlight-text'),
                         'sw-popover': await wrapTestComponent('sw-popover'),
                         'sw-popover-deprecated': await wrapTestComponent('sw-popover-deprecated', { sync: true }),
-                        'sw-alert': await wrapTestComponent('sw-alert'),
+                        'mt-banner': { template: `<div class="mt-banner"><slot></slot></div>` },
                         'sw-import-export-exporter': await wrapTestComponent('sw-import-export-exporter', { sync: true }),
                         'sw-button': true,
                         'sw-product-variant-info': true,
                         'sw-inheritance-switch': true,
                         'sw-ai-copilot-badge': true,
                         'sw-help-text': true,
-                        'sw-alert-deprecated': {
-                            template: '<div><slot></slot></div>',
-                        },
                     },
                     provide: {
                         shortcutService: {

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-importer/sw-import-export-importer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-importer/sw-import-export-importer.html.twig
@@ -57,8 +57,8 @@
     <template v-if="showProductVariantsInfo">
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_import_export_importer_product_variants_warning %}
-        <sw-alert
-            variant="warning"
+        <mt-banner
+            variant="attention"
             class="sw-import-export-importer__variants-warning"
         >
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
@@ -84,7 +84,7 @@
                 </a>
             </p>
             {% endblock %}
-        </sw-alert>
+        </mt-banner>
         {% endblock %}
     </template>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-importer/sw-import-export-importer.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-importer/sw-import-export-importer.spec.js
@@ -64,7 +64,7 @@ async function createWrapper() {
                 'sw-highlight-text': await wrapTestComponent('sw-highlight-text'),
                 'sw-popover': await wrapTestComponent('sw-popover'),
                 'sw-popover-deprecated': await wrapTestComponent('sw-popover-deprecated', { sync: true }),
-                'sw-alert': await wrapTestComponent('sw-alert'),
+                'mt-banner': { template: '<div class="mt-banner"><slot /></div>' },
                 'sw-modal': {
                     template: `
                         <div class="sw-modal">
@@ -92,9 +92,6 @@ async function createWrapper() {
                 'sw-import-export-progress': true,
                 'sw-inheritance-switch': true,
                 'sw-field-error': true,
-                'sw-alert-deprecated': {
-                    template: '<div><slot></slot></div>',
-                },
             },
             provide: {
                 importExport: {

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.html.twig
@@ -184,13 +184,13 @@
 
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_integration_list_detail_modal_inner_helptext %}
-                    <sw-alert
+                    <mt-banner
                         v-if="showSecretAccessKey"
-                        variant="warning"
+                        variant="attention"
                         class="sw-integration-list__secret-help-text-alert"
                     >
                         {{ $tc('sw-integration.detail.secretHelpText') }}
-                    </sw-alert>
+                    </mt-banner>
                     {% endblock %}
 
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-integration/page/sw-integration-list/sw-integration-list.spec.js
@@ -124,7 +124,7 @@ async function createWrapper(privileges = []) {
                     `,
                 },
                 'sw-context-menu-item': await wrapTestComponent('sw-context-menu-item'),
-                'sw-alert': true,
+                'mt-banner': true,
                 'sw-label': true,
                 'router-link': true,
                 'sw-loader': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-login/sw-login-login.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-login/sw-login-login.html.twig
@@ -13,15 +13,14 @@
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_login_login_alert %}
-    <sw-alert
+    <mt-banner
         v-if="showLoginAlert"
         variant="info"
-        appearance="default"
         :show-icon="true"
         :closable="false"
     >
         {{ loginAlertMessage }}
-    </sw-alert>
+    </mt-banner>
     {% endblock %}
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-login/sw-login-login.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-login/sw-login-login.spec.js
@@ -66,10 +66,9 @@ async function createWrapper(loginSuccessfull) {
                 'router-link': true,
                 'sw-button': await wrapTestComponent('sw-button'),
                 'sw-button-deprecated': await wrapTestComponent('sw-button-deprecated'),
-                'sw-alert': await wrapTestComponent('sw-alert', {
-                    sync: true,
-                }),
-                'sw-alert-deprecated': await wrapTestComponent('sw-alert-deprecated', { sync: true }),
+                'mt-banner': {
+                    template: '<div class="mt-banner"><div class="mt-banner__message"><slot></slot></div></div>',
+                },
                 'sw-checkbox-field': await wrapTestComponent('sw-checkbox-field'),
                 'sw-checkbox-field-deprecated': await wrapTestComponent('sw-checkbox-field-deprecated', { sync: true }),
                 'sw-base-field': await wrapTestComponent('sw-base-field'),
@@ -106,7 +105,7 @@ describe('module/sw-login/view/sw-login-login/sw-login-login.spec.js', () => {
         await wrapper.get('#sw-field--username').setValue('Username');
         await wrapper.get('#sw-field--password').setValue('Password');
 
-        expect(wrapper.find('.sw-alert').exists()).toBe(false);
+        expect(wrapper.find('.mt-banner').exists()).toBe(false);
 
         await wrapper.get('.sw-login-login').trigger('submit');
 
@@ -116,13 +115,13 @@ describe('module/sw-login/view/sw-login-login/sw-login-login.spec.js', () => {
         expect(setTimeout).toHaveBeenCalledTimes(2);
         expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
 
-        expect(wrapper.get('.sw-alert__message').text()).toBe('["sw-login.index.messageAuthThrottled",0,{"seconds":1}]');
+        expect(wrapper.get('.mt-banner__message').text()).toBe('["sw-login.index.messageAuthThrottled",0,{"seconds":1}]');
 
         // advance the timer to make the warning disappear
         jest.advanceTimersByTime(1001);
         await wrapper.vm.$nextTick();
 
-        expect(wrapper.find('.sw-alert').exists()).toBe(false);
+        expect(wrapper.find('.mt-banner').exists()).toBe(false);
     });
 
     it('should handle login', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery-info/sw-login-recovery-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery-info/sw-login-recovery-info.html.twig
@@ -21,17 +21,17 @@
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_login_recovery_info_info %}
     <template v-if="!rateLimitTime">
-        <sw-alert variant="info">
+        <mt-banner variant="info">
             {{ $tc('sw-login.recovery.info.info') }}
-        </sw-alert>
-        <sw-alert variant="warning">
+        </mt-banner>
+        <mt-banner variant="attention">
             {{ $tc('sw-login.recovery.info.warning') }}
-        </sw-alert>
+        </mt-banner>
     </template>
     <template v-else>
-        <sw-alert variant="info">
+        <mt-banner variant="info">
             {{ $tc('global.error-codes.FRAMEWORK__RATE_LIMIT_EXCEEDED', 0, { seconds: rateLimitTime }) }}
-        </sw-alert>
+        </mt-banner>
     </template>
     {% endblock %}
 </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery-info/sw-login-recovery-info.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery-info/sw-login-recovery-info.spec.js
@@ -5,7 +5,7 @@
 import { config, mount } from '@vue/test-utils';
 
 function hasNormalWarningAlert(wrapper) {
-    const alerts = wrapper.findAll('.sw-alert');
+    const alerts = wrapper.findAll('.mt-banner');
 
     expect(alerts).toHaveLength(2);
     expect(alerts.at(0).text()).toBe('["sw-login.recovery.info.info"]');
@@ -26,8 +26,7 @@ async function createWrapper(routeParams) {
             stubs: {
                 'router-view': true,
                 'router-link': true,
-                'sw-alert': await wrapTestComponent('sw-alert'),
-                'sw-alert-deprecated': await wrapTestComponent('sw-alert-deprecated'),
+                'mt-banner': { template: `<div class="mt-banner"><slot></slot></div>` },
                 'sw-icon': true,
             },
         },
@@ -65,7 +64,7 @@ describe('module/sw-login/recovery-info.spec.js', () => {
 
         expect(wrapper.get('.sw-login__form-headline').text()).toBe('["sw-login.recovery.info.headline"]');
 
-        const alerts = wrapper.findAll('.sw-alert');
+        const alerts = wrapper.findAll('.mt-banner');
 
         expect(alerts).toHaveLength(1);
         expect(alerts.at(0).text()).toBe('["global.error-codes.FRAMEWORK__RATE_LIMIT_EXCEEDED",0,{"seconds":1}]');

--- a/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery/sw-login-recovery.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-login/view/sw-login-recovery/sw-login-recovery.spec.js
@@ -7,7 +7,6 @@ import { config, mount } from '@vue/test-utils';
 import 'src/module/sw-login/view/sw-login-recovery';
 import 'src/app/component/form/sw-text-field';
 import 'src/app/component/base/sw-button';
-import 'src/app/component/base/sw-alert';
 
 async function createWrapper() {
     // delete global $router and $routes mocks
@@ -65,7 +64,7 @@ async function createWrapper() {
                 'sw-contextual-field': true,
                 'router-link': true,
                 'sw-button': await Shopware.Component.build('sw-button'),
-                'sw-alert': await Shopware.Component.build('sw-alert'),
+                'mt-banner': true,
                 'sw-icon': true,
                 'sw-button-deprecated': true,
             },
@@ -87,7 +86,7 @@ describe('module/sw-login/recovery.spec.js', () => {
     it('should redirect on submit', async () => {
         await wrapper.get('#email').setValue('test@example.com');
 
-        expect(wrapper.find('.sw-alert').exists()).toBe(false);
+        expect(wrapper.find('.mt-banner').exists()).toBe(false);
 
         await wrapper.get('.sw-login__recovery-form').trigger('submit');
 

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -335,12 +335,12 @@
                 class="sw-mail-template-detail__test-mail-sidebar"
             >
                 <div class="sw-mail-template-detail__test-mail-sidebar-container">
-                    <sw-alert
+                    <mt-banner
                         v-if="showLanguageNotAssignedToSalesChannelWarning"
-                        variant="warning"
+                        variant="attention"
                     >
                         {{ $tc('sw-mail-template.detail.sidebar.languageNotAssignedToSalesChannel') }}
-                    </sw-alert>
+                    </mt-banner>
 
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_mail_template_mail_text_form_test_mail_field %}

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.spec.js
@@ -166,7 +166,7 @@ async function createWrapper(privileges = []) {
                 'sw-modal': true,
                 'sw-text-field': true,
                 'sw-context-menu-item': true,
-                'sw-alert': true,
+                'mt-banner': true,
                 'sw-code-editor': {
                     props: [
                         'disabled',

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.html.twig
@@ -3,14 +3,14 @@
 <div class="sw-media-quickinfo">
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_media_quickinfo_broken_file %}
-    <sw-alert
+    <mt-banner
         v-if="!item.hasFile"
         class="sw-media-quickinfo__alert-file-missing"
-        variant="warning"
+        variant="attention"
         :title="$tc('sw-media.sidebar.infoMissingFile.titleMissingFile')"
     >
         {{ $tc('sw-media.sidebar.infoMissingFile.descriptionMissingFile') }}
-    </sw-alert>
+    </mt-banner>
     {% endblock %}
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.spec.js
@@ -72,7 +72,7 @@ async function createWrapper(itemMockOptions, mediaServiceFunctions = {}, mediaR
                             <slot></slot>
                         </div>`,
                 },
-                'sw-alert': true,
+                'mt-banner': true,
                 'sw-icon': true,
                 'sw-media-collapse': {
                     template: `

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.html.twig
@@ -163,13 +163,13 @@
                 {% endblock %}
 
                 {% block sw_order_customer_grid_sales_channel_notification_alert %}
-                <sw-alert
+                <mt-banner
                     class="sw-order-customer-grid__sales-channel-selection--notification-alert"
-                    variant="warning"
+                    variant="attention"
                     :show-icon="false"
                 >
                     {{ $tc('sw-order.initialModal.customerGrid.alertSelectSalesChannel') }}
-                </sw-alert>
+                </mt-banner>
                 {% endblock %}
             </template>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.spec.js
@@ -137,7 +137,7 @@ async function createWrapper() {
                     },
                 },
                 'sw-bulk-edit-modal': true,
-                'sw-alert': true,
+                'mt-banner': true,
                 'sw-data-grid-inline-edit': true,
                 'sw-data-grid-column-boolean': true,
                 'sw-select-field': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.html.twig
@@ -105,18 +105,18 @@
         {% endblock %}
         <sw-card-view>
 
-            <sw-alert
+            <mt-banner
                 v-if="isOrderEditing"
                 class="sw-order-detail__alert"
-                variant="warning"
+                variant="attention"
             >
                 {{ $tc('sw-order.detail.textUnsavedOrderWarning') }}
-            </sw-alert>
+            </mt-banner>
 
-            <sw-alert
+            <mt-banner
                 v-if="missingProductLineItems.length > 0"
                 class="sw-order-detail__alert"
-                variant="warning"
+                variant="attention"
             >
                 {{ $tc('sw-order.detailBase.textMissingProductLineItems') }}
 
@@ -130,9 +130,9 @@
                 </ul>
 
                 {{ $tc('sw-order.detailBase.textMissingProductLineItemsDescription') }}
-            </sw-alert>
+            </mt-banner>
 
-            <sw-alert
+            <mt-banner
                 v-if="convertedProductLineItems.length > 0"
                 class="sw-order-detail__alert"
                 variant="info"
@@ -149,7 +149,7 @@
                 </ul>
 
                 {{ $tc('sw-order.detailBase.textConvertedProductLineItemsDescription') }}
-            </sw-alert>
+            </mt-banner>
 
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_order_detail_content_tabs %}

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/sw-order-detail.spec.js
@@ -53,7 +53,7 @@ async function createWrapper(order = {}) {
                             <slot></slot>
                         </div>`,
                 },
-                'sw-alert': true,
+                'mt-banner': true,
                 'sw-loader': true,
                 'router-view': true,
                 'sw-tabs': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-generate-codes-modal/sw-promotion-v2-generate-codes-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-generate-codes-modal/sw-promotion-v2-generate-codes-modal.html.twig
@@ -12,13 +12,13 @@
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
         {% block sw_promotion_v2_generate_codes_modal_warning %}
-        <sw-alert
+        <mt-banner
             v-if="promotion.individualCodes && promotion.individualCodes.length > 0"
             class="sw-promotion-v2-generate-codes-modal__warning"
-            variant="warning"
+            variant="attention"
         >
             {{ $tc('sw-promotion-v2.detail.base.codes.individual.generateModal.warning') }}
-        </sw-alert>
+        </mt-banner>
         {% endblock %}
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-generate-codes-modal/sw-promotion-v2-generate-codes-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/promotion-codes/sw-promotion-v2-generate-codes-modal/sw-promotion-v2-generate-codes-modal.spec.js
@@ -75,7 +75,7 @@ async function createWrapper(propsData = {}) {
                     'sw-modal': {
                         template: '<div class="sw-modal"><slot /></div>',
                     },
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-button': true,
                     'sw-button-process': true,
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/component/sw-settings-price-rounding/sw-settings-price-rounding.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/component/sw-settings-price-rounding/sw-settings-price-rounding.html.twig
@@ -3,13 +3,13 @@
 <div class="sw-settings-price-rounding">
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_settings_price_rounding_header_warning %}
-    <sw-alert
+    <mt-banner
         v-if="showHeaderWarning"
         class="sw-settings-price-rounding__header-warning"
-        variant="warning"
+        variant="attention"
     >
         {{ $tc('sw-settings-currency.price-rounding.headerWarning') }}
-    </sw-alert>
+    </mt-banner>
     {% endblock %}
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
@@ -107,13 +107,13 @@
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_settings_price_rounding_header_info %}
-    <sw-alert
+    <mt-banner
         v-if="showHeaderInfo"
         class="sw-settings-price-rounding__header-info"
         variant="info"
     >
         {{ $tc('sw-settings-currency.price-rounding.headerInfo') }}
-    </sw-alert>
+    </mt-banner>
     {% endblock %}
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-currency/component/sw-settings-price-rounding/sw-settings-price-rounding.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-currency/component/sw-settings-price-rounding/sw-settings-price-rounding.spec.js
@@ -17,7 +17,7 @@ async function createWrapper() {
                     'sw-switch-field': true,
                     'sw-number-field': true,
                     'sw-single-select': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                 },
             },
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.html.twig
@@ -209,14 +209,14 @@
                     </sw-container>
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_settings_language_detail_content_alert_change_parent %}
-                    <sw-alert
+                    <mt-banner
                         v-if="showAlertForChangeParentLanguage"
                         class="sw-settings-language--alert-change-parent"
                         :title="$tc('global.default.warning')"
-                        variant="warning"
+                        variant="attention"
                     >
                         {{ $tc('sw-settings-language.detail.textAlertChangeParent') }}
-                    </sw-alert>
+                    </mt-banner>
                     {% endblock %}
                 </sw-card>
                 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-language/page/sw-settings-language-detail/sw-settings-language-detail.spec.js
@@ -123,7 +123,7 @@ async function createWrapper(privileges = [], languageId = null, stubTranslation
                 'sw-inheritance-switch': true,
                 'sw-highlight-text': true,
                 'sw-select-result': true,
-                'sw-alert': true,
+                'mt-banner': true,
                 'sw-custom-field-set-renderer': true,
                 'sw-product-variant-info': true,
                 'sw-icon': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-create/sw-settings-number-range-create.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-create/sw-settings-number-range-create.html.twig
@@ -8,14 +8,14 @@
 
 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
 {% block sw_settings_number_range_detail_content_global_product_warning %}
-<sw-alert
+<mt-banner
     v-if="isShowProductWarning"
     class="sw-number_range-quickinfo__alert-global-type sw-number_range-quickinfo__product-alert"
-    variant="warning"
+    variant="attention"
     :title="$tc('sw-settings-number-range.general.infoGlobalTypeTitle', 0, { typeName: 'Product'})"
 >
     {{ $tc('sw-settings-number-range.general.infoGlobalType', 0, { typeName: 'Product' }) }}
-</sw-alert>
+</mt-banner>
 {% endblock %}
 
 {% block sw_settings_number_range_detail_assignment_card_global_warning %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-create/sw-settings-number-range-create.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-create/sw-settings-number-range-create.spec.js
@@ -94,7 +94,7 @@ async function createWrapper() {
                         />
                       `,
                     },
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-skeleton': true,
                     'sw-language-switch': true,
                     'sw-custom-field-set-renderer': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-detail/sw-settings-number-range-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-detail/sw-settings-number-range-detail.html.twig
@@ -73,14 +73,14 @@
                 >
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_settings_number_range_detail_content_global_warning %}
-                    <sw-alert
+                    <mt-banner
                         v-if="numberRange && numberRange.type && numberRange.type.global"
                         class="sw-number_range-quickinfo__alert-global-type"
-                        variant="warning"
+                        variant="attention"
                         :title="$tc('sw-settings-number-range.general.infoGlobalTypeTitle', 0, {typeName: numberRange.type.typeName})"
                     >
                         {{ $tc('sw-settings-number-range.general.infoGlobalType', 0, {typeName: numberRange.type.typeName}) }}
-                    </sw-alert>
+                    </mt-banner>
                     {% endblock %}
 
                     <sw-container
@@ -232,24 +232,24 @@
                 >
                     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                     {% block sw_settings_number_range_detail_assignment_card_global_warning %}
-                    <sw-alert
+                    <mt-banner
                         v-if="numberRange !== null && numberRange.global"
                         class="sw-number_range-quickinfo__alert-global-type"
                         variant="info"
                         :title="$tc('sw-settings-number-range.general.infoGlobalTitle', 0, {name: numberRange.name})"
                     >
                         {{ $tc('sw-settings-number-range.general.infoGlobal', 0, {name: numberRange.name}) }}
-                    </sw-alert>
-                    <sw-alert
+                    </mt-banner>
+                    <mt-banner
                         v-if="
                             numberRange.type !== null &&
                                 numberRange.numberRangeSalesChannels &&
                                 numberRange.numberRangeSalesChannels.length > 0"
                         class="sw-number_range-quickinfo__alert-global-type"
-                        variant="warning"
+                        variant="attention"
                     >
                         {{ $tc('sw-settings-number-range.general.infoSalesChannelBound', 0, {name: numberRange.name}) }}
-                    </sw-alert>
+                    </mt-banner>
                     {% endblock %}
                     <sw-container
                         columns="repeat(auto-fit, minmax(100%, 1fr))"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-detail/sw-settings-number-range-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-number-range/page/sw-settings-number-range-detail/sw-settings-number-range-detail.spec.js
@@ -86,7 +86,7 @@ async function createWrapper() {
                         template: '<div class="sw-entity-single-select"></div>',
                         props: ['disabled'],
                     },
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-skeleton': true,
                     'sw-language-switch': true,
                     'sw-custom-field-set-renderer': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.html.twig
@@ -8,10 +8,10 @@
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_settings_search_search_index_description %}
-    <sw-alert
+    <mt-banner
         v-if="isRebuildInProgress"
         class="sw-settings-search__search-index-warning-text"
-        variant="warning"
+        variant="attention"
     >
 
         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
@@ -26,7 +26,7 @@
         <p>{{ $tc('sw-settings-search.generalTab.textRebuildSearchIndexDescription') }}</p>
         {% endblock %}
 
-    </sw-alert>
+    </mt-banner>
     {% endblock %}
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-search-index/sw-settings-search-search-index.spec.js
@@ -93,8 +93,8 @@ async function createWrapper(privileges = []) {
                     'sw-progress-bar': {
                         template: '<div class="sw-progress-bar"><slot></slot></div>',
                     },
-                    'sw-alert': {
-                        template: '<div class="sw-alert"><slot></slot></div>',
+                    'mt-banner': {
+                        template: '<div class="mt-banner"><slot></slot></div>',
                     },
                     'sw-icon': true,
                     'sw-loader': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.html.twig
@@ -8,15 +8,15 @@
 >
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_settings_shipping_price_matrix_topbar_alert %}
-    <sw-alert
+    <mt-banner
         v-if="priceGroup.isNew"
         class="sw-settings-shipping-price-matrix__new-matrix-alert"
-        variant="warning"
+        variant="attention"
         :title="$tc('global.default.warning')"
         :closable="false"
     >
         {{ $tc('sw-settings-shipping.priceMatrix.newMatrixAlertMessage') }}
-    </sw-alert>
+    </mt-banner>
     {% endblock %}
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_settings_shipping_price_matrix_topbar %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.spec.js
@@ -23,7 +23,7 @@ const createWrapper = async () => {
                     'sw-context-button': true,
                     'sw-data-grid': true,
                     'sw-context-menu-item': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-price-rule-modal': true,
                     'sw-number-field': true,
                     'sw-inheritance-switch': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.html.twig
@@ -85,19 +85,19 @@
             variant="small"
             @modal-close="updateModalShown = false"
         >
-            <sw-alert
+            <mt-banner
                 v-if="displayUnknownPluginsWarning"
-                variant="warning"
+                variant="attention"
             >
                 {{ $tc('sw-settings-shopware-updates.updateModal.messageNotInStore') }}
-            </sw-alert>
+            </mt-banner>
 
-            <sw-alert
+            <mt-banner
                 v-if="displayIncompatiblePluginsWarning"
-                variant="warning"
+                variant="attention"
             >
                 {{ $tc('sw-settings-shopware-updates.updateModal.messageIncompatible') }}
-            </sw-alert>
+            </mt-banner>
 
             <sw-radio-field
                 v-if="displayIncompatiblePluginsWarning"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.scss
@@ -5,12 +5,12 @@
     }
 
     .sw-changelog {
-        .sw-alert__icon {
+        .mt-banner__icon {
             left: 25px;
             top: 27px;
         }
 
-        .sw-alert__title {
+        .mt-banner__title {
             margin-left: 26px;
         }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.spec.js
@@ -177,7 +177,7 @@ describe('module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-
                         'sw-empty-state': true,
                         'sw-data-grid-column-boolean': true,
                         'sw-context-button': true,
-                        'sw-alert': true,
+                        'mt-banner': true,
                         'sw-radio-field': true,
                         'sw-ai-copilot-badge': true,
                         'sw-context-menu-item': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/sw-system-config.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/sw-system-config.html.twig
@@ -37,9 +37,9 @@
         <template v-if="hasCssFields">
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_system_config_content_compile_notice %}
-            <sw-alert variant="warning">
+            <mt-banner variant="attention">
                 {{ $tc('sw-settings.system-config.compileNotice') }}
-            </sw-alert>
+            </mt-banner>
 
             {% endblock %}
         </template>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/sw-system-config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/component/sw-system-config/sw-system-config.spec.js
@@ -80,7 +80,7 @@ async function createWrapper(defaultValues = {}) {
                 'sw-text-editor': await wrapTestComponent('sw-text-field'),
                 'sw-extension-component-section': true,
                 'sw-ai-copilot-badge': true,
-                'sw-alert': true,
+                'mt-banner': true,
                 'sw-context-button': true,
                 'sw-product-variant-info': true,
                 'sw-help-text': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.html.twig
@@ -438,25 +438,25 @@
 
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_settings_user_detail_detail_modal_inner_field_help_text %}
-            <sw-alert
+            <mt-banner
                 v-if="!showSecretAccessKey"
-                variant="warning"
+                variant="attention"
                 class="sw-settings-user-detail__secret-help-text-alert"
             >
                 {{ $tc('sw-users-permissions.users.user-detail.modal.hintCreateNewApiKeys') }}
-            </sw-alert>
+            </mt-banner>
             {% endblock %}
             {% endblock %}
 
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_settings_user_detail_detail_modal_inner_help_text %}
-            <sw-alert
+            <mt-banner
                 v-else
-                variant="warning"
+                variant="attention"
                 class="sw-settings-user-detail__secret-help-text-alert"
             >
                 {{ $tc('sw-users-permissions.users.user-detail.modal.secretHelpText') }}
-            </sw-alert>
+            </mt-banner>
             {% endblock %}
 
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/page/sw-users-permissions-user-detail/sw-users-permissions-user-detail.spec.js
@@ -162,7 +162,7 @@ async function createWrapper(
                     'sw-button': true,
                     'sw-verify-user-modal': true,
                     'sw-media-modal-v2': true,
-                    'sw-alert': true,
+                    'mt-banner': true,
                     'sw-text-field-deprecated': true,
                     'sw-help-text': true,
                     'sw-inheritance-switch': true,


### PR DESCRIPTION
…riant attention

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In 6.7 version, use meteor component library `mt-banner` to replace `sw-alert` component. The variant "warning" will not work with `mt-banner`. Instead, we will use variant `attention`

**Not correct**
![Screenshot 2025-01-10 at 15 55 50](https://github.com/user-attachments/assets/40636b3b-275b-426b-8607-45bf480917fa)

**Correct**
![image](https://github.com/user-attachments/assets/1c8d383f-10a3-4ecf-89f9-ce050ddcbeb2)



### 2. What does this change do, exactly?
Change `mt-alert` with variant warning to `mt-banner` with variant attention.


### The link of mt-banner meteor component 
https://meteor-component-library.vercel.app/?path=/story/interaction-tests-feedback-indicator-mt-banner--visual-test-banner-attention
