### PR TITLE
fix(accessibility): Remove unneeded tax info in order item

### DIFF
--- a/changelog/_unreleased/2025-01-31-remove-unneeded-tax-info-in-order-item.md
+++ b/changelog/_unreleased/2025-01-31-remove-unneeded-tax-info-in-order-item.md
@@ -1,0 +1,6 @@
+---
+title: Remove unneeded tax info in order item
+issue: NEXT-39225
+---
+# Storefront
+* Deprecated block `page_account_order_item_detail_table_footnote`. Block and its content will be removed. Tax and shipping information is already displayed in the summary above.

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -721,9 +721,7 @@
     "newsletterInput": "E-Mail-Adresse",
     "newsletter": "Abonnieren Sie jetzt unseren regelmäßig erscheinenden Newsletter, um rechtzeitig über neue Produkte und Angebote informiert zu werden.",
     "includeVatText": "%star%Alle Preise inkl. gesetzl. Mehrwertsteuer zzgl. <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
-    "includeVatTextPage": "%star%Alle Preise inkl. gesetzl. Mehrwertsteuer zzgl. <a href=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
-    "excludeVatText": "%star%Alle Preise exkl. gesetzl. Mehrwertsteuer zzgl. <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
-    "excludeVatTextPage": "%star%Alle Preise exkl. gesetzl. Mehrwertsteuer zzgl. <a href=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
+    "includeVatTextPage": "Alle Preise inkl. gesetzl. Mehrwertsteuer zzgl. <a href=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
     "copyrightInfo": "Realisiert mit Shopware"
   },
   "captcha": {

--- a/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
+++ b/src/Storefront/Resources/snippet/de_DE/storefront.de-DE.json
@@ -722,6 +722,8 @@
     "newsletter": "Abonnieren Sie jetzt unseren regelmäßig erscheinenden Newsletter, um rechtzeitig über neue Produkte und Angebote informiert zu werden.",
     "includeVatText": "%star%Alle Preise inkl. gesetzl. Mehrwertsteuer zzgl. <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
     "includeVatTextPage": "Alle Preise inkl. gesetzl. Mehrwertsteuer zzgl. <a href=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
+    "excludeVatText": "%star%Alle Preise exkl. gesetzl. Mehrwertsteuer zzgl. <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
+    "excludeVatTextPage": "Alle Preise exkl. gesetzl. Mehrwertsteuer zzgl. <a href=\"%url%\">Versandkosten</a> und ggf. Nachnahmegebühren, wenn nicht anders angegeben.",
     "copyrightInfo": "Realisiert mit Shopware"
   },
   "captcha": {

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -722,6 +722,8 @@
     "newsletter": "Subscribe to our regular newsletter now to stay tuned on the latest products and special offers.",
     "includeVatText": "%star%All prices incl. VAT plus <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
     "includeVatTextPage": "All prices incl. VAT plus <a href=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
+    "excludeVatText": "%star%All prices excl. VAT plus <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
+    "excludeVatTextPage": "All prices excl. VAT plus <a href=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
     "copyrightInfo": "Realised with Shopware"
   },
   "captcha": {

--- a/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
+++ b/src/Storefront/Resources/snippet/en_GB/storefront.en-GB.json
@@ -721,9 +721,7 @@
     "newsletterInput": "Email address",
     "newsletter": "Subscribe to our regular newsletter now to stay tuned on the latest products and special offers.",
     "includeVatText": "%star%All prices incl. VAT plus <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
-    "includeVatTextPage": "%star%All prices incl. VAT plus <a href=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
-    "excludeVatText": "%star%All prices excl. VAT plus <a data-ajax-modal=\"true\" href=\"%url%\" data-url=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
-    "excludeVatTextPage": "%star%All prices excl. VAT plus <a href=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
+    "includeVatTextPage": "All prices incl. VAT plus <a href=\"%url%\">shipping costs</a> and possible delivery charges, if not stated otherwise.",
     "copyrightInfo": "Realised with Shopware"
   },
   "captcha": {

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
@@ -224,19 +224,22 @@
                             </div>
                         {% endblock %}
 
+                        {#
+                            @deprecated tag:v6.7.0 - Block page_account_order_item_detail_table_footnote and its content will be removed.
+                            Tax and shipping information is already displayed in the summary above.
+                        #}
                         {% block page_account_order_item_detail_table_footnote %}
-                            <div class="order-item-detail-footnote">
-                                {%- if feature('ACCESSIBILITY_TWEAKS') -%}
-                                    {% set taxSnippetKey = order.taxStatus == 'gross' ? 'includeVatTextPage' : 'excludeVatTextPage' %}
-                                {%- else -%}
-                                   {% set taxSnippetKey = order.taxStatus == 'gross' ? 'includeVatText' : 'excludeVatText' %}
-                                {%- endif -%}
-                                {% set cmsPath = feature('ACCESSIBILITY_TWEAKS') ? 'frontend.cms.page.full' : 'frontend.cms.page' %}
+                            {%- if not feature('ACCESSIBILITY_TWEAKS') -%}
+                                <div class="order-item-detail-footnote">
+                                    {% set taxSnippetKey = order.taxStatus == 'gross' ? 'includeVatText' : 'excludeVatText' %}
+                                    {% set cmsPath = 'frontend.cms.page' %}
 
-                                {{ 'footer.%s'|format(taxSnippetKey)|trans({
-                                    '%url%': path(cmsPath, { id: config('core.basicInformation.shippingPaymentInfoPage') })
-                                })|raw }}
-                            </div>
+                                    {{ 'footer.%s'|format(taxSnippetKey)|trans({
+                                        '%url%': path(cmsPath, { id: config('core.basicInformation.shippingPaymentInfoPage') }),
+                                        '%star%': '* '
+                                    })|raw }}
+                                </div>
+                            {% endif %}
                         {% endblock %}
                     </div>
                 {% endblock %}


### PR DESCRIPTION
* Inside the account order items the translation for the VAT & Shipping text is broken because the `%star%` parameter is not passed from the template.
* Remove the VAT & Shipping text behind the a11y flag. The information about shipping and taxes is already displayed in the summary above.
* Delete `%star%` for the new snippets `includeVatTextPage` and `excludeVatTextPage`. The * can never be rendered because those snippets are only applied with active a11y flag.

### Before (%star% is now fixed):

![image](https://github.com/user-attachments/assets/a34980bf-319e-4f30-b8ce-d538c1ae5b77)

### After (with `ACCESSIBILITY_TWEAKS` flag)

![image](https://github.com/user-attachments/assets/d7dcf43f-537d-4b10-84db-63b5d058a910)
