### PR TITLE
feat(bootstrap): reduce custom CSS for line-items

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_line-item.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_line-item.scss
@@ -420,8 +420,7 @@
             .line-item-unit-price-label,
             .line-item-total-price-label,
             .line-item-tax-price-label {
-                // display: none;
-                @include visually-hidden();
+                display: none;
             }
         }
     }
@@ -632,8 +631,7 @@
     }
 
     .line-item-unit-price-label {
-        // display: none;
-        @include visually-hidden();
+        display: none;
     }
 
     .line-item-tax-price-label {
@@ -648,8 +646,7 @@
 
     @include media-breakpoint-only(sm) {
         .line-item-unit-price-label {
-            // display: block;
-            @include not-visually-hidden();
+            display: block;
         }
     }
 
@@ -671,8 +668,7 @@
 
     .is-offcanvas {
         .line-item-unit-price-label {
-            @include visually-hidden();
-            //display: none;
+            display: none;
         }
 
         .line-item-total-price-label {

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_line-item.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_line-item.scss
@@ -1,690 +1,705 @@
-.line-item {
-    margin-bottom: $spacer;
+// @deprecated tag:v6.7.0 - Deprecate custom styling for line-items. Using Bootstrap grid classes in template instead.
+@if feature('v6.7.0.0') {
+    .line-item-img-container {
+        width: 4.375rem;
+    }
 
-    &.is-discount {
-        .line-item-total-price {
-            color: $success;
+    .line-item-img {
+        height: 4.375rem;
+    }
+} @else {
+    .line-item {
+        margin-bottom: $spacer;
+
+        &.is-discount {
+            .line-item-total-price {
+                color: $success;
+            }
         }
     }
-}
 
-.line-item-info {
-    // Equals: .col-10 .col-md-5
-    @include make-col-ready();
-    @include make-col(10);
-    @include media-breakpoint-up(md) {
-        @include make-col(5);
-    }
-}
-
-.line-item-details {
-    // Equals: .col-12 .col-sm-7 .col-md-8;
-    @include make-col-ready();
-    @include make-col(12);
-    @include media-breakpoint-up(sm) {
-        @include make-col(7);
-    }
-    @include media-breakpoint-up(md) {
-        @include make-col(8);
-    }
-}
-
-.line-item-quantity {
-    // Equals: .col-12 .col-sm-4 .col-md-2;
-    @include make-col-ready();
-    @include make-col(12);
-    @include media-breakpoint-up(sm) {
-        @include make-col(4);
-    }
-    @include media-breakpoint-up(md) {
-        @include make-col(2);
-    }
-}
-
-.line-item-quantity-label {
-    @include make-col-ready();
-    @include make-col(6);
-    @include media-breakpoint-up(sm) {
-        @include make-col(12);
-    }
-}
-
-.line-item-quantity-select-wrapper {
-    @include make-col-ready();
-    @include make-col(6);
-    @include media-breakpoint-up(sm) {
-        @include make-col(12);
-    }
-}
-
-
-.line-item-unit-price {
-    // Equals: .col-12 .col-sm-4 .col-md-2;
-    @include make-col(12);
-    @include media-breakpoint-up(sm) {
-        @include make-col(4);
-    }
-    @include media-breakpoint-up(md) {
-        @include make-col(2);
-    }
-}
-
-.line-item-tax-price {
-    @include make-col(12);
-    @include media-breakpoint-up(sm) {
-        @include make-col(4);
-    }
-    @include media-breakpoint-up(md) {
-        @include make-col(2);
-    }
-}
-
-.line-item-total-price {
-    // Equals: .col-12 .col-sm-4 .col-md-2;
-    @include make-col-ready();
-    @include make-col(12);
-    @include media-breakpoint-up(sm) {
-        @include make-col(4);
-    }
-    @include media-breakpoint-up(md) {
-        @include make-col(2);
-    }
-}
-
-.line-item-remove {
-    // Equals: .col-2 .col-md-1;
-    @include make-col-ready();
-    @include make-col(2);
-    @include media-breakpoint-up(md) {
-        @include make-col(1);
-    }
-}
-
-// Always display columns underneath each other for offcanvas mode
-.is-offcanvas {
     .line-item-info {
+        // Equals: .col-10 .col-md-5
+        @include make-col-ready();
         @include make-col(10);
+        @include media-breakpoint-up(md) {
+            @include make-col(5);
+        }
     }
 
     .line-item-details {
+        // Equals: .col-12 .col-sm-7 .col-md-8;
+        @include make-col-ready();
         @include make-col(12);
+        @include media-breakpoint-up(sm) {
+            @include make-col(7);
+        }
+        @include media-breakpoint-up(md) {
+            @include make-col(8);
+        }
     }
 
     .line-item-quantity {
+        // Equals: .col-12 .col-sm-4 .col-md-2;
+        @include make-col-ready();
         @include make-col(12);
+        @include media-breakpoint-up(sm) {
+            @include make-col(4);
+        }
+        @include media-breakpoint-up(md) {
+            @include make-col(2);
+        }
     }
 
     .line-item-quantity-label {
-        @include make-col(7);
+        @include make-col-ready();
+        @include make-col(6);
+        @include media-breakpoint-up(sm) {
+            @include make-col(12);
+        }
     }
 
     .line-item-quantity-select-wrapper {
-        @include make-col(5);
+        @include make-col-ready();
+        @include make-col(6);
+        @include media-breakpoint-up(sm) {
+            @include make-col(12);
+        }
     }
 
+
     .line-item-unit-price {
+        // Equals: .col-12 .col-sm-4 .col-md-2;
         @include make-col(12);
+        @include media-breakpoint-up(sm) {
+            @include make-col(4);
+        }
+        @include media-breakpoint-up(md) {
+            @include make-col(2);
+        }
     }
 
     .line-item-tax-price {
         @include make-col(12);
+        @include media-breakpoint-up(sm) {
+            @include make-col(4);
+        }
+        @include media-breakpoint-up(md) {
+            @include make-col(2);
+        }
     }
 
     .line-item-total-price {
+        // Equals: .col-12 .col-sm-4 .col-md-2;
+        @include make-col-ready();
         @include make-col(12);
+        @include media-breakpoint-up(sm) {
+            @include make-col(4);
+        }
+        @include media-breakpoint-up(md) {
+            @include make-col(2);
+        }
     }
 
     .line-item-remove {
+        // Equals: .col-2 .col-md-1;
+        @include make-col-ready();
         @include make-col(2);
-    }
-
-    .line-item-details-container {
-        padding-left: 0;
-    }
-}
-
-.no-remove-button {
-    // Info column needs to use more gird space when no remove button exists as last row.
-    .line-item-info {
         @include media-breakpoint-up(md) {
-            @include make-col(6);
+            @include make-col(1);
         }
     }
-}
 
-.line-item.is-order {
-    margin-left: 20px;
-    margin-right: 20px;
-}
-
-.line-item.is-order .line-item-children .line-item {
-    margin-left: 0;
-    margin-right: 0;
-}
-
-// Reduced table spacing for table grid
-.line-item-info,
-.line-item-details,
-.line-item-quantity,
-.line-item-unit-price,
-.line-item-total-price,
-.line-item-tax-price,
-.line-item-remove {
-    padding-right: $spacer-sm / 2;
-    padding-left: $spacer-sm / 2;
-}
-
-.line-item-discount-icon,
-.line-item-icon {
-    text-align: center;
-    height: 100%;
-
-    .icon {
-        height: 100%;
-
-        > svg {
-            top: 0;
-        }
-    }
-}
-
-.line-item-discount,
-.line-item-promotion {
-    .line-item-icon .icon {
-        color: $success;
-    }
-}
-
-.line-item-container {
-    .line-item-icon .icon {
-        color: $secondary;
-    }
-}
-
-.line-item-nested-icon {
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    display: flex;
-    margin: 0 auto;
-    width: 65px;
-    height: 65px;
-
-    .icon {
-        > svg {
-            top: 0;
-        }
-    }
-}
-
-.line-item-info {
-    order: 1;
-}
-
-.line-item-quantity {
-    order: 3;
-}
-
-.line-item-unit-price,
-.line-item-tax-price {
-    order: 5;
-}
-
-.line-item-total-price {
-    order: 4;
-}
-
-.line-item-remove {
-    order: 2;
-    text-align: right;
-}
-
-.line-item-img-container {
-    text-align: center;
-    width: 70px;
-    margin-bottom: $spacer-sm;
-}
-
-.line-item-img-link {
-    display: block;
-}
-
-.line-item-img {
-    width: 100%;
-    height: 70px;
-    object-fit: contain;
-}
-
-.line-item-info {
-    margin-bottom: $spacer;
-}
-
-.line-item-total-price {
-    font-weight: $font-weight-bold;
-}
-
-.line-item-total-price,
-.line-item-tax-price {
-    justify-content: space-between;
-    display: flex;
-}
-
-.line-item-total-price {
-    justify-content: flex-end;
-}
-
-.line-item-tax-price {
-    justify-content: flex-end;
-}
-
-@include media-breakpoint-only(xs) {
-    .line-item-tax-price,
-    .line-item-unit-price {
-        font-size: $font-size-sm;
-        font-style: italic;
-    }
-}
-
-.line-item-unit-price {
-    display: none;
-}
-
-@include media-breakpoint-up(sm) {
-    .line-item-unit-price {
-        display: flex;
-        justify-content: flex-end;
-    }
-}
-
-.line-item-unit-price.is-shown {
-    display: flex;
-    justify-content: flex-end;
-}
-
-.is-offcanvas .line-item-unit-price {
-    display: none;
-    font-size: $font-size-sm;
-    font-style: italic;
-}
-
-.is-offcanvas .line-item-unit-price {
-    &.is-shown {
-        display: flex;
-        justify-content: flex-end;
-    }
-}
-
-.line-item-quantity-label,
-.line-item-unit-price-label,
-.line-item-total-price-label,
-.line-item-tax-price-label {
-    font-weight: $font-weight-bold;
-    margin-bottom: $spacer-sm;
-}
-
-.line-item-quantity-row {
-    align-items: center;
-    margin-bottom: $spacer-sm;
-}
-
-.line-item-quantity {
-    margin-bottom: $spacer-sm;
-}
-
-.line-item-details-characteristics {
-    margin: $spacer-sm 0;
-    font-size: $font-size-sm;
-
-    .line-item-details-characteristics-option {
-        font-weight: $font-weight-bold;
-    }
-}
-
-.line-item-variants {
-    margin-bottom: $spacer-sm;
-}
-
-.line-item-variants-properties {
-    display: flex;
-}
-
-.line-item-variants-properties-name {
-    margin-right: $spacer-sm;
-}
-
-// Apply tablet and desktop styling only for default and order items
-.is-default,
-.is-order {
-    @include media-breakpoint-up(sm) {
-        .line-item-quantity-container {
-            margin-left: auto;
+    // Always display columns underneath each other for offcanvas mode
+    .is-offcanvas {
+        .line-item-info {
+            @include make-col(10);
         }
 
-        .line-item-quantity-row {
-            align-items: normal;
-            margin-bottom: 0;
+        .line-item-details {
+            @include make-col(12);
         }
 
         .line-item-quantity {
-            flex-direction: column;
-            display: flex;
+            @include make-col(12);
         }
 
-        .line-item-unit-price,
-        .line-item-total-price,
-        .line-item-tax-price {
-            text-align: right;
+        .line-item-quantity-label {
+            @include make-col(7);
         }
 
-        .line-item-unit-price,
-        .line-item-total-price,
-        .line-item-tax-price {
-            justify-content: normal;
-            flex-direction: column;
+        .line-item-quantity-select-wrapper {
+            @include make-col(5);
+        }
+
+        .line-item-unit-price {
+            @include make-col(12);
         }
 
         .line-item-tax-price {
-            order: 4;
+            @include make-col(12);
         }
 
         .line-item-total-price {
-            order: 5;
+            @include make-col(12);
+        }
+
+        .line-item-remove {
+            @include make-col(2);
+        }
+
+        .line-item-details-container {
+            padding-left: 0;
+        }
+    }
+
+    .no-remove-button {
+        // Info column needs to use more gird space when no remove button exists as last row.
+        .line-item-info {
+            @include media-breakpoint-up(md) {
+                @include make-col(6);
+            }
+        }
+    }
+
+    .line-item.is-order {
+        margin-left: 20px;
+        margin-right: 20px;
+    }
+
+    .line-item.is-order .line-item-children .line-item {
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    // Reduced table spacing for table grid
+    .line-item-info,
+    .line-item-details,
+    .line-item-quantity,
+    .line-item-unit-price,
+    .line-item-total-price,
+    .line-item-tax-price,
+    .line-item-remove {
+        padding-right: $spacer-sm / 2;
+        padding-left: $spacer-sm / 2;
+    }
+
+    .line-item-discount-icon,
+    .line-item-icon {
+        text-align: center;
+        height: 100%;
+
+        .icon {
+            height: 100%;
+
+            > svg {
+                top: 0;
+            }
+        }
+    }
+
+    .line-item-discount,
+    .line-item-promotion {
+        .line-item-icon .icon {
+            color: $success;
+        }
+    }
+
+    .line-item-container {
+        .line-item-icon .icon {
+            color: $secondary;
+        }
+    }
+
+    .line-item-nested-icon {
+        align-items: center;
+        justify-content: center;
+        border-radius: 50%;
+        display: flex;
+        margin: 0 auto;
+        width: 65px;
+        height: 65px;
+
+        .icon {
+            > svg {
+                top: 0;
+            }
+        }
+    }
+
+    .line-item-info {
+        order: 1;
+    }
+
+    .line-item-quantity {
+        order: 3;
+    }
+
+    .line-item-unit-price,
+    .line-item-tax-price {
+        order: 5;
+    }
+
+    .line-item-total-price {
+        order: 4;
+    }
+
+    .line-item-remove {
+        order: 2;
+        text-align: right;
+    }
+
+    .line-item-img-container {
+        text-align: center;
+        width: 70px;
+        margin-bottom: $spacer-sm;
+    }
+
+    .line-item-img-link {
+        display: block;
+    }
+
+    .line-item-img {
+        width: 100%;
+        height: 70px;
+        object-fit: contain;
+    }
+
+    .line-item-info {
+        margin-bottom: $spacer;
+    }
+
+    .line-item-total-price {
+        font-weight: $font-weight-bold;
+    }
+
+    .line-item-total-price,
+    .line-item-tax-price {
+        justify-content: space-between;
+        display: flex;
+    }
+
+    .line-item-total-price {
+        justify-content: flex-end;
+    }
+
+    .line-item-tax-price {
+        justify-content: flex-end;
+    }
+
+    @include media-breakpoint-only(xs) {
+        .line-item-tax-price,
+        .line-item-unit-price {
+            font-size: $font-size-sm;
+            font-style: italic;
+        }
+    }
+
+    .line-item-unit-price {
+        display: none;
+    }
+
+    @include media-breakpoint-up(sm) {
+        .line-item-unit-price {
+            display: flex;
+            justify-content: flex-end;
+        }
+    }
+
+    .line-item-unit-price.is-shown {
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    .is-offcanvas .line-item-unit-price {
+        display: none;
+        font-size: $font-size-sm;
+        font-style: italic;
+    }
+
+    .is-offcanvas .line-item-unit-price {
+        &.is-shown {
+            display: flex;
+            justify-content: flex-end;
+        }
+    }
+
+    .line-item-quantity-label,
+    .line-item-unit-price-label,
+    .line-item-total-price-label,
+    .line-item-tax-price-label {
+        font-weight: $font-weight-bold;
+        margin-bottom: $spacer-sm;
+    }
+
+    .line-item-quantity-row {
+        align-items: center;
+        margin-bottom: $spacer-sm;
+    }
+
+    .line-item-quantity {
+        margin-bottom: $spacer-sm;
+    }
+
+    .line-item-details-characteristics {
+        margin: $spacer-sm 0;
+        font-size: $font-size-sm;
+
+        .line-item-details-characteristics-option {
+            font-weight: $font-weight-bold;
+        }
+    }
+
+    .line-item-variants {
+        margin-bottom: $spacer-sm;
+    }
+
+    .line-item-variants-properties {
+        display: flex;
+    }
+
+    .line-item-variants-properties-name {
+        margin-right: $spacer-sm;
+    }
+
+    // Apply tablet and desktop styling only for default and order items
+    .is-default,
+    .is-order {
+        @include media-breakpoint-up(sm) {
+            .line-item-quantity-container {
+                margin-left: auto;
+            }
+
+            .line-item-quantity-row {
+                align-items: normal;
+                margin-bottom: 0;
+            }
+
+            .line-item-quantity {
+                flex-direction: column;
+                display: flex;
+            }
+
+            .line-item-unit-price,
+            .line-item-total-price,
+            .line-item-tax-price {
+                text-align: right;
+            }
+
+            .line-item-unit-price,
+            .line-item-total-price,
+            .line-item-tax-price {
+                justify-content: normal;
+                flex-direction: column;
+            }
+
+            .line-item-tax-price {
+                order: 4;
+            }
+
+            .line-item-total-price {
+                order: 5;
+            }
+        }
+
+        @include media-breakpoint-up(md) {
+            .line-item-info,
+            .line-item-quantity,
+            .line-item-unit-price,
+            .line-item-total-price,
+            .line-item-tax-price,
+            .line-item-remove {
+                order: 0;
+            }
+
+            .line-item-info {
+                margin-bottom: 0;
+            }
+
+            .line-item-quantity-label,
+            .line-item-unit-price-label,
+            .line-item-total-price-label,
+            .line-item-tax-price-label {
+                // display: none;
+                @include visually-hidden();
+            }
+        }
+    }
+
+    // Styling for nested line items
+    .line-item-children {
+        background-color: $gray-100;
+        font-size: $font-size-sm;
+        width: 100%;
+        padding: 10px 20px;
+        order: 10;
+        margin-top: 10px;
+        flex-shrink: initial;
+
+        .line-item-children-elements {
+            padding: 12px 0 0;
+        }
+
+        .line-item-headline {
+            padding: 0;
+            font-weight: $font-weight-semibold;
+        }
+
+        .line-item-change-button {
+            width: fit-content;
+            margin: 0 12px;
+            font-size: 12px;
+            text-decoration: underline;
+            background-color: transparent;
+            border-style: none;
+
+            &:focus {
+                outline: none;
+            }
+        }
+
+        .line-item-collapse {
+            margin: 0;
+        }
+
+        .line-item-collapse-container,
+        .line-item-child-label {
+            padding: 0;
+        }
+
+        .line-item-child-label {
+            position: relative;
+        }
+
+        .line-item-collapse-icon-container {
+            padding: 0;
+            text-align: right;
+        }
+
+        .line-item-collapse-button,
+        .line-item-child-remove-icon {
+            background-color: transparent;
+            border-style: none;
+
+            &:focus {
+                outline: none;
+            }
+        }
+
+        .line-item-collapse-button > .line-item-collapse-icon {
+            transform: rotate(180deg);
+            transition: all 0.2s ease-out;
+        }
+
+        .line-item-collapse-button.collapsed > .line-item-collapse-icon {
+            transform: rotate(0deg);
+        }
+
+        .line-item-children-element {
+            margin: 0;
+            padding: 8px 4px 0;
+        }
+
+        .line-item-children-element > .nesting-level-0 {
+            list-style: none;
+        }
+
+        .line-item-children-element:last-child,
+        .line-item-children-element-divider:last-child {
+            border-style: none;
+        }
+
+        .line-item-child-label-bullet {
+            display: list-item;
+        }
+
+        .line-item-child-total-price {
+            padding: 0;
+            text-align: right;
+            font-weight: $font-weight-semibold;
+        }
+
+        .line-item-child-remove-icon-container {
+            padding: 0;
+            text-align: right;
+        }
+
+        .line-item-children-element-divider {
+            border-top: 1px solid $sw-border-color;
+            margin: $spacer-md 0;
         }
     }
 
     @include media-breakpoint-up(md) {
-        .line-item-info,
-        .line-item-quantity,
-        .line-item-unit-price,
-        .line-item-total-price,
-        .line-item-tax-price,
-        .line-item-remove {
-            order: 0;
-        }
-
-        .line-item-info {
-            margin-bottom: 0;
-        }
-
-        .line-item-quantity-label,
-        .line-item-unit-price-label,
-        .line-item-total-price-label,
-        .line-item-tax-price-label {
-            display: none;
-        }
-    }
-}
-
-// Styling for nested line items
-.line-item-children {
-    background-color: $gray-100;
-    font-size: $font-size-sm;
-    width: 100%;
-    padding: 10px 20px;
-    order: 10;
-    margin-top: 10px;
-    flex-shrink: initial;
-
-    .line-item-children-elements {
-        padding: 12px 0 0;
-    }
-
-    .line-item-headline {
-        padding: 0;
-        font-weight: $font-weight-semibold;
-    }
-
-    .line-item-change-button {
-        width: fit-content;
-        margin: 0 12px;
-        font-size: 12px;
-        text-decoration: underline;
-        background-color: transparent;
-        border-style: none;
-
-        &:focus {
-            outline: none;
+        .line-item-children.nesting-level-1 {
+            margin-left: 96px;
         }
     }
 
-    .line-item-collapse {
+    @include media-breakpoint-up(lg) {
+        .line-item-children.nesting-level-1 {
+            margin-left: 4px;
+        }
+    }
+
+    @include media-breakpoint-up(xl) {
+        .line-item-children.nesting-level-1 {
+            margin-left: 96px;
+        }
+    }
+
+    // Always avoid nested line item indentation for offcanvas
+    .is-offcanvas .line-item-children {
+        margin-left: 0;
+        padding-left: 12px;
+        padding-right: 12px;
+    }
+
+    .line-item-children {
+        font-size: $font-size-sm;
+
+        &.nesting-level-2 {
+            background-color: darken($gray-100, 3.5%);
+        }
+
+        &.nesting-level-3 {
+            background-color: darken($gray-100, 5.5%);
+        }
+
+        .line-item-details-container {
+            padding-left: 0;
+        }
+
+        .line-item-headline-text {
+            font-weight: normal;
+        }
+
+        .line-item-collapse {
+            align-items: center;
+        }
+    }
+
+    .line-item {
         margin: 0;
-    }
+        padding: 10px 0;
+        border-bottom: 1px solid $border-color;
 
-    .line-item-collapse-container,
-    .line-item-child-label {
-        padding: 0;
-    }
-
-    .line-item-child-label {
-        position: relative;
-    }
-
-    .line-item-collapse-icon-container {
-        padding: 0;
-        text-align: right;
-    }
-
-    .line-item-collapse-button,
-    .line-item-child-remove-icon {
-        background-color: transparent;
-        border-style: none;
-
-        &:focus {
-            outline: none;
+        &:last-child {
+            border-bottom: 0;
         }
     }
 
-    .line-item-collapse-button > .line-item-collapse-icon {
-        transform: rotate(180deg);
-        transition: all 0.2s ease-out;
+    .line-item-nested-icon {
+        background-color: $gray-600;
     }
 
-    .line-item-collapse-button.collapsed > .line-item-collapse-icon {
-        transform: rotate(0deg);
+    .line-item-img {
+        padding: $spacer-xs;
+        border: 1px solid $border-color;
+        border-radius: $border-radius-sm;
     }
 
-    .line-item-children-element {
-        margin: 0;
-        padding: 8px 4px 0;
+    .line-item-product-number {
+        margin-bottom: $spacer-sm;
+        font-size: $font-size-sm;
     }
 
-    .line-item-children-element > .nesting-level-0 {
-        list-style: none;
+    .line-item-delivery-date {
+        font-size: $font-size-sm;
     }
 
-    .line-item-children-element:last-child,
-    .line-item-children-element-divider:last-child {
-        border-style: none;
+    .line-item-variants {
+        font-size: $font-size-sm;
     }
 
-    .line-item-child-label-bullet {
-        display: list-item;
+    .line-item-variants-properties-name {
+        font-weight: $font-weight-bold;
     }
 
-    .line-item-child-total-price {
-        padding: 0;
+    .line-item-label {
+        color: $body-color;
+        font-weight: $font-weight-bold;
+    }
+
+    a.line-item-label {
+        &:hover {
+            color: $primary;
+        }
+    }
+
+    .line-item-total-price-value {
         text-align: right;
-        font-weight: $font-weight-semibold;
     }
 
-    .line-item-child-remove-icon-container {
-        padding: 0;
-        text-align: right;
-    }
-
-    .line-item-children-element-divider {
-        border-top: 1px solid $sw-border-color;
-        margin: $spacer-md 0;
-    }
-}
-
-@include media-breakpoint-up(md) {
-    .line-item-children.nesting-level-1 {
-        margin-left: 96px;
-    }
-}
-
-@include media-breakpoint-up(lg) {
-    .line-item-children.nesting-level-1 {
-        margin-left: 4px;
-    }
-}
-
-@include media-breakpoint-up(xl) {
-    .line-item-children.nesting-level-1 {
-        margin-left: 96px;
-    }
-}
-
-// Always avoid nested line item indentation for offcanvas
-.is-offcanvas .line-item-children {
-    margin-left: 0;
-    padding-left: 12px;
-    padding-right: 12px;
-}
-
-.line-item-children {
-    font-size: $font-size-sm;
-
-    &.nesting-level-2 {
-        background-color: darken($gray-100, 3.5%);
-    }
-
-    &.nesting-level-3 {
-        background-color: darken($gray-100, 5.5%);
-    }
-
-    .line-item-details-container {
-        padding-left: 0;
-    }
-
-    .line-item-headline-text {
-        font-weight: normal;
-    }
-
-    .line-item-collapse {
-        align-items: center;
-    }
-}
-
-.line-item {
-    margin: 0;
-    padding: 10px 0;
-    border-bottom: 1px solid $border-color;
-
-    &:last-child {
-        border-bottom: 0;
-    }
-}
-
-.line-item-nested-icon {
-    background-color: $gray-600;
-}
-
-.line-item-img {
-    padding: $spacer-xs;
-    border: 1px solid $border-color;
-    border-radius: $border-radius-sm;
-}
-
-.line-item-product-number {
-    margin-bottom: $spacer-sm;
-    font-size: $font-size-sm;
-}
-
-.line-item-delivery-date {
-    font-size: $font-size-sm;
-}
-
-.line-item-variants {
-    font-size: $font-size-sm;
-}
-
-.line-item-variants-properties-name {
-    font-weight: $font-weight-bold;
-}
-
-.line-item-label {
-    color: $body-color;
-    font-weight: $font-weight-bold;
-}
-
-a.line-item-label {
-    &:hover {
-        color: $primary;
-    }
-}
-
-.line-item-total-price-value {
-    text-align: right;
-}
-
-.line-item-unit-price-label {
-    display: none;
-}
-
-.line-item-tax-price-label {
-    display: inline;
-    font-weight: normal;
-    margin-right: 5px;
-}
-
-.line-item-total-price-label {
-    display: none;
-}
-
-@include media-breakpoint-only(sm) {
     .line-item-unit-price-label {
-        display: block;
-    }
-}
-
-@include media-breakpoint-up(sm) {
-    .line-item-unit-price-value-descriptor {
-        display: none;
-    }
-
-    .line-item-total-price-label {
-        display: block;
+        // display: none;
+        @include visually-hidden();
     }
 
     .line-item-tax-price-label {
-        display: block;
-        font-weight: bold;
-        margin-right: 0;
-    }
-}
-
-.is-offcanvas {
-    .line-item-unit-price-label {
-        display: none;
+        display: inline;
+        font-weight: normal;
+        margin-right: 5px;
     }
 
     .line-item-total-price-label {
         display: none;
     }
 
-    .line-item-unit-price-value-descriptor {
-        display: inline;
+    @include media-breakpoint-only(sm) {
+        .line-item-unit-price-label {
+            // display: block;
+            @include not-visually-hidden();
+        }
     }
-}
 
-@include media-breakpoint-up(md) {
-    .line-item-details-container {
-        padding-left: $spacer-xs;
+    @include media-breakpoint-up(sm) {
+        .line-item-unit-price-value-descriptor {
+            display: none;
+        }
+
+        .line-item-total-price-label {
+            display: block;
+        }
+
+        .line-item-tax-price-label {
+            display: block;
+            font-weight: bold;
+            margin-right: 0;
+        }
     }
-}
 
-.line-item-characteristics {
-    margin: $spacer-sm 0;
-    font-size: $font-size-sm;
+    .is-offcanvas {
+        .line-item-unit-price-label {
+            @include visually-hidden();
+            //display: none;
+        }
 
-    .line-item-characteristics-option {
-        font-weight: $font-weight-bold;
+        .line-item-total-price-label {
+            display: none;
+        }
+
+        .line-item-unit-price-value-descriptor {
+            display: inline;
+        }
     }
-}
 
-.line-item-remove-button .icon {
-    color: inherit;
+    @include media-breakpoint-up(md) {
+        .line-item-details-container {
+            padding-left: $spacer-xs;
+        }
+    }
+
+    .line-item-characteristics {
+        margin: $spacer-sm 0;
+        font-size: $font-size-sm;
+
+        .line-item-characteristics-option {
+            font-weight: $font-weight-bold;
+        }
+    }
+
+    .line-item-remove-button .icon {
+        color: inherit;
+    }
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
@@ -43,17 +43,21 @@
     text-align: center;
 }
 
+// @deprecated tag:v6.7.0 - Variable $cart-grid-gutter-width is deprecated. Using gutter variable `g-1` in template instead.
 $cart-grid-gutter-width: $spacer-sm;
 
-.cart-header-row,
-.line-item-row {
-    margin-right: -$cart-grid-gutter-width / 2;
-    margin-left: -$cart-grid-gutter-width / 2;
+// @deprecated tag:v6.7.0 - Using gutter variable `g-1` in template instead.
+@if not feature('ACCESSIBILITY_TWEAKS') {
+    .cart-header-row,
+    .line-item-row {
+        margin-right: -$cart-grid-gutter-width / 2;
+        margin-left: -$cart-grid-gutter-width / 2;
 
-    > .col,
-    > [class*='col-'] {
-        padding-right: $cart-grid-gutter-width / 2;
-        padding-left: $cart-grid-gutter-width / 2;
+        > .col,
+        > [class*='col-'] {
+            padding-right: $cart-grid-gutter-width / 2;
+            padding-left: $cart-grid-gutter-width / 2;
+        }
     }
 }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/page/checkout/_cart.scss
@@ -47,7 +47,7 @@
 $cart-grid-gutter-width: $spacer-sm;
 
 // @deprecated tag:v6.7.0 - Using gutter variable `g-1` in template instead.
-@if not feature('ACCESSIBILITY_TWEAKS') {
+@if not feature('v6.7.0.0') {
     .cart-header-row,
     .line-item-row {
         margin-right: -$cart-grid-gutter-width / 2;

--- a/src/Storefront/Resources/views/storefront/component/checkout/cart-header.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/cart-header.html.twig
@@ -16,7 +16,7 @@
         {%- else -%}
             <div class="card-title cart-table-header" role="listitem" aria-hidden="true">
         {%- endif -%}
-            <div class="row cart-header-row">
+            <div class="row g-1 cart-header-row">
                 {% block component_checkout_cart_header_product_info %}
                     <div class="{{ infoColumnClass }} cart-header-info">
                         {{ 'checkout.cartHeaderInfo'|trans|sw_sanitize }}

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/delivery-date.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/delivery-date.html.twig
@@ -9,7 +9,7 @@
 
     {% if deliveryPosition and deliveryPosition.deliveryDate %}
         {% block component_line_item_delivery_date_inner %}
-            <div class="line-item-delivery-date">
+            <div class="line-item-delivery-date fs-6">
                 {{ 'checkout.lineItemDeliveryDate'|trans({
                     '%earliest%': deliveryPosition.deliveryDate.earliest|format_date('short', locale=app.request.locale),
                     '%latest%': deliveryPosition.deliveryDate.latest|format_date('short', locale=app.request.locale)

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/image.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/image.html.twig
@@ -2,7 +2,7 @@
     {% set thumbnail %}
         {% if lineItem.cover.url and lineItem.cover.isSpatialObject() == false %}
             {% set attributes = {
-                class: 'img-fluid line-item-img',
+                class: 'img-fluid line-item-img p-1 border object-fit-contain',
                 title: (lineItem.cover.translated.title ?: '')
             } %}
 

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/label.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/label.html.twig
@@ -4,7 +4,7 @@
 
     {% if lineItemLink %}
         <a href="{{ lineItemLink }}"
-           class="line-item-label"
+           class="line-item-label fw-bold"
            title="{{ label }}"
             {% if lineItemModalLink %}
                 data-ajax-modal="modal"

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/quantity.html.twig
@@ -23,15 +23,15 @@
     {% set isDigital = lineItem.states is defined and DOWNLOAD_STATE in lineItem.states and (DOWNLOAD_STATE not in lineItem.states or quantityInformation.maxPurchase === 1) %}
 
     {% block component_line_item_quantity_inner %}
-        <div class="row line-item-quantity-row">
+        <div class="row line-item-quantity-row g-1">
             {% block component_line_item_quantity_label %}
-                <div class="line-item-quantity-label" aria-hidden="true">
+                <div class="line-item-quantity-label fw-bold col-6 col-md-12 d-md-none" aria-hidden="true">
                     {{ 'checkout.cartHeaderQuantity'|trans|sw_sanitize }}
                 </div>
             {% endblock %}
 
             {% block component_line_item_quantity_select_wrapper %}
-                <div class="line-item-quantity-select-wrapper">
+                <div class="line-item-quantity-select-wrapper col-6 col-md-12">
 
                     {% if showQuantitySelect and lineItem.quantityInformation and lineItem.stackable and nestingLevel < 1 %}
                         {% block component_line_item_quantity_select_form %}

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
@@ -1,12 +1,16 @@
 {% block component_line_item_total_price %}
+    {% if feature('v6.7.0.0') %}
+        <div class="row g-1">
+    {% endif %}
+
     {% block component_line_item_total_price_label %}
-        <div class="line-item-total-price-label">
+        <div class="line-item-total-price-label fw-bold col-6 col-md-12 d-md-none py-1">
             {{ 'checkout.cartHeaderTotalPrice'|trans|sw_sanitize }}
         </div>
     {% endblock %}
 
     {% block component_line_item_total_price_value %}
-        <div class="line-item-total-price-value">
+        <div class="line-item-total-price-value col-6 col-md-12 text-end py-1">
             {# Shipping costs discounts always have a price of 0, which might be confusing, therefore we do not show those #}
             {% if lineItem.payload.discountScope != 'delivery' %}
                 {% set lineItemTotalPrice = lineItem.price.totalPrice ?? 0 %}
@@ -31,4 +35,8 @@
             {% endif %}
         </div>
     {% endblock %}
+
+    {% if feature('v6.7.0.0') %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/unit-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/unit-price.html.twig
@@ -1,18 +1,29 @@
 {% block component_line_item_unit_price %}
+    {% if feature('v6.7.0.0') %}
+        <div class="row g-1">
+    {% endif %}
+
     {% block component_line_item_unit_price_label %}
-        <div class="line-item-unit-price-label">
+        <div class="line-item-unit-price-label fw-bold col-6 col-md-12 d-md-none py-1">
             {{ 'checkout.cartHeaderUnitPrice'|trans|sw_sanitize }}
         </div>
     {% endblock %}
 
     {% block component_line_item_unit_price_inner %}
-        <div class="line-item-unit-price-value">
+        <div class="line-item-unit-price-value col-6 col-md-12 text-end py-1">
             {% if displayMode === 'order' %}
                 {{ lineItem.price.unitPrice|currency(order.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }}
             {% else %}
                 {{ lineItem.price.unitPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}
             {% endif %}
-            <span class="line-item-unit-price-value-descriptor"> / {{ 'checkout.lineItemUnitPriceDescriptor'|trans|sw_sanitize }}</span>
+
+            {% if not feature('v6.7.0.0') %}
+                <span class="line-item-unit-price-value-descriptor"> / {{ 'checkout.lineItemUnitPriceDescriptor'|trans|sw_sanitize }}</span>
+            {% endif %}
         </div>
      {% endblock %}
+
+    {% if feature('v6.7.0.0') %}
+        </div>
+    {% endif %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/type/product.html.twig
@@ -28,18 +28,18 @@
     {%- endif -%}
         {% block component_line_item_type_product_inner %}
             {% block component_line_item_type_product_row %}
-                <div class="row line-item-row">
+                <div class="row line-item-row g-1">
                     {% block component_line_item_type_product_row_inner %}
                         {% block component_line_item_type_product_col_info %}
-                            <div class="line-item-info">
+                            <div class="line-item-info col-10 col-md-5 order-1">
                                 {% block component_line_item_type_product_info_row %}
-                                    <div class="row line-item-row">
+                                    <div class="row line-item-row g-1 g-md-2">
                                         {% set showLineItemModal = controllerAction is same as('confirmPage') %}
 
                                         {% if nestingLevel < 1 %}
                                             {% block component_line_item_type_product_image %}
                                                 <div class="col-auto line-item-info-img">
-                                                    <div class="line-item-img-container">
+                                                    <div class="line-item-img-container mb-2">
                                                         {% block component_line_item_type_product_image_inner %}
                                                             {% sw_include '@Storefront/storefront/component/line-item/element/image.html.twig' with {
                                                                 lineItemLink: displayMode !== 'order' or lineItem.productId ? seoUrl('frontend.detail.page', { productId: lineItem.referencedId }) : null,
@@ -52,7 +52,7 @@
                                         {% endif %}
 
                                         {% block component_line_item_type_product_details %}
-                                            <div class="line-item-details">
+                                            <div class="line-item-details col-12 col-md-8">
                                                 {% block component_line_item_type_product_details_container %}
                                                     <div class="line-item-details-container">
                                                     {% block component_line_item_type_product_label %}
@@ -78,7 +78,7 @@
 
                                                     {% if lineItem.payload.productNumber %}
                                                         {% block component_line_item_type_product_number %}
-                                                            <div class="line-item-product-number">
+                                                            <div class="line-item-product-number fs-6 mb-2">
                                                                 {{ 'checkout.cartItemInfoId'|trans|sw_sanitize }} {{ lineItem.payload.productNumber }}
                                                             </div>
                                                         {% endblock %}
@@ -109,14 +109,14 @@
                         {% endblock %}
 
                         {% block component_line_item_type_product_col_quantity %}
-                            <div class="line-item-quantity">
+                            <div class="line-item-quantity col-12 col-md-2 order-3">
                                 {% sw_include '@Storefront/storefront/component/line-item/element/quantity.html.twig' %}
                             </div>
                         {% endblock %}
 
                         {% if showTaxPrice %}
                             {% block component_line_item_type_product_col_tax_price %}
-                                <div class="line-item-tax-price">
+                                <div class="line-item-tax-price col-md-2 col-12">
                                     {% if context.salesChannel.taxCalculationType == 'horizontal' %}
                                         {% sw_include '@Storefront/storefront/component/line-item/element/tax-price.html.twig' %}
                                     {% endif %}
@@ -124,14 +124,14 @@
                             {% endblock %}
                         {% else %}
                             {% block component_line_item_type_product_col_unit_price %}
-                                <div class="line-item-unit-price{% if lineItem.quantity > 1 %} is-shown{% endif %}">
+                                <div class="line-item-unit-price{% if lineItem.quantity > 1 %} is-shown{% endif %} col-12 col-md-2 order-5">
                                     {% sw_include '@Storefront/storefront/component/line-item/element/unit-price.html.twig' %}
                                 </div>
                             {% endblock %}
                         {% endif %}
 
                         {% block component_line_item_type_product_col_total_price %}
-                            <div class="line-item-total-price line-item-price">
+                            <div class="line-item-total-price line-item-price col-12 col-md-2 order-4">
                                 {% sw_include '@Storefront/storefront/component/line-item/element/total-price.html.twig' with {
                                     currency: lineItem.order.currency.isoCode
                                 } %}
@@ -140,7 +140,7 @@
 
                         {% if showRemoveButton %}
                             {% block component_line_item_type_product_col_remove %}
-                                <div class="line-item-remove">
+                                <div class="line-item-remove col-2 col-md-1 order-2 order-md-5 text-end">
                                     {% if lineItem.removable and nestingLevel < 1 %}
                                         {% sw_include '@Storefront/storefront/component/line-item/element/remove.html.twig' %}
                                     {% endif %}


### PR DESCRIPTION
### Reduce custom CSS for Storefront line-items

* The line-items have a rather complex CSS and many layout variations depending on the breakpoint/viewport.
* We also received the feedback that the CSS is complicated and a pain to overwrite.

### Approach

* When using Bootstrap `col-` helper classes and removing almost all 600+ lines in `_line-item.scss` you have kind of the the same layout.
* Working mobile first and removing the special "tablet" layout. You just have "mobile" > "desktop (table)" and the layout is way simpler.
* With the mobile first approarch, we could skip the `col-md-*` for the OffCanvas in the template and would not need special CSS.
* Deprecate the manual gutter overrides using `$cart-grid-gutter-width` and use the build-in gutter variable `g-1` etc. instead.

### Checklist

- [ ] Other line-item types, promotion etc.
- [ ] OffCanvas styling (same as mobile)
- [ ] Digital products with download
- [ ] Order linte-items
- [ ] Nested line-items 😨 
- [ ] Feature 6.7 toggles

#### Mobile

![image](https://github.com/user-attachments/assets/d56f5f26-b13a-4227-8c4a-0bd209943b5e)

#### Desktop

![image](https://github.com/user-attachments/assets/2c665e4e-5b92-4b6c-ba3d-a19c46014d7f)
