### PR TITLE
feat: add label to 3d media settings

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.html.twig
@@ -46,6 +46,8 @@
                     <mt-slider
                         v-if="!isLoading"
                         v-model="sliderValue"
+                        :label="$tc('sw-settings-media.3d.lightIntensity.label')"
+                        :help-text="$tc('sw-settings-media.3d.lightIntensity.helpText')"
                         :min="0"
                         :max="100"
                         @input="onSliderChange"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-media/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-media/snippet/de-DE.json
@@ -4,6 +4,12 @@
       "title": "Medien",
       "description": "Verwaltung von Medieneinstellungen.",
       "buttonSave": "Speichern"
+    },
+    "3d": {
+      "lightIntensity": {
+        "label": "Lichtintensität",
+        "helpText": "Verändert die Lichtintensität in der 3D-Ansicht."
+      }
     }
   }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-media/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-media/snippet/en-GB.json
@@ -4,6 +4,12 @@
       "title": "Media",
       "description": "Manage media settings here.",
       "buttonSave": "Save"
+    },
+    "3d": {
+      "lightIntensity": {
+        "label": "Light Intensity",
+        "helpText": "Change the light intensity in the 3D view."
+      }
     }
   }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

Currently the slider do change the 3d light intensity has not title, so it is hard to get the purpose of the slider.

### 2. What does this change do, exactly?

It adds a title and help text to the slide, to make it's purpose more obvious.

### 3. Describe each step to reproduce the issue or behaviour.

Navigate to Settings -> Media -> 3D Files

### 4. Link to the relevant issues.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40423