### PR TITLE
fix: force cache invaldiation during test

### DIFF
--- a/src/Core/Framework/Adapter/Cache/CacheInvalidator.php
+++ b/src/Core/Framework/Adapter/Cache/CacheInvalidator.php
@@ -30,6 +30,7 @@ class CacheInvalidator
         private readonly EventDispatcherInterface $dispatcher,
         private readonly LoggerInterface $logger,
         private readonly RequestStack $requestStack,
+        private readonly string $environment
     ) {
     }
 
@@ -103,6 +104,7 @@ class CacheInvalidator
 
     private function shouldForceInvalidate(): bool
     {
-        return $this->requestStack->getMainRequest()?->headers->get(PlatformRequest::HEADER_FORCE_CACHE_INVALIDATE) === '1';
+        return $this->environment === 'test' // immediately invalidate in test environment, to make tests deterministic
+            || $this->requestStack->getMainRequest()?->headers->get(PlatformRequest::HEADER_FORCE_CACHE_INVALIDATE) === '1';
     }
 }

--- a/src/Core/Framework/DependencyInjection/cache.xml
+++ b/src/Core/Framework/DependencyInjection/cache.xml
@@ -55,6 +55,7 @@
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Psr\Log\LoggerInterface"/>
             <argument type="service" id="request_stack"/>
+            <argument>%kernel.environment%</argument>
         </service>
 
         <service id="Shopware\Core\Framework\Adapter\Cache\InvalidateCacheTask">

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
@@ -44,6 +44,7 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
+            'test'
         );
 
         $invalidator->invalidate([]);
@@ -69,9 +70,36 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
+            'prod'
         );
 
         $invalidator->invalidate(['foo'], true);
+    }
+
+    public function testInvalidationIsImplicitlyForcedOnNonProdEnvs(): void
+    {
+        $tagAwareAdapter = $this->createMock(TagAwareAdapterInterface::class);
+        $tagAwareAdapter
+            ->expects(static::once())
+            ->method('invalidateTags')
+            ->with(['foo']);
+
+        $redisInvalidatorStorage = $this->createMock(RedisInvalidatorStorage::class);
+        $redisInvalidatorStorage
+            ->expects(static::never())
+            ->method('store');
+
+        $invalidator = new CacheInvalidator(
+            0,
+            [$tagAwareAdapter],
+            $redisInvalidatorStorage,
+            new EventDispatcher(),
+            new NullLogger(),
+            new RequestStack([new Request()]),
+            'dev'
+        );
+
+        $invalidator->invalidate(['foo']);
     }
 
     public function testInvalidationIsImplicitlyForcedWhenRequestHeaderIsSet(): void
@@ -97,6 +125,7 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([$request]),
+            'prod'
         );
 
         $invalidator->invalidate(['foo']);
@@ -121,6 +150,7 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
+            'prod'
         );
 
         $invalidator->invalidate(['foo']);
@@ -153,6 +183,7 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
+            'prod'
         );
 
         $invalidator->invalidate(['foo'], $force);
@@ -211,6 +242,7 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
+            'test'
         );
 
         $invalidator->invalidateExpired();
@@ -239,6 +271,7 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
+            'test'
         );
 
         $invalidator->invalidateExpired();

--- a/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
+++ b/tests/unit/Core/Framework/Adapter/Cache/CacheInvalidatorTest.php
@@ -76,7 +76,7 @@ class CacheInvalidatorTest extends TestCase
         $invalidator->invalidate(['foo'], true);
     }
 
-    public function testInvalidationIsImplicitlyForcedOnNonProdEnvs(): void
+    public function testInvalidationIsImplicitlyForcedOnTestEnvs(): void
     {
         $tagAwareAdapter = $this->createMock(TagAwareAdapterInterface::class);
         $tagAwareAdapter
@@ -96,7 +96,7 @@ class CacheInvalidatorTest extends TestCase
             new EventDispatcher(),
             new NullLogger(),
             new RequestStack([new Request()]),
-            'dev'
+            'test'
         );
 
         $invalidator->invalidate(['foo']);


### PR DESCRIPTION
Apparently the env check was needed to not require redis during test setup. see https://github.com/shopware/shopware/pull/6061#discussion_r1907221508