### PR TITLE
test: add bc-check exception for twig upgrade

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -57,5 +57,9 @@ return [
         // Was not intended to be extended, declared as final
         'Class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Attribute\\\\Entity became final',
         'Parameter hydratorClass was added to Method __construct\(\) of class Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Attribute\\\\Entity',
+
+        // twig upgrade
+        'Method Twig\\\\Cache\\\\FilesystemCache#remove\\(\\) was removed',
+        'These ancestors of Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\ConfigurableFilesystemCache have been removed: .*',
     ],
 ];


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

Fix bc errors in trunk 

If I understand this correctly, shopware 6.6.9.0 picks a newer twig version than trunk.

Do we need to fix the conflicts package for 6.6.9.0?