### PR TITLE
fix: buildOnlyExtensions is only working in production builds

### DIFF
--- a/changelog/_unreleased/2025-01-17-shopware_admin_build_only_extensions-flag-is-now-only-working-in-production-builds.md
+++ b/changelog/_unreleased/2025-01-17-shopware_admin_build_only_extensions-flag-is-now-only-working-in-production-builds.md
@@ -1,0 +1,9 @@
+---
+title: SHOPWARE_ADMIN_BUILD_ONLY_EXTENSIONS flag is now only working in production builds
+issue: NEXT-40210
+author: Jannis Leifeld
+author_email: j.leifeld@shopware.com
+author_github: @Jannis Leifeld
+---
+# Administration
+* Added additional check for SHOPWARE_ADMIN_BUILD_ONLY_EXTENSIONS flag to only work in production builds

--- a/src/Administration/Resources/app/administration/webpack.config.js
+++ b/src/Administration/Resources/app/administration/webpack.config.js
@@ -51,6 +51,10 @@ const openBrowserForWatch = process.env.DISABLE_DEVSERVER_OPEN !== '1';
 const useSourceMap = isDev && process.env.SHOPWARE_ADMIN_SKIP_SOURCEMAP_GENERATION !== '1';
 const disableAdminImportsFromPlugins = process.env.DISABLE_ADMIN_IMPORTS_FROM_PLUGINS === '1' || process.env.DISABLE_ADMIN_IMPORTS_FROM_PLUGINS === 'true';
 
+if (buildOnlyExtensions && isDev) {
+    console.log(chalk.yellow('# Build only extensions is deactivated in development mode'));
+}
+
 if (isDev) {
     console.log(chalk.yellow('# Development mode is activated \u{1F6E0}'));
     console.log(chalk.yellow(`BaseUrl for proxy is set to "${process.env.APP_URL}"`));
@@ -979,6 +983,6 @@ coreSvgInlineLoader.include.push(/@shopware-ag\/meteor-icon-kit\/icons/);
  * Export all single configs in a array. Webpack uses then the webpack-multi-compiler for isolated
  * builds for each configuration (core + plugins).
  */
-module.exports = buildOnlyExtensions
+module.exports = (buildOnlyExtensions && isProd)
     ? [...configsForPlugins]
     : [mergedCoreConfig, ...configsForPlugins];


### PR DESCRIPTION
### 1. Why is this change necessary?

https://github.com/shopware/shopware/issues/6055

### 2. What does this change do, exactly?

Adds a additional check that the building of only extensions is disabled in watch mode.