### PR TITLE
fix: Reboot container 

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,7 +15,7 @@ parameters:
     # run `php src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php` to create the container
     symfony:
         constantHassers: false
-        containerXmlPath: 'var/cache/phpstan_dev/Shopware_Core_DevOps_StaticAnalyze_StaticAnalyzeKernelPhpstan_devDebugContainer.xml'
+        containerXmlPath: 'var/cache/static_phpstan_dev/Shopware_Core_DevOps_StaticAnalyze_StaticAnalyzeKernelPhpstan_devDebugContainer.xml'
         consoleApplicationLoader: src/Core/DevOps/StaticAnalyze/console-application.php
 
     excludePaths:

--- a/src/Core/DevOps/StaticAnalyze/StaticAnalyzeKernel.php
+++ b/src/Core/DevOps/StaticAnalyze/StaticAnalyzeKernel.php
@@ -14,9 +14,9 @@ class StaticAnalyzeKernel extends Kernel
     public function getCacheDir(): string
     {
         return \sprintf(
-            '%s/var/cache/%s',
+            '%s/var/cache/static_%s',
             $this->getProjectDir(),
-            $this->getEnvironment()
+            $this->getEnvironment(),
         );
     }
 }

--- a/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
@@ -72,9 +72,9 @@ class PluginManagementServiceTest extends TestCase
 
         Kernel::getConnection()->executeStatement('DELETE FROM plugin');
 
-        //make sure to boot the main container again
-        //eg in `boot` we bind the container to \Shopware\Core\Framework\Telemetry\Metrics\MeterProvider
-        //if we don't reboot, we hold an old reference to the deleted container used for testing in this class
+        // make sure to boot the main container again
+        // eg in `boot` we bind the container to \Shopware\Core\Framework\Telemetry\Metrics\MeterProvider
+        // if we don't reboot, we hold an old reference to the deleted container used for testing in this class
         $this->getKernel()->reboot(null);
     }
 

--- a/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
@@ -73,7 +73,7 @@ class PluginManagementServiceTest extends TestCase
         Kernel::getConnection()->executeStatement('DELETE FROM plugin');
 
         // make sure to boot the main container again
-        // eg in `boot` we bind the container to \Shopware\Core\Framework\Telemetry\Metrics\MeterProvider
+        // eg in `\Shopware\Core\Framework\Framework::boot()` we bind the container to \Shopware\Core\Framework\Telemetry\Metrics\MeterProvider
         // if we don't reboot, we hold an old reference to the deleted container used for testing in this class
         $this->getKernel()->reboot(null);
     }

--- a/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
@@ -71,6 +71,11 @@ class PluginManagementServiceTest extends TestCase
         $this->filesystem->remove($this->cacheDir);
 
         Kernel::getConnection()->executeStatement('DELETE FROM plugin');
+
+        //make sure to boot the main container again
+        //eg in `boot` we bind the container to \Shopware\Core\Framework\Telemetry\Metrics\MeterProvider
+        //if we don't reboot, we hold an old reference to the deleted container used for testing in this class
+        $this->getKernel()->reboot(null);
     }
 
     public function testUploadPlugin(): void


### PR DESCRIPTION
### 1. Why is this change necessary?

`\Shopware\Core\Framework\Telemetry\Metrics\MeterProvider` references a deleted container when it executes after `\Shopware\Tests\Integration\Core\Framework\Plugin\PluginManagementServiceTest`

`\Shopware\Core\DevOps\StaticAnalyze\StaticAnalyzeKernel` `getCacheDir` returns same directory as normal test container, when it is deleted, the live test container is also deleted. 

### 2. What does this change do, exactly?

1. Rescope the static kernel cache dir so it's separate from the normal test one.
2. Reboot the test container in `\Shopware\Tests\Integration\Core\Framework\Plugin\PluginManagementServiceTest` on `tearDown` so `MeterProvider` gets binded with correct container for subsequent tests.

### 3. Describe each step to reproduce the issue or behaviour.

https://github.com/shopware/shopware/pull/6059 

Specifically when `\Shopware\Tests\Integration\Core\Framework\Plugin\PluginManagementServiceTest` runs before `MySQLInvalidatorStorageTest`

This was pure pain and suffering.