### PR TITLE
feat: added support for string in iap request method

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/store/in-app-purchase-checkout.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/store/in-app-purchase-checkout.store.spec.js
@@ -3,25 +3,76 @@
  */
 import './in-app-purchase-checkout.store';
 
-describe('src/app/store/in-app-purchases.store.ts', () => {
+describe('src/app/store/in-app-purchase-checkout.store.ts', () => {
     let store = null;
+
     beforeEach(() => {
         store = Shopware.Store.get('inAppPurchaseCheckout');
     });
 
+    it('should have initial state', () => {
+        expect(store.entry).toBeNull();
+        expect(store.extension).toBeNull();
+    });
+
     it('should open the modal with the correct data', () => {
         const checkoutRequest = {
-            featureId: 'Test Feature',
+            featureId: 'TestFeature',
+        };
+        const extension = {
+            name: 'TestExtension',
+            baseUrl: 'http://example.com',
+            permissions: [],
+            type: 'app',
         };
 
-        store.request(checkoutRequest);
+        store.request(checkoutRequest, extension);
 
         expect(store.entry).toEqual(checkoutRequest);
+        expect(store.extension).toEqual(extension);
+    });
+
+    it('should open the modal with the correct data when extension is a string', () => {
+        const checkoutRequest = {
+            featureId: 'TestFeature',
+        };
+        const extensionName = 'TestExtension';
+        const extension = {
+            name: extensionName,
+            baseUrl: 'http://example.com',
+            permissions: [],
+            version: '1.0.0',
+            type: 'plugin',
+            integrationId: '123',
+            active: true,
+        };
+
+        Shopware.State._store.state.extensions = {};
+        Shopware.State.commit('extensions/addExtension', extension);
+
+        store.request(checkoutRequest, extensionName);
+
+        expect(store.entry).toEqual(checkoutRequest);
+        expect(store.extension).toEqual(extension);
+    });
+
+    it('should throw an error if the extension is not found', () => {
+        const checkoutRequest = {
+            featureId: 'TestFeature',
+        };
+        const extensionName = 'TestExtension';
+
+        Shopware.State._store.state.extensions = {};
+
+        expect(() => {
+            store.request(checkoutRequest, extensionName);
+        }).toThrow(new Error('Extension with the name "TestExtension" not found.'));
     });
 
     it('should close the modal', () => {
         store.dismiss();
 
         expect(store.entry).toBeNull();
+        expect(store.extension).toBeNull();
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/store/in-app-purchase-checkout.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/in-app-purchase-checkout.store.ts
@@ -27,7 +27,16 @@ const inAppPurchaseCheckoutStore = Shopware.Store.register({
     }),
 
     actions: {
-        request(entry: InAppPurchaseRequest, extension: Extension): void {
+        request(entry: InAppPurchaseRequest, extension: Extension | string): void {
+            if (typeof extension === 'string') {
+                const extensionObject = Object.values(Shopware.State.get('extensions')).find(
+                    (ext) => ext.name === extension,
+                );
+                if (extensionObject === undefined) {
+                    throw new Error(`Extension with the name "${extension}" not found.`);
+                }
+                extension = extensionObject;
+            }
             this.entry = entry;
             this.extension = extension;
         },


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Ease of use for extension developers to not have to find their own extension in the store

### 2. What does this change do, exactly?
it moves the finding of an extension to the method, instead of expecting it to be passed along

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://shopware.atlassian.net/browse/NEXT-40268

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
