### PR TITLE
chore: change package names

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEvent.php
+++ b/src/Core/Content/Product/SalesChannel/Review/Event/ProductReviewsLoadedEvent.php
@@ -10,7 +10,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Request;
 
-#[Package('content')]
+#[Package('after-sales')]
 final class ProductReviewsLoadedEvent extends NestedEvent implements ShopwareSalesChannelEvent
 {
     public function __construct(

--- a/src/Core/Framework/Log/Package.php
+++ b/src/Core/Framework/Log/Package.php
@@ -5,7 +5,7 @@ namespace Shopware\Core\Framework\Log;
 /**
  * @internal
  *
- * @phpstan-type PackageString 'buyers-experience'|'services-settings'|'inventory'|'content'|'sales-channel'|'customer-order'|'checkout'|'merchant-services'|'storefront'|'core'|'administration'|'data-services'|'innovation'|'discovery'|'b2b'|'fundamentals@discovery'|'after-sales'|'fundamentals@after-sales'
+ * @phpstan-type PackageString 'buyers-experience'|'services-settings'|'inventory'|'checkout'|'after-sales'|'framework'|'storefront'|'core'|'administration'|'data-services'|'innovation'|'discovery'|'b2b'|'fundamentals@framework'|'fundamentals@discovery'|'fundamentals@checkout'|'fundamentals@after-sales'
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 #[Package('core')]


### PR DESCRIPTION
I removed some extremely old package names and added `framework`, `fundamentals@framework` and `fundamentals@checkout` (in preparation for Rufus). 