### PR TITLE
chore: update require-package-annotation eslint rule

### DIFF
--- a/src/Administration/Resources/app/administration/eslint-rules/core-rules/require-package-annotation.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/core-rules/require-package-annotation.js
@@ -1,6 +1,30 @@
 /**
  * @package admin
  */
+
+// Should be kept in sync with phpstan-type in src/Core/Framework/Log/Package.php
+const VALID_DOMAINS = [
+    // ToDo: exclude the old areas
+    'buyers-experience',
+    'services-settings',
+    'administration',
+    'data-services',
+    'innovation',
+
+    // new domains starting at 2025
+    'framework',
+    'inventory',
+    'discovery',
+    'checkout',
+    'after-sales',
+    'b2b',
+    'fundamentals@framework',
+    'fundamentals@discovery',
+    'fundamentals@checkout',
+    'fundamentals@after-sales',
+];
+const VALID_DOMAIN_LIST = VALID_DOMAINS.map(s => `'${s}'`).join(', ');
+
 /* eslint-disable max-len */
 module.exports = {
     meta: {
@@ -10,6 +34,8 @@ module.exports = {
             description: 'Each file should have a package annotation',
             recommended: true,
         },
+
+        fixable: "code",
     },
     create(context) {
         const sourceCode = context.getSourceCode();
@@ -27,23 +53,70 @@ module.exports = {
 
         // Check every comment in the file
         let hasPackageAnnotation = false;
+        let annotationRegex = /(@package|@sw-package)\s+([a-zA-Z0-9-@]+)/i
 
         for (const comment of comments) {
-            if (comment.type === 'Block' && comment.value.includes('@sw-package')) {
+            if (comment.type !== 'Block') {
+                continue;
+            }
+
+            const match = comment.value.match(annotationRegex);
+            if (match) {
+                const annotation = match[1];
+                const domain = match[2];
                 hasPackageAnnotation = true;
+
+                checkAnnotation(context, sourceCode, comment, annotation, domain);
             }
         }
 
         if (!hasPackageAnnotation) {
             context.report({
                 loc: {
-                    start: { line: 1, column: 0 },
-                    end: { line: 1, column: 0 },
+                    start: {line: 1, column: 0},
+                    end: {line: 1, column: 0},
                 },
-                message: 'Missing package annotation',
+                message: `File is missing '@sw-package' annotation`,
             });
         }
 
         return {};
     },
 };
+
+function checkAnnotation(context, sourceCode, comment, annotation, domain) {
+    if (!VALID_DOMAINS.includes(domain)) {
+        const offsetInComment = comment.value.indexOf(domain);
+        const commentStart = comment.range[0] + '/*'.length; // isn't included in value, thus add its length
+        const locStart = sourceCode.getLocFromIndex(commentStart + offsetInComment);
+        const locEnd = sourceCode.getLocFromIndex(commentStart + offsetInComment + domain.length);
+
+        context.report({
+            loc: {
+                start: locStart,
+                end: locEnd,
+            },
+            message: `Invalid domain '${domain}'. Must be one of ${VALID_DOMAIN_LIST}`
+        });
+    }
+
+    if (annotation === '@package') {
+        const offsetInComment = comment.value.indexOf(annotation);
+        const commentStart = comment.range[0] + '/*'.length; // isn't included in value, thus add its length
+        const rangeStart = commentStart + offsetInComment;
+        const locStart = sourceCode.getLocFromIndex(rangeStart);
+        const rangeEnd = commentStart + offsetInComment + annotation.length;
+        const locEnd = sourceCode.getLocFromIndex(rangeEnd);
+
+        context.report({
+            loc: {
+                start: locStart,
+                end: locEnd,
+            },
+            message: `Use '@sw-package' instead of '@package'`,
+            fix: function (fixer) {
+                return fixer.replaceTextRange([rangeStart, rangeEnd], '@sw-package');
+            },
+        });
+    }
+}

--- a/src/Administration/Resources/app/administration/eslint-rules/core-rules/require-package-annotation.spec.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/core-rules/require-package-annotation.spec.js
@@ -14,7 +14,7 @@ tester.run('require-package-annotation', rule, {
             filename: 'test.js',
             code: `
 /**
-* @sw-package admin
+* @sw-package framework
 */
 const foo = 'bar';`
         },
@@ -23,7 +23,7 @@ const foo = 'bar';`
             filename: 'test.ts',
             code: `
 /**
-* @sw-package admin
+* @sw-package framework
 */
 const foo = 'bar';`
         },
@@ -34,7 +34,7 @@ const foo = 'bar';`
 // This is a comment
 
 /**
-* @sw-package admin
+* @sw-package framework
 */
 const foo = 'bar';`
         },
@@ -45,7 +45,7 @@ const foo = 'bar';`
 // This is a comment
 
 /**
-* @sw-package admin
+* @sw-package framework
 */
 const foo = 'bar';`
         },
@@ -71,7 +71,7 @@ const foo = 'bar';`
             filename: 'test.js',
             code: `const foo = 'bar';`,
             errors: [{
-                message: 'Missing package annotation',
+                message: 'File is missing \'@sw-package\' annotation',
                 line: 1,
             }]
         },
@@ -80,7 +80,7 @@ const foo = 'bar';`
             filename: 'test.ts',
             code: `const foo = 'bar';`,
             errors: [{
-                message: 'Missing package annotation',
+                message: 'File is missing \'@sw-package\' annotation',
                 line: 1,
             }]
         },
@@ -88,12 +88,12 @@ const foo = 'bar';`
             name: 'JS File with package annotation in line comment',
             filename: 'test.js',
             code: `
-// @sw-package admin
+// @sw-package framework
 
 const foo = 'bar';
 `,
             errors: [{
-                message: 'Missing package annotation',
+                message: 'File is missing \'@sw-package\' annotation',
                 line: 1,
             }]
         },
@@ -101,15 +101,90 @@ const foo = 'bar';
             name: 'TS File with package annotation in line comment',
             filename: 'test.ts',
             code: `
-// @sw-package admin
+// @sw-package framework
 
 const foo = 'bar';
             `,
             errors: [{
-                message: 'Missing package annotation',
+                message: 'File is missing \'@sw-package\' annotation',
                 line: 1,
             }]
         },
-    ]
-})
+        {
+            name: 'JS File with old package annotation',
+            filename: 'test.js',
+            code: `
+/*
+ *
+ *    @package    framework
+*/
 
+const foo = 'bar';
+`,
+            errors: [{
+                message: 'Use \'@sw-package\' instead of \'@package\'',
+                line: 4,
+            }],
+            output: `
+/*
+ *
+ *    @sw-package    framework
+*/
+
+const foo = 'bar';
+`,
+        },
+        {
+            name: 'TS File with old package annotation',
+            filename: 'test.ts',
+            code: `
+/*
+ * @package framework
+*/
+
+const foo = 'bar';
+`,
+            errors: [{
+                message: 'Use \'@sw-package\' instead of \'@package\'',
+                line: 3,
+            }],
+            output: `
+/*
+ * @sw-package framework
+*/
+
+const foo = 'bar';
+`,
+        },
+        {
+            name: 'JS File with wrong package annotation',
+            filename: 'test.js',
+            code: `
+/*
+ * @sw-package missing
+*/
+
+const foo = 'bar';
+`,
+            errors: [{
+                message: 'Invalid domain \'missing\'. Must be one of \'buyers-experience\', \'services-settings\', \'administration\', \'data-services\', \'innovation\', \'framework\', \'inventory\', \'discovery\', \'checkout\', \'after-sales\', \'b2b\', \'fundamentals@framework\', \'fundamentals@discovery\', \'fundamentals@checkout\', \'fundamentals@after-sales\'',
+                line: 3,
+            }]
+        },
+        {
+            name: 'TS File with wrong package annotation',
+            filename: 'test.ts',
+            code: `
+/*
+ * @sw-package missing
+*/
+
+const foo = 'bar';
+`,
+            errors: [{
+                message: 'Invalid domain \'missing\'. Must be one of \'buyers-experience\', \'services-settings\', \'administration\', \'data-services\', \'innovation\', \'framework\', \'inventory\', \'discovery\', \'checkout\', \'after-sales\', \'b2b\', \'fundamentals@framework\', \'fundamentals@discovery\', \'fundamentals@checkout\', \'fundamentals@after-sales\'',
+                line: 3,
+            }]
+        },
+    ]
+});

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/filter/sw-string-filter/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/filter/sw-string-filter/index.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import type { PropType } from 'vue';

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/filter/sw-string-filter/sw-string-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/filter/sw-string-filter/sw-string-filter.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-image-slider/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-image-slider/index.js
@@ -6,7 +6,7 @@ const { Filter } = Shopware;
 /**
  * @description Renders an image slider with possible image descriptions
  * @status ready
- * @sw-package content
+ * @sw-package discovery
  * @example-type static
  * @component-example
  * <sw-image-slider

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-image-slider/sw-image-slider.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-image-slider/sw-image-slider.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-add-thumbnail-form/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-add-thumbnail-form/index.js
@@ -3,7 +3,7 @@ import './sw-media-add-thumbnail-form.scss';
 
 /**
  * @private
- * @sw-package content
+ * @sw-package discovery
  */
 export default {
     template,

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-base-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-base-item/index.js
@@ -4,7 +4,7 @@ import './sw-media-base-item.scss';
 /**
  * @status ready
  * @description The <u>sw-media-base-item</u> component is the base for items in the media manager.
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-media-base-item

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-base-item/sw-media-base-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-base-item/sw-media-base-item.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 import { MtIcon } from '@shopware-ag/meteor-component-library';

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-compact-upload-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-compact-upload-v2/index.js
@@ -2,7 +2,7 @@ import template from './sw-media-compact-upload-v2.html.twig';
 import './sw-media-compact-upload-v2.scss';
 
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-compact-upload-v2/sw-media-compact-upload-v2.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-entity-mapper/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-entity-mapper/index.js
@@ -1,6 +1,6 @@
 /**
  * @private
- * @sw-package content
+ * @sw-package discovery
  */
 export default {
     functional: true,

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-field/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-field/index.js
@@ -7,7 +7,7 @@ const { Criteria } = Shopware.Data;
 /**
  * @status ready
  * @description The <u>sw-media-field</u> component is used to bind your
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-media-field v-model="manufacturer.mediaId"></sw-media-field>

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-field/sw-media-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-field/sw-media-field.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-folder-content/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-folder-content/index.js
@@ -5,7 +5,7 @@ const { Context } = Shopware;
 const { Criteria } = Shopware.Data;
 
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-folder-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-folder-item/index.js
@@ -5,7 +5,7 @@ const { Application, Mixin, Context } = Shopware;
 const { warn } = Shopware.Utils.debug;
 
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-folder-item/sw-media-folder-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-folder-item/sw-media-folder-item.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-list-selection-item-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-list-selection-item-v2/index.js
@@ -5,7 +5,7 @@ import './sw-media-list-selection-item-v2.scss';
  * @private
  * @description Component which renders an image.
  * @status ready
- * @sw-package content
+ * @sw-package discovery
  */
 export default {
     template,

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-list-selection-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-list-selection-v2/index.js
@@ -5,7 +5,7 @@ const { Mixin, Context } = Shopware;
 const utils = Shopware.Utils;
 
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-list-selection-v2/sw-media-list-selection-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-list-selection-v2/sw-media-list-selection-v2.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 import { reactive } from 'vue';

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-media-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-media-item/index.js
@@ -8,7 +8,7 @@ const { dom } = Shopware.Utils;
  * @status ready
  * @description The <u>sw-media-media-item</u> component is used to store the media item and manage it through the
  * <u>sw-media-base-item</u> component. Use the default slot to add additional context menu items.
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-media-media-item

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-delete/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-delete/index.js
@@ -6,7 +6,7 @@ const { Context, Mixin, Filter } = Shopware;
 /**
  * @status ready
  * @description The <u>sw-media-modal-delete</u> component is used to validate the delete action.
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-media-modal-delete :itemsToDelete="[items]">

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-delete/sw-media-modal-delete.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-delete/sw-media-modal-delete.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-folder-dissolve/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-folder-dissolve/index.js
@@ -5,7 +5,7 @@ const { Mixin } = Shopware;
 /**
  * @status ready
  * @description The <u>sw-media-modal-folder-dissolve</u> component is used to validate the dissolve folder action.
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-media-modal-folder-dissolve :itemsToDissolve="[items]">

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-folder-settings/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-folder-settings/index.js
@@ -7,7 +7,7 @@ const { mapPropertyErrors } = Component.getComponentHelper();
 
 /**
  * @private
- * @sw-package content
+ * @sw-package discovery
  */
 export default {
     template,

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-move/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-move/index.js
@@ -10,7 +10,7 @@ const {
 /**
  * @status ready
  * @description The <u>sw-media-modal-move</u> component is used to validate the move action.
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-media-modal-move :items-to-move="[items]"></sw-media-modal-move>

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-replace/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-replace/index.js
@@ -7,7 +7,7 @@ const { Mixin } = Shopware;
  * @status ready
  * @description The <u>sw-media-modal-replace</u> component is used to let the user upload a new image for an
  * existing media object.
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-media-modal-replace itemToReplace="item">

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-preview-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-preview-v2/index.js
@@ -7,7 +7,7 @@ const { fileReader } = Shopware.Utils;
 /**
  * @status ready
  * @description The <u>sw-media-preview-v2</u> component is used to show a preview of media objects.
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-media-preview-v2

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-preview-v2/sw-media-preview-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-preview-v2/sw-media-preview-v2.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 import { deepMergeObject } from 'src/core/service/utils/object.utils';

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-replace/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-replace/index.js
@@ -3,7 +3,7 @@
  * @status ready
  * @description The <u>sw-media-replace</u> component extends the <u>sw-media-upload</u> component. It is
  * used in cases of replacing items rather than uploading them.
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-media-replace

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-upload-v2/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-upload-v2/index.js
@@ -11,7 +11,7 @@ const INPUT_TYPE_URL_UPLOAD = 'url-upload';
  * @status ready
  * @description The <u>sw-media-upload-v2</u> component is used wherever an upload is needed. It supports drag & drop-,
  * file- and url-upload and comes in various forms.
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-media-upload-v2

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-upload-v2/sw-media-upload-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-upload-v2/sw-media-upload-v2.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 import FileValidationService from 'src/app/service/file-validation.service';

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-url-form/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-url-form/index.js
@@ -3,7 +3,7 @@ import template from './sw-media-url-form.html.twig';
 /**
  * @status ready
  * @description The <u>sw-media-url-form</u> component is used to validate urls from the user.
- * @sw-package content
+ * @sw-package discovery
  * @example-type static
  * @component-example
  * <sw-media-url-form variant="inline">

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-sidebar-media-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-sidebar-media-item/index.js
@@ -8,7 +8,7 @@ const { Criteria } = Shopware.Data;
  * @status ready
  * @description The <u>sw-sidebar-media-item</u> component is used everywhere you need media objects outside the media
  * manager. Use the additional properties to filter the shown media.
- * @sw-package content
+ * @sw-package discovery
  * @example-type code-only
  * @component-example
  * <sw-sidebar-media-item>

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-button/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-button/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package customer-order
+ * @sw-package innovation
  */
 
 import template from './sw-app-topbar-button.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-button/sw-app-topbar-button.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/app/sw-app-topbar-button/sw-app-topbar-button.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package customer-order
+ * @sw-package innovation
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-icon-deprecated/sw-icon-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-icon-deprecated/sw-icon-deprecated.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-icon/sw-icon.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-icon/sw-icon.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-item/sw-tabs-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-item/sw-tabs-item.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-bulk-edit-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-bulk-edit-modal/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-bulk-edit-modal.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-product-stream-grid-preview/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-product-stream-grid-preview/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package inventory
  */
 
 import template from './sw-product-stream-grid-preview.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-teaser-popover/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-teaser-popover/index.ts
@@ -17,7 +17,7 @@ interface TeaserPopoverConfig {
 }
 
 /**
- * @sw-package customer-order
+ * @sw-package innovation
  *
  * @private
  * @description A teaser popover for upselling service only, no public usage

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-teaser-sales-channel/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-teaser-sales-channel/index.ts
@@ -20,7 +20,7 @@ interface TeaserSalesChannelConfig {
 }
 
 /**
- * @sw-package customer-order
+ * @sw-package innovation
  *
  * @private
  * @description A teaser sales channel for upselling service only, no public usage

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-base-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-base-filter/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-base-filter.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-base-filter/sw-base-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-base-filter/sw-base-filter.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-boolean-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-boolean-filter/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-boolean-filter.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-boolean-filter/sw-boolean-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-boolean-filter/sw-boolean-filter.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-date-filter.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-existence-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-existence-filter/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-existence-filter.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-existence-filter/sw-existence-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-existence-filter/sw-existence-filter.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import 'src/app/component/filter/sw-existence-filter';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-filter-panel.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/sw-filter-panel.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/sw-filter-panel.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import 'src/app/component/filter/sw-filter-panel';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-multi-select-filter.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/sw-multi-select-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/sw-multi-select-filter.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-number-filter.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/sw-number-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/sw-number-filter.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { shallowMount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-range-filter.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/sw-range-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/sw-range-filter.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import 'src/app/component/filter/sw-range-filter';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-sidebar-filter-panel/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-sidebar-filter-panel/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-sidebar-filter-panel.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-advanced-selection-product.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-entity-advanced-selection-modal.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-many-to-many-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-many-to-many-select/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-entity-many-to-many-select.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-id-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-id-select/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-entity-multi-id-select.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-entity-multi-select.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import './sw-entity-single-select.scss';

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-tag-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-tag-select/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 const { Component } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-and-container/sw-condition-and-container.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-and-container/sw-condition-and-container.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package fundamentals@after-sales
  */
 
 import { mount, config } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-base/sw-condition-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-base/sw-condition-base.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package fundamentals@after-sales
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-operator-select/sw-condition-operator-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-operator-select/sw-condition-operator-select.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package fundamentals@after-sales
  */
 
 import { shallowMount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-or-container/sw-condition-or-container.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-or-container/sw-condition-or-container.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package fundamentals@after-sales
  */
 
 import { shallowMount, config } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-tree-node/sw-condition-tree-node.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-tree-node/sw-condition-tree-node.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package fundamentals@after-sales
  */
 
 import { mount, config } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-type-select/sw-condition-type-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-type-select/sw-condition-type-select.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package fundamentals@after-sales
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package fundamentals@after-sales
  */
 
 import template from './sw-condition-unit-menu.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/sw-condition-unit-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/sw-condition-unit-menu.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package fundamentals@after-sales
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-rule-modal/sw-rule-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-rule-modal/sw-rule-modal.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package fundamentals@after-sales
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/_sw-admin-menu-item/catalogues.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/_sw-admin-menu-item/catalogues.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/_sw-admin-menu-item/catalogues.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/_sw-admin-menu-item/catalogues.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/sw-admin-menu.html.twig
@@ -40,8 +40,16 @@
         >
             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
             {% block sw_admin_menu_navigation_main %}
-            <nav class="sw-admin-menu__navigation" aria-labelledby="mainmenulabel">
-                <h2 id="mainmenulabel" class="visually-hidden">{{ $tc('global.sw-admin-menu.navigation.label') }}</h2>
+            <nav
+                class="sw-admin-menu__navigation"
+                aria-labelledby="mainmenulabel"
+            >
+                <h2
+                    id="mainmenulabel"
+                    class="visually-hidden"
+                >
+                    {{ $tc('global.sw-admin-menu.navigation.label') }}
+                </h2>
 
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_admin_menu_navigation_main_list %}

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin/sw-admin.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin/sw-admin.html.twig
@@ -9,7 +9,10 @@
     @keyup="onUserActivity"
 >
     <!-- @experimental stableVersion:v6.8.0 feature:ADMIN_COMPOSITION_API_EXTENSION_SYSTEM -->
-    <div id="overrideComponents" style="display: none;">
+    <div
+        id="overrideComponents"
+        style="display: none;"
+    >
         <component
             :is="overrideComponent"
             v-for="(overrideComponent, index) in overrideComponents"

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-skip-link/sw-skip-link.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-skip-link/sw-skip-link.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import 'src/app/component/structure/sw-skip-link';

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/fixtures/treeItems.js
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/fixtures/treeItems.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 export default function getTreeItems() {

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-license-violation/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-license-violation/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-license-violation.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import './sw-notification-center-item.scss';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { POLL_BACKGROUND_INTERVAL, POLL_FOREGROUND_INTERVAL } from 'src/core/worker/worker-notification-listener';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-notifications.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-overlay/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-overlay/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import './sw-overlay.scss';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover-deprecated/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-popover.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-progress-bar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-progress-bar/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-progress-bar.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview-item/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-shortcut-overview-item.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-shortcut-overview.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton-bar-deprecated/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton-bar-deprecated/index.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-skeleton-bar-deprecated.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton/index.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-skeleton.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-step-display/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-step-display/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-step-display.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-step-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-step-item/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-step-item.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-text-preview/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-text-preview/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import './sw-text-preview.scss';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-upload-listener/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-upload-listener/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { UploadEvents } from 'src/core/service/api/media.api.service';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-verify-user-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-verify-user-modal/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-verify-user-modal.html.twig';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-vnode-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-vnode-renderer/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { compatUtils } from '@vue/compat';

--- a/src/Administration/Resources/app/administration/src/app/component/wizard/sw-wizard-dot-navigation/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/wizard/sw-wizard-dot-navigation/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import './sw-wizard-dot-navigation.scss';

--- a/src/Administration/Resources/app/administration/src/app/component/wizard/sw-wizard-page/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/wizard/sw-wizard-page/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import './sw-wizard-page.scss';

--- a/src/Administration/Resources/app/administration/src/app/composables/use-block-context.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-block-context.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 describe('use-block-context', () => {

--- a/src/Administration/Resources/app/administration/src/app/decorator/index.js
+++ b/src/Administration/Resources/app/administration/src/app/decorator/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/app/directive/click-outside.directive.ts
+++ b/src/Administration/Resources/app/administration/src/app/directive/click-outside.directive.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 // @ts-expect-error

--- a/src/Administration/Resources/app/administration/src/app/filter/media-name.filter.ts
+++ b/src/Administration/Resources/app/administration/src/app/filter/media-name.filter.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 Shopware.Filter.register(
     'mediaName',

--- a/src/Administration/Resources/app/administration/src/app/filter/thumbnail-size.filter.ts
+++ b/src/Administration/Resources/app/administration/src/app/filter/thumbnail-size.filter.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 Shopware.Filter.register('thumbnailSize', (value: Entity<'media_thumbnail_size'>) => {
     if (!value || !(value.getEntityName() === 'media_thumbnail_size')) {

--- a/src/Administration/Resources/app/administration/src/app/init/shortcut.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/shortcut.init.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/app/init/teaser-popover.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init/teaser-popover.init.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package innovation
  */
 
 import initTeaserButtons from 'src/app/init/teaser-popover.init';

--- a/src/Administration/Resources/app/administration/src/app/init/teaser-popover.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/teaser-popover.init.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package customer-order
+ * @sw-package innovation
  *
  * @private
  * @description Apply for upselling service only, no public usage

--- a/src/Administration/Resources/app/administration/src/app/init/topbar-button.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init/topbar-button.init.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package customer-order
+ * @sw-package innovation
  */
 import initTopbarButtons from 'src/app/init/topbar-button.init';
 import { send } from '@shopware-ag/meteor-admin-sdk/es/channel';

--- a/src/Administration/Resources/app/administration/src/app/init/topbar-button.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/topbar-button.init.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package customer-order
+ * @sw-package innovation
  *
  * @private
  * @description Apply for upselling service only, no public usage

--- a/src/Administration/Resources/app/administration/src/app/plugin/devtool-helper.plugin.ts
+++ b/src/Administration/Resources/app/administration/src/app/plugin/devtool-helper.plugin.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import type { Plugin } from 'vue';

--- a/src/Administration/Resources/app/administration/src/app/service/app-cms.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/service/app-cms.service.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 import AppCmsService from 'src/app/service/app-cms.service';

--- a/src/Administration/Resources/app/administration/src/app/service/criteria-helper.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/criteria-helper.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import Criteria from '@shopware-ag/meteor-admin-sdk/es/data/Criteria';

--- a/src/Administration/Resources/app/administration/src/app/service/custom-entity-definition.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/service/custom-entity-definition.service.spec.js
@@ -107,7 +107,7 @@ function createCustomEntityDefinitionService() {
 let service;
 
 /**
- * @sw-package content
+ * @sw-package framework
  */
 describe('src/app/service/custom-entity-definition.service', () => {
     beforeEach(() => {

--- a/src/Administration/Resources/app/administration/src/app/service/custom-entity-definition.service.ts
+++ b/src/Administration/Resources/app/administration/src/app/service/custom-entity-definition.service.ts
@@ -97,7 +97,7 @@ type NavigationMenuEntry = {
 
 /**
  * @private
- * @sw-package content
+ * @sw-package framework
  */
 export default class CustomEntityDefinitionService {
     #state = reactive({

--- a/src/Administration/Resources/app/administration/src/app/service/media-default-folder.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/media-default-folder.service.js
@@ -1,7 +1,7 @@
 const { Criteria } = Shopware.Data;
 
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default function createMediaDefaultFolderService() {

--- a/src/Administration/Resources/app/administration/src/app/service/media-default-folder.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/service/media-default-folder.service.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import MediaDefaultFolderService from 'src/app/service/media-default-folder.service';
 

--- a/src/Administration/Resources/app/administration/src/app/service/search-preferences.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/search-preferences.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package inventory
  */
 
 import { KEY_USER_SEARCH_PREFERENCE } from 'src/app/service/search-ranking.service';

--- a/src/Administration/Resources/app/administration/src/app/service/search-type.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/search-type.service.js
@@ -1,9 +1,6 @@
 /**
- * @sw-package unknown
- */
-
-/**
  * @module app/service/search-type
+ * @sw-package inventory
  */
 
 /**

--- a/src/Administration/Resources/app/administration/src/app/state/error.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/state/error.store.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import instance from './error.store';

--- a/src/Administration/Resources/app/administration/src/app/state/marketing.store.js
+++ b/src/Administration/Resources/app/administration/src/app/state/marketing.store.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package innovation
  */
 
 /**

--- a/src/Administration/Resources/app/administration/src/app/state/marketing.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/state/marketing.store.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package innovation
  */
 
 import ShopwareDiscountCampaignService from 'src/app/service/discount-campaign.service';

--- a/src/Administration/Resources/app/administration/src/app/state/rule-conditions-config.store.js
+++ b/src/Administration/Resources/app/administration/src/app/state/rule-conditions-config.store.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package fundamentals@after-sales
  */
 
 /**

--- a/src/Administration/Resources/app/administration/src/app/state/usage-data.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/state/usage-data.store.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package innovation
  */
 
 import Vuex from 'vuex';

--- a/src/Administration/Resources/app/administration/src/app/state/usage-data.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/state/usage-data.store.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package innovation
  */
 
 /**

--- a/src/Administration/Resources/app/administration/src/app/store/block-override.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/store/block-override.store.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import './block-override.store';

--- a/src/Administration/Resources/app/administration/src/app/store/block-override.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/block-override.store.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package customer-order
+ * @sw-package framework
  * @private
  */
 import useBlockContext from '../composables/use-block-context';

--- a/src/Administration/Resources/app/administration/src/app/store/teaser-popover.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/store/teaser-popover.store.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package innovation
  */
 
 import './teaser-popover.store';

--- a/src/Administration/Resources/app/administration/src/app/store/teaser-popover.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/teaser-popover.store.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package customer-order
+ * @sw-package innovation
  * @private
  * @description Apply for upselling service only, no public usage
  */

--- a/src/Administration/Resources/app/administration/src/app/store/topbar-button.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/store/topbar-button.store.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package customer-order
+ * @sw-package innovation
  */
 
 describe('topbar-button.store', () => {

--- a/src/Administration/Resources/app/administration/src/app/store/topbar-button.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/store/topbar-button.store.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package customer-order
+ * @sw-package innovation
  * @private
  * @description Apply for upselling service only, no public usage
  */

--- a/src/Administration/Resources/app/administration/src/core/data/error-codes/login.error-codes.js
+++ b/src/Administration/Resources/app/administration/src/core/data/error-codes/login.error-codes.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 const title = 'global.default.error';

--- a/src/Administration/Resources/app/administration/src/core/service/api/app-cms-blocks.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/app-cms-blocks.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import ApiService from '../api.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/app-modules.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/app-modules.service.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import type { AxiosInstance } from 'axios';

--- a/src/Administration/Resources/app/administration/src/core/service/api/cart-store-api.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/cart-store-api.api.service.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package checkout
  */
 
 import { deepCopyObject } from 'src/core/service/utils/object.utils';

--- a/src/Administration/Resources/app/administration/src/core/service/api/checkout-store.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/checkout-store.api.service.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package checkout
  */
 
 import type { AxiosInstance } from 'axios';

--- a/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.spec.js
@@ -1,8 +1,4 @@
 /**
- * @sw-package unknown
- */
-
-/**
  * @package checkout
  */
 import MailApiService from 'src/core/service/api/mail.api.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/media-folder.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/media-folder.api.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import ApiService from '../api.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/notifications.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/notifications.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import ApiService from '../api.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/number-range.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/number-range.api.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 const ApiService = Shopware.Classes.ApiService;

--- a/src/Administration/Resources/app/administration/src/core/service/api/product-export.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/product-export.api.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import ApiService from '../api.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/recommendations.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/recommendations.api.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 const ApiService = Shopware.Classes.ApiService;

--- a/src/Administration/Resources/app/administration/src/core/service/api/search.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/search.api.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package inventory
  */
 
 import { CanceledError } from 'axios';

--- a/src/Administration/Resources/app/administration/src/core/service/api/search.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/search.api.service.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package inventory
  */
 
 import createLoginService from 'src/core/service/login.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/seo-url-template.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/seo-url-template.api.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package inventory
  */
 
 import ApiService from '../api.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/seo-url.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/seo-url.api.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package inventory
  */
 
 import ApiService from '../api.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/store-context.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/store-context.api.service.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import type { AxiosInstance } from 'axios';

--- a/src/Administration/Resources/app/administration/src/core/service/api/user-input-sanitize.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/user-input-sanitize.service.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import ApiService from '../api.service';

--- a/src/Administration/Resources/app/administration/src/core/service/utils/eventBus.utils.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/eventBus.utils.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import mitt from 'mitt';

--- a/src/Administration/Resources/app/administration/src/core/service/utils/vue-helper.utils.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/vue-helper.utils.ts
@@ -1,9 +1,6 @@
 /**
- * @sw-package unknown
- */
-
-/**
  * @private
+ * @sw-package framework
  *
  * These helper methods shouldn't be used.
  * They are only needed used for internal purposes.

--- a/src/Administration/Resources/app/administration/src/core/worker/admin-notification-worker.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/worker/admin-notification-worker.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import AdminNotificationWorker from 'src/core/worker/admin-notification-worker';

--- a/src/Administration/Resources/app/administration/src/core/worker/admin-worker.shared-worker.js
+++ b/src/Administration/Resources/app/administration/src/core/worker/admin-worker.shared-worker.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import AdminWorker from 'src/core/worker/admin-worker';

--- a/src/Administration/Resources/app/administration/src/core/worker/admin-worker.worker.js
+++ b/src/Administration/Resources/app/administration/src/core/worker/admin-worker.worker.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import AdminWorker from 'src/core/worker/admin-worker';

--- a/src/Administration/Resources/app/administration/src/index.vite.ts
+++ b/src/Administration/Resources/app/administration/src/index.vite.ts
@@ -1,8 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
+ * @sw-package framework
  * @experimental stableVersion:v6.7.0 feature:VITE
  */
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/acl/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 Shopware.Service('privileges')

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/index.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import './app/app-renderer';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-contact/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-contact/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import template from './sw-cms-el-form-contact.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-newsletter/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-newsletter/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import template from './sw-cms-el-form-newsletter.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/index.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import './text';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-slider/config/sw-cms-el-config-product-slider.html.twig
@@ -92,7 +92,10 @@
                         @modal-close="onCloseProductStreamModal"
                     />
 
-                    <sw-container columns="1fr 1fr" gap="30px">
+                    <sw-container
+                        columns="1fr 1fr"
+                        gap="30px"
+                    >
                         <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                         {% block sw_cms_element_product_slider_config_content_product_stream_sorting %}
                         <sw-single-select
@@ -155,7 +158,10 @@
                         </sw-product-variant-info>
                     </template>
                     <template #result-item="{ item, index }">
-                        <slot name="result-item" v-bind="{ item, index }">
+                        <slot
+                            name="result-item"
+                            v-bind="{ item, index }"
+                        >
                             <sw-select-result v-bind="{ item, index, selected: isSelected(item.id)}">
                                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                                 {% block sw_entity_single_select_base_results_list_result_label %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-block-favorites.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-block-favorites.service.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import { reactive } from 'vue';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-element-favorites.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-element-favorites.service.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import { reactive } from 'vue';

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-custom-entity-input-field/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-custom-entity-input-field/index.ts
@@ -3,7 +3,7 @@ import template from './sw-custom-entity-input-field.html.twig';
 
 /**
  * @private
- * @sw-package content
+ * @sw-package framework
  */
 export default Shopware.Component.wrapComponentConfig({
     template,

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-custom-entity-input-field/sw-custom-entity-input-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-custom-entity-input-field/sw-custom-entity-input-field.spec.js
@@ -65,7 +65,7 @@ const basicMockData = {
 };
 
 /**
- * @sw-package content
+ * @sw-package framework
  */
 describe('module/sw-custom-entity/component/sw-custom-entity-input-field', () => {
     [

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-cms-page-assignment/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-cms-page-assignment/index.ts
@@ -14,7 +14,7 @@ interface CmsSlotOverrides {
 
 /**
  * @private
- * @sw-package content
+ * @sw-package discovery
  */
 export default Shopware.Component.wrapComponentConfig({
     template,

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-cms-page-assignment/sw-generic-cms-page-assignment.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-cms-page-assignment/sw-generic-cms-page-assignment.spec.js
@@ -33,7 +33,7 @@ const pageMock = {
 };
 
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 async function createWrapper() {
     return mount(
@@ -90,7 +90,7 @@ async function createWrapper() {
 }
 
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 describe('module/sw-custom-entity/component/sw-generic-cms-page-assignment', () => {
     beforeEach(() => {

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/index.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package inventory
  */
 
 import type { PropType } from 'vue';

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/sw-generic-seo-general-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/sw-generic-seo-general-card.spec.js
@@ -38,7 +38,7 @@ async function createWrapper() {
 }
 
 /**
- * @sw-package content
+ * @sw-package inventory
  */
 describe('src/module/sw-custom-entity/component/sw-generic-seo-general-card', () => {
     it('should display the seoMetaTitle and allow changing it', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/index.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import './sw-generic-social-media-card.scss';

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/sw-generic-social-media-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/sw-generic-social-media-card.spec.js
@@ -10,7 +10,7 @@ const TEST_OG_IMAGE = {
 };
 
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 async function createWrapper() {
     return mount(await wrapTestComponent('sw-generic-social-media-card', { sync: true }), {
@@ -93,7 +93,7 @@ async function createWrapper() {
 }
 
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 describe('src/module/sw-custom-entity/component/sw-generic-social-media-card', () => {
     it('should display the ogTitle and allow changing it', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/generic_custom_entities.d.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/generic_custom_entities.d.ts
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 declare namespace EntitySchema {

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/index.ts
@@ -2,28 +2,28 @@
 
 /**
  * @private
- * @sw-package content
+ * @sw-package framework
  */
 Shopware.Component.register('sw-generic-custom-entity-detail', () => import('./page/sw-generic-custom-entity-detail'));
 /**
  * @private
- * @sw-package content
+ * @sw-package framework
  */
 Shopware.Component.register('sw-generic-custom-entity-list', () => import('./page/sw-generic-custom-entity-list'));
 /**
  * @private
- * @sw-package content
+ * @sw-package framework
  */
 Shopware.Component.register('sw-custom-entity-input-field', () => import('./component/sw-custom-entity-input-field'));
 /**
  * @private
- * @sw-package content
+ * @sw-package framework
  */
 Shopware.Component.register('sw-generic-cms-page-assignment', () => import('./component/sw-generic-cms-page-assignment'));
 
 /**
  * @private
- * @sw-package content
+ * @sw-package framework
  */
 Shopware.Component.register('sw-generic-seo-general-card', () => import('./component/sw-generic-seo-general-card'));
 /**
@@ -67,6 +67,6 @@ Shopware.Module.register('sw-custom-entity', {
 
 /**
  * @private
- * @sw-package content
+ * @sw-package framework
  */
 export {};

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-detail/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-detail/index.ts
@@ -20,7 +20,7 @@ type GenericCustomEntityDetailData = {
 
 /**
  * @private
- * @sw-package content
+ * @sw-package framework
  */
 export default Shopware.Component.wrapComponentConfig({
     template,

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-detail/sw-generic-custom-entity-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-detail/sw-generic-custom-entity-detail.spec.js
@@ -4,7 +4,7 @@ import swGenericCustomEntityDetail from 'src/module/sw-custom-entity/page/sw-gen
 import 'src/app/component/base/sw-button-process';
 
 /**
- * @sw-package content
+ * @sw-package framework
  */
 
 Shopware.Component.register('sw-generic-custom-entity-detail', swGenericCustomEntityDetail);
@@ -262,7 +262,7 @@ const numberOfElementsDataProvider = [
 ];
 
 /**
- * @sw-package content
+ * @sw-package framework
  */
 describe('module/sw-custom-entity/page/sw-generic-custom-entity-detail', () => {
     it('should render the correct number of tabs, tab-items and activeTabs with correct labels', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/index.ts
@@ -41,7 +41,7 @@ interface RouteParseOptions {
 
 /**
  * @private
- * @sw-package content
+ * @sw-package framework
  */
 export default Shopware.Component.wrapComponentConfig({
     template,

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/sw-generic-custom-entity-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-list/sw-generic-custom-entity-list.spec.js
@@ -126,7 +126,7 @@ async function createWrapper(query = {}) {
 }
 
 /**
- * @sw-package content
+ * @sw-package framework
  */
 describe('module/sw-custom-entity/page/sw-generic-custom-entity-list', () => {
     it('should display the empty state when 0 entities are found', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/sw-custom-entity.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/sw-custom-entity.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package framework
  */
 import './index';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package checkout
  */
 
 import ApiService from 'src/core/service/api.service';

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import './page/sw-extension-sdk-module';

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import template from './sw-extension-sdk-module.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-store-landing-page/sw-extension-store-landing-page.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-store-landing-page/sw-extension-store-landing-page.html.twig
@@ -74,7 +74,10 @@
                 alt=""
             >
 
-            <span v-if="!insideModal" class="sw-extension-store-landing-page__wrapper-label">
+            <span
+                v-if="!insideModal"
+                class="sw-extension-store-landing-page__wrapper-label"
+            >
                 {{ $tc('sw-extension-store.landing-page.label') }}
             </span>
 

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/acl/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package after-sales
  */
 
 Shopware.Service('privileges').addPrivilegeMappingEntry({

--- a/src/Administration/Resources/app/administration/src/module/sw-landing-page/default-search-configuration.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-landing-page/default-search-configuration.js
@@ -15,7 +15,7 @@ const defaultSearchConfiguration = {
 };
 
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default defaultSearchConfiguration;

--- a/src/Administration/Resources/app/administration/src/module/sw-landing-page/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-landing-page/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import defaultSearchConfiguration from './default-search-configuration';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/acl/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package after-sales
  */
 
 Shopware.Service('privileges').addPrivilegeMappingEntry({

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-folder-info/sw-media-folder-info.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-folder-info/sw-media-folder-info.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 import 'src/module/sw-media/mixin/media-sidebar-modal.mixin';

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/sw-media-quickinfo-usage.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-usage/sw-media-quickinfo-usage.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo/sw-media-quickinfo.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 import 'src/module/sw-media/mixin/media-sidebar-modal.mixin';

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-tag/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-tag/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package discovery
  */
 
 import template from './sw-media-tag.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/sw-media-library.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-library/sw-media-library.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 import 'src/module/sw-media/mixin/media-grid-listener.mixin';

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-modal-v2/sw-media-modal-v2.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-modal-v2/sw-media-modal-v2.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/page/sw-media-index/sw-media-index.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package content
+ * @sw-package discovery
  */
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package inventory
  */
 
 import template from './sw-product-cross-selling-form.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-download-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-download-form/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package inventory
  */
 
 import template from './sw-product-download-form.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cache/page/sw-settings-cache-index/sw-settings-cache-index.html.twig
@@ -108,8 +108,15 @@
 
                 <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                 {% block sw_settings_cache_content_clear_data_cache_row %}
-                <sw-card-section v-if="feature.isActive('cache_rework')" divider="bottom">
-                    <sw-container align="center" columns="1fr auto" gap="20px">
+                <sw-card-section
+                    v-if="feature.isActive('cache_rework')"
+                    divider="bottom"
+                >
+                    <sw-container
+                        align="center"
+                        columns="1fr auto"
+                        gap="20px"
+                    >
                         <div>
                             <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
                             {% block sw_settings_cache_content_clear_data_cache_row_heading %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cart/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cart/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package checkout
  */
 
 const { Module } = Shopware;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cart/page/sw-settings-cart/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cart/page/sw-settings-cart/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package checkout
  */
 
 import template from './sw-settings-cart.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-multi-snippet-drag-and-drop/sw-multi-snippet-drag-and-drop.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-multi-snippet-drag-and-drop/sw-multi-snippet-drag-and-drop.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 
 /**
- * @sw-package customer-order
+ * @sw-package discovery
  */
 async function createWrapper(customPropsData = {}) {
     return mount(

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-new-snippet-modal/sw-settings-country-new-snippet-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-new-snippet-modal/sw-settings-country-new-snippet-modal.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 
 /**
- * @sw-package customer-order
+ * @sw-package discovery
  */
 async function createWrapper(customPropsData = {}) {
     return mount(

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-preview-template/sw-settings-country-preview-template.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-country/component/sw-settings-country-preview-template/sw-settings-country-preview-template.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 
 /**
- * @sw-package customer-order
+ * @sw-package fundamentals@discovery
  */
 async function createWrapper() {
     return mount(

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/acl/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package after-sales
  */
 
 Shopware.Service('privileges').addPrivilegeMappingEntry({

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-newsletter/page/sw-settings-newsletter/sw-settings-newsletter.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-newsletter/page/sw-settings-newsletter/sw-settings-newsletter.spec.js
@@ -1,7 +1,7 @@
 import { mount } from '@vue/test-utils';
 
 /**
- * @sw-package customer-order
+ * @sw-package after-sales
  */
 
 const classes = {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/sw-settings-salutation-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/sw-settings-salutation-detail.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package checkout
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-list/sw-settings-salutation-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-list/sw-settings-salutation-list.spec.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package checkout
  */
 
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-live-search-keyword/sw-settings-search-live-search-keyword.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-search/component/sw-settings-search-live-search-keyword/sw-settings-search-live-search-keyword.html.twig
@@ -4,7 +4,10 @@
 
     <!-- eslint-disable-next-line sw-deprecation-rules/no-twigjs-blocks -->
     {% block sw_settings_search_view_live_search_keyword_highlight %}
-    <span v-if="textIsHighlighted" v-html="text"></span>
+    <span
+        v-if="textIsHighlighted"
+        v-html="text"
+    ></span>
     <span
         v-for="(keyword, i) in parsedMsg"
         v-else

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/component/sw-settings-shipping-price-matrix/sw-settings-shipping-price-matrix.html.twig
@@ -232,13 +232,15 @@
         </template>
         {% endblock %}
     </sw-data-grid>
-    <div v-if="showDataGrid && !showAllPrices"
-         class="sw-settings-shipping-price-matrix__price-load-all"
+    <div
+        v-if="showDataGrid && !showAllPrices"
+        class="sw-settings-shipping-price-matrix__price-load-all"
     >
-        <sw-button variant="ghost"
-                   size="small"
-                   class="sw-settings-shipping-price-matrix__price-load-all-button"
-                   @click="updateShowAllPrices"
+        <sw-button
+            variant="ghost"
+            size="small"
+            class="sw-settings-shipping-price-matrix__price-load-all-button"
+            @click="updateShowAllPrices"
         >
             {{ $tc('sw-settings-shipping.priceMatrix.buttonLoadAllPrices') }}
         </sw-button>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/index.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 import './page/sw-settings-shopware-updates-wizard';

--- a/src/Administration/Resources/app/administration/test/_helper_/allowedErrors.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/allowedErrors.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  */
 
 export const unknownOptionError = {

--- a/src/Administration/Resources/app/administration/test/_helper_/componentWrapper/index.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/componentWrapper/index.js
@@ -1,10 +1,7 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
-/**
- * @package admin
-*/
 /* eslint-disable sw-test-rules/await-async-functions */
 import { defineAsyncComponent } from 'vue';
 // eslint-disable-next-line import/no-unresolved, import/extensions

--- a/src/Administration/Resources/app/administration/test/_helper_/componentWrapper/syncComponents.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/componentWrapper/syncComponents.js
@@ -1,10 +1,6 @@
 /**
- * @sw-package unknown
- */
-
-/**
  * @private
- * @package admin
+ * @sw-package framework
  */
 export default [
     'sw-admin',

--- a/src/Administration/Resources/app/administration/test/_helper_/flushPromises.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/flushPromises.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  */
 
 const scheduler = typeof setImmediate === 'function' ? setImmediate : setTimeout;

--- a/src/Administration/Resources/app/administration/test/_helper_/id.collection.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/id.collection.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  */
 
 import utils from 'src/core/service/util.service';

--- a/src/Administration/Resources/app/administration/test/_helper_/uuid.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/uuid.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  */
 
 const crypto = require('crypto');

--- a/src/Administration/Resources/app/administration/test/_setup/_mocks_/acl.service.mock.js
+++ b/src/Administration/Resources/app/administration/test/_setup/_mocks_/acl.service.mock.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  *
  * You can activate acl roles in the each test like this:
  * global.activeAclRoles = ['product.editor'];

--- a/src/Administration/Resources/app/administration/test/_setup/_mocks_/feature.service.mock.js
+++ b/src/Administration/Resources/app/administration/test/_setup/_mocks_/feature.service.mock.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  */
 
 import Feature from 'src/app/service/feature.service';

--- a/src/Administration/Resources/app/administration/test/_setup/_mocks_/repositoryFactory.service.mock.js
+++ b/src/Administration/Resources/app/administration/test/_setup/_mocks_/repositoryFactory.service.mock.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
+++ b/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  */
 
 import { config, enableAutoUnmount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/test/globalTeardown.js
+++ b/src/Administration/Resources/app/administration/test/globalTeardown.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  */
 
 /* eslint-disable */

--- a/src/Administration/Resources/app/administration/test/transformer/svgStringifyTransformer.js
+++ b/src/Administration/Resources/app/administration/test/transformer/svgStringifyTransformer.js
@@ -1,5 +1,5 @@
 /**
- * @sw-package unknown
+ * @sw-package framework
  */
 
 module.exports = {

--- a/src/Administration/Resources/app/administration/test/webpack/assets/ExamplePluginForTesting/src/Resources/administration/main.js
+++ b/src/Administration/Resources/app/administration/test/webpack/assets/ExamplePluginForTesting/src/Resources/administration/main.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  */
 
 import './src/app/component/dummy-component';

--- a/src/Administration/Resources/app/administration/test/webpack/assets/ExamplePluginForTesting/src/Resources/administration/src/app/component/dummy-component/index.js
+++ b/src/Administration/Resources/app/administration/test/webpack/assets/ExamplePluginForTesting/src/Resources/administration/src/app/component/dummy-component/index.js
@@ -1,9 +1,5 @@
 /**
- * @sw-package unknown
- */
-
-/**
- * @package admin
+ * @sw-package framework
  */
 
 const { Component } = Shopware;

--- a/src/Core/Framework/Log/Package.php
+++ b/src/Core/Framework/Log/Package.php
@@ -6,6 +6,10 @@ namespace Shopware\Core\Framework\Log;
  * @internal
  *
  * @phpstan-type PackageString 'buyers-experience'|'services-settings'|'inventory'|'checkout'|'after-sales'|'framework'|'data-services'|'innovation'|'discovery'|'b2b'|'fundamentals@framework'|'fundamentals@discovery'|'fundamentals@checkout'|'fundamentals@after-sales'
+ *
+ * # Important
+ * if the above valid types / domains are changed, please also update them here:
+ * src/Administration/Resources/app/administration/eslint-rules/core-rules/require-package-annotation.js
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 #[Package('framework')]


### PR DESCRIPTION
- Update `require-package-annotation.js` ESLint rule:
  - Report and auto fix any old `@package` annotation to be replaced by `@sw-package`
  - Report any `@sw-package {domain}` annotation with an unknown domain. This should match the linting behaviour we have in PHP
 - Replaced domain annotations for:
   - `unknown`
   - `content`
   - `customer-order`

Further ideas which might be worth further exploring in future PRs:
- report annotation of test `.spec` files, to make that consistent as some contain annotations and others not
- only allow one annotation per JS/TS file