### PR TITLE
fix: Double submit issue of CMS form handler

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/forms/form-cms-handler.plugin.js
@@ -16,7 +16,6 @@ export default class FormCmsHandler extends Plugin {
 
     init() {
         this._client = new HttpClient();
-        this._getButton();
         this._getHiddenSubmit();
         this._registerEvents();
         this._getCmsBlock();
@@ -32,11 +31,6 @@ export default class FormCmsHandler extends Plugin {
 
     _registerEvents() {
         this.el.addEventListener('submit', this._handleSubmit.bind(this));
-
-        if (this._button) {
-            this._button.addEventListener('submit', this._handleSubmit.bind(this));
-            this._button.addEventListener('click', this._handleSubmit.bind(this));
-        }
     }
 
     _getConfirmationText() {
@@ -44,10 +38,6 @@ export default class FormCmsHandler extends Plugin {
         if (input) {
             this._confirmationText = input.value;
         }
-    }
-
-    _getButton() {
-        this._button = this.el.querySelector('button[type="submit"]');
     }
 
     _getCmsBlock() {


### PR DESCRIPTION
### 1. Why is this change necessary?

Within `form-cms-handler.plugin.js` in the Storefront, there are two additional event listeners on the submit button itself in addition to the normal submit event. This is unnecessary and leads to issues of the form being submitted twice.

### 2. What does this change do, exactly?

The button event listener and corresponding code is removed, as it is unnecessary and leads to unwanted event calls.

