### PR TITLE
test: do not error on dependency deprecations in unit test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,7 +110,7 @@
         "scssphp/scssphp": "v1.12.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/conflicts": ">=0.2.0",
+        "shopware/conflicts": ">=0.3.0",
         "shyim/opensearch-php-dsl": "^1.0.5",
         "squirrelphp/twig-php-syntax": "^1.8.0",
         "symfony/asset": "~7.2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -101,7 +101,7 @@
         <server name="HTTPS" value="off"/>
         <!--To see the full stackTrace of a Deprecation set the value to a regex matching the deprecation warning-->
         <!--https://symfony.com/doc/current/components/phpunit_bridge.html#display-the-full-stack-trace-->
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0&amp;ignoreFile=./deprecation.ignore" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;ignoreFile=./deprecation.ignore" />
     </php>
     <testsuites>
         <testsuite name="unit">

--- a/src/Core/Framework/Adapter/Twig/TokenParser/ExtendsTokenParser.php
+++ b/src/Core/Framework/Adapter/Twig/TokenParser/ExtendsTokenParser.php
@@ -6,6 +6,7 @@ use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinderInterface;
 use Shopware\Core\Framework\Adapter\Twig\TemplateScopeDetector;
 use Shopware\Core\Framework\Log\Package;
+use Twig\Node\EmptyNode;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ConstantExpression;
@@ -54,7 +55,7 @@ final class ExtendsTokenParser extends AbstractTokenParser
 
         $stream->injectTokens($tokens);
 
-        return new Node();
+        return new EmptyNode($token->getLine());
     }
 
     public function getTag(): string

--- a/src/Core/Framework/Adapter/Twig/TokenParser/ExtendsTokenParser.php
+++ b/src/Core/Framework/Adapter/Twig/TokenParser/ExtendsTokenParser.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Twig\TemplateFinderInterface;
 use Shopware\Core\Framework\Adapter\Twig\TemplateScopeDetector;
 use Shopware\Core\Framework\Log\Package;
-use Twig\Node\EmptyNode;
 use Twig\Node\Expression\AbstractExpression;
 use Twig\Node\Expression\ArrayExpression;
 use Twig\Node\Expression\ConstantExpression;
@@ -55,7 +54,7 @@ final class ExtendsTokenParser extends AbstractTokenParser
 
         $stream->injectTokens($tokens);
 
-        return new EmptyNode($token->getLine());
+        return new Node();
     }
 
     public function getTag(): string


### PR DESCRIPTION
Adjusted SYFONY_DEPRECATION_HELPER config to only error on self deprecations. This should not break the whole pipeline when there are new deprecations in dependencies.

https://symfony.com/doc/current/components/phpunit_bridge.html#making-tests-fail