### PR TITLE
fix(css): remove underlined text from category navigation

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_category-navigation.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_category-navigation.scss
@@ -40,6 +40,7 @@ Styling for category navigation component.
     padding: 8px 20px;
     font-weight: $font-weight-normal;
     color: $sw-text-color;
+    text-decoration: none;
 
     &:hover {
         text-decoration: none;


### PR DESCRIPTION
* Because of accessibility links are underlined by default with active `ACCESSIBILITY_TWEAKS` and `V6_7_0_0`
* Remove the underline from category navigation which is already a distinguishable navigation element.

![image](https://github.com/user-attachments/assets/46fd638e-d14f-4d60-9251-77a0ef82cf15)

----

![image](https://github.com/user-attachments/assets/e8166624-591a-49bc-8ab2-3320dd23f12b)
