### PR TITLE
fix: Execute composer remove on plugin update if necessary

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2631,11 +2631,6 @@ parameters:
 			path: src/Core/Framework/Plugin/Composer/PackageProvider.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Plugin\\\\Exception\\\\PluginComposerJsonInvalidException\\:\\:__construct\\(\\) has parameter \\$errors with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/Plugin/Exception/PluginComposerJsonInvalidException.php
-
-		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 4
 			path: src/Core/Framework/Plugin/KernelPluginLoader/KernelPluginLoader.php
@@ -2649,11 +2644,6 @@ parameters:
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 3
 			path: src/Core/Framework/Plugin/PluginExtractor.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 12
-			path: src/Core/Framework/Plugin/PluginLifecycleService.php
 
 		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"

--- a/src/Core/Framework/Plugin/BundleConfigGenerator.php
+++ b/src/Core/Framework/Plugin/BundleConfigGenerator.php
@@ -28,7 +28,7 @@ class BundleConfigGenerator implements BundleConfigGeneratorInterface
     ) {
         $projectDir = $this->kernel->getContainer()->getParameter('kernel.project_dir');
         if (!\is_string($projectDir)) {
-            throw PluginException::projectDirNotInContainer();
+            throw PluginException::invalidContainerParameter('kernel.project_dir', 'string');
         }
         $this->projectDir = $projectDir;
     }

--- a/src/Core/Framework/Plugin/BundleConfigGenerator.php
+++ b/src/Core/Framework/Plugin/BundleConfigGenerator.php
@@ -127,8 +127,7 @@ class BundleConfigGenerator implements BundleConfigGeneratorInterface
         $absolutePath = $rootPath . '/' . $path;
 
         return file_exists($absolutePath . '/main.ts') ? $path . '/main.ts'
-            : (file_exists($absolutePath . '/main.js') ? $path . '/main.js'
-                : null);
+            : (file_exists($absolutePath . '/main.js') ? $path . '/main.js' : null);
     }
 
     private function getWebpackConfig(string $rootPath, string $componentPath): ?string

--- a/src/Core/Framework/Plugin/Exception/PluginBaseClassNotFoundException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginBaseClassNotFoundException.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class PluginBaseClassNotFoundException extends PluginException
 {

--- a/src/Core/Framework/Plugin/Exception/PluginBaseClassNotFoundException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginBaseClassNotFoundException.php
@@ -3,27 +3,19 @@
 namespace Shopware\Core\Framework\Plugin\Exception;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\ShopwareHttpException;
+use Shopware\Core\Framework\Plugin\PluginException;
 use Symfony\Component\HttpFoundation\Response;
 
 #[Package('framework')]
-class PluginBaseClassNotFoundException extends ShopwareHttpException
+class PluginBaseClassNotFoundException extends PluginException
 {
     public function __construct(string $baseClass)
     {
         parent::__construct(
+            Response::HTTP_BAD_REQUEST,
+            'FRAMEWORK__PLUGIN_BASE_CLASS_NOT_FOUND',
             'The class "{{ baseClass }}" is not found. Probably a class loader error. Check your plugin composer.json',
             ['baseClass' => $baseClass]
         );
-    }
-
-    public function getErrorCode(): string
-    {
-        return 'FRAMEWORK__PLUGIN_BASE_CLASS_NOT_FOUND';
-    }
-
-    public function getStatusCode(): int
-    {
-        return Response::HTTP_BAD_REQUEST;
     }
 }

--- a/src/Core/Framework/Plugin/Exception/PluginComposerJsonInvalidException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginComposerJsonInvalidException.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class PluginComposerJsonInvalidException extends PluginException
 {

--- a/src/Core/Framework/Plugin/Exception/PluginComposerJsonInvalidException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginComposerJsonInvalidException.php
@@ -3,29 +3,24 @@
 namespace Shopware\Core\Framework\Plugin\Exception;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\ShopwareHttpException;
+use Shopware\Core\Framework\Plugin\PluginException;
 use Symfony\Component\HttpFoundation\Response;
 
 #[Package('framework')]
-class PluginComposerJsonInvalidException extends ShopwareHttpException
+class PluginComposerJsonInvalidException extends PluginException
 {
+    /**
+     * @param list<string> $errors
+     */
     public function __construct(
         string $composerJsonPath,
         array $errors
     ) {
         parent::__construct(
+            Response::HTTP_BAD_REQUEST,
+            'FRAMEWORK__PLUGIN_COMPOSER_JSON_INVALID',
             'The file "{{ composerJsonPath }}" is invalid. Errors:' . \PHP_EOL . '{{ errorsString }}',
             ['composerJsonPath' => $composerJsonPath, 'errorsString' => implode(\PHP_EOL, $errors), 'errors' => $errors]
         );
-    }
-
-    public function getErrorCode(): string
-    {
-        return 'FRAMEWORK__PLUGIN_COMPOSER_JSON_INVALID';
-    }
-
-    public function getStatusCode(): int
-    {
-        return Response::HTTP_BAD_REQUEST;
     }
 }

--- a/src/Core/Framework/Plugin/Exception/PluginHasActiveDependantsException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginHasActiveDependantsException.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Plugin\PluginException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class PluginHasActiveDependantsException extends PluginException
 {

--- a/src/Core/Framework/Plugin/Exception/PluginHasActiveDependantsException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginHasActiveDependantsException.php
@@ -4,13 +4,14 @@ namespace Shopware\Core\Framework\Plugin\Exception;
 
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginEntity;
-use Shopware\Core\Framework\ShopwareHttpException;
+use Shopware\Core\Framework\Plugin\PluginException;
+use Symfony\Component\HttpFoundation\Response;
 
 #[Package('framework')]
-class PluginHasActiveDependantsException extends ShopwareHttpException
+class PluginHasActiveDependantsException extends PluginException
 {
     /**
-     * @param PluginEntity[] $dependants
+     * @param list<PluginEntity> $dependants
      */
     public function __construct(
         string $dependency,
@@ -19,6 +20,8 @@ class PluginHasActiveDependantsException extends ShopwareHttpException
         $dependantNameList = array_map(static fn ($plugin) => \sprintf('"%s"', $plugin->getName()), $dependants);
 
         parent::__construct(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            'FRAMEWORK__PLUGIN_HAS_DEPENDANTS',
             'The following plugins depend on "{{ dependency }}": {{ dependantNames }}. They need to be deactivated before "{{ dependency }}" can be deactivated or uninstalled itself.',
             [
                 'dependency' => $dependency,
@@ -26,10 +29,5 @@ class PluginHasActiveDependantsException extends ShopwareHttpException
                 'dependantNames' => implode(', ', $dependantNameList),
             ]
         );
-    }
-
-    public function getErrorCode(): string
-    {
-        return 'FRAMEWORK__PLUGIN_HAS_DEPENDANTS';
     }
 }

--- a/src/Core/Framework/Plugin/Exception/PluginNotActivatedException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginNotActivatedException.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class PluginNotActivatedException extends PluginException
 {

--- a/src/Core/Framework/Plugin/Exception/PluginNotActivatedException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginNotActivatedException.php
@@ -3,21 +3,19 @@
 namespace Shopware\Core\Framework\Plugin\Exception;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\ShopwareHttpException;
+use Shopware\Core\Framework\Plugin\PluginException;
+use Symfony\Component\HttpFoundation\Response;
 
 #[Package('framework')]
-class PluginNotActivatedException extends ShopwareHttpException
+class PluginNotActivatedException extends PluginException
 {
     public function __construct(string $pluginName)
     {
         parent::__construct(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            'FRAMEWORK__PLUGIN_NOT_ACTIVATED',
             'Plugin "{{ plugin }}" is not activated.',
             ['plugin' => $pluginName]
         );
-    }
-
-    public function getErrorCode(): string
-    {
-        return 'FRAMEWORK__PLUGIN_NOT_ACTIVATED';
     }
 }

--- a/src/Core/Framework/Plugin/Exception/PluginNotInstalledException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginNotInstalledException.php
@@ -6,6 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\PluginException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class PluginNotInstalledException extends PluginException
 {

--- a/src/Core/Framework/Plugin/Exception/PluginNotInstalledException.php
+++ b/src/Core/Framework/Plugin/Exception/PluginNotInstalledException.php
@@ -3,21 +3,19 @@
 namespace Shopware\Core\Framework\Plugin\Exception;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\ShopwareHttpException;
+use Shopware\Core\Framework\Plugin\PluginException;
+use Symfony\Component\HttpFoundation\Response;
 
 #[Package('framework')]
-class PluginNotInstalledException extends ShopwareHttpException
+class PluginNotInstalledException extends PluginException
 {
     public function __construct(string $pluginName)
     {
         parent::__construct(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            'FRAMEWORK__PLUGIN_NOT_INSTALLED',
             'Plugin "{{ plugin }}" is not installed.',
             ['plugin' => $pluginName]
         );
-    }
-
-    public function getErrorCode(): string
-    {
-        return 'FRAMEWORK__PLUGIN_NOT_INSTALLED';
     }
 }

--- a/src/Core/Framework/Plugin/PluginException.php
+++ b/src/Core/Framework/Plugin/PluginException.php
@@ -2,9 +2,16 @@
 
 namespace Shopware\Core\Framework\Plugin;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin;
+use Shopware\Core\Framework\Plugin\Exception\PluginBaseClassNotFoundException;
+use Shopware\Core\Framework\Plugin\Exception\PluginComposerJsonInvalidException;
+use Shopware\Core\Framework\Plugin\Exception\PluginHasActiveDependantsException;
+use Shopware\Core\Framework\Plugin\Exception\PluginNotActivatedException;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotFoundException;
+use Shopware\Core\Framework\Plugin\Exception\PluginNotInstalledException;
 use Symfony\Component\HttpFoundation\Response;
 
 #[Package('framework')]
@@ -17,9 +24,16 @@ class PluginException extends HttpException
     public const NO_PLUGIN_IN_ZIP = 'FRAMEWORK__PLUGIN_NO_PLUGIN_FOUND_IN_ZIP';
     public const STORE_NOT_AVAILABLE = 'FRAMEWORK__STORE_NOT_AVAILABLE';
     public const CANNOT_CREATE_TEMPORARY_DIRECTORY = 'FRAMEWORK__PLUGIN_CANNOT_CREATE_TEMPORARY_DIRECTORY';
+
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed with next major, as it is unused
+     */
     public const PROJECT_DIR_IS_NOT_A_STRING = 'FRAMEWORK__PROJECT_DIR_IS_NOT_A_STRING';
 
     public const CANNOT_DELETE_SHOPWARE_MIGRATIONS = 'FRAMEWORK__PLUGIN_CANNOT_DELETE_SHOPWARE_MIGRATIONS';
+    public const PLUGIN_INVALID_CONTAINER_PARAMETER = 'FRAMEWORK__PLUGIN_INVALID_CONTAINER_PARAMETER';
+    public const PLUGIN_KERNEL_REBOOT_FAILED = 'FRAMEWORK__PLUGIN_KERNEL_REBOOT_FAILED';
+    public const PLUGIN_WRONG_BASE_CLASS = 'FRAMEWORK__PLUGIN_WRONG_BASE_CLASS';
 
     /**
      * @internal will be removed once store extensions are installed over composer
@@ -92,12 +106,34 @@ class PluginException extends HttpException
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be removed with next major. Use PluginException::invalidContainerParameter instead
+     */
     public static function projectDirNotInContainer(): self
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            Feature::triggerDeprecationOrThrow(
+                'v6.8.0.0',
+                Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0', 'PluginException::invalidContainerParameter')
+            );
+
+            return new self(
+                Response::HTTP_INTERNAL_SERVER_ERROR,
+                self::PROJECT_DIR_IS_NOT_A_STRING,
+                'Container parameter "kernel.project_dir" needs to be a string'
+            );
+        }
+
+        return self::invalidContainerParameter('kernel.project_dir', 'string');
+    }
+
+    public static function invalidContainerParameter(string $name, string $expectedType): self
     {
         return new self(
             Response::HTTP_INTERNAL_SERVER_ERROR,
-            self::PROJECT_DIR_IS_NOT_A_STRING,
-            'Container parameter "kernel.project_dir" needs to be a string'
+            self::PLUGIN_INVALID_CONTAINER_PARAMETER,
+            'Container parameter "{{ name }}" needs to be of type "{{ type }}"',
+            ['name' => $name, 'type' => $expectedType]
         );
     }
 
@@ -113,5 +149,55 @@ class PluginException extends HttpException
     public static function notFound(string $name): PluginNotFoundException
     {
         return new PluginNotFoundException($name);
+    }
+
+    public static function notInstalled(string $name): PluginNotInstalledException
+    {
+        return new PluginNotInstalledException($name);
+    }
+
+    public static function notActivated(string $name): PluginNotActivatedException
+    {
+        return new PluginNotActivatedException($name);
+    }
+
+    /**
+     * @param list<PluginEntity> $dependants
+     */
+    public static function hasActiveDependants(string $name, array $dependants): PluginHasActiveDependantsException
+    {
+        return new PluginHasActiveDependantsException($name, $dependants);
+    }
+
+    /**
+     * @param list<string> $errors
+     */
+    public static function composerJsonInvalid(string $composerJsonPath, array $errors): PluginComposerJsonInvalidException
+    {
+        return new PluginComposerJsonInvalidException($composerJsonPath, $errors);
+    }
+
+    public static function baseClassNotFound(string $baseClass): PluginBaseClassNotFoundException
+    {
+        return new PluginBaseClassNotFoundException($baseClass);
+    }
+
+    public static function failedKernelReboot(): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::PLUGIN_KERNEL_REBOOT_FAILED,
+            'Failed to reboot the kernel'
+        );
+    }
+
+    public static function wrongBaseClass(string $pluginBaseClassString): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::PLUGIN_WRONG_BASE_CLASS,
+            '"{{ baseClass }}" in the container should be an instance of ' . Plugin::class,
+            ['baseClass' => $pluginBaseClassString]
+        );
     }
 }

--- a/src/Core/Framework/Plugin/PluginException.php
+++ b/src/Core/Framework/Plugin/PluginException.php
@@ -14,6 +14,9 @@ use Shopware\Core\Framework\Plugin\Exception\PluginNotFoundException;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotInstalledException;
 use Symfony\Component\HttpFoundation\Response;
 
+/**
+ * @codeCoverageIgnore
+ */
 #[Package('framework')]
 class PluginException extends HttpException
 {

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -237,23 +237,7 @@ class PluginLifecycleService
         }
 
         if ($pluginBaseClass->executeComposerCommands()) {
-            if (\PHP_SAPI === 'cli') {
-                // only remove the plugin composer dependency directly when running in CLI
-                // otherwise do it async in kernel.response
-                $this->removePluginComposerDependency($plugin, $shopwareContext);
-            // @codeCoverageIgnoreStart -> code path can not be executed in unit tests as SAPI will always be CLI
-            } else {
-                self::$pluginToBeDeleted = [
-                    'plugin' => $plugin,
-                    'context' => $shopwareContext,
-                ];
-                // @codeCoverageIgnoreEnd
-
-                if (!self::$registeredListener) {
-                    $this->eventDispatcher->addListener(KernelEvents::RESPONSE, $this->onResponse(...), \PHP_INT_MAX);
-                    self::$registeredListener = true;
-                }
-            }
+            $this->executeComposerRemoveCommand($plugin, $shopwareContext);
         }
 
         $this->eventDispatcher->dispatch(new PluginPostUninstallEvent($plugin, $uninstallContext));
@@ -285,6 +269,10 @@ class PluginLifecycleService
         if ($pluginBaseClass->executeComposerCommands()) {
             $this->executeComposerRequireWhenNeeded($plugin, $pluginBaseClass, $updateContext->getUpdatePluginVersion(), $shopwareContext);
         } else {
+            if ($plugin->getManagedByComposer()) {
+                // If the plugin was previously managed by composer, but should no longer due to the update, we need to remove the composer dependency
+                $this->executeComposerRemoveCommand($plugin, $shopwareContext);
+            }
             $this->requirementValidator->validateRequirements($plugin, $shopwareContext, 'update');
         }
 
@@ -721,5 +709,26 @@ class PluginLifecycleService
         $this->pluginService->refreshPlugins($shopwareContext, new NullIO());
 
         return true;
+    }
+
+    private function executeComposerRemoveCommand(PluginEntity $plugin, Context $shopwareContext): void
+    {
+        if (\PHP_SAPI === 'cli') {
+            // only remove the plugin composer dependency directly when running in CLI
+            // otherwise do it async in kernel.response
+            $this->removePluginComposerDependency($plugin, $shopwareContext);
+        // @codeCoverageIgnoreStart -> code path can not be executed in unit tests as SAPI will always be CLI
+        } else {
+            self::$pluginToBeDeleted = [
+                'plugin' => $plugin,
+                'context' => $shopwareContext,
+            ];
+            // @codeCoverageIgnoreEnd
+
+            if (!self::$registeredListener) {
+                $this->eventDispatcher->addListener(KernelEvents::RESPONSE, $this->onResponse(...), \PHP_INT_MAX);
+                self::$registeredListener = true;
+            }
+        }
     }
 }

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -36,8 +36,6 @@ use Shopware\Core\Framework\Plugin\Event\PluginPreDeactivateEvent;
 use Shopware\Core\Framework\Plugin\Event\PluginPreInstallEvent;
 use Shopware\Core\Framework\Plugin\Event\PluginPreUninstallEvent;
 use Shopware\Core\Framework\Plugin\Event\PluginPreUpdateEvent;
-use Shopware\Core\Framework\Plugin\Exception\PluginBaseClassNotFoundException;
-use Shopware\Core\Framework\Plugin\Exception\PluginComposerJsonInvalidException;
 use Shopware\Core\Framework\Plugin\Exception\PluginHasActiveDependantsException;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotActivatedException;
 use Shopware\Core\Framework\Plugin\Exception\PluginNotInstalledException;
@@ -179,7 +177,7 @@ class PluginLifecycleService
         bool $keepUserData = false
     ): UninstallContext {
         if ($plugin->getInstalledAt() === null) {
-            throw new PluginNotInstalledException($plugin->getName());
+            throw PluginException::notInstalled($plugin->getName());
         }
 
         if ($plugin->getActive()) {
@@ -251,7 +249,7 @@ class PluginLifecycleService
     public function updatePlugin(PluginEntity $plugin, Context $shopwareContext): UpdateContext
     {
         if ($plugin->getInstalledAt() === null) {
-            throw new PluginNotInstalledException($plugin->getName());
+            throw PluginException::notInstalled($plugin->getName());
         }
 
         $pluginBaseClassString = $plugin->getBaseClass();
@@ -338,7 +336,7 @@ class PluginLifecycleService
     public function activatePlugin(PluginEntity $plugin, Context $shopwareContext, bool $reactivate = false): ActivateContext
     {
         if ($plugin->getInstalledAt() === null) {
-            throw new PluginNotInstalledException($plugin->getName());
+            throw PluginException::notInstalled($plugin->getName());
         }
 
         $pluginBaseClassString = $plugin->getBaseClass();
@@ -408,14 +406,14 @@ class PluginLifecycleService
     public function deactivatePlugin(PluginEntity $plugin, Context $shopwareContext): DeactivateContext
     {
         if ($plugin->getInstalledAt() === null) {
-            throw new PluginNotInstalledException($plugin->getName());
+            throw PluginException::notInstalled($plugin->getName());
         }
 
         if ($plugin->getActive() === false) {
-            throw new PluginNotActivatedException($plugin->getName());
+            throw PluginException::notActivated($plugin->getName());
         }
 
-        $dependantPlugins = $this->getEntities($this->pluginCollection->all(), $shopwareContext)->getEntities()->getElements();
+        $dependantPlugins = array_values($this->getEntities($this->pluginCollection->all(), $shopwareContext)->getEntities()->getElements());
 
         $dependants = $this->requirementValidator->resolveActiveDependants(
             $plugin,
@@ -423,7 +421,7 @@ class PluginLifecycleService
         );
 
         if (\count($dependants) > 0) {
-            throw new PluginHasActiveDependantsException($plugin->getName(), $dependants);
+            throw PluginException::hasActiveDependants($plugin->getName(), $dependants);
         }
 
         $pluginBaseClassString = $plugin->getBaseClass();
@@ -516,7 +514,7 @@ class PluginLifecycleService
 
         $pluginComposerName = $plugin->getComposerName();
         if ($pluginComposerName === null) {
-            throw new PluginComposerJsonInvalidException(
+            throw PluginException::composerJsonInvalid(
                 $plugin->getPath() . '/composer.json',
                 ['No name defined in composer.json']
             );
@@ -539,7 +537,7 @@ class PluginLifecycleService
         $baseClass = $this->pluginCollection->get($pluginBaseClassString);
 
         if ($baseClass === null) {
-            throw new PluginBaseClassNotFoundException($pluginBaseClassString);
+            throw PluginException::baseClassNotFound($pluginBaseClassString);
         }
 
         // set container because the plugin has not been initialized yet and therefore has no container set
@@ -604,7 +602,7 @@ class PluginLifecycleService
 
         $pluginDir = $kernel->getContainer()->getParameter('kernel.plugin_dir');
         if (!\is_string($pluginDir)) {
-            throw new \RuntimeException('Container parameter "kernel.plugin_dir" needs to be a string');
+            throw PluginException::invalidContainerParameter('kernel.plugin_dir', 'string');
         }
 
         $pluginLoader = $this->container->get(KernelPluginLoader::class);
@@ -628,7 +626,7 @@ class PluginLifecycleService
             $newContainer = $kernel->getContainer();
         } catch (\LogicException) {
             // If symfony throws an exception when calling getContainer on a not booted kernel and catch it here
-            throw new \RuntimeException('Failed to reboot the kernel');
+            throw PluginException::failedKernelReboot();
         }
 
         $this->container = $newContainer;
@@ -640,7 +638,7 @@ class PluginLifecycleService
         if ($this->container->has($pluginBaseClassString)) {
             $containerPlugin = $this->container->get($pluginBaseClassString);
             if (!$containerPlugin instanceof Plugin) {
-                throw new \RuntimeException($pluginBaseClassString . ' in the container should be an instance of ' . Plugin::class);
+                throw PluginException::wrongBaseClass($pluginBaseClassString);
             }
 
             return $containerPlugin;
@@ -681,7 +679,7 @@ class PluginLifecycleService
 
         $pluginComposerName = $plugin->getComposerName();
         if ($pluginComposerName === null) {
-            throw new PluginComposerJsonInvalidException(
+            throw PluginException::composerJsonInvalid(
                 $pluginBaseClass->getPath() . '/composer.json',
                 ['No name defined in composer.json']
             );

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -715,18 +715,18 @@ class PluginLifecycleService
             // only remove the plugin composer dependency directly when running in CLI
             // otherwise do it async in kernel.response
             $this->removePluginComposerDependency($plugin, $shopwareContext);
-        // @codeCoverageIgnoreStart -> code path can not be executed in unit tests as SAPI will always be CLI
+        /* @codeCoverageIgnoreStart -> code path can not be executed in unit tests as SAPI will always be CLI */
         } else {
             self::$pluginToBeDeleted = [
                 'plugin' => $plugin,
                 'context' => $shopwareContext,
             ];
-            // @codeCoverageIgnoreEnd
 
             if (!self::$registeredListener) {
                 $this->eventDispatcher->addListener(KernelEvents::RESPONSE, $this->onResponse(...), \PHP_INT_MAX);
                 self::$registeredListener = true;
             }
         }
+        /* @codeCoverageIgnoreEnd */
     }
 }

--- a/src/Core/Framework/Plugin/Requirement/RequirementsValidator.php
+++ b/src/Core/Framework/Plugin/Requirement/RequirementsValidator.php
@@ -70,19 +70,19 @@ class RequirementsValidator
     /**
      * resolveActiveDependants returns all active dependants of the given plugin.
      *
-     * @param PluginEntity[] $dependants the plugins to check for a dependency on the given plugin
+     * @param list<PluginEntity> $dependants the plugins to check for a dependency on the given plugin
      *
-     * @return PluginEntity[]
+     * @return list<PluginEntity>
      */
     public function resolveActiveDependants(PluginEntity $dependency, array $dependants): array
     {
-        return array_filter($dependants, function (PluginEntity $dependant) use ($dependency) {
+        return array_values(array_filter($dependants, function (PluginEntity $dependant) use ($dependency) {
             if (!$dependant->getActive()) {
                 return false;
             }
 
             return $this->dependsOn($dependant, $dependency);
-        });
+        }));
     }
 
     /**

--- a/tests/unit/Core/Framework/Plugin/BundleConfigGeneratorTest.php
+++ b/tests/unit/Core/Framework/Plugin/BundleConfigGeneratorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Plugin;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\ActiveAppsLoader;
+use Shopware\Core\Framework\Plugin\BundleConfigGenerator;
+use Shopware\Core\Framework\Plugin\PluginException;
+use Shopware\Core\Kernel;
+
+/**
+ * @internal
+ */
+#[CoversClass(BundleConfigGenerator::class)]
+class BundleConfigGeneratorTest extends TestCase
+{
+    public function testConstructorThrowsException(): void
+    {
+        $this->expectException(PluginException::class);
+        $this->expectExceptionMessage('Container parameter "kernel.project_dir" needs to be of type "string"');
+        new BundleConfigGenerator(
+            $this->createMock(Kernel::class),
+            $this->createMock(ActiveAppsLoader::class)
+        );
+    }
+}

--- a/tests/unit/Core/Framework/Plugin/PluginExceptionTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginExceptionTest.php
@@ -58,8 +58,8 @@ class PluginExceptionTest extends TestCase
 
     public function testProjectDirNotInContainer(): void
     {
-        static::expectException(PluginException::class);
-        static::expectExceptionMessage('Container parameter "kernel.project_dir" needs to be a string');
+        $this->expectException(PluginException::class);
+        $this->expectExceptionMessage('Container parameter "kernel.project_dir" needs to be of type "string"');
 
         throw PluginException::projectDirNotInContainer();
     }

--- a/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -33,6 +33,7 @@ use Shopware\Core\Framework\Plugin\Exception\PluginNotInstalledException;
 use Shopware\Core\Framework\Plugin\KernelPluginCollection;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\KernelPluginLoader;
 use Shopware\Core\Framework\Plugin\PluginEntity;
+use Shopware\Core\Framework\Plugin\PluginException;
 use Shopware\Core\Framework\Plugin\PluginLifecycleService;
 use Shopware\Core\Framework\Plugin\PluginService;
 use Shopware\Core\Framework\Plugin\Requirement\RequirementsValidator;
@@ -482,8 +483,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->container->set('kernel', $kernelMock);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Container parameter "kernel.plugin_dir" needs to be a string');
+        $this->expectException(PluginException::class);
+        $this->expectExceptionMessage('Container parameter "kernel.plugin_dir" needs to be of type "string"');
 
         $this->pluginLifecycleService->activatePlugin($pluginEntityMock, $context);
     }
@@ -710,8 +711,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->cacheItemPoolInterfaceMock->method('getItem')->willReturn(new CacheItem());
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('Shopware\Core\Framework\Plugin in the container should be an instance of Shopware\Core\Framework\Plugin');
+        $this->expectException(PluginException::class);
+        $this->expectExceptionMessage('"Shopware\Core\Framework\Plugin" in the container should be an instance of Shopware\Core\Framework\Plugin');
 
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
     }

--- a/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -161,8 +161,8 @@ class PluginLifecycleServiceTest extends TestCase
         $this->pluginMock->expects(static::once())->method('executeComposerCommands')->willReturn(true);
         $this->pluginMock->expects(static::once())->method('install')->willThrowException(new \Exception('not working'));
 
-        static::expectException(\Exception::class);
-        static::expectExceptionMessage('not working');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('not working');
 
         $this->pluginLifecycleService->installPlugin($pluginEntityMock, $context);
     }
@@ -199,7 +199,7 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->pluginMock->expects(static::once())->method('executeComposerCommands')->willReturn(true);
 
-        static::expectException(PluginComposerJsonInvalidException::class);
+        $this->expectException(PluginComposerJsonInvalidException::class);
 
         $this->pluginLifecycleService->installPlugin($pluginEntityMock, $context);
     }
@@ -291,7 +291,7 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock->setInstalledAt(new \DateTime());
         $this->pluginMock->expects(static::once())->method('executeComposerCommands')->willReturn(true);
 
-        static::expectException(PluginComposerJsonInvalidException::class);
+        $this->expectException(PluginComposerJsonInvalidException::class);
 
         $this->pluginLifecycleService->uninstallPlugin($pluginEntityMock, $context);
     }
@@ -301,7 +301,7 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock = $this->getPluginEntityMock();
         $context = Context::createDefaultContext();
 
-        static::expectException(PluginNotInstalledException::class);
+        $this->expectException(PluginNotInstalledException::class);
 
         $this->pluginLifecycleService->uninstallPlugin($pluginEntityMock, $context);
     }
@@ -348,7 +348,7 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock->setInstalledAt(new \DateTime());
         $this->pluginMock->expects(static::once())->method('executeComposerCommands')->willReturn(true);
 
-        static::expectException(PluginComposerJsonInvalidException::class);
+        $this->expectException(PluginComposerJsonInvalidException::class);
 
         $this->pluginLifecycleService->updatePlugin($pluginEntityMock, $context);
     }
@@ -358,7 +358,7 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock = $this->getPluginEntityMock();
         $context = Context::createDefaultContext();
 
-        static::expectException(PluginNotInstalledException::class);
+        $this->expectException(PluginNotInstalledException::class);
 
         $this->pluginLifecycleService->updatePlugin($pluginEntityMock, $context);
     }
@@ -372,9 +372,23 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->pluginMock->expects(static::once())->method('update')->willThrowException(new \Exception('not working'));
 
-        static::expectException(\Exception::class);
+        $this->expectException(\Exception::class);
 
         $this->pluginLifecycleService->updatePlugin($pluginEntityMock, $context);
+    }
+
+    public function testUpdatePluginWithComposerCommandExecutionDisabledAfterUpdate(): void
+    {
+        $plugin = $this->getPluginEntityMock();
+        $plugin->setInstalledAt(new \DateTime());
+        $plugin->setActive(true);
+        $plugin->setUpgradeVersion('1.0.1');
+        $plugin->setManagedByComposer(true);
+        $plugin->setComposerName('swag/mock-plugin');
+
+        $this->commandExecutor->expects(static::once())->method('remove');
+
+        $this->pluginLifecycleService->updatePlugin($plugin, Context::createDefaultContext());
     }
 
     public function testActivatePlugin(): void
@@ -403,7 +417,7 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock = $this->getPluginEntityMock();
         $context = Context::createDefaultContext();
 
-        static::expectException(PluginNotInstalledException::class);
+        $this->expectException(PluginNotInstalledException::class);
 
         $this->pluginLifecycleService->activatePlugin($pluginEntityMock, $context);
     }
@@ -468,8 +482,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->container->set('kernel', $kernelMock);
 
-        static::expectException(\RuntimeException::class);
-        static::expectExceptionMessage('Container parameter "kernel.plugin_dir" needs to be a string');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Container parameter "kernel.plugin_dir" needs to be a string');
 
         $this->pluginLifecycleService->activatePlugin($pluginEntityMock, $context);
     }
@@ -505,15 +519,15 @@ class PluginLifecycleServiceTest extends TestCase
             ]
         ));
 
-        static::expectException(\RuntimeException::class);
-        static::expectExceptionMessage('Failed to reboot the kernel');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Failed to reboot the kernel');
 
         $this->pluginLifecycleService->activatePlugin($pluginEntityMock, $context);
     }
 
     // ------ ActivatePlugin -----
 
-    // +++++ DectivatePlugin method ++++
+    // +++++ DeactivatePlugin method ++++
 
     public function testDeactivatePlugin(): void
     {
@@ -542,7 +556,7 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntityMock = $this->getPluginEntityMock();
         $context = Context::createDefaultContext();
 
-        static::expectException(PluginNotInstalledException::class);
+        $this->expectException(PluginNotInstalledException::class);
 
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
     }
@@ -555,7 +569,7 @@ class PluginLifecycleServiceTest extends TestCase
         $context = Context::createDefaultContext();
         $this->cacheItemPoolInterfaceMock->method('getItem')->willReturn(new CacheItem());
 
-        static::expectException(PluginNotActivatedException::class);
+        $this->expectException(PluginNotActivatedException::class);
 
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
         static::assertCount(0, $this->eventDispatcher->getEvents());
@@ -574,7 +588,7 @@ class PluginLifecycleServiceTest extends TestCase
             ->expects(static::once())
             ->method('resolveActiveDependants')->willReturn([$this->pluginMock]);
 
-        static::expectException(PluginHasActiveDependantsException::class);
+        $this->expectException(PluginHasActiveDependantsException::class);
 
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
     }
@@ -617,8 +631,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->pluginRepoMock->method('update')->willThrowException(new \Exception('failed update'));
 
-        static::expectException(\Exception::class);
-        static::expectExceptionMessage('failed update');
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('failed update');
 
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
     }
@@ -636,7 +650,7 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->kernelPluginCollectionMock->method('get')->willReturn(null);
 
-        static::expectException(PluginBaseClassNotFoundException::class);
+        $this->expectException(PluginBaseClassNotFoundException::class);
 
         $this->pluginLifecycleService->installPlugin($pluginEntityMock, $context);
     }
@@ -696,8 +710,8 @@ class PluginLifecycleServiceTest extends TestCase
 
         $this->cacheItemPoolInterfaceMock->method('getItem')->willReturn(new CacheItem());
 
-        static::expectException(\RuntimeException::class);
-        static::expectExceptionMessage('Shopware\Core\Framework\Plugin in the container should be an instance of Shopware\Core\Framework\Plugin');
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Shopware\Core\Framework\Plugin in the container should be an instance of Shopware\Core\Framework\Plugin');
 
         $this->pluginLifecycleService->deactivatePlugin($pluginEntityMock, $context);
     }
@@ -757,6 +771,7 @@ class PluginLifecycleServiceTest extends TestCase
         $pluginEntity->setName('MockPlugin');
         $pluginEntity->setBaseClass(Plugin::class);
         $pluginEntity->setVersion('1.0.0');
+        $pluginEntity->setManagedByComposer(false);
 
         $this->kernelPluginCollectionMock->method('get')->with(Plugin::class)->willReturn($this->pluginMock);
 


### PR DESCRIPTION
### 1. Why is this change necessary?

If the plugin should not execute composer commands anymore due to an update, the plugin should be removed from the require section of the root `composer.json`

### 2. What does this change do, exactly?

Execute composer remove if the plugin was previously managed by composer, but should not any longer.

### 3. Describe each step to reproduce the issue or behaviour.

- Install plugin, that executes composer commands
- change it so it not executes the composer commands anymore
- increase plugin version
- do plugin update

### 4. Please link to the relevant issues (if any).
- closes #6442
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40447

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
