### PR TITLE
fix: product page default feature set typo

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/page/sw-product-detail/index.js
@@ -659,7 +659,7 @@ export default {
                 }
 
                 if (this.getDefaultFeatureSet?.length) {
-                    this.product.featureSetId = this.getdefaultFeatureSet[0].id;
+                    this.product.featureSetId = this.getDefaultFeatureSet[0].id;
                 }
 
                 Shopware.Store.get('swProductDetail').setLoading([


### PR DESCRIPTION
Fix minor typo, which breaks the product page

Introduced with https://github.com/shopware/shopware/pull/5840/