### PR TITLE
fix: vite plugin build without admin path

### DIFF
--- a/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
+++ b/src/Administration/Resources/app/administration/build/vite-plugins/utils/index.ts
@@ -136,12 +136,13 @@ export function loadExtensions(): ExtensionDefinition[] {
                 const appEntryPath = path.resolve(
                     process.env.PROJECT_ROOT as string,
                     definition.basePath,
-                    // @ts-expect-error - We know it is defined at this point because of the filter above
-                    definition.administration.path,
+                    definition.administration?.path ?? '',
                     '../..',
                     'meteor-app',
                 );
-                return fs.existsSync(path.resolve(appEntryPath, 'index.html'));
+
+                return definition.administration?.path
+                    && fs.existsSync(path.resolve(appEntryPath, 'index.html'));
             },
         )
         .map(


### PR DESCRIPTION
### 1. Why is this change necessary?

Vite build fails if an app doesn't have an admin path

### 2. What does this change do, exactly?

Removed type suppression and did the fix.

