### PR TITLE
fix: missing custom field on struct element when select category type

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-base/sw-category-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-category-detail-base/sw-category-detail-base.html.twig
@@ -100,7 +100,7 @@
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_category_detail_attribute_sets %}
     <sw-card
-        v-if="customFieldSetsArray.length > 0 && category.type !=='folder'"
+        v-if="customFieldSetsArray.length > 0"
         position-identifier="sw-category-detail-attribute-sets"
         :title="$tc('sw-settings-custom-field.general.mainMenuItemGeneral')"
         :is-loading="isLoading"


### PR DESCRIPTION
### Solution 

![screencapture-localhost-5173-2025-01-15-11_54_20](https://github.com/user-attachments/assets/1660c1eb-1882-4c24-a67f-d42c68ae6693)
