### PR TITLE
fix: add abstract annotation to getEntityName

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/EntityExtension.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityExtension.php
@@ -40,6 +40,7 @@ abstract class EntityExtension
 
     /**
      * @deprecated tag:v6.7.0 - reason:visibility-change - Becomes abstract
+     *
      * @abstract
      */
     public function getEntityName(): string

--- a/src/Core/Framework/DataAbstractionLayer/EntityExtension.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityExtension.php
@@ -40,6 +40,7 @@ abstract class EntityExtension
 
     /**
      * @deprecated tag:v6.7.0 - reason:visibility-change - Becomes abstract
+     * @abstract
      */
     public function getEntityName(): string
     {


### PR DESCRIPTION
### 1. Why is this change necessary?

Custom PHPStan rule can annoy that implementing classes are missing that new method


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
