### PR TITLE
chore: github format feature is limited to 10 warnings, we need more

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -78,7 +78,7 @@ jobs:
             phpstan-result-cache-
 
       - name: PHPStan
-        run: composer run phpstan -- --error-format=github --no-progress
+        run: composer run phpstan -- --error-format=table --no-progress
 
       - name: "Save result cache"
         uses: actions/cache/save@v4


### PR DESCRIPTION
### 1. Why is this change necessary?
On PR that enters the case of 10+ warnings towards unchanged files with PHPStan analysis, we won't see them due to hard limit of this beta feature with `github` format.


### 2. What does this change do, exactly?
Fallback on `table` format, which is the same output as running in CLI
