### PR TITLE
refactor: Increase account content width on the XL viewport

### DIFF
--- a/changelog/_unreleased/2025-01-11-increase-account-main-content-width-on-xl-viewport.md
+++ b/changelog/_unreleased/2025-01-11-increase-account-main-content-width-on-xl-viewport.md
@@ -1,0 +1,8 @@
+---
+title: Increase account main content width on XL viewport
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed the default account page template `storefront/page/account/_page.html.twig` to occupy more space on the `XL` viewport, by changing the classes `offset-xl-1 col-xl-9` on the `.account-content-main` element to `col-xl-10`

--- a/src/Storefront/Resources/views/storefront/page/account/_page.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/_page.html.twig
@@ -12,7 +12,7 @@
             {% endblock %}
 
             {% block page_account_main %}
-                <div class="account-content-main col-lg-9 offset-xl-1 col-xl-9">
+                <div class="account-content-main col-lg-9 col-xl-10">
                     {% block page_account_main_content %}{% endblock %}
                 </div>
             {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
There is empty space, which can be utilized on the `XL` viewport:
![image](https://github.com/user-attachments/assets/3c4df0a1-75a4-4046-8dea-052a90ba6411)

### 2. What does this change do, exactly?
![image](https://github.com/user-attachments/assets/b21bcfc5-663f-41d3-a800-a840029239a9)

As this might be a breaking change, I added this behind a feature flag for Shopware 6.7.0.0.

### 3. Describe each step to reproduce the issue or behaviour.
Develop a module in the account area, which needs more space.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
