### PR TITLE
chore: experiment for unchanged files preview

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -69,13 +69,13 @@ jobs:
       - name: Generate Schema
         run: composer run framework:schema:dump
 
-#      - name: "Restore result cache"
-#        uses: actions/cache/restore@v4
-#        with:
-#          path: var/cache/phpstan
-#          key: "phpstan-result-cache-${{ github.run_id }}"
-#          restore-keys: |
-#            phpstan-result-cache-
+      - name: "Restore result cache"
+        uses: actions/cache/restore@v4
+        with:
+          path: var/cache/phpstan
+          key: "phpstan-result-cache-${{ github.run_id }}"
+          restore-keys: |
+            phpstan-result-cache-
 
       - name: PHPStan
         run: composer run phpstan -- --error-format=table --no-progress

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -69,16 +69,16 @@ jobs:
       - name: Generate Schema
         run: composer run framework:schema:dump
 
-      - name: "Restore result cache"
-        uses: actions/cache/restore@v4
-        with:
-          path: var/cache/phpstan
-          key: "phpstan-result-cache-${{ github.run_id }}"
-          restore-keys: |
-            phpstan-result-cache-
+#      - name: "Restore result cache"
+#        uses: actions/cache/restore@v4
+#        with:
+#          path: var/cache/phpstan
+#          key: "phpstan-result-cache-${{ github.run_id }}"
+#          restore-keys: |
+#            phpstan-result-cache-
 
       - name: PHPStan
-        run: composer run phpstan -- --error-format=github --no-progress
+        run: composer run phpstan -- --error-format=table --no-progress
 
       - name: "Save result cache"
         uses: actions/cache/save@v4

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,4612 +1,5611 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Cart\\\\CartException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 1
+			path: src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
+
+		-
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Cart\\CartException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/Checkout/Cart/Order/Api/OrderRecalculationController.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\Transformer\\\\AddressTransformer\\:\\:transform\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\Order\\Transformer\\AddressTransformer\:\:transform\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/Order/Transformer/AddressTransformer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\Transformer\\\\AddressTransformer\\:\\:transformCollection\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\Order\\Transformer\\AddressTransformer\:\:transformCollection\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/Order/Transformer/AddressTransformer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\Transformer\\\\CustomerTransformer\\:\\:transform\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\Order\\Transformer\\CustomerTransformer\:\:transform\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/Order/Transformer/CustomerTransformer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Order\\\\Transformer\\\\CustomerTransformer\\:\\:transformCollection\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\Order\\Transformer\\CustomerTransformer\:\:transformCollection\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/Order/Transformer/CustomerTransformer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\PriceDefinitionInterface\\:\\:getConstraints\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\Price\\Struct\\PriceDefinitionInterface\:\:getConstraints\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/Price/Struct/PriceDefinitionInterface.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\QuantityPriceDefinition\\:\\:fromArray\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\Price\\Struct\\QuantityPriceDefinition\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\QuantityPriceDefinition\\:\\:getConstraints\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\Price\\Struct\\QuantityPriceDefinition\:\:getConstraints\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\PriceDefinitionFactory\\:\\:factory\\(\\) has parameter \\$priceDefinition with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\PriceDefinitionFactory\:\:factory\(\) has parameter \$priceDefinition with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/PriceDefinitionFactory.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 1
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 2
 			path: src/Core/Checkout/Cart/PriceDefinitionFactory.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Cart/Rule/CartVolumeRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Cart/Rule/LineItemActualStockRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 1
+			path: src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+
+		-
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Cart/Rule/LineItemStockRule.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\SalesChannel\\\\AbstractCartItemAddRoute\\:\\:add\\(\\) has parameter \\$items with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\SalesChannel\\AbstractCartItemAddRoute\:\:add\(\) has parameter \$items with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/SalesChannel/AbstractCartItemAddRoute.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Tax\\\\Struct\\\\TaxRule\\:\\:getConstraints\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\Tax\\Struct\\TaxRule\:\:getConstraints\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/Tax/Struct/TaxRule.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Validator\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Cart\\Validator\:\:validate\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Cart/Validator.php
 
 		-
-			message: "#^Parameter \\#2 \\$customerGroup of class Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerGroupRegistrationAccepted constructor expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerGroup\\\\CustomerGroupEntity, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity given\\.$#"
+			message: '#^Parameter \#2 \$customerGroup of class Shopware\\Core\\Checkout\\Customer\\Event\\CustomerGroupRegistrationAccepted constructor expects Shopware\\Core\\Checkout\\Customer\\Aggregate\\CustomerGroup\\CustomerGroupEntity, Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Checkout/Customer/Api/CustomerGroupRegistrationActionController.php
 
 		-
-			message: "#^Parameter \\#2 \\$customerGroup of class Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerGroupRegistrationDeclined constructor expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Aggregate\\\\CustomerGroup\\\\CustomerGroupEntity, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity given\\.$#"
+			message: '#^Parameter \#2 \$customerGroup of class Shopware\\Core\\Checkout\\Customer\\Event\\CustomerGroupRegistrationDeclined constructor expects Shopware\\Core\\Checkout\\Customer\\Aggregate\\CustomerGroup\\CustomerGroupEntity, Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Checkout/Customer/Api/CustomerGroupRegistrationActionController.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Checkout/Customer/CustomerValueResolver.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Event/CustomerBeforeLoginEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Customer\\Event\\CustomerIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Customer/Event/CustomerIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerIndexerEvent\\:\\:__construct\\(\\) has parameter \\$skip with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Customer\\Event\\CustomerIndexerEvent\:\:__construct\(\) has parameter \$skip with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Customer/Event/CustomerIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Customer\\Event\\CustomerIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Customer/Event/CustomerIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\CustomerIndexerEvent\\:\\:getSkip\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Customer\\Event\\CustomerIndexerEvent\:\:getSkip\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Customer/Event/CustomerIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\WishlistMergedEvent\\:\\:__construct\\(\\) has parameter \\$product with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Customer\\Event\\WishlistMergedEvent\:\:__construct\(\) has parameter \$product with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Customer/Event/WishlistMergedEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\WishlistMergedEvent\\:\\:getProducts\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Customer\\Event\\WishlistMergedEvent\:\:getProducts\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Customer/Event/WishlistMergedEvent.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\WishlistMergedEvent\\:\\:\\$products type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Checkout\\Customer\\Event\\WishlistMergedEvent\:\:\$products type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Customer/Event/WishlistMergedEvent.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/AffiliateCodeRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/BillingCityRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/BillingStreetRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/CampaignCodeRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/CustomerAgeRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/CustomerBirthdayRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/CustomerNumberRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 2
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 3
 			path: src/Core/Checkout/Customer/Rule/EmailRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/LastNameRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/ShippingCityRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/ShippingStreetRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/SalesChannel/AddWishlistProductRoute.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/SalesChannel/ChangePaymentMethodRoute.php
 
 		-
-			message: "#^Parameter \\#1 \\$object of class Shopware\\\\Core\\\\Checkout\\\\Customer\\\\SalesChannel\\\\CustomerResponse constructor expects Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\|null given\\.$#"
+			message: '#^Parameter \#1 \$object of class Shopware\\Core\\Checkout\\Customer\\SalesChannel\\CustomerResponse constructor expects Shopware\\Core\\Checkout\\Customer\\CustomerEntity, Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Checkout/Customer/SalesChannel/CustomerRoute.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Customer\\CustomerException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/SalesChannel/DownloadRoute.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerEmailUnique.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerEmailUniqueValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerPasswordMatches.php
 
 		-
-			message: "#^Cannot call method getEmail\\(\\) on Shopware\\\\Core\\\\Checkout\\\\Customer\\\\CustomerEntity\\|null\\.$#"
+			message: '#^Cannot call method getEmail\(\) on Shopware\\Core\\Checkout\\Customer\\CustomerEntity\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerPasswordMatchesValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerVatIdentification.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerVatIdentificationValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerZipCodeValidator.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Document\\DocumentException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Document/Controller/DocumentController.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfigurationFactory\\:\\:cleanConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Document\\DocumentConfigurationFactory\:\:cleanConfig\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Document/DocumentConfigurationFactory.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfigurationFactory\\:\\:cleanConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Document\\DocumentConfigurationFactory\:\:cleanConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Document/DocumentConfigurationFactory.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfigurationFactory\\:\\:createConfiguration\\(\\) has parameter \\$specificConfig with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Document\\DocumentConfigurationFactory\:\:createConfiguration\(\) has parameter \$specificConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Document/DocumentConfigurationFactory.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfigurationFactory\\:\\:mergeConfiguration\\(\\) has parameter \\$additionalConfig with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Document\\DocumentConfigurationFactory\:\:mergeConfiguration\(\) has parameter \$additionalConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Document/DocumentConfigurationFactory.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Document\\DocumentException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Document/DocumentGeneratorController.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\Event\\\\DocumentTemplateRendererParameterEvent\\:\\:__construct\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Document\\Event\\DocumentTemplateRendererParameterEvent\:\:__construct\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Document/Event/DocumentTemplateRendererParameterEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\Event\\\\DocumentTemplateRendererParameterEvent\\:\\:getParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Document\\Event\\DocumentTemplateRendererParameterEvent\:\:getParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Document/Event/DocumentTemplateRendererParameterEvent.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentException, got Shopware\\\\Core\\\\Checkout\\\\Cart\\\\CartException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Document\\DocumentException, got Shopware\\Core\\Checkout\\Cart\\CartException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Document/SalesChannel/DocumentRoute.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 5
 			path: src/Core/Checkout/Document/Service/DocumentGenerator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerEntity\\:\\:getVatIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Order\\Aggregate\\OrderCustomer\\OrderCustomerEntity\:\:getVatIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Order/Aggregate/OrderCustomer/OrderCustomerEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Order\\\\Aggregate\\\\OrderCustomer\\\\OrderCustomerEntity\\:\\:\\$vatIds type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Checkout\\Order\\Aggregate\\OrderCustomer\\OrderCustomerEntity\:\:\$vatIds type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Order/Aggregate/OrderCustomer/OrderCustomerEntity.php
 
 		-
-			message: "#^Cannot call method getTechnicalName\\(\\) on Shopware\\\\Core\\\\System\\\\StateMachine\\\\Aggregation\\\\StateMachineState\\\\StateMachineStateEntity\\|null\\.$#"
+			message: '#^Cannot call method getTechnicalName\(\) on Shopware\\Core\\System\\StateMachine\\Aggregation\\StateMachineState\\StateMachineStateEntity\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Core/Checkout/Order/Aggregate/OrderTransaction/OrderTransactionCollection.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Order/Event/OrderPaymentMethodChangedEvent.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Order/Event/OrderStateMachineStateChangeEvent.php
 
 		-
-			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getOrder\\(\\)\\.$#"
+			message: '#^Call to an undefined method Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity\:\:getOrder\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
 
 		-
-			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getOrderId\\(\\)\\.$#"
+			message: '#^Call to an undefined method Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity\:\:getOrderId\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
 
 		-
-			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getPaymentMethod\\(\\)\\.$#"
+			message: '#^Call to an undefined method Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity\:\:getPaymentMethod\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Core/Checkout/Order/Listener/OrderStateChangeEventListener.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Order\\OrderException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Order/SalesChannel/CancelOrderRoute.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderException, got Shopware\\\\Core\\\\Checkout\\\\Cart\\\\CartException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Order\\OrderException, got Shopware\\Core\\Checkout\\Cart\\CartException$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Checkout/Order/SalesChannel/OrderRoute.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Checkout/Order/SalesChannel/OrderRoute.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderException, got Shopware\\\\Core\\\\System\\\\StateMachine\\\\StateMachineException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Order\\OrderException, got Shopware\\Core\\System\\StateMachine\\StateMachineException$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Checkout/Order/SalesChannel/OrderService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Order/SalesChannel/OrderService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Checkout/Order/SalesChannel/SetPaymentOrderRoute.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Payment\\\\PaymentException, got Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Payment\\PaymentException, got Shopware\\Core\\Checkout\\Order\\OrderException$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Checkout/Payment/Cart/PaymentRecurringProcessor.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Payment\\\\PaymentException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Payment\\PaymentException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Payment/Controller/PaymentController.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Event\\\\PaymentMethodIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Payment\\Event\\PaymentMethodIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Payment/Event/PaymentMethodIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Event\\\\PaymentMethodIndexerEvent\\:\\:__construct\\(\\) has parameter \\$skip with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Payment\\Event\\PaymentMethodIndexerEvent\:\:__construct\(\) has parameter \$skip with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Payment/Event/PaymentMethodIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Event\\\\PaymentMethodIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Payment\\Event\\PaymentMethodIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Payment/Event/PaymentMethodIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Payment\\\\Event\\\\PaymentMethodIndexerEvent\\:\\:getSkip\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Payment\\Event\\PaymentMethodIndexerEvent\:\:getSkip\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Payment/Event/PaymentMethodIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Aggregate\\\\PromotionIndividualCode\\\\PromotionIndividualCodeCollection\\:\\:getCodeArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\Aggregate\\PromotionIndividualCode\\PromotionIndividualCodeCollection\:\:getCodeArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/Aggregate/PromotionIndividualCode/PromotionIndividualCodeCollection.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\PromotionException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Checkout\\Promotion\\PromotionException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Checkout/Promotion/Api/PromotionController.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\Discount\\\\Composition\\\\DiscountCompositionBuilder\\:\\:adjustCompositionItemValues\\(\\) has parameter \\$targetItems with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\Cart\\Discount\\Composition\\DiscountCompositionBuilder\:\:adjustCompositionItemValues\(\) has parameter \$targetItems with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/Cart/Discount/Composition/DiscountCompositionBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\Discount\\\\Composition\\\\DiscountCompositionBuilder\\:\\:adjustCompositionItemValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\Cart\\Discount\\Composition\\DiscountCompositionBuilder\:\:adjustCompositionItemValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/Cart/Discount/Composition/DiscountCompositionBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\Discount\\\\Composition\\\\DiscountCompositionBuilder\\:\\:aggregateCompositionItems\\(\\) has parameter \\$items with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\Cart\\Discount\\Composition\\DiscountCompositionBuilder\:\:aggregateCompositionItems\(\) has parameter \$items with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/Cart/Discount/Composition/DiscountCompositionBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\Discount\\\\Composition\\\\DiscountCompositionBuilder\\:\\:aggregateCompositionItems\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\Cart\\Discount\\Composition\\DiscountCompositionBuilder\:\:aggregateCompositionItems\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/Cart/Discount/Composition/DiscountCompositionBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\Discount\\\\Composition\\\\DiscountCompositionBuilder\\:\\:buildCompositionPayload\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\Cart\\Discount\\Composition\\DiscountCompositionBuilder\:\:buildCompositionPayload\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/Cart/Discount/Composition/DiscountCompositionBuilder.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Checkout/Promotion/Cart/Discount/DiscountPackage.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\Discount\\\\Filter\\\\AdvancedPackageFilter\\:\\:collectPackageItems\\(\\) has parameter \\$applierIndexes with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\Cart\\Discount\\Filter\\AdvancedPackageFilter\:\:collectPackageItems\(\) has parameter \$applierIndexes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/Cart/Discount/Filter/AdvancedPackageFilter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\Discount\\\\Filter\\\\Applier\\\\Applier\\:\\:findIndexes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\Cart\\Discount\\Filter\\Applier\\Applier\:\:findIndexes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/Cart/Discount/Filter/Applier/Applier.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Checkout/Promotion/Cart/Discount/Filter/FilterServiceRegistry.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\PromotionCartAddedInformationError\\:\\:\\$name \\(string\\) does not accept string\\|null\\.$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 2
+			path: src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+
+		-
+			message: '#^Property Shopware\\Core\\Checkout\\Promotion\\Cart\\PromotionCartAddedInformationError\:\:\$name \(string\) does not accept string\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/Core/Checkout/Promotion/Cart/PromotionCartAddedInformationError.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\Cart\\\\PromotionCartDeletedInformationError\\:\\:\\$name \\(string\\) does not accept string\\|null\\.$#"
+			message: '#^Property Shopware\\Core\\Checkout\\Promotion\\Cart\\PromotionCartDeletedInformationError\:\:\$name \(string\) does not accept string\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/Core/Checkout/Promotion/Cart/PromotionCartDeletedInformationError.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\DataAbstractionLayer\\\\PromotionExclusionUpdater\\:\\:addToJSON\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\DataAbstractionLayer\\PromotionExclusionUpdater\:\:addToJSON\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\DataAbstractionLayer\\\\PromotionExclusionUpdater\\:\\:convertHexArrayToByteArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\DataAbstractionLayer\\PromotionExclusionUpdater\:\:convertHexArrayToByteArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\DataAbstractionLayer\\\\PromotionExclusionUpdater\\:\\:getExclusionIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\DataAbstractionLayer\\PromotionExclusionUpdater\:\:getExclusionIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\DataAbstractionLayer\\\\PromotionExclusionUpdater\\:\\:getExistingIds\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\DataAbstractionLayer\\PromotionExclusionUpdater\:\:getExistingIds\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\DataAbstractionLayer\\\\PromotionExclusionUpdater\\:\\:getExistingIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\DataAbstractionLayer\\PromotionExclusionUpdater\:\:getExistingIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Promotion\\\\DataAbstractionLayer\\\\PromotionExclusionUpdater\\:\\:update\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Checkout\\Promotion\\DataAbstractionLayer\\PromotionExclusionUpdater\:\:update\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Checkout/Promotion/DataAbstractionLayer/PromotionExclusionUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSlotTranslation\\\\CmsSlotTranslationEntity\\:\\:getConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Cms\\Aggregate\\CmsSlotTranslation\\CmsSlotTranslationEntity\:\:getConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSlotTranslation\\\\CmsSlotTranslationEntity\\:\\:setConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Cms\\Aggregate\\CmsSlotTranslation\\CmsSlotTranslationEntity\:\:setConfig\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Cms\\\\Aggregate\\\\CmsSlotTranslation\\\\CmsSlotTranslationEntity\\:\\:\\$config type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Cms\\Aggregate\\CmsSlotTranslation\\CmsSlotTranslationEntity\:\:\$config type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Cms/Aggregate/CmsSlotTranslation/CmsSlotTranslationEntity.php
 
 		-
-			message: "#^Parameter \\#1 \\$object of class Shopware\\\\Core\\\\Content\\\\Cms\\\\SalesChannel\\\\CmsRouteResponse constructor expects Shopware\\\\Core\\\\Content\\\\Cms\\\\CmsPageEntity, Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity given\\.$#"
+			message: '#^Parameter \#1 \$object of class Shopware\\Core\\Content\\Cms\\SalesChannel\\CmsRouteResponse constructor expects Shopware\\Core\\Content\\Cms\\CmsPageEntity, Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Content/Cms/SalesChannel/CmsRoute.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Cms/SalesChannel/CmsRoute.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\SalesChannel\\\\Struct\\\\ImageSliderStruct\\:\\:getNavigation\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Cms\\SalesChannel\\Struct\\ImageSliderStruct\:\:getNavigation\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Cms/SalesChannel/Struct/ImageSliderStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Cms\\\\SalesChannel\\\\Struct\\\\ImageSliderStruct\\:\\:setNavigation\\(\\) has parameter \\$navigation with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Cms\\SalesChannel\\Struct\\ImageSliderStruct\:\:setNavigation\(\) has parameter \$navigation with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Cms/SalesChannel/Struct/ImageSliderStruct.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Cms\\\\SalesChannel\\\\Struct\\\\ImageSliderStruct\\:\\:\\$navigation type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Cms\\SalesChannel\\Struct\\ImageSliderStruct\:\:\$navigation type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Cms/SalesChannel/Struct/ImageSliderStruct.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Content/Cms/Subscriber/CmsPageDefaultChangeSubscriber.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Content\\\\Flow\\\\FlowException, got Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\DataAbstractionLayerException$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 1
+			path: src/Core/Content/Flow/Controller/TriggerFlowController.php
+
+		-
+			message: '#^Expected domain exception class Shopware\\Core\\Content\\Flow\\FlowException, got Shopware\\Core\\Framework\\DataAbstractionLayer\\DataAbstractionLayerException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Flow/DataAbstractionLayer/FieldSerializer/FlowTemplateConfigFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\AbstractFlowLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\AbstractFlowLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/AbstractFlowLoader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Content/Flow/Dispatching/Action/SendMailAction.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Content\\\\Flow\\\\FlowException, got Shopware\\\\Core\\\\System\\\\StateMachine\\\\StateMachineException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Content\\Flow\\FlowException, got Shopware\\Core\\System\\StateMachine\\StateMachineException$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Content/Flow/Dispatching/Action/SetOrderStateAction.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\CachedFlowLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\CachedFlowLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/CachedFlowLoader.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\CachedFlowLoader\\:\\:\\$flows type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Flow\\Dispatching\\CachedFlowLoader\:\:\$flows type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/CachedFlowLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\FlowBuilder\\:\\:build\\(\\) has parameter \\$flowSequences with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:build\(\) has parameter \$flowSequences with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\FlowBuilder\\:\\:buildHierarchyTree\\(\\) has parameter \\$flowSequences with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:buildHierarchyTree\(\) has parameter \$flowSequences with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\FlowBuilder\\:\\:buildHierarchyTree\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:buildHierarchyTree\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\FlowBuilder\\:\\:createNestedAction\\(\\) has parameter \\$currentSequence with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:createNestedAction\(\) has parameter \$currentSequence with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\FlowBuilder\\:\\:createNestedAction\\(\\) has parameter \\$siblingSequences with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:createNestedAction\(\) has parameter \$siblingSequences with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\FlowBuilder\\:\\:createNestedIf\\(\\) has parameter \\$currentSequence with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:createNestedIf\(\) has parameter \$currentSequence with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\FlowBuilder\\:\\:createNestedSequence\\(\\) has parameter \\$sequence with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:createNestedSequence\(\) has parameter \$sequence with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\FlowBuilder\\:\\:createNestedSequence\\(\\) has parameter \\$siblings with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\FlowBuilder\:\:createNestedSequence\(\) has parameter \$siblings with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/FlowBuilder.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/FlowExecutor.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/Storer/ScalarValuesStorer.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\Struct\\\\ActionSequence\\:\\:\\$config type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Flow\\Dispatching\\Struct\\ActionSequence\:\:\$config type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/Struct/ActionSequence.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Dispatching\\\\Struct\\\\Sequence\\:\\:createAction\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Dispatching\\Struct\\Sequence\:\:createAction\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Dispatching/Struct/Sequence.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Events\\\\FlowIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Events\\FlowIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Events/FlowIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Events\\\\FlowIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Events\\FlowIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Events/FlowIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Indexing\\\\FlowPayloadUpdater\\:\\:update\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Indexing\\FlowPayloadUpdater\:\:update\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Indexing/FlowPayloadUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Flow\\\\Indexing\\\\FlowPayloadUpdater\\:\\:update\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Flow\\Indexing\\FlowPayloadUpdater\:\:update\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Flow/Indexing/FlowPayloadUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity\\:\\:getConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Aggregate\\ImportExportLog\\ImportExportLogEntity\:\:getConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity\\:\\:getResult\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Aggregate\\ImportExportLog\\ImportExportLogEntity\:\:getResult\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity\\:\\:setConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Aggregate\\ImportExportLog\\ImportExportLogEntity\:\:setConfig\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity\\:\\:setResult\\(\\) has parameter \\$result with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Aggregate\\ImportExportLog\\ImportExportLogEntity\:\:setResult\(\) has parameter \$result with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity\\:\\:\\$config type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\ImportExport\\Aggregate\\ImportExportLog\\ImportExportLogEntity\:\:\$config type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Aggregate\\\\ImportExportLog\\\\ImportExportLogEntity\\:\\:\\$result type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\ImportExport\\Aggregate\\ImportExportLog\\ImportExportLogEntity\:\:\$result type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Aggregate/ImportExportLog/ImportExportLogEntity.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/AbstractEntitySerializer.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/MediaSerializer.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Field/ToOneSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\PrimaryKeyResolver\\:\\:getValueFromPath\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\PrimaryKeyResolver\:\:getValueFromPath\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\PrimaryKeyResolver\\:\\:getValueFromPath\\(\\) has parameter \\$keyPath with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\PrimaryKeyResolver\:\:getValueFromPath\(\) has parameter \$keyPath with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\PrimaryKeyResolver\\:\\:handleManyToManyAssociations\\(\\) has parameter \\$record with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\PrimaryKeyResolver\:\:handleManyToManyAssociations\(\) has parameter \$record with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\PrimaryKeyResolver\\:\\:handleManyToManyAssociations\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\PrimaryKeyResolver\:\:handleManyToManyAssociations\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\PrimaryKeyResolver\\:\\:handleTranslationsAssociation\\(\\) has parameter \\$updateByFieldPath with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\PrimaryKeyResolver\:\:handleTranslationsAssociation\(\) has parameter \$updateByFieldPath with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\PrimaryKeyResolver\\:\\:resolvePrimaryKey\\(\\) has parameter \\$record with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\PrimaryKeyResolver\:\:resolvePrimaryKey\(\) has parameter \$record with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\PrimaryKeyResolver\\:\\:resolvePrimaryKey\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\PrimaryKeyResolver\:\:resolvePrimaryKey\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\PrimaryKeyResolver\\:\\:resolvePrimaryKeyFromUpdatedBy\\(\\) has parameter \\$record with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\PrimaryKeyResolver\:\:resolvePrimaryKeyFromUpdatedBy\(\) has parameter \$record with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\PrimaryKeyResolver\\:\\:resolvePrimaryKeyFromUpdatedBy\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\PrimaryKeyResolver\:\:resolvePrimaryKeyFromUpdatedBy\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/PrimaryKeyResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\SerializerRegistry\\:\\:__construct\\(\\) has parameter \\$entitySerializers with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\SerializerRegistry\:\:__construct\(\) has parameter \$entitySerializers with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/SerializerRegistry.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\SerializerRegistry\\:\\:__construct\\(\\) has parameter \\$fieldSerializers with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\SerializerRegistry\:\:__construct\(\) has parameter \$fieldSerializers with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/SerializerRegistry.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/SerializerRegistry.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportAfterImportRecordEvent\\:\\:__construct\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportAfterImportRecordEvent\:\:__construct\(\) has parameter \$record with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportAfterImportRecordEvent\\:\\:__construct\\(\\) has parameter \\$row with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportAfterImportRecordEvent\:\:__construct\(\) has parameter \$row with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportAfterImportRecordEvent\\:\\:getRecord\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportAfterImportRecordEvent\:\:getRecord\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportAfterImportRecordEvent\\:\\:getRow\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportAfterImportRecordEvent\:\:getRow\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeExportRecordEvent\\:\\:__construct\\(\\) has parameter \\$originalRecord with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeExportRecordEvent\:\:__construct\(\) has parameter \$originalRecord with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeExportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeExportRecordEvent\\:\\:__construct\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeExportRecordEvent\:\:__construct\(\) has parameter \$record with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeExportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeExportRecordEvent\\:\\:getOriginalRecord\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeExportRecordEvent\:\:getOriginalRecord\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeExportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeExportRecordEvent\\:\\:getRecord\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeExportRecordEvent\:\:getRecord\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeExportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeExportRecordEvent\\:\\:setRecord\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeExportRecordEvent\:\:setRecord\(\) has parameter \$record with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeExportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeImportRecordEvent\\:\\:__construct\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeImportRecordEvent\:\:__construct\(\) has parameter \$record with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeImportRecordEvent\\:\\:__construct\\(\\) has parameter \\$row with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeImportRecordEvent\:\:__construct\(\) has parameter \$row with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeImportRecordEvent\\:\\:getRecord\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeImportRecordEvent\:\:getRecord\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeImportRecordEvent\\:\\:getRow\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeImportRecordEvent\:\:getRow\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeImportRecordEvent\\:\\:setRecord\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeImportRecordEvent\:\:setRecord\(\) has parameter \$record with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeImportRowEvent\\:\\:__construct\\(\\) has parameter \\$row with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeImportRowEvent\:\:__construct\(\) has parameter \$row with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeImportRowEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeImportRowEvent\\:\\:getRow\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeImportRowEvent\:\:getRow\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeImportRowEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportBeforeImportRowEvent\\:\\:setRow\\(\\) has parameter \\$row with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportBeforeImportRowEvent\:\:setRow\(\) has parameter \$row with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportBeforeImportRowEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportExceptionImportRecordEvent\\:\\:__construct\\(\\) has parameter \\$record with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportExceptionImportRecordEvent\:\:__construct\(\) has parameter \$record with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportExceptionImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportExceptionImportRecordEvent\\:\\:__construct\\(\\) has parameter \\$row with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportExceptionImportRecordEvent\:\:__construct\(\) has parameter \$row with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportExceptionImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportExceptionImportRecordEvent\\:\\:getRecord\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportExceptionImportRecordEvent\:\:getRecord\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportExceptionImportRecordEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Event\\\\ImportExportExceptionImportRecordEvent\\:\\:getRow\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Event\\ImportExportExceptionImportRecordEvent\:\:getRow\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Event/ImportExportExceptionImportRecordEvent.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/ImportExport/Event/Subscriber/ProductVariantsSubscriber.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Exception\\\\DeleteDefaultProfileException\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Exception\\DeleteDefaultProfileException\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Exception/DeleteDefaultProfileException.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Exception\\\\LogNotWritableException\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Exception\\LogNotWritableException\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Exception/LogNotWritableException.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Message\\\\DeleteFileMessage\\:\\:getFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Message\\DeleteFileMessage\:\:getFiles\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Message/DeleteFileMessage.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Message\\\\DeleteFileMessage\\:\\:setFiles\\(\\) has parameter \\$files with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Message\\DeleteFileMessage\:\:setFiles\(\) has parameter \$files with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Message/DeleteFileMessage.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Message\\\\DeleteFileMessage\\:\\:\\$files type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\ImportExport\\Message\\DeleteFileMessage\:\:\$files type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Message/DeleteFileMessage.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Mapping/Mapping.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Mapping\\\\UpdateBy\\:\\:fromArray\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Mapping\\UpdateBy\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Mapping/UpdateBy.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Mapping/UpdateBy.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Mapping\\\\UpdateByCollection\\:\\:fromIterable\\(\\) has parameter \\$data with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Mapping\\UpdateByCollection\:\:fromIterable\(\) has parameter \$data with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Mapping/UpdateByCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\AbstractPipe\\:\\:in\\(\\) has parameter \\$record with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\AbstractPipe\:\:in\(\) has parameter \$record with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/AbstractPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\AbstractPipe\\:\\:in\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\AbstractPipe\:\:in\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/AbstractPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\AbstractPipe\\:\\:out\\(\\) has parameter \\$record with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\AbstractPipe\:\:out\(\) has parameter \$record with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/AbstractPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\AbstractPipe\\:\\:out\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\AbstractPipe\:\:out\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/AbstractPipe.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/AbstractPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\ChainPipe\\:\\:in\\(\\) has parameter \\$record with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\ChainPipe\:\:in\(\) has parameter \$record with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/ChainPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\ChainPipe\\:\\:in\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\ChainPipe\:\:in\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/ChainPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\ChainPipe\\:\\:out\\(\\) has parameter \\$record with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\ChainPipe\:\:out\(\) has parameter \$record with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/ChainPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\ChainPipe\\:\\:out\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\ChainPipe\:\:out\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/ChainPipe.php
 
 		-
-			message: "#^Cannot call method deserialize\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\AbstractEntitySerializer\\|null\\.$#"
+			message: '#^Cannot call method deserialize\(\) on Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\Entity\\AbstractEntitySerializer\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
 
 		-
-			message: "#^Cannot call method serialize\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\DataAbstractionLayer\\\\Serializer\\\\Entity\\\\AbstractEntitySerializer\\|null\\.$#"
+			message: '#^Cannot call method serialize\(\) on Shopware\\Core\\Content\\ImportExport\\DataAbstractionLayer\\Serializer\\Entity\\AbstractEntitySerializer\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\EntityPipe\\:\\:in\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\EntityPipe\:\:in\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\EntityPipe\\:\\:out\\(\\) has parameter \\$record with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\EntityPipe\:\:out\(\) has parameter \$record with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Pipe\\\\EntityPipe\\:\\:out\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Pipe\\EntityPipe\:\:out\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Pipe/EntityPipe.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Processing\\\\Reader\\\\AbstractReader\\:\\:read\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Processing\\Reader\\AbstractReader\:\:read\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Reader/AbstractReader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Reader/AbstractReader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Reader/CsvReader.php
 
 		-
-			message: "#^Cannot call method getFileType\\(\\) on Shopware\\\\Core\\\\Content\\\\ImportExport\\\\ImportExportProfileEntity\\|null\\.$#"
+			message: '#^Cannot call method getFileType\(\) on Shopware\\Core\\Content\\ImportExport\\ImportExportProfileEntity\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Core/Content/ImportExport/Processing/Reader/CsvReaderFactory.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\ImportExport\\\\Service\\\\AbstractFileService\\:\\:updateFile\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\ImportExport\\Service\\AbstractFileService\:\:updateFile\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/ImportExport/Service/AbstractFileService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Content/ImportExport/Service/SupportedFeaturesService.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\LandingPage\\\\Aggregate\\\\LandingPageTranslation\\\\LandingPageTranslationEntity\\:\\:getSlotConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\LandingPage\\Aggregate\\LandingPageTranslation\\LandingPageTranslationEntity\:\:getSlotConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\LandingPage\\\\Aggregate\\\\LandingPageTranslation\\\\LandingPageTranslationEntity\\:\\:setSlotConfig\\(\\) has parameter \\$slotConfig with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\LandingPage\\Aggregate\\LandingPageTranslation\\LandingPageTranslationEntity\:\:setSlotConfig\(\) has parameter \$slotConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\LandingPage\\\\Aggregate\\\\LandingPageTranslation\\\\LandingPageTranslationEntity\\:\\:\\$slotConfig type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\LandingPage\\Aggregate\\LandingPageTranslation\\LandingPageTranslationEntity\:\:\$slotConfig type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/Aggregate/LandingPageTranslation/LandingPageTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\LandingPage\\\\Event\\\\LandingPageIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\LandingPage\\Event\\LandingPageIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/Event/LandingPageIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\LandingPage\\\\Event\\\\LandingPageIndexerEvent\\:\\:__construct\\(\\) has parameter \\$skip with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\LandingPage\\Event\\LandingPageIndexerEvent\:\:__construct\(\) has parameter \$skip with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/Event/LandingPageIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\LandingPage\\\\Event\\\\LandingPageIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\LandingPage\\Event\\LandingPageIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/Event/LandingPageIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\LandingPage\\\\Event\\\\LandingPageIndexerEvent\\:\\:getSkip\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\LandingPage\\Event\\LandingPageIndexerEvent\:\:getSkip\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/Event/LandingPageIndexerEvent.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\LandingPage\\\\Event\\\\LandingPageIndexerEvent\\:\\:\\$ids type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\LandingPage\\Event\\LandingPageIndexerEvent\:\:\$ids type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/Event/LandingPageIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\LandingPage\\\\Event\\\\LandingPageRouteCacheTagsEvent\\:\\:__construct\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\LandingPage\\Event\\LandingPageRouteCacheTagsEvent\:\:__construct\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/Event/LandingPageRouteCacheTagsEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\LandingPage\\\\LandingPageEntity\\:\\:getSlotConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\LandingPage\\LandingPageEntity\:\:getSlotConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/LandingPageEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\LandingPage\\\\LandingPageEntity\\:\\:setSlotConfig\\(\\) has parameter \\$slotConfig with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\LandingPage\\LandingPageEntity\:\:setSlotConfig\(\) has parameter \$slotConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/LandingPageEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\LandingPage\\\\LandingPageEntity\\:\\:\\$slotConfig type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\LandingPage\\LandingPageEntity\:\:\$slotConfig type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/LandingPage/LandingPageEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Mail\\\\Service\\\\AbstractMailService\\:\\:send\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Mail\\Service\\AbstractMailService\:\:send\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Mail/Service/AbstractMailService.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Mail\\\\Service\\\\AbstractMailService\\:\\:send\\(\\) has parameter \\$templateData with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Mail\\Service\\AbstractMailService\:\:send\(\) has parameter \$templateData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Mail/Service/AbstractMailService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Mail/Service/MailService.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Aggregate\\\\MailTemplateType\\\\MailTemplateTypeEntity\\:\\:getAvailableEntities\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\MailTemplate\\Aggregate\\MailTemplateType\\MailTemplateTypeEntity\:\:getAvailableEntities\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Aggregate\\\\MailTemplateType\\\\MailTemplateTypeEntity\\:\\:getTemplateData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\MailTemplate\\Aggregate\\MailTemplateType\\MailTemplateTypeEntity\:\:getTemplateData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Aggregate\\\\MailTemplateType\\\\MailTemplateTypeEntity\\:\\:setAvailableEntities\\(\\) has parameter \\$availableEntities with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\MailTemplate\\Aggregate\\MailTemplateType\\MailTemplateTypeEntity\:\:setAvailableEntities\(\) has parameter \$availableEntities with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Aggregate\\\\MailTemplateType\\\\MailTemplateTypeEntity\\:\\:setTemplateData\\(\\) has parameter \\$templateData with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\MailTemplate\\Aggregate\\MailTemplateType\\MailTemplateTypeEntity\:\:setTemplateData\(\) has parameter \$templateData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Aggregate\\\\MailTemplateType\\\\MailTemplateTypeEntity\\:\\:\\$availableEntities type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\MailTemplate\\Aggregate\\MailTemplateType\\MailTemplateTypeEntity\:\:\$availableEntities type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Aggregate\\\\MailTemplateType\\\\MailTemplateTypeEntity\\:\\:\\$templateData type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\MailTemplate\\Aggregate\\MailTemplateType\\MailTemplateTypeEntity\:\:\$templateData type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/MailTemplate/Aggregate/MailTemplateType/MailTemplateTypeEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\MailTemplate\\\\Exception\\\\MailTransportFailedException\\:\\:__construct\\(\\) has parameter \\$failedRecipients with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\MailTemplate\\Exception\\MailTransportFailedException\:\:__construct\(\) has parameter \$failedRecipients with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/MailTemplate/Exception/MailTransportFailedException.php
 
 		-
-			message: "#^Mixed variable in a `\\$sliderItems\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$sliderItems\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 2
 			path: src/Core/Content/Media/Cms/Type/ImageSliderTypeDataResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaFolderConfigurationIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 1
+			path: src/Core/Content/Media/Core/Application/AbstractMediaPathStrategy.php
+
+		-
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaFolderConfigurationIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaFolderConfigurationIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaFolderConfigurationIndexerEvent\\:\\:__construct\\(\\) has parameter \\$skip with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaFolderConfigurationIndexerEvent\:\:__construct\(\) has parameter \$skip with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaFolderConfigurationIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaFolderConfigurationIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaFolderConfigurationIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaFolderConfigurationIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaFolderConfigurationIndexerEvent\\:\\:getSkip\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaFolderConfigurationIndexerEvent\:\:getSkip\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaFolderConfigurationIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaFolderIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaFolderIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaFolderIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaFolderIndexerEvent\\:\\:__construct\\(\\) has parameter \\$skip with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaFolderIndexerEvent\:\:__construct\(\) has parameter \$skip with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaFolderIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaFolderIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaFolderIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaFolderIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaFolderIndexerEvent\\:\\:getSkip\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaFolderIndexerEvent\:\:getSkip\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaFolderIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaIndexerEvent\\:\\:__construct\\(\\) has parameter \\$skip with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaIndexerEvent\:\:__construct\(\) has parameter \$skip with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Event\\\\MediaIndexerEvent\\:\\:getSkip\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Event\\MediaIndexerEvent\:\:getSkip\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Event/MediaIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\MediaType\\\\MediaType\\:\\:addFlags\\(\\) has parameter \\$flags with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\MediaType\\MediaType\:\:addFlags\(\) has parameter \$flags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/MediaType/MediaType.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\MediaType\\\\MediaType\\:\\:getFlags\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\MediaType\\MediaType\:\:getFlags\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/MediaType/MediaType.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Message\\\\DeleteFileMessage\\:\\:__construct\\(\\) has parameter \\$files with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Message\\DeleteFileMessage\:\:__construct\(\) has parameter \$files with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Message/DeleteFileMessage.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Message\\\\DeleteFileMessage\\:\\:getFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Message\\DeleteFileMessage\:\:getFiles\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Message/DeleteFileMessage.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Message\\\\DeleteFileMessage\\:\\:setFiles\\(\\) has parameter \\$files with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Message\\DeleteFileMessage\:\:setFiles\(\) has parameter \$files with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Message/DeleteFileMessage.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\Metadata\\\\MetadataLoader\\:\\:loadFromFile\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\Metadata\\MetadataLoader\:\:loadFromFile\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Media/Metadata/MetadataLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Media\\\\TypeDetector\\\\TypeDetector\\:\\:detect\\(\\) should return Shopware\\\\Core\\\\Content\\\\Media\\\\MediaType\\\\MediaType but returns Shopware\\\\Core\\\\Content\\\\Media\\\\MediaType\\\\MediaType\\|null\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Media\\TypeDetector\\TypeDetector\:\:detect\(\) should return Shopware\\Core\\Content\\Media\\MediaType\\MediaType but returns Shopware\\Core\\Content\\Media\\MediaType\\MediaType\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Core/Content/Media/TypeDetector/TypeDetector.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Newsletter\\\\Event\\\\NewsletterRecipientIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Newsletter\\Event\\NewsletterRecipientIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Newsletter/Event/NewsletterRecipientIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Newsletter\\\\Event\\\\NewsletterRecipientIndexerEvent\\:\\:__construct\\(\\) has parameter \\$skip with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Newsletter\\Event\\NewsletterRecipientIndexerEvent\:\:__construct\(\) has parameter \$skip with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Newsletter/Event/NewsletterRecipientIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Newsletter\\\\Event\\\\NewsletterRecipientIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Newsletter\\Event\\NewsletterRecipientIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Newsletter/Event/NewsletterRecipientIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Newsletter\\\\Event\\\\NewsletterRecipientIndexerEvent\\:\\:getSkip\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Newsletter\\Event\\NewsletterRecipientIndexerEvent\:\:getSkip\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Newsletter/Event/NewsletterRecipientIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Newsletter\\\\Event\\\\NewsletterSubscribeUrlEvent\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Newsletter\\Event\\NewsletterSubscribeUrlEvent\:\:__construct\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Newsletter\\\\Event\\\\NewsletterSubscribeUrlEvent\\:\\:getData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Newsletter\\Event\\NewsletterSubscribeUrlEvent\:\:getData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Newsletter/Event/NewsletterSubscribeUrlEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductFeatureSet\\\\ProductFeatureSetEntity\\:\\:getFeatures\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Aggregate\\ProductFeatureSet\\ProductFeatureSetEntity\:\:getFeatures\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductFeatureSet\\\\ProductFeatureSetEntity\\:\\:setFeatures\\(\\) has parameter \\$features with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Aggregate\\ProductFeatureSet\\ProductFeatureSetEntity\:\:setFeatures\(\) has parameter \$features with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductFeatureSet\\\\ProductFeatureSetEntity\\:\\:\\$features type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Product\\Aggregate\\ProductFeatureSet\\ProductFeatureSetEntity\:\:\$features type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductFeatureSet/ProductFeatureSetEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductReview\\\\ProductReviewEntity\\:\\:\\$status \\(bool\\) does not accept bool\\|null\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Product\\Aggregate\\ProductReview\\ProductReviewEntity\:\:\$status \(bool\) does not accept bool\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductReview/ProductReviewEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductSearchConfig\\\\ProductSearchConfigEntity\\:\\:getExcludedTerms\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Aggregate\\ProductSearchConfig\\ProductSearchConfigEntity\:\:getExcludedTerms\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductSearchConfig\\\\ProductSearchConfigEntity\\:\\:setExcludedTerms\\(\\) has parameter \\$excludedTerms with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Aggregate\\ProductSearchConfig\\ProductSearchConfigEntity\:\:setExcludedTerms\(\) has parameter \$excludedTerms with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductSearchConfig\\\\ProductSearchConfigEntity\\:\\:\\$excludedTerms type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Product\\Aggregate\\ProductSearchConfig\\ProductSearchConfigEntity\:\:\$excludedTerms type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductSearchConfig/ProductSearchConfigEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductTranslation\\\\ProductTranslationEntity\\:\\:getCustomSearchKeywords\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Aggregate\\ProductTranslation\\ProductTranslationEntity\:\:getCustomSearchKeywords\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductTranslation\\\\ProductTranslationEntity\\:\\:getSlotConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Aggregate\\ProductTranslation\\ProductTranslationEntity\:\:getSlotConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductTranslation\\\\ProductTranslationEntity\\:\\:setCustomSearchKeywords\\(\\) has parameter \\$customSearchKeywords with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Aggregate\\ProductTranslation\\ProductTranslationEntity\:\:setCustomSearchKeywords\(\) has parameter \$customSearchKeywords with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductTranslation\\\\ProductTranslationEntity\\:\\:setSlotConfig\\(\\) has parameter \\$slotConfig with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Aggregate\\ProductTranslation\\ProductTranslationEntity\:\:setSlotConfig\(\) has parameter \$slotConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Product\\\\Aggregate\\\\ProductTranslation\\\\ProductTranslationEntity\\:\\:\\$slotConfig type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Product\\Aggregate\\ProductTranslation\\ProductTranslationEntity\:\:\$slotConfig type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Aggregate/ProductTranslation/ProductTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Cart\\\\ProductGatewayInterface\\:\\:get\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Cart\\ProductGatewayInterface\:\:get\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Cart/ProductGatewayInterface.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\DataAbstractionLayer\\\\RatingAverageUpdater\\:\\:update\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\DataAbstractionLayer\\RatingAverageUpdater\:\:update\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/DataAbstractionLayer/RatingAverageUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Events\\\\CrossSellingRouteCacheTagsEvent\\:\\:__construct\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Events\\CrossSellingRouteCacheTagsEvent\:\:__construct\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Events/CrossSellingRouteCacheTagsEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Events\\\\ProductGatewayCriteriaEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Events\\ProductGatewayCriteriaEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Events/ProductGatewayCriteriaEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Events\\\\ProductGatewayCriteriaEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Events\\ProductGatewayCriteriaEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Events/ProductGatewayCriteriaEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Events\\\\ProductListingResolvePreviewEvent\\:\\:__construct\\(\\) has parameter \\$mapping with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Events\\ProductListingResolvePreviewEvent\:\:__construct\(\) has parameter \$mapping with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Events/ProductListingResolvePreviewEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Events\\\\ProductListingResolvePreviewEvent\\:\\:getMapping\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Events\\ProductListingResolvePreviewEvent\:\:getMapping\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Events/ProductListingResolvePreviewEvent.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Product/Events/ProductListingResolvePreviewEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Events\\\\ProductListingRouteCacheTagsEvent\\:\\:__construct\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Events\\ProductListingRouteCacheTagsEvent\:\:__construct\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Events/ProductListingRouteCacheTagsEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\Exception\\\\VariantNotFoundException\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\Exception\\VariantNotFoundException\:\:__construct\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/Exception/VariantNotFoundException.php
 
 		-
-			message: "#^Mixed variable in a `\\$a\\-\\>get\\('group'\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$a\-\>get\(''group''\)\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 3
 			path: src/Core/Content/Product/ProductVariationBuilder.php
 
 		-
-			message: "#^Mixed variable in a `\\$b\\-\\>get\\('group'\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$b\-\>get\(''group''\)\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 3
 			path: src/Core/Content/Product/ProductVariationBuilder.php
 
 		-
-			message: "#^Mixed variable in a `\\$option\\-\\>get\\('group'\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$option\-\>get\(''group''\)\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 1
 			path: src/Core/Content/Product/ProductVariationBuilder.php
 
 		-
-			message: "#^Mixed variable in a `\\$group\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$group\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 5
 			path: src/Core/Content/Product/PropertyGroupSorter.php
 
 		-
-			message: "#^Mixed variable in a `\\$group\\-\\>get\\('options'\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$group\-\>get\(''options''\)\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 1
 			path: src/Core/Content/Product/PropertyGroupSorter.php
 
 		-
-			message: "#^Mixed variable in a `\\$origin\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$origin\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 1
 			path: src/Core/Content/Product/PropertyGroupSorter.php
 
 		-
-			message: "#^Mixed variable in a `\\$sorted\\[\\$groupId\\]\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$sorted\[\$groupId\]\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 2
 			path: src/Core/Content/Product/PropertyGroupSorter.php
 
 		-
-			message: "#^Mixed variable in a `\\$sorted\\[\\$groupId\\]\\-\\>get\\('options'\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$sorted\[\$groupId\]\-\>get\(''options''\)\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 1
 			path: src/Core/Content/Product/PropertyGroupSorter.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Product/SalesChannel/Detail/ProductDetailRoute.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Product/SalesChannel/FindVariant/FindProductVariantRoute.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Product\\\\SalesChannel\\\\FindVariant\\\\FoundCombination\\:\\:getOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Product\\SalesChannel\\FindVariant\\FoundCombination\:\:getOptions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Product/SalesChannel/FindVariant/FoundCombination.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Content\\\\Product\\\\ProductException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Content\\Product\\ProductException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Product/SalesChannel/Search/ProductSearchRoute.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Content\\\\Product\\\\ProductException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Content\\Product\\ProductException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Product/SalesChannel/Suggest/ResolvedCriteriaProductSuggestRoute.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Content\\\\Product\\\\ProductException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Content\\Product\\ProductException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Product/SearchKeyword/ProductSearchBuilder.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/ProductExport/Event/ProductExportLoggingEvent.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/ProductExport/ScheduledTask/ProductExportPartialGenerationHandler.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Content/ProductStream/Service/ProductStreamBuilder.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Rule/DataAbstractionLayer/RulePayloadUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Rule\\\\Event\\\\RuleIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Rule\\Event\\RuleIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Rule/Event/RuleIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Rule\\\\Event\\\\RuleIndexerEvent\\:\\:__construct\\(\\) has parameter \\$skip with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Rule\\Event\\RuleIndexerEvent\:\:__construct\(\) has parameter \$skip with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Rule/Event/RuleIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Rule\\\\Event\\\\RuleIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Rule\\Event\\RuleIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Rule/Event/RuleIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Rule\\\\Event\\\\RuleIndexerEvent\\:\\:getSkip\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Rule\\Event\\RuleIndexerEvent\:\:getSkip\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Rule/Event/RuleIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\Event\\\\SeoUrlUpdateEvent\\:\\:__construct\\(\\) has parameter \\$seoUrls with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\Event\\SeoUrlUpdateEvent\:\:__construct\(\) has parameter \$seoUrls with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/Event/SeoUrlUpdateEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\Event\\\\SeoUrlUpdateEvent\\:\\:getSeoUrls\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\Event\\SeoUrlUpdateEvent\:\:getSeoUrls\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/Event/SeoUrlUpdateEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\HreflangLoaderParameter\\:\\:__construct\\(\\) has parameter \\$routeParameters with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\HreflangLoaderParameter\:\:__construct\(\) has parameter \$routeParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/HreflangLoaderParameter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\HreflangLoaderParameter\\:\\:getRouteParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\HreflangLoaderParameter\:\:getRouteParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/HreflangLoaderParameter.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Seo\\\\HreflangLoaderParameter\\:\\:\\$routeParameters type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Seo\\HreflangLoaderParameter\:\:\$routeParameters type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/HreflangLoaderParameter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlMapping\\:\\:__construct\\(\\) has parameter \\$infoPathContext with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlRoute\\SeoUrlMapping\:\:__construct\(\) has parameter \$infoPathContext with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/SeoUrlRoute/SeoUrlMapping.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlMapping\\:\\:__construct\\(\\) has parameter \\$seoPathInfoContext with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlRoute\\SeoUrlMapping\:\:__construct\(\) has parameter \$seoPathInfoContext with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/SeoUrlRoute/SeoUrlMapping.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlMapping\\:\\:getInfoPathContext\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlRoute\\SeoUrlMapping\:\:getInfoPathContext\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/SeoUrlRoute/SeoUrlMapping.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlMapping\\:\\:getSeoPathInfoContext\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlRoute\\SeoUrlMapping\:\:getSeoPathInfoContext\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/SeoUrlRoute/SeoUrlMapping.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlRouteRegistry\\:\\:__construct\\(\\) has parameter \\$seoUrlRoutes with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlRoute\\SeoUrlRouteRegistry\:\:__construct\(\) has parameter \$seoUrlRoutes with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteRegistry.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlRoute\\\\SeoUrlRouteRegistry\\:\\:getSeoUrlRoutes\\(\\) return type has no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlRoute\\SeoUrlRouteRegistry\:\:getSeoUrlRoutes\(\) return type has no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/SeoUrlRoute/SeoUrlRouteRegistry.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlTemplate\\\\TemplateGroup\\:\\:__construct\\(\\) has parameter \\$salesChannels with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlTemplate\\TemplateGroup\:\:__construct\(\) has parameter \$salesChannels with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlTemplate\\\\TemplateGroup\\:\\:getSalesChannelIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlTemplate\\TemplateGroup\:\:getSalesChannelIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlTemplate\\\\TemplateGroup\\:\\:getSalesChannels\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlTemplate\\TemplateGroup\:\:getSalesChannels\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Seo\\\\SeoUrlTemplate\\\\TemplateGroup\\:\\:setSalesChannels\\(\\) has parameter \\$salesChannels with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Seo\\SeoUrlTemplate\\TemplateGroup\:\:setSalesChannels\(\) has parameter \$salesChannels with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Seo/SeoUrlTemplate/TemplateGroup.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Content/Seo/SeoUrlUpdater.php
 
 		-
-			message: "#^Cannot call method map\\(\\) on Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelDomain\\\\SalesChannelDomainCollection\\|null\\.$#"
+			message: '#^Cannot call method map\(\) on Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelDomain\\SalesChannelDomainCollection\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Core/Content/Sitemap/Commands/SitemapGenerateCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ConfigHandler\\\\ConfigHandlerInterface\\:\\:getSitemapConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\ConfigHandler\\ConfigHandlerInterface\:\:getSitemapConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/ConfigHandler/ConfigHandlerInterface.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ConfigHandler\\\\File\\:\\:__construct\\(\\) has parameter \\$sitemapConfig with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\ConfigHandler\\File\:\:__construct\(\) has parameter \$sitemapConfig with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Content/Sitemap/ConfigHandler/File.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ConfigHandler\\\\File\\:\\:getSitemapConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\ConfigHandler\\File\:\:getSitemapConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/ConfigHandler/File.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ConfigHandler\\\\File\\:\\:getSitemapCustomUrls\\(\\) has parameter \\$customUrls with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\ConfigHandler\\File\:\:getSitemapCustomUrls\(\) has parameter \$customUrls with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/ConfigHandler/File.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ConfigHandler\\\\File\\:\\:getSitemapCustomUrls\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\ConfigHandler\\File\:\:getSitemapCustomUrls\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/ConfigHandler/File.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ConfigHandler\\\\File\\:\\:\\$customUrls type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Sitemap\\ConfigHandler\\File\:\:\$customUrls type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/ConfigHandler/File.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Content\\\\Sitemap\\\\ConfigHandler\\\\File\\:\\:\\$excludedUrls type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Content\\Sitemap\\ConfigHandler\\File\:\:\$excludedUrls type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/ConfigHandler/File.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Provider\\\\CustomUrlProvider\\:\\:isAvailableForSalesChannel\\(\\) has parameter \\$url with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\Provider\\CustomUrlProvider\:\:isAvailableForSalesChannel\(\) has parameter \$url with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/Provider/CustomUrlProvider.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Service\\\\ConfigHandler\\:\\:addUrls\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\Service\\ConfigHandler\:\:addUrls\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/Service/ConfigHandler.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Service\\\\ConfigHandler\\:\\:addUrls\\(\\) has parameter \\$urls with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\Service\\ConfigHandler\:\:addUrls\(\) has parameter \$urls with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/Service/ConfigHandler.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Service\\\\ConfigHandler\\:\\:addUrls\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\Service\\ConfigHandler\:\:addUrls\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/Service/ConfigHandler.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Service\\\\ConfigHandler\\:\\:get\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\Service\\ConfigHandler\:\:get\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/Service/ConfigHandler.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Content/Sitemap/Service/ConfigHandler.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Content/Sitemap/Service/SitemapExporter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Service\\\\SitemapHandleInterface\\:\\:write\\(\\) has parameter \\$urls with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Content\\Sitemap\\Service\\SitemapHandleInterface\:\:write\(\) has parameter \$urls with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Content/Sitemap/Service/SitemapHandleInterface.php
 
 		-
-			message: "#^Unsafe access to private property Shopware\\\\Core\\\\Content\\\\Test\\\\Category\\\\Service\\\\CountingEntitySearcher\\:\\:\\$count through static\\:\\:\\.$#"
+			message: '#^Unsafe access to private property Shopware\\Core\\Content\\Test\\Category\\Service\\CountingEntitySearcher\:\:\$count through static\:\:\.$#'
+			identifier: staticClassAccess.privateProperty
 			count: 3
 			path: src/Core/Content/Test/Category/Service/CountingEntitySearcher.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/DevOps/Docs/App/HookableEventDoc.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/DevOps/Docs/ArrayWriter.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 6
 			path: src/Core/DevOps/Docs/Script/HooksReferenceGenerator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 7
 			path: src/Core/DevOps/Docs/Script/ServiceReferenceGenerator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/DevOps/Environment/EnvironmentHelper.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 1
+			path: src/Core/DevOps/System/Command/OpenApiValidationCommand.php
+
+		-
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Adapter/Cache/CacheClearer.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Adapter/Cache/CacheValueCompressor.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Cache\\\\StoreApiRouteCacheTagsEvent\\:\\:__construct\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Cache\\StoreApiRouteCacheTagsEvent\:\:__construct\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Cache/StoreApiRouteCacheTagsEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Cache\\\\StoreApiRouteCacheTagsEvent\\:\\:addTags\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Cache\\StoreApiRouteCacheTagsEvent\:\:addTags\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Cache/StoreApiRouteCacheTagsEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Cache\\\\StoreApiRouteCacheTagsEvent\\:\\:getTags\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Cache\\StoreApiRouteCacheTagsEvent\:\:getTags\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Cache/StoreApiRouteCacheTagsEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Cache\\\\StoreApiRouteCacheTagsEvent\\:\\:setTags\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Cache\\StoreApiRouteCacheTagsEvent\:\:setTags\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Cache/StoreApiRouteCacheTagsEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Filesystem\\\\Adapter\\\\AdapterFactoryInterface\\:\\:create\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Filesystem\\Adapter\\AdapterFactoryInterface\:\:create\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Filesystem/Adapter/AdapterFactoryInterface.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Adapter/Filesystem/FilesystemFactory.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Adapter/Filesystem/PrefixFilesystem.php
 
 		-
-			message: "#^Class Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\AppTemplateIterator implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
+			message: '#^Class Shopware\\Core\\Framework\\Adapter\\Twig\\AppTemplateIterator implements generic interface IteratorAggregate but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/AppTemplateIterator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\CategoryUrlExtension\\:\\:getCategoryUrl\\(\\) has parameter \\$twigContext with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Extension\\CategoryUrlExtension\:\:getCategoryUrl\(\) has parameter \$twigContext with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Extension/CategoryUrlExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\ComparisonExtension\\:\\:compareArray\\(\\) has parameter \\$comparable with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Extension\\ComparisonExtension\:\:compareArray\(\) has parameter \$comparable with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\InstanceOfExtension\\:\\:isInstanceOf\\(\\) has parameter \\$class with no type specified\\.$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 3
+			path: src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
+
+		-
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Extension\\InstanceOfExtension\:\:isInstanceOf\(\) has parameter \$class with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Extension/InstanceOfExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\InstanceOfExtension\\:\\:isInstanceOf\\(\\) has parameter \\$var with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Extension\\InstanceOfExtension\:\:isInstanceOf\(\) has parameter \$var with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Extension/InstanceOfExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\MediaExtension\\:\\:searchMedia\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Extension\\MediaExtension\:\:searchMedia\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Extension/MediaExtension.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Adapter/Twig/Extension/PcreExtension.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Adapter/Twig/Extension/PhpSyntaxExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\RawUrlFunctionExtension\\:\\:rawUrl\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Extension\\RawUrlFunctionExtension\:\:rawUrl\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Extension/RawUrlFunctionExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\SeoUrlFunctionExtension\\:\\:seoUrl\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Extension\\SeoUrlFunctionExtension\:\:seoUrl\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Extension/SeoUrlFunctionExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\SwSanitizeTwigFilter\\:\\:sanitize\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Extension\\SwSanitizeTwigFilter\:\:sanitize\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Extension/SwSanitizeTwigFilter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Filter\\\\CurrencyFilter\\:\\:formatCurrency\\(\\) has no return type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Filter\\CurrencyFilter\:\:formatCurrency\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Filter\\\\CurrencyFilter\\:\\:formatCurrency\\(\\) has parameter \\$currencyIsoCode with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Filter\\CurrencyFilter\:\:formatCurrency\(\) has parameter \$currencyIsoCode with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Filter\\\\CurrencyFilter\\:\\:formatCurrency\\(\\) has parameter \\$languageId with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Filter\\CurrencyFilter\:\:formatCurrency\(\) has parameter \$languageId with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Filter\\\\CurrencyFilter\\:\\:formatCurrency\\(\\) has parameter \\$price with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Filter\\CurrencyFilter\:\:formatCurrency\(\) has parameter \$price with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Filter\\\\CurrencyFilter\\:\\:formatCurrency\\(\\) has parameter \\$twigContext with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\Filter\\CurrencyFilter\:\:formatCurrency\(\) has parameter \$twigContext with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Adapter/Twig/Filter/CurrencyFilter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\NamespaceHierarchy\\\\NamespaceHierarchyBuilder\\:\\:buildHierarchy\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\NamespaceHierarchy\\NamespaceHierarchyBuilder\:\:buildHierarchy\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/NamespaceHierarchy/NamespaceHierarchyBuilder.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/Framework/Adapter/Twig/SecurityExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\TwigVariableParser\\:\\:getVariables\\(\\) has parameter \\$aliases with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\TwigVariableParser\:\:getVariables\(\) has parameter \$aliases with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/TwigVariableParser.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\TwigVariableParser\\:\\:getVariables\\(\\) has parameter \\$nodes with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\TwigVariableParser\:\:getVariables\(\) has parameter \$nodes with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/TwigVariableParser.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\TwigVariableParser\\:\\:getVariables\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\TwigVariableParser\:\:getVariables\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/TwigVariableParser.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\TwigVariableParser\\:\\:parse\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Adapter\\Twig\\TwigVariableParser\:\:parse\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/TwigVariableParser.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\AclCriteriaValidator\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Acl\\AclCriteriaValidator\:\:validate\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Acl/AclCriteriaValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Api/Acl/AclCriteriaValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\Event\\\\AclGetAdditionalPrivilegesEvent\\:\\:__construct\\(\\) has parameter \\$privileges with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Acl\\Event\\AclGetAdditionalPrivilegesEvent\:\:__construct\(\) has parameter \$privileges with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Acl/Event/AclGetAdditionalPrivilegesEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\Event\\\\AclGetAdditionalPrivilegesEvent\\:\\:getPrivileges\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Acl\\Event\\AclGetAdditionalPrivilegesEvent\:\:getPrivileges\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Acl/Event/AclGetAdditionalPrivilegesEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\Event\\\\AclGetAdditionalPrivilegesEvent\\:\\:setPrivileges\\(\\) has parameter \\$privileges with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Acl\\Event\\AclGetAdditionalPrivilegesEvent\:\:setPrivileges\(\) has parameter \$privileges with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Acl/Event/AclGetAdditionalPrivilegesEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\Role\\\\AclRoleEntity\\:\\:getPrivileges\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Acl\\Role\\AclRoleEntity\:\:getPrivileges\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Acl/Role/AclRoleEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\Role\\\\AclRoleEntity\\:\\:setPrivileges\\(\\) has parameter \\$privileges with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Acl\\Role\\AclRoleEntity\:\:setPrivileges\(\) has parameter \$privileges with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Acl/Role/AclRoleEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Api\\\\Acl\\\\Role\\\\AclRoleEntity\\:\\:\\$privileges type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\Api\\Acl\\Role\\AclRoleEntity\:\:\$privileges type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Acl/Role/AclRoleEntity.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Api/ApiDefinition/DefinitionService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/Framework/Api/ApiDefinition/Generator/EntitySchemaGenerator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
 
 		-
-			message: "#^Cannot cast PhpParser\\\\Node\\\\Expr\\|PhpParser\\\\Node\\\\Name to string\\.$#"
+			message: '#^Cannot cast PhpParser\\Node\\Expr\|PhpParser\\Node\\Name to string\.$#'
+			identifier: cast.string
 			count: 1
 			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:__construct\\(\\) has parameter \\$bundles with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Command\\DumpClassSchemaCommand\:\:__construct\(\) has parameter \$bundles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:dumpProperties\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Command\\DumpClassSchemaCommand\:\:dumpProperties\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:parseFile\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Command\\DumpClassSchemaCommand\:\:parseFile\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:resolveNames\\(\\) has parameter \\$stmts with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Command\\DumpClassSchemaCommand\:\:resolveNames\(\) has parameter \$stmts with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:resolveNames\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Command\\DumpClassSchemaCommand\:\:resolveNames\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$code of method PhpParser\\\\Parser\\:\\:parse\\(\\) expects string, string\\|false given\\.$#"
+			message: '#^Parameter \#1 \$code of method PhpParser\\Parser\:\:parse\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$filePath of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:parseFile\\(\\) expects string, string\\|false given\\.$#"
+			message: '#^Parameter \#1 \$filePath of method Shopware\\Core\\Framework\\Api\\Command\\DumpClassSchemaCommand\:\:parseFile\(\) expects string, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$stmts of method Shopware\\\\Core\\\\Framework\\\\Api\\\\Command\\\\DumpClassSchemaCommand\\:\\:resolveNames\\(\\) expects array, array\\<PhpParser\\\\Node\\\\Stmt\\>\\|null given\\.$#"
+			message: '#^Parameter \#1 \$stmts of method Shopware\\Core\\Framework\\Api\\Command\\DumpClassSchemaCommand\:\:resolveNames\(\) expects array, array\<PhpParser\\Node\\Stmt\>\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Api/Command/DumpClassSchemaCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Api/Command/DumpSchemaCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Api/Controller/AuthController.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/Api/Controller/IndexingController.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Api/EventListener/JsonRequestTransformerListener.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Exception\\\\IncompletePrimaryKeyException\\:\\:__construct\\(\\) has parameter \\$primaryKeyFields with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Exception\\IncompletePrimaryKeyException\:\:__construct\(\) has parameter \$primaryKeyFields with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Exception/IncompletePrimaryKeyException.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Exception\\\\MissingPrivilegeException\\:\\:__construct\\(\\) has parameter \\$privilege with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Exception\\MissingPrivilegeException\:\:__construct\(\) has parameter \$privilege with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Exception/MissingPrivilegeException.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\Exception\\\\ResourceNotFoundException\\:\\:__construct\\(\\) has parameter \\$primaryKey with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\Exception\\ResourceNotFoundException\:\:__construct\(\) has parameter \$primaryKey with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/Exception/ResourceNotFoundException.php
 
 		-
-			message: "#^Parameter \\#1 \\$uuid of static method Shopware\\\\Core\\\\Framework\\\\Uuid\\\\Uuid\\:\\:fromHexToBytes\\(\\) expects string, int\\|string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$uuid of static method Shopware\\Core\\Framework\\Uuid\\Uuid\:\:fromHexToBytes\(\) expects string, int\|string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Framework/Api/OAuth/RefreshTokenRepository.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\OAuth\\\\ScopeRepository\\:\\:removeScope\\(\\) has parameter \\$scopes with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\OAuth\\ScopeRepository\:\:removeScope\(\) has parameter \$scopes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/OAuth/ScopeRepository.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\OAuth\\\\ScopeRepository\\:\\:removeScope\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\OAuth\\ScopeRepository\:\:removeScope\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/OAuth/ScopeRepository.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\OAuth\\\\ScopeRepository\\:\\:uniqueScopes\\(\\) has parameter \\$scopes with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\OAuth\\ScopeRepository\:\:uniqueScopes\(\) has parameter \$scopes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/OAuth/ScopeRepository.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Api\\\\OAuth\\\\ScopeRepository\\:\\:uniqueScopes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Api\\OAuth\\ScopeRepository\:\:uniqueScopes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Api/OAuth/ScopeRepository.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Api/Response/ResponseFactoryRegistry.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 7
 			path: src/Core/Framework/Api/Serializer/JsonApiDecoder.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/App/ActionButton/AppAction.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/App/Api/AppUrlChangeController.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/App/AppLocaleProvider.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/App/AppStateService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/App/AppUrlChangeResolver/Resolver.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/App/Cms/BlockTemplateLoader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/App/Command/CreateAppCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/App/Command/UninstallAppCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/App/Command/ValidateAppCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/Framework/App/Hmac/Guzzle/AuthMiddleware.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/App/Manifest/Xml/Administration/Admin.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/App/Manifest/Xml/CustomField/CustomFieldTypes/CustomFieldTypeFactory.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/App/Manifest/Xml/XmlElement.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/App/ShopId/ShopIdProvider.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/App/Validation/ManifestValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Changelog/Command/ChangelogChangeCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/Changelog/Command/ChangelogCreateCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Changelog/Command/ChangelogReleaseCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Changelog/Processor/ChangelogReleaseCreator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Command\\\\CreateHydratorCommand\\:\\:renderClass\\(\\) has parameter \\$calls with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Command\\CreateHydratorCommand\:\:renderClass\(\) has parameter \$calls with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Command/CreateHydratorCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Command\\\\CreateHydratorCommand\\:\\:renderClass\\(\\) has parameter \\$fields with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Command\\CreateHydratorCommand\:\:renderClass\(\) has parameter \$fields with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Command/CreateHydratorCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Command/CreateHydratorCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/CompiledFieldCollection.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/Common/RepositoryIterator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/CriteriaQueryBuilder.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+
+		-
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 12
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityDefinitionQueryHelper.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 6
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/EntityHydrator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldAccessorBuilder/DefaultFieldAccessorBuilder.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/CriteriaPartResolver.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToManyAssociationFieldResolver.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/ManyToOneAssociationFieldResolver.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/FieldResolver/TranslationFieldResolver.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Dbal\\\\QueryBuilder\\:\\:getStates\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Dbal\\QueryBuilder\:\:getStates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Dbal/QueryBuilder.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/DataAbstractionLayer/EntityDefinition.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/Framework/DataAbstractionLayer/EntityProtection/EntityProtectionValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\EntityProtection\\\\WriteProtection\\:\\:getAllowedScopes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\EntityProtection\\WriteProtection\:\:getAllowedScopes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/EntityProtection/WriteProtection.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/DataAbstractionLayer/EntityRepository.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DataAbstractionLayer/EntityTranslationDefinition.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/EntityWriteResult.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityDeletedEvent\\:\\:__construct\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityDeletedEvent\:\:__construct\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityDeletedEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityDeletedEvent\\:\\:__construct\\(\\) has parameter \\$writeResult with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityDeletedEvent\:\:__construct\(\) has parameter \$writeResult with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityDeletedEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityLoadedContainerEvent\\:\\:__construct\\(\\) has parameter \\$events with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityLoadedContainerEvent\:\:__construct\(\) has parameter \$events with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityLoadedContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:__construct\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:__construct\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:createEvents\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:createEvents\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:createEvents\\(\\) has parameter \\$identifiers with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:createEvents\(\) has parameter \$identifiers with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:createWithDeletedEvents\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:createWithDeletedEvents\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:createWithDeletedEvents\\(\\) has parameter \\$identifiers with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:createWithDeletedEvents\(\) has parameter \$identifiers with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:createWithWrittenEvents\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:createWithWrittenEvents\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:createWithWrittenEvents\\(\\) has parameter \\$identifiers with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:createWithWrittenEvents\(\) has parameter \$identifiers with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:findPrimaryKeys\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:findPrimaryKeys\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:getDeletedPrimaryKeys\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:getDeletedPrimaryKeys\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:getErrors\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:getErrors\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:getList\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:getList\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:getPrimaryKeys\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:getPrimaryKeys\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:getPrimaryKeysWithPayload\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:getPrimaryKeysWithPayload\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:getPrimaryKeysWithPayloadIgnoringFields\\(\\) has parameter \\$ignoredFields with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:getPrimaryKeysWithPayloadIgnoringFields\(\) has parameter \$ignoredFields with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:getPrimaryKeysWithPayloadIgnoringFields\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:getPrimaryKeysWithPayloadIgnoringFields\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:getPrimaryKeysWithPropertyChange\\(\\) has parameter \\$properties with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:getPrimaryKeysWithPropertyChange\(\) has parameter \$properties with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenContainerEvent\\:\\:getPrimaryKeysWithPropertyChange\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenContainerEvent\:\:getPrimaryKeysWithPropertyChange\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenContainerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenEvent\\:\\:__construct\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenEvent\:\:__construct\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenEvent\\:\\:__construct\\(\\) has parameter \\$writeResults with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenEvent\:\:__construct\(\) has parameter \$writeResults with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenEvent\\:\\:getErrors\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenEvent\:\:getErrors\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenEvent\\:\\:getPayloads\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenEvent\:\:getPayloads\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenEvent\\:\\:\\$errors type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenEvent\:\:\$errors type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenEvent\\:\\:\\$ids type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenEvent\:\:\$ids type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Event\\\\EntityWrittenEvent\\:\\:\\$payloads type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Event\\EntityWrittenEvent\:\:\$payloads type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Event/EntityWrittenEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Exception\\\\ImpossibleWriteOrderException\\:\\:__construct\\(\\) has parameter \\$remaining with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Exception\\ImpossibleWriteOrderException\:\:__construct\(\) has parameter \$remaining with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Exception/ImpossibleWriteOrderException.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Exception\\\\SearchRequestException\\:\\:__construct\\(\\) has parameter \\$exceptions with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Exception\\SearchRequestException\:\:__construct\(\) has parameter \$exceptions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Exception/SearchRequestException.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Facade\\\\AppContextCreator\\:\\:fetchPrivileges\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Facade\\AppContextCreator\:\:fetchPrivileges\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Facade/AppContextCreator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Facade/AppContextCreator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Facade/RepositoryFacade.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\CreatedByField\\:\\:__construct\\(\\) has parameter \\$allowedWriteScopes with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\CreatedByField\:\:__construct\(\) has parameter \$allowedWriteScopes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\CreatedByField\\:\\:getAllowedWriteScopes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\CreatedByField\:\:getAllowedWriteScopes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Field/CreatedByField.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Flag\\\\Runtime\\:\\:__construct\\(\\) has parameter \\$dependsOn with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Flag\\Runtime\:\:__construct\(\) has parameter \$dependsOn with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Field/Flag/Runtime.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Flag\\\\Runtime\\:\\:getDepends\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Flag\\Runtime\:\:getDepends\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Field/Flag/Runtime.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Flag\\\\WriteProtected\\:\\:getAllowedScopes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Flag\\WriteProtected\:\:getAllowedScopes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Field/Flag/WriteProtected.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StateMachineStateField\\:\\:__construct\\(\\) has parameter \\$allowedWriteScopes with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\StateMachineStateField\:\:__construct\(\) has parameter \$allowedWriteScopes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Field/StateMachineStateField.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\StateMachineStateField\\:\\:getAllowedWriteScopes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\StateMachineStateField\:\:getAllowedWriteScopes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Field/StateMachineStateField.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\UpdatedByField\\:\\:__construct\\(\\) has parameter \\$allowedWriteScopes with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\UpdatedByField\:\:__construct\(\) has parameter \$allowedWriteScopes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\UpdatedByField\\:\\:getAllowedWriteScopes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\UpdatedByField\:\:getAllowedWriteScopes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Field/UpdatedByField.php
 
 		-
-			message: "#^Cannot call method is\\(\\) on Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Field\\\\Field\\|null\\.$#"
+			message: '#^Cannot call method is\(\) on Shopware\\Core\\Framework\\DataAbstractionLayer\\Field\\Field\|null\.$#'
+			identifier: method.nonObject
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\AbstractFieldSerializer\\:\\:requiresValidation\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\AbstractFieldSerializer\:\:requiresValidation\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\AbstractFieldSerializer\\:\\:validate\\(\\) has parameter \\$constraints with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\AbstractFieldSerializer\:\:validate\(\) has parameter \$constraints with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
 
 		-
-			message: "#^Parameter \\#1 \\$entityName of method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\DefinitionInstanceRegistry\\:\\:getByEntityName\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#1 \$entityName of method Shopware\\Core\\Framework\\DataAbstractionLayer\\DefinitionInstanceRegistry\:\:getByEntityName\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/AbstractFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ListFieldSerializer\\:\\:decode\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\ListFieldSerializer\:\:decode\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ListFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\ListFieldSerializer\\:\\:validateTypes\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\ListFieldSerializer\:\:validateTypes\(\) has parameter \$values with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/ListFieldSerializer.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PHPUnserializeFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:buildViolation\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\PriceDefinitionFieldSerializer\:\:buildViolation\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:decodeRule\\(\\) has parameter \\$rule with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\PriceDefinitionFieldSerializer\:\:decodeRule\(\) has parameter \$rule with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:validateConsistence\\(\\) has parameter \\$fieldValidations with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\PriceDefinitionFieldSerializer\:\:validateConsistence\(\) has parameter \$fieldValidations with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:validateConsistence\\(\\) has parameter \\$payload with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\PriceDefinitionFieldSerializer\:\:validateConsistence\(\) has parameter \$payload with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:validateProperties\\(\\) has parameter \\$constraints with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\PriceDefinitionFieldSerializer\:\:validateProperties\(\) has parameter \$constraints with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:validateProperties\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\PriceDefinitionFieldSerializer\:\:validateProperties\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldSerializer\\\\PriceDefinitionFieldSerializer\\:\\:validateRules\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldSerializer\\PriceDefinitionFieldSerializer\:\:validateRules\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 8
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/PriceDefinitionFieldSerializer.php
 
-
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldSerializer/StateMachineStateFieldSerializer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldVisibility\\:\\:filterInvisible\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldVisibility\:\:filterInvisible\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldVisibility.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\FieldVisibility\\:\\:filterInvisible\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\FieldVisibility\:\:filterInvisible\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/FieldVisibility.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Indexing/EntityIndexerRegistry.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Indexing/InheritanceUpdater.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Indexing/ManyToManyIdFieldUpdater.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdater.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\TreeUpdaterBag\\:\\:addEntity\\(\\) has parameter \\$entity with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Indexing\\TreeUpdaterBag\:\:addEntity\(\) has parameter \$entity with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdaterBag.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\TreeUpdaterBag\\:\\:getEntity\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Indexing\\TreeUpdaterBag\:\:getEntity\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdaterBag.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\TreeUpdaterBag\\:\\:\\$entities type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Indexing\\TreeUpdaterBag\:\:\$entities type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdaterBag.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Indexing\\\\TreeUpdaterBag\\:\\:\\$updated type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Indexing\\TreeUpdaterBag\:\:\$updated type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Indexing/TreeUpdaterBag.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DataAbstractionLayer/MappingEntityDefinition.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price\\:\\:__construct\\(\\) has parameter \\$percentage with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Pricing\\Price\:\:__construct\(\) has parameter \$percentage with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Pricing/Price.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price\\:\\:getPercentage\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Pricing\\Price\:\:getPercentage\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Pricing/Price.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price\\:\\:setPercentage\\(\\) has parameter \\$percentage with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Pricing\\Price\:\:setPercentage\(\) has parameter \$percentage with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Pricing/Price.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Pricing\\\\Price\\:\\:\\$percentage type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Pricing\\Price\:\:\$percentage type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Pricing/Price.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DataAbstractionLayer/SchemaGenerator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/DataAbstractionLayer/Search/ApiCriteriaValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DataAbstractionLayer/Search/Filter/MultiFilter.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DataAbstractionLayer/Search/IdSearchResult.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:addParameter\\(\\) has parameter \\$type with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\Parser\\ParseResult\:\:addParameter\(\) has parameter \$type with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:addParameter\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\Parser\\ParseResult\:\:addParameter\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:getParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\Parser\\ParseResult\:\:getParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:getType\\(\\) has no return type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\Parser\\ParseResult\:\:getType\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:getTypes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\Parser\\ParseResult\:\:getTypes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:\\$parameters type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\Parser\\ParseResult\:\:\$parameters type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\ParseResult\\:\\:\\$types type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\Parser\\ParseResult\:\:\$types type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/ParseResult.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\SqlQueryParser\\:\\:parseRanking\\(\\) has parameter \\$queries with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Search\\Parser\\SqlQueryParser\:\:parseRanking\(\) has parameter \$queries with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 1
+			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+
+		-
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/DataAbstractionLayer/Validation/EntityExists.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Validation/EntityExistsValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Validation/EntityNotExistsValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Version\\\\Aggregate\\\\VersionCommitData\\\\VersionCommitDataCollection\\:\\:filterByEntityPrimary\\(\\) has parameter \\$primary with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Version\\Aggregate\\VersionCommitData\\VersionCommitDataCollection\:\:filterByEntityPrimary\(\) has parameter \$primary with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Version/Aggregate/VersionCommitData/VersionCommitDataCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\CloneBehavior\\:\\:__construct\\(\\) has parameter \\$overwrites with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\CloneBehavior\:\:__construct\(\) has parameter \$overwrites with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/CloneBehavior.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\CloneBehavior\\:\\:getOverwrites\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\CloneBehavior\:\:getOverwrites\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/CloneBehavior.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Command\\\\ChangeSet\\:\\:__construct\\(\\) has parameter \\$payload with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\Command\\ChangeSet\:\:__construct\(\) has parameter \$payload with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSet.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Command\\\\ChangeSet\\:\\:__construct\\(\\) has parameter \\$state with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\Command\\ChangeSet\:\:__construct\(\) has parameter \$state with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSet.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Command\\\\ChangeSet\\:\\:\\$after type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\Command\\ChangeSet\:\:\$after type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSet.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Command\\\\ChangeSet\\:\\:\\$state type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\Command\\ChangeSet\:\:\$state type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Command/ChangeSet.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DataAbstractionLayer/Write/EntityWriter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\PrimaryKeyBag\\:\\:add\\(\\) has parameter \\$primaryKey with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\PrimaryKeyBag\:\:add\(\) has parameter \$primaryKey with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/PrimaryKeyBag.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\PrimaryKeyBag\\:\\:addExistenceState\\(\\) has parameter \\$primaryKey with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\PrimaryKeyBag\:\:addExistenceState\(\) has parameter \$primaryKey with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/PrimaryKeyBag.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\PrimaryKeyBag\\:\\:addExistenceState\\(\\) has parameter \\$state with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\PrimaryKeyBag\:\:addExistenceState\(\) has parameter \$state with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/PrimaryKeyBag.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\PrimaryKeyBag\\:\\:getCacheKey\\(\\) has parameter \\$primaryKey with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\PrimaryKeyBag\:\:getCacheKey\(\) has parameter \$primaryKey with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/PrimaryKeyBag.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\PrimaryKeyBag\\:\\:getExistenceState\\(\\) has parameter \\$primaryKey with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\PrimaryKeyBag\:\:getExistenceState\(\) has parameter \$primaryKey with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/PrimaryKeyBag.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\PrimaryKeyBag\\:\\:getExistenceState\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\PrimaryKeyBag\:\:getExistenceState\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/PrimaryKeyBag.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\PrimaryKeyBag\\:\\:getPrimaryKeys\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\PrimaryKeyBag\:\:getPrimaryKeys\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/PrimaryKeyBag.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\PrimaryKeyBag\\:\\:hasExistence\\(\\) has parameter \\$primaryKey with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\PrimaryKeyBag\:\:hasExistence\(\) has parameter \$primaryKey with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/PrimaryKeyBag.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\PrimaryKeyBag\\:\\:\\$existences type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\PrimaryKeyBag\:\:\$existences type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/PrimaryKeyBag.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Validation\\\\ConstraintBuilder\\:\\:isInArray\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\Validation\\ConstraintBuilder\:\:isInArray\(\) has parameter \$values with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/ConstraintBuilder.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Validation\\\\ConstraintBuilder\\:\\:\\$constraints type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\Validation\\ConstraintBuilder\:\:\$constraints type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/ConstraintBuilder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Validation\\\\RestrictDeleteViolation\\:\\:getRestrictions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\Validation\\RestrictDeleteViolation\:\:getRestrictions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/RestrictDeleteViolation.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Validation\\\\Validator\\:\\:addConstraint\\(\\) has parameter \\$propertyValue with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\Validation\\Validator\:\:addConstraint\(\) has parameter \$propertyValue with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/Validator.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Validation\\\\Validator\\:\\:\\$data type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\Validation\\Validator\:\:\$data type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/Validator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\Validation\\\\WriteCommandExceptionEvent\\:\\:getCommands\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\Validation\\WriteCommandExceptionEvent\:\:getCommands\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/Validation/WriteCommandExceptionEvent.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DataAbstractionLayer/Write/WriteContext.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Write\\\\WriteException\\:\\:getExceptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DataAbstractionLayer\\Write\\WriteException\:\:getExceptions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Write/WriteException.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Demodata/Command/DemodataCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Demodata/DemodataService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Demodata/Generator/ProductGenerator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Demodata/PersonalData/CleanPersonalDataCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/DependencyInjection/CompilerPass/FeatureFlagCompilerPass.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DependencyInjection\\\\FrameworkExtension\\:\\:addShopwareConfig\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\DependencyInjection\\FrameworkExtension\:\:addShopwareConfig\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/DependencyInjection/FrameworkExtension.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Event/BusinessEventCollector.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Event/EventData/ScalarValueType.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/MessageQueue/ScheduledTask/Registry/TaskRegistry.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/MessageQueue/ScheduledTask/Scheduler/TaskScheduler.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 5
 			path: src/Core/Framework/Migration/Command/CreateMigrationCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/Migration/Command/MigrationCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\Command\\\\RefreshMigrationCommand\\:\\:updateMigrationFile\\(\\) has parameter \\$replace with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\Command\\RefreshMigrationCommand\:\:updateMigrationFile\(\) has parameter \$replace with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\Command\\\\RefreshMigrationCommand\\:\\:updateMigrationFile\\(\\) has parameter \\$search with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\Command\\RefreshMigrationCommand\:\:updateMigrationFile\(\) has parameter \$search with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Migration/Command/RefreshMigrationCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\IndexerQueuer\\:\\:fetchCurrent\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\IndexerQueuer\:\:fetchCurrent\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/IndexerQueuer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\IndexerQueuer\\:\\:finishIndexer\\(\\) has parameter \\$names with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\IndexerQueuer\:\:finishIndexer\(\) has parameter \$names with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/IndexerQueuer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\IndexerQueuer\\:\\:registerIndexer\\(\\) has parameter \\$requiredIndexers with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\IndexerQueuer\:\:registerIndexer\(\) has parameter \$requiredIndexers with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/IndexerQueuer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\IndexerQueuer\\:\\:upsert\\(\\) has parameter \\$indexerList with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\IndexerQueuer\:\:upsert\(\) has parameter \$indexerList with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/IndexerQueuer.php
 
 		-
-			message: "#^PHPDoc tag @var for variable \\$options has no value type specified in iterable type array\\.$#"
+			message: '#^PHPDoc tag @var for variable \$options has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/IndexerQueuer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:createAddColumnsAndKeysPlaybookEntries\\(\\) has parameter \\$keyStructures with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:createAddColumnsAndKeysPlaybookEntries\(\) has parameter \$keyStructures with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:createAddColumnsAndKeysPlaybookEntries\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:createAddColumnsAndKeysPlaybookEntries\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:createAddKeysPlaybookEntries\\(\\) has parameter \\$keyStructures with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:createAddKeysPlaybookEntries\(\) has parameter \$keyStructures with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:createAddKeysPlaybookEntries\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:createAddKeysPlaybookEntries\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:createDropKeysPlaybookEntries\\(\\) has parameter \\$keyStructures with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:createDropKeysPlaybookEntries\(\) has parameter \$keyStructures with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:createDropKeysPlaybookEntries\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:createDropKeysPlaybookEntries\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:createSql\\(\\) has parameter \\$keyStructures with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:createSql\(\) has parameter \$keyStructures with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:createSql\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:createSql\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:determineAddColumnSql\\(\\) has parameter \\$keyStructure with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:determineAddColumnSql\(\) has parameter \$keyStructure with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:determineModifyPrimaryKeySql\\(\\) has parameter \\$keyStructure with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:determineModifyPrimaryKeySql\(\) has parameter \$keyStructure with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:fetchRelationData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:fetchRelationData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:filterHydrateForeignKeyData\\(\\) has parameter \\$hydratedData with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:filterHydrateForeignKeyData\(\) has parameter \$hydratedData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:filterHydrateForeignKeyData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:filterHydrateForeignKeyData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:findForeignKeyDefinition\\(\\) has parameter \\$keyStructure with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:findForeignKeyDefinition\(\) has parameter \$keyStructure with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:getAddForeignKeySql\\(\\) has parameter \\$keyStructure with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:getAddForeignKeySql\(\) has parameter \$keyStructure with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:getRelationData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:getRelationData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:hydrateForeignKeyData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:hydrateForeignKeyData\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:hydrateForeignKeyData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:hydrateForeignKeyData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:implodeColumns\\(\\) has parameter \\$columns with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:implodeColumns\(\) has parameter \$columns with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:isEqualForeignKey\\(\\) has parameter \\$foreignFieldNames with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:isEqualForeignKey\(\) has parameter \$foreignFieldNames with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:mapHydrateForeignKeyData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:mapHydrateForeignKeyData\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Migration\\\\MakeVersionableMigrationHelper\\:\\:mapHydrateForeignKeyData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Migration\\MakeVersionableMigrationHelper\:\:mapHydrateForeignKeyData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Migration/MakeVersionableMigrationHelper.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Migration/MigrationCollection.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Migration/MigrationRuntime.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Migration/Trigger.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Parameter\\\\AdditionalBundleParameters\\:\\:__construct\\(\\) has parameter \\$kernelParameters with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Parameter\\AdditionalBundleParameters\:\:__construct\(\) has parameter \$kernelParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Parameter/AdditionalBundleParameters.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Parameter\\\\AdditionalBundleParameters\\:\\:getKernelParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Parameter\\AdditionalBundleParameters\:\:getKernelParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Parameter/AdditionalBundleParameters.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Parameter\\\\AdditionalBundleParameters\\:\\:setKernelParameters\\(\\) has parameter \\$kernelParameters with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Parameter\\AdditionalBundleParameters\:\:setKernelParameters\(\) has parameter \$kernelParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Parameter/AdditionalBundleParameters.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Command\\\\Lifecycle\\\\AbstractPluginLifecycleCommand\\:\\:parsePluginArgument\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Plugin\\Command\\Lifecycle\\AbstractPluginLifecycleCommand\:\:parsePluginArgument\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
 
 		-
-			message: "#^Parameter \\#1 \\$elements of class Shopware\\\\Core\\\\Framework\\\\Plugin\\\\PluginCollection constructor expects iterable\\<Shopware\\\\Core\\\\Framework\\\\Plugin\\\\PluginEntity\\>, array\\<int, Shopware\\\\Core\\\\Framework\\\\Plugin\\\\PluginEntity\\|null\\> given\\.$#"
+			message: '#^Parameter \#1 \$elements of class Shopware\\Core\\Framework\\Plugin\\PluginCollection constructor expects iterable\<Shopware\\Core\\Framework\\Plugin\\PluginEntity\>, array\<int, Shopware\\Core\\Framework\\Plugin\\PluginEntity\|null\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Plugin/Composer/CommandExecutor.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Plugin/Composer/PackageProvider.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Exception\\\\PluginComposerJsonInvalidException\\:\\:__construct\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Plugin\\Exception\\PluginComposerJsonInvalidException\:\:__construct\(\) has parameter \$errors with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Plugin/Exception/PluginComposerJsonInvalidException.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\KernelPluginLoader\\\\StaticKernelPluginLoader\\:\\:__construct\\(\\) has parameter \\$plugins with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Plugin\\KernelPluginLoader\\StaticKernelPluginLoader\:\:__construct\(\) has parameter \$plugins with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Plugin/KernelPluginLoader/StaticKernelPluginLoader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/Plugin/PluginExtractor.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 12
 			path: src/Core/Framework/Plugin/PluginLifecycleService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Plugin/PluginService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Plugin/Requirement/RequirementExceptionStack.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Util\\\\VersionSanitizer\\:\\:sanitizePluginVersion\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Plugin\\Util\\VersionSanitizer\:\:sanitizePluginVersion\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Core/Framework/Plugin/Util/VersionSanitizer.php
 
 		-
-			message: "#^Parameter \\#1 \\$interval of static method Symfony\\\\Component\\\\RateLimiter\\\\Util\\\\TimeUtil\\:\\:dateIntervalToSeconds\\(\\) expects DateInterval, DateInterval\\|false given\\.$#"
+			message: '#^Parameter \#1 \$interval of static method Symfony\\Component\\RateLimiter\\Util\\TimeUtil\:\:dateIntervalToSeconds\(\) expects DateInterval, DateInterval\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Framework/RateLimiter/Policy/TimeBackoff.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$arg1 of function min expects non\\-empty\\-array, list\\<int\\> given\\.$#"
+			message: '#^Parameter \#1 \.\.\.\$arg1 of function min expects non\-empty\-array, list\<int\> given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/Framework/RateLimiter/Policy/TimeBackoff.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/RateLimiter/Policy/TimeBackoff.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/RateLimiter/Policy/TimeBackoffLimiter.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/RateLimiter/RateLimiter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Routing\\\\AbstractRouteScope\\:\\:getRoutePrefixes\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Routing\\AbstractRouteScope\:\:getRoutePrefixes\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Routing/AbstractRouteScope.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Routing/Annotation/CriteriaValueResolver.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Routing/ApiRequestContextResolver.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/Routing/RouteScopeListener.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Routing/RouteScopeRegistry.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Rule/Collector/RuleConditionRegistry.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Rule/Container/DaysSinceRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Rule/Container/NotRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 1
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 2
 			path: src/Core/Framework/Rule/Container/ZipCodeRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 1
+			path: src/Core/Framework/Rule/CustomFieldRule.php
+
+		-
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Rule/DateRangeRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Rule/Rule.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Script\\\\Debugging\\\\Debug\\:\\:all\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 5
+			path: src/Core/Framework/Rule/RuleComparison.php
+
+		-
+			message: '#^Method Shopware\\Core\\Framework\\Script\\Debugging\\Debug\:\:all\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Script/Debugging/Debug.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Script\\\\Debugging\\\\Debug\\:\\:\\$dumps type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\Script\\Debugging\\Debug\:\:\$dumps type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Script/Debugging/Debug.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Script\\\\Execution\\\\Script\\:\\:__construct\\(\\) has parameter \\$includes with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Script\\Execution\\Script\:\:__construct\(\) has parameter \$includes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Script/Execution/Script.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Script\\\\Execution\\\\Script\\:\\:__construct\\(\\) has parameter \\$twigOptions with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Script\\Execution\\Script\:\:__construct\(\) has parameter \$twigOptions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Script/Execution/Script.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Script\\\\Execution\\\\Script\\:\\:getTwigOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Script\\Execution\\Script\:\:getTwigOptions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Script/Execution/Script.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Framework\\\\Store\\\\StoreException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Framework\\Store\\StoreException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Api/ExtensionStoreActionsController.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Api/ExtensionStoreActionsController.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 9
 			path: src/Core/Framework/Store/Api/FirstRunWizardController.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 8
 			path: src/Core/Framework/Store/Api/StoreController.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Authentication/AbstractStoreRequestOptionsProvider.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Authentication/FrwRequestOptionsProvider.php
 
 		-
-			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getLocale\\(\\)\\.$#"
+			message: '#^Call to an undefined method Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity\:\:getLocale\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Core/Framework/Store/Authentication/LocaleProvider.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Authentication/LocaleProvider.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Store/Authentication/StoreRequestOptionsProvider.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Store/Command/StoreDownloadCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/Framework/Store/Command/StoreLoginCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Search\\\\EqualsFilterStruct\\:\\:fromArray\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Search\\EqualsFilterStruct\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Search/EqualsFilterStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Search\\\\ExtensionCriteria\\:\\:addFilter\\(\\) has parameter \\$filter with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Search\\ExtensionCriteria\:\:addFilter\(\) has parameter \$filter with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Search/ExtensionCriteria.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Search\\\\ExtensionCriteria\\:\\:fromArray\\(\\) has parameter \\$parameter with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Search\\ExtensionCriteria\:\:fromArray\(\) has parameter \$parameter with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Search/ExtensionCriteria.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Search\\\\FilterStruct\\:\\:fromArray\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Search\\FilterStruct\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Search/FilterStruct.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Search/FilterStruct.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Services/ExtensionDownloader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Store/Services/FirstRunWizardClient.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Store/Services/FirstRunWizardService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Services/ShopSecretInvalidMiddleware.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/Framework/Store/Services/StoreClient.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Services/StoreSessionExpiredMiddleware.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartPositionCollection\\:\\:getElementFromArray\\(\\) has parameter \\$element with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionCollection\:\:getElementFromArray\(\) has parameter \$element with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartPositionCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartPositionStruct\\:\\:fromArray\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartPositionStruct\\:\\:getExtensionInformation\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:getExtensionInformation\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartPositionStruct\\:\\:getVariant\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:getVariant\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartPositionStruct\\:\\:setExtensionInformation\\(\\) has parameter \\$extensionInformation with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:setExtensionInformation\(\) has parameter \$extensionInformation with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartPositionStruct\\:\\:setVariant\\(\\) has parameter \\$variant with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:setVariant\(\) has parameter \$variant with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartPositionStruct\\:\\:\\$extension type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:\$extension type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartPositionStruct\\:\\:\\$variant type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\Store\\Struct\\CartPositionStruct\:\:\$variant type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartPositionStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartStruct\\:\\:fromArray\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartStruct\:\:fromArray\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartStruct\\:\\:getShop\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartStruct\:\:getShop\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartStruct\\:\\:setShop\\(\\) has parameter \\$shop with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\CartStruct\:\:setShop\(\) has parameter \$shop with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartStruct.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\CartStruct\\:\\:\\$shop type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\Store\\Struct\\CartStruct\:\:\$shop type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/CartStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\PluginRegionStruct\\:\\:__construct\\(\\) has parameter \\$categories with no value type specified in iterable type iterable\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\PluginRegionStruct\:\:__construct\(\) has parameter \$categories with no value type specified in iterable type iterable\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/PluginRegionStruct.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\Framework\\\\Store\\\\StoreException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\Framework\\Store\\StoreException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/Framework/Store/Struct/ReviewStruct.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Store/Struct/ReviewStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Store\\\\Struct\\\\StoreLicenseViolationStruct\\:\\:getActions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Store\\Struct\\StoreLicenseViolationStruct\:\:getActions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Store/Struct/StoreLicenseViolationStruct.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/Framework/Struct/Serializer/StructNormalizer.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Struct/Struct.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Test\\\\Filesystem\\\\Adapter\\\\MemoryAdapterFactory\\:\\:create\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Test\\Filesystem\\Adapter\\MemoryAdapterFactory\:\:create\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/Filesystem/Adapter/MemoryAdapterFactory.php
 
 		-
-			message: "#^Unsafe access to private property Shopware\\\\Core\\\\Framework\\\\Test\\\\Filesystem\\\\Adapter\\\\MemoryAdapterFactory\\:\\:\\$instances through static\\:\\:\\.$#"
+			message: '#^Unsafe access to private property Shopware\\Core\\Framework\\Test\\Filesystem\\Adapter\\MemoryAdapterFactory\:\:\$instances through static\:\:\.$#'
+			identifier: staticClassAccess.privateProperty
 			count: 7
 			path: src/Core/Framework/Test/Filesystem/Adapter/MemoryAdapterFactory.php
 
 		-
-			message: "#^Unsafe call to private method Shopware\\\\Core\\\\Framework\\\\Test\\\\Filesystem\\\\Adapter\\\\MemoryAdapterFactory\\:\\:addAdapter\\(\\) through static\\:\\:\\.$#"
+			message: '#^Unsafe call to private method Shopware\\Core\\Framework\\Test\\Filesystem\\Adapter\\MemoryAdapterFactory\:\:addAdapter\(\) through static\:\:\.$#'
+			identifier: staticClassAccess.privateMethod
 			count: 1
 			path: src/Core/Framework/Test/Filesystem/Adapter/MemoryAdapterFactory.php
 
 		-
-			message: "#^Argument of an invalid type array\\<string\\>\\|null supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Argument of an invalid type array\<string\>\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: src/Core/Framework/Test/TestCaseHelper/ExtensionHelper.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Test\\\\TestCaseHelper\\\\ExtensionHelper\\:\\:removeExtensions\\(\\) has parameter \\$object with no type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Test\\TestCaseHelper\\ExtensionHelper\:\:removeExtensions\(\) has parameter \$object with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Core/Framework/Test/TestCaseHelper/ExtensionHelper.php
 
 		-
-			message: "#^Mixed variable in a `\\$oldBag\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$oldBag\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 3
 			path: src/Core/Framework/Test/TestSessionStorage.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Test\\\\TestSessionStorage\\:\\:\\$data type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\Test\\TestSessionStorage\:\:\$data type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/TestSessionStorage.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Test\\\\Webhook\\\\_fixtures\\\\BusinessEvents\\\\BusinessEventEncoderTestInterface\\:\\:getEncodeValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Test\\Webhook\\_fixtures\\BusinessEvents\\BusinessEventEncoderTestInterface\:\:getEncodeValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/Webhook/_fixtures/BusinessEvents/BusinessEventEncoderTestInterface.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Test\\\\Webhook\\\\_fixtures\\\\BusinessEvents\\\\ScalarBusinessEvent\\:\\:getEncodeValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Test\\Webhook\\_fixtures\\BusinessEvents\\ScalarBusinessEvent\:\:getEncodeValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/Webhook/_fixtures/BusinessEvents/ScalarBusinessEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Test\\\\Webhook\\\\_fixtures\\\\BusinessEvents\\\\StructuredArrayObjectBusinessEvent\\:\\:getEncodeValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Test\\Webhook\\_fixtures\\BusinessEvents\\StructuredArrayObjectBusinessEvent\:\:getEncodeValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/Webhook/_fixtures/BusinessEvents/StructuredArrayObjectBusinessEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Test\\\\Webhook\\\\_fixtures\\\\BusinessEvents\\\\StructuredArrayObjectBusinessEvent\\:\\:getInner\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Test\\Webhook\\_fixtures\\BusinessEvents\\StructuredArrayObjectBusinessEvent\:\:getInner\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/Webhook/_fixtures/BusinessEvents/StructuredArrayObjectBusinessEvent.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Test\\\\Webhook\\\\_fixtures\\\\BusinessEvents\\\\StructuredArrayObjectBusinessEvent\\:\\:\\$inner type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\Test\\Webhook\\_fixtures\\BusinessEvents\\StructuredArrayObjectBusinessEvent\:\:\$inner type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/Webhook/_fixtures/BusinessEvents/StructuredArrayObjectBusinessEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Test\\\\Webhook\\\\_fixtures\\\\BusinessEvents\\\\StructuredObjectBusinessEvent\\:\\:getEncodeValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Test\\Webhook\\_fixtures\\BusinessEvents\\StructuredObjectBusinessEvent\:\:getEncodeValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/Webhook/_fixtures/BusinessEvents/StructuredObjectBusinessEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Test\\\\Webhook\\\\_fixtures\\\\BusinessEvents\\\\UnstructuredObjectBusinessEvent\\:\\:getEncodeValues\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Test\\Webhook\\_fixtures\\BusinessEvents\\UnstructuredObjectBusinessEvent\:\:getEncodeValues\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/Webhook/_fixtures/BusinessEvents/UnstructuredObjectBusinessEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Test\\\\Webhook\\\\_fixtures\\\\BusinessEvents\\\\UnstructuredObjectBusinessEvent\\:\\:getNested\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Test\\Webhook\\_fixtures\\BusinessEvents\\UnstructuredObjectBusinessEvent\:\:getNested\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/Webhook/_fixtures/BusinessEvents/UnstructuredObjectBusinessEvent.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Test\\\\Webhook\\\\_fixtures\\\\BusinessEvents\\\\UnstructuredObjectBusinessEvent\\:\\:\\$nested type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Framework\\Test\\Webhook\\_fixtures\\BusinessEvents\\UnstructuredObjectBusinessEvent\:\:\$nested type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Test/Webhook/_fixtures/BusinessEvents/UnstructuredObjectBusinessEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Util\\\\Random\\:\\:getRandomArrayElement\\(\\) has no return type specified\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Util\\Random\:\:getRandomArrayElement\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/Core/Framework/Util/Random.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Util\\\\Random\\:\\:getRandomArrayElement\\(\\) has parameter \\$array with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Util\\Random\:\:getRandomArrayElement\(\) has parameter \$array with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Util/Random.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/Util/Random.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Framework/Uuid/Uuid.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Validation/Constraint/ArrayOfTypeValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Validation/Constraint/ArrayOfUuidValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Framework/Validation/Constraint/UuidValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Validation\\\\DataValidator\\:\\:getViolations\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Validation\\DataValidator\:\:getViolations\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Validation/DataValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Validation\\\\DataValidator\\:\\:validate\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Validation\\DataValidator\:\:validate\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Validation/DataValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Validation\\\\DataValidator\\:\\:validateListDefinitions\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Validation\\DataValidator\:\:validateListDefinitions\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Validation/DataValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Validation\\\\DataValidator\\:\\:validateProperties\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Validation\\DataValidator\:\:validateProperties\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Validation/DataValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Validation\\\\DataValidator\\:\\:validateSubDefinitions\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Validation\\DataValidator\:\:validateSubDefinitions\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Validation/DataValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Validation\\\\Exception\\\\ConstraintViolationException\\:\\:__construct\\(\\) has parameter \\$inputData with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Validation\\Exception\\ConstraintViolationException\:\:__construct\(\) has parameter \$inputData with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Validation/Exception/ConstraintViolationException.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Validation\\\\Exception\\\\ConstraintViolationException\\:\\:getInputData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Validation\\Exception\\ConstraintViolationException\:\:getInputData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Validation/Exception/ConstraintViolationException.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Framework/Webhook/BusinessEventEncoder.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Webhook\\\\Hookable\\\\HookableEventCollector\\:\\:getBusinessEventNamesWithPrivileges\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Webhook\\Hookable\\HookableEventCollector\:\:getBusinessEventNamesWithPrivileges\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Webhook/Hookable/HookableEventCollector.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Webhook\\\\Hookable\\\\HookableEventCollector\\:\\:getEventNamesWithPrivileges\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Webhook\\Hookable\\HookableEventCollector\:\:getEventNamesWithPrivileges\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Webhook/Hookable/HookableEventCollector.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Webhook\\\\Hookable\\\\HookableEventCollector\\:\\:getHookableEventNames\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Webhook\\Hookable\\HookableEventCollector\:\:getHookableEventNames\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Webhook/Hookable/HookableEventCollector.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Webhook\\\\Hookable\\\\HookableEventCollector\\:\\:getHookableEventNamesWithPrivileges\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Framework\\Webhook\\Hookable\\HookableEventCollector\:\:getHookableEventNamesWithPrivileges\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Framework/Webhook/Hookable/HookableEventCollector.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/Installer/Configuration/ShopConfigurationService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Installer/InstallerKernel.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/Installer/Requirements/Struct/RequirementCheck.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Traits\\\\StateMachineMigration\\:\\:__construct\\(\\) has parameter \\$states with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Migration\\Traits\\StateMachineMigration\:\:__construct\(\) has parameter \$states with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Migration/Traits/StateMachineMigration.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Traits\\\\StateMachineMigration\\:\\:__construct\\(\\) has parameter \\$transitions with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Migration\\Traits\\StateMachineMigration\:\:__construct\(\) has parameter \$transitions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Migration/Traits/StateMachineMigration.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Traits\\\\StateMachineMigration\\:\\:getStates\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Migration\\Traits\\StateMachineMigration\:\:getStates\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Migration/Traits/StateMachineMigration.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Traits\\\\StateMachineMigration\\:\\:getTransitions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Migration\\Traits\\StateMachineMigration\:\:getTransitions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Migration/Traits/StateMachineMigration.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Traits\\\\StateMachineMigration\\:\\:setStates\\(\\) has parameter \\$states with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Migration\\Traits\\StateMachineMigration\:\:setStates\(\) has parameter \$states with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Migration/Traits/StateMachineMigration.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Traits\\\\StateMachineMigration\\:\\:setTransitions\\(\\) has parameter \\$transitions with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Migration\\Traits\\StateMachineMigration\:\:setTransitions\(\) has parameter \$transitions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Migration/Traits/StateMachineMigration.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Traits\\\\StateMachineMigration\\:\\:state\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Migration\\Traits\\StateMachineMigration\:\:state\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Migration/Traits/StateMachineMigration.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Traits\\\\StateMachineMigration\\:\\:transition\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Migration\\Traits\\StateMachineMigration\:\:transition\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Migration/Traits/StateMachineMigration.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Traits\\\\StateMachineMigrationImporter\\:\\:createOrSkipExistingStateMachineState\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Migration\\Traits\\StateMachineMigrationImporter\:\:createOrSkipExistingStateMachineState\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Migration/Traits/StateMachineMigrationImporter.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Migration\\\\Traits\\\\StateMachineMigrationImporter\\:\\:createOrSkipExistingStateMachineStateTransitions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Migration\\Traits\\StateMachineMigrationImporter\:\:createOrSkipExistingStateMachineStateTransitions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Migration/Traits/StateMachineMigrationImporter.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 7
 			path: src/Core/Migration/Traits/StateMachineMigrationImporter.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Migration/V6_4/Migration1632721037OrderDocumentMailTemplate.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/Migration/V6_5/Migration1672931011ReviewFormMailTemplate.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Integration\\\\Datadog\\:\\:start\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Profiling\\Integration\\Datadog\:\:start\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Profiling/Integration/Datadog.php
 
 		-
-			message: "#^Mixed variable in a `\\$span\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$span\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 1
 			path: src/Core/Profiling/Integration/Datadog.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Profiling\\\\Integration\\\\Datadog\\:\\:\\$spans type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Profiling\\Integration\\Datadog\:\:\$spans type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Profiling/Integration/Datadog.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Integration\\\\ProfilerInterface\\:\\:start\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Profiling\\Integration\\ProfilerInterface\:\:start\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Profiling/Integration/ProfilerInterface.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Profiling\\\\Integration\\\\Tideways\\:\\:start\\(\\) has parameter \\$tags with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Profiling\\Integration\\Tideways\:\:start\(\) has parameter \$tags with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Profiling/Integration/Tideways.php
 
 		-
-			message: "#^Mixed variable in a `\\$span\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$span\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 1
 			path: src/Core/Profiling/Integration/Tideways.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Profiling\\\\Integration\\\\Tideways\\:\\:\\$spans type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Profiling\\Integration\\Tideways\:\:\$spans type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Profiling/Integration/Tideways.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Country\\\\Aggregate\\\\CountryStateTranslation\\\\CountryStateTranslationCollection\\:\\:getCountryStateIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Country\\Aggregate\\CountryStateTranslation\\CountryStateTranslationCollection\:\:getCountryStateIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Country/Aggregate/CountryStateTranslation/CountryStateTranslationCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Country\\\\Aggregate\\\\CountryStateTranslation\\\\CountryStateTranslationCollection\\:\\:getLanguageIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Country\\Aggregate\\CountryStateTranslation\\CountryStateTranslationCollection\:\:getLanguageIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Country/Aggregate/CountryStateTranslation/CountryStateTranslationCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Country\\\\Aggregate\\\\CountryTranslation\\\\CountryTranslationCollection\\:\\:getCountryIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Country\\Aggregate\\CountryTranslation\\CountryTranslationCollection\:\:getCountryIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Country/Aggregate/CountryTranslation/CountryTranslationCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Country\\\\Aggregate\\\\CountryTranslation\\\\CountryTranslationCollection\\:\\:getLanguageIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Country\\Aggregate\\CountryTranslation\\CountryTranslationCollection\:\:getLanguageIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Country/Aggregate/CountryTranslation/CountryTranslationCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Currency\\\\Aggregate\\\\CurrencyTranslation\\\\CurrencyTranslationCollection\\:\\:getCurrencyIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Currency\\Aggregate\\CurrencyTranslation\\CurrencyTranslationCollection\:\:getCurrencyIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Currency/Aggregate/CurrencyTranslation/CurrencyTranslationCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Currency\\\\Aggregate\\\\CurrencyTranslation\\\\CurrencyTranslationCollection\\:\\:getLanguageIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Currency\\Aggregate\\CurrencyTranslation\\CurrencyTranslationCollection\:\:getLanguageIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Currency/Aggregate/CurrencyTranslation/CurrencyTranslationCollection.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/CustomEntity/Schema/CustomEntitySchemaUpdater.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\CustomEntity\\\\Schema\\\\DynamicMappingEntityDefinition\\:\\:\\$fieldDefinitions type has no value type specified in iterable type array\\.$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 1
+			path: src/Core/System/CustomEntity/Schema/DynamicFieldFactory.php
+
+		-
+			message: '#^Property Shopware\\Core\\System\\CustomEntity\\Schema\\DynamicMappingEntityDefinition\:\:\$fieldDefinitions type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/CustomEntity/Schema/DynamicMappingEntityDefinition.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/CustomEntity/Schema/SchemaUpdater.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\System\\\\CustomEntity\\\\CustomEntityException, got Shopware\\\\Core\\\\System\\\\CustomEntity\\\\Xml\\\\Config\\\\CustomEntityConfigurationException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\System\\CustomEntity\\CustomEntityException, got Shopware\\Core\\System\\CustomEntity\\Xml\\Config\\CustomEntityConfigurationException$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/System/CustomEntity/Xml/Config/AdminUi/AdminUiXmlSchemaValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/System/CustomEntity/Xml/CustomEntityXmlSchemaValidator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/CustomEntity/Xml/Field/FieldFactory.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\CustomField\\\\Aggregate\\\\CustomFieldSet\\\\CustomFieldSetEntity\\:\\:getConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\CustomField\\Aggregate\\CustomFieldSet\\CustomFieldSetEntity\:\:getConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\CustomField\\\\Aggregate\\\\CustomFieldSet\\\\CustomFieldSetEntity\\:\\:setConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\CustomField\\Aggregate\\CustomFieldSet\\CustomFieldSetEntity\:\:setConfig\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\CustomField\\\\Aggregate\\\\CustomFieldSet\\\\CustomFieldSetEntity\\:\\:\\$config type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\System\\CustomField\\Aggregate\\CustomFieldSet\\CustomFieldSetEntity\:\:\$config type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/CustomField/Aggregate/CustomFieldSet/CustomFieldSetEntity.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/Language/Rule/LanguageRule.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/Language/TranslationValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Locale\\\\Aggregate\\\\LocaleTranslation\\\\LocaleTranslationCollection\\:\\:getLanguageIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Locale\\Aggregate\\LocaleTranslation\\LocaleTranslationCollection\:\:getLanguageIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Locale/Aggregate/LocaleTranslation/LocaleTranslationCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Locale\\\\Aggregate\\\\LocaleTranslation\\\\LocaleTranslationCollection\\:\\:getLocaleIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Locale\\Aggregate\\LocaleTranslation\\LocaleTranslationCollection\:\:getLocaleIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Locale/Aggregate/LocaleTranslation/LocaleTranslationCollection.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/NumberRange/ValueGenerator/NumberRangeValueGenerator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\NumberRange\\\\ValueGenerator\\\\Pattern\\\\AbstractValueGenerator\\:\\:generate\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\NumberRange\\ValueGenerator\\Pattern\\AbstractValueGenerator\:\:generate\(\) has parameter \$args with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/NumberRange/ValueGenerator/Pattern/AbstractValueGenerator.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/NumberRange/ValueGenerator/Pattern/IncrementStorage/IncrementStorageRegistry.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelTranslation\\\\SalesChannelTranslationEntity\\:\\:getHomeSlotConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelTranslation\\SalesChannelTranslationEntity\:\:getHomeSlotConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Aggregate/SalesChannelTranslation/SalesChannelTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelTranslation\\\\SalesChannelTranslationEntity\\:\\:setHomeSlotConfig\\(\\) has parameter \\$homeSlotConfig with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelTranslation\\SalesChannelTranslationEntity\:\:setHomeSlotConfig\(\) has parameter \$homeSlotConfig with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Aggregate/SalesChannelTranslation/SalesChannelTranslationEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelTranslation\\\\SalesChannelTranslationEntity\\:\\:\\$homeSlotConfig type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelTranslation\\SalesChannelTranslationEntity\:\:\$homeSlotConfig type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Aggregate/SalesChannelTranslation/SalesChannelTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelType\\\\SalesChannelTypeEntity\\:\\:getCoverUrl\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelType\\SalesChannelTypeEntity\:\:getCoverUrl\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelType\\\\SalesChannelTypeEntity\\:\\:getIconName\\(\\) should return string but returns string\\|null\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelType\\SalesChannelTypeEntity\:\:getIconName\(\) should return string but returns string\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelType\\\\SalesChannelTypeEntity\\:\\:getScreenshotUrls\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelType\\SalesChannelTypeEntity\:\:getScreenshotUrls\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelType\\\\SalesChannelTypeEntity\\:\\:getScreenshotUrls\\(\\) should return array but returns array\\|null\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelType\\SalesChannelTypeEntity\:\:getScreenshotUrls\(\) should return array but returns array\|null\.$#'
+			identifier: return.type
 			count: 1
 			path: src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelType\\\\SalesChannelTypeEntity\\:\\:setScreenshotUrls\\(\\) has parameter \\$screenshotUrls with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelType\\SalesChannelTypeEntity\:\:setScreenshotUrls\(\) has parameter \$screenshotUrls with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelType\\\\SalesChannelTypeEntity\\:\\:\\$screenshotUrls type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelType\\SalesChannelTypeEntity\:\:\$screenshotUrls type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Aggregate/SalesChannelType/SalesChannelTypeEntity.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/System/SalesChannel/Api/StructEncoder.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelException, got Shopware\\\\Core\\\\Checkout\\\\Order\\\\OrderException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\System\\SalesChannel\\SalesChannelException, got Shopware\\Core\\Checkout\\Order\\OrderException$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/System/SalesChannel/Context/SalesChannelContextRestorer.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/SalesChannel/Entity/SalesChannelDefinitionInstanceRegistry.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Event\\\\SalesChannelContextPermissionsChangedEvent\\:\\:__construct\\(\\) has parameter \\$permissions with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Event\\SalesChannelContextPermissionsChangedEvent\:\:__construct\(\) has parameter \$permissions with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Event/SalesChannelContextPermissionsChangedEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Event\\\\SalesChannelContextPermissionsChangedEvent\\:\\:getPermissions\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Event\\SalesChannelContextPermissionsChangedEvent\:\:getPermissions\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Event/SalesChannelContextPermissionsChangedEvent.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Event\\\\SalesChannelContextPermissionsChangedEvent\\:\\:\\$permissions type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\System\\SalesChannel\\Event\\SalesChannelContextPermissionsChangedEvent\:\:\$permissions type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Event/SalesChannelContextPermissionsChangedEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Event\\\\SalesChannelIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Event\\SalesChannelIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Event/SalesChannelIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Event\\\\SalesChannelIndexerEvent\\:\\:__construct\\(\\) has parameter \\$skip with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Event\\SalesChannelIndexerEvent\:\:__construct\(\) has parameter \$skip with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Event/SalesChannelIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Event\\\\SalesChannelIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Event\\SalesChannelIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Event/SalesChannelIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Event\\\\SalesChannelIndexerEvent\\:\\:getSkip\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SalesChannel\\Event\\SalesChannelIndexerEvent\:\:getSkip\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SalesChannel/Event/SalesChannelIndexerEvent.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelException, got Shopware\\\\Core\\\\Checkout\\\\Cart\\\\CartException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\System\\SalesChannel\\SalesChannelException, got Shopware\\Core\\Checkout\\Cart\\CartException$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/System/SalesChannel/SalesChannel/ContextSwitchRoute.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\System\\SalesChannel\\SalesChannelException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/SalesChannel/SalesChannel/StoreApiInfoController.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\Command\\\\ValidateSnippetsCommand\\:\\:hydrateMissingSnippets\\(\\) has parameter \\$missingSnippetsArray with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Snippet\\Command\\ValidateSnippetsCommand\:\:hydrateMissingSnippets\(\) has parameter \$missingSnippetsArray with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFileHandler\\:\\:findAdministrationSnippetFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFileHandler\:\:findAdministrationSnippetFiles\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Snippet/SnippetFileHandler.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFileHandler\\:\\:findSnippetFilesByPath\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFileHandler\:\:findSnippetFilesByPath\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Snippet/SnippetFileHandler.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFileHandler\\:\\:findStorefrontSnippetFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFileHandler\:\:findStorefrontSnippetFiles\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Snippet/SnippetFileHandler.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFileHandler\\:\\:openJsonFile\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFileHandler\:\:openJsonFile\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Snippet/SnippetFileHandler.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFileHandler\\:\\:writeJsonFile\\(\\) has parameter \\$content with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFileHandler\:\:writeJsonFile\(\) has parameter \$content with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Snippet/SnippetFileHandler.php
 
 		-
-			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/System/Snippet/SnippetFileHandler.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/Snippet/SnippetFileHandler.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFixer\\:\\:addTranslationUsingSnippetKey\\(\\) has parameter \\$json with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFixer\:\:addTranslationUsingSnippetKey\(\) has parameter \$json with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Snippet/SnippetFixer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFixer\\:\\:addTranslationUsingSnippetKey\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetFixer\:\:addTranslationUsingSnippetKey\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Snippet/SnippetFixer.php
 
 		-
-			message: "#^Parameter \\#2 \\$translation of method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFixer\\:\\:addTranslationUsingSnippetKey\\(\\) expects string, string\\|null given\\.$#"
+			message: '#^Parameter \#2 \$translation of method Shopware\\Core\\System\\Snippet\\SnippetFixer\:\:addTranslationUsingSnippetKey\(\) expects string, string\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/Core/System/Snippet/SnippetFixer.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetValidatorInterface\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Snippet\\SnippetValidatorInterface\:\:validate\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Snippet/SnippetValidatorInterface.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\StateMachine\\\\Loader\\\\InitialStateIdLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\StateMachine\\Loader\\InitialStateIdLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/StateMachine/Loader/InitialStateIdLoader.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\StateMachine\\\\Loader\\\\InitialStateIdLoader\\:\\:\\$ids type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\System\\StateMachine\\Loader\\InitialStateIdLoader\:\:\$ids type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/StateMachine/Loader/InitialStateIdLoader.php
 
 		-
-			message: "#^Argument of an invalid type Shopware\\\\Core\\\\System\\\\StateMachine\\\\Aggregation\\\\StateMachineState\\\\StateMachineStateCollection\\|null supplied for foreach, only iterables are supported\\.$#"
+			message: '#^Argument of an invalid type Shopware\\Core\\System\\StateMachine\\Aggregation\\StateMachineState\\StateMachineStateCollection\|null supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
 			count: 1
 			path: src/Core/System/StateMachine/StateMachineEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\AbstractSystemConfigLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\AbstractSystemConfigLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/AbstractSystemConfigLoader.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\System\\SystemConfig\\SystemConfigException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/System/SystemConfig/Api/SystemConfigController.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\CachedSystemConfigLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\CachedSystemConfigLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/CachedSystemConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Command\\\\ConfigGet\\:\\:writeConfigDefault\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Command\\ConfigGet\:\:writeConfigDefault\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Command/ConfigGet.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Command\\\\ConfigGet\\:\\:writeConfigJson\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Command\\ConfigGet\:\:writeConfigJson\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Command/ConfigGet.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Command\\\\ConfigGet\\:\\:writeConfigLegacy\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Command\\ConfigGet\:\:writeConfigLegacy\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Command/ConfigGet.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Core/System/SystemConfig/Command/ConfigGet.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Command\\\\ConfigSet\\:\\:handleDecode\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Command\\ConfigSet\:\:handleDecode\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Command/ConfigSet.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Event\\\\SystemConfigDomainLoadedEvent\\:\\:__construct\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Event\\SystemConfigDomainLoadedEvent\:\:__construct\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Event/SystemConfigDomainLoadedEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Event\\\\SystemConfigDomainLoadedEvent\\:\\:getConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Event\\SystemConfigDomainLoadedEvent\:\:getConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Event/SystemConfigDomainLoadedEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Event\\\\SystemConfigDomainLoadedEvent\\:\\:setConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Event\\SystemConfigDomainLoadedEvent\:\:setConfig\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Event/SystemConfigDomainLoadedEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Facade\\\\SystemConfigFacade\\:\\:app\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Facade\\SystemConfigFacade\:\:app\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Facade/SystemConfigFacade.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Facade\\\\SystemConfigFacade\\:\\:fetchAppPrivileges\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Facade\\SystemConfigFacade\:\:fetchAppPrivileges\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Facade/SystemConfigFacade.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Facade\\\\SystemConfigFacade\\:\\:get\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Facade\\SystemConfigFacade\:\:get\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Facade/SystemConfigFacade.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Facade\\\\SystemConfigFacade\\:\\:\\$appData type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\System\\SystemConfig\\Facade\\SystemConfigFacade\:\:\$appData type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Facade/SystemConfigFacade.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Core/System/SystemConfig/Facade/SystemConfigFacade.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\MemoizedSystemConfigLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\MemoizedSystemConfigLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/MemoizedSystemConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Store\\\\MemoizedSystemConfigStore\\:\\:getConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Store\\MemoizedSystemConfigStore\:\:getConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Store/MemoizedSystemConfigStore.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Store\\\\MemoizedSystemConfigStore\\:\\:setConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\Store\\MemoizedSystemConfigStore\:\:setConfig\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Store/MemoizedSystemConfigStore.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\SystemConfig\\\\Store\\\\MemoizedSystemConfigStore\\:\\:\\$configs type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\System\\SystemConfig\\Store\\MemoizedSystemConfigStore\:\:\$configs type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/Store/MemoizedSystemConfigStore.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigEntity\\:\\:getConfigurationValue\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigEntity\:\:getConfigurationValue\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigEntity\\:\\:setConfigurationValue\\(\\) has parameter \\$configurationValue with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigEntity\:\:setConfigurationValue\(\) has parameter \$configurationValue with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigEntity\\:\\:\\$configurationValue type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\System\\SystemConfig\\SystemConfigEntity\:\:\$configurationValue type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigLoader\\:\\:buildSystemConfigArray\\(\\) has parameter \\$systemConfigs with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigLoader\:\:buildSystemConfigArray\(\) has parameter \$systemConfigs with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigLoader\\:\\:buildSystemConfigArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigLoader\:\:buildSystemConfigArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigLoader\\:\\:filterNotActivatedPlugins\\(\\) has parameter \\$configValues with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigLoader\:\:filterNotActivatedPlugins\(\) has parameter \$configValues with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigLoader\\:\\:filterNotActivatedPlugins\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigLoader\:\:filterNotActivatedPlugins\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigLoader\\:\\:getSubArray\\(\\) has parameter \\$configValues with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigLoader\:\:getSubArray\(\) has parameter \$configValues with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigLoader\\:\\:getSubArray\\(\\) has parameter \\$keys with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigLoader\:\:getSubArray\(\) has parameter \$keys with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigLoader\\:\\:getSubArray\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigLoader\:\:getSubArray\(\) has parameter \$value with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigLoader\\:\\:getSubArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigLoader\:\:getSubArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\SystemConfig\\\\SystemConfigLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\SystemConfig\\SystemConfigLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/SystemConfig/SystemConfigLoader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 6
 			path: src/Core/System/SystemConfig/SystemConfigService.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Core/System/SystemConfig/Util/ConfigReader.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Tax\\\\Aggregate\\\\TaxRule\\\\TaxRuleEntity\\:\\:getData\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Tax\\Aggregate\\TaxRule\\TaxRuleEntity\:\:getData\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Tax\\\\Aggregate\\\\TaxRule\\\\TaxRuleEntity\\:\\:setData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Tax\\Aggregate\\TaxRule\\TaxRuleEntity\:\:setData\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\Tax\\\\Aggregate\\\\TaxRule\\\\TaxRuleEntity\\:\\:\\$data type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\System\\Tax\\Aggregate\\TaxRule\\TaxRuleEntity\:\:\$data type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Tax/Aggregate/TaxRule/TaxRuleEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Unit\\\\Aggregate\\\\UnitTranslation\\\\UnitTranslationCollection\\:\\:getLanguageIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Unit\\Aggregate\\UnitTranslation\\UnitTranslationCollection\:\:getLanguageIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Unit/Aggregate/UnitTranslation/UnitTranslationCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Unit\\\\Aggregate\\\\UnitTranslation\\\\UnitTranslationCollection\\:\\:getUnitIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\Unit\\Aggregate\\UnitTranslation\\UnitTranslationCollection\:\:getUnitIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/Unit/Aggregate/UnitTranslation/UnitTranslationCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\User\\\\Aggregate\\\\UserAccessKey\\\\UserAccessKeyCollection\\:\\:getUserIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\User\\Aggregate\\UserAccessKey\\UserAccessKeyCollection\:\:getUserIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/User/Aggregate/UserAccessKey/UserAccessKeyCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\User\\\\Aggregate\\\\UserConfig\\\\UserConfigEntity\\:\\:getValue\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\User\\Aggregate\\UserConfig\\UserConfigEntity\:\:getValue\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/User/Aggregate/UserConfig/UserConfigEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\User\\\\Aggregate\\\\UserConfig\\\\UserConfigEntity\\:\\:setValue\\(\\) has parameter \\$value with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\User\\Aggregate\\UserConfig\\UserConfigEntity\:\:setValue\(\) has parameter \$value with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/User/Aggregate/UserConfig/UserConfigEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\System\\\\User\\\\Aggregate\\\\UserConfig\\\\UserConfigEntity\\:\\:\\$value type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\System\\User\\Aggregate\\UserConfig\\UserConfigEntity\:\:\$value type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/User/Aggregate/UserConfig/UserConfigEntity.php
 
 		-
-			message: "#^Expected domain exception class Shopware\\\\Core\\\\System\\\\User\\\\UserException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
+			message: '#^Expected domain exception class Shopware\\Core\\System\\User\\UserException, got Shopware\\Core\\Framework\\Routing\\RoutingException$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Core/System/User/Api/UserValidationController.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\User\\\\UserCollection\\:\\:getLocaleIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\System\\User\\UserCollection\:\:getLocaleIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/System/User/UserCollection.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Test\\\\Integration\\\\Helper\\\\MailEventListener\\:\\:__construct\\(\\) has parameter \\$mapping with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Test\\Integration\\Helper\\MailEventListener\:\:__construct\(\) has parameter \$mapping with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Test/Integration/Helper/MailEventListener.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Test\\\\Integration\\\\Helper\\\\MailEventListener\\:\\:get\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Core\\Test\\Integration\\Helper\\MailEventListener\:\:get\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Test/Integration/Helper/MailEventListener.php
 
 		-
-			message: "#^Property Shopware\\\\Core\\\\Test\\\\Integration\\\\Helper\\\\MailEventListener\\:\\:\\$events type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Core\\Test\\Integration\\Helper\\MailEventListener\:\:\$events type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Core/Test/Integration/Helper/MailEventListener.php
 
 		-
-			message: "#^Method Shopware\\\\Elasticsearch\\\\DependencyInjection\\\\ElasticsearchExtension\\:\\:addConfig\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Elasticsearch\\DependencyInjection\\ElasticsearchExtension\:\:addConfig\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Elasticsearch/DependencyInjection/ElasticsearchExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Elasticsearch\\\\DependencyInjection\\\\ElasticsearchExtension\\:\\:getConfiguration\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Elasticsearch\\DependencyInjection\\ElasticsearchExtension\:\:getConfiguration\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Elasticsearch/DependencyInjection/ElasticsearchExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\DataAbstractionLayer\\\\AbstractElasticsearchAggregationHydrator\\:\\:hydrate\\(\\) has parameter \\$result with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Elasticsearch\\Framework\\DataAbstractionLayer\\AbstractElasticsearchAggregationHydrator\:\:hydrate\(\) has parameter \$result with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Elasticsearch/Framework/DataAbstractionLayer/AbstractElasticsearchAggregationHydrator.php
 
 		-
-			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\DataAbstractionLayer\\\\AbstractElasticsearchSearchHydrator\\:\\:hydrate\\(\\) has parameter \\$result with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Elasticsearch\\Framework\\DataAbstractionLayer\\AbstractElasticsearchSearchHydrator\:\:hydrate\(\) has parameter \$result with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Elasticsearch/Framework/DataAbstractionLayer/AbstractElasticsearchSearchHydrator.php
 
 		-
-			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\ElasticsearchDateHistogramAggregation\\:\\:getArray\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
+			count: 2
+			path: src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+
+		-
+			message: '#^Method Shopware\\Elasticsearch\\Framework\\ElasticsearchDateHistogramAggregation\:\:getArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Elasticsearch/Framework/ElasticsearchDateHistogramAggregation.php
 
 		-
-			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\IndexingDto\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Elasticsearch\\Framework\\Indexing\\IndexingDto\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Elasticsearch/Framework/Indexing/IndexingDto.php
 
 		-
-			message: "#^Method Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\IndexingDto\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Elasticsearch\\Framework\\Indexing\\IndexingDto\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Elasticsearch/Framework/Indexing/IndexingDto.php
 
 		-
-			message: "#^Property Shopware\\\\Elasticsearch\\\\Framework\\\\Indexing\\\\IndexingDto\\:\\:\\$ids type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Elasticsearch\\Framework\\Indexing\\IndexingDto\:\:\$ids type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Elasticsearch/Framework/Indexing/IndexingDto.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 3
 			path: src/Storefront/Controller/AddressController.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Controller/NewsletterController.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Controller/RegisterController.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\DependencyInjection\\\\StorefrontExtension\\:\\:addConfig\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\DependencyInjection\\StorefrontExtension\:\:addConfig\(\) has parameter \$options with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/DependencyInjection/StorefrontExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\DependencyInjection\\\\StorefrontExtension\\:\\:registerThemeServiceAliases\\(\\) has parameter \\$theme with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\DependencyInjection\\StorefrontExtension\:\:registerThemeServiceAliases\(\) has parameter \$theme with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/DependencyInjection/StorefrontExtension.php
 
 		-
-			message: "#^Mixed variable in a `\\$session\\-\\>getFlashBag\\(\\)\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$session\-\>getFlashBag\(\)\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 1
 			path: src/Storefront/Event/CartMergedSubscriber.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Framework/Media/StorefrontMediaValidatorRegistry.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Framework/Routing/RequestTransformer.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Framework/Seo/SeoUrlRoute/LandingPageSeoUrlRoute.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Framework/Seo/SeoUrlRoute/NavigationPageSeoUrlRoute.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Framework/Seo/SeoUrlRoute/ProductPageSeoUrlRoute.php
 
 		-
-			message: "#^Mixed variable in a `\\$expr\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$expr\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 2
 			path: src/Storefront/Framework/Twig/TokenParser/IconTokenParser.php
 
 		-
-			message: "#^Mixed variable in a `\\$expr\\-\\>\\.\\.\\.\\(\\)` can skip important errors\\. Make sure the type is known$#"
+			message: '#^Mixed variable in a `\$expr\-\>\.\.\.\(\)` can skip important errors\. Make sure the type is known$#'
+			identifier: typePerfect.noMixedMethodCaller
 			count: 2
 			path: src/Storefront/Framework/Twig/TokenParser/ThumbnailTokenParser.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Page\\\\Address\\\\AddressEditorModalStruct\\:\\:getMessages\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Page\\Address\\AddressEditorModalStruct\:\:getMessages\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Page/Address/AddressEditorModalStruct.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Page\\\\Address\\\\AddressEditorModalStruct\\:\\:setMessages\\(\\) has parameter \\$messages with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Page\\Address\\AddressEditorModalStruct\:\:setMessages\(\) has parameter \$messages with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Page/Address/AddressEditorModalStruct.php
 
 		-
-			message: "#^Property Shopware\\\\Storefront\\\\Page\\\\Address\\\\AddressEditorModalStruct\\:\\:\\$messages type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Storefront\\Page\\Address\\AddressEditorModalStruct\:\:\$messages type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Page/Address/AddressEditorModalStruct.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Page/Address/Detail/AddressDetailPageLoader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Page/LandingPage/LandingPageLoader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Storefront/Page/Maintenance/MaintenancePageLoader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Page/Navigation/Error/ErrorPageLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Page\\\\Sitemap\\\\SitemapPage\\:\\:getSitemaps\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Page\\Sitemap\\SitemapPage\:\:getSitemaps\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Page/Sitemap/SitemapPage.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Page\\\\Sitemap\\\\SitemapPage\\:\\:setSitemaps\\(\\) has parameter \\$sitemaps with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Page\\Sitemap\\SitemapPage\:\:setSitemaps\(\) has parameter \$sitemaps with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Page/Sitemap/SitemapPage.php
 
 		-
-			message: "#^Property Shopware\\\\Storefront\\\\Page\\\\Sitemap\\\\SitemapPage\\:\\:\\$sitemaps type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Storefront\\Page\\Sitemap\\SitemapPage\:\:\$sitemaps type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Page/Sitemap/SitemapPage.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Pagelet/Header/HeaderPageletLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\AbstractResolvedConfigLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\AbstractResolvedConfigLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/AbstractResolvedConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Aggregate\\\\ThemeTranslationEntity\\:\\:getHelpTexts\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Aggregate\\ThemeTranslationEntity\:\:getHelpTexts\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Aggregate/ThemeTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Aggregate\\\\ThemeTranslationEntity\\:\\:getLabels\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Aggregate\\ThemeTranslationEntity\:\:getLabels\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Aggregate/ThemeTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Aggregate\\\\ThemeTranslationEntity\\:\\:setHelpTexts\\(\\) has parameter \\$helpTexts with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Aggregate\\ThemeTranslationEntity\:\:setHelpTexts\(\) has parameter \$helpTexts with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Aggregate/ThemeTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Aggregate\\\\ThemeTranslationEntity\\:\\:setLabels\\(\\) has parameter \\$labels with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Aggregate\\ThemeTranslationEntity\:\:setLabels\(\) has parameter \$labels with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Aggregate/ThemeTranslationEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\Aggregate\\\\ThemeTranslationEntity\\:\\:\\$helpTexts type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Storefront\\Theme\\Aggregate\\ThemeTranslationEntity\:\:\$helpTexts type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Aggregate/ThemeTranslationEntity.php
 
 		-
-			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\Aggregate\\\\ThemeTranslationEntity\\:\\:\\$labels type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Storefront\\Theme\\Aggregate\\ThemeTranslationEntity\:\:\$labels type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Aggregate/ThemeTranslationEntity.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\CachedResolvedConfigLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\CachedResolvedConfigLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/CachedResolvedConfigLoader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Theme/Command/ThemeCreateCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Command\\\\ThemePrepareIconsCommand\\:\\:getChildren\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Command\\ThemePrepareIconsCommand\:\:getChildren\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Command/ThemePrepareIconsCommand.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Theme/ConfigLoader/StaticFileAvailableThemeProvider.php
 
 		-
-			message: "#^Call to function is_string\\(\\) with string will always evaluate to true\\.$#"
+			message: '#^Call to function is_string\(\) with string will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
 			count: 1
 			path: src/Storefront/Theme/ConfigLoader/StaticFileConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ConfigLoader\\\\StaticFileConfigLoader\\:\\:prepareCollections\\(\\) has parameter \\$fileObject with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ConfigLoader\\StaticFileConfigLoader\:\:prepareCollections\(\) has parameter \$fileObject with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ConfigLoader/StaticFileConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ConfigLoader\\\\StaticFileConfigLoader\\:\\:prepareCollections\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ConfigLoader\\StaticFileConfigLoader\:\:prepareCollections\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ConfigLoader/StaticFileConfigLoader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Theme/ConfigLoader/StaticFileConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Event\\\\ThemeConfigChangedEvent\\:\\:__construct\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Event\\ThemeConfigChangedEvent\:\:__construct\(\) has parameter \$config with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Event/ThemeConfigChangedEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Event\\\\ThemeConfigChangedEvent\\:\\:getConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Event\\ThemeConfigChangedEvent\:\:getConfig\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Event/ThemeConfigChangedEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Event\\\\ThemeIndexerEvent\\:\\:__construct\\(\\) has parameter \\$ids with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Event\\ThemeIndexerEvent\:\:__construct\(\) has parameter \$ids with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Event/ThemeIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Event\\\\ThemeIndexerEvent\\:\\:__construct\\(\\) has parameter \\$skip with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Event\\ThemeIndexerEvent\:\:__construct\(\) has parameter \$skip with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Event/ThemeIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Event\\\\ThemeIndexerEvent\\:\\:getIds\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Event\\ThemeIndexerEvent\:\:getIds\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Event/ThemeIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Event\\\\ThemeIndexerEvent\\:\\:getSkip\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Event\\ThemeIndexerEvent\:\:getSkip\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Event/ThemeIndexerEvent.php
 
 		-
-			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getId\\(\\)\\.$#"
+			message: '#^Call to an undefined method Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity\:\:getId\(\)\.$#'
+			identifier: method.notFound
 			count: 2
 			path: src/Storefront/Theme/ResolvedConfigLoader.php
 
 		-
-			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getUrl\\(\\)\\.$#"
+			message: '#^Call to an undefined method Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity\:\:getUrl\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Storefront/Theme/ResolvedConfigLoader.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ResolvedConfigLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ResolvedConfigLoader\:\:load\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ResolvedConfigLoader.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 4
 			path: src/Storefront/Theme/StorefrontPluginConfiguration/StorefrontPluginConfigurationFactory.php
 
 		-
-			message: "#^Call to an undefined method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Entity\\:\\:getName\\(\\)\\.$#"
+			message: '#^Call to an undefined method Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity\:\:getName\(\)\.$#'
+			identifier: method.notFound
 			count: 1
 			path: src/Storefront/Theme/Subscriber/AppLifecycleSubscriber.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Theme/Subscriber/FirstRunWizardSubscriber.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Theme/Subscriber/PluginLifecycleSubscriber.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:getCustom\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ThemeConfigField\:\:getCustom\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:getHelpText\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ThemeConfigField\:\:getHelpText\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:getLabel\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ThemeConfigField\:\:getLabel\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:getValue\\(\\) has no return type specified\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ThemeConfigField\:\:getValue\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:setCustom\\(\\) has parameter \\$custom with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ThemeConfigField\:\:setCustom\(\) has parameter \$custom with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:setHelpText\\(\\) has parameter \\$helpText with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ThemeConfigField\:\:setHelpText\(\) has parameter \$helpText with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:setLabel\\(\\) has parameter \\$label with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ThemeConfigField\:\:setLabel\(\) has parameter \$label with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:setValue\\(\\) has parameter \\$value with no type specified\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ThemeConfigField\:\:setValue\(\) has parameter \$value with no type specified\.$#'
+			identifier: missingType.parameter
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:\\$custom type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Storefront\\Theme\\ThemeConfigField\:\:\$custom type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:\\$helpText type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Storefront\\Theme\\ThemeConfigField\:\:\$helpText type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:\\$label \\(array\\) does not accept array\\|null\\.$#"
+			message: '#^Property Shopware\\Storefront\\Theme\\ThemeConfigField\:\:\$label \(array\) does not accept array\|null\.$#'
+			identifier: assign.propertyType
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:\\$label type has no value type specified in iterable type array\\.$#"
+			message: '#^Property Shopware\\Storefront\\Theme\\ThemeConfigField\:\:\$label type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Property Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigField\\:\\:\\$value has no type specified\\.$#"
+			message: '#^Property Shopware\\Storefront\\Theme\\ThemeConfigField\:\:\$value has no type specified\.$#'
+			identifier: missingType.property
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigField.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\ThemeConfigFieldFactory\\:\\:create\\(\\) has parameter \\$configFieldArray with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\ThemeConfigFieldFactory\:\:create\(\) has parameter \$configFieldArray with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigFieldFactory.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Theme/ThemeConfigFieldFactory.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 1
 			path: src/Storefront/Theme/ThemeFileResolver.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
+			message: '#^Throwing new exceptions within classes are not allowed\. Please use domain exception pattern\. See https\://github\.com/shopware/platform/blob/v6\.4\.20\.0/adr/2022\-02\-24\-domain\-exceptions\.md$#'
+			identifier: shopware.domainException
 			count: 2
 			path: src/Storefront/Theme/ThemeLifecycleHandler.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Twig\\\\ThemeInheritanceBuilderInterface\\:\\:build\\(\\) has parameter \\$bundles with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Twig\\ThemeInheritanceBuilderInterface\:\:build\(\) has parameter \$bundles with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Twig/ThemeInheritanceBuilderInterface.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Twig\\\\ThemeInheritanceBuilderInterface\\:\\:build\\(\\) has parameter \\$themes with no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Twig\\ThemeInheritanceBuilderInterface\:\:build\(\) has parameter \$themes with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Twig/ThemeInheritanceBuilderInterface.php
 
 		-
-			message: "#^Method Shopware\\\\Storefront\\\\Theme\\\\Twig\\\\ThemeInheritanceBuilderInterface\\:\\:build\\(\\) return type has no value type specified in iterable type array\\.$#"
+			message: '#^Method Shopware\\Storefront\\Theme\\Twig\\ThemeInheritanceBuilderInterface\:\:build\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
 			count: 1
 			path: src/Storefront/Theme/Twig/ThemeInheritanceBuilderInterface.php

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/MessagesShouldNotUsePHPStanTypes.php
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/Rules/MessagesShouldNotUsePHPStanTypes.php
@@ -2,17 +2,12 @@
 
 namespace Shopware\Core\DevOps\StaticAnalyze\PHPStan\Rules;
 
+use phpDocumentor\Reflection\DocBlock;
+use phpDocumentor\Reflection\DocBlockFactory;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\InClassNode;
-use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocNode;
 use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
-use PHPStan\PhpDocParser\Lexer\Lexer;
-use PHPStan\PhpDocParser\Parser\ConstExprParser;
-use PHPStan\PhpDocParser\Parser\PhpDocParser;
-use PHPStan\PhpDocParser\Parser\TokenIterator;
-use PHPStan\PhpDocParser\Parser\TypeParser;
-use PHPStan\PhpDocParser\ParserConfig;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -90,16 +85,10 @@ class MessagesShouldNotUsePHPStanTypes implements Rule
         return $errors;
     }
 
-    private function parsePhpDoc(string $tokens): PhpDocNode
+    private function parsePhpDoc(string $tokens): DocBlock
     {
-        $parserConfig = new ParserConfig([]);
-        $lexer = new Lexer($parserConfig);
-        $constExprParser = new ConstExprParser($parserConfig);
-        $typeParser = new TypeParser($parserConfig, $constExprParser);
-        $phpDocParser = new PhpDocParser($parserConfig, $typeParser, $constExprParser);
+        $phpDocParser = DocBlockFactory::createInstance();
 
-        $tokenIterator = new TokenIterator($lexer->tokenize($tokens));
-
-        return $phpDocParser->parse($tokenIterator);
+        return $phpDocParser->create($tokens);
     }
 }

--- a/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
+++ b/src/Core/DevOps/StaticAnalyze/PHPStan/common.neon
@@ -1,5 +1,5 @@
 includes:
-    - ../../../../../vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - phar://phpstan.phar/conf/bleedingEdge.neon
     - extension.neon
     - rules.neon
 


### PR DESCRIPTION
Do not merge this.

This PR is only a demonstration of showing population of PHPStan analysis using the github action feature about `Unchanged  files with annotations`. 

So far we can see max 10 in the preview of changes, section `Unchanged  files with annotations` https://github.com/shopware/shopware/pull/6280 while the logs formatted for github shows more, without specifying the lines and files within the logs (on local we can still see all from cli command) https://github.com/shopware/shopware/actions/runs/12826721228/job/35767216197?pr=6280

Derived from this work, this simple branch to ignore on purpose many them, leaving some.
This will of course not fly to trunk, danger job would not allow it anyway

