### PR TITLE
chore: Add missing deprecation notices for cache rework

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Listing/CachedProductListingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/CachedProductListingRoute.php
@@ -19,6 +19,9 @@ use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
+/**
+ * @deprecated tag:v6.7.0 - reason:decoration-will-be-removed - Will be removed
+ */
 #[Route(defaults: ['_routeScope' => ['store-api']])]
 #[Package('inventory')]
 class CachedProductListingRoute extends AbstractProductListingRoute

--- a/src/Core/Framework/Adapter/Cache/CacheTracer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheTracer.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
- * @deprecated tag:v6.7.0 - Will be removed, cache tags are collected via AddCacheTagEvent
+ * @deprecated tag:v6.7.0 - reason:decoration-will-be-removed - Will be removed, cache tags are collected via AddCacheTagEvent
  *
  * @extends AbstractCacheTracer<mixed|null>
  */

--- a/src/Core/Framework/Adapter/Cache/CacheTracer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheTracer.php
@@ -8,6 +8,8 @@ use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
+ * @deprecated tag:v6.7.0 - Will be removed, cache tags are collected via AddCacheTagEvent
+ *
  * @extends AbstractCacheTracer<mixed|null>
  */
 #[Package('framework')]

--- a/src/Core/Framework/DependencyInjection/cache.xml
+++ b/src/Core/Framework/DependencyInjection/cache.xml
@@ -117,6 +117,7 @@
             <argument>%shopware.product_stream.indexing%</argument>
 
             <tag name="kernel.event_listener" event="Shopware\Core\Content\Category\Event\CategoryIndexerEvent" method="invalidateCategoryRouteByCategoryIds" priority="2000" />
+            <!--     @deprecated tag:v6.7.0 - Remove listener  -->
             <tag name="kernel.event_listener" event="Shopware\Core\Content\Category\Event\CategoryIndexerEvent" method="invalidateListingRouteByCategoryIds" priority="2001" />
             <tag name="kernel.event_listener" event="Shopware\Core\Content\LandingPage\Event\LandingPageIndexerEvent" method="invalidateIndexedLandingPages" priority="2000" />
             <!--     @deprecated tag:v6.7.0 - Remove listener  -->
@@ -153,9 +154,11 @@
             <tag name="kernel.event_listener" event="Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent" method="invalidateLanguageRoute" priority="2003" />
             <tag name="kernel.event_listener" event="Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent" method="invalidateNavigationRoute" priority="2004" />
             <tag name="kernel.event_listener" event="Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent" method="invalidatePaymentMethodRoute" priority="2005" />
+            <!--     @deprecated tag:v6.7.0 - Remove listener  -->
             <tag name="kernel.event_listener" event="Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent" method="invalidateProductAssignment" priority="2006" />
             <tag name="kernel.event_listener" event="Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent" method="invalidateManufacturerFilters" priority="2007" />
             <tag name="kernel.event_listener" event="Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent" method="invalidatePropertyFilters" priority="2008" />
+            <!--     @deprecated tag:v6.7.0 - Remove listener  -->
             <tag name="kernel.event_listener" event="Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent" method="invalidateCrossSellingRoute" priority="2009" />
             <tag name="kernel.event_listener" event="Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent" method="invalidateContext" priority="2010" />
             <tag name="kernel.event_listener" event="Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent" method="invalidateShippingMethodRoute" priority="2011" />
@@ -177,6 +180,7 @@
             <tag name="kernel.event_listener" event="Shopware\Core\Framework\Plugin\Event\PluginPostDeactivateEvent" method="invalidateConfig" priority="2001" />
             <tag name="kernel.event_listener" event="Shopware\Core\System\SystemConfig\Event\SystemConfigChangedHook" method="invalidateConfigKey" priority="2000" />
             <tag name="kernel.event_listener" event="Shopware\Core\Content\Sitemap\Event\SitemapGeneratedEvent" method="invalidateSitemap" priority="2000" />
+            <!--     @deprecated tag:v6.7.0 - Remove listener  -->
             <tag name="kernel.event_listener" event="product_search_config.written" method="invalidateSearch" priority="2002" />
             <tag name="kernel.event_listener" event="Shopware\Core\Content\Media\Event\MediaIndexerEvent" method="invalidateMedia" priority="2000" />
         </service>

--- a/src/Storefront/Resources/views/storefront/layout/header/actions/currency-widget.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header/actions/currency-widget.html.twig
@@ -72,6 +72,7 @@
                                 </ul>
                             {% endblock %}
 
+                            {# @deprecated tag:v6.7.0 - Block will be removed #}
                             {% block layout_header_actions_currency_widget_form_redirect %}
                                 <input name="redirectTo"
                                        type="hidden"

--- a/src/Storefront/Theme/ThemeConfigValueAccessor.php
+++ b/src/Storefront/Theme/ThemeConfigValueAccessor.php
@@ -17,6 +17,8 @@ class ThemeConfigValueAccessor
     private array $themeConfig = [];
 
     /**
+     * @deprecated tag:v6.7.0 - Will be removed, cache tags are collected via events
+     *
      * @var array<string, bool>
      */
     private array $keys = ['all' => true];
@@ -100,6 +102,8 @@ class ThemeConfigValueAccessor
     }
 
     /**
+     * @deprecated tag:v6.7.0 - reason:decoration-will-be-removed - Will be removed, cache tags are collected via events
+     *
      * @return array<int, string>
      */
     public function getTrace(string $key): array


### PR DESCRIPTION
Not everything was properly deprecated for the cache rework. 

Related PR https://github.com/shopware/shopware/pull/6575