### PR TITLE
fix: Updated child order line item quantity on parent quantity change

### DIFF
--- a/changelog/_unreleased/2025-01-13-updated-child-order-line-item-quantity-on-parent-quantity-change.md
+++ b/changelog/_unreleased/2025-01-13-updated-child-order-line-item-quantity-on-parent-quantity-change.md
@@ -1,0 +1,9 @@
+---
+title: Updated child order line item quantity on parent quantity change
+issue: NEXT-19806
+author: Michel Bade
+author_email: m.bade@shopware.com
+author_github: @cyl3x
+---
+# Administration
+* Changed `sw-order-line-items-grid` to update child line items when the parent line item quantity is updated.

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/index.js
@@ -408,12 +408,32 @@ export default {
             return get(item, 'price.calculatedTaxes') && item.price.calculatedTaxes.length > 1;
         },
 
-        updateItemQuantity(item) {
-            if (item.type !== this.lineItemTypes.CUSTOM) {
+        updateItemQuantity(item, newQuantity = undefined) {
+            if (!Number.isInteger(newQuantity)) {
+                if (item.type === this.lineItemTypes.CUSTOM) {
+                    item.priceDefinition.quantity = item.quantity;
+                }
+
                 return;
             }
 
-            item.priceDefinition.quantity = item.quantity;
+            this.refreshChildrenQuantity([item], item.quantity, newQuantity);
+        },
+
+        refreshChildrenQuantity(children, oldParentQuantity, newParentQuantity) {
+            children.forEach((item) => {
+                const newQuantity = Math.floor(item.quantity / oldParentQuantity) * newParentQuantity;
+
+                if (this.hasChildren(item)) {
+                    this.refreshChildrenQuantity(item.children, item.quantity, newQuantity);
+                }
+
+                item.quantity = newQuantity;
+
+                if (item.type === this.lineItemTypes.CUSTOM) {
+                    item.priceDefinition.quantity = item.quantity;
+                }
+            });
         },
 
         showTaxRulesInlineEdit(item) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.html.twig
@@ -260,14 +260,14 @@
             {% block sw_order_line_items_grid_grid_columns_quantity_inline_edit %}
             <sw-number-field
                 v-if="isInlineEdit && !isCreditItem(item.id)"
-                v-model:value="item.quantity"
+                :value="item.quantity"
                 name="sw-field--item-quantity"
                 number-type="int"
                 :min="1"
                 size="small"
                 placeholder="0"
                 number-align-end
-                @update:value="updateItemQuantity(item)"
+                @update:value="updateItemQuantity(item, $event)"
             />
             {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec.js
@@ -154,6 +154,30 @@ const mockMultipleTaxesItem = {
     },
 };
 
+const mockNestedItem = {
+    ...mockItems[0],
+    children: [
+        {
+            ...mockItems[0],
+            id: '6',
+            label: 'Nested in level 1',
+            quantity: 3,
+        },
+        {
+            ...mockItems[0],
+            id: '7',
+            label: 'Nested in level 1 (2)',
+            quantity: 1,
+            children: [{
+                ...mockItems[0],
+                id: '8',
+                label: 'Nested in level 2',
+                quantity: 2,
+            }],
+        },
+    ]
+}
+
 const deleteEndpoint = jest.fn(() => Promise.resolve());
 
 async function createWrapper() {
@@ -923,5 +947,25 @@ describe('src/module/sw-order/component/sw-order-line-items-grid', () => {
         const labelLink = wrapper.find('.sw-order-line-items-grid__item-product');
 
         expect(labelLink.exists()).toBeFalsy();
+    });
+
+    it('should recursively update nested line item quantities', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.setProps({
+            order: {
+                ...wrapper.props().order,
+                lineItems: [mockNestedItem],
+            },
+        });
+
+        const productItem = wrapper.vm.order.lineItems[0];
+
+        wrapper.vm.updateItemQuantity(productItem, 3);
+
+        expect(productItem.quantity).toBe(3);
+        expect(productItem.children[0].quantity).toBe(9);
+        expect(productItem.children[1].quantity).toBe(3);
+        expect(productItem.children[1].children[0].quantity).toBe(6);
     });
 });


### PR DESCRIPTION
fixes #6211

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When changing the quantity of an order line that has children/nested items via the administration order page, an error complaining about a quantity mismatch will occur. This happens because the quantity of a child item needs to be a multiple of the parent, but the administration misses updating all the children accordingly.

### 2. What does this change do, exactly?
Update all children of a line item recursively, like [LineItem::refreshChildQuantity](https://github.com/shopware/shopware/blob/e62f7a52beb127cb38216aedf4e65e536042a2be/src/Core/Checkout/Cart/LineItem/LineItem.php#L609) does.

### 3. Describe each step to reproduce the issue or behaviour.
1. Place an order with an item that includes a child
2. (or - place an order with two line items and change one order line item in the DB to have a parentId of the other)
3. Attempt to update the quantity of the line item via the administration order detail page
 
### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- fixes #6211 

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
