### PR TITLE
fix: support image gallery navigation 'none' configurations

### DIFF
--- a/changelog/_unreleased/2025-01-19-fix-image-gallery-navigation-none-configurations.md
+++ b/changelog/_unreleased/2025-01-19-fix-image-gallery-navigation-none-configurations.md
@@ -1,0 +1,12 @@
+---
+title: Fix image gallery navigation 'none' configurations
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Administration
+* Changed `navigationDots` default config of `image-gallery` cms element from `null` to `none`.
+* Changed value of `navigationArrows` and `navigationDots` options from `null` to `none` to prevent dynamic values with different translations of option labels.
+___
+# Storefront
+* Changed `cms-element-image-gallery.html.twig` template to support `none` configurations for `navigationArrows` and `navigationDots`.

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/component/component.spec.js
@@ -87,6 +87,7 @@ async function createWrapper(propsOverride) {
                     },
                     navigationDots: {
                         source: 'static',
+                        value: 'none',
                     },
                 },
                 ...propsOverride,

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/config.spec.js
@@ -89,7 +89,7 @@ async function createWrapper(activeTab = 'content') {
                         },
                         navigationDots: {
                             source: 'static',
-                            value: null,
+                            value: 'none',
                         },
                         galleryPosition: {
                             source: 'static',

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/config/sw-cms-el-config-image-gallery.html.twig
@@ -206,7 +206,7 @@
                                 @update:value="emitUpdateEl"
                             >
 
-                                <option :value="null">
+                                <option value="none">
                                     {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionNone') }}
                                 </option>
                                 <option value="inside">
@@ -229,7 +229,7 @@
                                 @update:value="emitUpdateEl"
                             >
 
-                                <option :value="null">
+                                <option value="none">
                                     {{ $tc('sw-cms.elements.imageSlider.config.label.navigationPositionNone') }}
                                 </option>
                                 <option value="inside">

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-gallery/index.ts
@@ -53,7 +53,7 @@ Shopware.Service('cmsService').registerCmsElement({
         },
         navigationDots: {
             source: 'static',
-            value: null,
+            value: 'none',
         },
         galleryPosition: {
             source: 'static',

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -67,7 +67,7 @@
                     navPosition: 'bottom',
                     speed: 500,
                     gutter: gutter ? gutter : 0,
-                    controls: navigationArrows ? true : false,
+                    controls: navigationArrows != "none",
                     autoHeight: false,
                     startIndex: startIndexThumbnails ? startIndexThumbnails : null
                 },
@@ -274,9 +274,9 @@
                                             {% endblock %}
 
                                             {% block element_image_gallery_inner_controls %}
-                                                {% if navigationArrows %}
+                                                {% if navigationArrows != "none" %}
                                                     <div class="gallery-slider-controls"
-                                                         data-gallery-slider-controls="{% if navigationArrows %}true{% else %}false{% endif %}">
+                                                         data-gallery-slider-controls="true">
                                                         {% block element_image_gallery_inner_control_items %}
                                                             {% block element_image_gallery_inner_control_prev %}
                                                                 <button class="base-slider-controls-prev gallery-slider-controls-prev{% if navigationArrows == "outside" %} is-nav-prev-outside{% elseif navigationArrows == "inside" %} is-nav-prev-inside{% endif %}"
@@ -410,7 +410,7 @@
                                 {% endblock %}
 
                                 {% block element_image_gallery_slider_dots %}
-                                    {% if imageCount > 1 and navigationDots %}
+                                    {% if imageCount > 1 and navigationDots != "none" %}
                                         <div class="base-slider-dots {% if imageCount > maxItemsToShowNav %} hide-dots{% elseif imageCount > maxItemsToShowMobileNav %} hide-dots-mobile{% endif %}">
                                             {% block element_image_gallery_slider_dots_buttons %}
                                                 {% for image in mediaItems %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Setting navigation arrows and/or navigation dots to 'None' in the image-gallery cms element actually does nothing. There is also a buggy behavior when configuring 'None' and then switch to another Administration language > The select box now shows nothing as selected option instead of the translated 'None'.

### 2. What does this change do, exactly?
# Administration
* Changed `navigationDots` default config of `image-gallery` cms element from `null` to `none`.
* Changed value of `navigationArrows` and `navigationDots` options from `null` to `none` to prevent dynamic values with different translations of option labels.

# Storefront
* Changed `cms-element-image-gallery.html.twig` template to support `none` configurations for `navigationArrows` and `navigationDots`.

### 3. Describe each step to reproduce the issue or behaviour.
Try setting navigation arrows and/or navigation dots to 'None' in the image-gallery cms element config > Check Storefront presentation.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #5646 
- closes #4499 
- closes #3641 
- closes #4659 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
