### PR TITLE
fix: cms can not be duplicated

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
@@ -57,7 +57,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         duplicateDisabled() {
-            return !this.block.id || this.block.isNew();
+            return !this.block.id;
         },
 
         combinedDuplicateDisabled() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
@@ -56,7 +56,21 @@ export default Shopware.Component.wrapComponentConfig({
             return !this.isSystemDefaultLanguage || this.blockConfig?.removable === false;
         },
 
-        quickactionClasses() {
+        duplicateDisabled() {
+            return !this.block.id || this.block.isNew();
+        },
+
+        combinedDuplicateDisabled() {
+            return this.quickactionsDisabled || this.duplicateDisabled;
+        },
+
+        combinedDuplicateClasses() {
+            return {
+                'is--disabled': this.combinedDuplicateDisabled
+            };
+        },
+
+        deleteClasses() {
             return {
                 'is--disabled': this.quickactionsDisabled,
             };
@@ -109,7 +123,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         onBlockDuplicate() {
-            if (this.quickactionsDisabled) {
+            if (this.combinedDuplicateDisabled) {
                 return;
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
@@ -57,7 +57,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         duplicateDisabled() {
-            return !this.block.id || this.block.isNew;
+            return !this.block.id;
         },
 
         combinedDuplicateDisabled() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
@@ -57,7 +57,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         duplicateDisabled() {
-            return !this.block.id;
+            return !this.block.id || this.block.isNew();
         },
 
         combinedDuplicateDisabled() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
@@ -57,7 +57,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         duplicateDisabled() {
-            return !this.block.id || this.block.isNew();
+            return !this.block.id || this.block._isNew;
         },
 
         combinedDuplicateDisabled() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/index.ts
@@ -57,7 +57,7 @@ export default Shopware.Component.wrapComponentConfig({
         },
 
         duplicateDisabled() {
-            return !this.block.id;
+            return !this.block.id || this.block.isNew;
         },
 
         combinedDuplicateDisabled() {
@@ -66,11 +66,11 @@ export default Shopware.Component.wrapComponentConfig({
 
         combinedDuplicateClasses() {
             return {
-                'is--disabled': this.combinedDuplicateDisabled
+                'is--disabled': this.combinedDuplicateDisabled,
             };
         },
 
-        deleteClasses() {
+        quickactionClasses() {
             return {
                 'is--disabled': this.quickactionsDisabled,
             };

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.html.twig
@@ -4,11 +4,11 @@
     {% block sw_cms_block_config__quickactions %}
     <ul
         class="sw-cms-block-config__quickactions-list"
-        :class="quickactionClasses"
     >
         {% block sw_cms_block_config__quickaction_duplicate %}
         <li
             class="sw-cms-block-config__quickaction"
+            :class="combinedDuplicateClasses"
             role="button"
             tabindex="0"
             @click="onBlockDuplicate"
@@ -25,6 +25,7 @@
         {% block sw_cms_block_config__quickaction_delete %}
         <li
             class="sw-cms-block-config__quickaction is--danger"
+            :class="deleteClasses"
             role="button"
             tabindex="0"
             @click="onBlockDelete"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.html.twig
@@ -25,7 +25,7 @@
         {% block sw_cms_block_config__quickaction_delete %}
         <li
             class="sw-cms-block-config__quickaction is--danger"
-            :class="deleteClasses"
+            :class="quickactionClasses"
             role="button"
             tabindex="0"
             @click="onBlockDelete"

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.scss
@@ -24,6 +24,7 @@
         .sw-cms-block-config__quickaction {
             cursor: not-allowed;
             opacity: 0.3;
+            pointer-events: none;
 
             &.is--danger .mt-icon {
                 color: $color-crimson-200;
@@ -41,6 +42,12 @@
                 color: $color-menu-start;
             }
         }
+    }
+
+    .sw-cms-block-config__quickaction.is--disabled {
+        cursor: not-allowed;
+        opacity: 0.3;
+        pointer-events: none;
     }
 
     .sw-cms-block-config__quickaction {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.spec.js
@@ -6,6 +6,7 @@ import 'src/module/sw-cms/mixin/sw-cms-state.mixin';
 import { setupCmsEnvironment } from 'src/module/sw-cms/test-utils';
 
 const block = {
+    id: 'blockId',
     name: 'Block name',
     type: 'text',
     backgroundColor: '',

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.spec.js
@@ -14,7 +14,6 @@ const block = {
     backgroundMediaId: 'mediaId',
     backgroundMediaMode: '',
     removable: true,
-    isNew: () => false,
 };
 
 jest.useFakeTimers();

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block-config/sw-cms-block-config.spec.js
@@ -14,6 +14,7 @@ const block = {
     backgroundMediaId: 'mediaId',
     backgroundMediaMode: '',
     removable: true,
+    isNew: () => false,
 };
 
 jest.useFakeTimers();

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
@@ -33,6 +33,7 @@ async function createWrapper(versionId = '0fa91ce3e96a4bc2be4bd9ce752c3425') {
                         desktop: true,
                     },
                 ],
+                isNew: () => false,
             }),
         ),
         save: jest.fn(() => Promise.resolve()),

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/page/sw-cms-detail/sw-cms-detail.spec.js
@@ -33,7 +33,6 @@ async function createWrapper(versionId = '0fa91ce3e96a4bc2be4bd9ce752c3425') {
                         desktop: true,
                     },
                 ],
-                isNew: () => false,
             }),
         ),
         save: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
**Problem**: When we attempt to duplicate a CMS block that has not yet been saved to the database, the duplication process calls the versioning functionality.Since the block does not exist in the database , we get an error.

**Solution**: If there is no id assign to the cms element(new element) disable the duplicate button until the block is saved

https://github.com/user-attachments/assets/463566aa-2c41-451f-b520-c24dd2157998


