### PR TITLE
feat: Added skip button to image gallery element

### DIFF
--- a/changelog/_unreleased/2025-01-30-add-skip-image-gallery-button.md
+++ b/changelog/_unreleased/2025-01-30-add-skip-image-gallery-button.md
@@ -1,0 +1,6 @@
+---
+title: Added skip button to image gallery element for better accessibility.
+issue: NEXT-39102
+---
+# Storefront
+* Added new Twig block `element_image_gallery_inner_skip_gallery` and `element_image_gallery_target_after_gallery` to `storefront/element/cms-element-image-gallery.html.twig` which includes a skip button to skip the image gallery as a keyboard user.

--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -134,6 +134,13 @@
             {% endif %}
 
             {% block element_image_gallery_inner %}
+                {% block element_image_gallery_inner_skip_gallery %}
+                    {% sw_include '@Storefront/storefront/component/skip-target.html.twig' with {
+                        targetId: block.id,
+                        snippet: 'component.cms.imageGallery.skipImageGallery',
+                    } %}
+                {% endblock %}
+
                 <div class="row gallery-slider-row{% if imageCount == 1 %} is-single-image{% else %} is-loading{% endif %} js-gallery-zoom-modal-container"
                     {% if zoom %}
                         data-magnifier="true"
@@ -824,4 +831,8 @@
             {% endif %}
         {% endblock %}
     </div>
+
+    {% block element_image_gallery_target_after_gallery %}
+        <div id="content-after-target-{{ block.id }}"></div>
+    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?
Navigating a page with an image gallery element containing many elements can be difficult for a keyboard user.

### 2. What does this change do, exactly?
We added a skip button above the image gallery element that is only visible on focus, so keyboard users can skip the gallery content.

Closes: https://github.com/shopware/shopware/pull/6320


