### PR TITLE
Fix: fixed negative zero

### DIFF
--- a/changelog/_unreleased/2025-01-24-fix-negative-zero-when-calculating-price.md
+++ b/changelog/_unreleased/2025-01-24-fix-negative-zero-when-calculating-price.md
@@ -1,0 +1,11 @@
+---
+title: Fix negative zero when calculating price
+issue: NEXT-00000
+author: Jasper Peeters
+author_email: jasper.peeters@meteor.be
+author_github: JasperP98
+---
+
+# Core
+
+* When rounding the cash price in `\Shopware\Core\Checkout\Cart\Price\CashRounding::mathRound` the result should always result in a positive zero.

--- a/changelog/_unreleased/2025-01-24-fix-negative-zero-when-calculating-price.md
+++ b/changelog/_unreleased/2025-01-24-fix-negative-zero-when-calculating-price.md
@@ -1,11 +1,9 @@
 ---
 title: Fix negative zero when calculating price
-issue: NEXT-00000
+issue: #6418
 author: Jasper Peeters
 author_email: jasper.peeters@meteor.be
 author_github: JasperP98
 ---
-
 # Core
-
 * Changed `\Shopware\Core\Checkout\Cart\Price\CashRounding::mathRound` to always round a zero cash price to a positive zero.

--- a/changelog/_unreleased/2025-01-24-fix-negative-zero-when-calculating-price.md
+++ b/changelog/_unreleased/2025-01-24-fix-negative-zero-when-calculating-price.md
@@ -8,4 +8,4 @@ author_github: JasperP98
 
 # Core
 
-* Changed: When rounding the cash price in `\Shopware\Core\Checkout\Cart\Price\CashRounding::mathRound` the result should always result in a positive zero.
+* Changed `\Shopware\Core\Checkout\Cart\Price\CashRounding::mathRound` to always round a zero cash price to a positive zero.

--- a/changelog/_unreleased/2025-01-24-fix-negative-zero-when-calculating-price.md
+++ b/changelog/_unreleased/2025-01-24-fix-negative-zero-when-calculating-price.md
@@ -8,4 +8,4 @@ author_github: JasperP98
 
 # Core
 
-* When rounding the cash price in `\Shopware\Core\Checkout\Cart\Price\CashRounding::mathRound` the result should always result in a positive zero.
+* Changed: When rounding the cash price in `\Shopware\Core\Checkout\Cart\Price\CashRounding::mathRound` the result should always result in a positive zero.

--- a/src/Core/Checkout/Cart/Price/CashRounding.php
+++ b/src/Core/Checkout/Cart/Price/CashRounding.php
@@ -10,7 +10,7 @@ class CashRounding
 {
     public function mathRound(float $price, CashRoundingConfig $config): float
     {
-        return round($price, $config->getDecimals());
+        return round($price, $config->getDecimals()) + 0;
     }
 
     public function cashRound(float $price, CashRoundingConfig $config): float

--- a/tests/unit/Core/Checkout/Cart/Price/CashRoundingTest.php
+++ b/tests/unit/Core/Checkout/Cart/Price/CashRoundingTest.php
@@ -69,6 +69,17 @@ class CashRoundingTest extends TestCase
         static::assertEquals($expected, $actual);
     }
 
+    public function testNegativeZeroHandling(): void
+    {
+        $service = new CashRounding();
+        $config = new CashRoundingConfig(2, 0.01, true);
+
+        $result = $service->mathRound(-0.001, $config);
+
+        // Convert to string to check if it's positive zero (should not start with '-')
+        static::assertEquals('0', (string) $result);
+    }
+
     public static function provider_german(): \Generator
     {
         yield '19.990 should be 19.99' => [19.990, 19.99];

--- a/tests/unit/Core/Checkout/Cart/Price/CashRoundingTest.php
+++ b/tests/unit/Core/Checkout/Cart/Price/CashRoundingTest.php
@@ -77,7 +77,7 @@ class CashRoundingTest extends TestCase
         $result = $service->mathRound(-0.001, $config);
 
         // Convert to string to check if it's positive zero (should not start with '-')
-        static::assertEquals('0', (string) $result);
+        static::assertSame('0', (string) $result);
     }
 
     public static function provider_german(): \Generator


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The price should never result in a negative zero. -0.000001 should be rounded to 0 instead of -0.

### 2. What does this change do, exactly?
This change adds the round with a 0 zo it becomes positive.

### 3. Describe each step to reproduce the issue or behaviour.
1. Add a line item with price 125
2. Add a delivery with shipping cost of 4.9
3. Add a line item with price -129,4

The cart total should be 0 but now it is -0.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
