### PR TITLE
chore: Fix deprecation notice of JS plugin

### DIFF
--- a/changelog/_unreleased/2024-12-17-refactor-form-handling.md
+++ b/changelog/_unreleased/2024-12-17-refactor-form-handling.md
@@ -185,7 +185,7 @@ issue: NEXT-39235
   * Deprecated block `page_account_guest_auth_postcode_label` in `guest-auth.html.twig`.
   * Deprecated block `page_account_guest_auth_postcode_input` in `guest-auth.html.twig`.
 * Deprecated `form-validation.plugin.js` for v.6.8.0 - Use `form-handler.plugin.js` instead.
-* Deprecated `form-scroll-to-invalid-field.plugin.js` for v.6.8.0 - Use `form-handler.plugin.js` instead.
+* Deprecated `form-scroll-to-invalid-field.plugin.js` for v.6.7.0 - Use `form-handler.plugin.js` instead.
 * Deprecated `form-submit-loader.plugin.js` for v.6.8.0 - Use `form-handler.plugin.js` instead.
 
 ___

--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-scroll-to-invalid-field.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-scroll-to-invalid-field.plugin.js
@@ -4,7 +4,7 @@ import Iterator from 'src/helper/iterator.helper';
 import DomAccess from 'src/helper/dom-access.helper';
 
 /**
- * @deprecated tag:v6.8.0 - Use the `form-handler.plugin.js` instead.
+ * @deprecated tag:v6.7.0 - Use the `form-handler.plugin.js` instead.
  *
  * This plugin scrolls to invalid form fields when the form is submitted.
  *


### PR DESCRIPTION
There was a typo in the deprecation notice that targeted the wrong version.
