### PR TITLE
feat: add `addTrailingSlash` option to sw-url-field

### DIFF
--- a/changelog/_unreleased/2025-01-30-add-addtrailingslash-option-to-url-field.md
+++ b/changelog/_unreleased/2025-01-30-add-addtrailingslash-option-to-url-field.md
@@ -1,0 +1,20 @@
+---
+title: Add addTrailingSlash option to url field
+issue: NEXT-21017
+author: Iván Tajes Vidal
+author_email: tajespasarela@gmail.com
+author_github: @Iván Tajes Vidal
+---
+# Administration
+* Added `addTrailingSlash` option to the `sw-url-field` component.
+___
+# Upgrade Information
+
+## Added `addTrailingSlash` option to the `sw-url-field` component
+This option allows you to add a trailing slash to the URL and adds it to the value if it is missing.
+The option is disabled by default.
+
+### Example
+```html
+<sw-url-field v-model:value="currentValue" addTrailingSlash />
+```

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field-deprecated/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field-deprecated/index.js
@@ -51,6 +51,10 @@ Component.extend('sw-url-field-deprecated', 'sw-text-field-deprecated', {
             type: Boolean,
             default: false,
         },
+        addTrailingSlash: {
+            type: Boolean,
+            default: false,
+        },
     },
 
     data() {
@@ -166,7 +170,8 @@ Component.extend('sw-url-field-deprecated', 'sw-text-field-deprecated', {
             }
 
             // when a hash or search query is provided we want to allow trailing slash, eg a vue route `admin#/`
-            const removeTrailingSlash = url.hash === '' && url.search === '' ? URL_REGEX.TRAILING_SLASH : '';
+            const removeTrailingSlash =
+                url.hash === '' && url.search === '' && !this.addTrailingSlash ? URL_REGEX.TRAILING_SLASH : '';
 
             // build URL via native URL.toString() function instead by hand @see NEXT-15747
             return url

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field-deprecated/sw-url-field-deprecated.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-url-field-deprecated/sw-url-field-deprecated.spec.js
@@ -11,7 +11,7 @@ import 'src/app/component/form/field-base/sw-base-field';
 import 'src/app/component/base/sw-icon';
 import 'src/app/component/form/field-base/sw-field-error';
 import 'src/app/filter/unicode-uri';
-import { ref } from 'vue';
+import { nextTick, ref } from 'vue';
 
 async function createWrapper({ provide, ...additionalOptions } = {}) {
     return mount(await wrapTestComponent('sw-url-field-deprecated', { sync: true }), {
@@ -283,5 +283,26 @@ describe('components/form/sw-url-field', () => {
         await flushPromises();
 
         expect(wrapper.find('input').attributes('aria-label')).toBe('Aria Label');
+    });
+
+    it('adds the trailing slash if the prop is set', async () => {
+        const wrapper = await createWrapper({
+            props: {
+                value: 'https://shopware.com',
+                addTrailingSlash: true,
+            },
+        });
+        await flushPromises();
+
+        const input = wrapper.find('input');
+        expect(input.element.value).toBe('shopware.com/');
+
+        await input.setValue('shopware.com');
+        await input.trigger('blur');
+        await nextTick();
+        expect(wrapper.vm.currentUrlValue).toBe('shopware.com/');
+        expect(wrapper.emitted('update:value')).toStrictEqual([
+            ['https://shopware.com/'],
+        ]);
     });
 });


### PR DESCRIPTION

### 1. Why is this change necessary?
In some cases, the trailing slash is necessary in a URL


### 2. What does this change do, exactly?
Adds a new `addTrailingSlash` prop to the `sw-url-field` component, that enforces the trailing slash


### 3. Describe each step to reproduce the issue or behaviour.
1. Go to any `<sw-url-field/>` used in the project
2. add the `addTrailingSlash` attribute: `<sw-url-field v-model:value="currentValue" addTrailingSlash />`
3. Try to input any URL without trailing slash
4. After blur the field the slash is added


### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-21017


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
