### PR TITLE
fix: set the trusted hosts back correctly

### DIFF
--- a/src/Storefront/Framework/SystemCheck/SaleChannelsReadinessCheck.php
+++ b/src/Storefront/Framework/SystemCheck/SaleChannelsReadinessCheck.php
@@ -20,6 +20,9 @@ use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @internal
+ *
+ * @codeCoverageIgnore
+ * covered with integration tests/integration/Storefront/Framework/HealthCheck/SaleChannelsReadinessCheckTest.php
  */
 #[Package('framework')]
 class SaleChannelsReadinessCheck extends BaseCheck
@@ -136,7 +139,12 @@ class SaleChannelsReadinessCheck extends BaseCheck
 
     private function whileTrustingAllHosts(callable $callback): Result
     {
-        $trustedHosts = Request::getTrustedHosts();
+        // Remove '{' from start and '}i' from end, applied by Request::setTrustedHosts.
+        $trustedHosts = array_map(
+            fn (string $pattern) => preg_replace('/^\{(.*)\}i$/', '$1', $pattern),
+            Request::getTrustedHosts()
+        );
+
         Request::setTrustedHosts([]);
         try {
             return $callback();

--- a/tests/integration/Storefront/Framework/HealthCheck/SaleChannelsReadinessCheckTest.php
+++ b/tests/integration/Storefront/Framework/HealthCheck/SaleChannelsReadinessCheckTest.php
@@ -14,6 +14,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Kernel;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Framework\SystemCheck\SaleChannelsReadinessCheck;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -78,6 +79,20 @@ class SaleChannelsReadinessCheckTest extends TestCase
 
         static::assertFalse($result->healthy);
         static::assertSame(Status::FAILURE, $result->status);
+    }
+
+    public function testTrustedHostsAreTheSameBeforeAndAfterCheck(): void
+    {
+        // empty test state, if this assertion fails, some other test is leaking.
+        static::assertEmpty(Request::getTrustedHosts());
+        Request::setTrustedHosts(['foo.bar', 'test.com']);
+        $trustedHostsBefore = Request::getTrustedHosts();
+        $check = $this->createCheck();
+        $check->run();
+
+        static::assertSame($trustedHostsBefore, Request::getTrustedHosts());
+        // reset the trusted hosts to avoid leaking state
+        Request::setTrustedHosts([]);
     }
 
     private function createCheck((MockObject&Kernel)|null $kernel = null): SaleChannelsReadinessCheck


### PR DESCRIPTION
### 1. Why is this change necessary?

Using the Request object after running the check can cause issues with TrustedHosts.

### 2. What does this change do, exactly?

Make sure that the check correctly reset the global state.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
