### PR TITLE
test: VersionManagerTest was flaky on transaction usage

### DIFF
--- a/tests/integration/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/VersionManagerTest.php
@@ -24,7 +24,6 @@ use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\DataAbstractionLayer
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ManyToOneProductDefinition;
 use Shopware\Core\Framework\Test\DataAbstractionLayer\Field\TestDefinition\ToOneProductExtension;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
-use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
@@ -73,15 +72,14 @@ class VersionManagerTest extends TestCase
             ALTER TABLE `product`
             DROP FOREIGN KEY `fk.product.many_to_one_id`;
         ');
-        $this->connection->executeStatement('DROP TABLE `many_to_one_product`');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS `many_to_one_product`');
         $this->connection->executeStatement('
             ALTER TABLE `product`
             DROP COLUMN `many_to_one_id`
         ');
         $this->connection->beginTransaction();
 
-        // reboot kernel to create a new container since we manipulated the original one
-        KernelLifecycleManager::bootKernel();
+        parent::tearDown();
     }
 
     public function testWhenAddAnExtensionWithFKIdThenFKIdShouldBeCloned(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Integration test VersionManagerTest is flaky since a new test has been introduced, which is not creating a table that is dropped in teardown and, with the shape of that teardown does not end well on the trait DatabaseTransactionBehaviour opening/closing transactions.

### 2. What does this change do, exactly?
Fix the teardown shape by securing the `DROP` with `IF EXISTS`, invoke teardown parent

Note:
there is a different approach there: https://github.com/shopware/shopware/pull/6323/commits/ae0169fc2490dd1ffbb970739f9fb3b04137a4f0
which removes entirely the IntegrationTestBehaviour, and highlight more deeper issues on failing job

