### PR TITLE
test: fix flakiness issues in php integration tests

### DIFF
--- a/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/RepositoryIteratorTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Dbal/RepositoryIteratorTest.php
@@ -86,7 +86,7 @@ class RepositoryIteratorTest extends TestCase
         $builder->price(3);
         $productRepository->create([$builder->build()], $context);
 
-        $criteria = new Criteria();
+        $criteria = new Criteria([$ids->get('product1'), $ids->get('product2'), $ids->get('product3')]);
         $criteria->setLimit(1);
         $iterator = new RepositoryIterator($productRepository, $context, $criteria);
 

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionReadTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionReadTest.php
@@ -166,7 +166,7 @@ class EntityExtensionReadTest extends TestCase
         static::assertIsArray($reference);
         static::assertSame($extendableId, Uuid::fromBytesToHex($reference['id']));
 
-        $criteria = new Criteria();
+        $criteria = new Criteria([$productId]);
         $criteria->addAssociation('manyToOne');
 
         $product = $this->productRepository->search($criteria, Context::createDefaultContext())->first();

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventFactoryTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Event/EntityLoadedEventFactoryTest.php
@@ -50,7 +50,7 @@ class EntityLoadedEventFactoryTest extends TestCase
 
         $this->productRepository->create([$builder->build()], Context::createDefaultContext());
 
-        $criteria = new Criteria();
+        $criteria = new Criteria([$this->ids->get('p1')]);
         $criteria->addAssociations([
             'manufacturer',
             'prices',

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Reader/EntityReaderTest.php
@@ -147,7 +147,7 @@ class EntityReaderTest extends TestCase
         $this->productRepository
             ->create([$product->build()], Context::createDefaultContext());
 
-        $criteria = new Criteria();
+        $criteria = new Criteria([$ids->get('p1')]);
         $criteria->addFields(['productNumber', 'name', 'categories.name']);
 
         $values = $this->productRepository
@@ -183,7 +183,7 @@ class EntityReaderTest extends TestCase
         static::getContainer()->get('product.repository')
             ->create([$product->build()], Context::createDefaultContext());
 
-        $criteria = new Criteria();
+        $criteria = new Criteria([$ids->get('p1')]);
         $criteria->addFields(['id', 'productNumber', 'name', 'manufacturer.id', 'manufacturer.name']);
 
         $values = static::getContainer()
@@ -2177,7 +2177,7 @@ class EntityReaderTest extends TestCase
 
         $this->productRepository->create($products, Context::createDefaultContext());
 
-        $criteria = new Criteria();
+        $criteria = new Criteria([$ids->get('product-1'), $ids->get('product-2')]);
         $criteria->addAssociation('translations.language.categoryTranslations');
 
         $products = $this->productRepository

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregationTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Aggregation/Metric/RangeAggregationTest.php
@@ -102,7 +102,16 @@ class RangeAggregationTest extends TestCase
 
         $this->repository->create($data, $this->context);
 
-        $criteria = new Criteria();
+        $criteria = new Criteria([
+            $ids->get('a'),
+            $ids->get('b'),
+            $ids->get('c'),
+            $ids->get('d'),
+            $ids->get('e'),
+            $ids->get('f'),
+            $ids->get('g'),
+            $ids->get('h'),
+        ]);
         $criteria->addAggregation(
             new RangeAggregation(
                 'test-range-aggregation',

--- a/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
@@ -54,7 +54,12 @@ class SqlQueryParserTest extends TestCase
 
     public function testFindProductsWithoutCategory(): void
     {
-        $criteria = new Criteria();
+        $criteria = new Criteria([
+            $this->ids->get('product1-with-category'),
+            $this->ids->get('product2-with-category'),
+            $this->ids->get('product1-without-category'),
+            $this->ids->get('product2-without-category'),
+        ]);
         $criteria->addFilter(new EqualsFilter('categoryIds', null));
 
         $result = $this->repository->searchIds($criteria, $this->context);

--- a/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
@@ -71,11 +71,6 @@ class PluginManagementServiceTest extends TestCase
         $this->filesystem->remove($this->cacheDir);
 
         Kernel::getConnection()->executeStatement('DELETE FROM plugin');
-
-        // make sure to boot the main container again
-        // eg in `\Shopware\Core\Framework\Framework::boot()` we bind the container to \Shopware\Core\Framework\Telemetry\Metrics\MeterProvider
-        // if we don't reboot, we hold an old reference to the deleted container used for testing in this class
-        $this->getKernel()->reboot(null);
     }
 
     public function testUploadPlugin(): void


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

integration tests are flaky

### 2. What does this change do, exactly?

- removes `$kernel->reboot`. The reboot caused some issue with the db transaction
   - which as a follow up issues caused the test `PluginManagementServiceTest` to not clean up the products it create
   - which made many tests fail that expect the db to have to products
- change the tests that expect no products in the db to actually restrict the criterias to the products that are actually created in the test


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
