### PR TITLE
fix: Use plugin upgrade version, if available, when checking requirements

### DIFF
--- a/changelog/_unreleased/2025-01-20-use-plugin-upgrade-version-to-check-conflicts.md
+++ b/changelog/_unreleased/2025-01-20-use-plugin-upgrade-version-to-check-conflicts.md
@@ -1,0 +1,10 @@
+---
+title: Use plugin upgrade version, if available, to check for plugin conflicts
+author: Julian Drauz
+author_email: julian.drauz@pickware.de
+author_github: @DrauzJu
+---
+# Core
+* Changed `Shopware\Core\Framework\Plugin\Requirement\RequirementsValidator` to use plugins upgrade version instead of 
+  installed version to check for conflicts. This is important when updating a plugin, because in this case the new
+  upgrade version is relevant, not the previously installed version.

--- a/src/Core/Framework/Plugin/Requirement/RequirementsValidator.php
+++ b/src/Core/Framework/Plugin/Requirement/RequirementsValidator.php
@@ -226,7 +226,7 @@ class RequirementsValidator
                 $installedPluginComposerPackage->getConflicts(),
                 $installedPluginComposerPackage->getName(),
                 $this->pluginComposer->getPackage()->getName(),
-                new Constraint('==', $parser->normalize($installingPlugin->getVersion())),
+                new Constraint('==', $parser->normalize($installingPlugin->getUpgradeVersion() ?? $installingPlugin->getVersion())),
                 $exceptionStack
             );
 

--- a/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagTestValidateConflictsValidOtherPluginDuringUpdateA/composer.json
+++ b/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagTestValidateConflictsValidOtherPluginDuringUpdateA/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "swag/test-validate-conflicts-valid-other-plugin-during-update-a",
+    "description": "Test conflict handling",
+    "version": "v2.0.0",
+    "type": "shopware-platform-plugin",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "shopware AG",
+            "role": "Manufacturer"
+        }
+    ],
+    "extra": {
+        "shopware-plugin-class": "SwagTestValidateConflictsValidOtherPluginDuringUpdateA\\SwagTestValidateConflictsValidOtherPluginDuringUpdateA",
+        "copyright": "(c) by shopware AG",
+        "label": {
+            "de-DE": "Test für Konflikte-Handling",
+            "en-GB": "Test for conflict handling"
+        }
+    }
+}

--- a/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagTestValidateConflictsValidOtherPluginDuringUpdateB/composer.json
+++ b/src/Core/Framework/Test/Plugin/Requirement/_fixture/SwagTestValidateConflictsValidOtherPluginDuringUpdateB/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "swag/test-validate-conflicts-valid-other-plugin-during-update-b",
+    "description": "Test conflict handling",
+    "version": "v1.0.0",
+    "type": "shopware-platform-plugin",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "shopware AG",
+            "role": "Manufacturer"
+        }
+    ],
+    "conflict": {
+        "swag/test-validate-conflicts-valid-other-plugin-during-update-a": "< 2.0.0"
+    },
+    "extra": {
+        "shopware-plugin-class": "SwagTestValidateConflictsValidOtherPluginDuringUpdateB\\SwagTestValidateConflictsValidOtherPluginDuringUpdateB",
+        "copyright": "(c) by shopware AG",
+        "label": {
+            "de-DE": "Test für Konflikte-Handling",
+            "en-GB": "Test for conflict handling"
+        }
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

When installing, activating or updating a plugin, the plugin requirements and conflicts are checked. Currently, it always uses the plugin `version` to do so. This is a problem when updating the inactive plugin A from version 1.0.0 to version 2.0.0, but the active plugin B has a conflict on version 1.0.0. of plugin A (but not on version 2.0.0). In this case, updating plugin A fails, even though after the update no conflicts would exist.

### 2. What does this change do, exactly?

With this change, when checking plugin conflicts, the plugins `upgrade_version`, if available, is used instead of the `version`.

- When installing the plugin, no `upgrade_version` is available, so the behavior remains unchanged.
- When activating the plugin, the `upgrade_version` should be preferred as well, because in this version the plugins source code is actually present. Normally, the plugin should be updated to its `upgrade_version` before activating it, so the behavior remains unchanged.
- When updating the plugin, the faulty behavior explained above is fixed by using the plugins `upgrade_version` to check for conflicts.

### 3. Describe each step to reproduce the issue or behaviour.

See error description.

### 4. Please link to the relevant issues (if any).

None

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
