### PR TITLE
fix: revert changes to RetryableQuery

### DIFF
--- a/src/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorage.php
+++ b/src/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorage.php
@@ -85,9 +85,12 @@ class MySQLInvalidatorStorage extends AbstractInvalidatorStorage
 
         $query = new RetryableQuery(
             $this->connection,
-            $this->connection->prepare(\sprintf('DELETE FROM %s WHERE id BETWEEN ? AND ?', self::TABLE_NAME))
+            $this->connection->prepare(\sprintf('DELETE FROM %s WHERE id BETWEEN :firstTagId AND :lastTagId', self::TABLE_NAME))
         );
-        $query->execute([$firstTagId, $lastTagId]);
+        $query->execute([
+            'firstTagId' => $firstTagId,
+            'lastTagId' => $lastTagId,
+        ]);
 
         return array_column($rows, 'tag');
     }

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableQuery.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/RetryableQuery.php
@@ -19,7 +19,7 @@ class RetryableQuery
     }
 
     /**
-     * @param array<int|string, mixed> $params
+     * @param array<string, mixed> $params
      */
     public function execute(array $params = []): int
     {

--- a/tests/integration/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorageTest.php
+++ b/tests/integration/Core/Framework/Adapter/Cache/InvalidatorStorage/MySQLInvalidatorStorageTest.php
@@ -176,12 +176,15 @@ class MySQLInvalidatorStorageTest extends TestCase
 
         $statement
             ->method('executeStatement')
-            ->with(['id1', 'id2'])
+            ->with([
+                'firstTagId' => 'id1',
+                'lastTagId' => 'id2',
+            ])
             ->willThrowException($e);
 
         $connection->expects(static::once())
             ->method('prepare')
-            ->with('DELETE FROM invalidation_tags WHERE id BETWEEN ? AND ?')
+            ->with('DELETE FROM invalidation_tags WHERE id BETWEEN :firstTagId AND :lastTagId')
             ->willReturn($statement);
 
         $connection->expects(static::once())


### PR DESCRIPTION
### 1. Why is this change necessary?

In https://github.com/shopware/shopware/pull/6059 support for integer keys was added to `Shopware\Core\Framework\DataAbstractionLayer\Doctrine\RetryableQuery::execute`. In short discussion we decided that probably we could revert this change before it has been released.

### 2. What does this change do, exactly?

Removes int type from the type hint of `RetryableQuery::execute` $params array and updates MySQLInvalidatorStorage to use named parameters in it's implementation.