### PR TITLE
fix(sw-data-grid): inline edit issues

### DIFF
--- a/changelog/_unreleased/2025-01-29-fix-data-grid-inline-edit.md
+++ b/changelog/_unreleased/2025-01-29-fix-data-grid-inline-edit.md
@@ -1,0 +1,8 @@
+---
+title: Fix data grid inline edit
+author: Iván Tajes Vidal
+author_email: tajespasarela@gmail.com
+author_github: @Iván Tajes Vidal
+---
+# Administration
+* Changed how `sw-data-grid-inline-edit` component emits the `update:value` event to fix an error on inline edit in data grid

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-inline-edit/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-inline-edit/index.js
@@ -67,16 +67,9 @@ Component.register('sw-data-grid-inline-edit', {
     methods: {
         createdComponent() {
             this.currentValue = this.value;
-
-            if (this.isCompatEnabled('INSTANCE_CHILDREN') && this.isCompatEnabled('INSTANCE_EVENT_EMITTER')) {
-                this.$parent.$parent.$on('inline-edit-assign', this.emitInput);
-            }
         },
 
         beforeDestroyComponent() {
-            if (this.isCompatEnabled('INSTANCE_CHILDREN') && this.isCompatEnabled('INSTANCE_EVENT_EMITTER')) {
-                this.$parent.$parent.$off('inline-edit-assign', this.emitInput);
-            }
         },
 
         emitInput() {

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-inline-edit/sw-data-grid-inline-edit.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid-inline-edit/sw-data-grid-inline-edit.html.twig
@@ -10,6 +10,7 @@
         v-model:value="currentValue"
         name="sw-field--currentValue"
         :size="inputFieldSize"
+        @update:value="emitInput"
     />
     {% endblock %}
 
@@ -21,6 +22,7 @@
         name="sw-field--currentValue"
         :size="inputFieldSize"
         :number-align-end="true"
+        @update:value="emitInput"
     />
     {% endblock %}
 
@@ -30,6 +32,7 @@
         key="boolean"
         v-model:value="currentValue"
         name="sw-field--currentValue"
+        @update:value="emitInput"
     />
     {% endblock %}
 

--- a/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/data-grid/sw-data-grid/sw-data-grid.html.twig
@@ -332,10 +332,9 @@
                                         <template v-if="isInlineEdit(item) && column.hasOwnProperty('inlineEdit')">
                                             {% block sw_data_grid_columns_render_inline_edit %}
                                             <sw-data-grid-inline-edit
+                                                v-model:value="item[column.property]"
                                                 :column="column"
                                                 :compact="compact"
-                                                :value="item[column.property]"
-                                                @update:value="item[column.property] = $event"
                                             />
                                             {% endblock %}
                                         </template>


### PR DESCRIPTION
### 1. Why is this change necessary?
This PR fixes #6460 inline edit in the sw-data-grid


### 2. What does this change do, exactly?
Fixes the `sw-data-grid-inline-edit` component to update the value when a record is edited inline in the sw-data-grid.

### 3. Describe each step to reproduce the issue or behavior.
1. Go to `Settings > Search > Excluded search terms`
2. Add a new excluded search term
3. Save and without the fix, you get an error notification

### 4. Please link to the relevant issues (if any).
fixes #6460 
### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
