### PR TITLE
Fix to handle Google ReCaptcha double form submit

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
@@ -21,6 +21,8 @@ export default class FormCmsHandler extends Plugin {
         this._registerEvents();
         this._getCmsBlock();
         this._getConfirmationText();
+
+        this.formSubmittedByCaptcha = false;
     }
 
     sendAjaxFormSubmit() {
@@ -75,7 +77,9 @@ export default class FormCmsHandler extends Plugin {
     _submitForm() {
         this.$emitter.publish('beforeSubmit');
 
-        this.sendAjaxFormSubmit();
+        if (!this.formSubmittedByCaptcha) {
+            this.sendAjaxFormSubmit();
+        }
     }
 
     _handleResponse(res) {


### PR DESCRIPTION
Follow-up for https://github.com/shopware/shopware/pull/4746 to prevent a double form submit for the FormCmsHandler plugin

### 1. Why is this change necessary?
FormCmsHandler with useAjax= true emits beforeSubmit event and right after executes sendAjaxFormSubmit function.
 
`GoogleReCaptchaBasePlugin` binds to beforeSubmit event and calls sendAjaxFormSubmit as well, resulting in a double form submission.
 
 ### 2. What does this change do, exactly?
 Checks for `GoogleReCaptcha` V2 or V3 instance on the form and avoid `sendAjaxFormSubmit` to be called from `form-ajax-submit` and `form-auto-submit` plugins
 
 ### 3. Describe each step to reproduce the issue or behaviour.
 On a form with GoogleReCaptcha active, trigger a submit with missing required fields, then fill the missing fields and submit the form. FormCmsHandler will execute their `sendAjaxFormSubmit` method, `GoogleReCaptcha` will call that method too, causing a double form submission.
 
 ### 4. Please link to the relevant issues (if any).
 #4347
 #4746
 
 ### 5. Checklist
 * [x]  I have rebased my changes to remove merge conflicts
 * [ ]  I have written tests and verified that they fail without my change
 * [ ]  I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-hangelog.md) with all necessary information about my changes
 * [ ]  I have written or adjusted the documentation according to my changes
 * [ ]  This change has comments for package types, values, functions, and non-obvious lines of code
 * [x]  I have read the contribution requirements and fulfil them.

