### PR TITLE
fix: make package annotations mandatory

### DIFF
--- a/src/Administration/Resources/app/administration/.eslintrc.js
+++ b/src/Administration/Resources/app/administration/.eslintrc.js
@@ -28,7 +28,7 @@ const baseRules = {
             'sw-extension-component-section',
         ],
     }],
-    'sw-core-rules/require-package-annotation': ['warn'],
+    'sw-core-rules/require-package-annotation': ['error'],
     'sw-deprecation-rules/private-feature-declarations': 'error',
     'no-restricted-exports': 'off',
     'filename-rules/match': [2, /^.*(?:\.js|\.ts|\.html|\.html\.twig)$/],

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/filter/sw-string-filter/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/filter/sw-string-filter/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import type { PropType } from 'vue';
 import template from './sw-string-filter.html.twig';
 

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/filter/sw-string-filter/sw-string-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/filter/sw-string-filter/sw-string-filter.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 const { Criteria } = Shopware.Data;

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-icon-deprecated/sw-icon-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-icon-deprecated/sw-icon-deprecated.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-icon/sw-icon.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-icon/sw-icon.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-item/sw-tabs-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs-item/sw-tabs-item.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(props = {}) {

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-bulk-edit-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-bulk-edit-modal/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-bulk-edit-modal.html.twig';
 import './sw-bulk-edit-modal.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/entity/sw-product-stream-grid-preview/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/entity/sw-product-stream-grid-preview/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-product-stream-grid-preview.html.twig';
 import './sw-product-stream-grid-preview.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-base-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-base-filter/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-base-filter.html.twig';
 import './sw-base-filter.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-base-filter/sw-base-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-base-filter/sw-base-filter.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-boolean-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-boolean-filter/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-boolean-filter.html.twig';
 
 const { Component } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-boolean-filter/sw-boolean-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-boolean-filter/sw-boolean-filter.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 const { Criteria } = Shopware.Data;

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-date-filter.html.twig';
 import './sw-date-filter.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-date-filter/sw-date-filter.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 const { Criteria } = Shopware.Data;

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-existence-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-existence-filter/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-existence-filter.html.twig';
 
 const { Component } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-existence-filter/sw-existence-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-existence-filter/sw-existence-filter.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import 'src/app/component/filter/sw-existence-filter';
 import 'src/app/component/filter/sw-base-filter';
 import 'src/app/component/form/sw-select-field';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-filter-panel.html.twig';
 import './sw-filter-panel.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/sw-filter-panel.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-filter-panel/sw-filter-panel.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import 'src/app/component/filter/sw-filter-panel';
 import 'src/app/component/filter/sw-boolean-filter';
 import 'src/app/component/filter/sw-existence-filter';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-multi-select-filter.html.twig';
 
 const { Component } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/sw-multi-select-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/sw-multi-select-filter.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 const { Criteria, EntityCollection } = Shopware.Data;

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-number-filter.html.twig';
 import './sw-number-filter.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/sw-number-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-number-filter/sw-number-filter.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { shallowMount } from '@vue/test-utils';
 
 const { Criteria } = Shopware.Data;

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-range-filter.html.twig';
 import './sw-range-filter.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/sw-range-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-range-filter/sw-range-filter.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import 'src/app/component/filter/sw-range-filter';
 import 'src/app/component/filter/sw-base-filter';
 import { mount } from '@vue/test-utils';

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-sidebar-filter-panel/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-sidebar-filter-panel/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-sidebar-filter-panel.html.twig';
 import './sw-sidebar-filter-panel.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/advanced-selection-entities/sw-advanced-selection-product/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-advanced-selection-product.html.twig';
 
 const { Component } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-entity-advanced-selection-modal.html.twig';
 import './sw-entity-advanced-selection-modal.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-many-to-many-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-many-to-many-select/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-entity-many-to-many-select.html.twig';
 
 const { Component } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-id-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-id-select/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-entity-multi-id-select.html.twig';
 
 const { Component, Context, Mixin } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-entity-multi-select.html.twig';
 import './sw-entity-multi-select.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-single-select/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './sw-entity-single-select.scss';
 import template from './sw-entity-single-select.html.twig';
 

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-tag-select/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-tag-select/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 const { Component } = Shopware;
 const { Criteria } = Shopware.Data;
 

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-and-container/sw-condition-and-container.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-and-container/sw-condition-and-container.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount, config } from '@vue/test-utils';
 
 async function createWrapper(customProps = {}) {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-base/sw-condition-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-base/sw-condition-base.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(customProps = {}) {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-operator-select/sw-condition-operator-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-operator-select/sw-condition-operator-select.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { shallowMount } from '@vue/test-utils';
 
 async function createWrapper(customProps = {}) {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-or-container/sw-condition-or-container.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-or-container/sw-condition-or-container.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { shallowMount, config } from '@vue/test-utils';
 
 async function createWrapper(customProps = {}) {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-tree-node/sw-condition-tree-node.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-tree-node/sw-condition-tree-node.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount, config } from '@vue/test-utils';
 
 const subComponent = {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-type-select/sw-condition-type-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-type-select/sw-condition-type-select.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(customProps = {}, customOptions = {}) {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-condition-unit-menu.html.twig';
 import './sw-condition-unit-menu.scss';
 import convertUnit, { baseUnits } from '../../../../module/sw-settings-rule/utils/unit-conversion.utils';

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/sw-condition-unit-menu.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/sw-condition-unit-menu.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 async function createWrapper({ type, value, visibleValue }) {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-rule-modal/sw-rule-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-rule-modal/sw-rule-modal.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 function createRuleMock(isNew) {

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/_sw-admin-menu-item/catalogues.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu-item/_sw-admin-menu-item/catalogues.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
     id: 'sw-catalogue',

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/_sw-admin-menu-item/catalogues.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-admin-menu/_sw-admin-menu-item/catalogues.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
     id: 'sw-catalogue',

--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-skip-link/sw-skip-link.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-skip-link/sw-skip-link.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import 'src/app/component/structure/sw-skip-link';
 import { mount } from '@vue/test-utils';
 

--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/fixtures/treeItems.js
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/fixtures/treeItems.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 export default function getTreeItems() {
     return [
         {

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-license-violation/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-license-violation/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-license-violation.html.twig';
 import './sw-license-violation.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center-item/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './sw-notification-center-item.scss';
 import template from './sw-notification-center-item.html.twig';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notification-center/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { POLL_BACKGROUND_INTERVAL, POLL_FOREGROUND_INTERVAL } from 'src/core/worker/worker-notification-listener';
 import template from './sw-notification-center.html.twig';
 import './sw-notification-center.scss';

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-notifications/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-notifications.html.twig';
 import './sw-notifications.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-overlay/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-overlay/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './sw-overlay.scss';
 import template from './sw-overlay.html.twig';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover-deprecated/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-popover.html.twig';
 import './sw-popover.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-progress-bar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-progress-bar/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-progress-bar.html.twig';
 import './sw-progress-bar.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview-item/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-shortcut-overview-item.html.twig';
 import './sw-shortcut-overview-item.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-shortcut-overview/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-shortcut-overview.html.twig';
 import './sw-shortcut-overview.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton-bar-deprecated/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton-bar-deprecated/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-skeleton-bar-deprecated.html.twig';
 import './sw-skeleton-bar.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-skeleton/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-skeleton.html.twig';
 import './sw-skeleton.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-step-display/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-step-display/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-step-display.html.twig';
 
 const { Component } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-step-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-step-item/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-step-item.html.twig';
 import './sw-step-item.scss';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-text-preview/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-text-preview/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './sw-text-preview.scss';
 import template from './sw-text-preview.html.twig';
 

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-upload-listener/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-upload-listener/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { UploadEvents } from 'src/core/service/api/media.api.service';
 
 const { Component, Mixin, Context } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-verify-user-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-verify-user-modal/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-verify-user-modal.html.twig';
 
 const { Component, Mixin } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-vnode-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-vnode-renderer/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { compatUtils } from '@vue/compat';
 
 const { Component } = Shopware;

--- a/src/Administration/Resources/app/administration/src/app/component/wizard/sw-wizard-dot-navigation/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/wizard/sw-wizard-dot-navigation/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './sw-wizard-dot-navigation.scss';
 import template from './sw-wizard-dot-navigation.html.twig';
 

--- a/src/Administration/Resources/app/administration/src/app/component/wizard/sw-wizard-page/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/wizard/sw-wizard-page/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './sw-wizard-page.scss';
 import template from './sw-wizard-page.html.twig';
 

--- a/src/Administration/Resources/app/administration/src/app/composables/use-block-context.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/composables/use-block-context.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 describe('use-block-context', () => {
     let useBlockContext;
     beforeEach(async () => {

--- a/src/Administration/Resources/app/administration/src/app/decorator/index.js
+++ b/src/Administration/Resources/app/administration/src/app/decorator/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default (() => {
     if (window._features_.ADMIN_VITE) {

--- a/src/Administration/Resources/app/administration/src/app/directive/click-outside.directive.ts
+++ b/src/Administration/Resources/app/administration/src/app/directive/click-outside.directive.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 // @ts-expect-error
 import vClickOutside from 'v-click-outside';
 

--- a/src/Administration/Resources/app/administration/src/app/init/shortcut.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/shortcut.init.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default function initializeShortcutService() {
     const factoryContainer = Shopware.Application.getContainer('factory');

--- a/src/Administration/Resources/app/administration/src/app/init/teaser-popover.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init/teaser-popover.init.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import initTeaserButtons from 'src/app/init/teaser-popover.init';
 import { send } from '@shopware-ag/meteor-admin-sdk/es/channel';
 

--- a/src/Administration/Resources/app/administration/src/app/plugin/devtool-helper.plugin.ts
+++ b/src/Administration/Resources/app/administration/src/app/plugin/devtool-helper.plugin.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import type { Plugin } from 'vue';
 
 const DevtoolHelperPlugin: Plugin = {

--- a/src/Administration/Resources/app/administration/src/app/service/criteria-helper.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/criteria-helper.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import Criteria from '@shopware-ag/meteor-admin-sdk/es/data/Criteria';
 
 /**

--- a/src/Administration/Resources/app/administration/src/app/service/search-preferences.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/search-preferences.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { KEY_USER_SEARCH_PREFERENCE } from 'src/app/service/search-ranking.service';
 
 /**

--- a/src/Administration/Resources/app/administration/src/app/service/search-type.service.js
+++ b/src/Administration/Resources/app/administration/src/app/service/search-type.service.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @module app/service/search-type
  */
 

--- a/src/Administration/Resources/app/administration/src/app/state/error.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/state/error.store.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import instance from './error.store';
 
 describe('Test actions at file src/app/state/error.store.js', () => {

--- a/src/Administration/Resources/app/administration/src/app/state/marketing.store.js
+++ b/src/Administration/Resources/app/administration/src/app/state/marketing.store.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @deprecated tag:v6.7.0 - Will be replaced with Pinia store
  */
 

--- a/src/Administration/Resources/app/administration/src/app/state/marketing.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/state/marketing.store.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import ShopwareDiscountCampaignService from 'src/app/service/discount-campaign.service';
 import marketingStore from 'src/app/state/marketing.store';
 

--- a/src/Administration/Resources/app/administration/src/app/state/rule-conditions-config.store.js
+++ b/src/Administration/Resources/app/administration/src/app/state/rule-conditions-config.store.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @deprecated tag:v6.7.0 - Will be replaced with Pinia store
  */
 

--- a/src/Administration/Resources/app/administration/src/app/state/usage-data.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/state/usage-data.store.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import Vuex from 'vuex';
 import usageDataStoreModule from './usage-data.store';
 

--- a/src/Administration/Resources/app/administration/src/app/state/usage-data.store.ts
+++ b/src/Administration/Resources/app/administration/src/app/state/usage-data.store.ts
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @deprecated tag:v6.7.0 - Will be replaced with Pinia store
  */
 

--- a/src/Administration/Resources/app/administration/src/app/store/block-override.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/store/block-override.store.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './block-override.store';
 
 describe('block-override.store', () => {

--- a/src/Administration/Resources/app/administration/src/app/store/teaser-popover.store.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/store/teaser-popover.store.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './teaser-popover.store';
 
 describe('teaser-popover.store', () => {

--- a/src/Administration/Resources/app/administration/src/core/data/error-codes/login.error-codes.js
+++ b/src/Administration/Resources/app/administration/src/core/data/error-codes/login.error-codes.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 const title = 'global.default.error';
 
 const codes = {

--- a/src/Administration/Resources/app/administration/src/core/service/api/app-cms-blocks.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/app-cms-blocks.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import ApiService from '../api.service';
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/core/service/api/app-modules.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/app-modules.service.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import type { AxiosInstance } from 'axios';
 import type { LoginService } from '../login.service';
 import ApiService from '../api.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/cart-store-api.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/cart-store-api.api.service.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { deepCopyObject } from 'src/core/service/utils/object.utils';
 import utils from 'src/core/service/util.service';
 import type { AxiosInstance } from 'axios';

--- a/src/Administration/Resources/app/administration/src/core/service/api/checkout-store.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/checkout-store.api.service.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import type { AxiosInstance } from 'axios';
 import ApiService from '../api.service';
 import type { LoginService } from '../login.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.js
@@ -16,7 +16,7 @@ class MailApiService extends ApiService {
         const apiContext = {
             ...Shopware.Context.api,
             ...additionalHeaders,
-        }
+        };
 
         let languageIdHeader = {};
 

--- a/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/mail.api.service.spec.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package checkout
  */
 import MailApiService from 'src/core/service/api/mail.api.service';
@@ -49,7 +53,7 @@ describe('mailApiService', () => {
                 contentPlain: 'Test',
                 subject: 'Test Subject',
                 senderMail: 'sender@example.com',
-                senderName: 'Sender'
+                senderName: 'Sender',
             };
             const templateData = { test: 'data' };
             const mailTemplateMedia = { getIds: jest.fn().mockReturnValue(['media-id']) };
@@ -66,7 +70,7 @@ describe('mailApiService', () => {
                 templateData,
                 null,
                 null,
-                { languageId: 'language-id' }
+                { languageId: 'language-id' },
             );
 
             expect(clientMock.history.post[0].url).toBe(`/_action/mail-template/send`);
@@ -89,7 +93,7 @@ describe('mailApiService', () => {
                 contentPlain: 'Test',
                 subject: 'Test Subject',
                 senderMail: 'sender@example.com',
-                senderName: 'Sender'
+                senderName: 'Sender',
             };
 
             await mailApiService.buildRenderPreview('invoice', mailTemplate);

--- a/src/Administration/Resources/app/administration/src/core/service/api/media-folder.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/media-folder.api.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import ApiService from '../api.service';
 
 /**

--- a/src/Administration/Resources/app/administration/src/core/service/api/notifications.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/notifications.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import ApiService from '../api.service';
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/core/service/api/number-range.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/number-range.api.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 const ApiService = Shopware.Classes.ApiService;
 
 /**

--- a/src/Administration/Resources/app/administration/src/core/service/api/product-export.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/product-export.api.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import ApiService from '../api.service';
 
 /**

--- a/src/Administration/Resources/app/administration/src/core/service/api/recommendations.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/recommendations.api.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 const ApiService = Shopware.Classes.ApiService;
 
 /**

--- a/src/Administration/Resources/app/administration/src/core/service/api/search.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/search.api.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { CanceledError } from 'axios';
 import ApiService from '../api.service';
 

--- a/src/Administration/Resources/app/administration/src/core/service/api/search.api.service.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/search.api.service.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import createLoginService from 'src/core/service/login.service';
 import createHTTPClient from 'src/core/factory/http.factory';
 import MockAdapter from 'axios-mock-adapter';

--- a/src/Administration/Resources/app/administration/src/core/service/api/seo-url-template.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/seo-url-template.api.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import ApiService from '../api.service';
 
 /**

--- a/src/Administration/Resources/app/administration/src/core/service/api/seo-url.api.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/seo-url.api.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import ApiService from '../api.service';
 
 /**

--- a/src/Administration/Resources/app/administration/src/core/service/api/store-context.api.service.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/api/store-context.api.service.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import type { AxiosInstance } from 'axios';
 import ApiService from '../api.service';
 import type { LoginService } from '../login.service';

--- a/src/Administration/Resources/app/administration/src/core/service/api/user-input-sanitize.service.js
+++ b/src/Administration/Resources/app/administration/src/core/service/api/user-input-sanitize.service.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import ApiService from '../api.service';
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/core/service/utils/eventBus.utils.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/eventBus.utils.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import mitt from 'mitt';
 
 /**

--- a/src/Administration/Resources/app/administration/src/core/service/utils/vue-helper.utils.ts
+++ b/src/Administration/Resources/app/administration/src/core/service/utils/vue-helper.utils.ts
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @private
  *
  * These helper methods shouldn't be used.

--- a/src/Administration/Resources/app/administration/src/core/worker/admin-notification-worker.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/worker/admin-notification-worker.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import AdminNotificationWorker from 'src/core/worker/admin-notification-worker';
 
 describe('src/core/worker/admin-notification-worker', () => {

--- a/src/Administration/Resources/app/administration/src/core/worker/admin-worker.shared-worker.js
+++ b/src/Administration/Resources/app/administration/src/core/worker/admin-worker.shared-worker.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import AdminWorker from 'src/core/worker/admin-worker';
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/core/worker/admin-worker.worker.js
+++ b/src/Administration/Resources/app/administration/src/core/worker/admin-worker.worker.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import AdminWorker from 'src/core/worker/admin-worker';
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/index.vite.ts
+++ b/src/Administration/Resources/app/administration/src/index.vite.ts
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @experimental stableVersion:v6.7.0 feature:VITE
  */
 

--- a/src/Administration/Resources/app/administration/src/module/sw-category/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/acl/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 Shopware.Service('privileges')
     .addPrivilegeMappingEntry({
         category: 'permissions',

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './app/app-renderer';
 
 import './text/text';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-contact/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-contact/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-cms-el-form-contact.html.twig';
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-newsletter/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-newsletter/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-cms-el-form-newsletter.html.twig';
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './text';
 import './image';
 import './image-slider';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-block-favorites.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-block-favorites.service.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { reactive } from 'vue';
 import UserConfigClass from '../../../core/service/support/user-config.class';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-element-favorites.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/service/cms-element-favorites.service.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { reactive } from 'vue';
 import UserConfigClass from '../../../core/service/support/user-config.class';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import type { PropType } from 'vue';
 
 import template from './sw-generic-seo-general-card.html.twig';

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/index.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './sw-generic-social-media-card.scss';
 
 import type { PropType } from 'vue';

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/generic_custom_entities.d.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/generic_custom_entities.d.ts
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 declare namespace EntitySchema {
     interface generic_custom_entity {
         id: string;

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import ApiService from 'src/core/service/api.service';
 import template from './sw-customer-imitate-customer-modal.html.twig';
 import './sw-customer-imitate-customer-modal.scss';

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './page/sw-extension-sdk-module';
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension-sdk/page/sw-extension-sdk-module/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-extension-sdk-module.html.twig';
 import './sw-extension-sdk-module.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-index/sw-extension-my-extensions-index.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 async function createWrapper() {

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/acl/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 Shopware.Service('privileges').addPrivilegeMappingEntry({
     category: 'permissions',
     parent: 'settings',

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/acl/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 Shopware.Service('privileges').addPrivilegeMappingEntry({
     category: 'permissions',
     parent: 'settings',

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-tag/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-tag/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-media-tag.html.twig';
 import './sw-media-tag.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/index.js
@@ -176,12 +176,12 @@ export default {
             ];
 
             if (this.$route.name === 'sw.order.detail.documents') {
-                columns.splice(3, 0,   {
+                columns.splice(3, 0, {
                     property: 'fileTypes',
                     dataIndex: 'fileTypes',
                     label: 'sw-order.documentCard.labelAvailableFormats',
                     allowResize: false,
-                })
+                });
             }
 
             if (this.attachView) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.spec.js
@@ -211,7 +211,7 @@ async function createWrapper() {
             mocks: {
                 $route: {
                     query: '',
-                    name: 'sw.order.detail.documents'
+                    name: 'sw.order.detail.documents',
                 },
             },
             directives: {
@@ -724,11 +724,11 @@ describe('src/module/sw-order/component/sw-order-document-card', () => {
                 {
                     ...documentFixture,
                     documentMediaFile: {
-                        fileExtension: 'pdf'
+                        fileExtension: 'pdf',
                     },
                     documentA11yMediaFile: {
-                        fileExtension: 'html'
-                    }
+                        fileExtension: 'html',
+                    },
                 },
             ]),
         });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/index.js
@@ -146,7 +146,7 @@ export default {
         },
 
         onPreview(fileType = 'pdf') {
-            this.$emit('preview-show', { ...this.documentConfig, fileTypes: [fileType]}, fileType);
+            this.$emit('preview-show', { ...this.documentConfig, fileTypes: [fileType] }, fileType);
         },
 
         onConfirm() {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/sw-order-document-settings-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/sw-order-document-settings-modal.spec.js
@@ -224,5 +224,5 @@ describe('src/module/sw-order/component/sw-order-document-settings-modal', () =>
         expect(wrapper.emitted()['preview-show']).toBeTruthy();
         expect(wrapper.emitted()['preview-show'][0][1]).toBe('html');
         expect(wrapper.emitted()['preview-show'][0][0].fileTypes).toEqual(['html']);
-    })
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/index.js
@@ -190,11 +190,7 @@ export default {
             };
 
             this.mailTemplateRepository
-                .get(
-                    this.mailTemplateId,
-                    apiContext,
-                    this.mailTemplateSendCriteria,
-                )
+                .get(this.mailTemplateId, apiContext, this.mailTemplateSendCriteria)
                 .then((mailTemplate) => {
                     this.mailService
                         .sendMailTemplate(

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-cross-selling-form/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-product-cross-selling-form.html.twig';
 import './sw-product-cross-selling-form.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-download-form/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-download-form/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-product-download-form.html.twig';
 import './sw-product-download-form.scss';
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cart/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cart/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 const { Module } = Shopware;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-cart/page/sw-settings-cart/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-cart/page/sw-settings-cart/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import template from './sw-settings-cart.html.twig';
 
 const { Mixin } = Shopware;

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/acl/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/acl/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 Shopware.Service('privileges').addPrivilegeMappingEntry({
     category: 'permissions',
     parent: 'settings',

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-document/page/sw-settings-document-detail/index.js
@@ -615,7 +615,7 @@ export default {
         onRemoveDocumentType(type) {
             let fileTypes = this.documentConfig.config.fileTypes ?? [];
             if (fileTypes.length === 1) {
-               return;
+                return;
             }
 
             fileTypes = fileTypes.filter((fileType) => fileType !== type.id);

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/sw-settings-salutation-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-detail/sw-settings-salutation-detail.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(privileges = []) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-list/sw-settings-salutation-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-salutation/page/sw-settings-salutation-list/sw-settings-salutation-list.spec.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import { mount } from '@vue/test-utils';
 
 async function createWrapper(privileges = []) {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shopware-updates/index.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 import './page/sw-settings-shopware-updates-wizard';
 import './page/sw-settings-shopware-updates-index';
 import './view/sw-settings-shopware-updates-info';

--- a/src/Administration/Resources/app/administration/test/_helper_/allowedErrors.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/allowedErrors.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  */
 

--- a/src/Administration/Resources/app/administration/test/_helper_/componentWrapper/index.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/componentWrapper/index.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
 */
 /* eslint-disable sw-test-rules/await-async-functions */

--- a/src/Administration/Resources/app/administration/test/_helper_/componentWrapper/syncComponents.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/componentWrapper/syncComponents.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @private
  * @package admin
  */

--- a/src/Administration/Resources/app/administration/test/_helper_/flushPromises.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/flushPromises.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  */
 

--- a/src/Administration/Resources/app/administration/test/_helper_/id.collection.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/id.collection.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  */
 

--- a/src/Administration/Resources/app/administration/test/_helper_/uuid.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/uuid.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  */
 

--- a/src/Administration/Resources/app/administration/test/_setup/_mocks_/acl.service.mock.js
+++ b/src/Administration/Resources/app/administration/test/_setup/_mocks_/acl.service.mock.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  *
  * You can activate acl roles in the each test like this:

--- a/src/Administration/Resources/app/administration/test/_setup/_mocks_/feature.service.mock.js
+++ b/src/Administration/Resources/app/administration/test/_setup/_mocks_/feature.service.mock.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  */
 

--- a/src/Administration/Resources/app/administration/test/_setup/_mocks_/repositoryFactory.service.mock.js
+++ b/src/Administration/Resources/app/administration/test/_setup/_mocks_/repositoryFactory.service.mock.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  */
 

--- a/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
+++ b/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  */
 

--- a/src/Administration/Resources/app/administration/test/globalTeardown.js
+++ b/src/Administration/Resources/app/administration/test/globalTeardown.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  */
 

--- a/src/Administration/Resources/app/administration/test/transformer/svgStringifyTransformer.js
+++ b/src/Administration/Resources/app/administration/test/transformer/svgStringifyTransformer.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package unknown
+ */
+
 module.exports = {
     process(sourceText) {
         return {

--- a/src/Administration/Resources/app/administration/test/webpack/assets/ExamplePluginForTesting/src/Resources/administration/main.js
+++ b/src/Administration/Resources/app/administration/test/webpack/assets/ExamplePluginForTesting/src/Resources/administration/main.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  */
 

--- a/src/Administration/Resources/app/administration/test/webpack/assets/ExamplePluginForTesting/src/Resources/administration/src/app/component/dummy-component/index.js
+++ b/src/Administration/Resources/app/administration/test/webpack/assets/ExamplePluginForTesting/src/Resources/administration/src/app/component/dummy-component/index.js
@@ -1,4 +1,8 @@
 /**
+ * @sw-package unknown
+ */
+
+/**
  * @package admin
  */
 


### PR DESCRIPTION
With this PR we added `@sw-package unknown` annotations to missing files and changed the rule from warning to error.