### PR TITLE
fix: convert uuid to hex before dispatching SystemLanguageChangeEvent

### DIFF
--- a/src/Core/Maintenance/System/Service/ShopConfigurator.php
+++ b/src/Core/Maintenance/System/Service/ShopConfigurator.php
@@ -103,7 +103,7 @@ class ShopConfigurator
             $this->changeDefaultLanguageData($newDefaultLanguageId, $currentLocale, $locale);
         }
 
-        $this->eventDispatcher->dispatch(new SystemLanguageChangeEvent($newDefaultLanguageId));
+        $this->eventDispatcher->dispatch(new SystemLanguageChangeEvent(Uuid::fromBytesToHex($newDefaultLanguageId)));
     }
 
     public function setDefaultCurrency(string $currencyCode): void

--- a/tests/unit/Core/Maintenance/System/Service/ShopConfiguratorTest.php
+++ b/tests/unit/Core/Maintenance/System/Service/ShopConfiguratorTest.php
@@ -88,7 +88,7 @@ class ShopConfiguratorTest extends TestCase
 
     public function testSetDefaultLanguageMatchCurrentLocale(): void
     {
-        $currentLocaleId = Uuid::randomHex();
+        $currentLocaleId = Uuid::randomBytes();
 
         $this->connection->expects(static::once())->method('fetchAssociative')->willReturnCallback(function (string $sql, array $parameters) use ($currentLocaleId) {
             static::assertSame(
@@ -128,7 +128,7 @@ class ShopConfiguratorTest extends TestCase
         $this->expectException(MaintenanceException::class);
         $this->expectExceptionMessage('Locale with iso-code "vi-VN" not found');
 
-        $currentLocaleId = Uuid::randomHex();
+        $currentLocaleId = Uuid::randomBytes();
 
         $this->connection->expects(static::once())->method('fetchAssociative')->willReturnCallback(function (string $sql, array $parameters) use ($currentLocaleId) {
             static::assertSame(
@@ -172,7 +172,8 @@ class ShopConfiguratorTest extends TestCase
         int $expectedInsertCall,
         callable $insertCallback
     ): void {
-        $currentLocaleId = Uuid::randomHex();
+        $currentLocaleId = Uuid::randomBytes();
+        $languageId = Uuid::randomBytes();
 
         $this->connection->expects(static::once())->method('fetchAssociative')->willReturnCallback(function (string $sql, array $parameters) use ($currentLocaleId) {
             static::assertSame(
@@ -189,9 +190,12 @@ class ShopConfiguratorTest extends TestCase
             return ['id' => $currentLocaleId, 'code' => 'en-GB'];
         });
 
-        $viLocaleId = Uuid::randomHex();
+        $viLocaleId = Uuid::randomBytes();
 
-        $this->connection->expects(static::atLeast(2))->method('fetchOne')->willReturn($viLocaleId);
+        $this->connection->expects(static::atLeast(2))->method('fetchOne')->willReturnOnConsecutiveCalls(
+            $viLocaleId,
+            $languageId
+        );
 
         $methodReturns = array_values(array_filter([$expectedMissingTranslations, $expectedStateTranslations], static fn (array $item) => $item !== []));
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The `languageId` passed to the `SystemLanguageChangeEvent` should be a hex value, not byte, since directly using SQL should be the exception and thus hex values are expected.

This will fix the current pipeline issues in rufus, which is failing because of the LanguagePack also being installed during unit tests, which has a subscriber expecting a hex value.

### 2. What does this change do, exactly?
Convert the `languageId` before dispatching the event.

### 3. Describe each step to reproduce the issue or behaviour.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
