### PR TITLE
feat(a11y): add injectable aria-label to data grid component

### DIFF
--- a/changelog/_unreleased/2025-01-15-inject-aria-label-from-data-grid-component-to-the-form-controles-in-a-column.md
+++ b/changelog/_unreleased/2025-01-15-inject-aria-label-from-data-grid-component-to-the-form-controles-in-a-column.md
@@ -1,0 +1,11 @@
+---
+title: Inject aria-label from data grid component to the form controles in a column
+issue: NEXT-39830
+author: Iván Tajes Vidal
+author_email: tajespasarela@gmail.com
+author_github: @Iván Tajes Vidal
+---
+
+# Administration
+* Added `sw-provide` component to inject any value to children of a component.
+* Added aria-label to the form controls in a column of the data grid component. This aria-label is injected from the data grid component using the `sw-provide` component to inject the column label as aria-label to the cells. 

--- a/src/Administration/Resources/app/administration/.eslintrc.js
+++ b/src/Administration/Resources/app/administration/.eslintrc.js
@@ -31,7 +31,7 @@ const baseRules = {
     'sw-core-rules/require-package-annotation': ['warn'],
     'sw-deprecation-rules/private-feature-declarations': 'error',
     'no-restricted-exports': 'off',
-    'filename-rules/match': [2, /^(?!.*\.spec\.ts$).*(?:\.js|\.ts|\.html|\.html\.twig)$/],
+    'filename-rules/match': [2, /^.*(?:\.js|\.ts|\.html|\.html\.twig)$/],
     'vue/multi-word-component-names': ['error', {
         ignores: ['index.html'],
     }],

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.html.twig
@@ -340,80 +340,82 @@
                         role="gridcell"
                         @dblclick="onDbClickCell(item)"
                     >
-
-                        <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                        {% block sw_data_grid_body_columns_content %}
-                        <div class="sw-data-grid__cell-content">
+                        <sw-provide :aria-label="column.label">
 
                             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                            {% block sw_data_grid_preview_slot %}
-                            <slot
-                                v-if="previews && !isInlineEdit(item)"
-                                :name="`preview-${column.property}`"
-                                v-bind="{ item, column, compact }"
-                            ></slot>
-                            {% endblock %}
+                            {% block sw_data_grid_body_columns_content %}
+                            <div class="sw-data-grid__cell-content">
 
-                            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                            {% block sw_data_grid_columns_slot %}
-                            <slot
-                                :name="`column-${column.property}`"
-                                v-bind="{ item, itemIndex, column, columnIndex, compact, isInlineEdit: (isInlineEdit(item) && column.hasOwnProperty('inlineEdit')), selectItem }"
-                            >
-                                <template v-if="column.inlineEdit === 'boolean'">
-                                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                                    {% block sw_data_grid_columns_boolean %}
-                                    <sw-data-grid-column-boolean
-                                        v-model:value="item[column.property]"
-                                        :is-inline-edit="isInlineEdit(item) && column.hasOwnProperty('inlineEdit')"
-                                    />
-                                    {% endblock %}
-                                </template>
-                                <template v-else>
-                                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                                    {% block sw_data_grid_columns_inline_edit %}
-                                    <template v-if="isInlineEdit(item) && column.hasOwnProperty('inlineEdit')">
+                                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                                {% block sw_data_grid_preview_slot %}
+                                <slot
+                                    v-if="previews && !isInlineEdit(item)"
+                                    :name="`preview-${column.property}`"
+                                    v-bind="{ item, column, compact }"
+                                ></slot>
+                                {% endblock %}
+
+                                <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                                {% block sw_data_grid_columns_slot %}
+                                <slot
+                                    :name="`column-${column.property}`"
+                                    v-bind="{ item, itemIndex, column, columnIndex, compact, isInlineEdit: (isInlineEdit(item) && column.hasOwnProperty('inlineEdit')), selectItem }"
+                                >
+                                    <template v-if="column.inlineEdit === 'boolean'">
                                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                                        {% block sw_data_grid_columns_render_inline_edit %}
-                                        <sw-data-grid-inline-edit
-                                            :column="column"
-                                            :compact="compact"
-                                            :value="item[column.property]"
-                                            @update:value="item[column.property] = $event"
+                                        {% block sw_data_grid_columns_boolean %}
+                                        <sw-data-grid-column-boolean
+                                            v-model:value="item[column.property]"
+                                            :is-inline-edit="isInlineEdit(item) && column.hasOwnProperty('inlineEdit')"
                                         />
                                         {% endblock %}
                                     </template>
-                                    {% endblock %}
-
-                                    <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                                    {% block sw_data_grid_columns_value %}
                                     <template v-else>
                                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                                        {% block sw_data_grid_columns_render_router_link %}
-                                        <router-link
-                                            v-if="column.routerLink"
-                                            class="sw-data-grid__cell-value"
-                                            :to="{ name: column.routerLink, params: { id: item.id } }"
-                                        >
-                                            {{ renderColumn(item, column) }}
-                                        </router-link>
+                                        {% block sw_data_grid_columns_inline_edit %}
+                                        <template v-if="isInlineEdit(item) && column.hasOwnProperty('inlineEdit')">
+                                            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                                            {% block sw_data_grid_columns_render_inline_edit %}
+                                            <sw-data-grid-inline-edit
+                                                :column="column"
+                                                :compact="compact"
+                                                :value="item[column.property]"
+                                                @update:value="item[column.property] = $event"
+                                            />
+                                            {% endblock %}
+                                        </template>
                                         {% endblock %}
+
                                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
-                                        {% block sw_data_grid_columns_render_value %}
-                                        <span
-                                            v-else
-                                            class="sw-data-grid__cell-value"
-                                        >
-                                            {{ renderColumn(item, column) }}
-                                        </span>
+                                        {% block sw_data_grid_columns_value %}
+                                        <template v-else>
+                                            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                                            {% block sw_data_grid_columns_render_router_link %}
+                                            <router-link
+                                                v-if="column.routerLink"
+                                                class="sw-data-grid__cell-value"
+                                                :to="{ name: column.routerLink, params: { id: item.id } }"
+                                            >
+                                                {{ renderColumn(item, column) }}
+                                            </router-link>
+                                            {% endblock %}
+                                            <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
+                                            {% block sw_data_grid_columns_render_value %}
+                                            <span
+                                                v-else
+                                                class="sw-data-grid__cell-value"
+                                            >
+                                                {{ renderColumn(item, column) }}
+                                            </span>
+                                            {% endblock %}
+                                        </template>
                                         {% endblock %}
                                     </template>
-                                    {% endblock %}
-                                </template>
-                            </slot>
+                                </slot>
+                                {% endblock %}
+                            </div>
                             {% endblock %}
-                        </div>
-                        {% endblock %}
+                        </sw-provide>
                     </td>
                     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.spec.js
@@ -97,6 +97,7 @@ describe('components/data-grid/sw-data-grid', () => {
             'sw-loader': true,
             'mt-floating-ui': true,
             'mt-switch': true,
+            'sw-provide': true,
         };
 
         return mount(await wrapTestComponent('sw-data-grid', { sync: true }), {

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-bulk-edit-modal/sw-bulk-edit-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-bulk-edit-modal/sw-bulk-edit-modal.spec.js
@@ -85,6 +85,7 @@ describe('src/app/component/entity/sw-bulk-edit-modal', () => {
             'sw-data-grid-inline-edit': true,
             'router-link': true,
             'sw-data-grid-skeleton': true,
+            'sw-provide': true,
         };
     });
 

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/sw-entity-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-entity-listing/sw-entity-listing.spec.js
@@ -54,6 +54,7 @@ async function createWrapper(propsData = {}) {
                 'sw-data-grid-inline-edit': true,
                 'router-link': true,
                 'sw-button-group': true,
+                'sw-provide': true,
             },
         },
     });

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-one-to-many-grid/sw-one-to-many-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-one-to-many-grid/sw-one-to-many-grid.spec.js
@@ -56,6 +56,7 @@ async function createWrapper() {
                 'router-link': true,
                 'sw-button': true,
                 'sw-data-grid-skeleton': true,
+                'sw-provide': true,
             },
         },
     });

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-product-stream-grid-preview/sw-product-stream-grid-preview.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-product-stream-grid-preview/sw-product-stream-grid-preview.spec.js
@@ -75,6 +75,7 @@ const createWrapper = async () => {
                     'sw-ai-copilot-badge': true,
                     'sw-help-text': true,
                     'mt-checkbox': true,
+                    'sw-provide': true,
                 },
                 mocks: {
                     $route: { meta: { $module: { icon: 'default' } } },

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal-grid/sw-entity-advanced-selection-modal-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal-grid/sw-entity-advanced-selection-modal-grid.spec.js
@@ -78,6 +78,7 @@ async function createWrapper(isSelectable, tooltip) {
                     'sw-inheritance-switch': true,
                     'sw-ai-copilot-badge': true,
                     'sw-help-text': true,
+                    'sw-provide': { template: '<slot/>', inheritAttrs: false },
                 },
                 directives: {
                     tooltip: {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-checkbox-field-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-checkbox-field-deprecated/index.js
@@ -1,3 +1,4 @@
+import { inject } from 'vue';
 import template from './sw-checkbox-field-deprecated.html.twig';
 import './sw-checkbox-field.scss';
 
@@ -101,7 +102,9 @@ Component.register('sw-checkbox-field-deprecated', {
         ariaLabel: {
             type: String,
             required: false,
-            default: null,
+            default() {
+                return inject('ariaLabel', null)?.value;
+            },
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-checkbox-field-deprecated/sw-checkbox-field-deprecated.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-checkbox-field-deprecated/sw-checkbox-field-deprecated.html.twig
@@ -19,7 +19,7 @@
                 :disabled="disabled"
                 :indeterminate.prop="partlyChecked"
                 v-bind="attrsWithoutClass"
-                :aria-label="ariaLabel || label"
+                :aria-label="(ariaLabel && $tc(ariaLabel) || label)"
                 @change="onChange"
             >
             <!-- eslint-enable vue/no-duplicate-attributes, vue/no-parsing-error -->

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-checkbox-field-deprecated/sw-checkbox-field-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-checkbox-field-deprecated/sw-checkbox-field-deprecated.spec.js
@@ -5,6 +5,7 @@
 import { mount } from '@vue/test-utils';
 import 'src/app/component/form/field-base/sw-base-field';
 import 'src/app/component/form/sw-checkbox-field';
+import { ref } from 'vue';
 
 const defaultData = {
     indeterminateOne: false,
@@ -250,5 +251,30 @@ describe('app/component/form/sw-checkbox-field', () => {
 
         const secondCheckbox = wrapper.findAll('.sw-field--checkbox').at(1);
         expect(secondCheckbox.find('input').attributes('aria-label')).toBe('Check Two');
+    });
+
+    it('injects ariaLabel prop from global injection', async () => {
+        const wrapper = mount(
+            { template: `<sw-checkbox-field-deprecated />` },
+            {
+                global: {
+                    stubs: {
+                        'sw-checkbox-field-deprecated': await wrapTestComponent('sw-checkbox-field-deprecated'),
+                        'sw-base-field': await wrapTestComponent('sw-base-field'),
+                        'sw-icon': true,
+                        'sw-field-error': { template: '<div></div>' },
+                        'sw-help-text': true,
+                        'sw-ai-copilot-badge': true,
+                        'sw-inheritance-switch': true,
+                    },
+                    provide: {
+                        ariaLabel: ref('Aria Label'),
+                    },
+                },
+            },
+        );
+        await flushPromises();
+
+        expect(wrapper.find('input').attributes('aria-label')).toBe('Aria Label');
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-email-field-deprecated/sw-email-field-deprecated.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-email-field-deprecated/sw-email-field-deprecated.html.twig
@@ -42,6 +42,7 @@
             :disabled="disabled"
             :value="currentValue"
             :placeHolder="placeholder"
+            :aria-label="ariaLabel && $tc(ariaLabel)"
             @input="onInput"
             @change="onChange"
             @focus="setFocusClass"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-maintain-currencies-modal/sw-maintain-currencies-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-maintain-currencies-modal/sw-maintain-currencies-modal.spec.js
@@ -58,6 +58,7 @@ async function createWrapper() {
                 'sw-data-grid-column-boolean': true,
                 'sw-data-grid-inline-edit': true,
                 'router-link': true,
+                'sw-provide': { template: `<slot/>`, inheritAttrs: false },
             },
         },
         props: {

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-number-field-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-number-field-deprecated/index.js
@@ -1,3 +1,4 @@
+import { inject } from 'vue';
 import template from './sw-number-field.html.twig';
 import './sw-number-field.scss';
 
@@ -99,6 +100,14 @@ Component.extend('sw-number-field-deprecated', 'sw-text-field-deprecated', {
             type: Boolean,
             required: false,
             default: false,
+        },
+
+        ariaLabel: {
+            type: String,
+            required: false,
+            default() {
+                return inject('ariaLabel', null)?.value;
+            },
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-number-field-deprecated/sw-number-field-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-number-field-deprecated/sw-number-field-deprecated.spec.js
@@ -3,8 +3,9 @@
  */
 
 import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
 
-const createWrapper = async (additionalOptions = {}, value = null) => {
+const createWrapper = async ({ provide, ...additionalOptions } = {}, value = null) => {
     return mount(await wrapTestComponent('sw-number-field-deprecated', { sync: true }), {
         global: {
             stubs: {
@@ -21,6 +22,7 @@ const createWrapper = async (additionalOptions = {}, value = null) => {
             },
             provide: {
                 validationService: {},
+                ...provide,
             },
         },
         props: {
@@ -366,5 +368,16 @@ describe('app/component/form/sw-number-field-deprecated', () => {
         expect(wrapper.emitted('ends-with-decimal-separator')).toStrictEqual([
             [false],
         ]);
+    });
+
+    it('injects ariaLabel prop from global injection', async () => {
+        const wrapper = await createWrapper({
+            provide: {
+                ariaLabel: ref('Aria Label'),
+            },
+        });
+        await flushPromises();
+
+        expect(wrapper.find('input').attributes('aria-label')).toBe('Aria Label');
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-number-field-deprecated/sw-number-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-number-field-deprecated/sw-number-field.html.twig
@@ -23,7 +23,6 @@
     </template>
 
     <template #sw-field-input="{ identification, error, disabled, size, setFocusClass, removeFocusClass }">
-        <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -->
         <input
             :id="identification"
             :name="identification"
@@ -32,6 +31,7 @@
             :class="numberAlignEnd ? 'sw-field--number__align-end' : ''"
             :placeholder="placeholder"
             :disabled="disabled"
+            :aria-label="ariaLabel && $tc(ariaLabel)"
             autocomplete="off"
             @input="onInput"
             @keydown.up="increaseNumberByStep"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-password-field-deprecated/sw-password-field-deprecated.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-password-field-deprecated/sw-password-field-deprecated.html.twig
@@ -23,6 +23,7 @@
                 :disabled="disabled"
                 :value="currentValue"
                 :autocomplete="autocomplete"
+                :aria-label="ariaLabel && $tc(ariaLabel)"
                 @input="onInput"
                 @change="onChange"
                 @focus="setFocusClass"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-password-field-deprecated/sw-password-field-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-password-field-deprecated/sw-password-field-deprecated.spec.js
@@ -8,8 +8,9 @@ import 'src/app/component/form/sw-password-field';
 import 'src/app/component/form/field-base/sw-contextual-field';
 import 'src/app/component/form/field-base/sw-block-field';
 import 'src/app/component/form/field-base/sw-base-field';
+import { ref } from 'vue';
 
-async function createWrapper(additionalOptions = {}) {
+async function createWrapper({ provide, ...additionalOptions } = {}) {
     return mount(await wrapTestComponent('sw-password-field-deprecated', { sync: true }), {
         global: {
             stubs: {
@@ -28,6 +29,7 @@ async function createWrapper(additionalOptions = {}) {
             },
             provide: {
                 validationService: {},
+                ...provide,
             },
         },
         ...additionalOptions,
@@ -123,5 +125,16 @@ describe('components/form/sw-password-field', () => {
         await flushPromises();
 
         expect(wrapper.find('label').text()).toBe('Label from slot');
+    });
+
+    it('injects ariaLabel prop from global injection', async () => {
+        const wrapper = await createWrapper({
+            provide: {
+                ariaLabel: ref('Aria Label'),
+            },
+        });
+        await flushPromises();
+
+        expect(wrapper.find('input').attributes('aria-label')).toBe('Aria Label');
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-switch-field-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-switch-field-deprecated/index.js
@@ -1,3 +1,4 @@
+import { inject } from 'vue';
 import template from './sw-switch-field-deprecated.html.twig';
 import './sw-switch-field-deprecated.scss';
 
@@ -45,6 +46,13 @@ Component.extend('sw-switch-field-deprecated', 'sw-checkbox-field-deprecated', {
                     'medium',
                     'default',
                 ].includes(val);
+            },
+        },
+        ariaLabel: {
+            type: String,
+            required: false,
+            default() {
+                return inject('ariaLabel', null)?.value;
             },
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-switch-field-deprecated/sw-switch-field-deprecated.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-switch-field-deprecated/sw-switch-field-deprecated.html.twig
@@ -16,6 +16,7 @@
                 :name="formFieldName || identification"
                 :checked="inputState"
                 :disabled="disabled || undefined"
+                :aria-label="ariaLabel && $tc(ariaLabel)"
                 @change="onChange"
             >
             <!-- eslint-enable vue/no-duplicate-attributes, vue/no-parsing-error -->

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-switch-field-deprecated/sw-switch-field-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-switch-field-deprecated/sw-switch-field-deprecated.spec.js
@@ -3,6 +3,7 @@
  */
 
 import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
 
 const createWrapper = async () => {
     const baseComponent = {
@@ -176,5 +177,32 @@ describe('app/component/form/sw-switch-field-deprecated', () => {
         expect(checkboxContentWrappers.at(1).classes()).toContain('sw-field--switch-padded');
         expect(checkboxContentWrappers.at(2).classes()).toContain('sw-field--switch-bordered');
         expect(checkboxContentWrappers.at(2).classes()).toContain('sw-field--switch-padded');
+    });
+
+    it('injects ariaLabel prop from global injection', async () => {
+        const wrapper = mount(
+            { template: `<sw-switch-field-deprecated />` },
+            {
+                global: {
+                    stubs: {
+                        'sw-switch-field-deprecated': await wrapTestComponent('sw-switch-field-deprecated'),
+                        'sw-base-field': await wrapTestComponent('sw-base-field'),
+                        'sw-field-error': {
+                            template: '<div></div>',
+                        },
+                        'sw-inheritance-switch': true,
+                        'sw-ai-copilot-badge': true,
+                        'sw-help-text': true,
+                    },
+                    provide: {
+                        ariaLabel: ref('Aria Label'),
+                    },
+                },
+            },
+        );
+
+        await flushPromises();
+
+        expect(wrapper.find('input').attributes('aria-label')).toBe('Aria Label');
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-field-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-field-deprecated/index.js
@@ -1,3 +1,4 @@
+import { inject } from 'vue';
 import template from './sw-text-field-deprecated.html.twig';
 
 const { Component, Mixin } = Shopware;
@@ -62,6 +63,14 @@ Component.register('sw-text-field-deprecated', {
             required: false,
             default() {
                 return '';
+            },
+        },
+
+        ariaLabel: {
+            type: String,
+            required: false,
+            default() {
+                return inject('ariaLabel', null)?.value;
             },
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-field-deprecated/sw-text-field-deprecated.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-field-deprecated/sw-text-field-deprecated.html.twig
@@ -31,6 +31,7 @@
             :disabled="disabled"
             :value="currentValue"
             :placeholder="placeholder"
+            :aria-label="ariaLabel && $tc(ariaLabel)"
             @input="onInput"
             @change="onChange"
             @focus="setFocusClass"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-text-field-deprecated/sw-text-field-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-text-field-deprecated/sw-text-field-deprecated.spec.js
@@ -4,8 +4,9 @@
 
 import { mount } from '@vue/test-utils';
 import 'src/app/component/form/sw-text-field';
+import { ref } from 'vue';
 
-async function createWrapper(options = {}) {
+async function createWrapper({ provide, ...options } = {}) {
     const wrapper = mount(await wrapTestComponent('sw-text-field-deprecated', { sync: true }), {
         global: {
             stubs: {
@@ -21,6 +22,7 @@ async function createWrapper(options = {}) {
             },
             provide: {
                 validationService: {},
+                ...provide,
             },
         },
         ...options,
@@ -124,5 +126,16 @@ describe('src/app/component/form/sw-text-field', () => {
         });
 
         expect(wrapper.find('label').text()).toBe('Label from slot');
+    });
+
+    it('injects ariaLabel prop from global injection', async () => {
+        const wrapper = await createWrapper({
+            provide: {
+                ariaLabel: ref('Aria Label'),
+            },
+        });
+        await flushPromises();
+
+        expect(wrapper.find('input').attributes('aria-label')).toBe('Aria Label');
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-textarea-field-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-textarea-field-deprecated/index.js
@@ -1,3 +1,4 @@
+import { inject } from 'vue';
 import template from './sw-textarea-field.html.twig';
 import './sw-textarea-field.scss';
 
@@ -45,6 +46,14 @@ Component.register('sw-textarea-field-deprecated', {
             type: String,
             required: false,
             default: null,
+        },
+
+        ariaLabel: {
+            type: String,
+            required: false,
+            default() {
+                return inject('ariaLabel', null)?.value;
+            },
         },
     },
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-textarea-field-deprecated/sw-textarea-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-textarea-field-deprecated/sw-textarea-field.html.twig
@@ -18,6 +18,7 @@
             :placeholder="placeholder"
             :disabled="disabled"
             :value="currentValue"
+            :aria-label="ariaLabel && $tc(ariaLabel)"
             @change="onChange"
             @input="onInput"
             @focus="setFocusClass"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field-deprecated/sw-url-field-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field-deprecated/sw-url-field-deprecated.spec.js
@@ -11,8 +11,9 @@ import 'src/app/component/form/field-base/sw-base-field';
 import 'src/app/component/base/sw-icon';
 import 'src/app/component/form/field-base/sw-field-error';
 import 'src/app/filter/unicode-uri';
+import { ref } from 'vue';
 
-async function createWrapper(additionalOptions = {}) {
+async function createWrapper({ provide, ...additionalOptions } = {}) {
     return mount(await wrapTestComponent('sw-url-field-deprecated', { sync: true }), {
         global: {
             stubs: {
@@ -35,6 +36,7 @@ async function createWrapper(additionalOptions = {}) {
             },
             provide: {
                 validationService: {},
+                ...provide,
             },
         },
         ...additionalOptions,
@@ -270,5 +272,16 @@ describe('components/form/sw-url-field', () => {
             ['https://shopware.com'],
             [''],
         ]);
+    });
+
+    it('injects ariaLabel prop from global injection', async () => {
+        const wrapper = await createWrapper({
+            provide: {
+                ariaLabel: ref('Aria Label'),
+            },
+        });
+        await flushPromises();
+
+        expect(wrapper.find('input').attributes('aria-label')).toBe('Aria Label');
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field-deprecated/sw-url-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field-deprecated/sw-url-field.html.twig
@@ -46,6 +46,7 @@
             :value="unicodeUriFilter(currentUrlValue)"
             :placeholder="placeholder"
             :disabled="disabled"
+            :aria-label="ariaLabel && $tc(ariaLabel)"
             @focus="setFocusClass"
             @blur="onBlur($event); removeFocusClass();"
         >

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-provide/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-provide/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @package admin
+ */
+import { computed, provide } from 'vue';
+
+/**
+ * @private
+ */
+Shopware.Component.register('sw-provide', {
+    template: '<slot />',
+    inheritAttrs: false,
+    setup(_props, { attrs }) {
+        Object.keys(attrs).forEach((key) =>
+            provide(
+                Shopware.Utils.string.camelCase(key),
+                computed(() => attrs[key]),
+            ),
+        );
+        return {};
+    },
+});

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-provide/sw-provide.spec.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-provide/sw-provide.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * @package admin
+ */
+
+import { mount } from '@vue/test-utils';
+
+async function createWrapper({ template = '<sw-provide />', components = {}, data = {} } = {}) {
+    return mount({
+        template,
+        components: {
+            'sw-provide': await wrapTestComponent('sw-provide', { sync: true }),
+            ...components,
+        },
+        data() {
+            return data;
+        },
+    });
+}
+
+describe('src/app/component/base/sw-provide', () => {
+    it('should be a Vue.js component', async () => {
+        const wrapper = await createWrapper();
+
+        expect(wrapper.vm).toBeTruthy();
+    });
+
+    it('renders the children without adding extra HTML', async () => {
+        const wrapper = await createWrapper({
+            template: `
+            <sw-provide>
+                <div class="test-child" />
+            </sw-provide>`,
+        });
+
+        expect(wrapper.html()).toBe('<div class="test-child"></div>');
+    });
+
+    it('provides the attributes to the children', async () => {
+        const wrapper = await createWrapper({
+            template: `
+            <sw-provide :foo="42" :bar="true">
+                    <child-component>{{ foo }} {{ bar }}</child-component>
+            </sw-provide>`,
+            components: {
+                'child-component': {
+                    template: '<div>{{ foo }} {{ bar }}</div>',
+                    inject: [
+                        'foo',
+                        'bar',
+                    ],
+                },
+            },
+        });
+
+        expect(wrapper.text()).toBe('42 true');
+    });
+
+    it('keeps reactivity of provided attributes', async () => {
+        const wrapper = await createWrapper({
+            template: `
+            <sw-provide :foo="foo">
+                <child-component>{{ foo }}</child-component>
+            </sw-provide>`,
+            components: {
+                'child-component': {
+                    template: '<div>{{ foo }}</div>',
+                    inject: ['foo'],
+                },
+            },
+            data: {
+                foo: 'bar',
+            },
+        });
+
+        expect(wrapper.text()).toBe('bar');
+        await wrapper.setData({ foo: 'baz' });
+        expect(wrapper.text()).toBe('baz');
+    });
+
+    it('converts attrs name to camelCase', async () => {
+        const wrapper = await createWrapper({
+            template: `
+            <sw-provide :foo-bar="42" :barFoo="true">
+                <child-component>{{ fooBar }}</child-component>
+            </sw-provide>`,
+            components: {
+                'child-component': {
+                    template: '<div>{{ fooBar }} {{ barFoo }}</div>',
+                    inject: [
+                        'fooBar',
+                        'barFoo',
+                    ],
+                },
+            },
+        });
+
+        expect(wrapper.text()).toBe('42 true');
+    });
+});

--- a/src/Administration/Resources/app/administration/src/meta/meta.spec.js
+++ b/src/Administration/Resources/app/administration/src/meta/meta.spec.js
@@ -53,6 +53,9 @@ describe('Administration meta tests', () => {
             const specFileWithFolderName = whole.replace(fileName, `${lastFolder}.spec.js`);
             const specFileWithFolderNameExists = fs.existsSync(specFileWithFolderName);
 
+            const specTsFileWithFolderName = whole.replace(fileName, `${lastFolder}.spec.ts`);
+            const specTsFileWithFolderNameExists = fs.existsSync(specTsFileWithFolderName);
+
             let specFileAlternativeExtension = '';
             let specFileWithFolderNameAlternativeExtension = '';
             if (extension === 'js') {
@@ -72,6 +75,7 @@ describe('Administration meta tests', () => {
                 specFileExists ||
                 specTsFileExists ||
                 specFileWithFolderNameExists ||
+                specTsFileWithFolderNameExists ||
                 specFileAlternativeExtensionExists ||
                 specFileWithFolderNameAlternativeExtensionExists;
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-modal/sw-cms-layout-modal.spec.js
@@ -116,6 +116,7 @@ async function createWrapper() {
                     'sw-data-grid-skeleton': true,
                     'sw-help-text': true,
                     'sw-ai-copilot-badge': true,
+                    'sw-provide': { template: `<slot/>`, inheritAttrs: false },
                 },
             },
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-listing/config/config.spec.js
@@ -93,6 +93,7 @@ async function createWrapper(activeTab = 'sorting') {
                     'router-link': true,
                     'sw-button': true,
                     'sw-data-grid-skeleton': true,
+                    'sw-provide': true,
                 },
                 provide: {
                     cmsService: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-list/sw-cms-list.spec.js
@@ -108,6 +108,7 @@ async function createWrapper(
                     'sw-checkbox-field': true,
                     'sw-data-grid-column-boolean': true,
                     'sw-data-grid-inline-edit': true,
+                    'sw-provide': true,
                 },
                 mocks: {
                     $route: { query: '' },

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-mail-send-modal/sw-flow-mail-send-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-mail-send-modal/sw-flow-mail-send-modal.spec.js
@@ -141,6 +141,7 @@ async function createWrapper(sequence = {}) {
                 'sw-data-grid-inline-edit': true,
                 'sw-data-grid-skeleton': true,
                 'sw-field-copyable': true,
+                'sw-provide': { template: '<slot/>', inheritAttrs: false },
             },
             provide: {
                 repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list-flow-templates/sw-flow-list-flow-templates.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/listing/sw-flow-list-flow-templates/sw-flow-list-flow-templates.spec.js
@@ -62,6 +62,7 @@ async function createWrapper(privileges = [], props = {}) {
                 'sw-data-grid-settings': true,
                 'sw-data-grid-column-boolean': true,
                 'sw-data-grid-inline-edit': true,
+                'sw-provide': { template: '<slot/>', inheritAttrs: false },
             },
             provide: {
                 repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-activity/sw-import-export-activity.spec.js
@@ -814,6 +814,7 @@ const createWrapper = async (options = {}) => {
                 'sw-data-grid-inline-edit': true,
                 'router-link': true,
                 'sw-ai-copilot-badge': true,
+                'sw-provide': { template: '<slot/>', inheritAttrs: false },
             },
             mocks: {
                 $tc: (key, pluralization) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-identifiers/sw-import-export-edit-profile-modal-identifiers.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-identifiers/sw-import-export-edit-profile-modal-identifiers.spec.js
@@ -103,6 +103,7 @@ describe('module/sw-import-export/components/sw-import-export-edit-profile-modal
                         'sw-inheritance-switch': true,
                         'sw-ai-copilot-badge': true,
                         'sw-help-text': true,
+                        'sw-provide': { template: `<slot/>`, inheritAttrs: false },
                     },
                 },
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-mapping/sw-import-export-edit-profile-modal-mapping.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-edit-profile-modal-mapping/sw-import-export-edit-profile-modal-mapping.spec.js
@@ -93,6 +93,7 @@ describe('module/sw-import-export/components/sw-import-export-edit-profile-modal
                         'sw-inheritance-switch': true,
                         'sw-ai-copilot-badge': true,
                         'sw-help-text': true,
+                        'sw-provide': { template: '<slot/>', inheritAttrs: false },
                     },
                 },
             },

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/view/sw-import-export-view-profiles/sw-import-export-view-profiles.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/view/sw-import-export-view-profiles/sw-import-export-view-profiles.spec.js
@@ -76,6 +76,7 @@ async function createWrapper(profiles = null) {
                     'sw-data-grid-inline-edit': true,
                     'sw-data-grid-skeleton': true,
                     'sw-pagination': true,
+                    'sw-provide': true,
                 },
                 provide: {
                     importExport: new ImportExportService(),

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-grid/sw-order-customer-grid.spec.js
@@ -150,6 +150,7 @@ async function createWrapper() {
                 'sw-popover': {
                     template: '<div class="sw-popover"><slot></slot></div>',
                 },
+                'sw-provide': { template: '<slot/>', inheritAttrs: false },
             },
             provide: {
                 searchRankingService: () => {},

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
@@ -155,6 +155,7 @@ async function createWrapper() {
                 'sw-upload-listener': true,
                 'sw-media-upload-v2': true,
                 'sw-media-modal-v2': true,
+                'sw-provide': { template: '<slot/>', inheritAttrs: false },
             },
             provide: {
                 documentService: {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/sw-order-line-items-grid-sales-channel.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid-sales-channel/sw-order-line-items-grid-sales-channel.spec.js
@@ -216,6 +216,7 @@ async function createWrapper() {
                     'sw-data-grid-column-boolean': true,
                     'sw-data-grid-skeleton': true,
                     'sw-highlight-text': true,
+                    'sw-provide': { template: '<slot/>', inheritAttrs: false },
                 },
                 mocks: {
                     $tc: (t, count, value) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-line-items-grid/sw-order-line-items-grid.spec.js
@@ -292,6 +292,7 @@ async function createWrapper() {
                 'sw-field-error': true,
                 'sw-icon-deprecated': true,
                 'sw-highlight-text': true,
+                'sw-provide': { template: '<slot/>', inheritAttrs: false },
             },
             mocks: {
                 $tc: (t, count, value) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/sw-order-state-history-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/sw-order-state-history-modal.spec.js
@@ -145,6 +145,7 @@ describe('src/module/sw-order/component/sw-order-state-history-modal', () => {
                     'router-link': true,
                     'sw-select-field': true,
                     'sw-loader': true,
+                    'sw-provide': { template: `<slot/>`, inheritAttrs: false },
                 },
                 provide: {
                     stateStyleDataProviderService: {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-list/sw-order-list.spec.js
@@ -88,6 +88,7 @@ async function createWrapper() {
                 'sw-sidebar': true,
                 'sw-data-grid-column-boolean': true,
                 'sw-data-grid-inline-edit': true,
+                'sw-provide': { template: '<slot/>', inheritAttrs: false },
             },
             provide: {
                 stateStyleDataProviderService: {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-assignment/sw-product-cross-selling-assignment.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-assignment/sw-product-cross-selling-assignment.spec.js
@@ -76,6 +76,7 @@ async function createWrapper() {
                     'sw-button': true,
                     'sw-data-grid-skeleton': true,
                     'sw-highlight-text': true,
+                    'sw-provide': { template: `<slot/>`, inheritAttrs: false },
                 },
                 provide: {
                     repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-restrictions/sw-product-variants-configurator-restrictions.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-configurator/sw-product-variants-configurator-restrictions/sw-product-variants-configurator-restrictions.spec.js
@@ -134,6 +134,7 @@ describe('components/base/sw-product-variants-configurator-restrictions', () => 
                     'sw-ai-copilot-badge': true,
                     'sw-help-text': true,
                     'sw-field-error': true,
+                    'sw-provide': true,
                 },
             },
         });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.spec.js
@@ -116,6 +116,7 @@ async function createWrapper(propsOverride = {}, repositoryFactoryOverride = {})
                 'sw-media-preview-v2': true,
                 'sw-context-menu-divider': true,
                 'sw-media-modal-v2': true,
+                'sw-provide': { template: '<slot/>', inheritAttrs: false },
             },
         },
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-list/sw-product-list.spec.js
@@ -352,6 +352,7 @@ async function createWrapper() {
                     'sw-sidebar-filter-panel': true,
                     'sw-data-grid-column-boolean': true,
                     'sw-data-grid-inline-edit': true,
+                    'sw-provide': { template: '<slot/>', inheritAttrs: false },
                 },
             },
         }),

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/sw-product-detail-context-prices.spec.js
@@ -53,6 +53,7 @@ const createWrapper = async () => {
                     'sw-data-grid-skeleton': true,
                     'sw-field-copyable': true,
                     'sw-maintain-currencies-modal': true,
+                    'sw-provide': { template: `<slot/>`, inheritAttrs: false },
                 },
                 provide: {
                     repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-option-list/sw-property-option-list.spec.js
@@ -172,6 +172,7 @@ async function createWrapper() {
                 'sw-data-grid-inline-edit': true,
                 'router-link': true,
                 'sw-data-grid-skeleton': true,
+                'sw-provide': { template: `<slot/>`, inheritAttrs: false },
             },
         },
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/sw-sales-channel-detail-domains.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/sw-sales-channel-detail-domains.spec.js
@@ -46,6 +46,7 @@ async function createWrapper(customProps = {}, domains = []) {
                     'sw-loader': true,
                     'sw-highlight-text': true,
                     'sw-select-result': true,
+                    'sw-provide': { template: `<slot/>`, inheritAttrs: false },
                 },
                 provide: {
                     repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-single-products/sw-sales-channel-products-assignment-single-products.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-products-assignment-single-products/sw-sales-channel-products-assignment-single-products.spec.js
@@ -78,6 +78,7 @@ async function createWrapper() {
                 'sw-inheritance-switch': true,
                 'sw-ai-copilot-badge': true,
                 'sw-help-text': true,
+                'sw-provide': true,
             },
             provide: {
                 repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/component/sw-settings-listing-option-criteria-grid/sw-settings-listing-option-criteria-grid.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/component/sw-settings-listing-option-criteria-grid/sw-settings-listing-option-criteria-grid.spec.js
@@ -88,6 +88,7 @@ describe('src/module/sw-settings-listing/component/sw-settings-listing-option-cr
                         'sw-inheritance-switch': true,
                         'sw-ai-copilot-badge': true,
                         'sw-help-text': true,
+                        'sw-provide': true,
                     },
                 },
                 props: {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing/sw-settings-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-listing/page/sw-settings-listing/sw-settings-listing.spec.js
@@ -540,6 +540,7 @@ describe('src/module/sw-settings-listing/page/sw-settings-listing', () => {
                         'sw-loader': true,
                         'sw-select-field': true,
                         'sw-ai-copilot-badge': true,
+                        'sw-provide': { template: `<slot/>`, inheritAttrs: false },
                     },
                     mocks: {
                         $tc: (param) => {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-modal/sw-settings-product-feature-sets-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-modal/sw-settings-product-feature-sets-modal.spec.js
@@ -92,6 +92,7 @@ describe('src/module/sw-settings-product-feature-sets/component/sw-settings-prod
                         'router-link': true,
                         'sw-field-copyable': true,
                         'sw-contextual-field': true,
+                        'sw-provide': true,
                     },
                     data() {
                         return {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-values-card/sw-settings-product-feature-sets-values-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/component/sw-settings-product-feature-sets-values-card/sw-settings-product-feature-sets-values-card.spec.js
@@ -72,6 +72,7 @@ describe('src/module/sw-settings-product-feature-sets/component/sw-settings-prod
                         'sw-data-grid-column-boolean': true,
                         'sw-data-grid-inline-edit': true,
                         'sw-data-grid-skeleton': true,
+                        'sw-provide': true,
                         i18n: true,
                     },
                     provide: {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-list/sw-settings-product-feature-sets-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-list/sw-settings-product-feature-sets-list.spec.js
@@ -53,6 +53,7 @@ async function createWrapper(additionalOptions = {}, privileges = []) {
                     'sw-bulk-edit-modal': true,
                     'sw-data-grid-column-boolean': true,
                     'sw-data-grid-inline-edit': true,
+                    'sw-provide': true,
                 },
                 mocks: {
                     $route: {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/component/sw-settings-rule-add-assignment-listing/sw-settings-rule-add-assignment-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/component/sw-settings-rule-add-assignment-listing/sw-settings-rule-add-assignment-listing.spec.js
@@ -107,6 +107,7 @@ async function createWrapper(props = defaultProps) {
                     'sw-field-copyable': true,
                     'sw-inheritance-switch': true,
                     'sw-help-text': true,
+                    'sw-provide': { template: '<slot/>', inheritAttrs: false },
                 },
             },
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/component/sw-settings-rule-add-assignment-modal/sw-settings-rule-add-assignment-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/component/sw-settings-rule-add-assignment-modal/sw-settings-rule-add-assignment-modal.spec.js
@@ -117,6 +117,7 @@ async function createWrapper(props = defaultProps) {
                     'sw-field-error': true,
                     'sw-inheritance-switch': true,
                     'sw-help-text': true,
+                    'sw-provide': true,
                 },
                 provide: {
                     repositoryFactory: {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/component/sw-settings-rule-assignment-listing/sw-settings-rule-assignment-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/component/sw-settings-rule-assignment-listing/sw-settings-rule-assignment-listing.spec.js
@@ -80,6 +80,7 @@ async function createWrapper(props = defaultProps) {
                     'sw-help-text': true,
                     'sw-loader': true,
                     'router-link': true,
+                    'sw-provide': true,
                 },
             },
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/view/sw-settings-rule-detail-assignments/sw-settings-rule-detail-assignments.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/view/sw-settings-rule-detail-assignments/sw-settings-rule-detail-assignments.spec.js
@@ -176,6 +176,7 @@ async function createWrapper(
                     'sw-data-grid-skeleton': true,
                     'sw-settings-rule-add-assignment-listing': true,
                     'sw-settings-rule-category-tree': true,
+                    'sw-provide': { template: '<slot/>', inheritAttrs: false },
                 },
                 provide: {
                     ruleConditionDataProviderService: ruleConditionDataProviderServiceMock,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-excluded-search-terms/sw-settings-search-excluded-search-terms.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-excluded-search-terms/sw-settings-search-excluded-search-terms.spec.js
@@ -103,6 +103,7 @@ async function createWrapper(privileges = [], resetError = false) {
                     'sw-inheritance-switch': true,
                     'sw-ai-copilot-badge': true,
                     'sw-help-text': true,
+                    'sw-provide': true,
                 },
             },
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-live-search/sw-settings-search-live-search.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-live-search/sw-settings-search-live-search.spec.js
@@ -121,6 +121,7 @@ async function createWrapper() {
                     'sw-data-grid-inline-edit': true,
                     'router-link': true,
                     'sw-data-grid-skeleton': true,
+                    'sw-provide': true,
                 },
 
                 provide: {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-searchable-content-customfields/sw-settings-search-searchable-content-customfields.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-searchable-content-customfields/sw-settings-search-searchable-content-customfields.spec.js
@@ -78,6 +78,7 @@ async function createWrapper() {
                     'sw-data-grid-column-boolean': true,
                     'sw-data-grid-inline-edit': true,
                     'router-link': true,
+                    'sw-provide': true,
                 },
             },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-searchable-content-general/sw-settings-search-searchable-content-general.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-searchable-content-general/sw-settings-search-searchable-content-general.spec.js
@@ -55,6 +55,7 @@ async function createWrapper() {
                     'sw-data-grid-settings': true,
                     'sw-data-grid-inline-edit': true,
                     'router-link': true,
+                    'sw-provide': true,
                 },
             },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrices/sw-settings-shipping-price-matrices.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrices/sw-settings-shipping-price-matrices.spec.js
@@ -58,6 +58,7 @@ describe('module/sw-settings-shipping/component/sw-settings-shipping-price-matri
                         'sw-data-grid-inline-edit': true,
                         'sw-data-grid-skeleton': true,
                         'sw-help-text': true,
+                        'sw-provide': true,
                     },
                     mocks: {
                         $te: () => false,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-wizard/sw-settings-shopware-updates-wizard.spec.js
@@ -184,6 +184,7 @@ describe('module/sw-settings-shopware-updates/page/sw-settings-shopware-updates-
                         'sw-data-grid-settings': true,
                         'sw-data-grid-inline-edit': true,
                         'sw-data-grid-skeleton': true,
+                        'sw-provide': true,
                     },
                     attachTo: document.body,
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/sw-settings-snippet-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-list/sw-settings-snippet-list.spec.js
@@ -141,6 +141,7 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-list', () => {
                         'sw-checkbox-field': true,
                         'sw-data-grid-column-boolean': true,
                         'sw-data-grid-inline-edit': true,
+                        'sw-provide': true,
                     },
                 },
             },


### PR DESCRIPTION
NEXT-39830

### 1. Why is this change necessary?
To improve accessibility by adding aria-label attributes to form fields and data grid components.

### 2. What does this change do, exactly?
Adds aria-label attributes to form fields.
Introduces a sw-provide component for global aria-label injection.
Updates data grid to include sw-provide for grid cells.

### 3. Describe each step to reproduce the issue or behaviour.
Go to products grid edit one line, inspect the line inputs and check that the aria-label attribute has the same label as the column


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
