### PR TITLE
feat(SDK): add `compareShopwareVersion` to context from Meteor SDK

### DIFF
--- a/changelog/_unreleased/2025-02-03-add-compare-shopware-version-to-meteor-sdk.md
+++ b/changelog/_unreleased/2025-02-03-add-compare-shopware-version-to-meteor-sdk.md
@@ -1,0 +1,21 @@
+---
+title: Add compare Shopware Version to meteor SDK
+issue: NEXT-36291
+author: Iván Tajes Vidal
+author_email: tajespasarela@gmail.com
+author_github: @tajespasarela
+---
+# Administration
+* Added new compare Shopware Version to meteor SDK
+___
+# Upgrade Information
+
+The context from the meteor SDK now has a new method `compareShopwareVersion` that allows you to compare the current Shopware version with a given version.
+
+## Example
+
+```typescript
+import { context } from '@shopware-ag/meteor-admin-sdk';
+
+const isRightVersion = await context.compareShopwareVersion({version:'6.4.0', comparator: '>='});
+```

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@shopware-ag/meteor-admin-sdk": "5.6.2",
-        "@shopware-ag/meteor-component-library": "^4.4.1",
+        "@shopware-ag/meteor-admin-sdk": "5.7.0",
+        "@shopware-ag/meteor-component-library": "4.4.1",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
         "@swc/core": "1.10.7",
         "@types/fs-extra": "^11.0.4",
@@ -4759,12 +4759,12 @@
       }
     },
     "node_modules/@shopware-ag/meteor-admin-sdk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-admin-sdk/-/meteor-admin-sdk-5.6.2.tgz",
-      "integrity": "sha512-YOFn1vx1oTH12Bk+gQX521fgaqOohLOsrUHOoUGVVWCEECZ3oHqWWXi7I61D5ckiRyz1Zjiqx3vCZvyu8At+6w==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-admin-sdk/-/meteor-admin-sdk-5.7.0.tgz",
+      "integrity": "sha512-pIaVRsKGFx7BEo29Epwpmi9KXB25PW8srWvznZYVV4ankaZYKsgOKkop45bQvSYXawzjc3zhDLc2PuhLfQGVjA==",
       "license": "MIT",
       "dependencies": {
-        "@shopware-ag/meteor-component-library": "4.0.1",
+        "@shopware-ag/meteor-component-library": "4.1.0",
         "localforage": "^1.10.0",
         "lodash": "^4.17.21"
       }
@@ -4814,9 +4814,9 @@
       }
     },
     "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/@shopware-ag/meteor-component-library": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.0.1.tgz",
-      "integrity": "sha512-1OMe3m0+e3TtV8l5pGpIDd/lB3ZxWEQpSSETrx+J/LXgvR6enT07fZy/p3G4806viiXpzwT+HtN3cCRxFw5zmA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.1.0.tgz",
+      "integrity": "sha512-BDZ5CSAq0a6E8n7EaFe9wtXbaKcapav+PZ7efQrFJV5jZopl7Ca8h0pZNlLnIHokSuMYWTZe28k6hT/1FGDUpg==",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
         "@floating-ui/dom": "^1.4.3",
@@ -4851,11 +4851,10 @@
         "@vueuse/components": "^12.4.0",
         "@vueuse/core": "^12.4.0",
         "codemirror": "^6.0.1",
-        "date-fns": "^2.30.0",
-        "date-fns-tz": "^2.0.0",
+        "date-fns": "4.1.0",
+        "date-fns-tz": "3.2.0",
         "focus-trap": "^7.5.4",
         "inter-ui": "^3.19.3",
-        "lodash-es": "^4.17.21",
         "nanoid": "^5.0.7",
         "vue-codemirror6": "^1.3.8",
         "vue-i18n": "^9.9.1",
@@ -4917,6 +4916,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@shopware-ag/meteor-admin-sdk/node_modules/dom-accessibility-api": {
@@ -17317,12 +17335,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -48,8 +48,8 @@
     "safari >= 7"
   ],
   "dependencies": {
-    "@shopware-ag/meteor-admin-sdk": "5.6.2",
-    "@shopware-ag/meteor-component-library": "^4.4.1",
+    "@shopware-ag/meteor-admin-sdk": "5.7.0",
+    "@shopware-ag/meteor-component-library": "4.4.1",
     "@shopware-ag/meteor-icon-kit": "5.4.0",
     "@swc/core": "1.10.7",
     "@types/fs-extra": "^11.0.4",

--- a/src/Administration/Resources/app/administration/src/app/init/context.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/context.init.ts
@@ -6,6 +6,7 @@ import { watch } from 'vue';
 import { publish } from '@shopware-ag/meteor-admin-sdk/es/channel';
 import '../store/context.store';
 import useSession from '../composables/use-session';
+import compareVersions from '../../core/helper/compare-versions.helper';
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default function initializeContext(): void {
@@ -38,6 +39,13 @@ export default function initializeContext(): void {
     Shopware.ExtensionAPI.handle('contextShopwareVersion', () => {
         return Shopware.Context.app.config.version ?? '';
     });
+
+    Shopware.ExtensionAPI.handle(
+        'contextCompareShopwareVersion',
+        ({ version, comparator = '=' }: { version: string; comparator?: '=' | '>' | '<' | '<=' | '>=' }) => {
+            return compareVersions(Shopware.Context.app.config.version ?? '', version, comparator);
+        },
+    );
 
     Shopware.ExtensionAPI.handle('contextUserTimezone', () => {
         return Shopware.Store.get('session').currentUser?.timeZone ?? 'UTC';

--- a/src/Administration/Resources/app/administration/src/core/helper/compare-versions.helper.spec.ts
+++ b/src/Administration/Resources/app/administration/src/core/helper/compare-versions.helper.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * @sw-package framework
+ */
+import compareVersions from './compare-versions.helper';
+
+describe('compareVersions', () => {
+    it('should return true for equal versions with "=" comparator', () => {
+        expect(compareVersions('1.0.0', '1.0.0', '=')).toBe(true);
+        expect(compareVersions('1.0.0.0', '1.0.0.0', '=')).toBe(true);
+    });
+
+    it('should return false for different versions with "=" comparator', () => {
+        expect(compareVersions('1.0.0', '1.0.1', '=')).toBe(false);
+        expect(compareVersions('1.0.0.0', '1.0.0.1', '=')).toBe(false);
+    });
+
+    it('should return true for greater version with ">" comparator', () => {
+        expect(compareVersions('1.0.1', '1.0.0', '>')).toBe(true);
+        expect(compareVersions('1.0.0.1', '1.0.0.0', '>')).toBe(true);
+    });
+
+    it('should return false for lesser version with ">" comparator', () => {
+        expect(compareVersions('1.0.0', '1.0.1', '>')).toBe(false);
+        expect(compareVersions('1.0.0.0', '1.0.0.1', '>')).toBe(false);
+    });
+
+    it('should return true for lesser version with "<" comparator', () => {
+        expect(compareVersions('1.0.0', '1.0.1', '<')).toBe(true);
+        expect(compareVersions('1.0.0.0', '1.0.0.1', '<')).toBe(true);
+    });
+
+    it('should return false for greater version with "<" comparator', () => {
+        expect(compareVersions('1.0.1', '1.0.0', '<')).toBe(false);
+        expect(compareVersions('1.0.0.1', '1.0.0.0', '<')).toBe(false);
+    });
+
+    it('should return true for equal or greater version with ">=" comparator', () => {
+        expect(compareVersions('1.0.1', '1.0.0', '>=')).toBe(true);
+        expect(compareVersions('1.0.0', '1.0.0', '>=')).toBe(true);
+        expect(compareVersions('1.0.0.1', '1.0.0.0', '>=')).toBe(true);
+        expect(compareVersions('1.0.0.0', '1.0.0.0', '>=')).toBe(true);
+    });
+
+    it('should return false for lesser version with ">=" comparator', () => {
+        expect(compareVersions('1.0.0', '1.0.1', '>=')).toBe(false);
+        expect(compareVersions('1.0.0.0', '1.0.0.1', '>=')).toBe(false);
+    });
+
+    it('should return true for equal or lesser version with "<=" comparator', () => {
+        expect(compareVersions('1.0.0', '1.0.1', '<=')).toBe(true);
+        expect(compareVersions('1.0.0', '1.0.0', '<=')).toBe(true);
+        expect(compareVersions('1.0.0.0', '1.0.0.1', '<=')).toBe(true);
+        expect(compareVersions('1.0.0.0', '1.0.0.0', '<=')).toBe(true);
+    });
+
+    it('should return false for greater version with "<=" comparator', () => {
+        expect(compareVersions('1.0.1', '1.0.0', '<=')).toBe(false);
+        expect(compareVersions('1.0.0.1', '1.0.0.0', '<=')).toBe(false);
+    });
+
+    it('should handle versions with suffixes correctly', () => {
+        expect(compareVersions('1.0.0.0-alpha', '1.0.0.0-beta', '<')).toBe(true);
+        expect(compareVersions('1.0.0.0-beta', '1.0.0.0-alpha', '>')).toBe(true);
+        expect(compareVersions('1.0.0.0-alpha', '1.0.0.0-alpha', '=')).toBe(true);
+    });
+
+    it('should consider versions without suffixes as greater', () => {
+        expect(compareVersions('1.0.0.0', '1.0.0.0-alpha', '>')).toBe(true);
+        expect(compareVersions('1.0.0.0-alpha', '1.0.0.0', '<')).toBe(true);
+    });
+});

--- a/src/Administration/Resources/app/administration/src/core/helper/compare-versions.helper.ts
+++ b/src/Administration/Resources/app/administration/src/core/helper/compare-versions.helper.ts
@@ -1,0 +1,47 @@
+/**
+ * @sw-package framework
+ */
+function compareVersions(version1: string, version2: string, comparator: '=' | '>' | '<' | '<=' | '>='): boolean {
+    const comparison = compareVersionsRaw(version1, version2);
+    return {
+        '=': comparison === 0,
+        '>': comparison === 1,
+        '<': comparison === -1,
+        '>=': comparison >= 0,
+        '<=': comparison <= 0,
+    }[comparator];
+}
+
+function compareVersionsRaw(version1: string, version2: string): number {
+    const v1 = parseVersion(version1);
+    const v2 = parseVersion(version2);
+
+    // Compare the four numeric parts
+    for (let i = 0; i < Math.min(v1.parts.length, v2.parts.length); i += 1) {
+        const num1 = v1.parts[i] || 0;
+        const num2 = v2.parts[i] || 0;
+        if (num1 !== num2) return num1 > num2 ? 1 : -1;
+    }
+
+    // Compare suffixes alphabetically (versions without a suffix are considered greater)
+    if (v1.suffix !== v2.suffix) {
+        if (!v1.suffix) return 1;
+        if (!v2.suffix) return -1;
+        return v1.suffix.localeCompare(v2.suffix);
+    }
+
+    return 0; // Versions are equal
+}
+
+function parseVersion(version: string) {
+    const [
+        numbers,
+        suffix = '',
+    ] = version.split('-');
+    return { parts: numbers.split('.').map(Number), suffix };
+}
+
+/**
+ * @private
+ */
+export default compareVersions;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Added a new feature to compare Shopware Version using the meteor SDK to enhance the version comparison functionality by supporting versions that have four numeric parts and suffixes.

### 2. What does this change do, exactly?
Added compareVersions helper to compare four-digit versions.
Added handler to Shopware.ExtensionAPI to return the comparison result

### 3. Describe each step to reproduce the issue or behaviour.
1. create a new App and install it
2. import the context and call the `compareShopwareVersion` to compare with any version: ` console.log('compareVersion', await context.compareShopwareVersion({version:'6.4.0', comparator: '>='}));`
3. Run the project and see the console


### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-36291


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
