### PR TITLE
invalid(ci): add conventional commits danger rule

### DIFF
--- a/.danger.php
+++ b/.danger.php
@@ -422,4 +422,14 @@ return (new Config())
             }
         }
     })
+    ->useRule(function (Context $context): void {
+        $conventionalCommitRegex = '/\s*(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?:\s*.+$/i';
+
+        $prTitle = $context->platform->pullRequest->title;
+        $pregMatch = preg_match($conventionalCommitRegex, $prTitle);
+
+        if ($pregMatch === 0 || $pregMatch === false) {
+            $context->failure(sprintf('The pr title "%s" does not conform to conventional commits standard (%s)', $prTitle, $conventionalCommitRegex));
+        }
+    })
 ;


### PR DESCRIPTION
Make sure the mr title match conventional commits format.

This is necessary because we can't change the commit message anymore with the introduction of merge queues