### PR TITLE
fix: use native history API

### DIFF
--- a/changelog/_unreleased/2025-01-28-fix-history-back-for-listing-filters.md
+++ b/changelog/_unreleased/2025-01-28-fix-history-back-for-listing-filters.md
@@ -1,0 +1,10 @@
+---
+title: Fixed the listing when using the browser back button and filters
+issue: NEXT-37455
+author: Björn Meyer
+author_email: b.meyer@shopware.com
+author_github: @BrocksiNet
+---
+# Storefront
+* Changed `ListingPlugin` to use native `window.history` instead of `HistoryUtil`
+  * This fixes the issue that the listing was not updated when using the browser's back button

--- a/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/listing/listing.plugin.js
@@ -8,7 +8,6 @@ import Iterator from 'src/helper/iterator.helper';
 import DomAccess from 'src/helper/dom-access.helper';
 import querystring from 'query-string';
 import ElementReplaceHelper from 'src/helper/element-replace.helper';
-import HistoryUtil from 'src/utility/history/history.util';
 import Debouncer from 'src/helper/debouncer.helper';
 
 export default class ListingPlugin extends Plugin {
@@ -52,7 +51,7 @@ export default class ListingPlugin extends Plugin {
 
         this.httpClient = new HttpClient();
 
-        this._urlFilterParams = querystring.parse(HistoryUtil.getSearch());
+        this._urlFilterParams = querystring.parse(window.location.search);
 
         this._filterPanel = DomAccess.querySelector(document, this.options.filterPanelSelector, false);
         this._filterPanelActive = !!this._filterPanel;
@@ -252,7 +251,7 @@ export default class ListingPlugin extends Plugin {
     }
 
     _updateHistory(query) {
-        HistoryUtil.push(HistoryUtil.getLocation().pathname, query, {});
+        window.history.pushState({}, '', `${window.location.pathname}?${query}`);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?
When you applied some filters and used the back button of the browser, the listing was not updated.

### 2. What does this change do, exactly?
Instead of using our HistoryUtil, we now use the browser's default window.history.

### 3. Describe each step to reproduce the issue or behaviour.
See Jira or Issue that will be closed. :arrow_down_small: 

### 4. Please link to the relevant issues (if any).
- closes #4430
- Jira issue: https://shopware.atlassian.net/browse/NEXT-37455

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
