### PR TITLE
test: NEXT-40281 - create prodcut search test on storefront

### DIFF
--- a/tests/acceptance/tests/Search/ProductSearch.spec.ts
+++ b/tests/acceptance/tests/Search/ProductSearch.spec.ts
@@ -5,6 +5,7 @@ test ('Customer is able to search products in shop', {tag: '@Search'}, async ({
     TestDataService,
     StorefrontHome,
     StorefrontSearchSuggest,
+    SearchForTerm,
 }) => {
     await TestDataService.createBasicProduct({
         name: 'Bottle',
@@ -15,18 +16,18 @@ test ('Customer is able to search products in shop', {tag: '@Search'}, async ({
 
     await test.step('Customer searches with an invalid input and sees no results', async () => {
         await ShopCustomer.goesTo(StorefrontHome.url());
-        await StorefrontSearchSuggest.searchForTerm('Be');
+        await ShopCustomer.attemptsTo(SearchForTerm('Be'));
         await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestNoResult).toBeVisible();
     });
 
     await test.step('Customer searches for a partial term and sees multiple matching products', async () => {
-        await StorefrontSearchSuggest.searchForTerm('Bow');
+        await ShopCustomer.attemptsTo(SearchForTerm('Bow'))
         const totalCount1 = await StorefrontSearchSuggest.getTotalSearchResultCount();
         await ShopCustomer.expects(totalCount1).toBe(1);
     });
 
     await test.step('Customer refines the search term and sees a single matching product', async () => {
-        await StorefrontSearchSuggest.searchForTerm('Bo');
+        await ShopCustomer.attemptsTo(SearchForTerm('Bo'));
         const totalCount2 = await StorefrontSearchSuggest.getTotalSearchResultCount();
         await ShopCustomer.expects(totalCount2).toBe(2);
     });

--- a/tests/acceptance/tests/Search/ProductSearch.spec.ts
+++ b/tests/acceptance/tests/Search/ProductSearch.spec.ts
@@ -7,8 +7,8 @@ test ('Customer is able to search products in shop', {tag: '@Search'}, async ({
     StorefrontSearchSuggest,
     SalesChannelBaseConfig,
 }) => {
-    const product = await TestDataService.createBasicProduct({
-        name: 'Shopware',
+    const product1 = await TestDataService.createBasicProduct({
+        name: 'Bottle',
         price: [{
             currencyId: SalesChannelBaseConfig.defaultCurrencyId,
             gross: 10.00,
@@ -16,27 +16,42 @@ test ('Customer is able to search products in shop', {tag: '@Search'}, async ({
             net: 7.55,
         }],
     });
-    const productListing = await StorefrontHome.getListingItemByProductId(product.id);
-
+    const product2 = await TestDataService.createBasicProduct({
+        name: 'Bowl',
+        price: [{
+            currencyId: SalesChannelBaseConfig.defaultCurrencyId,
+            gross: 10.00,
+            linked: false,
+            net: 7.55,
+        }],
+    });
 
     await ShopCustomer.goesTo(StorefrontHome.url());
 
     await test.step('Customer tries search with invalid input', async () => {
-        await StorefrontSearchSuggest.searchInput.fill('Sf');
+        await StorefrontSearchSuggest.searchInput.fill('Be');
         await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestNoResult).toBeVisible();
     });
 
     await test.step('Customer tries search with valid input', async () => {
-        await StorefrontSearchSuggest.searchInput.fill('Sh');
-        await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestLineItemName).toHaveText(product.name);
-        await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestLineItemPrice).toContainText('€10.00*');
+        await StorefrontSearchSuggest.searchInput.fill('Bo');
+
+        const totalCount = await StorefrontSearchSuggest.getTotalSearchResultCount();
+        await ShopCustomer.expects(totalCount).toBe(2);
+
+        await StorefrontSearchSuggest.searchInput.fill('Bow');
+        await ShopCustomer.expects(StorefrontSearchSuggest.searchResultTotal).toBeVisible();
+        await ShopCustomer.expects(totalCount).toBe(1);
+
     
     });
 
     await test.step('Customer navigates to result page and wants to see all result', async () => {
         await StorefrontSearchSuggest.searchSuggestTotalLink.click();
-        await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText('Sh');
-        await ShopCustomer.expects(productListing.productName).toHaveText(product.name);
-        await ShopCustomer.expects(productListing.productPrice).toContainText('€10.00*');     
+        await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText('Bow');
+
+        const productListing2 = await StorefrontSearchSuggest.getListingItemByProductId(product2.id);
+        await ShopCustomer.expects(productListing2.productName).toHaveText(product2.name);
+        await ShopCustomer.expects(productListing2.productPrice).toContainText('€10.00*');     
     });
 });

--- a/tests/acceptance/tests/Search/ProductSearch.spec.ts
+++ b/tests/acceptance/tests/Search/ProductSearch.spec.ts
@@ -1,43 +1,46 @@
 import { test } from '@fixtures/AcceptanceTest';
 
-test ('Customer is able to search products in shop', {tag: '@Search'}, async ({
+test('Customer is able to search products in shop', { tag: '@Search' }, async ({ 
     ShopCustomer,
     TestDataService,
     StorefrontHome,
     StorefrontSearchSuggest,
     SearchForTerm,
+    IdProvider
 }) => {
-    await TestDataService.createBasicProduct({
-        name: 'Bottle',
-    });
-    await TestDataService.createBasicProduct({
-        name: 'Bowl',
-    });
+        const productNameSuffix = IdProvider.getIdPair().uuid;
 
-    await test.step('Customer searches with an invalid input and sees no results', async () => {
-        await ShopCustomer.goesTo(StorefrontHome.url());
-        await ShopCustomer.attemptsTo(SearchForTerm('Be'));
-        await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestNoResult).toBeVisible();
-    });
+        await TestDataService.createBasicProduct({
+            name: 'Bottle' + productNameSuffix,
+        });
+        await TestDataService.createBasicProduct({
+            name: 'Bowl' + productNameSuffix,
+        });
 
-    await test.step('Customer searches for a partial term and sees multiple matching products', async () => {
-        await ShopCustomer.attemptsTo(SearchForTerm('Bow'))
-        const totalCount1 = await StorefrontSearchSuggest.getTotalSearchResultCount();
-        await ShopCustomer.expects(totalCount1).toBe(1);
-    });
+        await test.step('Customer searches with an invalid input and sees no results', async () => {
+            await ShopCustomer.goesTo(StorefrontHome.url());
+            await ShopCustomer.attemptsTo(SearchForTerm('Be'));
+            await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestNoResult).toBeVisible();
+        });
 
-    await test.step('Customer refines the search term and sees a single matching product', async () => {
-        await ShopCustomer.attemptsTo(SearchForTerm('Bo'));
-        const totalCount2 = await StorefrontSearchSuggest.getTotalSearchResultCount();
-        await ShopCustomer.expects(totalCount2).toBe(2);
-    });
+        await test.step('Customer searches term and sees a single matching product', async () => {
+            await ShopCustomer.attemptsTo(SearchForTerm('Bowl' + productNameSuffix));
+            const totalCount1 = await StorefrontSearchSuggest.getTotalSearchResultCount();
+            await ShopCustomer.expects(totalCount1).toBe(1);
+        });
 
-    await test.step('Customer navigates to the results page to view all matching products', async () => {
-        await StorefrontSearchSuggest.searchSuggestTotalLink.click();
-        await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText('Bo');
-        await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText('2');
+        await test.step('Customer searches for a partial term and sees multiple matching products', async () => {
+            await ShopCustomer.attemptsTo(SearchForTerm('Bo'));
+            const totalCount2 = await StorefrontSearchSuggest.getTotalSearchResultCount();
+            await ShopCustomer.expects(totalCount2).toBeGreaterThanOrEqual(2);
+        });
 
-        const listedItemsCount = await StorefrontSearchSuggest.productListItems.count();
-        await ShopCustomer.expects(listedItemsCount).toBe(2);
-    });
-});
+        await test.step('Customer navigates to the results page to view all matching products', async () => {
+            await StorefrontSearchSuggest.searchSuggestTotalLink.click();
+            await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText('Bo');
+
+            const listedItemsCount = await StorefrontSearchSuggest.productListItems.count();
+            await ShopCustomer.expects(listedItemsCount).toBeGreaterThanOrEqual(2);
+        });
+    }
+);

--- a/tests/acceptance/tests/Search/ProductSearch.spec.ts
+++ b/tests/acceptance/tests/Search/ProductSearch.spec.ts
@@ -5,53 +5,38 @@ test ('Customer is able to search products in shop', {tag: '@Search'}, async ({
     TestDataService,
     StorefrontHome,
     StorefrontSearchSuggest,
-    SalesChannelBaseConfig,
 }) => {
-    const product1 = await TestDataService.createBasicProduct({
+    await TestDataService.createBasicProduct({
         name: 'Bottle',
-        price: [{
-            currencyId: SalesChannelBaseConfig.defaultCurrencyId,
-            gross: 10.00,
-            linked: false,
-            net: 7.55,
-        }],
     });
-    const product2 = await TestDataService.createBasicProduct({
+    await TestDataService.createBasicProduct({
         name: 'Bowl',
-        price: [{
-            currencyId: SalesChannelBaseConfig.defaultCurrencyId,
-            gross: 10.00,
-            linked: false,
-            net: 7.55,
-        }],
     });
 
-    await ShopCustomer.goesTo(StorefrontHome.url());
-
-    await test.step('Customer tries search with invalid input', async () => {
-        await StorefrontSearchSuggest.searchInput.fill('Be');
+    await test.step('Customer searches with an invalid input and sees no results', async () => {
+        await ShopCustomer.goesTo(StorefrontHome.url());
+        await StorefrontSearchSuggest.searchForTerm('Be');
         await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestNoResult).toBeVisible();
     });
 
-    await test.step('Customer tries search with valid input', async () => {
-        await StorefrontSearchSuggest.searchInput.fill('Bo');
-
-        const totalCount = await StorefrontSearchSuggest.getTotalSearchResultCount();
-        await ShopCustomer.expects(totalCount).toBe(2);
-
-        await StorefrontSearchSuggest.searchInput.fill('Bow');
-        await ShopCustomer.expects(StorefrontSearchSuggest.searchResultTotal).toBeVisible();
-        await ShopCustomer.expects(totalCount).toBe(1);
-
-    
+    await test.step('Customer searches for a partial term and sees multiple matching products', async () => {
+        await StorefrontSearchSuggest.searchForTerm('Bow');
+        const totalCount1 = await StorefrontSearchSuggest.getTotalSearchResultCount();
+        await ShopCustomer.expects(totalCount1).toBe(1);
     });
 
-    await test.step('Customer navigates to result page and wants to see all result', async () => {
-        await StorefrontSearchSuggest.searchSuggestTotalLink.click();
-        await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText('Bow');
+    await test.step('Customer refines the search term and sees a single matching product', async () => {
+        await StorefrontSearchSuggest.searchForTerm('Bo');
+        const totalCount2 = await StorefrontSearchSuggest.getTotalSearchResultCount();
+        await ShopCustomer.expects(totalCount2).toBe(2);
+    });
 
-        const productListing2 = await StorefrontSearchSuggest.getListingItemByProductId(product2.id);
-        await ShopCustomer.expects(productListing2.productName).toHaveText(product2.name);
-        await ShopCustomer.expects(productListing2.productPrice).toContainText('€10.00*');     
+    await test.step('Customer navigates to the results page to view all matching products', async () => {
+        await StorefrontSearchSuggest.searchSuggestTotalLink.click();
+        await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText('Bo');
+        await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText('2');
+
+        const listedItemsCount = await StorefrontSearchSuggest.productListItems.count();
+        await ShopCustomer.expects(listedItemsCount).toBe(2);
     });
 });

--- a/tests/acceptance/tests/Search/ProductSearch.spec.ts
+++ b/tests/acceptance/tests/Search/ProductSearch.spec.ts
@@ -1,0 +1,42 @@
+import { test } from '@fixtures/AcceptanceTest';
+
+test ('Customer is able to search products in shop', {tag: '@Search'}, async ({
+    ShopCustomer,
+    TestDataService,
+    StorefrontHome,
+    StorefrontSearchSuggest,
+    SalesChannelBaseConfig,
+}) => {
+    const product = await TestDataService.createBasicProduct({
+        name: 'Shopware',
+        price: [{
+            currencyId: SalesChannelBaseConfig.defaultCurrencyId,
+            gross: 10.00,
+            linked: false,
+            net: 7.55,
+        }],
+    });
+    const productListing = await StorefrontHome.getListingItemByProductId(product.id);
+
+
+    await ShopCustomer.goesTo(StorefrontHome.url());
+
+    await test.step('Customer tries search with invalid input', async () => {
+        await StorefrontSearchSuggest.searchInput.fill('Sf');
+        await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestNoResult).toBeVisible();
+    });
+
+    await test.step('Customer tries search with valid input', async () => {
+        await StorefrontSearchSuggest.searchInput.fill('Sh');
+        await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestLineItemName).toHaveText(product.name);
+        await ShopCustomer.expects(StorefrontSearchSuggest.searchSuggestLineItemPrice).toContainText('€10.00*');
+    
+    });
+
+    await test.step('Customer navigates to result page and wants to see all result', async () => {
+        await StorefrontSearchSuggest.searchSuggestTotalLink.click();
+        await ShopCustomer.expects(StorefrontSearchSuggest.searchHeadline).toContainText('Sh');
+        await ShopCustomer.expects(productListing.productName).toHaveText(product.name);
+        await ShopCustomer.expects(productListing.productPrice).toContainText('€10.00*');     
+    });
+});


### PR DESCRIPTION
We would like to migrate and also improve some of the test scenarios previously created using Cypress into our Playwright acceptance test suite.
I also added new verifications to the original Cypress tests to ensure they align with the current requirements or functionality.