### PR TITLE
fix: revert deprecation of ImportExportAfterImportRecordEvent

### DIFF
--- a/changelog/_unreleased/2025-01-29-mark-import-export-internal.md
+++ b/changelog/_unreleased/2025-01-29-mark-import-export-internal.md
@@ -4,7 +4,6 @@ issue: NEXT-40446
 ---
 # Core
 * Added `\Shopware\Core\Content\ImportExport\Event\ImportExportAfterProcessFinishedEvent` which is dispatched upon completion of import/export operations. This event exposes the `Context`, `ImportExportLogEntity`, and progress information through its respective getter methods.
-* Deprecated `\Shopware\Core\Content\ImportExport\Event\ImportExportAfterImportRecordEvent` which will be removed in 6.7.0.0 without replacement
 * Deprecated the following classes which will marked as internal in 6.7.0.0
   * `\Shopware\Core\Content\ImportExport\ImportExport`
   * `\Shopware\Core\Content\ImportExport\Processing\Pipe\AbstractPipe`
@@ -24,7 +23,5 @@ The following classes are now marked as internal:
 * `\Shopware\Core\Content\ImportExport\Processing\Pipe\EntityPipe`
 * `\Shopware\Core\Content\ImportExport\Processing\Pipe\KeyMappingPipe`
 * `\Shopware\Core\Content\ImportExport\Processing\Pipe\PipeFactory`
-
-This class is now removed without replacement `\Shopware\Core\Content\ImportExport\Event\ImportExportAfterImportRecordEvent`.
 
 This method is removed without replacement `\Shopware\Core\Content\ImportExport\Processing\Pipe\AbstractPipe::getDecorated()` cause the `AbstractPipe` class is now marked as internal.

--- a/src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
+++ b/src/Core/Content/ImportExport/Event/ImportExportAfterImportRecordEvent.php
@@ -5,13 +5,9 @@ namespace Shopware\Core\Content\ImportExport\Event;
 use Shopware\Core\Content\ImportExport\Struct\Config;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
-/**
- * @deprecated tag:v6.7.0 - will be removed with no replacement
- */
 #[Package('fundamentals@after-sales')]
 class ImportExportAfterImportRecordEvent extends Event
 {
@@ -26,51 +22,26 @@ class ImportExportAfterImportRecordEvent extends Event
 
     public function getResult(): EntityWrittenContainerEvent
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.7.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.7.0.0'),
-        );
-
         return $this->result;
     }
 
     public function getRecord(): array
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.7.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.7.0.0'),
-        );
-
         return $this->record;
     }
 
     public function getRow(): array
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.7.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.7.0.0'),
-        );
-
         return $this->row;
     }
 
     public function getConfig(): Config
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.7.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.7.0.0'),
-        );
-
         return $this->config;
     }
 
     public function getContext(): Context
     {
-        Feature::triggerDeprecationOrThrow(
-            'v6.7.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.7.0.0'),
-        );
-
         return $this->context;
     }
 }

--- a/src/Core/Content/ImportExport/Strategy/Import/BatchImportStrategy.php
+++ b/src/Core/Content/ImportExport/Strategy/Import/BatchImportStrategy.php
@@ -9,7 +9,6 @@ use Shopware\Core\Content\ImportExport\Struct\ImportResult;
 use Shopware\Core\Content\ImportExport\Struct\Progress;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Service\ResetInterface;
@@ -76,12 +75,9 @@ class BatchImportStrategy extends OneByOneImportStrategy implements ResetInterfa
                 $result = $this->repository->upsert($records, $context);
             }
 
-            // @deprecated tag:v6.7.0 - remove the whole loop with no replacement
-            if (!Feature::isActive('v6.7.0.0')) {
-                foreach ($this->toImport as $data) {
-                    $afterRecord = new ImportExportAfterImportRecordEvent($result, $data['record'], $data['original'], $config, $context);
-                    $this->eventDispatcher->dispatch($afterRecord);
-                }
+            foreach ($this->toImport as $data) {
+                $afterRecord = new ImportExportAfterImportRecordEvent($result, $data['record'], $data['original'], $config, $context);
+                $this->eventDispatcher->dispatch($afterRecord);
             }
 
             $progress->addProcessedRecords(\count($this->toImport));

--- a/src/Core/Content/ImportExport/Strategy/Import/OneByOneImportStrategy.php
+++ b/src/Core/Content/ImportExport/Strategy/Import/OneByOneImportStrategy.php
@@ -9,7 +9,6 @@ use Shopware\Core\Content\ImportExport\Struct\ImportResult;
 use Shopware\Core\Content\ImportExport\Struct\Progress;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -50,11 +49,8 @@ class OneByOneImportStrategy implements ImportStrategyService
                 $result = $this->repository->upsert([$record], $context);
             }
 
-            // @deprecated tag:v6.7.0 - remove this event with no replacement
-            if (!Feature::isActive('v6.7.0.0')) {
-                $afterRecord = new ImportExportAfterImportRecordEvent($result, $record, $row, $config, $context);
-                $this->eventDispatcher->dispatch($afterRecord);
-            }
+            $afterRecord = new ImportExportAfterImportRecordEvent($result, $record, $row, $config, $context);
+            $this->eventDispatcher->dispatch($afterRecord);
 
             $progress->addProcessedRecords(1);
 

--- a/tests/unit/Core/Content/ImportExport/Strategy/Import/BatchImportStrategyTest.php
+++ b/tests/unit/Core/Content/ImportExport/Strategy/Import/BatchImportStrategyTest.php
@@ -12,7 +12,6 @@ use Shopware\Core\Content\ImportExport\Struct\Progress;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\Event\NestedEventCollection;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -59,10 +58,7 @@ class BatchImportStrategyTest extends ImportStrategyTestCase
 
         $this->repository->expects(static::once())->method($method)->willReturn($writeResult);
 
-        // @deprecated tag:v6.7.0 - remove this expectation with no replacement
-        if (!Feature::isActive('v6.7.0.0')) {
-            $this->eventDispatcher->expects(static::exactly(2))->method('dispatch');
-        }
+        $this->eventDispatcher->expects(static::exactly(2))->method('dispatch');
 
         $progress = new Progress('logId', Progress::STATE_PROGRESS);
 
@@ -103,15 +99,12 @@ class BatchImportStrategyTest extends ImportStrategyTestCase
             }
         );
 
-        // @deprecated tag:v6.7.0 - remove this expectation with no replacement
-        if (!Feature::isActive('v6.7.0.0')) {
-            $this->eventDispatcher->expects(static::exactly(2))
-                ->method('dispatch')
-                ->with(static::logicalOr(
-                    static::isInstanceOf(ImportExportAfterImportRecordEvent::class),
-                    static::isInstanceOf(ImportExportExceptionImportRecordEvent::class)
-                ));
-        }
+        $this->eventDispatcher->expects(static::exactly(2))
+            ->method('dispatch')
+            ->with(static::logicalOr(
+                static::isInstanceOf(ImportExportAfterImportRecordEvent::class),
+                static::isInstanceOf(ImportExportExceptionImportRecordEvent::class)
+            ));
 
         $result = $this->strategy->commit($config, $progress, $context);
 

--- a/tests/unit/Core/Content/ImportExport/Strategy/Import/OneByOneImportStrategyTest.php
+++ b/tests/unit/Core/Content/ImportExport/Strategy/Import/OneByOneImportStrategyTest.php
@@ -11,7 +11,6 @@ use Shopware\Core\Content\ImportExport\Struct\Progress;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Event\EntityWrittenContainerEvent;
 use Shopware\Core\Framework\Event\NestedEventCollection;
-use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 
 /**
@@ -42,10 +41,7 @@ class OneByOneImportStrategyTest extends ImportStrategyTestCase
 
         $this->repository->expects(static::once())->method($method)->willReturn($writeResult);
 
-        // @deprecated tag:v6.7.0 - remove this expectation with no replacement
-        if (!Feature::isActive('v6.7.0.0')) {
-            $this->eventDispatcher->expects(static::once())->method('dispatch');
-        }
+        $this->eventDispatcher->expects(static::once())->method('dispatch');
 
         $progress = new Progress('logId', Progress::STATE_PROGRESS);
 
@@ -73,12 +69,9 @@ class OneByOneImportStrategyTest extends ImportStrategyTestCase
             }
         );
 
-        // @deprecated tag:v6.7.0 - remove this expectation with no replacement
-        if (!Feature::isActive('v6.7.0.0')) {
-            $this->eventDispatcher->expects(static::once())
-                ->method('dispatch')
-                ->with(static::isInstanceOf(ImportExportExceptionImportRecordEvent::class));
-        }
+        $this->eventDispatcher->expects(static::once())
+            ->method('dispatch')
+            ->with(static::isInstanceOf(ImportExportExceptionImportRecordEvent::class));
 
         $config = new Config(
             mapping: [],


### PR DESCRIPTION
We need to revert the deprecation of ImportExportAfterImportRecordEvent unfortunately because our ProductVariantsSubscriber depends on it and removing it would mean that variants are not correctly imported. 

We will depreacate this event as part of the refactor. 