### PR TITLE
fix: missing mbstring error in gitlab pipelines

### DIFF
--- a/.gitlab/templates/plugin.yml
+++ b/.gitlab/templates/plugin.yml
@@ -186,7 +186,7 @@ default:
 build and validate zip:
     stage: build
     image:
-        name: ghcr.io/friendsofshopware/shopware-cli:0.4.44
+        name: ghcr.io/friendsofshopware/shopware-cli:0.4.63
         entrypoint: [ "/usr/local/bin/entrypoint.sh" ]
     rules:
         - exists:


### PR DESCRIPTION
### 1. Why is this change necessary?

fixes https://gitlab.shopware.com/shopware/6/services/migration-assistant/-/jobs/7529683

added here https://github.com/FriendsOfShopware/shopware-cli/commit/d12ebcf03cc0b29409b096197cc8a6fdd21b732c mbstring to container


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
