### PR TITLE
perf: fix elasticsearch indexing performance for orders in administration

### DIFF
--- a/changelog/_unreleased/2025-01-30-fix-order-elasticsearch-indexing-performance-for-administration.md
+++ b/changelog/_unreleased/2025-01-30-fix-order-elasticsearch-indexing-performance-for-administration.md
@@ -1,0 +1,11 @@
+---
+title: Fix elasticsearch indexing performance for orders in administration
+issue: NEXT-40478
+author: Niklas Wolf
+author_email: 16021919+niklaswolf@users.noreply.github.com
+author_github: @niklaswolf
+---
+
+# Core
+
+* Changed query that is used to index orders for elasticsearch for the administration to use indices

--- a/src/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexer.php
+++ b/src/Elasticsearch/Admin/Indexer/OrderAdminSearchIndexer.php
@@ -86,21 +86,21 @@ final class OrderAdminSearchIndexer extends AbstractAdminIndexer
                    order_delivery.tracking_codes
             FROM `order`
                 LEFT JOIN order_customer
-                    ON `order`.id = order_customer.order_id
+                    ON `order`.id = order_customer.order_id AND order_customer.order_version_id = :versionId
                 LEFT JOIN order_address
-                    ON `order`.id = order_address.order_id
+                    ON `order`.id = order_address.order_id AND order_address.order_version_id = :versionId
                 LEFT JOIN country
                     ON order_address.country_id = country.id
                 LEFT JOIN country_translation
                     ON country.id = country_translation.country_id
                 LEFT JOIN order_tag
-                    ON `order`.id = order_tag.order_id
+                    ON `order`.id = order_tag.order_id AND order_tag.order_version_id = :versionId
                 LEFT JOIN tag
                     ON order_tag.tag_id = tag.id
                 LEFT JOIN order_delivery
-                    ON `order`.id = order_delivery.order_id
+                    ON `order`.id = order_delivery.order_id AND order_delivery.order_version_id = :versionId
                 LEFT JOIN document
-                    ON `order`.id = document.order_id
+                    ON `order`.id = document.order_id AND document.order_version_id = :versionId
             WHERE order.id IN (:ids) AND `order`.version_id = :versionId
             GROUP BY order.id
         ',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
The order indexer for elasticsearch for the administration (bin/console es:admin:index) is reeeeeaaaallly slow, when you have a significant amount of orders.
This is due to mysql indices not being used.

### 2. What does this change do, exactly?
Adds the order_version_id to some joins, so that the indices of the tables can be used by mysql.
In our tests, before the changes the query took > 15min for one chunk (!), after adding the version_id the complete indexing finished in ~45s!

### 3. Describe each step to reproduce the issue or behaviour.
see #6484 

### 4. Please link to the relevant issues (if any).
- closes #6484 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
