### PR TITLE
chore: fix flaky 8.4 unit test issue

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -163,7 +163,6 @@ jobs:
         ports:
           - "3306:3306"
         options: --health-cmd="mysqladmin ping || mariadb-admin ping"
-    continue-on-error: ${{ matrix.php == '8.4' && true || false }}
     steps:
       - name: Setup Shopware
         uses: shopware/setup-shopware@main

--- a/deprecation.ignore
+++ b/deprecation.ignore
@@ -9,3 +9,6 @@
 
 %Twig Filter "spaceless" is deprecated in%
 %The "tag" constructor argument of the ".*" class is deprecated and ignored \(check which TokenParser class set it to ".*"\), the tag is now automatically set by the Parser when needed.%
+
+# league/event 2.x has not fixed this php 8.4 issue yet
+%Implicitly marking parameter \$emitter as nullable is deprecated, the explicit nullable type must be used instead%

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -102,8 +102,11 @@ class TestBootstrapper
         if ($this->classLoader !== null) {
             return $this->classLoader;
         }
-
         $classLoader = require $this->getProjectDir() . '/vendor/autoload.php';
+
+        $prev = error_reporting(0);
+        class_exists(\League\OAuth2\Server\AuthorizationServer::class);
+        error_reporting($prev);
 
         $this->addPluginAutoloadDev($classLoader);
 

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -104,8 +104,10 @@ class TestBootstrapper
         }
         $classLoader = require $this->getProjectDir() . '/vendor/autoload.php';
 
+        // workaround for league/event deprecation in php 8.4
         $prev = error_reporting(0);
         class_exists(\League\OAuth2\Server\AuthorizationServer::class);
+        error_clear_last();
         error_reporting($prev);
 
         $this->addPluginAutoloadDev($classLoader);

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -104,7 +104,8 @@ class TestBootstrapper
         }
         $classLoader = require $this->getProjectDir() . '/vendor/autoload.php';
 
-        // workaround for league/event deprecation in php 8.4
+        // TODO: NEXT-39363 - Remove on league/oauth2-server update
+        // Workaround for league/event deprecation in php 8.4
         $prev = error_reporting(0);
         class_exists(\League\OAuth2\Server\AuthorizationServer::class);
         error_clear_last();


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

We've made phpunit with php 8.4 allowed to fail due to a flaky phpunit test

### 2. What does this change do, exactly?

Load the class which would trigger the deprecation in the TestBootstrapper, so that it does not cause the test to fail randomly. 

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
