### PR TITLE
fix: foreign key of the 1:1 and n:1 association is now using the defi…

### DIFF
--- a/changelog/_unreleased/2025-01-12-fix-foreign-key-definition.md
+++ b/changelog/_unreleased/2025-01-12-fix-foreign-key-definition.md
@@ -1,0 +1,10 @@
+---
+title: Fix foreign key definition
+issue: 
+author: Oliver Skroblin
+author_email: oliver@goblin-coders.de
+author_github: OliverSkroblin
+---
+
+# Core
+* Changed `AttributeEntityCompiler` to fix the foreign key name, if a foreign key column is defined.  

--- a/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
+++ b/src/Core/Framework/DataAbstractionLayer/AttributeEntityCompiler.php
@@ -230,11 +230,11 @@ class AttributeEntityCompiler
     {
         if ($field->column) {
             $column = $field->column;
+            $fk = $column;
         } else {
             $column = $this->converter->normalize($property->getName());
+            $fk = $column . '_id';
         }
-
-        $fk = $column . '_id';
 
         return match (true) {
             $field instanceof State => [$column, $property->getName(), $field->machine, $field->scopes],

--- a/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/AttributeEntityIntegrationTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\AttributeMappingDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\AttributeTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\ManyToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldType\DateInterval;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\Price;
@@ -83,6 +84,27 @@ class AttributeEntityIntegrationTest extends TestCase
         static::assertInstanceOf(EntityRepository::class, static::getContainer()->get('attribute_entity_currency.repository'));
         static::assertInstanceOf(EntityRepository::class, static::getContainer()->get('attribute_entity_agg.repository'));
         static::assertInstanceOf(EntityRepository::class, static::getContainer()->get('attribute_entity_translation.repository'));
+    }
+
+    public function testAssociationDefinitions(): void
+    {
+        $definition = static::getContainer()->get('attribute_entity_agg.definition');
+
+        static::assertInstanceOf(AttributeEntityDefinition::class, $definition);
+        static::assertNotNull($definition->getFields()->get('ownColumn'));
+        static::assertNotNull($definition->getFields()->get('attributeEntity'));
+
+        $field = $definition->getFields()->get('ownColumn');
+        static::assertInstanceOf(ManyToOneAssociationField::class, $field);
+        static::assertSame('attribute_entity_id', $field->getStorageName());
+        static::assertSame('id', $field->getReferenceField());
+        static::assertSame('attribute_entity', $field->getReferenceEntity());
+
+        $field = $definition->getFields()->get('attributeEntity');
+        static::assertInstanceOf(ManyToOneAssociationField::class, $field);
+        static::assertSame('attribute_entity_id', $field->getStorageName());
+        static::assertSame('id', $field->getReferenceField());
+        static::assertSame('attribute_entity', $field->getReferenceEntity());
     }
 
     public function testCrudRoot(): void

--- a/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntityAgg.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/fixture/AttributeEntityAgg.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Entity;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\Field;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\FieldType;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ForeignKey;
+use Shopware\Core\Framework\DataAbstractionLayer\Attribute\ManyToOne;
 use Shopware\Core\Framework\DataAbstractionLayer\Attribute\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity as EntityStruct;
 
@@ -24,4 +25,10 @@ class AttributeEntityAgg extends EntityStruct
 
     #[Field(type: FieldType::STRING)]
     public string $number;
+
+    #[ManyToOne(entity: 'attribute_entity', column: 'attribute_entity_id')]
+    public ?AttributeEntity $ownColumn = null;
+
+    #[ManyToOne(entity: 'attribute_entity')]
+    public ?AttributeEntity $attributeEntity = null;
 }


### PR DESCRIPTION
### 1. Why is this change necessary?
You are not able to define many to one and one to one associations right now, which point to another attribute entity

### 2. What does this change do, exactly?
It removes the duplicate suffix from the association FK column

### 3. Describe each step to reproduce the issue or behaviour.
- Create an attribute entity which defines a 1:1 assocaition (or n:1 - 1:n) to your own entity
- Check definition of the "underlying" definition. 

a) Auto detection broken: When you have a one-to-one definition, the foreign key is: `id_id`.
b) When you define a column in your association attribute, it got suffixed. When you try column: `id`, the FK is `id_id`

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have read the contribution requirements and fulfill them.
