### PR TITLE
fix: breadcrumb API response does not return an object, but an array instead

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/breadcrumb.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/breadcrumb.json
@@ -4,23 +4,10 @@
     "components": {
         "schemas": {
             "BreadcrumbCollection": {
-                "type": "object",
-                "properties": {
-                    "breadcrumbs": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/Breadcrumb"
-                        }
-                    },
-                    "apiAlias": {
-                        "type": "string",
-                        "enum": ["breadcrumb_collection"]
-                    }
-                },
-                "required": [
-                    "breadcrumbs",
-                    "apiAlias"
-                ]
+                "type": "array",
+                "items": {
+                    "$ref": "#/components/schemas/Breadcrumb"
+                }
             }
         }
     },
@@ -50,7 +37,13 @@
                         "in": "query",
                         "description": "Type: category or product (optional - default: product)",
                         "required": false,
-                        "schema": { "type": "string", "enum": ["product", "category"] }
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "product",
+                                "category"
+                            ]
+                        }
                     },
                     {
                         "name": "referrerCategoryId",
@@ -74,7 +67,9 @@
                             }
                         }
                     },
-                    "400": { "$ref": "#/components/responses/400" }
+                    "400": {
+                        "$ref": "#/components/responses/400"
+                    }
                 },
                 "security": [
                     {


### PR DESCRIPTION
### 1. Why is this change necessary?

Due to https://github.com/shopware/shopware/pull/6025 the API response of the breadcrumb API changed slightly

### 2. What does this change do, exactly?

Adjust the schema JSON file to represent the returned response correctly

### 3. Describe each step to reproduce the issue or behaviour.

Generated client from the schema and call the breadcrumb API. It should fail

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
