### PR TITLE
refactor: use global entity & entity collection types

### DIFF
--- a/changelog/_unreleased/2024-11-12-use-global-entity-and-entity-collection-types.md
+++ b/changelog/_unreleased/2024-11-12-use-global-entity-and-entity-collection-types.md
@@ -1,0 +1,10 @@
+---
+title: Use global entity & entity collection types
+issue: NEXT-39733
+author: Benjamin Wittwer
+author_email: benjamin.wittwer@a-k-f.de
+author_github: akf-bw
+---
+# Administration
+* Changed `src/global.types.ts` to directly provide the global `Entity` & `EntityCollection` types without a namespace from the `EntitySchema` namespace of the `@shopware-ag/meteor-admin-sdk` package
+* Changed multiple files to remove now unnecessary imports of `Entity` & `EntityCollection` types

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-dynamic-url-field/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-dynamic-url-field/index.ts
@@ -1,6 +1,5 @@
 import type CriteriaType from 'src/core/data/criteria.data';
 import type RepositoryType from 'src/core/data/repository.data';
-import type EntityCollectionType from 'src/core/data/entity-collection.data';
 import template from './sw-dynamic-url-field.html.twig';
 import './sw-dynamic-url-field.scss';
 
@@ -37,7 +36,7 @@ Component.register('sw-dynamic-url-field', {
         isHTTPs: boolean;
         displayAsButton: boolean;
         linkCategory: LinkCategories;
-        categoryCollection?: EntityCollectionType<'category'>;
+        categoryCollection?: EntityCollection<'category'>;
     } {
         return {
             lastEmittedLink: '',
@@ -111,7 +110,7 @@ Component.register('sw-dynamic-url-field', {
             this.categoryCollection = this.getEmptyCategoryCollection();
         },
 
-        getEmptyCategoryCollection(): EntityCollectionType<'category'> {
+        getEmptyCategoryCollection(): EntityCollection<'category'> {
             return new EntityCollection(
                 this.categoryRepository.route,
                 this.categoryRepository.entityName,
@@ -119,7 +118,7 @@ Component.register('sw-dynamic-url-field', {
             );
         },
 
-        getCategoryCollection(categoryId: string): Promise<EntityCollectionType<'category'>> {
+        getCategoryCollection(categoryId: string): Promise<EntityCollection<'category'>> {
             const categoryCriteria = new Criteria(1, 25).addFilter(Criteria.equals('id', categoryId));
             return this.categoryRepository.search(categoryCriteria);
         },

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-editor/sw-text-editor-link-menu/index.ts
@@ -1,6 +1,5 @@
 import type CriteriaType from 'src/core/data/criteria.data';
 import type RepositoryType from 'src/core/data/repository.data';
-import type EntityCollectionType from 'src/core/data/entity-collection.data';
 import template from './sw-text-editor-link-menu.html.twig';
 import './sw-text-editor-link-menu.scss';
 
@@ -51,7 +50,7 @@ Component.register('sw-text-editor-link-menu', {
         displayAsButton: boolean;
         buttonVariant: ButtonVariant;
         linkCategory: LinkCategories;
-        categoryCollection?: EntityCollectionType<'category'>;
+        categoryCollection?: EntityCollection<'category'>;
         buttonVariantList: Array<{ id: ButtonVariant; name: string }>;
     } {
         return {
@@ -144,12 +143,12 @@ Component.register('sw-text-editor-link-menu', {
             this.$emit('mounted');
         },
 
-        getCategoryCollection(categoryId: string): Promise<EntityCollectionType<'category'>> {
+        getCategoryCollection(categoryId: string): Promise<EntityCollection<'category'>> {
             const categoryCriteria = new Criteria(1, 25).addFilter(Criteria.equals('id', categoryId));
             return this.categoryRepository.search(categoryCriteria);
         },
 
-        getEmptyCategoryCollection(): EntityCollectionType<'category'> {
+        getEmptyCategoryCollection(): EntityCollection<'category'> {
             return new EntityCollection(
                 this.categoryRepository.route,
                 this.categoryRepository.entityName,

--- a/src/Administration/Resources/app/administration/src/app/component/list/sw-sortable-list/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/list/sw-sortable-list/index.ts
@@ -1,5 +1,4 @@
 import type { PropType } from 'vue';
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import template from './sw-sortable-list.html.twig';
 import './sw-sortable-list.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/filter/thumbnail-size.filter.ts
+++ b/src/Administration/Resources/app/administration/src/app/filter/thumbnail-size.filter.ts
@@ -1,8 +1,6 @@
 /**
  * @package content
  */
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
-
 Shopware.Filter.register('thumbnailSize', (value: Entity<'media_thumbnail_size'>) => {
     if (!value || !(value.getEntityName() === 'media_thumbnail_size')) {
         return '';

--- a/src/Administration/Resources/app/administration/src/app/init/extension-data-handling.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/extension-data-handling.init.ts
@@ -2,8 +2,6 @@
  * @package admin
  */
 
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
-import type EntityCollection from '../../core/data/entity-collection.data';
 import type Repository from '../../core/data/repository.data';
 
 function getRepository(

--- a/src/Administration/Resources/app/administration/src/app/mixin/discard-detail-page-changes.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/discard-detail-page-changes.mixin.ts
@@ -61,7 +61,7 @@ export default Mixin.register('discard-detail-page-changes', (...entityNames: Ar
                     // @ts-expect-error - we check if the entity exists on the component
                     // eslint-disable-next-line max-len
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
-                    const entity: EntitySchema.Entity<any> = this[entityName];
+                    const entity: Entity<any> = this[entityName];
 
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                     if (entity && typeof entity.discardChanges === 'function') {

--- a/src/Administration/Resources/app/administration/src/app/mixin/placeholder.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/placeholder.mixin.ts
@@ -15,8 +15,8 @@ export default Shopware.Mixin.register(
     defineComponent({
         methods: {
             placeholder<EntityName extends keyof EntitySchema.Entities>(
-                entity: EntitySchema.Entity<EntityName>,
-                field: keyof EntitySchema.Entity<EntityName>,
+                entity: Entity<EntityName>,
+                field: keyof Entity<EntityName>,
                 fallbackSnippet: string,
             ) {
                 if (!entity) {

--- a/src/Administration/Resources/app/administration/src/app/mixin/position.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/position.mixin.ts
@@ -5,7 +5,6 @@
  */
 import type Repository from 'src/core/data/repository.data';
 import Criteria from 'src/core/data/criteria.data';
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import { defineComponent } from 'vue';
 
 /**

--- a/src/Administration/Resources/app/administration/src/app/service/entity-validation.service.ts
+++ b/src/Administration/Resources/app/administration/src/app/service/entity-validation.service.ts
@@ -3,7 +3,6 @@
  * @package services-settings
  * @module app/entity-validation-service
  */
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type ChangesetGenerator from 'src/core/data/changeset-generator.data';
 import type EntityDefinition from 'src/core/data/entity-definition.data';
 import type ErrorResolver from 'src/core/data/error-resolver.data';

--- a/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.ts
+++ b/src/Administration/Resources/app/administration/src/app/service/rule-condition.service.ts
@@ -1,5 +1,3 @@
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
-
 const { Criteria } = Shopware.Data;
 
 type appScriptCondition = {

--- a/src/Administration/Resources/app/administration/src/core/data/entity-definition.data.ts
+++ b/src/Administration/Resources/app/administration/src/core/data/entity-definition.data.ts
@@ -47,11 +47,11 @@ export function getJsonTypes() {
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default class EntityDefinition<EntityName extends keyof EntitySchema.Entities> {
-    readonly entity: EntitySchema.Entity<EntityName>;
+    readonly entity: Entity<EntityName>;
 
     readonly properties: Properties;
 
-    constructor({ entity, properties }: { entity: EntitySchema.Entity<EntityName>; properties: Properties }) {
+    constructor({ entity, properties }: { entity: Entity<EntityName>; properties: Properties }) {
         this.entity = entity;
         this.properties = properties;
     }

--- a/src/Administration/Resources/app/administration/src/core/data/entity-hydrator.data.ts
+++ b/src/Administration/Resources/app/administration/src/core/data/entity-hydrator.data.ts
@@ -4,8 +4,7 @@
 
 import types from 'src/core/service/utils/types.utils';
 import type { AxiosResponse } from 'axios';
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
-import EntityClass from './entity.data';
+import Entity from './entity.data';
 import Criteria from './criteria.data';
 import EntityCollection from './entity-collection.data';
 import type { Property } from './entity-definition.data';
@@ -235,7 +234,7 @@ export default class EntityHydrator {
             return true;
         });
 
-        const e = new EntityClass<EntityName>(id, entityName, data as unknown as EntitySchema.Entities[EntityName]);
+        const e = new Entity<EntityName>(id, entityName, data as unknown as EntitySchema.Entities[EntityName]);
 
         this.cache[cacheKey] = e as unknown as Entity<entityNames>;
 

--- a/src/Administration/Resources/app/administration/src/core/data/entity.data.ts
+++ b/src/Administration/Resources/app/administration/src/core/data/entity.data.ts
@@ -2,7 +2,6 @@
  * @package admin
  */
 
-import type Vue from 'vue';
 import Entity, { assignSetterMethod } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 
 assignSetterMethod((draft, property, value) => {

--- a/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
+++ b/src/Administration/Resources/app/administration/src/core/data/repository.data.ts
@@ -3,14 +3,12 @@
  */
 
 import type { AxiosInstance, AxiosResponse } from 'axios';
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import Criteria from './criteria.data';
 import type EntityHydrator from './entity-hydrator.data';
 import type ChangesetGenerator from './changeset-generator.data';
 import type ErrorResolver from './error-resolver.data';
 import type EntityFactory from './entity-factory.data';
 import type EntityDefinition from './entity-definition.data';
-import type EntityCollection from './entity-collection.data';
 
 type options = {
     [key: string]: unknown;

--- a/src/Administration/Resources/app/administration/src/core/service/support/user-config.class.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/support/user-config.class.ts
@@ -1,8 +1,6 @@
 /**
  * @package admin
  */
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
-
 const { Context, Data, Service, State } = Shopware;
 const { Criteria } = Data;
 

--- a/src/Administration/Resources/app/administration/src/global.types.ts
+++ b/src/Administration/Resources/app/administration/src/global.types.ts
@@ -155,6 +155,9 @@ declare global {
      */
     const Shopware: ShopwareClass;
 
+    type Entity<EntityName extends keyof EntitySchema.Entities> = EntitySchema.Entity<EntityName>;
+    type EntityCollection<EntityName extends keyof EntitySchema.Entities> = EntitySchema.EntityCollection<EntityName>;
+
     interface CustomShopwareProperties {}
 
     interface Window {
@@ -325,7 +328,7 @@ declare global {
         paymentOverviewCardState: PaymentOverviewCardState;
         swOrder: SwOrderState;
         session: {
-            currentUser: EntitySchema.Entities['user'];
+            currentUser: Entity<'user'>;
             userPending: boolean;
             languageId: string;
             currentLocale: string | null;

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-custom-entity/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-custom-entity/index.ts
@@ -1,6 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
-import type EntityCollection from 'src/core/data/entity-collection.data';
-
 import Criteria from '@shopware-ag/meteor-admin-sdk/es/data/Criteria';
 import template from './sw-category-detail-custom-entity.html.twig';
 import './sw-category-detail-custom-entity.scss';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/index.ts
@@ -18,7 +18,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         block: {
-            type: Object as PropType<EntitySchema.Entity<'cms_block'>>,
+            type: Object as PropType<Entity<'cms_block'>>,
             required: true,
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
@@ -28,7 +28,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         block: {
-            type: Object as PropType<EntitySchema.Entity<'cms_block'>>,
+            type: Object as PropType<Entity<'cms_block'>>,
             required: true,
         },
     },
@@ -66,7 +66,7 @@ export default Shopware.Component.wrapComponentConfig({
     },
 
     methods: {
-        onSetBackgroundMedia([mediaItem]: EntitySchema.Entity<'media'>[]) {
+        onSetBackgroundMedia([mediaItem]: Entity<'media'>[]) {
             this.block.backgroundMediaId = mediaItem.id;
             this.block.backgroundMedia = mediaItem;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-layout-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-layout-config/index.ts
@@ -13,7 +13,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         block: {
-            type: Object as PropType<EntitySchema.Entity<'cms_block'>>,
+            type: Object as PropType<Entity<'cms_block'>>,
             required: true,
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-create-wizard/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-create-wizard/index.ts
@@ -26,7 +26,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         page: {
-            type: Object as PropType<EntitySchema.Entity<'cms_page'>>,
+            type: Object as PropType<Entity<'cms_page'>>,
             required: true,
         },
     },
@@ -146,7 +146,7 @@ export default Shopware.Component.wrapComponentConfig({
             this.goToStep('sectionType');
         },
 
-        onSectionSelect(section: EntitySchema.Entity<'cms_section'>) {
+        onSectionSelect(section: Entity<'cms_section'>) {
             this.goToStep('pageName');
 
             this.$emit('on-section-select', section);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
@@ -30,7 +30,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         page: {
-            type: Object as PropType<EntitySchema.Entity<'cms_page'>>,
+            type: Object as PropType<Entity<'cms_page'>>,
             required: true,
         },
     },
@@ -38,9 +38,9 @@ export default Shopware.Component.wrapComponentConfig({
     data() {
         return {
             shopPageSalesChannelId: null as string | null,
-            previousCategories: [] as EntitySchema.Entity<'category'>[],
+            previousCategories: [] as Entity<'category'>[],
             previousCategoryIds: [] as string[],
-            previousLandingPages: [] as EntitySchema.Entity<'landing_page'>[],
+            previousLandingPages: [] as Entity<'landing_page'>[],
             previousLandingPageIds: [] as string[],
             showConfirmChangesModal: false,
             isLoading: false,
@@ -57,7 +57,7 @@ export default Shopware.Component.wrapComponentConfig({
             hasCategoriesWithAssignedLayouts: false,
             hasProductsWithAssignedLayouts: false,
             hasLandingPagesWithAssignedLayouts: false,
-            previousProducts: [] as EntitySchema.Entity<'product'>[],
+            previousProducts: [] as Entity<'product'>[],
             previousProductIds: [] as string[],
             categoryIndex: 1,
             isCategoriesLoading: false,

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/index.ts
@@ -25,7 +25,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         page: {
-            type: Object as PropType<EntitySchema.Entity<'cms_page'>>,
+            type: Object as PropType<Entity<'cms_page'>>,
             required: false,
             default: null,
         },
@@ -108,7 +108,7 @@ export default Shopware.Component.wrapComponentConfig({
     },
 
     methods: {
-        onChangePreviewImage(page: EntitySchema.Entity<'cms_page'>) {
+        onChangePreviewImage(page: Entity<'cms_page'>) {
             this.$emit('preview-image-change', page);
         },
 
@@ -122,7 +122,7 @@ export default Shopware.Component.wrapComponentConfig({
             this.$emit('element-click', this.page);
         },
 
-        onItemClick(page: EntitySchema.Entity<'cms_page'>) {
+        onItemClick(page: Entity<'cms_page'>) {
             if (this.disabled) {
                 return;
             }
@@ -131,7 +131,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         /** @deprecated tag:v6.7.0 - `onRemovePreviewImage` will be removed without replacement */
-        onRemovePreviewImage(page: EntitySchema.Entity<'cms_page'>) {
+        onRemovePreviewImage(page: Entity<'cms_page'>) {
             page.previewMediaId = undefined;
             // eslint-disable-next-line max-len
             // eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-unsafe-call
@@ -139,7 +139,7 @@ export default Shopware.Component.wrapComponentConfig({
             page.previewMedia = undefined;
         },
 
-        onDelete(page: EntitySchema.Entity<'cms_page'>) {
+        onDelete(page: Entity<'cms_page'>) {
             this.$emit('cms-page-delete', page);
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-page-form/index.ts
@@ -16,7 +16,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         page: {
-            type: Object as PropType<EntitySchema.Entity<'cms_page'>>,
+            type: Object as PropType<Entity<'cms_page'>>,
             required: true,
         },
         elementUpdate: {
@@ -74,7 +74,7 @@ export default Shopware.Component.wrapComponentConfig({
             });
         },
 
-        getBlockTitle(block: EntitySchema.Entity<'cms_block'>) {
+        getBlockTitle(block: Entity<'cms_block'>) {
             if (typeof block.name === 'string' && block.name.length !== 0) {
                 return block.name;
             }
@@ -86,7 +86,7 @@ export default Shopware.Component.wrapComponentConfig({
             return '';
         },
 
-        displaySectionType(block: EntitySchema.Entity<'cms_block'>) {
+        displaySectionType(block: Entity<'cms_block'>) {
             const blockSection = this.page.sections!.find((section) => section.id === block.sectionId);
 
             if (!blockSection) {
@@ -111,7 +111,7 @@ export default Shopware.Component.wrapComponentConfig({
             return firstBlockInPosition.id === block.id;
         },
 
-        getSectionName(section: EntitySchema.Entity<'cms_section'>) {
+        getSectionName(section: Entity<'cms_section'>) {
             if (section.name) {
                 return section.name;
             }
@@ -119,17 +119,13 @@ export default Shopware.Component.wrapComponentConfig({
             return section.type === 'sidebar' ? this.$tc('sw-cms.section.isSidebar') : this.$tc('sw-cms.section.isDefault');
         },
 
-        getSectionPosition(block: EntitySchema.Entity<'cms_block'>) {
+        getSectionPosition(block: Entity<'cms_block'>) {
             return block.sectionPosition === 'main'
                 ? this.$tc('sw-cms.section.positionRight')
                 : this.$tc('sw-cms.section.positionLeft');
         },
 
-        getDeviceActive(
-            viewport: string,
-            section: EntitySchema.Entity<'cms_section'>,
-            block: EntitySchema.Entity<'cms_block'> | null = null,
-        ) {
+        getDeviceActive(viewport: string, section: Entity<'cms_section'>, block: Entity<'cms_block'> | null = null) {
             const sectionVisibility = section.visibility as {
                 [key: string]: boolean;
             };
@@ -142,7 +138,7 @@ export default Shopware.Component.wrapComponentConfig({
             return isActive ? `regular-${viewport}` : `regular-${viewport}-slash`;
         },
 
-        displayNotification(section: EntitySchema.Entity<'cms_section'>, block: EntitySchema.Entity<'cms_block'>) {
+        displayNotification(section: Entity<'cms_section'>, block: Entity<'cms_block'>) {
             const sectionVisibility = section.visibility as {
                 [key: string]: boolean;
             };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.ts
@@ -53,12 +53,12 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         page: {
-            type: Object as PropType<EntitySchema.Entity<'cms_page'>>,
+            type: Object as PropType<Entity<'cms_page'>>,
             required: true,
         },
 
         section: {
-            type: Object as PropType<EntitySchema.Entity<'cms_section'>>,
+            type: Object as PropType<Entity<'cms_section'>>,
             required: true,
         },
 
@@ -239,12 +239,12 @@ export default Shopware.Component.wrapComponentConfig({
             this.openBlockBar();
         },
 
-        onBlockSelection(block: EntitySchema.Entity<'cms_block'>) {
+        onBlockSelection(block: Entity<'cms_block'>) {
             Shopware.Store.get('cmsPage').setBlock(block);
             this.$emit('page-config-open', 'itemConfig');
         },
 
-        onBlockDuplicate(block: EntitySchema.Entity<'cms_block'>, section: EntitySchema.Entity<'cms_section'>) {
+        onBlockDuplicate(block: Entity<'cms_block'>, section: Entity<'cms_section'>) {
             this.$emit('block-duplicate', block, section);
         },
 
@@ -272,14 +272,14 @@ export default Shopware.Component.wrapComponentConfig({
             return this.blockTypes.includes(type);
         },
 
-        hasBlockErrors(block: EntitySchema.Entity<'cms_block'>) {
+        hasBlockErrors(block: Entity<'cms_block'>) {
             return [
                 this.hasUniqueBlockErrors(block),
                 this.hasSlotConfigErrors(block),
             ].some((error) => error);
         },
 
-        hasUniqueBlockErrors(block: EntitySchema.Entity<'cms_block'>) {
+        hasUniqueBlockErrors(block: Entity<'cms_block'>) {
             const errorElements = (this.pageSlotsError as SlotsErrorObject)?.parameters?.elements;
 
             if (!errorElements) {
@@ -289,7 +289,7 @@ export default Shopware.Component.wrapComponentConfig({
             return errorElements.some((errorType) => errorType.blockIds.includes(block.id));
         },
 
-        hasSlotConfigErrors(block: EntitySchema.Entity<'cms_block'>) {
+        hasSlotConfigErrors(block: Entity<'cms_block'>) {
             const errorElements = (this.pageSlotconfigError as SlotConfigErrorObject)?.parameters?.elements;
 
             if (!errorElements) {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-actions/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-actions/index.ts
@@ -13,7 +13,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         section: {
-            type: Object as PropType<EntitySchema.Entity<'cms_section'>>,
+            type: Object as PropType<Entity<'cms_section'>>,
             required: true,
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section-config/index.ts
@@ -29,7 +29,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         section: {
-            type: Object as PropType<EntitySchema.Entity<'cms_section'>>,
+            type: Object as PropType<Entity<'cms_section'>>,
             required: true,
         },
     },
@@ -59,7 +59,7 @@ export default Shopware.Component.wrapComponentConfig({
     },
 
     methods: {
-        onSetBackgroundMedia([mediaItem]: EntitySchema.Entity<'media'>[]) {
+        onSetBackgroundMedia([mediaItem]: Entity<'media'>[]) {
             this.section.backgroundMediaId = mediaItem.id;
             this.section.backgroundMedia = mediaItem;
         },
@@ -83,7 +83,7 @@ export default Shopware.Component.wrapComponentConfig({
             this.$emit('section-delete', sectionId);
         },
 
-        onSectionDuplicate(section: EntitySchema.Entity<'cms_section'>) {
+        onSectionDuplicate(section: Entity<'cms_section'>) {
             if (this.quickactionsDisabled) {
                 return;
             }

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
@@ -1,5 +1,4 @@
 import { type PropType } from 'vue';
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import template from './sw-cms-sidebar.html.twig';
 import CMS from '../../constant/sw-cms.constant';
 import './sw-cms-sidebar.scss';
@@ -12,7 +11,7 @@ const { Criteria } = Shopware.Data;
 const { cloneDeep } = Shopware.Utils.object;
 const types = Shopware.Utils.types;
 
-type DraggableBlock = EntitySchema.Entity<'cms_block'> & {
+type DraggableBlock = Entity<'cms_block'> & {
     isDragging?: boolean;
 };
 
@@ -24,7 +23,7 @@ type DragData = {
 type DropData = {
     dropIndex: number;
     block: DraggableBlock;
-    section: EntitySchema.Entity<'cms_section'> | null;
+    section: Entity<'cms_section'> | null;
     sectionPosition: string;
     sectionIndex: number;
 };
@@ -82,7 +81,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         page: {
-            type: Object as PropType<EntitySchema.Entity<'cms_page'>>,
+            type: Object as PropType<Entity<'cms_page'>>,
             required: true,
         },
 
@@ -366,12 +365,12 @@ export default Shopware.Component.wrapComponentConfig({
             itemConfigSidebar.openContent();
         },
 
-        blockIsRemovable(block: EntitySchema.Entity<'cms_block'>) {
+        blockIsRemovable(block: Entity<'cms_block'>) {
             const cmsBlocks = this.cmsService.getCmsBlockRegistry();
             return cmsBlocks[block.type]?.removable && this.isSystemDefaultLanguage;
         },
 
-        blockIsUnique(block: EntitySchema.Entity<'cms_block'>) {
+        blockIsUnique(block: Entity<'cms_block'>) {
             if (this.page.type !== CMS.PAGE_TYPES.PRODUCT_DETAIL) {
                 return false;
             }
@@ -381,11 +380,11 @@ export default Shopware.Component.wrapComponentConfig({
             });
         },
 
-        blockIsDuplicable(block: EntitySchema.Entity<'cms_block'>) {
+        blockIsDuplicable(block: Entity<'cms_block'>) {
             return !this.blockIsUnique(block);
         },
 
-        sectionIsDuplicable(section: EntitySchema.Entity<'cms_section'>) {
+        sectionIsDuplicable(section: Entity<'cms_section'>) {
             return section.blocks!.every((block) => this.blockIsDuplicable(block));
         },
 
@@ -510,7 +509,7 @@ export default Shopware.Component.wrapComponentConfig({
             });
         },
 
-        getDragData(block: EntitySchema.Entity<'cms_block'>, sectionIndex: number): DragObject {
+        getDragData(block: Entity<'cms_block'>, sectionIndex: number): DragObject {
             return {
                 delay: 300,
                 dragGroup: 'cms-navigator',
@@ -521,7 +520,7 @@ export default Shopware.Component.wrapComponentConfig({
             };
         },
 
-        getDropData(block: EntitySchema.Entity<'cms_block'>, sectionIndex: number): DropObject {
+        getDropData(block: Entity<'cms_block'>, sectionIndex: number): DropObject {
             return {
                 dragGroup: 'cms-navigator',
                 data: {
@@ -617,19 +616,19 @@ export default Shopware.Component.wrapComponentConfig({
             this.$emit('current-block-change', section.id, newBlock);
         },
 
-        moveSectionUp(section: EntitySchema.Entity<'cms_section'>) {
+        moveSectionUp(section: Entity<'cms_section'>) {
             this.page.sections!.moveItem(section.position, section.position - 1);
 
             this.$emit('page-save', true);
         },
 
-        moveSectionDown(section: EntitySchema.Entity<'cms_section'>) {
+        moveSectionDown(section: Entity<'cms_section'>) {
             this.page.sections!.moveItem(section.position, section.position + 1);
 
             this.$emit('page-save', true);
         },
 
-        onSectionDuplicate(section: EntitySchema.Entity<'cms_section'>) {
+        onSectionDuplicate(section: Entity<'cms_section'>) {
             this.$emit('section-duplicate', section);
         },
 
@@ -639,7 +638,7 @@ export default Shopware.Component.wrapComponentConfig({
             this.$emit('page-save');
         },
 
-        onBlockDelete(block: EntitySchema.Entity<'cms_block'>, section: EntitySchema.Entity<'cms_section'> | null) {
+        onBlockDelete(block: Entity<'cms_block'>, section: Entity<'cms_section'> | null) {
             if (!section) {
                 section = this.page.sections!.get(block.sectionId);
             }
@@ -653,7 +652,7 @@ export default Shopware.Component.wrapComponentConfig({
             this.$emit('page-save', true);
         },
 
-        onBlockDuplicate(block: EntitySchema.Entity<'cms_block'>, section: EntitySchema.Entity<'cms_section'> | null) {
+        onBlockDuplicate(block: Entity<'cms_block'>, section: Entity<'cms_section'> | null) {
             if (!section) {
                 section = this.page.sections!.get(block.sectionId);
             }
@@ -661,17 +660,14 @@ export default Shopware.Component.wrapComponentConfig({
             this.$emit('block-duplicate', block, section);
         },
 
-        onRemoveSectionBackgroundMedia(section: EntitySchema.Entity<'cms_section'>) {
+        onRemoveSectionBackgroundMedia(section: Entity<'cms_section'>) {
             section.backgroundMediaId = undefined;
             section.backgroundMedia = undefined;
 
             this.pageUpdate();
         },
 
-        onSetSectionBackgroundMedia(
-            [mediaItem]: [EntitySchema.Entity<'media'>],
-            section: EntitySchema.Entity<'cms_section'>,
-        ) {
+        onSetSectionBackgroundMedia([mediaItem]: [Entity<'media'>], section: Entity<'cms_section'>) {
             section.backgroundMediaId = mediaItem.id;
             section.backgroundMedia = mediaItem;
 
@@ -682,7 +678,7 @@ export default Shopware.Component.wrapComponentConfig({
             this.cmsBlockFavorites.update(!this.cmsBlockFavorites.isFavorite(blockName), blockName);
         },
 
-        successfulUpload(media: MediaUploadResult, section: EntitySchema.Entity<'cms_section'>) {
+        successfulUpload(media: MediaUploadResult, section: Entity<'cms_section'>) {
             section.backgroundMediaId = media.targetId;
 
             void this.mediaRepository.get(media.targetId).then((mediaItem) => {
@@ -691,7 +687,7 @@ export default Shopware.Component.wrapComponentConfig({
             });
         },
 
-        uploadTag(section: EntitySchema.Entity<'cms_section'>) {
+        uploadTag(section: Entity<'cms_section'>) {
             return `cms-section-media-config-${section.id}`;
         },
 
@@ -719,7 +715,7 @@ export default Shopware.Component.wrapComponentConfig({
             return this.blockTypes.includes(type);
         },
 
-        onVisibilityChange(selectedBlock: EntitySchema.Entity<'cms_block'>, viewport: string, isVisible: boolean) {
+        onVisibilityChange(selectedBlock: Entity<'cms_block'>, viewport: string, isVisible: boolean) {
             (selectedBlock.visibility as { [key: string]: boolean })[viewport] = isVisible;
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar-nav-element/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar-nav-element/index.ts
@@ -18,7 +18,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         block: {
-            type: Object as PropType<EntitySchema.Entity<'cms_block'>>,
+            type: Object as PropType<Entity<'cms_block'>>,
             required: true,
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-slot/index.ts
@@ -21,7 +21,7 @@ export default Shopware.Component.wrapComponentConfig({
 
     props: {
         element: {
-            type: Object as PropType<EntitySchema.Entity<'cms_slot'>>,
+            type: Object as PropType<Entity<'cms_slot'>>,
             required: true,
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/index.ts
@@ -23,7 +23,7 @@ type ImageGalleryItemConfig = {
 type ImageGalleryItem = {
     newTab: boolean;
     url: string;
-    media: EntitySchema.Entity<'media'> | null;
+    media: Entity<'media'> | null;
 };
 
 /**
@@ -124,7 +124,7 @@ Shopware.Service('cmsService').registerCmsElement({
                 const item: ImageGalleryItem = {
                     newTab: sliderItem.newTab,
                     url: sliderItem.url,
-                    media: data[entityKey].get(sliderItem.mediaId) as EntitySchema.Entity<'media'> | null,
+                    media: data[entityKey].get(sliderItem.mediaId) as Entity<'media'> | null,
                 };
 
                 items.push(item);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/index.ts
@@ -23,7 +23,7 @@ type ImageSliderItemConfig = {
 type ImageSliderItem = {
     newTab: boolean;
     url: string;
-    media: EntitySchema.Entity<'media'> | null;
+    media: Entity<'media'> | null;
 };
 
 /**
@@ -113,7 +113,7 @@ Shopware.Service('cmsService').registerCmsElement({
                 const item: ImageSliderItem = {
                     newTab: sliderItem.newTab,
                     url: sliderItem.url,
-                    media: data[entityKey].get(sliderItem.mediaId) as EntitySchema.Entity<'media'> | null,
+                    media: data[entityKey].get(sliderItem.mediaId) as Entity<'media'> | null,
                 };
 
                 items.push(item);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -5,13 +5,6 @@ const { Mixin } = Shopware;
 const { types } = Shopware.Utils;
 const { cloneDeep, merge } = Shopware.Utils.object;
 
-interface Translation {
-    languageId: string;
-}
-interface Entity {
-    translations: Translation[];
-}
-
 /**
  * @private
  * @package discovery
@@ -49,9 +42,9 @@ export default Mixin.register(
                 return this.cmsService.getCmsElementRegistry();
             },
 
-            category(): EntitySchema.Entities['category'] {
+            category(): Entity<'category'> {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                return Shopware.State.get('swCategoryDetail')?.category as EntitySchema.Entities['category'];
+                return Shopware.State.get('swCategoryDetail')?.category as Entity<'category'>;
             },
         },
 
@@ -93,7 +86,7 @@ export default Mixin.register(
                 return this.cmsService.getPropertyByMappingPath(this.cmsPageState.currentDemoEntity, mappingPath);
             },
 
-            getDefaultTranslations(entity: Entity) {
+            getDefaultTranslations(entity: Entity<'category'>) {
                 return entity.translations.find((translation) => {
                     return translation.languageId === Shopware.Context.api.systemLanguageId;
                 });

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-state.mixin.ts
@@ -18,7 +18,7 @@ export default Shopware.Mixin.register(
                     return this.cmsPageState.selectedBlock;
                 },
 
-                set(block: EntitySchema.Entity<'cms_block'>) {
+                set(block: Entity<'cms_block'>) {
                     this.cmsPageState.setSelectedBlock(block);
                 },
             },
@@ -28,7 +28,7 @@ export default Shopware.Mixin.register(
                     return this.cmsPageState.selectedSection;
                 },
 
-                set(section: EntitySchema.Entity<'cms_section'>) {
+                set(section: Entity<'cms_section'>) {
                     this.cmsPageState.setSelectedSection(section);
                 },
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms.service.ts
@@ -1,7 +1,5 @@
 import { reactive } from 'vue';
 import type Criteria from '@shopware-ag/meteor-admin-sdk/es/data/Criteria';
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 
 const { Application } = Shopware;
 
@@ -31,7 +29,7 @@ type CmsSlotData = {
     context?: unknown;
 };
 
-type RuntimeSlot = EntitySchema.Entity<'cms_slot'> & {
+type RuntimeSlot = Entity<'cms_slot'> & {
     config: CmsSlotConfig;
     data: {
         [key: string]: CmsSlotData;
@@ -550,7 +548,7 @@ function CmsElementEnrich<EntityName extends keyof EntitySchema.Entities>(
             slotData[configKey] = [];
 
             (slotConfigValue as unknown as string[]).forEach((value) => {
-                (slotData[configKey] as EntitySchema.Entity<EntityName>[]).push(collection.get(value) as Entity<EntityName>);
+                (slotData[configKey] as Entity<EntityName>[]).push(collection.get(value) as Entity<EntityName>);
             });
         } else {
             slotData[configKey] = collection.get(slotConfigValue);

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/store/cms-page.store.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/store/cms-page.store.ts
@@ -1,5 +1,5 @@
 type CmsPageState = {
-    currentPage: null | EntitySchema.Entity<'cms_page'>;
+    currentPage: null | Entity<'cms_page'>;
     currentPageType: null | string;
     currentMappingEntity: null | string;
     currentMappingTypes: Record<string, unknown>;
@@ -8,8 +8,8 @@ type CmsPageState = {
     pageEntityName: string;
     defaultMediaFolderId: null | string;
     currentCmsDeviceView: 'desktop' | 'tablet-landscape' | 'mobile' | 'form';
-    selectedSection: null | EntitySchema.Entity<'cms_section'>;
-    selectedBlock: null | EntitySchema.Entity<'cms_block'>;
+    selectedSection: null | Entity<'cms_section'>;
+    selectedBlock: null | Entity<'cms_block'>;
     isSystemDefaultLanguage: boolean;
 };
 
@@ -36,7 +36,7 @@ const cmsPageStore = Shopware.Store.register({
     }),
 
     actions: {
-        setCurrentPage(page: EntitySchema.Entity<'cms_page'>) {
+        setCurrentPage(page: Entity<'cms_page'>) {
             this.currentPage = page;
         },
 
@@ -104,7 +104,7 @@ const cmsPageStore = Shopware.Store.register({
             this.currentCmsDeviceView = 'desktop';
         },
 
-        setSelectedSection(section: EntitySchema.Entity<'cms_section'>) {
+        setSelectedSection(section: Entity<'cms_section'>) {
             this.selectedSection = section;
         },
 
@@ -112,7 +112,7 @@ const cmsPageStore = Shopware.Store.register({
             this.selectedSection = null;
         },
 
-        setSelectedBlock(block: EntitySchema.Entity<'cms_block'>) {
+        setSelectedBlock(block: Entity<'cms_block'>) {
             this.selectedBlock = block;
         },
 
@@ -132,12 +132,12 @@ const cmsPageStore = Shopware.Store.register({
             this.removeCurrentDemoProducts();
         },
 
-        setSection(section: EntitySchema.Entity<'cms_section'>) {
+        setSection(section: Entity<'cms_section'>) {
             this.removeSelectedBlock();
             this.setSelectedSection(section);
         },
 
-        setBlock(block: EntitySchema.Entity<'cms_block'>) {
+        setBlock(block: Entity<'cms_block'>) {
             this.removeSelectedSection();
             this.setSelectedBlock(block);
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-cms-page-assignment/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-cms-page-assignment/index.ts
@@ -1,5 +1,4 @@
 import type ChangesetGenerator from 'src/core/data/changeset-generator.data';
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type Repository from 'src/core/data/repository.data';
 import type { PropType } from 'vue';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/index.ts
@@ -1,6 +1,5 @@
 import './sw-generic-social-media-card.scss';
 
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type { PropType } from 'vue';
 
 import type Repository from 'src/core/data/repository.data';

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-detail/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-detail/index.ts
@@ -1,11 +1,9 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type {
     AdminTabsDefinition,
     CustomEntityDefinition,
     CustomEntityProperties,
     AdminUiDefinition,
 } from 'src/app/service/custom-entity-definition.service';
-import type EntityCollection from 'src/core/data/entity-collection.data';
 import type Repository from 'src/core/data/repository.data';
 
 import template from './sw-generic-custom-entity-detail.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/index.ts
@@ -1,5 +1,4 @@
 import type { AdminUiDefinition, CustomEntityDefinition } from 'src/app/service/custom-entity-definition.service';
-import type EntityCollection from 'src/core/data/entity-collection.data';
 import type CriteriaType from 'src/core/data/criteria.data';
 import type Repository from 'src/core/data/repository.data';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/component/sw-dashboard-statistics/index.ts
@@ -1,10 +1,9 @@
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import template from './sw-dashboard-statistics.html.twig';
 import './sw-dashboard-statistics.scss';
 
 const { Criteria } = Shopware.Data;
 
-type OrderEntity = EntitySchema.order;
+type OrderEntity = Entity<'order'>;
 
 type HistoryDateRange = {
     label: string;

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/service/flow-builder.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/service/flow-builder.service.ts
@@ -1,5 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import type { I18n } from 'vue-i18n';
 import {
     ACTION,

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list-flow-templates/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list-flow-templates/index.ts
@@ -1,5 +1,3 @@
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type Repository from '../../../../../core/data/repository.data';
 import type CriteriaType from '../../../../../core/data/criteria.data';
 import template from './sw-flow-list-flow-templates.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/index.ts
@@ -1,4 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import template from './sw-order-create-initial-modal.html.twig';
 import './sw-order-create-initial-modal.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-options/index.ts
@@ -1,4 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type { PropType } from 'vue';
 import type CriteriaType from 'src/core/data/criteria.data';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/index.ts
@@ -1,6 +1,4 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type { PropType } from 'vue';
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import template from './sw-order-customer-address-select.html.twig';
 import './sw-order-customer-address-select.scss';
 import type CriteriaType from '../../../../core/data/criteria.data';

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/index.ts
@@ -1,5 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import type CriteriaType from 'src/core/data/criteria.data';
 import type RepositoryType from '../../../../core/data/repository.data';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
@@ -1,5 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import type { PropType } from 'vue';
 import type RepositoryType from 'src/core/data/repository.data';
 import type CriteriaType from 'src/core/data/criteria.data';

--- a/src/Administration/Resources/app/administration/src/module/sw-order/order.types.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/order.types.ts
@@ -1,5 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
-
 /**
  * @package checkout
  */

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-create/index.ts
@@ -1,4 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type Repository from 'src/core/data/repository.data';
 import type { Cart, PromotionCodeTag } from '../../order.types';
 import swOrderState from '../../state/order.store';

--- a/src/Administration/Resources/app/administration/src/module/sw-order/state/order.store.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/state/order.store.ts
@@ -1,4 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type { Module } from 'vuex';
 import type { AxiosResponse } from 'axios';
 import type {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-details/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-details/index.ts
@@ -1,4 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import template from './sw-order-create-details.html.twig';
 // eslint-disable-next-line max-len
 import type {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-general/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-create-general/index.ts
@@ -1,4 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import template from './sw-order-create-general.html.twig';
 import type { CalculatedTax, CartDelivery, LineItem, Cart, PromotionCodeTag, SalesChannelContext } from '../../order.types';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-address-handling/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-address-handling/index.ts
@@ -1,7 +1,6 @@
 import camelCase from 'lodash/camelCase';
 import type CriteriaType from 'src/core/data/criteria.data';
 import type { PropType } from 'vue';
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type { DragConfig } from 'src/app/directive/dragdrop.directive';
 import template from './sw-settings-country-address-handling.html.twig';
 import './sw-settings-country-address-handling.scss';
@@ -57,7 +56,7 @@ Component.register('sw-settings-country-address-handling', {
 
     props: {
         country: {
-            type: Object as PropType<EntitySchema.Entities['country']>,
+            type: Object as PropType<Entity<'country'>>,
             required: true,
         },
 
@@ -467,7 +466,7 @@ Component.register('sw-settings-country-address-handling', {
                 .catch(() => {});
         },
 
-        renderFormattingAddress(address?: EntitySchema.Entities['customer_address']): Promise<unknown> {
+        renderFormattingAddress(address?: Entity<'customer_address'>): Promise<unknown> {
             if (!address) {
                 this.formattingAddress = '';
                 return Promise.resolve();

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/page/sw-settings-payment-overview/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/page/sw-settings-payment-overview/index.ts
@@ -1,7 +1,5 @@
 import type CriteriaType from 'src/core/data/criteria.data';
 import type Repository from 'src/core/data/repository.data';
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import type { PaymentOverviewCard } from '../../state/overview-cards.store';
 import template from './sw-settings-payment-overview.html.twig';
 import './sw-settings-payment-overview.scss';

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-provider-sorting-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/component/sw-settings-tax-provider-sorting-modal/index.ts
@@ -1,7 +1,5 @@
 import type { PropType } from 'vue';
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type Repository from 'src/core/data/repository.data';
-import type EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import template from './sw-settings-tax-provider-sorting-modal.html.twig';
 import './sw-settings-tax-provider-sorting-modal.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-provider-detail/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-provider-detail/index.ts
@@ -1,4 +1,3 @@
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import type Repository from 'src/core/data/repository.data';
 import type CriteriaType from 'src/core/data/criteria.data';
 import template from './sw-settings-tax-provider-detail.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-units/page/sw-settings-units-detail/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-units/page/sw-settings-units-detail/index.ts
@@ -1,7 +1,6 @@
 /**
  * @package inventory
  */
-import type { Entity } from '@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity';
 import Criteria from '@shopware-ag/meteor-admin-sdk/es/data/Criteria';
 import template from './index.html.twig';
 import type Repository from '../../../../core/data/repository.data';


### PR DESCRIPTION
NEXT-39733

fixes #5453

### 1. Why is this change necessary?
- Currently if you want to use `Entity` or `EntityCollection` you always have to import them (from `@shopware-ag/meteor-admin-sdk/es/_internals/data/Entity` or `src/core/data/entity-collection.data`) or use them with the namespace like `EntitySchema.Entity` or `EntitySchema.EntityCollection`, which all feels unnecessarily complex when using such a regular/commonly used type in administration.
- To reduce the need for all these imports I changed `src/global.types.ts` to provide the global types `Entity` and `EntityCollection` directly.
- With this change we can now easily use these types anywhere in the administration typescript files

### 2. What does this change do, exactly?
* Changed `src/global.types.ts` to directly provide the global `Entity` & `EntityCollection` types without a namespace from the `EntitySchema` namespace of the `@shopware-ag/meteor-admin-sdk` package
* Changed multiple files to remove now unnecessary imports of `Entity` & `EntityCollection` types

### 3. Describe each step to reproduce the issue or behaviour.
- /

### 4. Please link to the relevant issues (if any).
- /

### 5. Checklist

- [X] I have rebased my changes to remove merge conflicts
- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [X] I have written or adjusted the documentation according to my changes
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
