### PR TITLE
feat: Added new `checkout.place-order` extension point

### DIFF
--- a/src/Core/Checkout/Cart/Extension/CheckoutPlaceOrderExtension.php
+++ b/src/Core/Checkout/Cart/Extension/CheckoutPlaceOrderExtension.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Shopware\Core\Checkout\Cart\Extension;
+
+use Shopware\Core\Checkout\Cart\Cart;
+use Shopware\Core\Checkout\Cart\Order\OrderPlaceResult;
+use Shopware\Core\Framework\Extensions\Extension;
+use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @experimental stableVersion:v6.7.0 feature:EXTENSION_SYSTEM
+ *
+ * @codeCoverageIgnore
+ *
+ * @extends Extension<OrderPlaceResult>
+ */
+class CheckoutPlaceOrderExtension extends Extension
+{
+    public const NAME = 'checkout.place-order';
+
+    /**
+     * @internal shopware owns the __constructor, but the properties are public API
+     */
+    public function __construct(
+        /**
+         * @public
+         *
+         * @description The cart is already calculated and can be processed to place the order
+         */
+        public readonly Cart $cart,
+        /**
+         * @public
+         *
+         * @description Contains the current customer session parameters
+         */
+        public readonly SalesChannelContext $context,
+        /**
+         * @public
+         *
+         * @description Contains additional request parameters like customer comments etc.
+         */
+        public readonly RequestDataBag $data
+    ) {
+    }
+}

--- a/src/Core/Checkout/Cart/Order/OrderPlaceResult.php
+++ b/src/Core/Checkout/Cart/Order/OrderPlaceResult.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Shopware\Core\Checkout\Cart\Order;
+
+use Shopware\Core\Framework\Struct\Struct;
+
+class OrderPlaceResult extends Struct
+{
+    public function __construct(public string $orderId, public ?Struct $preOrderPayment = null)
+    {
+    }
+}

--- a/src/Core/Checkout/Cart/SalesChannel/CartOrderRoute.php
+++ b/src/Core/Checkout/Cart/SalesChannel/CartOrderRoute.php
@@ -9,7 +9,9 @@ use Shopware\Core\Checkout\Cart\CartContextHasher;
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedCriteriaEvent;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
+use Shopware\Core\Checkout\Cart\Extension\CheckoutPlaceOrderExtension;
 use Shopware\Core\Checkout\Cart\Order\OrderPersisterInterface;
+use Shopware\Core\Checkout\Cart\Order\OrderPlaceResult;
 use Shopware\Core\Checkout\Cart\TaxProvider\TaxProviderProcessor;
 use Shopware\Core\Checkout\Gateway\SalesChannel\AbstractCheckoutGatewayRoute;
 use Shopware\Core\Checkout\Order\OrderEntity;
@@ -18,6 +20,8 @@ use Shopware\Core\Checkout\Payment\PaymentProcessor;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Validation\DataBag\DataBag;
@@ -45,6 +49,7 @@ class CartOrderRoute extends AbstractCartOrderRoute
         private readonly TaxProviderProcessor $taxProviderProcessor,
         private readonly AbstractCheckoutGatewayRoute $checkoutGatewayRoute,
         private readonly CartContextHasher $cartContextHasher,
+        private readonly ExtensionDispatcher $extensions
     ) {
     }
 
@@ -65,19 +70,15 @@ class CartOrderRoute extends AbstractCartOrderRoute
         // we use this state in stock updater class, to prevent duplicate available stock updates
         $context->addState('checkout-order-route');
 
-        $calculatedCart = $this->cartCalculator->calculate($cart, $context);
+        $placed = $this->extensions->publish(
+            name: CheckoutPlaceOrderExtension::NAME,
+            extension: new CheckoutPlaceOrderExtension($cart, $context, $data),
+            function: $this->place(...)
+        );
 
-        $response = $this->checkoutGatewayRoute->load(new Request($data->all(), $data->all()), $cart, $context);
-        $calculatedCart->addErrors(...$response->getErrors());
+        $orderId = $placed->orderId;
 
-        $this->taxProviderProcessor->process($calculatedCart, $context);
-
-        $this->addCustomerComment($calculatedCart, $data);
-        $this->addAffiliateTracking($calculatedCart, $data);
-
-        $preOrderPayment = Profiler::trace('checkout-order::pre-payment', fn () => $this->paymentProcessor->validate($calculatedCart, $data, $context));
-
-        $orderId = Profiler::trace('checkout-order::order-persist', fn () => $this->orderPersister->persist($calculatedCart, $context));
+        $preOrderPayment = $placed->preOrderPayment;
 
         $criteria = new Criteria([$orderId]);
         $criteria
@@ -140,5 +141,24 @@ class CartOrderRoute extends AbstractCartOrderRoute
         if ($campaignCode) {
             $cart->setCampaignCode($campaignCode);
         }
+    }
+
+    private function place(Cart $cart, SalesChannelContext $context, RequestDataBag $data): OrderPlaceResult
+    {
+        $calculatedCart = $this->cartCalculator->calculate($cart, $context);
+
+        $response = $this->checkoutGatewayRoute->load(new Request($data->all(), $data->all()), $cart, $context);
+        $calculatedCart->addErrors(...$response->getErrors());
+
+        $this->taxProviderProcessor->process($calculatedCart, $context);
+
+        $this->addCustomerComment($calculatedCart, $data);
+        $this->addAffiliateTracking($calculatedCart, $data);
+
+        $preOrderPayment = Profiler::trace('checkout-order::pre-payment', fn () => $this->paymentProcessor->validate($calculatedCart, $data, $context));
+
+        $orderId = Profiler::trace('checkout-order::order-persist', fn () => $this->orderPersister->persist($calculatedCart, $context));
+
+        return new OrderPlaceResult($orderId, $preOrderPayment);
     }
 }

--- a/tests/unit/Core/Checkout/Cart/SalesChannel/CartOrderRouteTest.php
+++ b/tests/unit/Core/Checkout/Cart/SalesChannel/CartOrderRouteTest.php
@@ -12,8 +12,10 @@ use Shopware\Core\Checkout\Cart\CartContextHasher;
 use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedCriteriaEvent;
 use Shopware\Core\Checkout\Cart\Event\CheckoutOrderPlacedEvent;
+use Shopware\Core\Checkout\Cart\Extension\CheckoutPlaceOrderExtension;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Checkout\Cart\Order\OrderPersister;
+use Shopware\Core\Checkout\Cart\Order\OrderPlaceResult;
 use Shopware\Core\Checkout\Cart\Price\Struct\CartPrice;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartOrderRoute;
 use Shopware\Core\Checkout\Cart\Tax\Struct\CalculatedTaxCollection;
@@ -24,7 +26,11 @@ use Shopware\Core\Checkout\Order\OrderEntity;
 use Shopware\Core\Checkout\Payment\PaymentProcessor;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Struct\ArrayStruct;
+use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
+use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Generator;
@@ -70,7 +76,8 @@ class CartOrderRouteTest extends TestCase
             $this->createMock(PaymentProcessor::class),
             $this->createMock(TaxProviderProcessor::class),
             $this->createMock(AbstractCheckoutGatewayRoute::class),
-            $this->cartContextHasher
+            $this->cartContextHasher,
+            new ExtensionDispatcher(new EventDispatcher())
         );
 
         $this->context = Generator::generateSalesChannelContext();
@@ -276,5 +283,48 @@ class CartOrderRouteTest extends TestCase
         static::expectException(CartException::class);
 
         $this->route->order($cart, $this->context, $data);
+    }
+
+    public function testExtensionIsDispatched()
+    {
+        $cart = new Cart('test');
+
+        $context = $this->createMock(SalesChannelContext::class);
+
+        $dispatcher = new EventDispatcher();
+        $extensions = new ExtensionDispatcher($dispatcher);
+
+        $route = new CartOrderRoute(
+            $this->cartCalculator,
+            $this->orderRepository,
+            $this->orderPersister,
+            $this->createMock(AbstractCartPersister::class),
+            $this->eventDispatcher,
+            $this->createMock(PreparedPaymentService::class),
+            $this->createMock(PaymentProcessor::class),
+            $this->createMock(TaxProviderProcessor::class),
+            $this->createMock(AbstractCheckoutGatewayRoute::class),
+            $this->cartContextHasher,
+            $extensions
+        );
+
+        $post = $this->createMock(CallableClass::class);
+        $post->expects(static::exactly(1))->method('__invoke');
+        $dispatcher->addListener(ExtensionDispatcher::post(CheckoutPlaceOrderExtension::NAME), $post);
+
+        $dispatcher->addListener(
+            ExtensionDispatcher::pre(CheckoutPlaceOrderExtension::NAME),
+            function (CheckoutPlaceOrderExtension $extension) {
+                $extension->stopPropagation();
+
+                $extension->result = new OrderPlaceResult(Uuid::randomHex());
+            }
+        );
+
+        // we don't care about the follow up order process, the event listener above are already tested
+        static::expectException(CartException::class);
+        static::expectExceptionMessage('Order payment failed. The order was not stored.');
+
+        $route->order($cart, $context, new RequestDataBag());
     }
 }


### PR DESCRIPTION
### Why is this change necessary?
I would like to access the order process without decorating the whole order route and have a clear access point when the order get placed.

In the past i had to implement different real time stock validiations, which are cached during the store process but should be fetched live exactly at this point.

Having this as an extension point also offers me, to group my changes together instead of splitting the "feature" into multiple decorations, processors and other patterns.

### Question

Because of the `$preOrderPayment` i had to implement a Result struct. I was not sure which solution you would prefer, returning an array, a dedicated object, an array struct, an anonymous class etc. 

When this is clear - i can also provide some tests 

### Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
