### PR TITLE
feat: add index.html injection for plugins in vite

### DIFF
--- a/src/Administration/Controller/AdministrationController.php
+++ b/src/Administration/Controller/AdministrationController.php
@@ -142,15 +142,24 @@ class AdministrationController extends AbstractController
     public function pluginIndex(string $pluginName): Response
     {
         try {
-            $webpackIndexHtml = $this->fileSystem->read('bundles/' . $pluginName . '/administration/index.html');
             $publicAssetBaseUrl = $this->fileSystem->publicUrl('/');
+
+            if (Feature::isActive('ADMIN_VITE')) {
+                $viteIndexHtml = $this->fileSystem->read('bundles/' . $pluginName . '/meteor-app/index.html');
+            } else {
+                $webpackIndexHtml = $this->fileSystem->read('bundles/' . $pluginName . '/administration/index.html');
+            }
         } catch (FilesystemException $e) {
             return new Response('Plugin index.html not found', Response::HTTP_NOT_FOUND);
         }
 
-        $webpackIndexHtml = str_replace('__$ASSET_BASE_PATH$__', $publicAssetBaseUrl, $webpackIndexHtml);
+        if (Feature::isActive('ADMIN_VITE')) {
+            $indexHtml = str_replace('__$ASSET_BASE_PATH$__', \sprintf('%sbundles/%s/meteor-app/', $publicAssetBaseUrl, $pluginName), $viteIndexHtml);
+        } else {
+            $indexHtml = str_replace('__$ASSET_BASE_PATH$__', $publicAssetBaseUrl, $webpackIndexHtml);
+        }
 
-        $response = new Response($webpackIndexHtml, Response::HTTP_OK, [
+        $response = new Response($indexHtml, Response::HTTP_OK, [
             'Content-Type' => 'text/html',
             'Content-Security-Policy' => 'script-src * \'unsafe-eval\' \'unsafe-inline\'',
             PlatformRequest::HEADER_FRAME_OPTIONS => 'sameorigin',

--- a/src/Administration/Resources/app/administration/build/vite-plugins/externals-plugin/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/externals-plugin/index.ts
@@ -40,7 +40,7 @@ export default function viteExternalsPlugin(): Plugin {
 
             // Write temp vue.js file
             await ensureFile(vueJsCachePath);
-            await writeFile(vueJsCachePath, `module.exports = window['Shopware']['Vue'];`);
+            await writeFile(vueJsCachePath, `module.exports = window['Shopware']?.['Vue']`);
 
             return {
                 resolve: {

--- a/src/Administration/Resources/app/administration/build/vite-plugins/inject-html/index.spec.js
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/inject-html/index.spec.js
@@ -1,0 +1,31 @@
+/**
+ * @package framework
+ */
+import InjectHtmlPlugin from './index';
+
+describe('build/vite-plugins/inject-html', () => {
+    it('should return an object with a name and a transformIndexHtml function', () => {
+        const injections = [];
+        const plugin = InjectHtmlPlugin(injections);
+
+        expect(plugin).toEqual({
+            name: 'shopware-vite-plugin-inject-html',
+            transformIndexHtml: expect.any(Function),
+        });
+    });
+
+    it('should return the injections in the transformIndexHtml function', () => {
+        const injections = [
+            {
+                tag: 'script',
+                attrs: {
+                    src: 'https://example.com/script.js',
+                },
+            },
+        ];
+        const plugin = InjectHtmlPlugin(injections);
+        const transformedHtml = plugin.transformIndexHtml();
+
+        expect(transformedHtml).toEqual(injections);
+    });
+});

--- a/src/Administration/Resources/app/administration/build/vite-plugins/inject-html/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/inject-html/index.ts
@@ -1,0 +1,15 @@
+import type { HtmlTagDescriptor, Plugin } from 'vite';
+
+const injectHtml: (injections: HtmlTagDescriptor[]) => Plugin = (injections) => {
+    return {
+        name: 'shopware-vite-plugin-inject-html',
+        transformIndexHtml() {
+            return injections;
+        },
+    };
+};
+
+/**
+ * @private
+ */
+export default injectHtml;

--- a/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
@@ -79,14 +79,15 @@ export function copyDir(src: string, dest: string): void {
 /**
  * @private
  */
-export type PluginDefinition = {
+export type ExtensionDefinition = {
     name: string;
     technicalName: string;
     technicalFolderName: string;
     basePath: string;
     path: string;
     filePath: string;
-    hasHtmlFile: boolean;
+    isPlugin: boolean;
+    isApp: boolean;
 };
 
 /**
@@ -106,14 +107,14 @@ export type PluginDefinition = {
  *    ...
  * ]
  */
-export function loadPlugins(): PluginDefinition[] {
-    const pluginFile = path.resolve(process.env.PROJECT_ROOT as string, 'var/plugins.json');
+export function loadExtensions(): ExtensionDefinition[] {
+    const extensionFile = path.resolve(process.env.PROJECT_ROOT as string, 'var/plugins.json');
 
-    if (!fs.existsSync(pluginFile)) {
-        throw new Error(`The file ${pluginFile} could not be found. Try bin/console bundle:dump to create this file.`);
+    if (!fs.existsSync(extensionFile)) {
+        throw new Error(`The file ${extensionFile} could not be found. Try bin/console bundle:dump to create this file.`);
     }
 
-    const pluginDefinition = JSON.parse(fs.readFileSync(pluginFile, 'utf8')) as {
+    const extensionDefinitions = JSON.parse(fs.readFileSync(extensionFile, 'utf8')) as {
         [BundleName: string]: {
             basePath: string;
             views: string[];
@@ -126,7 +127,52 @@ export function loadPlugins(): PluginDefinition[] {
         };
     };
 
-    return Object.entries(pluginDefinition)
+    const apps = Object.entries(extensionDefinitions)
+        .filter(
+            ([
+                name,
+                definition,
+            ]) => {
+                const appEntryPath = path.resolve(
+                    process.env.PROJECT_ROOT as string,
+                    definition.basePath,
+                    // @ts-expect-error - We know it is defined at this point because of the filter above
+                    definition.administration.path,
+                    '../..',
+                    'meteor-app',
+                );
+                return fs.existsSync(path.resolve(appEntryPath, 'index.html'));
+            },
+        )
+        .map(
+            ([
+                name,
+                definition,
+            ]) => {
+                const technicalName = definition.technicalName || name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+                const appEntryPath = path.resolve(
+                    process.env.PROJECT_ROOT as string,
+                    definition.basePath,
+                    // @ts-expect-error - We know it is defined at this point because of the filter above
+                    definition.administration.path,
+                    '../..',
+                    'meteor-app',
+                );
+
+                return {
+                    name,
+                    isApp: true,
+                    isPlugin: false,
+                    basePath: path.resolve(process.env.PROJECT_ROOT as string, definition.basePath),
+                    path: appEntryPath,
+                    filePath: path.resolve(appEntryPath, 'index.html'),
+                    technicalName: technicalName,
+                    technicalFolderName: technicalName.replace(/(-)/g, '').toLowerCase(),
+                } as ExtensionDefinition;
+            },
+        );
+
+    const plugins = Object.entries(extensionDefinitions)
         .filter(
             ([
                 name,
@@ -142,18 +188,11 @@ export function loadPlugins(): PluginDefinition[] {
                 definition,
             ]) => {
                 const technicalName = definition.technicalName || name.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
-                const htmlFilePath = path.resolve(
-                    process.env.PROJECT_ROOT as string,
-                    definition.basePath,
-                    // @ts-expect-error - We know it is defined at this point because of the filter above
-                    definition.administration.path,
-                    '..',
-                    'index.html',
-                );
-                const hasHtmlFile = fs.existsSync(htmlFilePath);
 
                 return {
                     name,
+                    isPlugin: true,
+                    isApp: false,
                     technicalName: technicalName,
                     technicalFolderName: technicalName.replace(/(-)/g, '').toLowerCase(),
                     basePath: path.resolve(process.env.PROJECT_ROOT as string, definition.basePath),
@@ -169,10 +208,14 @@ export function loadPlugins(): PluginDefinition[] {
                         // @ts-expect-error - We know it is defined at this point because of the filter above
                         definition.administration.entryFilePath,
                     ),
-                    hasHtmlFile,
-                };
+                } as ExtensionDefinition;
             },
         );
+
+    return [
+        ...plugins,
+        ...apps,
+    ];
 }
 
 /**

--- a/src/Administration/Resources/app/administration/jest.config.js
+++ b/src/Administration/Resources/app/administration/jest.config.js
@@ -110,6 +110,7 @@ module.exports = {
         '<rootDir>/src/**/*.spec.ts',
         '<rootDir>/eslint-rules/**/*.spec.js',
         '<rootDir>/build/vite-plugins/**/*.spec.ts',
+        '<rootDir>/build/vite-plugins/**/*.spec.js',
         '!<rootDir>/src/**/*.spec.vue2.js',
     ],
 

--- a/src/Administration/Resources/app/administration/src/core/application.ts
+++ b/src/Administration/Resources/app/administration/src/core/application.ts
@@ -743,8 +743,10 @@ class ApplicationBootstrapper {
                 bundleName,
                 bundle,
             ]) => {
-                if (!bundle.baseUrl) {
-                    return;
+                if (!window._features_.ADMIN_VITE) {
+                    if (!bundle.baseUrl) {
+                        return;
+                    }
                 }
 
                 if (isDevelopmentMode) {
@@ -769,38 +771,46 @@ class ApplicationBootstrapper {
                     );
                 }
 
+                if (window._features_.ADMIN_VITE) {
+                    if (!bundle.baseUrl) {
+                        return;
+                    }
+                }
+
                 this.injectIframe({
                     active: bundle.active,
                     integrationId: bundle.integrationId,
                     bundleName,
                     bundleVersion: bundle.version,
-                    iframeSrc: bundle.baseUrl,
+                    iframeSrc: bundle.baseUrl!,
                     bundleType: bundle.type,
                 });
             },
         );
 
-        if (isDevelopmentMode) {
-            // inject iFrames of plugins which aren't detected yet from the config (no files in public folder)
-            Object.entries(plugins).forEach(
-                ([
-                    pluginName,
-                    entryFiles,
-                ]) => {
-                    const stringUtils = Shopware.Utils.string;
-                    const camelCasePluginName = stringUtils.upperFirst(stringUtils.camelCase(pluginName));
+        if (!window._features_.ADMIN_VITE) {
+            if (isDevelopmentMode) {
+                // inject iFrames of plugins which aren't detected yet from the config (no files in public folder)
+                Object.entries(plugins).forEach(
+                    ([
+                        pluginName,
+                        entryFiles,
+                    ]) => {
+                        const stringUtils = Shopware.Utils.string;
+                        const camelCasePluginName = stringUtils.upperFirst(stringUtils.camelCase(pluginName));
 
-                    if (Object.keys(bundles).includes(camelCasePluginName) || !entryFiles.html) {
-                        return;
-                    }
+                        if (Object.keys(bundles).includes(camelCasePluginName) || !entryFiles.html) {
+                            return;
+                        }
 
-                    this.injectIframe({
-                        bundleVersion: undefined,
-                        bundleName: camelCasePluginName,
-                        iframeSrc: entryFiles.html,
-                    });
-                },
-            );
+                        this.injectIframe({
+                            bundleVersion: undefined,
+                            bundleName: camelCasePluginName,
+                            iframeSrc: entryFiles.html,
+                        });
+                    },
+                );
+            }
         }
 
         return Promise.all(injectAllPlugins);

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -395,8 +395,8 @@ class InfoController extends AbstractController
             return null;
         }
 
-        if (Feature::isActive('ADMIN_VITE') &&
-            !$this->filesystem->fileExists(\sprintf('bundles/%s/meteor-app/index.html', mb_strtolower($bundle->getName())))
+        if (Feature::isActive('ADMIN_VITE')
+            && !$this->filesystem->fileExists(\sprintf('bundles/%s/meteor-app/index.html', mb_strtolower($bundle->getName())))
         ) {
             return null;
         }

--- a/src/Core/Framework/Api/Controller/InfoController.php
+++ b/src/Core/Framework/Api/Controller/InfoController.php
@@ -391,7 +391,13 @@ class InfoController extends AbstractController
         $defaultEntryFile = 'administration/index.html';
         $bundlePath = $bundle->getPath();
 
-        if (!file_exists($bundlePath . '/Resources/public/' . $defaultEntryFile)) {
+        if (!Feature::isActive('ADMIN_VITE') && !file_exists($bundlePath . '/Resources/public/' . $defaultEntryFile)) {
+            return null;
+        }
+
+        if (Feature::isActive('ADMIN_VITE') &&
+            !$this->filesystem->fileExists(\sprintf('bundles/%s/meteor-app/index.html', mb_strtolower($bundle->getName())))
+        ) {
             return null;
         }
 

--- a/tests/unit/Administration/Controller/AdministrationControllerTest.php
+++ b/tests/unit/Administration/Controller/AdministrationControllerTest.php
@@ -247,7 +247,7 @@ class AdministrationControllerTest extends TestCase
 
         $this->fileSystemOperator->expects(static::once())
             ->method('read')
-            ->with('bundles/foo/administration/index.html')
+            ->with('bundles/foo/meteor-app/index.html')
             ->willThrowException(new UnableToReadFile());
         $response = $controller->pluginIndex('foo');
 
@@ -262,7 +262,7 @@ class AdministrationControllerTest extends TestCase
         $fileContent = '<html><head></head><body></body></html>';
         $this->fileSystemOperator->expects(static::once())
             ->method('read')
-            ->with('bundles/foo/administration/index.html')
+            ->with('bundles/foo/meteor-app/index.html')
             ->willReturn($fileContent);
         $response = $controller->pluginIndex('foo');
 
@@ -277,7 +277,7 @@ class AdministrationControllerTest extends TestCase
         $fileContent = '<html><head><base href="__$ASSET_BASE_PATH$__" /></head><body></body></html>';
         $this->fileSystemOperator->expects(static::once())
             ->method('read')
-            ->with('bundles/foo/administration/index.html')
+            ->with('bundles/foo/meteor-app/index.html')
             ->willReturn($fileContent);
 
         $this->fileSystemOperator->expects(static::once())

--- a/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
+++ b/tests/unit/Core/Framework/Api/Controller/InfoControllerTest.php
@@ -77,6 +77,9 @@ class InfoControllerTest extends TestCase
             )
             ->willReturn('/admin/adminextensionapipluginwithlocalentrypoint/index.html');
 
+        $this->fileSystemOperator->method('fileExists')
+            ->willReturn(true);
+
         $response = $this->infoController->config(Context::createDefaultContext(), Request::create('http://localhost'));
         $content = $response->getContent();
         static::assertIsString($content);


### PR DESCRIPTION
### 1. Why is this change necessary?

In Webpack it was possible that plugins have a index.html file which get injected as a hidden iFrame to use it for the SDK

### 2. What does this change do, exactly?

It provides the same functionality now in the Vite setup

- [X] Implement reading out the index.html in Vite in Watcher
- [x] Implement reading out the index.html in Vite in Build
- [x] Implement injection of index.html in Admin in Watcher
- [x] Implement injection of index.html in Admin in Build
- [ ] Adjust PHP Unit tests
- [x] Adjust JS Unit tests
- [x] Refactor and beautify implementation code
- [x] Refactor PayPal App and test it with this branch (Watch + Build)
- [ ] (Optional, depending on status here) Refactor Example App in Meteor (@Haberkamp how is the progress?)
- [x] Test extendability of vite.config inside "meteor-app"
- [x] Adjust documentation 
- [x] Discuss folder name?