### PR TITLE
feat: update to doctrine/dbal 4.0 - MultiInsertQueryQueue rework

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
@@ -8,11 +8,14 @@ use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @phpstan-type DataRow array{data: array<string, mixed>, types: array<string, ParameterType>|null}
+ */
 #[Package('framework')]
 class MultiInsertQueryQueue
 {
     /**
-     * @var array<string, list<array{data: array<string, mixed>, columns: list<string>}>>
+     * @var array<string, list<DataRow>>
      */
     private array $inserts = [];
 
@@ -40,7 +43,7 @@ class MultiInsertQueryQueue
 
     /**
      * @param array<string, mixed> $data
-     * @param array<string, ParameterType::*>|null $types
+     * @param array<string, ParameterType>|null $types
      */
     public function addInsert(string $table, array $data, ?array $types = null): void
     {
@@ -52,7 +55,7 @@ class MultiInsertQueryQueue
 
     /**
      * @param list<array<string, mixed>> $rows
-     * @param array<string, ParameterType::*>|null $types
+     * @param array<string, ParameterType>|null $types
      */
     public function addInserts(string $table, array $rows, ?array $types = null): void
     {
@@ -87,7 +90,7 @@ class MultiInsertQueryQueue
     }
 
     /**
-     * @return array<array{query: string, values: list<string>, types: array<string, ParameterType::*>}>
+     * @return array<array{query: string, values: list<string>, types: list<ParameterType>}>
      */
     private function prepareQueries(): array
     {
@@ -104,23 +107,19 @@ class MultiInsertQueryQueue
 
         foreach ($this->inserts as $table => $rows) {
             $columns = $this->prepareColumns($rows);
+            $escapedColumns = implode(', ', array_map(EntityDefinitionQueryHelper::escape(...), $columns));
+            $escapedTable = EntityDefinitionQueryHelper::escape($table);
 
-            $tableTemplate =
-                $template
-                . $this->prepareOnDuplicateKeyUpdatePart(
-                    array_intersect($this->updateFieldsOnDuplicateKey[$table] ?? [], $columns)
-            ) . ';';
+            $onDuplicateKey = $this->prepareOnDuplicateKeyUpdatePart(
+                array_intersect($this->updateFieldsOnDuplicateKey[$table] ?? [], $columns) // only fields that are in the columns can be updated
+            );
+            $tableTemplate = \sprintf('%s%s;', $template, $onDuplicateKey);
 
             $rowsChunks = array_chunk($rows, $this->chunkSize);
             foreach ($rowsChunks as $rowsChunk) {
                 $data = $this->prepareValues($columns, $rowsChunk);
                 $queries[] = [
-                    'query' => \sprintf(
-                        $tableTemplate,
-                        EntityDefinitionQueryHelper::escape($table),
-                        implode(', ', array_map(EntityDefinitionQueryHelper::escape(...), $columns)),
-                        implode(', ', $data['placeholders']),
-                    ),
+                    'query' => \sprintf($tableTemplate, $escapedTable, $escapedColumns, implode(', ', $data['placeholders'])),
                     'values' => $data['values'],
                     'types' => $data['types'],
                 ];
@@ -130,11 +129,16 @@ class MultiInsertQueryQueue
         return $queries;
     }
 
-    private function prepareOnDuplicateKeyUpdatePart(array $fieldsToUpdate): string {
-        if (count($fieldsToUpdate) === 0) {
+    /**
+     * @param array<string> $fieldsToUpdate
+     */
+    private function prepareOnDuplicateKeyUpdatePart(array $fieldsToUpdate): string
+    {
+        if (\count($fieldsToUpdate) === 0) {
             return '';
         }
 
+        $updateParts = [];
         foreach ($fieldsToUpdate as $field) {
             // see https://stackoverflow.com/a/2714653/10064036
             $updateParts[] = \sprintf('%s = VALUES(%s)', EntityDefinitionQueryHelper::escape($field), EntityDefinitionQueryHelper::escape($field));
@@ -144,12 +148,13 @@ class MultiInsertQueryQueue
     }
 
     /**
-     * @param list<array{columns: list<string>}> $rows
+     * @param list<DataRow> $rows
      *
      * @return list<string>
      */
     private function prepareColumns(array $rows): array
     {
+        /** @var array<string, int> $columns */
         $columns = [];
         foreach ($rows as $row) {
             foreach (array_keys($row['data']) as $column) {
@@ -162,9 +167,9 @@ class MultiInsertQueryQueue
 
     /**
      * @param list<string> $columns
-     * @param list<array{data: array<string, mixed>, columns: list<string>}> $rows
+     * @param list<DataRow> $rows
      *
-     * @return array{placeholders: list<string>, values: list<mixed>, types: array<string, ParameterType::*>}
+     * @return array{placeholders: list<string>, values: list<mixed>, types: list<ParameterType>}
      */
     private function prepareValues(array $columns, array $rows): array
     {

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
@@ -117,17 +117,16 @@ class MultiInsertQueryQueue
                 . ';';
 
             $columns = $this->prepareColumns($rows);
-            $data = $this->prepareValues($columns, $rows);
+            $escapedColumns = array_map(EntityDefinitionQueryHelper::escape(...), $columns);
 
-            $columns = array_map(EntityDefinitionQueryHelper::escape(...), $columns);
-
-            $chunks = array_chunk($data, $this->chunkSize);
-            foreach ($chunks as $chunk) {
+            $rowsChunks = array_chunk($rows, $this->chunkSize);
+            foreach ($rowsChunks as $rowsChunk) {
+                $data = $this->prepareValues($columns, $rowsChunk);
                 $queries[] = \sprintf(
                     $tableTemplate,
                     EntityDefinitionQueryHelper::escape($table),
-                    implode(', ', $columns),
-                    implode(', ', $chunk)
+                    implode(', ', $escapedColumns),
+                    implode(', ', $data)
                 );
             }
         }

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
@@ -39,24 +39,12 @@ class MultiInsertQueryQueue
     }
 
     /**
-     * @todo migrate to prepared statements or remove $types parameter
-     *
      * @param array<string, mixed> $data
      * @param array<string, ParameterType::*>|null $types
      */
     public function addInsert(string $table, array $data, ?array $types = null): void
     {
-        $columns = [];
-
         foreach ($data as $key => &$value) {
-            $columns[] = $key;
-
-            $type = ParameterType::STRING;
-
-            if ($types !== null && isset($types[$key])) {
-                $type = $types[$key];
-            }
-
             if ($value === null) {
                 $value = 'NULL';
             } else {
@@ -66,7 +54,6 @@ class MultiInsertQueryQueue
 
         $this->inserts[$table][] = [
             'data' => $data,
-            'columns' => $columns,
             'types' => $types,
         ];
     }
@@ -124,18 +111,10 @@ class MultiInsertQueryQueue
         }
 
         foreach ($this->inserts as $table => $rows) {
-            $tableTemplate = $template;
-            if ($this->updateFieldsOnDuplicateKey !== []) {
-                $values = [];
-                foreach ($this->updateFieldsOnDuplicateKey[$table] ?? [] as $field) {
-                    // see https://stackoverflow.com/a/2714653/10064036
-                    $values[] = \sprintf('%s = VALUES(%s)', EntityDefinitionQueryHelper::escape($field), EntityDefinitionQueryHelper::escape($field));
-                }
-
-                $tableTemplate .= ' ON DUPLICATE KEY UPDATE ' . implode(', ', $values);
-            }
-
-            $tableTemplate .= ';';
+            $tableTemplate =
+                $template
+                . $this->prepareOnDuplicateKeyUpdatePart($this->updateFieldsOnDuplicateKey[$table] ?? [])
+                . ';';
 
             $columns = $this->prepareColumns($rows);
             $data = $this->prepareValues($columns, $rows);
@@ -156,6 +135,19 @@ class MultiInsertQueryQueue
         return $queries;
     }
 
+    private function prepareOnDuplicateKeyUpdatePart(array $fieldsToUpdate): string {
+        if (count($fieldsToUpdate) === 0) {
+            return '';
+        }
+
+        foreach ($fieldsToUpdate as $field) {
+            // see https://stackoverflow.com/a/2714653/10064036
+            $updateParts[] = \sprintf('%s = VALUES(%s)', EntityDefinitionQueryHelper::escape($field), EntityDefinitionQueryHelper::escape($field));
+        }
+
+        return ' ON DUPLICATE KEY UPDATE ' . implode(', ', $updateParts);
+    }
+
     /**
      * @param list<array{columns: list<string>}> $rows
      *
@@ -165,7 +157,7 @@ class MultiInsertQueryQueue
     {
         $columns = [];
         foreach ($rows as $row) {
-            foreach ($row['columns'] as $column) {
+            foreach (array_keys($row['data']) as $column) {
                 $columns[$column] = 1;
             }
         }

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
@@ -44,14 +44,6 @@ class MultiInsertQueryQueue
      */
     public function addInsert(string $table, array $data, ?array $types = null): void
     {
-        foreach ($data as $key => &$value) {
-            if ($value === null) {
-                $value = 'NULL';
-            } else {
-                $value = $this->connection->quote((string) $value);
-            }
-        }
-
         $this->inserts[$table][] = [
             'data' => $data,
             'types' => $types,
@@ -78,7 +70,7 @@ class MultiInsertQueryQueue
         $grouped = $this->prepare();
         RetryableTransaction::retryable($this->connection, function () use ($grouped): void {
             foreach ($grouped as $query) {
-                $this->connection->executeStatement($query);
+                $this->connection->executeStatement($query['query'], $query['values'], $query['types']);
             }
         });
         unset($grouped);
@@ -95,7 +87,7 @@ class MultiInsertQueryQueue
     }
 
     /**
-     * @return list<string>
+     * @return array<array{query: string, values: list<string>, types: array<string, ParameterType::*>}>
      */
     private function prepare(): array
     {
@@ -117,17 +109,20 @@ class MultiInsertQueryQueue
                 . ';';
 
             $columns = $this->prepareColumns($rows);
-            $escapedColumns = array_map(EntityDefinitionQueryHelper::escape(...), $columns);
 
             $rowsChunks = array_chunk($rows, $this->chunkSize);
             foreach ($rowsChunks as $rowsChunk) {
                 $data = $this->prepareValues($columns, $rowsChunk);
-                $queries[] = \sprintf(
-                    $tableTemplate,
-                    EntityDefinitionQueryHelper::escape($table),
-                    implode(', ', $escapedColumns),
-                    implode(', ', $data)
-                );
+                $queries[] = [
+                    'query' => \sprintf(
+                        $tableTemplate,
+                        EntityDefinitionQueryHelper::escape($table),
+                        implode(', ', array_map(EntityDefinitionQueryHelper::escape(...), $columns)),
+                        implode(', ', $data['placeholders']),
+                    ),
+                    'values' => $data['values'],
+                    'types' => $data['types'],
+                ];
             }
         }
 
@@ -168,33 +163,37 @@ class MultiInsertQueryQueue
      * @param list<string> $columns
      * @param list<array{data: array<string, mixed>, columns: list<string>}> $rows
      *
-     * @return list<string>
+     * @return array{placeholders: list<string>, values: list<mixed>, types: array<string, ParameterType::*>}
      */
     private function prepareValues(array $columns, array $rows): array
     {
-        $stackedValues = [];
-        /** @var array<string, mixed> $defaults */
-        $defaults = array_combine(
-            $columns,
-            array_fill(0, \count($columns), 'DEFAULT')
-        );
-        foreach ($rows as $row) {
-            $data = $row['data'];
-            $values = $defaults;
-            if (!\is_array($values)) {
-                continue;
-            }
+        $placeholders = [];
+        $values = [];
+        $types = [];
 
-            /**
-             * @var string $key
-             * @var mixed $value
-             */
-            foreach ($data as $key => $value) {
-                $values[$key] = $value;
+        foreach ($rows as $row) {
+            $rowPlaceholders = [];
+            foreach ($columns as $column) {
+                if (!\array_key_exists($column, $row['data'])) { // to use default values if the column is not set
+                    $rowPlaceholders[] = 'DEFAULT';
+                    continue;
+                }
+                if ($row['data'][$column] === null) { // to insert nulls if the value is null
+                    $rowPlaceholders[] = 'NULL';
+                    continue;
+                }
+
+                $rowPlaceholders[] = '?';
+                $values[] = $row['data'][$column];
+                $types[] = $row['types'][$column] ?? ParameterType::STRING;
             }
-            $stackedValues[] = '(' . implode(',', $values) . ')';
+            $placeholders[] = '(' . implode(',', $rowPlaceholders) . ')';
         }
 
-        return $stackedValues;
+        return [
+            'placeholders' => $placeholders,
+            'values' => $values,
+            'types' => $types,
+        ];
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
+++ b/src/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueue.php
@@ -67,13 +67,13 @@ class MultiInsertQueryQueue
             return;
         }
 
-        $grouped = $this->prepare();
-        RetryableTransaction::retryable($this->connection, function () use ($grouped): void {
-            foreach ($grouped as $query) {
+        $queries = $this->prepareQueries();
+        RetryableTransaction::retryable($this->connection, function () use ($queries): void {
+            foreach ($queries as $query) {
                 $this->connection->executeStatement($query['query'], $query['values'], $query['types']);
             }
         });
-        unset($grouped);
+        unset($queries);
 
         $this->inserts = [];
     }
@@ -89,7 +89,7 @@ class MultiInsertQueryQueue
     /**
      * @return array<array{query: string, values: list<string>, types: array<string, ParameterType::*>}>
      */
-    private function prepare(): array
+    private function prepareQueries(): array
     {
         $queries = [];
         $template = 'INSERT INTO %s (%s) VALUES %s';
@@ -103,12 +103,13 @@ class MultiInsertQueryQueue
         }
 
         foreach ($this->inserts as $table => $rows) {
+            $columns = $this->prepareColumns($rows);
+
             $tableTemplate =
                 $template
-                . $this->prepareOnDuplicateKeyUpdatePart($this->updateFieldsOnDuplicateKey[$table] ?? [])
-                . ';';
-
-            $columns = $this->prepareColumns($rows);
+                . $this->prepareOnDuplicateKeyUpdatePart(
+                    array_intersect($this->updateFieldsOnDuplicateKey[$table] ?? [], $columns)
+            ) . ';';
 
             $rowsChunks = array_chunk($rows, $this->chunkSize);
             foreach ($rowsChunks as $rowsChunk) {

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueueTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueueTest.php
@@ -1,0 +1,257 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Doctrine;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
+use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(MultiInsertQueryQueue::class)]
+class MultiInsertQueryQueueTest extends TestCase
+{
+    protected function setUp(): void
+    {
+    }
+
+    #[DataProvider('preparedQueriesDataProvider')]
+    public function testPrepareQueries(array $inserts, array $queries, int $batchSize = 5, bool $ignoreErrors = false, bool $useReplace = false): void
+    {
+        $queue = new MultiInsertQueryQueue($this->createMock(Connection::class), $batchSize, $ignoreErrors, $useReplace);
+        foreach ($inserts as $insert) {
+            $queue->addInsert($insert['table'], $insert['data'], $insert['types'] ?? null);
+        }
+
+        $prepareQueries = ReflectionHelper::getMethod(MultiInsertQueryQueue::class, 'prepareQueries');
+        $generatedQueries = $prepareQueries->invoke($queue);
+
+        static::assertIsArray($generatedQueries);
+        static::assertCount(count($queries), $generatedQueries);
+        foreach ($generatedQueries as $index => $query) {
+            static::assertArrayHasKey('query', $query);
+            static::assertArrayHasKey('values', $query);
+            static::assertArrayHasKey('types', $query);
+            static::assertSame($queries[$index]['query'], $query['query']);
+            static::assertSame($queries[$index]['values'], $query['values']);
+            // we don't want to provide types for default values
+            $types = $queries[$index]['types'] ?? array_fill(0, count($queries[$index]['values']), ParameterType::STRING);
+            static::assertSame($types, $query['types']);
+        }
+    }
+
+    public static function preparedQueriesDataProvider(): iterable
+    {
+        yield 'single insert with types' => [
+            'inserts' => [
+                [
+                    'table' => 'table1',
+                    'data' => [ 'id' => 1, 'name' => 'test',],
+                    'types' => [
+                        'id' => ParameterType::INTEGER,
+                        'name' => ParameterType::STRING,
+                    ],
+                ],
+            ],
+            'queries' => [
+                [
+                    'query' => 'INSERT INTO `table1` (`id`, `name`) VALUES (?,?);',
+                    'values' => [1, 'test'],
+                    'types' => [ParameterType::INTEGER, ParameterType::STRING],
+                ],
+            ],
+        ];
+
+        yield 'default types' => [
+            'inserts' => [
+                [
+                    'table' => 'table1',
+                    'data' => [ 'id' => 1, 'name' => 'test', ],
+                ],
+            ],
+            'queries' => [
+                [
+                    'query' => 'INSERT INTO `table1` (`id`, `name`) VALUES (?,?);',
+                    'values' => [1, 'test'],
+                ],
+            ],
+        ];
+
+        yield 'batching' => [
+            'inserts' => [
+                ['table' => 'table1', 'data' => ['id' => 1],],
+                ['table' => 'table1', 'data' => ['id' => 2],],
+                ['table' => 'table1', 'data' => ['id' => 3],],
+                ['table' => 'table1', 'data' => ['id' => 4],],
+                ['table' => 'table1', 'data' => ['id' => 5],],
+            ],
+            'queries' => [
+                [
+                    'query' => 'INSERT INTO `table1` (`id`) VALUES (?), (?);',
+                    'values' => [1,2],
+                ],
+                [
+                    'query' => 'INSERT INTO `table1` (`id`) VALUES (?), (?);',
+                    'values' => [3,4],
+                ],
+                [
+                    'query' => 'INSERT INTO `table1` (`id`) VALUES (?);',
+                    'values' => [5],
+                ],
+            ],
+            'batchSize' => 2,
+        ];
+
+        yield 'ignore errors' => [
+            'inserts' => [
+                ['table' => 'table1', 'data' => ['id' => 1],],
+                ['table' => 'table1', 'data' => ['id' => 2],],
+            ],
+            'queries' => [
+                [
+                    'query' => 'INSERT IGNORE INTO `table1` (`id`) VALUES (?), (?);',
+                    'values' => [1,2],
+                ],
+            ],
+            'batchSize' => 5,
+            'ignoreErrors' => true,
+        ];
+
+        yield 'use replace' => [
+            'inserts' => [
+                ['table' => 'table1', 'data' => ['id' => 1],],
+                ['table' => 'table1', 'data' => ['id' => 2],],
+            ],
+            'queries' => [
+                [
+                    'query' => 'REPLACE INTO `table1` (`id`) VALUES (?), (?);',
+                    'values' => [1,2],
+                ],
+            ],
+            'batchSize' => 5,
+            'ignoreErrors' => true, // ignore errors is ignored when using replace
+            'useReplace' => true,
+        ];
+
+        yield 'multiple inserts, inconsistent and null columns' => [
+            'inserts' => [
+                [
+                    'table' => 'table1',
+                    'data' => [
+                        'id' => 1,
+                        'name' => 'test_n_1',
+                        'description' => 'test_d_1',
+                    ],
+                    'types' => null,
+                ],
+                [
+                    'table' => 'table1',
+                    'data' => [
+                        'id' => 2,
+                        'name' => 'test_n_2',
+                        'description' => null, // nulls should be inserted as NULL
+                    ],
+                    'types' => [
+                        'id' => ParameterType::INTEGER,
+                        'description' => ParameterType::STRING, // this should be ignored as field will be default
+                        'bla' => ParameterType::LARGE_OBJECT, // this should be ignored as field does not exist in input
+                    ],
+                ],
+                [
+                    'table' => 'table1',
+                    'data' => [
+                        'id' => 3,
+                        'name' => 'test_n_3',
+                        // missing description should be replaced with DEFAULT
+                    ],
+                    'types' => null,
+                ],
+                [
+                    'table' => 'table2',
+                    'data' => [
+                        'tag' => 'test_tag',
+                    ],
+                    'types' => null,
+                ],
+            ],
+            'queries' => [
+                [
+                    'query' => 'INSERT INTO `table1` (`id`, `name`, `description`) VALUES (?,?,?), (?,?,NULL), (?,?,DEFAULT);',
+                    'values' => [1, 'test_n_1', 'test_d_1', 2, 'test_n_2', 3, 'test_n_3'],
+                    'types' => [ParameterType::STRING, ParameterType::STRING, ParameterType::STRING, ParameterType::INTEGER,  ParameterType::STRING, ParameterType::STRING, ParameterType::STRING],
+                ],
+                [
+                    'query' => 'INSERT INTO `table2` (`tag`) VALUES (?);',
+                    'values' => ['test_tag'],
+                ],
+            ],
+        ];
+    }
+
+    public function testAddInserts()
+    {
+        $queue = new MultiInsertQueryQueue($this->createMock(Connection::class));
+        $queue->addInserts('table1', [
+            ['id' => 1, 'name' => 'test1', 'description' => 'test1'],
+            ['id' => 2, 'name' => 'test2', 'description' => 'test2']
+        ]);
+
+        $prepareQueries = ReflectionHelper::getMethod(MultiInsertQueryQueue::class, 'prepareQueries');
+        $generatedQueries = $prepareQueries->invoke($queue);
+
+        static::assertIsArray($generatedQueries);
+        static::assertCount(1, $generatedQueries);
+        $query = reset($generatedQueries);
+
+        static::assertArrayHasKey('query', $query);
+        static::assertArrayHasKey('values', $query);
+        static::assertArrayHasKey('types', $query);
+        static::assertSame('INSERT INTO `table1` (`id`, `name`, `description`) VALUES (?,?,?), (?,?,?);', $query['query']);
+        static::assertSame([1, 'test1', 'test1', 2, 'test2', 'test2'], $query['values']);
+        static::assertSame(
+            array_fill(0, 6, ParameterType::STRING),
+            $query['types']
+        );
+    }
+
+    public function testUpdateOnDuplicateKeys()
+    {
+        $queue = new MultiInsertQueryQueue($this->createMock(Connection::class));
+        $queue->addInsert('table1', ['id' => 1, 'name' => 'test1', 'description' => 'test1']);
+        $queue->addInsert('table1', ['id' => 2, 'name' => 'test2', 'description' => 'test2']);
+        $queue->addUpdateFieldOnDuplicateKey('table1', 'name');
+        $queue->addUpdateFieldOnDuplicateKey('table1', 'non_existing_field');
+        $queue->addUpdateFieldOnDuplicateKey('table1', 'description');
+
+        $prepareQueries = ReflectionHelper::getMethod(MultiInsertQueryQueue::class, 'prepareQueries');
+        $generatedQueries = $prepareQueries->invoke($queue);
+        static::assertIsArray($generatedQueries);
+        static::assertCount(1, $generatedQueries);
+        $query = reset($generatedQueries);
+
+        static::assertArrayHasKey('query', $query);
+        static::assertArrayHasKey('values', $query);
+        static::assertArrayHasKey('types', $query);
+        static::assertSame('INSERT INTO `table1` (`id`, `name`, `description`) VALUES (?,?,?), (?,?,?) ON DUPLICATE KEY UPDATE `name` = VALUES(`name`), `description` = VALUES(`description`);', $query['query']);
+        static::assertSame([1, 'test1', 'test1', 2, 'test2', 'test2'], $query['values']);
+        static::assertSame(
+            array_fill(0, 6, ParameterType::STRING),
+            $query['types']);
+    }
+
+    public function testConstructorThrowsOnWrongBatchSize()
+    {
+        $connection = $this->createMock(Connection::class);
+        self::expectExceptionObject(DataAbstractionLayerException::invalidChunkSize(0));
+        new MultiInsertQueryQueue($connection, 0);
+    }
+
+}

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueueTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Doctrine/MultiInsertQueryQueueTest.php
@@ -8,21 +8,32 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
-use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\MultiInsertQueryQueue;
+use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\TestCaseHelper\ReflectionHelper;
 
 /**
  * @internal
+ *
+ * @phpstan-type Inserts list<array{
+ *          table: string,
+ *          data: array<string, mixed>,
+ *          types?: array<string, ParameterType>
+ *      }>
+ * @phpstan-type Queries list<array{
+ *          query: string,
+ *          values: list<mixed>,
+ *          types?: list<ParameterType>
+ *      }>
  */
 #[Package('framework')]
 #[CoversClass(MultiInsertQueryQueue::class)]
 class MultiInsertQueryQueueTest extends TestCase
 {
-    protected function setUp(): void
-    {
-    }
-
+    /**
+     * @param Inserts $inserts
+     * @param Queries $queries
+     */
     #[DataProvider('preparedQueriesDataProvider')]
     public function testPrepareQueries(array $inserts, array $queries, int $batchSize = 5, bool $ignoreErrors = false, bool $useReplace = false): void
     {
@@ -35,7 +46,7 @@ class MultiInsertQueryQueueTest extends TestCase
         $generatedQueries = $prepareQueries->invoke($queue);
 
         static::assertIsArray($generatedQueries);
-        static::assertCount(count($queries), $generatedQueries);
+        static::assertCount(\count($queries), $generatedQueries);
         foreach ($generatedQueries as $index => $query) {
             static::assertArrayHasKey('query', $query);
             static::assertArrayHasKey('values', $query);
@@ -43,18 +54,27 @@ class MultiInsertQueryQueueTest extends TestCase
             static::assertSame($queries[$index]['query'], $query['query']);
             static::assertSame($queries[$index]['values'], $query['values']);
             // we don't want to provide types for default values
-            $types = $queries[$index]['types'] ?? array_fill(0, count($queries[$index]['values']), ParameterType::STRING);
+            $types = $queries[$index]['types'] ?? array_fill(0, \count($queries[$index]['values']), ParameterType::STRING);
             static::assertSame($types, $query['types']);
         }
     }
 
+    /**
+     * @return iterable<string, array{
+     *     inserts: Inserts,
+     *     queries: Queries,
+     *     batchSize?: int,
+     *     ignoreErrors?: bool,
+     *     useReplace?: bool
+     * }>
+     */
     public static function preparedQueriesDataProvider(): iterable
     {
         yield 'single insert with types' => [
             'inserts' => [
                 [
                     'table' => 'table1',
-                    'data' => [ 'id' => 1, 'name' => 'test',],
+                    'data' => ['id' => 1, 'name' => 'test'],
                     'types' => [
                         'id' => ParameterType::INTEGER,
                         'name' => ParameterType::STRING,
@@ -74,7 +94,7 @@ class MultiInsertQueryQueueTest extends TestCase
             'inserts' => [
                 [
                     'table' => 'table1',
-                    'data' => [ 'id' => 1, 'name' => 'test', ],
+                    'data' => ['id' => 1, 'name' => 'test'],
                 ],
             ],
             'queries' => [
@@ -87,20 +107,20 @@ class MultiInsertQueryQueueTest extends TestCase
 
         yield 'batching' => [
             'inserts' => [
-                ['table' => 'table1', 'data' => ['id' => 1],],
-                ['table' => 'table1', 'data' => ['id' => 2],],
-                ['table' => 'table1', 'data' => ['id' => 3],],
-                ['table' => 'table1', 'data' => ['id' => 4],],
-                ['table' => 'table1', 'data' => ['id' => 5],],
+                ['table' => 'table1', 'data' => ['id' => 1]],
+                ['table' => 'table1', 'data' => ['id' => 2]],
+                ['table' => 'table1', 'data' => ['id' => 3]],
+                ['table' => 'table1', 'data' => ['id' => 4]],
+                ['table' => 'table1', 'data' => ['id' => 5]],
             ],
             'queries' => [
                 [
                     'query' => 'INSERT INTO `table1` (`id`) VALUES (?), (?);',
-                    'values' => [1,2],
+                    'values' => [1, 2],
                 ],
                 [
                     'query' => 'INSERT INTO `table1` (`id`) VALUES (?), (?);',
-                    'values' => [3,4],
+                    'values' => [3, 4],
                 ],
                 [
                     'query' => 'INSERT INTO `table1` (`id`) VALUES (?);',
@@ -112,13 +132,13 @@ class MultiInsertQueryQueueTest extends TestCase
 
         yield 'ignore errors' => [
             'inserts' => [
-                ['table' => 'table1', 'data' => ['id' => 1],],
-                ['table' => 'table1', 'data' => ['id' => 2],],
+                ['table' => 'table1', 'data' => ['id' => 1]],
+                ['table' => 'table1', 'data' => ['id' => 2]],
             ],
             'queries' => [
                 [
                     'query' => 'INSERT IGNORE INTO `table1` (`id`) VALUES (?), (?);',
-                    'values' => [1,2],
+                    'values' => [1, 2],
                 ],
             ],
             'batchSize' => 5,
@@ -127,13 +147,13 @@ class MultiInsertQueryQueueTest extends TestCase
 
         yield 'use replace' => [
             'inserts' => [
-                ['table' => 'table1', 'data' => ['id' => 1],],
-                ['table' => 'table1', 'data' => ['id' => 2],],
+                ['table' => 'table1', 'data' => ['id' => 1]],
+                ['table' => 'table1', 'data' => ['id' => 2]],
             ],
             'queries' => [
                 [
                     'query' => 'REPLACE INTO `table1` (`id`) VALUES (?), (?);',
-                    'values' => [1,2],
+                    'values' => [1, 2],
                 ],
             ],
             'batchSize' => 5,
@@ -150,7 +170,6 @@ class MultiInsertQueryQueueTest extends TestCase
                         'name' => 'test_n_1',
                         'description' => 'test_d_1',
                     ],
-                    'types' => null,
                 ],
                 [
                     'table' => 'table1',
@@ -172,14 +191,12 @@ class MultiInsertQueryQueueTest extends TestCase
                         'name' => 'test_n_3',
                         // missing description should be replaced with DEFAULT
                     ],
-                    'types' => null,
                 ],
                 [
                     'table' => 'table2',
                     'data' => [
                         'tag' => 'test_tag',
                     ],
-                    'types' => null,
                 ],
             ],
             'queries' => [
@@ -196,12 +213,12 @@ class MultiInsertQueryQueueTest extends TestCase
         ];
     }
 
-    public function testAddInserts()
+    public function testAddInserts(): void
     {
         $queue = new MultiInsertQueryQueue($this->createMock(Connection::class));
         $queue->addInserts('table1', [
             ['id' => 1, 'name' => 'test1', 'description' => 'test1'],
-            ['id' => 2, 'name' => 'test2', 'description' => 'test2']
+            ['id' => 2, 'name' => 'test2', 'description' => 'test2'],
         ]);
 
         $prepareQueries = ReflectionHelper::getMethod(MultiInsertQueryQueue::class, 'prepareQueries');
@@ -222,7 +239,7 @@ class MultiInsertQueryQueueTest extends TestCase
         );
     }
 
-    public function testUpdateOnDuplicateKeys()
+    public function testUpdateOnDuplicateKeys(): void
     {
         $queue = new MultiInsertQueryQueue($this->createMock(Connection::class));
         $queue->addInsert('table1', ['id' => 1, 'name' => 'test1', 'description' => 'test1']);
@@ -244,14 +261,14 @@ class MultiInsertQueryQueueTest extends TestCase
         static::assertSame([1, 'test1', 'test1', 2, 'test2', 'test2'], $query['values']);
         static::assertSame(
             array_fill(0, 6, ParameterType::STRING),
-            $query['types']);
+            $query['types']
+        );
     }
 
-    public function testConstructorThrowsOnWrongBatchSize()
+    public function testConstructorThrowsOnWrongBatchSize(): void
     {
         $connection = $this->createMock(Connection::class);
         self::expectExceptionObject(DataAbstractionLayerException::invalidChunkSize(0));
         new MultiInsertQueryQueue($connection, 0);
     }
-
 }


### PR DESCRIPTION
Refactoring of MultiInsertQueryQueue to use statements instead of manually calling $connection->quote.

**@Reviewers**: target branch is dbal update, but I would appreciate more detailed feedback on this change, it's easier to review in separate pr