### PR TITLE
fix: Vite build flex template

### DIFF
--- a/src/Administration/.gitattributes
+++ b/src/Administration/.gitattributes
@@ -1,7 +1,8 @@
 # General ignore rules
 /Test export-ignore
 /Resources/ide-twig.json export-ignore
-/Resources/app/administration/build export-ignore
+/Resources/app/administration/build/nuxt-component-library export-ignore
+/Resources/app/administration/build/artifacts export-ignore
 /Resources/app/administration/test export-ignore
 /Resources/app/administration/src/meta export-ignore
 /Resources/app/administration/src/scripts/create-spec-file export-ignore


### PR DESCRIPTION
The vite scripts and helper where excluded for the flex template. Therefore building with vite would fail.