### PR TITLE
test: navigation though breadcrumb in storefront menu

### DIFF
--- a/tests/acceptance/.prettierrc
+++ b/tests/acceptance/.prettierrc
@@ -1,6 +1,6 @@
 {
     "semi": true,
     "trailingComma": "es5",
-    "singleQuote": false,
+    "singleQuote": true,
     "printWidth": 120
 }

--- a/tests/acceptance/tests/Categories/NavigateThroughStorefrontMenu.spec.ts
+++ b/tests/acceptance/tests/Categories/NavigateThroughStorefrontMenu.spec.ts
@@ -1,0 +1,81 @@
+import { test } from '@fixtures/AcceptanceTest';
+
+test(
+    'As a customer, I want breadcrumb to update when I select a category to understand my location on the site.',
+    { tag: '@Categories' },
+    async ({ ShopCustomer, StorefrontHome, TestDataService, InstanceMeta }) => {
+        test.skip(InstanceMeta.features['V6_7_0_0'], 'Blocked by https://shopware.atlassian.net/browse/NEXT-40154');
+
+        const category1 = await TestDataService.createCategory({ type: 'folder' });
+        const category2 = await TestDataService.createCategory({ type: 'page' });
+        const category3 = await TestDataService.createCategory({ type: 'link' });
+        const subCategory1 = await TestDataService.createCategory({ parentId: category1.id });
+        const subCategory2 = await TestDataService.createCategory({ parentId: category2.id });
+        const subCategory3 = await TestDataService.createCategory({ parentId: category3.id });
+
+        await test.step('Verify if folder category has a sub category and the folder category in breadcrumb is a div element.', async () => {
+            const mainCategoryLocators = await StorefrontHome.getMenuItemByCategoryName(category1.name);
+            const subCategoryLocators = await StorefrontHome.getMenuItemByCategoryName(subCategory1.name);
+
+            await ShopCustomer.goesTo(StorefrontHome.url());
+            await ShopCustomer.expects(mainCategoryLocators.menuNavigationItem).toHaveText(category1.name);
+            await ShopCustomer.expects(mainCategoryLocators.offcanvasNavigationItem).toHaveText(category1.name);
+
+            await mainCategoryLocators.menuNavigationItem.hover();
+            await ShopCustomer.expects(mainCategoryLocators.flyoutCategoryLink).not.toBeVisible();
+
+            await subCategoryLocators.menuNavigationItem.click();
+
+            await ShopCustomer.expects(mainCategoryLocators.breadcrumbNavigationItem).toHaveText(category1.name);
+            await ShopCustomer.expects(mainCategoryLocators.breadcrumbNavigationLinkItem).not.toBeVisible();
+            const breadcrumbNavigationItemTagName = await mainCategoryLocators.breadcrumbNavigationItem.evaluate((el) =>
+                el.tagName.toLowerCase()
+            );
+            await ShopCustomer.expects(breadcrumbNavigationItemTagName).toBe('div');
+        });
+
+        await test.step('Verify if page category has a sub category and the page category in breadcrumb is a link element.', async () => {
+            const mainCategoryLocators = await StorefrontHome.getMenuItemByCategoryName(category2.name);
+            const subCategoryLocators = await StorefrontHome.getMenuItemByCategoryName(subCategory2.name);
+
+            await ShopCustomer.goesTo(StorefrontHome.url());
+
+            await ShopCustomer.expects(mainCategoryLocators.menuNavigationItem).toHaveText(category2.name);
+            await ShopCustomer.expects(mainCategoryLocators.offcanvasNavigationItem).toHaveText(category2.name);
+
+            await mainCategoryLocators.menuNavigationItem.hover();
+            await ShopCustomer.expects(mainCategoryLocators.flyoutCategoryLink).toBeVisible();
+
+            await subCategoryLocators.menuNavigationItem.click();
+
+            await ShopCustomer.expects(mainCategoryLocators.breadcrumbNavigationItem).toHaveText(category2.name);
+            await ShopCustomer.expects(mainCategoryLocators.breadcrumbNavigationLinkItem).toBeVisible();
+            const breadcrumbNavigationItemTagName = await mainCategoryLocators.breadcrumbNavigationItem.evaluate((el) =>
+                el.tagName.toLowerCase()
+            );
+            await ShopCustomer.expects(breadcrumbNavigationItemTagName).toBe('span');
+        });
+
+        await test.step('Verify if link category has a sub category and the link category in breadcrumb is a link element.', async () => {
+            const mainCategoryLocators = await StorefrontHome.getMenuItemByCategoryName(category3.name);
+            const subCategoryLocators = await StorefrontHome.getMenuItemByCategoryName(subCategory3.name);
+
+            await ShopCustomer.goesTo(StorefrontHome.url());
+
+            await ShopCustomer.expects(mainCategoryLocators.menuNavigationItem).toHaveText(category3.name);
+            await ShopCustomer.expects(mainCategoryLocators.offcanvasNavigationItem).toHaveText(category3.name);
+
+            await mainCategoryLocators.menuNavigationItem.hover();
+            await ShopCustomer.expects(mainCategoryLocators.flyoutCategoryLink).not.toBeVisible();
+
+            await subCategoryLocators.menuNavigationItem.click();
+
+            await ShopCustomer.expects(mainCategoryLocators.breadcrumbNavigationItem).toHaveText(category3.name);
+            await ShopCustomer.expects(mainCategoryLocators.breadcrumbNavigationLinkItem).toBeVisible();
+            const breadcrumbNavigationItemTagName = await mainCategoryLocators.breadcrumbNavigationItem.evaluate((el) =>
+                el.tagName.toLowerCase()
+            );
+            await ShopCustomer.expects(breadcrumbNavigationItemTagName).toBe('span');
+        });
+    }
+);


### PR DESCRIPTION
### 1. Why is this change necessary?
That test migrate the following cypress test to playwright. ([cypress test](https://gitlab.shopware.com/shopware/6/product/platform/-/blob/v6.4.20.2/tests/e2e/cypress/e2e/storefront/breadcrumb/breadcrumb.cy.js?ref_type=tags))

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
:heavy_check_mark:  Acceptance test suite PR has to be merged first: https://github.com/shopware/acceptance-test-suite/pull/276


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
