### PR TITLE
feat(storefront): Remove redundant asterisk next to every price

### DIFF
--- a/adr/2025-01-01-remove-asterisk-next-to-every-price.md
+++ b/adr/2025-01-01-remove-asterisk-next-to-every-price.md
@@ -1,0 +1,27 @@
+---
+title: Remove the asterisk (*) next to every price and replace it with actual text
+date: 2025-01-01
+area: framework
+tags: [storefront, prices, accessibility]
+---
+
+## Context
+
+Currently, all product prices that are displayed in the default Storefront have an asterisk (*) next to them, for example: `€ 50,00 *`
+This asterisk refers to the tax and shipping costs information in the page footer `* All prices incl. VAT plus shipping costs and possible delivery charges, if not stated otherwise.`
+
+Using the asterisk (*) next to every price has several downsides that we want to address:
+
+### Footer text not always in viewport
+
+When adding products to the shopping cart from within the listing the text might never be recognized.
+
+### Redundant and confusing information
+
+In some areas, the asterisk (*) referring to the footer text is more confusing than helpful. For example:
+* On the product detail page the "tax and shipping information" link is displayed already right underneath the price.
+* Inside the summary of the shopping cart the "tax and shipping information" is already part of the summary itself.
+
+## Decision
+
+## Consequences

--- a/adr/2025-01-01-remove-asterisk-next-to-every-price.md
+++ b/adr/2025-01-01-remove-asterisk-next-to-every-price.md
@@ -27,7 +27,7 @@ In some areas, the asterisk `*` referring to the footer text is more confusing t
 ### Accessibility issues
 
 The asterisk `*` is only plain text at the moment and has no actual relationship to its corresponding footer info text.
-A screen reader will always read "50 euros star" without further context. For a screen reader user the star is not accessible.
+A screen reader will always read "50 euros star" without further context. For a screen reader user, the asterisk is not accessible.
 
 ## Decision
 

--- a/adr/2025-01-01-remove-asterisk-next-to-every-price.md
+++ b/adr/2025-01-01-remove-asterisk-next-to-every-price.md
@@ -1,5 +1,5 @@
 ---
-title: Remove the asterisk (*) next to every price and replace it with actual text
+title: Remove the asterisk `*` next to every price and replace it with actual text
 date: 2025-01-01
 area: framework
 tags: [storefront, prices, accessibility]
@@ -7,10 +7,10 @@ tags: [storefront, prices, accessibility]
 
 ## Context
 
-Currently, all product prices that are displayed in the default Storefront have an asterisk (*) next to them, for example: `€ 50,00 *`
+Currently, all product prices that are displayed in the default Storefront have an asterisk `*` next to them, for example: `€ 50,00 *`
 This asterisk refers to the tax and shipping costs information in the page footer `* All prices incl. VAT plus shipping costs and possible delivery charges, if not stated otherwise.`
 
-Using the asterisk (*) next to every price has several downsides that we want to address:
+Using the asterisk `*` next to every price has several downsides that we want to address:
 
 ### Footer text not always in viewport
 
@@ -18,10 +18,39 @@ When adding products to the shopping cart from within the listing the text might
 
 ### Redundant and confusing information
 
-In some areas, the asterisk (*) referring to the footer text is more confusing than helpful. For example:
-* On the product detail page the "tax and shipping information" link is displayed already right underneath the price.
+In some areas, the asterisk `*` referring to the footer text is more confusing than helpful. For example:
+* On the product detail page the "tax and shipping information" link is already displayed right underneath the price.
 * Inside the summary of the shopping cart the "tax and shipping information" is already part of the summary itself.
+* When a form is shown on the same page, the asterisks `*` of the required fields are conflicting with the asterisks `*` of the prices.
+* In general the asterisk `*` might give the impression that the shown price is not the actual price and might change later.
+
+### Accessibility issues
+
+The asterisk `*` is only plain text at the moment and has no actual relationship to its corresponding footer info text.
+A screen reader will always read "50 euros star" without further context. For a screen reader user the star is not accessible.
 
 ## Decision
 
+The asterisk `*` next to every price will be removed because of the reasons mentioned above.
+In most areas of the Storefront the information that the asterisk `*` is referring to is already given, and it was therefore redundant.
+In areas where the asterisk `*` was actually needed, it will be replaced by the actual text "Prices incl. VAT plus shipping costs" instead to resolve the accessibility issues.
+
+### Affected areas
+
+| Area                                       | Explanation                                                                                 |
+|--------------------------------------------|---------------------------------------------------------------------------------------------|
+| Shopping cart and order line items         | Asterisk removed. Info is already shown in the cart summary.                                |
+| Shopping cart summary                      | Asterisk removed. Info is already part of the cart summary itself. (shipping, taxes)        |
+| Header cart widget                         | Asterisk removed. Info is not needed because no product can be added to the cart here.      |
+| Header search suggest box                  | Info is not needed because no product can be added to the cart here.                        |
+| Product-box (listing, product slider etc.) | Info is displayed as text instead when setting `core.listing.allowBuyInListing` is enabled. |
+| Buy-widget on product detail page          | Info is already shown on the product detail page underneath the price.                      |
+
+The changes can be activated by using the `ACCESSIBILITY_TWEAKS` feature flag and will be the default in the upcoming major version `v6.7.0`.
+
+See `2025-01-16-remove-the-asterisk-next-to-every-price.md` for the technical changelog.
+
 ## Consequences
+
+* With the next major `v6.7.0` or active `ACCESSIBILITY_TWEAKS` the asterisk `*` next to every price will be removed.
+* Product boxes that allow an "Add to cart" action from within the product listing will display the "Prices incl. VAT plus shipping costs" information as text instead. Only displayed when setting `core.listing.allowBuyInListing` is enabled.

--- a/adr/2025-01-01-remove-asterisk-next-to-every-price.md
+++ b/adr/2025-01-01-remove-asterisk-next-to-every-price.md
@@ -1,5 +1,5 @@
 ---
-title: Remove the asterisk `*` next to every price and replace it with actual text
+title: Remove the asterisk next to every price and replace it with actual text
 date: 2025-01-01
 area: framework
 tags: [storefront, prices, accessibility]

--- a/adr/2025-01-01-remove-asterisk-next-to-every-price.md
+++ b/adr/2025-01-01-remove-asterisk-next-to-every-price.md
@@ -32,7 +32,7 @@ A screen reader will always read "50 euros star" without further context. For a 
 ## Decision
 
 The asterisk `*` next to every price will be removed because of the reasons mentioned above.
-In most areas of the Storefront the information that the asterisk `*` is referring to is already given, and it was therefore redundant.
+In most areas of the Storefront, the information that the asterisk `*` refers to is already given, and it is therefore redundant.
 In areas where the asterisk `*` was actually needed, it will be replaced by the actual text "Prices incl. VAT plus shipping costs" instead to resolve the accessibility issues.
 
 ### Affected areas

--- a/changelog/_unreleased/2025-01-16-remove-the-asterisk-next-to-every-price.md
+++ b/changelog/_unreleased/2025-01-16-remove-the-asterisk-next-to-every-price.md
@@ -3,6 +3,7 @@ title: Remove the asterisk next to every price
 issue: NEXT-39225
 ---
 # Storefront
+* Added new block `component_product_box_price_tax_info` in `Resources/views/storefront/component/product/card/price-unit.html.twig` to display the tax and shipping information like on the product detail page.
 * Deprecated the asterisk (*) next to every price in the following templates. The tax and shipping costs information is either already shown in the current context or will be replaced with an actual text.
     * Cart and order line items (Info already shown in the cart summary)
         - `Resources/views/storefront/component/line-item/element/total-price.html.twig` 

--- a/changelog/_unreleased/2025-01-16-remove-the-asterisk-next-to-every-price.md
+++ b/changelog/_unreleased/2025-01-16-remove-the-asterisk-next-to-every-price.md
@@ -1,0 +1,24 @@
+---
+title: Remove the asterisk next to every price
+issue: NEXT-39225
+---
+# Storefront
+* Deprecated the asterisk (*) next to every price in the following templates. The tax and shipping costs information is either already shown in the current context or will be replaced with an actual text.
+    * Cart and order line items (Info already shown in the cart summary)
+        - `Resources/views/storefront/component/line-item/element/total-price.html.twig` 
+        - `Resources/views/storefront/component/line-item/element/unit-price.html.twig`
+    * Cart summary (Info is already shown in the cart summary itself)
+        - `Resources/views/storefront/page/checkout/summary/summary-position.html.twig`
+        - `Resources/views/storefront/page/checkout/summary/summary-shipping.html.twig`
+        - `Resources/views/storefront/page/checkout/summary/summary-total.html.twig`
+        - `Resources/views/storefront/page/checkout/summary/summary-total-rounded.html.twig`
+        - `Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig`
+    * Header cart widget (Info is not needed because no product can be added to the cart here)
+        - `Resources/views/storefront/layout/header/actions/cart-widget.html.twig` 
+    * Header search suggest box (Info is not needed because no product can be added to the cart here)
+        - `Resources/views/storefront/layout/header/search-suggest.html.twig`
+    * Product-box (Info is displayed as text instead when setting `core.listing.allowBuyInListing` is enabled)
+        - `Resources/views/storefront/component/product/card/price-unit.html.twig` 
+    * Buy-widget (Info is already shown on the product detail page)
+        - `Resources/views/storefront/component/product/block-price.html.twig` 
+        - `Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig`

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -712,8 +712,8 @@
     "serviceContactText": "Oder über unser <a data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\" title=\"Kontaktformular\">Kontaktformular</a>.",
     "newsletterInput": "E-Mail-Adresse",
     "newsletter": "Abonnieren Sie jetzt unseren regelmäßig erscheinenden Newsletter, um rechtzeitig über neue Produkte und Angebote informiert zu werden.",
-    "includeVatText": "* Alle Preise inkl. gesetzl. Mehrwertsteuer zzgl. <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
-    "excludeVatText": "* Alle Preise exkl. gesetzl. Mehrwertsteuer zzgl. <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
+    "includeVatText": "%star%Alle Preise inkl. gesetzl. Mehrwertsteuer zzgl. <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
+    "excludeVatText": "%star%Alle Preise exkl. gesetzl. Mehrwertsteuer zzgl. <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
     "copyrightInfo": "Realisiert mit Shopware"
   },
   "captcha": {

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -712,8 +712,8 @@
     "serviceContactText": "Or via our <a data-ajax-modal=\"true\" data-url=\"%url%\" href=\"%url%\" title=\"Contact form\">contact form</a>.",
     "newsletterInput": "Email address",
     "newsletter": "Subscribe to our regular newsletter now to stay tuned on the latest products and special offers.",
-    "includeVatText": "* All prices incl. VAT plus <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
-    "excludeVatText": "* All prices excl. VAT plus <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
+    "includeVatText": "%star%All prices incl. VAT plus <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
+    "excludeVatText": "%star%All prices excl. VAT plus <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
     "copyrightInfo": "Realised with Shopware"
   },
   "captcha": {

--- a/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/buy-widget-price.html.twig
@@ -59,7 +59,8 @@
                                             {% block buy_widget_price_block_table_body_cell_reference_price %}
                                                 {% if price.referencePrice is not null %}
                                                     <td class="product-block-prices-cell product-block-prices-cell-thin">
-                                                        {{ price.referencePrice.price|currency }}{{ 'general.star'|trans|sw_sanitize }} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }}
+                                                        {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed as text in the buy-widget on the product detail page. #}
+                                                        {{ price.referencePrice.price|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }}
                                                     </td>
                                                 {% endif %}
                                             {% endblock %}
@@ -89,7 +90,8 @@
             {% set isRegulationPrice = price.regulationPrice != null %}
 
             <p class="product-detail-price{% if isListPrice %} with-list-price{% endif %}{% if isRegulationPrice %} with-regulation-price{% endif %}">
-                {{ price.unitPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}
+                {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed as text in the buy-widget on the product detail page. #}
+                {{ price.unitPrice|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
             </p>
 
             {% if isListPrice %}
@@ -105,7 +107,8 @@
                         <span class="product-detail-list-price-wrapper">
                             {% if beforeListPriceSnippetExists %}{{'listing.beforeListPrice'|trans|trim}}{% endif %}
 
-                            <span{% if not (afterListPriceSnippetExists or beforeListPriceSnippetExists) %} class="list-price-price"{% endif %}>{{ listPrice.price|currency }}{{ 'general.star'|trans|sw_sanitize }}</span>
+                            {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed as text in the buy-widget on the product detail page. #}
+                            <span{% if not (afterListPriceSnippetExists or beforeListPriceSnippetExists) %} class="list-price-price"{% endif %}>{{ listPrice.price|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</span>
 
                             {% if afterListPriceSnippetExists %}
                                 {{'listing.afterListPrice'|trans|trim}}
@@ -118,7 +121,8 @@
             {% endif %}
             {% if isRegulationPrice %}
                 <span class="product-detail-list-price-wrapper">
-                    <span class="regulation-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}{{ 'general.star'|trans|sw_sanitize }}</span>
+                    {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed as text in the buy-widget on the product detail page. #}
+                    <span class="regulation-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</span>
                 </span>
             {% endif %}
         {% endblock %}
@@ -141,7 +145,8 @@
                     {% if price.referencePrice is not null %}
                         {% block buy_widget_price_unit_reference_content %}
                             <span class="price-unit-reference-content">
-                                ({{ price.referencePrice.price|currency }}{{ 'general.star'|trans|sw_sanitize }} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }})
+                                {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed as text in the buy-widget on the product detail page. #}
+                                ({{ price.referencePrice.price|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %} / {{ price.referencePrice.referenceUnit }} {{ price.referencePrice.unitName }})
                             </span>
                         {% endblock %}
                     {% endif %}

--- a/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/checkout/offcanvas-cart-summary.html.twig
@@ -10,7 +10,8 @@
 
                 {% block component_offcanvas_summary_total_value %}
                     <dd class="{% if feature('ACCESSIBILITY_TWEAKS') %}col-4{% else %}col-5{% endif %} summary-value summary-total">
-                        <strong>{{ page.cart.price.positionPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}</strong>
+                        {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+                        <strong>{{ page.cart.price.positionPrice|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</strong>
                     </dd>
                 {% endblock %}
             {% endblock %}
@@ -35,7 +36,8 @@
 
                         <span class="{% if feature('ACCESSIBILITY_TWEAKS') %}col-4{% else %}col-5{% endif %} pb-2 shipping-value shipping-cost">
                             {% set shippingTotalPrice = activeShipping.shippingCosts.totalPrice ?? 0 %}
-                            <strong>{{ shippingTotalPrice < 0 ? '&minus;' : '+' }} {{ shippingTotalPrice|abs|currency }}{{ 'general.star'|trans|sw_sanitize }}</strong>
+                            {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+                            <strong>{{ shippingTotalPrice < 0 ? '&minus;' : '+' }} {{ shippingTotalPrice|abs|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</strong>
                         </span>
                     </div>
                 {% endblock %}
@@ -78,7 +80,9 @@
     {% block component_offcanvas_summary_tax_info %}
         <p class="offcanvas-cart-tax">
             <small>
-                {{ 'general.star'|trans|sw_sanitize }}
+                {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+                {% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
+
                 {% if page.cart.price.taxStatus == 'gross' %}
                     {{ 'general.grossTaxInformation'|trans|sw_sanitize }}
                 {% else %}

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/total-price.html.twig
@@ -16,9 +16,11 @@
                 {% endif %}
 
                 {% if displayMode === 'order' %}
-                    {{ lineItemTotalPrice|abs|currency(order.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }}
+                    {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+                    {{ lineItemTotalPrice|abs|currency(order.currency.isoCode) }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
                 {% else %}
-                    {{ lineItemTotalPrice|abs|currency(currency) }}{{ 'general.star'|trans|sw_sanitize }}
+                    {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+                    {{ lineItemTotalPrice|abs|currency(currency) }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
                 {% endif %}
             {% endif %}
 
@@ -26,7 +28,8 @@
             {% if referencePrice is not null and displayMode == 'offcanvas' %}
                 <br>
                 <small class="line-item-reference-price">
-                    ({{ referencePrice.price|currency(currency) }}{{ 'general.star'|trans|sw_sanitize }} / {{ referencePrice.referenceUnit }}&nbsp;{{ referencePrice.unitName }})
+                    {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+                    ({{ referencePrice.price|currency(currency) }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %} / {{ referencePrice.referenceUnit }}&nbsp;{{ referencePrice.unitName }})
                 </small>
             {% endif %}
         </div>

--- a/src/Storefront/Resources/views/storefront/component/line-item/element/unit-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/line-item/element/unit-price.html.twig
@@ -8,9 +8,11 @@
     {% block component_line_item_unit_price_inner %}
         <div class="line-item-unit-price-value">
             {% if displayMode === 'order' %}
-                {{ lineItem.price.unitPrice|currency(order.currency.isoCode) }}{{ 'general.star'|trans|sw_sanitize }}
+                {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+                {{ lineItem.price.unitPrice|currency(order.currency.isoCode) }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
             {% else %}
-                {{ lineItem.price.unitPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}
+                {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+                {{ lineItem.price.unitPrice|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
             {% endif %}
             <span class="line-item-unit-price-value-descriptor"> / {{ 'checkout.lineItemUnitPriceDescriptor'|trans|sw_sanitize }}</span>
         </div>

--- a/src/Storefront/Resources/views/storefront/component/product/block-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/block-price.html.twig
@@ -5,7 +5,8 @@
     <div>
         {% block component_product_detail_block_price_content %}
             {% if price.listprice and isListPrice %}
-                <div class="product-detail-price{% if price %} with-advanced-list-price{% endif %}">{{ price.unitPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}</div>
+                {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed as text in the buy-widget on the product detail page. #}
+                <div class="product-detail-price{% if price %} with-advanced-list-price{% endif %}">{{ price.unitPrice|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</div>
 
                 {% block component_product_detail_block_list_price_wrapper %}
                     {% set afterListPriceSnippetExists = 'listing.afterListPrice'|trans|length > 0 %}
@@ -14,7 +15,8 @@
                     <span class="product-detail-advanced-list-price-wrapper{% if beforeListPriceSnippetExists or afterListPriceSnippetExists %} product-detail-advanced-list-price-wrapper-no-line-through{% endif %}">
                         {% if beforeListPriceSnippetExists %}{{ 'listing.beforeListPrice'|trans }}{% endif %}
 
-                        <span class="list-price-price">{{ price.listprice.price|currency }}{{ 'general.star'|trans|sw_sanitize }}</span>
+                        {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed as text in the buy-widget on the product detail page. #}
+                        <span class="list-price-price">{{ price.listprice.price|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</span>
 
                         {% if afterListPriceSnippetExists %}{{ 'listing.afterListPrice'|trans }}{% endif %}
 
@@ -22,11 +24,13 @@
                     </span>
                 {% endblock %}
             {% else %}
-                {{ price.unitPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}
+                {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed as text in the buy-widget on the product detail page. #}
+                {{ price.unitPrice|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
             {% endif %}
             {% if isRegulationPrice %}
                 <span class="product-detail-advanced-regulation-price-wrapper{% if isListPrice %} with-list-price{% endif %}">
-                    <span class="regulation-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}{{ 'general.star'|trans|sw_sanitize }}</span>
+                    {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed as text in the buy-widget on the product detail page. #}
+                    <span class="regulation-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</span>
                 </span>
             {% endif %}
         {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
@@ -37,7 +37,8 @@
                 {% block component_product_box_price_reference_unit %}
                     {% if referencePrice is not null %}
                         <span class="price-unit-reference">
-                            ({{ referencePrice.price|currency }}{{ 'general.star'|trans|sw_sanitize }} / {{ referencePrice.referenceUnit }} {{ referencePrice.unitName }})
+                            {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is displayed as text instead if `allowBuyInListing` is true. #}
+                            ({{ referencePrice.price|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %} / {{ referencePrice.referenceUnit }} {{ referencePrice.unitName }})
                         </span>
                     {% endif %}
                 {% endblock %}
@@ -52,7 +53,8 @@
 
                 <div class="product-cheapest-price{% if isListPrice and isRegulationPrice and not displayFrom and not displayFromVariants %} with-list-price{% endif %}{% if isRegulationPrice and not displayFrom and displayFromVariants %} with-regulation-price{% endif %}{% if displayFrom and isRegulationPrice %} with-from-price{% endif %}">
                     {% if cheapest.unitPrice != real.unitPrice and cheapest.variantId != product.id %}
-                        <div>{{ 'listing.cheapestPriceLabel'|trans|sw_sanitize }}<span class="product-cheapest-price-price"> {{ cheapest.unitPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}</span></div>
+                        {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is displayed as text instead if `allowBuyInListing` is true. #}
+                        <div>{{ 'listing.cheapestPriceLabel'|trans|sw_sanitize }}<span class="product-cheapest-price-price"> {{ cheapest.unitPrice|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</span></div>
                     {% endif %}
                 </div>
 
@@ -61,7 +63,8 @@
                 {% endif %}
 
                 <span class="product-price{% if isListPrice and not displayFrom and not displayFromVariants %} with-list-price{% endif %}">
-                    {{ price.unitPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}
+                    {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is displayed as text instead if `allowBuyInListing` is true. #}
+                    {{ price.unitPrice|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
 
                     {% if isListPrice and not displayFrom and not displayFromVariants %}
                         {% set afterListPriceSnippetExists = 'listing.afterListPrice'|trans|length > 0 %}
@@ -71,7 +74,8 @@
                         <span class="list-price{% if hideStrikeTrough %} list-price-no-line-through{% endif %}">
                             {% if beforeListPriceSnippetExists %}{{ 'listing.beforeListPrice'|trans|trim|sw_sanitize }}{% endif %}
 
-                            <span class="list-price-price">{{ price.listPrice.price|currency }}{{ 'general.star'|trans|sw_sanitize }}</span>
+                            {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is displayed as text instead if `allowBuyInListing` is true. #}
+                            <span class="list-price-price">{{ price.listPrice.price|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</span>
 
                             {% if afterListPriceSnippetExists %}{{ 'listing.afterListPrice'|trans|trim|sw_sanitize }}{% endif %}
 
@@ -81,10 +85,30 @@
                 </span>
                 {% if isRegulationPrice %}
                     <span class="product-price with-regulation-price">
-                        {% if isListPrice %}<br>{% endif %}<span class="regulation-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}{{ 'general.star'|trans|sw_sanitize }}</span>
+                        {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is displayed as text instead if `allowBuyInListing` is true. #}
+                        {% if isListPrice %}<br>{% endif %}<span class="regulation-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</span>
                     </span>
                 {% endif %}
             </div>
         {% endblock %}
+
+        {#
+            If a product can be added to the shipping directly from the listing,
+            we need to display information about taxes and shipping.
+        #}
+        {% if feature('ACCESSIBILITY_TWEAKS') and config('core.listing.allowBuyInListing') %}
+            {% block component_product_box_price_tax_info %}
+                <a class="product-price-tax-link fs-6"
+                   href="{{ path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') }) }}"
+                   data-ajax-modal="true"
+                   data-url="{{ path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') }) }}">
+                    {% if context.taxState == 'gross' %}
+                        {{ 'general.grossTaxInformation'|trans|sw_sanitize }}
+                    {% else %}
+                        {{ 'general.netTaxInformation'|trans|sw_sanitize }}
+                    {% endif %}
+                </a>
+            {% endblock %}
+        {% endif %}
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/card/price-unit.html.twig
@@ -98,16 +98,15 @@
         #}
         {% if feature('ACCESSIBILITY_TWEAKS') and config('core.listing.allowBuyInListing') %}
             {% block component_product_box_price_tax_info %}
-                <a class="product-price-tax-link fs-6"
-                   href="{{ path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') }) }}"
-                   data-ajax-modal="true"
-                   data-url="{{ path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') }) }}">
+                <button class="product-price-tax-link btn btn-link fw-normal p-0 fs-6 lh-base"
+                        data-ajax-modal="true"
+                        data-url="{{ path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') }) }}">
                     {% if context.taxState == 'gross' %}
                         {{ 'general.grossTaxInformation'|trans|sw_sanitize }}
                     {% else %}
                         {{ 'general.netTaxInformation'|trans|sw_sanitize }}
                     {% endif %}
-                </a>
+                </button>
             {% endblock %}
         {% endif %}
     </div>

--- a/src/Storefront/Resources/views/storefront/component/product/feature/types/feature-reference-price.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/feature/types/feature-reference-price.html.twig
@@ -6,5 +6,6 @@
 
 {% block component_product_feature_list_item_base_content_value %}
     {{ value.purchaseUnit|sw_sanitize }} {{ value.unitName|sw_sanitize }}
-    ({{ value.price|currency }}{{ 'general.star'|trans }} / {{ value.referenceUnit|sw_sanitize }} {{ value.unitName|sw_sanitize }})
+    {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+    ({{ value.price|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans }}{% endif %} / {{ value.referenceUnit|sw_sanitize }} {{ value.unitName|sw_sanitize }})
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -213,19 +213,21 @@
             {% block layout_footer_vat %}
                 {% if showVatNotice or showVatNotice is not defined %}
                     <div class="footer-vat">
-                        {% if context.taxState == 'gross' %}
-                            <p>
+                        <p>
+                            {% if context.taxState == 'gross' %}
+                                {# @deprecated tag:v6.7.0 - The %star% translation parameter will be removed. Translation text will no longer contain the asterisk/star. #}
                                 {{ 'footer.includeVatText'|trans({
-                                    '%url%': path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') })
+                                    '%url%': path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') }),
+                                    '%star%': feature('ACCESSIBILITY_TWEAKS') ? '' : '* '
                                 })|raw }}
-                            </p>
-                        {% else %}
-                            <p>
+                            {% else %}
+                                {# @deprecated tag:v6.7.0 - The %star% translation parameter will be removed. Translation text will no longer contain the asterisk/star. #}
                                 {{ 'footer.excludeVatText'|trans({
-                                    '%url%': path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') })
+                                    '%url%': path('frontend.cms.page', { id: config('core.basicInformation.shippingPaymentInfoPage') }),
+                                    '%star%': feature('ACCESSIBILITY_TWEAKS') ? '' : '* '
                                 })|raw }}
-                            </p>
-                        {% endif %}
+                            {% endif %}
+                        </p>
                     </div>
                 {% endif %}
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/cart-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/cart-widget.html.twig
@@ -8,6 +8,7 @@
         <span class="badge bg-primary header-cart-badge">{{ page.cart.lineItems|length }}</span>
     {% endif %}
     <span class="header-cart-total">
-        {{ page.cart.price.positionPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}
+        {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is only needed adjecent to "add to cart" buttons. #}
+        {{ page.cart.price.positionPrice|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
     </span>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/search-suggest.html.twig
@@ -72,15 +72,18 @@
                                                         {{ 'listing.listingTextFrom'|trans|sw_sanitize }}
                                                     {% endif %}
                                                     <span class="search-suggest-product-price">
-                                                        {{ price.unitPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}
+                                                        {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is only needed adjecent to "add to cart" buttons. #}
+                                                        {{ price.unitPrice|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
                                                     </span>
 
                                                     {% if price.referencePrice is not null %}
-                                                        <br><small class="search-suggest-product-reference-price">({{ price.referencePrice.price|currency }}{{ 'general.star'|trans|sw_sanitize }} / {{ price.referencePrice.referenceUnit }}&nbsp;{{ price.referencePrice.unitName }})</small>
+                                                        {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is only needed adjecent to "add to cart" buttons. #}
+                                                        <br><small class="search-suggest-product-reference-price">({{ price.referencePrice.price|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %} / {{ price.referencePrice.referenceUnit }}&nbsp;{{ price.referencePrice.unitName }})</small>
                                                     {% endif %}
 
                                                     {% if price.regulationPrice.price is not null %}
-                                                        <small class="search-suggest-product-list-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}{{ 'general.star'|trans|sw_sanitize }}</small>
+                                                        {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is only needed adjecent to "add to cart" buttons. #}
+                                                        <small class="search-suggest-product-list-price">{{ 'general.listPricePreviously'|trans({'%price%': price.regulationPrice.price|currency }) }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}</small>
                                                     {% endif %}
                                                 </div>
                                             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-position.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-position.html.twig
@@ -7,7 +7,8 @@
 
     {% block page_checkout_summary_position_value %}
         <dd class="col-5 checkout-aside-summary-value">
-            {{ summary.price.positionPrice|currency }}{{ 'general.star'|trans|sw_sanitize }}
+            {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+            {{ summary.price.positionPrice|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
         </dd>
     {% endblock %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-shipping.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-shipping.html.twig
@@ -14,7 +14,8 @@
                         &minus;
                     {% endif %}
 
-                    {{ deliveryPrice|abs|currency }}{{ 'general.star'|trans|sw_sanitize }}
+                    {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+                    {{ deliveryPrice|abs|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
                 </dd>
             {% endblock %}
         {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-total-rounded.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-total-rounded.html.twig
@@ -7,7 +7,8 @@
 
     {% block page_checkout_summary_total_rounded_value %}
         <dd class="col-5 checkout-aside-summary-value checkout-aside-summary-total-rounded">
-            {{ summary.price.totalPrice|currency(decimals=decimals) }}{{ 'general.star'|trans|sw_sanitize }}
+            {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+            {{ summary.price.totalPrice|currency(decimals=decimals) }}{% if not feature('ACCESSIBILITY_TWEAKS') %}{{ 'general.star'|trans|sw_sanitize }}{% endif %}
         </dd>
     {% endblock %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-total.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/summary/summary-total.html.twig
@@ -7,7 +7,8 @@
 
     {% block page_checkout_summary_total_value %}
         <dd class="col-5 checkout-aside-summary-value checkout-aside-summary-total">
-            {{ summary.price.rawTotal|currency }}{% if summary.price.taxStatus == 'gross' %}{{ 'general.star'|trans|sw_sanitize|trim }}{% endif %}
+            {# @deprecated tag:v6.7.0 - Showing asterisk next to every price is deprecated. Tax and shipping info is already displayed in the shopping cart summary. #}
+            {{ summary.price.rawTotal|currency }}{% if not feature('ACCESSIBILITY_TWEAKS') and summary.price.taxStatus == 'gross' %}{{ 'general.star'|trans|sw_sanitize|trim }}{% endif %}
         </dd>
     {% endblock %}
 {% endblock %}

--- a/tests/acceptance/tests/Checkout/CheckoutWithPromotionCode.spec.ts
+++ b/tests/acceptance/tests/Checkout/CheckoutWithPromotionCode.spec.ts
@@ -23,18 +23,18 @@ test('Registered shop customer should be able to use promotion code during check
     await ShopCustomer.goesTo(StorefrontCheckoutCart.url());
 
     // Value of test product with price of €10 and quantity of 10.
-    await ShopCustomer.expects(StorefrontCheckoutCart.grandTotalPrice).toHaveText('€100.00*');
+    await ShopCustomer.expects(StorefrontCheckoutCart.grandTotalPrice).toContainText('€100.00');
 
     await ShopCustomer.attemptsTo(AddPromotionCodeToCart(promotion.name, promotion.code));
     await ShopCustomer.attemptsTo(ProceedFromCartToCheckout());
     await ShopCustomer.attemptsTo(ConfirmTermsAndConditions());
 
     // Value of test product with price of €10 and quantity of 10 and 10% discount.
-    await ShopCustomer.expects(StorefrontCheckoutConfirm.grandTotalPrice).toHaveText('€90.00*');
+    await ShopCustomer.expects(StorefrontCheckoutConfirm.grandTotalPrice).toContainText('€90.00');
 
     await ShopCustomer.attemptsTo(SubmitOrder());
     await ShopCustomer.expects(StorefrontCheckoutFinish.page.getByText(promotion.name)).toBeVisible();
-    await ShopCustomer.expects(StorefrontCheckoutFinish.grandTotalPrice).toHaveText('€90.00*');
+    await ShopCustomer.expects(StorefrontCheckoutFinish.grandTotalPrice).toContainText('€90.00');
 
     const orderId = StorefrontCheckoutFinish.getOrderId();
 

--- a/tests/acceptance/tests/Checkout/RegisteredUserBuysProduct.spec.ts
+++ b/tests/acceptance/tests/Checkout/RegisteredUserBuysProduct.spec.ts
@@ -32,10 +32,10 @@ test('Registered shop customer buys a product.', { tag: '@Checkout' }, async ({
     await ShopCustomer.attemptsTo(SelectInvoicePaymentOption());
     await ShopCustomer.attemptsTo(SelectStandardShippingOption());
 
-    await ShopCustomer.expects(StorefrontCheckoutConfirm.grandTotalPrice).toHaveText('€10.00*');
+    await ShopCustomer.expects(StorefrontCheckoutConfirm.grandTotalPrice).toContainText('€10.00');
 
     await ShopCustomer.attemptsTo(SubmitOrder());
-    await ShopCustomer.expects(StorefrontCheckoutFinish.grandTotalPrice).toHaveText('€10.00*');
+    await ShopCustomer.expects(StorefrontCheckoutFinish.grandTotalPrice).toContainText('€10.00');
 
     const orderId = StorefrontCheckoutFinish.getOrderId();
 

--- a/tests/acceptance/tests/Product/ProductAvailabilityWithClearanceSale.spec.ts
+++ b/tests/acceptance/tests/Product/ProductAvailabilityWithClearanceSale.spec.ts
@@ -104,5 +104,5 @@ test('Stock reached message should be displayed if stock is changed to 1 and cle
     await ShopCustomer.goesTo(StorefrontCheckoutCart.url());
 
     await ShopCustomer.expects(StorefrontCheckoutCart.stockReachedAlert).toContainText(product.name);
-    await ShopCustomer.expects(StorefrontCheckoutCart.grandTotalPrice).toHaveText('€10.00*');
+    await ShopCustomer.expects(StorefrontCheckoutCart.grandTotalPrice).toContainText('€10.00');
 });

--- a/tests/acceptance/tests/Product/ProductWithAdvancedPricingPerQuantity.spec.ts
+++ b/tests/acceptance/tests/Product/ProductWithAdvancedPricingPerQuantity.spec.ts
@@ -18,34 +18,34 @@ test.skip('Customer gets a special product price depending on the amount of prod
         await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('th').nth(0)).toContainText('Quantity');
         await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('th').nth(1)).toContainText('Unit price');
         await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('th').nth(2)).toContainText('To 10');
-        await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('td').nth(0)).toContainText('€100.00*');
+        await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('td').nth(0)).toContainText('€100.00');
         await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('th').nth(3)).toContainText('To 20');
-        await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('td').nth(1)).toContainText('€90.00*');
+        await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('td').nth(1)).toContainText('€90.00');
         await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('th').nth(4)).toContainText('To 50');
-        await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('td').nth(2)).toContainText('€80.00*');
+        await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('td').nth(2)).toContainText('€80.00');
         await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('th').nth(5)).toContainText('From 51');
-        await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('td').nth(3)).toContainText('€70.00*');
+        await ShopCustomer.expects(StorefrontProductDetail.productPriceRangesRow.locator('td').nth(3)).toContainText('€70.00');
     });
 
     await test.step('Testing product with price range (1-10) @product', async () => {
         await ShopCustomer.attemptsTo(AddProductToCart(product, '10'));
         await ShopCustomer.goesTo(StorefrontCheckoutCart.url());
-        await ShopCustomer.expects(StorefrontCheckoutCart.unitPriceInfo).toContainText('€100.00*');
+        await ShopCustomer.expects(StorefrontCheckoutCart.unitPriceInfo).toContainText('€100.00');
     });
 
     await test.step('Testing product with price range (11-20) @product', async () => {
         await ShopCustomer.attemptsTo(ChangeProductQuantity('11'));
-        await ShopCustomer.expects(StorefrontCheckoutCart.unitPriceInfo).toContainText('€90.00*');
+        await ShopCustomer.expects(StorefrontCheckoutCart.unitPriceInfo).toContainText('€90.00');
     });
 
     await test.step('Testing product with price range (21-50) @product', async () => {
         await ShopCustomer.attemptsTo(ChangeProductQuantity('50'));
-        await ShopCustomer.expects(StorefrontCheckoutCart.unitPriceInfo).toContainText('€80.00*');
+        await ShopCustomer.expects(StorefrontCheckoutCart.unitPriceInfo).toContainText('€80.00');
     });
 
     await test.step('Testing product last price range (51-infinity) @product', async () => {
         await ShopCustomer.attemptsTo(ChangeProductQuantity('51'));
-        await ShopCustomer.expects(StorefrontCheckoutCart.unitPriceInfo).toContainText('€70.00*');
+        await ShopCustomer.expects(StorefrontCheckoutCart.unitPriceInfo).toContainText('€70.00');
     });
 
     await test.step('Testing product listing contains cheapest price @product', async () => {
@@ -53,7 +53,7 @@ test.skip('Customer gets a special product price depending on the amount of prod
         await ShopCustomer.expects(StorefrontHome.productListItems
             .filter({ hasText: product.name })
             .locator('.product-price-wrapper')
-        ).toHaveText('From €70.00*');
+        ).toContainText('From €70.00');
         await ShopCustomer.expects(StorefrontHome.productListItems
             .filter({ hasText: product.name })
             .getByTitle('Details')

--- a/tests/acceptance/tests/Product/ProductWithRuleSpecificPrice.spec.ts
+++ b/tests/acceptance/tests/Product/ProductWithRuleSpecificPrice.spec.ts
@@ -35,7 +35,7 @@ test('Customer gets a special product price depending on rules.', {
     expect(priceResponse.ok()).toBeTruthy();
 
     await ShopCustomer.goesTo(StorefrontProductDetail.url(product));
-    await ShopCustomer.expects(StorefrontProductDetail.productSinglePrice).toHaveText('€10.00*');
+    await ShopCustomer.expects(StorefrontProductDetail.productSinglePrice).toContainText('€10.00');
     await ShopCustomer.attemptsTo(AddProductToCart(product));
-    await ShopCustomer.expects(StorefrontProductDetail.offCanvasSummaryTotalPrice).toHaveText('€8.99*');
+    await ShopCustomer.expects(StorefrontProductDetail.offCanvasSummaryTotalPrice).toContainText('€8.99');
 });

--- a/tests/acceptance/tests/Settings/CurrencyRoundingByCountry.spec.ts
+++ b/tests/acceptance/tests/Settings/CurrencyRoundingByCountry.spec.ts
@@ -49,23 +49,23 @@ test('As a merchant, I would be able to adjust storefront rounding for defined c
     await ShopCustomer.goesTo(StorefrontHome.url());
     await ShopCustomer.attemptsTo(ChangeStorefrontCurrency(currency.isoCode));
     const productListingLocatorsByProductId = await StorefrontHome.getListingItemByProductId(product.id);
-    await ShopCustomer.expects(productListingLocatorsByProductId.productPrice).toHaveText(currency.isoCode+' 22.556*');
+    await ShopCustomer.expects(productListingLocatorsByProductId.productPrice).toContainText(currency.isoCode+' 22.556');
 
     await ShopCustomer.goesTo(StorefrontProductDetail.url(product));
-    await ShopCustomer.expects(StorefrontProductDetail.productSinglePrice).toHaveText(currency.isoCode+' 22.556*');
+    await ShopCustomer.expects(StorefrontProductDetail.productSinglePrice).toContainText(currency.isoCode+' 22.556');
 
     await ShopCustomer.attemptsTo(AddProductToCart(product));
-    await ShopCustomer.expects(StorefrontProductDetail.offCanvasSummaryTotalPrice).toHaveText(currency.isoCode+' 22.556*');
+    await ShopCustomer.expects(StorefrontProductDetail.offCanvasSummaryTotalPrice).toContainText(currency.isoCode+' 22.556');
     await ShopCustomer.attemptsTo(ProceedFromProductToCheckout());
 
     await ShopCustomer.attemptsTo(ConfirmTermsAndConditions());
     await ShopCustomer.attemptsTo(SelectInvoicePaymentOption());
     await ShopCustomer.attemptsTo(SelectStandardShippingOption());
 
-    await ShopCustomer.expects(StorefrontCheckoutConfirm.grandTotalPrice).toHaveText(currency.isoCode+' 22.556*');
+    await ShopCustomer.expects(StorefrontCheckoutConfirm.grandTotalPrice).toContainText(currency.isoCode+' 22.556');
 
     await ShopCustomer.attemptsTo(SubmitOrder());
-    await ShopCustomer.expects(StorefrontCheckoutFinish.grandTotalPrice).toHaveText(currency.isoCode+' 22.556*');
+    await ShopCustomer.expects(StorefrontCheckoutFinish.grandTotalPrice).toContainText(currency.isoCode+' 22.556');
 
     const orderId = StorefrontCheckoutFinish.getOrderId();
 


### PR DESCRIPTION
* This PR replaces the asterisk `*` next to every price.
* If needed, it is replaced by an actual text to improve accessibility.
* In some areas the asterisk `*` is not needed because the information is already visible on the current page / context.

For more information please look at the ADR `adr/2025-01-01-remove-asterisk-next-to-every-price.md`

<details><summary>Before</summary>

| ![image](https://github.com/user-attachments/assets/87b112cd-fe80-4eed-8535-2b29fc4676f3)
|:--:| 
| **The * refers to the footer text** |


| ![image](https://github.com/user-attachments/assets/15a3feee-822e-48b9-9d2a-e507fd0466c6)
|:--:| 
| **The tax and shipping information is right underneath the price and the * is redundant** |

| ![image](https://github.com/user-attachments/assets/ebe37949-9c9d-46dc-8073-315e77bb3b23)
|:--:| 
| **The tax and shipping information is already in the cart summary** |

</details> 

<details><summary>After (with ACCESSIBILITY_FLAG)</summary>

| ![image](https://github.com/user-attachments/assets/6b22cadd-589c-4468-8312-9c88c70887c2)
|:--:| 
| **The info is shown as actual text when `core.listing.allowBuyInListing` is true** |

| ![image](https://github.com/user-attachments/assets/80dc4ba5-d232-457e-a865-76b26162c3f1)
|:--:| 
| **The * is removed and already covered by the tax link** |

| ![image](https://github.com/user-attachments/assets/ed190641-7364-4739-9813-2ca9fbbea5ae)
|:--:| 
| **The * is removed and already covered by the cart summary** |

</details> 

