### PR TITLE
chore: fix wrong feature tag check

### DIFF
--- a/src/Core/Framework/Adapter/AdapterException.php
+++ b/src/Core/Framework/Adapter/AdapterException.php
@@ -164,7 +164,7 @@ class AdapterException extends HttpException
      */
     public static function invalidArgument(string $message): self|\InvalidArgumentException
     {
-        if (Feature::isActive('v6.7.0.0')) {
+        if (!Feature::isActive('v6.7.0.0')) {
             return new \InvalidArgumentException($message);
         }
 

--- a/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
+++ b/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\AdapterException;
-use Shopware\Core\Framework\Feature;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Node\Expression\AbstractExpression;
 
@@ -72,14 +72,22 @@ class AdapterExceptionTest extends TestCase
     public function testInvalidArgument(): void
     {
         $exception = AdapterException::invalidArgument('test');
-        if (Feature::isActive('v6.7.0.0')) {
-            static::assertInstanceOf(AdapterException::class, $exception);
-            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-            static::assertSame(AdapterException::INVALID_ARGUMENT, $exception->getErrorCode());
-            static::assertSame('test', $exception->getMessage());
-            static::assertEmpty($exception->getParameters());
-        } else {
-            static::expectExceptionObject(new \InvalidArgumentException('test'));
-        }
+
+        static::assertInstanceOf(AdapterException::class, $exception);
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(AdapterException::INVALID_ARGUMENT, $exception->getErrorCode());
+        static::assertSame('test', $exception->getMessage());
+        static::assertEmpty($exception->getParameters());
+    }
+
+    /**
+     * @deprecated tag:v6.7.0 - reason: see AdapterException::invalidArgument - to be removed
+     */
+    #[DisabledFeatures(['v6.7.0.0'])]
+    public function testInvalidArgumentDeprecated(): void
+    {
+        $exception = AdapterException::invalidArgument('test');
+        static::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        static::assertSame('test', $exception->getMessage());
     }
 }

--- a/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
+++ b/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\AdapterException;
+use Shopware\Core\Framework\Feature;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Node\Expression\AbstractExpression;
 
@@ -66,5 +67,19 @@ class AdapterExceptionTest extends TestCase
         static::assertSame(AdapterException::INVALID_TEMPLATE_SYNTAX, $exception->getErrorCode());
         static::assertSame('Failed rendering Twig string template due syntax error: "test"', $exception->getMessage());
         static::assertSame(['message' => 'test'], $exception->getParameters());
+    }
+
+    public function testInvalidArgument(): void
+    {
+        $exception = AdapterException::invalidArgument('test');
+        if (Feature::isActive('v6.7.0.0')) {
+            static::assertInstanceOf(AdapterException::class, $exception);
+            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+            static::assertSame(AdapterException::INVALID_ARGUMENT, $exception->getErrorCode());
+            static::assertSame('test', $exception->getMessage());
+            static::assertEmpty($exception->getParameters());
+        } else {
+            static::expectExceptionObject(new \InvalidArgumentException('test'));
+        }
     }
 }

--- a/tests/unit/Core/Framework/Adapter/Filesystem/Plugin/CopyBatchTest.php
+++ b/tests/unit/Core/Framework/Adapter/Filesystem/Plugin/CopyBatchTest.php
@@ -5,11 +5,13 @@ namespace Shopware\Tests\Unit\Core\Framework\Adapter\Filesystem\Plugin;
 use League\Flysystem\Filesystem;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Filesystem\Adapter\AsyncAwsS3WriteBatchAdapter;
 use Shopware\Core\Framework\Adapter\Filesystem\MemoryFilesystemAdapter;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatch;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\CopyBatchInput;
 use Shopware\Core\Framework\Adapter\Filesystem\Plugin\WriteBatchInterface;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -55,6 +57,17 @@ class CopyBatchTest extends TestCase
         unlink($tmpFile);
     }
 
+    public function testConstructorThrowsAnExceptionWithNoResource(): void
+    {
+        static::expectException(AdapterException::class);
+        // @phpstan-ignore-next-line - sourceFile is supposed to be a resource or a string only from doctag param
+        new CopyBatchInput(null, []);
+    }
+
+    /**
+     * @deprecated tag:v6.7.0 - reason: see AdapterException::invalidArgument - to be removed
+     */
+    #[DisabledFeatures(['v6.7.0.0'])]
     public function testConstructor(): void
     {
         static::expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
### 1. Why is this change necessary?
According to the tag `deprecated tag:v6.7.0 - reason:return-type-change - Will only return `self` in the future` we are getting a rid of ` \InvalidArgumentException($message);` in version 'v6.7.0.0'

### 2. What does this change do, exactly?
- adds a NOT in the check condition in AdapterException
- adds missing unit test for AdapterException::invalidArgument
