### PR TITLE
feat: [A11y-HTML] Include an HTML link in the email content when sending documents for order state changes.

### DIFF
--- a/changelog/_unreleased/2024-12-17-a11y-html-implement-logic-for-customize-document-template-to-support-html-accessibility.md
+++ b/changelog/_unreleased/2024-12-17-a11y-html-implement-logic-for-customize-document-template-to-support-html-accessibility.md
@@ -29,6 +29,9 @@ issue: NEXT-40059
 * Changed `Shopware\Core\Checkout\Document\Service\PdfRenderer` to use `documentTemplateRenderer` render the document.
 * Changed `Shopware\Core\Checkout\Document\Controller\DocumentController::downloadDocument` to add the `fileType` configuration to the `DocumentGenerator`.
 * Changed `src/Core/Framework/Resources/views/documents/base.html.twig` to implement accessibility for HTML documents.
+* Added `Shopware\Core\Framework\Event\A11yRenderedDocumentAware` to provide the document ids to render the A11y document.
+* Added `Shopware\Core\Content\Flow\Dispatching\Storer\A11yRenderedDocumentStorer` to store the document ids and documents to render the A11y documents.
+* Changed `Shopware\Core\Checkout\Order\Event\OrderStateMachineStateChangeEvent` to implements `A11yRenderedDocumentAware`
 ___
 # Administration
 * Changed method `getDocumentPreview` in `document.api.service` service to add the `fileType` like <html or pdf> attributes.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,11 +96,6 @@ parameters:
 			path: src/Core/Checkout/Customer/CustomerValueResolver.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 1
-			path: src/Core/Checkout/Customer/Event/CustomerBeforeLoginEvent.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Checkout/Customer/Event/CustomerIndexerEvent.php
@@ -294,11 +289,6 @@ parameters:
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 1
 			path: src/Core/Checkout/Order/Event/OrderPaymentMethodChangedEvent.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 1
-			path: src/Core/Checkout/Order/Event/OrderStateMachineStateChangeEvent.php
 
 		-
 			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getOrder\\(\\)\\.$#"
@@ -524,11 +514,6 @@ parameters:
 			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\AbstractFlowLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/AbstractFlowLoader.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 2
-			path: src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
 
 		-
 			message: "#^Expected domain exception class Shopware\\\\Core\\\\Content\\\\Flow\\\\FlowException, got Shopware\\\\Core\\\\System\\\\StateMachine\\\\StateMachineException$#"
@@ -1404,11 +1389,6 @@ parameters:
 			message: "#^Expected domain exception class Shopware\\\\Core\\\\Content\\\\Product\\\\ProductException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
 			count: 1
 			path: src/Core/Content/Product/SearchKeyword/ProductSearchBuilder.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 1
-			path: src/Core/Content/ProductExport/Event/ProductExportLoggingEvent.php
 
 		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"

--- a/src/Core/Checkout/Order/Event/OrderStateMachineStateChangeEvent.php
+++ b/src/Core/Checkout/Order/Event/OrderStateMachineStateChangeEvent.php
@@ -5,8 +5,11 @@ namespace Shopware\Core\Checkout\Order\Event;
 use Shopware\Core\Checkout\Order\OrderDefinition;
 use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Order\OrderException;
+use Shopware\Core\Content\Flow\Dispatching\Action\SendMailAction;
 use Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException;
+use Shopware\Core\Content\MailTemplate\Subscriber\MailSendSubscriberConfig;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\A11yRenderedDocumentAware;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Event\EventData\EntityType;
 use Shopware\Core\Framework\Event\EventData\EventDataCollection;
@@ -19,7 +22,7 @@ use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
 #[Package('checkout')]
-class OrderStateMachineStateChangeEvent extends Event implements SalesChannelAware, OrderAware, MailAware, CustomerAware, FlowEventAware
+class OrderStateMachineStateChangeEvent extends Event implements SalesChannelAware, OrderAware, MailAware, CustomerAware, A11yRenderedDocumentAware, FlowEventAware
 {
     private ?MailRecipientStruct $mailRecipientStruct = null;
 
@@ -85,5 +88,18 @@ class OrderStateMachineStateChangeEvent extends Event implements SalesChannelAwa
         }
 
         return $customer->getCustomerId();
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getA11yDocumentIds(): array
+    {
+        $extension = $this->context->getExtension(SendMailAction::MAIL_CONFIG_EXTENSION);
+        if (!$extension instanceof MailSendSubscriberConfig) {
+            return [];
+        }
+
+        return array_filter($extension->getDocumentIds());
     }
 }

--- a/src/Core/Content/DependencyInjection/flow.xml
+++ b/src/Core/Content/DependencyInjection/flow.xml
@@ -190,6 +190,13 @@
             <tag name="flow.storer"/>
         </service>
 
+        <service id="Shopware\Core\Content\Flow\Dispatching\Storer\A11yRenderedDocumentStorer">
+            <argument type="service" id="document.repository"/>
+            <argument type="service" id="event_dispatcher"/>
+
+            <tag name="flow.storer"/>
+        </service>
+
         <service id="Shopware\Core\Content\Flow\Dispatching\Storer\CustomerStorer">
             <argument type="service" id="customer.repository"/>
             <argument type="service" id="event_dispatcher"/>

--- a/src/Core/Content/Flow/Dispatching/Storer/A11yRenderedDocumentStorer.php
+++ b/src/Core/Content/Flow/Dispatching/Storer/A11yRenderedDocumentStorer.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Flow\Dispatching\Storer;
+
+use Shopware\Core\Checkout\Document\DocumentCollection;
+use Shopware\Core\Checkout\Document\DocumentDefinition;
+use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\Event\A11yRenderedDocumentAware;
+use Shopware\Core\Framework\Event\FlowEventAware;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @phpstan-type A11yDocument array{documentId: string, deepLinkCode: string, fileExtension: string|null}
+ */
+#[Package('after-sales')]
+class A11yRenderedDocumentStorer extends FlowStorer
+{
+    /**
+     * @internal
+     */
+    public function __construct(
+        private readonly EntityRepository $documentRepository,
+        private readonly EventDispatcherInterface $dispatcher
+    ) {
+    }
+
+    public function store(FlowEventAware $event, array $stored): array
+    {
+        if (!$event instanceof A11yRenderedDocumentAware || isset($stored[A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS])) {
+            return $stored;
+        }
+
+        $stored[A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS] = $event->getA11yDocumentIds();
+
+        return $stored;
+    }
+
+    public function restore(StorableFlow $storable): void
+    {
+        if (!$storable->hasStore(A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS)) {
+            return;
+        }
+
+        $storable->setData(A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS, $storable->getStore(A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS));
+
+        $storable->lazy(
+            A11yRenderedDocumentAware::A11Y_DOCUMENTS,
+            $this->lazyLoad(...)
+        );
+    }
+
+    /**
+     * @return A11yDocument[]
+     */
+    private function lazyLoad(StorableFlow $storableFlow): array
+    {
+        $ids = $storableFlow->getStore(A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS);
+        if (!\is_array($ids) || empty($ids)) {
+            return [];
+        }
+
+        $criteria = new Criteria($ids);
+
+        return $this->loadA11yDocuments($criteria, $storableFlow->getContext());
+    }
+
+    /**
+     * @return A11yDocument[]
+     */
+    private function loadA11yDocuments(Criteria $criteria, Context $context): array
+    {
+        $criteria->addAssociation('documentA11yMediaFile');
+
+        $event = new BeforeLoadStorableFlowDataEvent(
+            DocumentDefinition::ENTITY_NAME,
+            $criteria,
+            $context,
+        );
+
+        $this->dispatcher->dispatch($event, $event->getName());
+
+        /** @var DocumentCollection $documents */
+        $documents = $this->documentRepository
+            ->search($criteria, $context)
+            ->getEntities();
+
+        $a11yDocuments = [];
+        foreach ($documents as $document) {
+            if ($document->getDocumentA11yMediaFile() === null) {
+                continue;
+            }
+
+            $a11yDocuments[] = [
+                'documentId' => $document->getId(),
+                'deepLinkCode' => $document->getDeepLinkCode(),
+                'fileExtension' => $document->getDocumentA11yMediaFile()->getFileExtension(),
+            ];
+        }
+
+        return $a11yDocuments;
+    }
+}

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/extension.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/extension.neon
@@ -15,6 +15,7 @@ parameters:
             - Shopware\Core\Framework\Plugin\Exception\DecorationPatternException
             - Shopware\Core\Framework\Validation\Exception\ConstraintViolationException
             - Shopware\Core\Framework\Api\Controller\Exception\PermissionDeniedException
+            - Shopware\Core\Content\MailTemplate\Exception\MailEventConfigurationException
             - Twig\Error\LoaderError
             - Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
             - Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException

--- a/src/Core/Framework/Event/A11yRenderedDocumentAware.php
+++ b/src/Core/Framework/Event/A11yRenderedDocumentAware.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Event;
+
+use Shopware\Core\Framework\Log\Package;
+
+#[Package('services-settings')]
+#[IsFlowEventAware]
+interface A11yRenderedDocumentAware
+{
+    public const A11Y_DOCUMENTS = 'a11yDocuments';
+
+    public const A11Y_DOCUMENT_IDS = 'a11yDocumentIds';
+
+    /**
+     * @return array<string>
+     */
+    public function getA11yDocumentIds(): array;
+}

--- a/src/Core/Migration/Fixtures/mails/order.state.cancelled/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.cancelled/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order.state.cancelled/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.cancelled/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Bestellstatus: {{ order.stateMachineState.translate
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order.state.cancelled/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.cancelled/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order.state.cancelled/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.cancelled/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.stateMachineState.translated.name }}.
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order.state.completed/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.completed/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order.state.completed/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.completed/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Bestellstatus: {{ order.stateMachineState.translate
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order.state.completed/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.completed/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order.state.completed/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.completed/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.stateMachineState.translated.name }}.
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order.state.in_progress/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.in_progress/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order.state.in_progress/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.in_progress/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Bestellstatus: {{ order.stateMachineState.translate
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order.state.in_progress/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.in_progress/en-html.html.twig
@@ -8,5 +8,25 @@
     You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
     </br>
     However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+    {% if a11yDocuments %}
+        For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+        {% for a11y in a11yDocuments %}
+            {% set documentLink = rawUrl(
+                'frontend.account.order.single.document.a11y',
+                {
+                    documentId: a11y.documentId,
+                    deepLinkCode: a11y.deepLinkCode,
+                    fileType: a11y.fileExtension,
+                },
+                salesChannel.domains|first.url
+            )%}
+
+            - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+        {% endfor %}<br>
+        For data protection reasons the HTML version requires a login. <br><br>
+        In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+    {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order.state.in_progress/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.in_progress/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.stateMachineState.translated.name }}.
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order.state.open/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.open/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order.state.open/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.open/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Bestellstatus: {{ order.stateMachineState.translate
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order.state.open/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.open/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order.state.open/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order.state.open/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.stateMachineState.translated.name }}.
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.cancelled/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.cancelled/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.cancelled/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.cancelled/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Lieferstatus: {{ order.deliveries.first.stateMachin
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.cancelled/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.cancelled/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.cancelled/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.cancelled/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.deliveries.first.stateMachineState.transl
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.returned/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.returned/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.returned/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.returned/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Lieferstatus: {{ order.deliveries.first.stateMachin
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.returned/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.returned/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.returned/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.returned/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.deliveries.first.stateMachineState.transl
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.returned_partially/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.returned_partially/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.returned_partially/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.returned_partially/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Lieferstatus: {{ order.deliveries.first.stateMachin
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.returned_partially/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.returned_partially/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.returned_partially/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.returned_partially/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.deliveries.first.stateMachineState.transl
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Lieferstatus: {{ order.deliveries.first.stateMachin
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.deliveries.first.stateMachineState.transl
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped_partially/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped_partially/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped_partially/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped_partially/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Lieferstatus: {{ order.deliveries.first.stateMachin
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped_partially/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped_partially/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped_partially/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_delivery.state.shipped_partially/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.deliveries.first.stateMachineState.transl
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.authorized/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.authorized/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.authorized/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.authorized/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Zahlungsstatus: {{ order.transactions.first.stateMa
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.authorized/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.authorized/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.authorized/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.authorized/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.transactions.first.stateMachineState.tran
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig
@@ -148,6 +148,26 @@ Der Zahlungsprozess mit {{ order.transactions.first.paymentMethod.translated.nam
     Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
     </br>
     Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
+
+    {% if a11yDocuments %}
+        Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+        {% for a11y in a11yDocuments %}
+            {% set documentLink = rawUrl(
+                'frontend.account.order.single.document.a11y',
+                {
+                    documentId: a11y.documentId,
+                    deepLinkCode: a11y.deepLinkCode,
+                    fileType: a11y.fileExtension,
+                },
+                salesChannel.domains|first.url
+            )%}
+
+            - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+        {% endfor %}<br>
+
+        Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+        Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+    {% endif %}
 </p>
 <br>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/de-plain.html.twig
@@ -70,3 +70,24 @@ bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit.
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig
@@ -149,6 +149,25 @@ You have not completed your payment with {{ order.transactions.first.paymentMeth
     </br>
     If you have any questions, do not hesitate to contact us.
 
+    {% if a11yDocuments %}
+        For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+        {% for a11y in a11yDocuments %}
+            {% set documentLink = rawUrl(
+                'frontend.account.order.single.document.a11y',
+                {
+                    documentId: a11y.documentId,
+                    deepLinkCode: a11y.deepLinkCode,
+                    fileType: a11y.fileExtension,
+                },
+                salesChannel.domains|first.url
+            )%}
+
+            - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+        {% endfor %}<br>
+        For data protection reasons the HTML version requires a login. <br><br>
+        In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+    {% endif %}
 </p>
 <br>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.cancelled/en-plain.html.twig
@@ -71,3 +71,25 @@ You can check the current status of your order on our website under "My account"
 If you have any questions, do not hesitate to contact us.
 
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.chargeback/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.chargeback/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.chargeback/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.chargeback/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Zahlungsstatus: {{ order.transactions.first.stateMa
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.chargeback/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.chargeback/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.chargeback/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.chargeback/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.transactions.first.stateMachineState.tran
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.open/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.open/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.open/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.open/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Zahlungsstatus: {{ order.transactions.first.stateMa
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.open/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.open/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.open/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.open/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.transactions.first.stateMachineState.tran
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-html.html.twig
@@ -144,6 +144,26 @@ Bestellnummer: {{ order.orderNumber }}<br>
     Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
     </br>
     Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
+
+    {% if a11yDocuments %}
+        Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+        {% for a11y in a11yDocuments %}
+            {% set documentLink = rawUrl(
+                'frontend.account.order.single.document.a11y',
+                {
+                    documentId: a11y.documentId,
+                    deepLinkCode: a11y.deepLinkCode,
+                    fileType: a11y.fileExtension,
+                },
+                salesChannel.domains|first.url
+            )%}
+
+            - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+        {% endfor %}<br>
+
+        Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+        Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+    {% endif %}
 </p>
 <br>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/de-plain.html.twig
@@ -69,3 +69,24 @@ bestellen, erhalten Sie Ihre Ware umsatzsteuerbefreit.
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Für Rückfragen stehen wir Ihnen jederzeit gerne zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-html.html.twig
@@ -145,6 +145,25 @@ Order number: {{ order.orderNumber }}<br>
     </br>
     If you have any questions, do not hesitate to contact us.
 
+    {% if a11yDocuments %}
+        For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+        {% for a11y in a11yDocuments %}
+            {% set documentLink = rawUrl(
+                'frontend.account.order.single.document.a11y',
+                {
+                    documentId: a11y.documentId,
+                    deepLinkCode: a11y.deepLinkCode,
+                    fileType: a11y.fileExtension,
+                },
+                salesChannel.domains|first.url
+            )%}
+
+            - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+        {% endfor %}<br>
+        For data protection reasons the HTML version requires a login. <br><br>
+        In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+    {% endif %}
 </p>
 <br>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid/en-plain.html.twig
@@ -70,3 +70,25 @@ You can check the current status of your order on our website under "My account"
 If you have any questions, do not hesitate to contact us.
 
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid_partially/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid_partially/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid_partially/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid_partially/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Zahlungsstatus: {{ order.transactions.first.stateMa
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid_partially/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid_partially/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.paid_partially/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.paid_partially/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.transactions.first.stateMachineState.tran
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Zahlungsstatus: {{ order.transactions.first.stateMa
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.transactions.first.stateMachineState.tran
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded_partially/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded_partially/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded_partially/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded_partially/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Zahlungsstatus: {{ order.transactions.first.stateMa
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded_partially/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded_partially/en-html.html.twig
@@ -10,5 +10,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded_partially/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.refunded_partially/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.transactions.first.stateMachineState.tran
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.reminded/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.reminded/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.reminded/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.reminded/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Zahlungsstatus: {{ order.transactions.first.stateMa
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.reminded/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.reminded/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.reminded/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.reminded/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.transactions.first.stateMachineState.tran
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.unconfirmed/de-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.unconfirmed/de-html.html.twig
@@ -9,5 +9,25 @@
         Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+        {% if a11yDocuments %}
+            Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:<br><br>
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+
+            Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.<br><br>
+            Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.unconfirmed/de-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.unconfirmed/de-plain.html.twig
@@ -5,3 +5,24 @@ Die Bestellung hat jetzt den Zahlungsstatus: {{ order.transactions.first.stateMa
 
 Den aktuellen Status Ihrer Bestellung können Sie auch jederzeit auf unserer Webseite im  Bereich "Mein Konto" - "Meine Bestellungen" abrufen: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 Sollten Sie allerdings den Kauf ohne Registrierung, also ohne Anlage eines Kundenkontos, gewählt haben, steht Ihnen diese Möglichkeit nicht zur Verfügung.
+
+{% if a11yDocuments %}
+    Folgend stellen wir barrierefreie Dokumente als HTML-Version zur Verfügung:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                deepLinkCode: a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+    Aus Datenschutzgründen ist für die HTML-Version ein Login erforderlich.
+
+    Im Falle einer Gastbestellung können Sie Ihre Postanschrift und die Postleitzahl der Rechnungsanschrift verwenden.
+{% endif %}

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.unconfirmed/en-html.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.unconfirmed/en-html.html.twig
@@ -9,5 +9,25 @@
         You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
         </br>
         However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+        {% if a11yDocuments %}
+            For better accessibility we also provide an HTML version of the documents here:<br><br>
+
+            {% for a11y in a11yDocuments %}
+                {% set documentLink = rawUrl(
+                    'frontend.account.order.single.document.a11y',
+                    {
+                        documentId: a11y.documentId,
+                        deepLinkCode: a11y.deepLinkCode,
+                        fileType: a11y.fileExtension,
+                    },
+                    salesChannel.domains|first.url
+                )%}
+
+                - <a href="{{ documentLink }}" target="_blank">{{ documentLink }}</a> <br>
+            {% endfor %}<br>
+            For data protection reasons the HTML version requires a login. <br><br>
+            In case of a guest order, you can use your mail address and postal code of the billing address.<br>
+        {% endif %}
     </p>
 </div>

--- a/src/Core/Migration/Fixtures/mails/order_transaction.state.unconfirmed/en-plain.html.twig
+++ b/src/Core/Migration/Fixtures/mails/order_transaction.state.unconfirmed/en-plain.html.twig
@@ -5,3 +5,25 @@ The new status is as follows: {{ order.transactions.first.stateMachineState.tran
 
 You can check the current status of your order on our website under "My account" - "My orders" anytime: {{ rawUrl('frontend.account.order.single.page', { 'deepLinkCode': order.deepLinkCode }, salesChannel.domains|first.url) }}
 However, in case you have purchased without a registration or a customer account, you do not have this option.
+
+{% if a11yDocuments %}
+    For better accessibility we also provide an HTML version of the documents here:
+
+    {% for a11y in a11yDocuments %}
+        {% set documentLink = rawUrl(
+            'frontend.account.order.single.document.a11y',
+            {
+                documentId: a11y.documentId,
+                'deepLinkCode': a11y.deepLinkCode,
+                fileType: a11y.fileExtension,
+            },
+            salesChannel.domains|first.url
+        )%}
+
+        - {{ documentLink }}
+    {% endfor %}
+
+    For data protection reasons the HTML version requires a login.
+
+    In case of a guest order, you can use your mail address and postal code of the billing address.
+{% endif %}

--- a/src/Core/Migration/V6_6/Migration1737105721MigrateOrderStateChangeDocumentToA11Y.php
+++ b/src/Core/Migration/V6_6/Migration1737105721MigrateOrderStateChangeDocumentToA11Y.php
@@ -1,0 +1,398 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Migration\Traits\ImportTranslationsTrait;
+use Shopware\Core\Migration\Traits\Translations;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1737105721MigrateOrderStateChangeDocumentToA11Y extends MigrationStep
+{
+    use ImportTranslationsTrait;
+
+    private const LOCALE_EN_GB = 'en-GB';
+    private const LOCALE_DE_DE = 'de-DE';
+
+    public function getCreationTimestamp(): int
+    {
+        return 1737105721;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function update(Connection $connection): void
+    {
+        $documentTypeTranslationMapping = [
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED_PARTIALLY,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED_PARTIALLY,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REMINDED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_OPEN,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED_PARTIALLY,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_CANCELLED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_CANCELLED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CANCELLED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID_PARTIALLY,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_AUTHORIZED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CHARGEBACK,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_UNCONFIRMED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_OPEN,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_IN_PROGRESS,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_COMPLETED,
+        ];
+
+        $templateMapping = $this->getTemplateMapping();
+
+        foreach ($documentTypeTranslationMapping as $technicalName) {
+            $mailTemplateId = $connection->fetchOne('
+                SELECT `mail_template`.`id`
+                FROM `mail_template`
+                INNER JOIN `mail_template_type`
+                    ON `mail_template`.`mail_template_type_id` = `mail_template_type`.`id`
+                    AND `mail_template_type`.`technical_name` = :technicalName
+                WHERE `mail_template`.`updated_at` IS NULL
+           ', ['technicalName' => $technicalName]);
+
+            if (!$mailTemplateId) {
+                continue;
+            }
+
+            $translations = new Translations(
+                [
+                    'mail_template_id' => $mailTemplateId,
+                    'sender_name' => '{{ salesChannel.name }}',
+                    'subject' => 'Neues Dokument für Ihre Bestellung',
+                    'content_html' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_DE_DE, true),
+                    'content_plain' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_DE_DE, false),
+                ],
+                [
+                    'mail_template_id' => $mailTemplateId,
+                    'sender_name' => '{{ salesChannel.name }}',
+                    'subject' => 'New document for your order',
+                    'content_html' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_EN_GB, true),
+                    'content_plain' => $this->getMailTemplateContent($templateMapping, $technicalName, self::LOCALE_EN_GB, false),
+                ],
+            );
+
+            $this->importTranslation('mail_template_translation', $translations, $connection);
+        }
+    }
+
+    /**
+     * @return array<string, array<string, array<string, string|false>>>
+     */
+    private function getTemplateMapping(): array
+    {
+        $orderDeliveryStateShippedPartiallyEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.shipped_partially/en-html.html.twig');
+        $orderDeliveryStateShippedPartiallyEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.shipped_partially/en-plain.html.twig');
+        $orderDeliveryStateShippedPartiallyDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.shipped_partially/de-html.html.twig');
+        $orderDeliveryStateShippedPartiallyDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.shipped_partially/de-plain.html.twig');
+
+        $orderTransactionStateRefundedPartiallyEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.refunded_partially/en-html.html.twig');
+        $orderTransactionStateRefundedPartiallyEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.refunded_partially/en-plain.html.twig');
+        $orderTransactionStateRefundedPartiallyDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.refunded_partially/de-html.html.twig');
+        $orderTransactionStateRefundedPartiallyDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.refunded_partially/de-plain.html.twig');
+
+        $orderTransactionStateRemindedEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.reminded/en-html.html.twig');
+        $orderTransactionStateRemindedEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.reminded/en-plain.html.twig');
+        $orderTransactionStateRemindedDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.reminded/de-html.html.twig');
+        $orderTransactionStateRemindedDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.reminded/de-plain.html.twig');
+
+        $orderTransactionStateOpenEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.open/en-html.html.twig');
+        $orderTransactionStateOpenEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.open/en-plain.html.twig');
+        $orderTransactionStateOpenDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.open/de-html.html.twig');
+        $orderTransactionStateOpenDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.open/de-plain.html.twig');
+
+        $orderDeliveryStateReturnedPartiallyEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.returned_partially/en-html.html.twig');
+        $orderDeliveryStateReturnedPartiallyEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.returned_partially/en-plain.html.twig');
+        $orderDeliveryStateReturnedPartiallyDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.returned_partially/de-html.html.twig');
+        $orderDeliveryStateReturnedPartiallyDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.returned_partially/de-plain.html.twig');
+
+        $orderTransactionStatePaidEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/en-html.html.twig');
+        $orderTransactionStatePaidEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/en-plain.html.twig');
+        $orderTransactionStatePaidDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/de-html.html.twig');
+        $orderTransactionStatePaidDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid/de-plain.html.twig');
+
+        $orderDeliveryStateReturnedEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.returned/en-html.html.twig');
+        $orderDeliveryStateReturnedEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.returned/en-plain.html.twig');
+        $orderDeliveryStateReturnedDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.returned/de-html.html.twig');
+        $orderDeliveryStateReturnedDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.returned/de-plain.html.twig');
+
+        $orderStateCancelledEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.cancelled/en-html.html.twig');
+        $orderStateCancelledEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.cancelled/en-plain.html.twig');
+        $orderStateCancelledDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.cancelled/de-html.html.twig');
+        $orderStateCancelledDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.cancelled/de-plain.html.twig');
+
+        $orderDeliveryStateCancelledEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.cancelled/en-html.html.twig');
+        $orderDeliveryStateCancelledEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.cancelled/en-plain.html.twig');
+        $orderDeliveryStateCancelledDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.cancelled/de-html.html.twig');
+        $orderDeliveryStateCancelledDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.cancelled/de-plain.html.twig');
+
+        $orderDeliveryStateShippedEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.shipped/en-html.html.twig');
+        $orderDeliveryStateShippedEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.shipped/en-plain.html.twig');
+        $orderDeliveryStateShippedDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.shipped/de-html.html.twig');
+        $orderDeliveryStateShippedDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_delivery.state.shipped/de-plain.html.twig');
+
+        $orderTransactionStateCancelledEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/en-html.html.twig');
+        $orderTransactionStateCancelledEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/en-plain.html.twig');
+        $orderTransactionStateCancelledDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/de-html.html.twig');
+        $orderTransactionStateCancelledDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.cancelled/de-plain.html.twig');
+
+        $orderTransactionStateRefundedEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.refunded/en-html.html.twig');
+        $orderTransactionStateRefundedEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.refunded/en-plain.html.twig');
+        $orderTransactionStateRefundedDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.refunded/de-html.html.twig');
+        $orderTransactionStateRefundedDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.refunded/de-plain.html.twig');
+
+        $orderTransactionStatePaidPartiallyEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid_partially/en-html.html.twig');
+        $orderTransactionStatePaidPartiallyEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid_partially/en-plain.html.twig');
+        $orderTransactionStatePaidPartiallyDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid_partially/de-html.html.twig');
+        $orderTransactionStatePaidPartiallyDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.paid_partially/de-plain.html.twig');
+
+        $orderTransactionStateAuthorizedEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.authorized/en-html.html.twig');
+        $orderTransactionStateAuthorizedEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.authorized/en-plain.html.twig');
+        $orderTransactionStateAuthorizedDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.authorized/de-html.html.twig');
+        $orderTransactionStateAuthorizedDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.authorized/de-plain.html.twig');
+
+        $orderTransactionStateChargebackEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.chargeback/en-html.html.twig');
+        $orderTransactionStateChargebackEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.chargeback/en-plain.html.twig');
+        $orderTransactionStateChargebackDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.chargeback/de-html.html.twig');
+        $orderTransactionStateChargebackDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.chargeback/de-plain.html.twig');
+
+        $orderTransactionStateUnconfirmedEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.unconfirmed/en-html.html.twig');
+        $orderTransactionStateUnconfirmedEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.unconfirmed/en-plain.html.twig');
+        $orderTransactionStateUnconfirmedDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.unconfirmed/de-html.html.twig');
+        $orderTransactionStateUnconfirmedDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order_transaction.state.unconfirmed/de-plain.html.twig');
+
+        $orderStateOpenEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.open/en-html.html.twig');
+        $orderStateOpenEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.open/en-plain.html.twig');
+        $orderStateOpenDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.open/de-html.html.twig');
+        $orderStateOpenDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.open/de-plain.html.twig');
+
+        $orderStateInProgressEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.in_progress/en-html.html.twig');
+        $orderStateInProgressEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.in_progress/en-plain.html.twig');
+        $orderStateInProgressDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.in_progress/de-html.html.twig');
+        $orderStateInProgressDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.in_progress/de-plain.html.twig');
+
+        $orderStateCompletedEnHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.completed/en-html.html.twig');
+        $orderStateCompletedEnPlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.completed/en-plain.html.twig');
+        $orderStateCompletedDeHtml = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.completed/de-html.html.twig');
+        $orderStateCompletedDePlain = \file_get_contents(__DIR__ . '/../Fixtures/mails/order.state.completed/de-plain.html.twig');
+
+        return [
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED_PARTIALLY => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderDeliveryStateShippedPartiallyEnHtml,
+                    'plain' => $orderDeliveryStateShippedPartiallyEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderDeliveryStateShippedPartiallyDeHtml,
+                    'plain' => $orderDeliveryStateShippedPartiallyDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED_PARTIALLY => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderTransactionStateRefundedPartiallyEnHtml,
+                    'plain' => $orderTransactionStateRefundedPartiallyEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderTransactionStateRefundedPartiallyDeHtml,
+                    'plain' => $orderTransactionStateRefundedPartiallyDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REMINDED => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderTransactionStateRemindedEnHtml,
+                    'plain' => $orderTransactionStateRemindedEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderTransactionStateRemindedDeHtml,
+                    'plain' => $orderTransactionStateRemindedDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_OPEN => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderTransactionStateOpenEnHtml,
+                    'plain' => $orderTransactionStateOpenEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderTransactionStateOpenDeHtml,
+                    'plain' => $orderTransactionStateOpenDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED_PARTIALLY => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderDeliveryStateReturnedPartiallyEnHtml,
+                    'plain' => $orderDeliveryStateReturnedPartiallyEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderDeliveryStateReturnedPartiallyDeHtml,
+                    'plain' => $orderDeliveryStateReturnedPartiallyDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderTransactionStatePaidEnHtml,
+                    'plain' => $orderTransactionStatePaidEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderTransactionStatePaidDeHtml,
+                    'plain' => $orderTransactionStatePaidDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderDeliveryStateReturnedEnHtml,
+                    'plain' => $orderDeliveryStateReturnedEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderDeliveryStateReturnedDeHtml,
+                    'plain' => $orderDeliveryStateReturnedDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_CANCELLED => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderStateCancelledEnHtml,
+                    'plain' => $orderStateCancelledEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderStateCancelledDeHtml,
+                    'plain' => $orderStateCancelledDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_CANCELLED => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderDeliveryStateCancelledEnHtml,
+                    'plain' => $orderDeliveryStateCancelledEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderDeliveryStateCancelledDeHtml,
+                    'plain' => $orderDeliveryStateCancelledDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderDeliveryStateShippedEnHtml,
+                    'plain' => $orderDeliveryStateShippedEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderDeliveryStateShippedDeHtml,
+                    'plain' => $orderDeliveryStateShippedDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CANCELLED => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderTransactionStateCancelledEnHtml,
+                    'plain' => $orderTransactionStateCancelledEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderTransactionStateCancelledDeHtml,
+                    'plain' => $orderTransactionStateCancelledDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderTransactionStateRefundedEnHtml,
+                    'plain' => $orderTransactionStateRefundedEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderTransactionStateRefundedDeHtml,
+                    'plain' => $orderTransactionStateRefundedDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID_PARTIALLY => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderTransactionStatePaidPartiallyEnHtml,
+                    'plain' => $orderTransactionStatePaidPartiallyEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderTransactionStatePaidPartiallyDeHtml,
+                    'plain' => $orderTransactionStatePaidPartiallyDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_AUTHORIZED => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderTransactionStateAuthorizedEnHtml,
+                    'plain' => $orderTransactionStateAuthorizedEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderTransactionStateAuthorizedDeHtml,
+                    'plain' => $orderTransactionStateAuthorizedDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CHARGEBACK => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderTransactionStateChargebackEnHtml,
+                    'plain' => $orderTransactionStateChargebackEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderTransactionStateChargebackDeHtml,
+                    'plain' => $orderTransactionStateChargebackDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_UNCONFIRMED => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderTransactionStateUnconfirmedEnHtml,
+                    'plain' => $orderTransactionStateUnconfirmedEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderTransactionStateUnconfirmedDeHtml,
+                    'plain' => $orderTransactionStateUnconfirmedDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_OPEN => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderStateOpenEnHtml,
+                    'plain' => $orderStateOpenEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderStateOpenDeHtml,
+                    'plain' => $orderStateOpenDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_IN_PROGRESS => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderStateInProgressEnHtml,
+                    'plain' => $orderStateInProgressEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderStateInProgressDeHtml,
+                    'plain' => $orderStateInProgressDePlain,
+                ],
+            ],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_COMPLETED => [
+                self::LOCALE_EN_GB => [
+                    'html' => $orderStateCompletedEnHtml,
+                    'plain' => $orderStateCompletedEnPlain,
+                ],
+                self::LOCALE_DE_DE => [
+                    'html' => $orderStateCompletedDeHtml,
+                    'plain' => $orderStateCompletedDePlain,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, array<string, array<string, string|false>>> $templateMapping
+     */
+    private function getMailTemplateContent(array $templateMapping, string $technicalName, string $locale, bool $html): string
+    {
+        if (!\is_string($templateMapping[$technicalName][$locale][$html ? 'html' : 'plain'])) {
+            return '';
+        }
+
+        return $templateMapping[$technicalName][$locale][$html ? 'html' : 'plain'];
+    }
+}

--- a/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -19,6 +19,7 @@ use Shopware\Core\Framework\Api\ApiDefinition\DefinitionService;
 use Shopware\Core\Framework\Api\Controller\InfoController;
 use Shopware\Core\Framework\Api\Route\ApiRouteInfoResolver;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\A11yRenderedDocumentAware;
 use Shopware\Core\Framework\Event\BusinessEventCollector;
 use Shopware\Core\Framework\Event\CustomerAware;
 use Shopware\Core\Framework\Event\CustomerGroupAware;
@@ -352,6 +353,8 @@ class InfoControllerTest extends TestCase
                     lcfirst((new \ReflectionClass(OrderAware::class))->getShortName()),
                     CustomerAware::class,
                     lcfirst((new \ReflectionClass(CustomerAware::class))->getShortName()),
+                    A11yRenderedDocumentAware::class,
+                    lcfirst((new \ReflectionClass(A11yRenderedDocumentAware::class))->getShortName()),
                 ],
             ],
         ];

--- a/tests/migration/Core/V6_6/Migration1737105721MigrateOrderStateChangeDocumentToA11YTest.php
+++ b/tests/migration/Core/V6_6/Migration1737105721MigrateOrderStateChangeDocumentToA11YTest.php
@@ -1,0 +1,205 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_6;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\MailTemplate\MailTemplateTypes;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\Traits\ImportTranslationsTrait;
+use Shopware\Core\Migration\V6_6\Migration1737105721MigrateOrderStateChangeDocumentToA11Y;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+#[CoversClass(Migration1737105721MigrateOrderStateChangeDocumentToA11Y::class)]
+class Migration1737105721MigrateOrderStateChangeDocumentToA11YTest extends TestCase
+{
+    use ImportTranslationsTrait;
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = KernelLifecycleManager::getConnection();
+    }
+
+    public function testDuplicateMigration(): void
+    {
+        $migration = new Migration1737105721MigrateOrderStateChangeDocumentToA11Y();
+        static::assertSame(1737105721, $migration->getCreationTimestamp());
+
+        // make sure a migration can run multiple times without failing
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+    }
+
+    #[DataProvider('mailTypeProvider')]
+    public function testMigration(string $mailType): void
+    {
+        $this->prepareData($mailType);
+
+        $migration = new Migration1737105721MigrateOrderStateChangeDocumentToA11Y();
+        $migration->update($this->connection);
+
+        $documentTypeTranslationMapping = $this->getMailTemplateType();
+
+        foreach ($documentTypeTranslationMapping as $technicalName) {
+            $mailTemplateId = $this->connection->fetchOne('
+                SELECT `mail_template`.`id`
+                FROM `mail_template`
+                INNER JOIN `mail_template_type`
+                    ON `mail_template`.`mail_template_type_id` = `mail_template_type`.`id`
+                    AND `mail_template_type`.`technical_name` = :technicalName
+           ', ['technicalName' => $technicalName]);
+
+            if (!$mailTemplateId) {
+                continue;
+            }
+
+            /** @var array{id: string, content_html: string, content_plain: string}|null $mailTemplate */
+            $mailTemplate = $this->connection->fetchAssociative(
+                '
+                SELECT `mail_template`.`id`, `mail_template_translation`.`content_html`, `mail_template_translation`.`content_plain`
+                FROM `mail_template`
+                INNER JOIN `mail_template_translation`
+                    ON `mail_template`.`id` = `mail_template_translation`.`mail_template_id`
+                WHERE `mail_template`.`id` = :mailTemplateId',
+                ['mailTemplateId' => $mailTemplateId],
+            );
+
+            static::assertNotNull($mailTemplate);
+
+            if ($technicalName === $mailType) {
+                static::assertStringNotContainsString('{% if a11yDocuments', $mailTemplate['content_html']);
+                static::assertStringNotContainsString('{% if a11yDocuments', $mailTemplate['content_plain']);
+            } else {
+                static::assertStringContainsString('{% if a11yDocuments', $mailTemplate['content_html']);
+                static::assertStringContainsString('{% for a11y in a11yDocuments %}', $mailTemplate['content_html']);
+
+                static::assertStringContainsString('{% if a11yDocuments', $mailTemplate['content_plain']);
+                static::assertStringContainsString('{% for a11y in a11yDocuments %}', $mailTemplate['content_plain']);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, array<string>>
+     */
+    public static function mailTypeProvider(): array
+    {
+        return [
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED_PARTIALLY => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED_PARTIALLY],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED_PARTIALLY => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED_PARTIALLY],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REMINDED => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REMINDED],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_OPEN => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_OPEN],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED_PARTIALLY => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED_PARTIALLY],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_CANCELLED => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_CANCELLED],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_CANCELLED => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_CANCELLED],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CANCELLED => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CANCELLED],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID_PARTIALLY => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID_PARTIALLY],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_AUTHORIZED => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_AUTHORIZED],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CHARGEBACK => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CHARGEBACK],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_UNCONFIRMED => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_UNCONFIRMED],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_OPEN => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_OPEN],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_IN_PROGRESS => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_IN_PROGRESS],
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_COMPLETED => [MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_COMPLETED],
+        ];
+    }
+
+    private function prepareData(string $mailType): void
+    {
+        $documentTypeTranslationMapping = $this->getMailTemplateType();
+
+        $this->connection->executeStatement(
+            '
+                UPDATE `mail_template`
+                SET `updated_at` = :updatedAt
+                WHERE `mail_template_type_id` IN (
+                    SELECT `id`
+                    FROM `mail_template_type`
+                    WHERE `technical_name` IN (:technicalNames)
+                )',
+            [
+                'updatedAt' => null,
+                'technicalNames' => $documentTypeTranslationMapping,
+            ],
+            ['technicalNames' => ArrayParameterType::STRING],
+        );
+
+        $this->connection->executeStatement(
+            '
+            UPDATE `mail_template_translation`
+            SET `content_html` = :contentHtml,
+                `content_plain` = :contentPlain
+            WHERE `mail_template_id` IN (
+                SELECT `id`
+                FROM `mail_template`
+                WHERE `mail_template_type_id` IN (
+                    SELECT `id`
+                    FROM `mail_template_type`
+                    WHERE `technical_name` IN (:technicalNames)
+                )
+            )',
+            [
+                'contentHtml' => 'html content',
+                'contentPlain' => 'plain content',
+                'technicalNames' => $documentTypeTranslationMapping,
+            ],
+            ['technicalNames' => ArrayParameterType::STRING],
+        );
+
+        $this->connection->executeStatement('
+            UPDATE `mail_template`
+            SET `updated_at` = :updatedAt
+            WHERE `mail_template_type_id` IN (
+                SELECT `id`
+                FROM `mail_template_type`
+                WHERE `technical_name` = :technicalName
+            )
+        ', [
+            'updatedAt' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+            'technicalName' => $mailType,
+        ]);
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getMailTemplateType(): array
+    {
+        return [
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED_PARTIALLY,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED_PARTIALLY,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REMINDED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_OPEN,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED_PARTIALLY,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_RETURNED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_CANCELLED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_CANCELLED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_DELIVERY_STATE_SHIPPED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CANCELLED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_REFUNDED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_PAID_PARTIALLY,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_AUTHORIZED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_CHARGEBACK,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_TRANSACTION_STATE_UNCONFIRMED,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_OPEN,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_IN_PROGRESS,
+            MailTemplateTypes::MAILTYPE_STATE_ENTER_ORDER_STATE_COMPLETED,
+        ];
+    }
+}

--- a/tests/unit/Core/Content/Flow/Dispatching/Storer/A11yRenderedDocumentStorerTest.php
+++ b/tests/unit/Core/Content/Flow/Dispatching/Storer/A11yRenderedDocumentStorerTest.php
@@ -1,0 +1,153 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Flow\Dispatching\Storer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Document\DocumentCollection;
+use Shopware\Core\Checkout\Document\DocumentEntity;
+use Shopware\Core\Checkout\Order\Event\OrderStateMachineStateChangeEvent;
+use Shopware\Core\Content\Flow\Dispatching\StorableFlow;
+use Shopware\Core\Content\Flow\Dispatching\Storer\A11yRenderedDocumentStorer;
+use Shopware\Core\Content\Flow\Events\BeforeLoadStorableFlowDataEvent;
+use Shopware\Core\Content\Media\MediaEntity;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Event\A11yRenderedDocumentAware;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\User\Recovery\UserRecoveryRequestEvent;
+use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+#[Package('after-sales')]
+#[CoversClass(A11yRenderedDocumentStorer::class)]
+class A11yRenderedDocumentStorerTest extends TestCase
+{
+    private A11yRenderedDocumentStorer $storer;
+
+    /**
+     * @var StaticEntityRepository<DocumentCollection>
+     */
+    private StaticEntityRepository $repository;
+
+    private MockObject&EventDispatcherInterface $dispatcher;
+
+    protected function setUp(): void
+    {
+        $this->repository = new StaticEntityRepository([[]]);
+        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->storer = new A11yRenderedDocumentStorer($this->repository, $this->dispatcher);
+    }
+
+    public function testStoreWithAware(): void
+    {
+        $event = $this->createMock(OrderStateMachineStateChangeEvent::class);
+        $stored = [];
+        $stored = $this->storer->store($event, $stored);
+        static::assertArrayHasKey(A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS, $stored);
+    }
+
+    public function testStoreWithNotAware(): void
+    {
+        $event = $this->createMock(UserRecoveryRequestEvent::class);
+        $stored = [];
+        $stored = $this->storer->store($event, $stored);
+        static::assertArrayNotHasKey(A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS, $stored);
+    }
+
+    public function testRestoreHasStored(): void
+    {
+        $storable = new StorableFlow('name', Context::createDefaultContext(), [A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS => ['id']]);
+
+        $this->storer->restore($storable);
+
+        static::assertArrayHasKey(A11yRenderedDocumentAware::A11Y_DOCUMENTS, $storable->data());
+    }
+
+    public function testRestoreEmptyStored(): void
+    {
+        $storable = new StorableFlow('name', Context::createDefaultContext());
+
+        $this->storer->restore($storable);
+
+        static::assertEmpty($storable->data());
+    }
+
+    public function testLazyLoadEntity(): void
+    {
+        $a11yDocument = new MediaEntity();
+        $a11yDocument->setId('id');
+        $a11yDocument->setFileExtension('html');
+
+        $documentWithA11yMediaFile = new DocumentEntity();
+        $documentWithA11yMediaFile->setId('id');
+        $documentWithA11yMediaFile->setDeepLinkCode('code1');
+        $documentWithA11yMediaFile->setDocumentA11yMediaFile($a11yDocument);
+
+        $documentWithNoA11yMediaFile = new DocumentEntity();
+        $documentWithNoA11yMediaFile->setId('id2');
+        $documentWithNoA11yMediaFile->setDeepLinkCode('code2');
+
+        $documentCollections = new DocumentCollection();
+        $documentCollections->add($documentWithA11yMediaFile);
+        $documentCollections->add($documentWithNoA11yMediaFile);
+
+        $this->repository = new StaticEntityRepository([
+            new EntitySearchResult(
+                'document',
+                2,
+                $documentCollections,
+                null,
+                new Criteria(),
+                Context::createDefaultContext(),
+            ),
+        ]);
+
+        $this->storer = new A11yRenderedDocumentStorer($this->repository, $this->dispatcher);
+        $storable = new StorableFlow('name', Context::createDefaultContext(), [A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS => ['id', 'id2']]);
+        $this->storer->restore($storable);
+
+        $res = $storable->getData(A11yRenderedDocumentAware::A11Y_DOCUMENTS);
+
+        static::assertIsArray($res);
+        static::assertCount(1, $res);
+        static::assertIsArray($res[0]);
+        static::assertArrayHasKey('documentId', $res[0]);
+        static::assertArrayHasKey('deepLinkCode', $res[0]);
+        static::assertArrayHasKey('fileExtension', $res[0]);
+        static::assertEquals('id', $res[0]['documentId']);
+        static::assertEquals('code1', $res[0]['deepLinkCode']);
+        static::assertEquals('html', $res[0]['fileExtension']);
+    }
+
+    public function testLazyLoadNoEntity(): void
+    {
+        $storable = new StorableFlow('name', Context::createDefaultContext(), [A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS => []]);
+        $this->storer->restore($storable);
+
+        $res = $storable->getData(A11yRenderedDocumentAware::A11Y_DOCUMENTS);
+
+        static::assertIsArray($res);
+        static::assertCount(0, $res);
+    }
+
+    public function testDispatchBeforeLoadStorableFlowDataEvent(): void
+    {
+        $this->dispatcher
+            ->expects(static::once())
+            ->method('dispatch')
+            ->with(
+                static::isInstanceOf(BeforeLoadStorableFlowDataEvent::class),
+                'flow.storer.document.criteria.event'
+            );
+
+        $storable = new StorableFlow('name', Context::createDefaultContext(), [A11yRenderedDocumentAware::A11Y_DOCUMENT_IDS => ['id']]);
+        $this->storer->restore($storable);
+        $storable->getData(A11yRenderedDocumentAware::A11Y_DOCUMENTS);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?


### 2. What does this change do, exactly?
As long as the payment, order, or delivery status changes, we want to send the customer a mail with attached documents and include corresponding HTML links in the mail content.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40345

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
