### PR TITLE
chore: create v6.8.0.0 feature flag

### DIFF
--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -13,6 +13,10 @@ shopware:
         default: true
         major: true
         toggleable: false
+      - name: v6.8.0.0
+        default: false
+        major: true
+        toggleable: false
       - name: ADDRESS_SELECTION_REWORK
         default: true
         major: true


### PR DESCRIPTION
We have first external PRs with breaks coming in, that now need to point to v6.8.0.0, therefore we should create that feature flag.