### PR TITLE
refactor(checkout): move to constructor property promotion

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,11 +36,6 @@ parameters:
 			path: src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Price\\\\Struct\\\\QuantityPriceDefinition\\:\\:getConstraints\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\PriceDefinitionFactory\\:\\:factory\\(\\) has parameter \\$priceDefinition with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Checkout/Cart/PriceDefinitionFactory.php
@@ -69,11 +64,6 @@ parameters:
 			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\SalesChannel\\\\AbstractCartItemAddRoute\\:\\:add\\(\\) has parameter \\$items with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Checkout/Cart/SalesChannel/AbstractCartItemAddRoute.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Tax\\\\Struct\\\\TaxRule\\:\\:getConstraints\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Cart/Tax/Struct/TaxRule.php
 
 		-
 			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\Validator\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,21 +116,6 @@ parameters:
 			path: src/Core/Checkout/Customer/Event/CustomerIndexerEvent.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\WishlistMergedEvent\\:\\:__construct\\(\\) has parameter \\$product with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/Event/WishlistMergedEvent.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\WishlistMergedEvent\\:\\:getProducts\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/Event/WishlistMergedEvent.php
-
-		-
-			message: "#^Property Shopware\\\\Core\\\\Checkout\\\\Customer\\\\Event\\\\WishlistMergedEvent\\:\\:\\$products type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Customer/Event/WishlistMergedEvent.php
-
-		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/AffiliateCodeRule.php

--- a/src/Core/Checkout/Cart/Delivery/DeliveryProcessor.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryProcessor.php
@@ -27,13 +27,12 @@ class DeliveryProcessor implements CartProcessorInterface, CartDataCollectorInte
 
     /**
      * @internal
+     *
+     * @param EntityRepository<ShippingMethodCollection> $shippingMethodRepository
      */
     public function __construct(
         protected DeliveryBuilder $builder,
         protected DeliveryCalculator $deliveryCalculator,
-        /**
-         * @var EntityRepository<ShippingMethodCollection>
-         */
         protected EntityRepository $shippingMethodRepository
     ) {
     }

--- a/src/Core/Checkout/Cart/Delivery/DeliveryProcessor.php
+++ b/src/Core/Checkout/Cart/Delivery/DeliveryProcessor.php
@@ -25,26 +25,17 @@ class DeliveryProcessor implements CartProcessorInterface, CartDataCollectorInte
 
     final public const SKIP_DELIVERY_TAX_RECALCULATION = 'skipDeliveryTaxRecalculation';
 
-    protected DeliveryBuilder $builder;
-
-    protected DeliveryCalculator $deliveryCalculator;
-
-    /**
-     * @var EntityRepository<ShippingMethodCollection>
-     */
-    protected EntityRepository $shippingMethodRepository;
-
     /**
      * @internal
      */
     public function __construct(
-        DeliveryBuilder $builder,
-        DeliveryCalculator $deliveryCalculator,
-        EntityRepository $shippingMethodRepository
+        protected DeliveryBuilder $builder,
+        protected DeliveryCalculator $deliveryCalculator,
+        /**
+         * @var EntityRepository<ShippingMethodCollection>
+         */
+        protected EntityRepository $shippingMethodRepository
     ) {
-        $this->builder = $builder;
-        $this->deliveryCalculator = $deliveryCalculator;
-        $this->shippingMethodRepository = $shippingMethodRepository;
     }
 
     public static function buildKey(string $shippingMethodId): string

--- a/src/Core/Checkout/Cart/Delivery/Struct/Delivery.php
+++ b/src/Core/Checkout/Cart/Delivery/Struct/Delivery.php
@@ -10,28 +10,13 @@ use Shopware\Core\Framework\Struct\Struct;
 #[Package('checkout')]
 class Delivery extends Struct
 {
-    protected DeliveryPositionCollection $positions;
-
-    protected ShippingLocation $location;
-
-    protected DeliveryDate $deliveryDate;
-
-    protected ShippingMethodEntity $shippingMethod;
-
-    protected CalculatedPrice $shippingCosts;
-
     public function __construct(
-        DeliveryPositionCollection $positions,
-        DeliveryDate $deliveryDate,
-        ShippingMethodEntity $shippingMethod,
-        ShippingLocation $location,
-        CalculatedPrice $shippingCosts
+        protected DeliveryPositionCollection $positions,
+        protected DeliveryDate $deliveryDate,
+        protected ShippingMethodEntity $shippingMethod,
+        protected ShippingLocation $location,
+        protected CalculatedPrice $shippingCosts
     ) {
-        $this->location = $location;
-        $this->positions = $positions;
-        $this->deliveryDate = $deliveryDate;
-        $this->shippingMethod = $shippingMethod;
-        $this->shippingCosts = $shippingCosts;
     }
 
     public function getPositions(): DeliveryPositionCollection

--- a/src/Core/Checkout/Cart/Delivery/Struct/DeliveryPosition.php
+++ b/src/Core/Checkout/Cart/Delivery/Struct/DeliveryPosition.php
@@ -10,28 +10,13 @@ use Shopware\Core\Framework\Struct\Struct;
 #[Package('checkout')]
 class DeliveryPosition extends Struct
 {
-    protected LineItem $lineItem;
-
-    protected float $quantity;
-
-    protected CalculatedPrice $price;
-
-    protected string $identifier;
-
-    protected DeliveryDate $deliveryDate;
-
     public function __construct(
-        string $identifier,
-        LineItem $lineItem,
-        int $quantity,
-        CalculatedPrice $price,
-        DeliveryDate $deliveryDate
+        protected string $identifier,
+        protected LineItem $lineItem,
+        protected int $quantity,
+        protected CalculatedPrice $price,
+        protected DeliveryDate $deliveryDate
     ) {
-        $this->lineItem = $lineItem;
-        $this->quantity = $quantity;
-        $this->price = $price;
-        $this->identifier = $identifier;
-        $this->deliveryDate = $deliveryDate;
     }
 
     public function getLineItem(): LineItem
@@ -39,7 +24,7 @@ class DeliveryPosition extends Struct
         return $this->lineItem;
     }
 
-    public function getQuantity(): float
+    public function getQuantity(): int
     {
         return $this->quantity;
     }

--- a/src/Core/Checkout/Cart/Delivery/Struct/ShippingLocation.php
+++ b/src/Core/Checkout/Cart/Delivery/Struct/ShippingLocation.php
@@ -13,8 +13,8 @@ class ShippingLocation extends Struct
 {
     public function __construct(
         protected CountryEntity $country,
-        protected ?CountryStateEntity $state,
-        protected ?CustomerAddressEntity $address
+        protected ?CountryStateEntity $state = null,
+        protected ?CustomerAddressEntity $address = null
     ) {
     }
 

--- a/src/Core/Checkout/Cart/Event/AfterLineItemAddedEvent.php
+++ b/src/Core/Checkout/Cart/Event/AfterLineItemAddedEvent.php
@@ -13,25 +13,13 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 class AfterLineItemAddedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
-     * @var LineItem[]
-     */
-    protected array $lineItems;
-
-    protected Cart $cart;
-
-    protected SalesChannelContext $salesChannelContext;
-
-    /**
      * @param LineItem[] $lineItems
      */
     public function __construct(
-        array $lineItems,
-        Cart $cart,
-        SalesChannelContext $salesChannelContext
+        protected array $lineItems,
+        protected Cart $cart,
+        protected SalesChannelContext $salesChannelContext
     ) {
-        $this->lineItems = $lineItems;
-        $this->cart = $cart;
-        $this->salesChannelContext = $salesChannelContext;
     }
 
     /**

--- a/src/Core/Checkout/Cart/Event/AfterLineItemQuantityChangedEvent.php
+++ b/src/Core/Checkout/Cart/Event/AfterLineItemQuantityChangedEvent.php
@@ -12,25 +12,13 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 class AfterLineItemQuantityChangedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
-     * @var array<array<string, mixed>>
-     */
-    protected array $items;
-
-    protected Cart $cart;
-
-    protected SalesChannelContext $salesChannelContext;
-
-    /**
      * @param array<array<string, mixed>> $items
      */
     public function __construct(
-        Cart $cart,
-        array $items,
-        SalesChannelContext $salesChannelContext
+        protected Cart $cart,
+        protected array $items,
+        protected SalesChannelContext $salesChannelContext
     ) {
-        $this->cart = $cart;
-        $this->items = $items;
-        $this->salesChannelContext = $salesChannelContext;
     }
 
     public function getCart(): Cart

--- a/src/Core/Checkout/Cart/Event/AfterLineItemRemovedEvent.php
+++ b/src/Core/Checkout/Cart/Event/AfterLineItemRemovedEvent.php
@@ -13,25 +13,13 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 class AfterLineItemRemovedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
     /**
-     * @var LineItem[]
-     */
-    protected array $lineItems;
-
-    protected Cart $cart;
-
-    protected SalesChannelContext $salesChannelContext;
-
-    /**
      * @param LineItem[] $lineItems
      */
     public function __construct(
-        array $lineItems,
-        Cart $cart,
-        SalesChannelContext $salesChannelContext
+        protected array $lineItems,
+        protected Cart $cart,
+        protected SalesChannelContext $salesChannelContext
     ) {
-        $this->lineItems = $lineItems;
-        $this->cart = $cart;
-        $this->salesChannelContext = $salesChannelContext;
     }
 
     /**

--- a/src/Core/Checkout/Cart/Event/BeforeLineItemAddedEvent.php
+++ b/src/Core/Checkout/Cart/Event/BeforeLineItemAddedEvent.php
@@ -12,24 +12,12 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 #[Package('checkout')]
 class BeforeLineItemAddedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
-    protected LineItem $lineItem;
-
-    protected Cart $cart;
-
-    protected SalesChannelContext $salesChannelContext;
-
-    protected bool $merged;
-
     public function __construct(
-        LineItem $lineItem,
-        Cart $cart,
-        SalesChannelContext $salesChannelContext,
-        bool $merged = false
+        protected LineItem $lineItem,
+        protected Cart $cart,
+        protected SalesChannelContext $salesChannelContext,
+        protected bool $merged = false
     ) {
-        $this->lineItem = $lineItem;
-        $this->cart = $cart;
-        $this->salesChannelContext = $salesChannelContext;
-        $this->merged = $merged;
     }
 
     public function getLineItem(): LineItem

--- a/src/Core/Checkout/Cart/Event/BeforeLineItemRemovedEvent.php
+++ b/src/Core/Checkout/Cart/Event/BeforeLineItemRemovedEvent.php
@@ -12,20 +12,11 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 #[Package('checkout')]
 class BeforeLineItemRemovedEvent implements ShopwareSalesChannelEvent, CartEvent
 {
-    protected LineItem $lineItem;
-
-    protected Cart $cart;
-
-    protected SalesChannelContext $salesChannelContext;
-
     public function __construct(
-        LineItem $lineItem,
-        Cart $cart,
-        SalesChannelContext $salesChannelContext
+        protected LineItem $lineItem,
+        protected Cart $cart,
+        protected SalesChannelContext $salesChannelContext
     ) {
-        $this->lineItem = $lineItem;
-        $this->cart = $cart;
-        $this->salesChannelContext = $salesChannelContext;
     }
 
     public function getLineItem(): LineItem

--- a/src/Core/Checkout/Cart/Event/CartCreatedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartCreatedEvent.php
@@ -9,11 +9,9 @@ use Symfony\Contracts\EventDispatcher\Event;
 #[Package('checkout')]
 class CartCreatedEvent extends Event implements CartEvent
 {
-    protected Cart $cart;
-
-    public function __construct(Cart $cart)
-    {
-        $this->cart = $cart;
+    public function __construct(
+        protected Cart $cart
+    ) {
     }
 
     public function getCart(): Cart

--- a/src/Core/Checkout/Cart/Event/CartDeletedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartDeletedEvent.php
@@ -11,11 +11,9 @@ use Symfony\Contracts\EventDispatcher\Event;
 #[Package('checkout')]
 class CartDeletedEvent extends Event implements ShopwareSalesChannelEvent
 {
-    protected SalesChannelContext $context;
-
-    public function __construct(SalesChannelContext $context)
-    {
-        $this->context = $context;
+    public function __construct(
+        protected SalesChannelContext $context
+    ) {
     }
 
     public function getContext(): Context

--- a/src/Core/Checkout/Cart/Event/CartSavedEvent.php
+++ b/src/Core/Checkout/Cart/Event/CartSavedEvent.php
@@ -12,16 +12,10 @@ use Symfony\Contracts\EventDispatcher\Event;
 #[Package('checkout')]
 class CartSavedEvent extends Event implements ShopwareSalesChannelEvent, CartEvent
 {
-    protected SalesChannelContext $context;
-
-    protected Cart $cart;
-
     public function __construct(
-        SalesChannelContext $context,
-        Cart $cart
+        protected SalesChannelContext $context,
+        protected Cart $cart
     ) {
-        $this->context = $context;
-        $this->cart = $cart;
     }
 
     public function getContext(): Context

--- a/src/Core/Checkout/Cart/Event/LineItemRemovedEvent.php
+++ b/src/Core/Checkout/Cart/Event/LineItemRemovedEvent.php
@@ -13,20 +13,11 @@ use Symfony\Contracts\EventDispatcher\Event;
 #[Package('checkout')]
 class LineItemRemovedEvent extends Event implements ShopwareSalesChannelEvent, CartEvent
 {
-    protected LineItem $lineItem;
-
-    protected Cart $cart;
-
-    protected SalesChannelContext $context;
-
     public function __construct(
-        LineItem $lineItem,
-        Cart $cart,
-        SalesChannelContext $context
+        protected LineItem $lineItem,
+        protected Cart $cart,
+        protected SalesChannelContext $context
     ) {
-        $this->lineItem = $lineItem;
-        $this->cart = $cart;
-        $this->context = $context;
     }
 
     public function getLineItem(): LineItem

--- a/src/Core/Checkout/Cart/Order/IdStruct.php
+++ b/src/Core/Checkout/Cart/Order/IdStruct.php
@@ -8,11 +8,9 @@ use Shopware\Core\Framework\Struct\Struct;
 #[Package('checkout')]
 class IdStruct extends Struct
 {
-    protected string $id;
-
-    public function __construct(string $id)
-    {
-        $this->id = $id;
+    public function __construct(
+        protected string $id
+    ) {
     }
 
     public function getId(): string

--- a/src/Core/Checkout/Cart/Price/Struct/AbsolutePriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/AbsolutePriceDefinition.php
@@ -22,17 +22,14 @@ class AbsolutePriceDefinition extends Struct implements PriceDefinitionInterface
 
     protected float $price;
 
-    /**
-     * Allows to define a filter rule which line items should be considered for percentage discount/surcharge
-     */
-    protected ?Rule $filter;
-
     public function __construct(
         float $price,
-        ?Rule $filter = null
+        /**
+         * Allows to define a filter rule which line items should be considered for percentage discount/surcharge
+         */
+        protected ?Rule $filter = null
     ) {
         $this->price = FloatComparator::cast($price);
-        $this->filter = $filter;
     }
 
     public function getFilter(): ?Rule

--- a/src/Core/Checkout/Cart/Price/Struct/AbsolutePriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/AbsolutePriceDefinition.php
@@ -20,10 +20,8 @@ class AbsolutePriceDefinition extends Struct implements PriceDefinitionInterface
     final public const TYPE = 'absolute';
     final public const SORTING_PRIORITY = 75;
 
-    protected float $price;
-
     public function __construct(
-        float $price,
+        protected float $price,
         /**
          * Allows to define a filter rule which line items should be considered for percentage discount/surcharge
          */

--- a/src/Core/Checkout/Cart/Price/Struct/CartPrice.php
+++ b/src/Core/Checkout/Cart/Price/Struct/CartPrice.php
@@ -19,13 +19,7 @@ class CartPrice extends Struct
 
     protected float $totalPrice;
 
-    protected CalculatedTaxCollection $calculatedTaxes;
-
-    protected TaxRuleCollection $taxRules;
-
     protected float $positionPrice;
-
-    protected string $taxStatus;
 
     protected float $rawTotal;
 
@@ -33,17 +27,14 @@ class CartPrice extends Struct
         float $netPrice,
         float $totalPrice,
         float $positionPrice,
-        CalculatedTaxCollection $calculatedTaxes,
-        TaxRuleCollection $taxRules,
-        string $taxStatus,
+        protected CalculatedTaxCollection $calculatedTaxes,
+        protected TaxRuleCollection $taxRules,
+        protected string $taxStatus,
         ?float $rawTotal = null
     ) {
         $this->netPrice = FloatComparator::cast($netPrice);
         $this->totalPrice = FloatComparator::cast($totalPrice);
-        $this->calculatedTaxes = $calculatedTaxes;
-        $this->taxRules = $taxRules;
         $this->positionPrice = FloatComparator::cast($positionPrice);
-        $this->taxStatus = $taxStatus;
         $rawTotal ??= $totalPrice;
         $this->rawTotal = FloatComparator::cast($rawTotal);
     }

--- a/src/Core/Checkout/Cart/Price/Struct/CartPrice.php
+++ b/src/Core/Checkout/Cart/Price/Struct/CartPrice.php
@@ -15,18 +15,12 @@ class CartPrice extends Struct
     final public const TAX_STATE_NET = 'net';
     final public const TAX_STATE_FREE = 'tax-free';
 
-    protected float $netPrice;
-
-    protected float $totalPrice;
-
-    protected float $positionPrice;
-
     protected float $rawTotal;
 
     public function __construct(
-        float $netPrice,
-        float $totalPrice,
-        float $positionPrice,
+        protected float $netPrice,
+        protected float $totalPrice,
+        protected float $positionPrice,
         protected CalculatedTaxCollection $calculatedTaxes,
         protected TaxRuleCollection $taxRules,
         protected string $taxStatus,

--- a/src/Core/Checkout/Cart/Price/Struct/ListPrice.php
+++ b/src/Core/Checkout/Cart/Price/Struct/ListPrice.php
@@ -9,16 +9,10 @@ use Shopware\Core\Framework\Util\FloatComparator;
 #[Package('checkout')]
 class ListPrice extends Struct
 {
-    protected float $price;
-
-    protected float $discount;
-
-    protected float $percentage;
-
     private function __construct(
-        float $price,
-        float $discount,
-        float $percentage
+        protected float $price,
+        protected float $discount,
+        protected float $percentage
     ) {
         $this->price = FloatComparator::cast($price);
         $this->discount = FloatComparator::cast($discount);

--- a/src/Core/Checkout/Cart/Price/Struct/PercentagePriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/PercentagePriceDefinition.php
@@ -20,10 +20,8 @@ class PercentagePriceDefinition extends Struct implements PriceDefinitionInterfa
     final public const TYPE = 'percentage';
     final public const SORTING_PRIORITY = 50;
 
-    protected float $percentage;
-
     public function __construct(
-        float $percentage,
+        protected float $percentage,
         /**
          * Allows to define a filter rule which line items should be considered for percentage discount/surcharge
          */

--- a/src/Core/Checkout/Cart/Price/Struct/PercentagePriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/PercentagePriceDefinition.php
@@ -22,17 +22,14 @@ class PercentagePriceDefinition extends Struct implements PriceDefinitionInterfa
 
     protected float $percentage;
 
-    /**
-     * Allows to define a filter rule which line items should be considered for percentage discount/surcharge
-     */
-    protected ?Rule $filter;
-
     public function __construct(
         float $percentage,
-        ?Rule $filter = null
+        /**
+         * Allows to define a filter rule which line items should be considered for percentage discount/surcharge
+         */
+        protected ?Rule $filter = null
     ) {
         $this->percentage = FloatComparator::cast($percentage);
-        $this->filter = $filter;
     }
 
     public function getPercentage(): float

--- a/src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
@@ -7,6 +7,7 @@ use Shopware\Core\Checkout\Cart\Tax\Struct\TaxRuleCollection;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Util\FloatComparator;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
@@ -103,6 +104,9 @@ class QuantityPriceDefinition extends Struct implements PriceDefinitionInterface
         return self::SORTING_PRIORITY;
     }
 
+    /**
+     * @return array<string, list<Constraint>>
+     */
     public static function getConstraints(): array
     {
         return [

--- a/src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
@@ -23,10 +23,6 @@ class QuantityPriceDefinition extends Struct implements PriceDefinitionInterface
 
     protected float $price;
 
-    protected TaxRuleCollection $taxRules;
-
-    protected int $quantity;
-
     protected bool $isCalculated = true;
 
     protected ?ReferencePriceDefinition $referencePriceDefinition = null;
@@ -37,12 +33,10 @@ class QuantityPriceDefinition extends Struct implements PriceDefinitionInterface
 
     public function __construct(
         float $price,
-        TaxRuleCollection $taxRules,
-        int $quantity = 1
+        protected TaxRuleCollection $taxRules,
+        protected int $quantity = 1
     ) {
         $this->price = FloatComparator::cast($price);
-        $this->taxRules = $taxRules;
-        $this->quantity = $quantity;
     }
 
     public function getPrice(): float

--- a/src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
@@ -21,8 +21,6 @@ class QuantityPriceDefinition extends Struct implements PriceDefinitionInterface
     final public const TYPE = 'quantity';
     final public const SORTING_PRIORITY = 100;
 
-    protected float $price;
-
     protected bool $isCalculated = true;
 
     protected ?ReferencePriceDefinition $referencePriceDefinition = null;
@@ -32,7 +30,7 @@ class QuantityPriceDefinition extends Struct implements PriceDefinitionInterface
     protected ?float $regulationPrice = null;
 
     public function __construct(
-        float $price,
+        protected float $price,
         protected TaxRuleCollection $taxRules,
         protected int $quantity = 1
     ) {

--- a/src/Core/Checkout/Cart/Price/Struct/ReferencePrice.php
+++ b/src/Core/Checkout/Cart/Price/Struct/ReferencePrice.php
@@ -8,10 +8,8 @@ use Shopware\Core\Framework\Util\FloatComparator;
 #[Package('checkout')]
 class ReferencePrice extends ReferencePriceDefinition
 {
-    protected float $price;
-
     public function __construct(
-        float $price,
+        protected float $price,
         float $purchaseUnit,
         float $referenceUnit,
         string $unitName

--- a/src/Core/Checkout/Cart/Price/Struct/ReferencePriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/ReferencePriceDefinition.php
@@ -9,13 +9,9 @@ use Shopware\Core\Framework\Util\FloatComparator;
 #[Package('checkout')]
 class ReferencePriceDefinition extends Struct
 {
-    protected float $purchaseUnit;
-
-    protected float $referenceUnit;
-
     public function __construct(
-        float $purchaseUnit,
-        float $referenceUnit,
+        protected float $purchaseUnit,
+        protected float $referenceUnit,
         protected string $unitName
     ) {
         $this->purchaseUnit = FloatComparator::cast($purchaseUnit);

--- a/src/Core/Checkout/Cart/Price/Struct/ReferencePriceDefinition.php
+++ b/src/Core/Checkout/Cart/Price/Struct/ReferencePriceDefinition.php
@@ -13,16 +13,13 @@ class ReferencePriceDefinition extends Struct
 
     protected float $referenceUnit;
 
-    protected string $unitName;
-
     public function __construct(
         float $purchaseUnit,
         float $referenceUnit,
-        string $unitName
+        protected string $unitName
     ) {
         $this->purchaseUnit = FloatComparator::cast($purchaseUnit);
         $this->referenceUnit = FloatComparator::cast($referenceUnit);
-        $this->unitName = $unitName;
     }
 
     public function getPurchaseUnit(): float

--- a/src/Core/Checkout/Cart/Price/Struct/RegulationPrice.php
+++ b/src/Core/Checkout/Cart/Price/Struct/RegulationPrice.php
@@ -9,10 +9,9 @@ use Shopware\Core\Framework\Util\FloatComparator;
 #[Package('checkout')]
 class RegulationPrice extends Struct
 {
-    protected float $price;
-
-    public function __construct(float $price)
-    {
+    public function __construct(
+        protected float $price
+    ) {
         $this->price = FloatComparator::cast($price);
     }
 

--- a/src/Core/Checkout/Cart/Tax/Struct/TaxRule.php
+++ b/src/Core/Checkout/Cart/Tax/Struct/TaxRule.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Checkout\Cart\Tax\Struct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\Framework\Util\FloatComparator;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Type;
 
@@ -29,6 +30,9 @@ class TaxRule extends Struct
         return FloatComparator::cast($this->percentage);
     }
 
+    /**
+     * @return array<string, list<Constraint>>
+     */
     public static function getConstraints(): array
     {
         return [

--- a/src/Core/Checkout/Cart/Tax/Struct/TaxRule.php
+++ b/src/Core/Checkout/Cart/Tax/Struct/TaxRule.php
@@ -11,13 +11,9 @@ use Symfony\Component\Validator\Constraints\Type;
 #[Package('checkout')]
 class TaxRule extends Struct
 {
-    protected float $taxRate;
-
-    protected float $percentage;
-
     public function __construct(
-        float $taxRate,
-        float $percentage = 100.0
+        protected float $taxRate,
+        protected float $percentage = 100.0
     ) {
         $this->taxRate = FloatComparator::cast($taxRate);
         $this->percentage = FloatComparator::cast($percentage);

--- a/src/Core/Checkout/Cart/Transaction/Struct/Transaction.php
+++ b/src/Core/Checkout/Cart/Transaction/Struct/Transaction.php
@@ -9,18 +9,12 @@ use Shopware\Core\Framework\Struct\Struct;
 #[Package('checkout')]
 class Transaction extends Struct
 {
-    protected CalculatedPrice $amount;
-
-    protected string $paymentMethodId;
-
     protected ?Struct $validationStruct = null;
 
     public function __construct(
-        CalculatedPrice $amount,
-        string $paymentMethodId
+        protected CalculatedPrice $amount,
+        protected string $paymentMethodId
     ) {
-        $this->amount = $amount;
-        $this->paymentMethodId = $paymentMethodId;
     }
 
     public function getAmount(): CalculatedPrice

--- a/src/Core/Checkout/CheckoutRuleScope.php
+++ b/src/Core/Checkout/CheckoutRuleScope.php
@@ -10,11 +10,9 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 #[Package('checkout')]
 class CheckoutRuleScope extends RuleScope
 {
-    protected SalesChannelContext $context;
-
-    public function __construct(SalesChannelContext $context)
-    {
-        $this->context = $context;
+    public function __construct(
+        protected SalesChannelContext $context
+    ) {
     }
 
     public function getSalesChannelContext(): SalesChannelContext

--- a/src/Core/Checkout/Customer/Event/CustomerWishlistProductListingResultEvent.php
+++ b/src/Core/Checkout/Customer/Event/CustomerWishlistProductListingResultEvent.php
@@ -16,23 +16,14 @@ class CustomerWishlistProductListingResultEvent extends NestedEvent implements S
 {
     final public const EVENT_NAME = 'checkout.customer.wishlist_listing_product_result';
 
-    protected Request $request;
-
     /**
-     * @var EntitySearchResult<ProductCollection>
-     */
-    protected EntitySearchResult $result;
-
-    /**
-     * @param EntitySearchResult<ProductCollection> $wishlistProductListingResult
+     * @param EntitySearchResult<ProductCollection> $result
      */
     public function __construct(
-        Request $request,
-        EntitySearchResult $wishlistProductListingResult,
+        protected Request $request,
+        protected EntitySearchResult $result,
         private SalesChannelContext $context
     ) {
-        $this->request = $request;
-        $this->result = $wishlistProductListingResult;
     }
 
     public function getName(): string

--- a/src/Core/Checkout/Customer/Event/WishlistMergedEvent.php
+++ b/src/Core/Checkout/Customer/Event/WishlistMergedEvent.php
@@ -11,18 +11,18 @@ use Symfony\Contracts\EventDispatcher\Event;
 #[Package('checkout')]
 class WishlistMergedEvent extends Event implements ShopwareSalesChannelEvent
 {
-    protected array $products;
-
-    protected SalesChannelContext $context;
-
+    /**
+     * @param array<array{id: string, productId?: string, productVersionId?: string}> $products
+     */
     public function __construct(
-        array $product,
-        SalesChannelContext $context
+        protected array $products,
+        protected SalesChannelContext $context
     ) {
-        $this->products = $product;
-        $this->context = $context;
     }
 
+    /**
+     * @return array<array{id: string, productId?: string, productVersionId?: string}>
+     */
     public function getProducts(): array
     {
         return $this->products;

--- a/src/Core/Checkout/Customer/Rule/DifferentAddressesRule.php
+++ b/src/Core/Checkout/Customer/Rule/DifferentAddressesRule.php
@@ -18,12 +18,10 @@ class DifferentAddressesRule extends Rule
 {
     final public const RULE_NAME = 'customerDifferentAddresses';
 
-    protected bool $isDifferent;
-
-    public function __construct(bool $isDifferent = true)
-    {
+    public function __construct(
+        protected bool $isDifferent = true
+    ) {
         parent::__construct();
-        $this->isDifferent = $isDifferent;
     }
 
     public function match(RuleScope $scope): bool

--- a/src/Core/Checkout/Customer/Rule/IsCompanyRule.php
+++ b/src/Core/Checkout/Customer/Rule/IsCompanyRule.php
@@ -17,12 +17,10 @@ class IsCompanyRule extends Rule
 {
     final public const RULE_NAME = 'customerIsCompany';
 
-    protected bool $isCompany;
-
-    public function __construct(bool $isCompany = true)
-    {
+    public function __construct(
+        protected bool $isCompany = true
+    ) {
         parent::__construct();
-        $this->isCompany = $isCompany;
     }
 
     public function match(RuleScope $scope): bool

--- a/src/Core/Checkout/Customer/SalesChannel/LoadWishlistRouteResponse.php
+++ b/src/Core/Checkout/Customer/SalesChannel/LoadWishlistRouteResponse.php
@@ -12,25 +12,16 @@ use Shopware\Core\System\SalesChannel\StoreApiResponse;
 #[Package('checkout')]
 class LoadWishlistRouteResponse extends StoreApiResponse
 {
-    protected CustomerWishlistEntity $wishlist;
-
     /**
-     * @var EntitySearchResult<ProductCollection>
-     */
-    protected EntitySearchResult $productListing;
-
-    /**
-     * @param EntitySearchResult<ProductCollection> $listing
+     * @param EntitySearchResult<ProductCollection> $productListing
      */
     public function __construct(
-        CustomerWishlistEntity $wishlist,
-        EntitySearchResult $listing
+        protected CustomerWishlistEntity $wishlist,
+        protected EntitySearchResult $productListing
     ) {
-        $this->wishlist = $wishlist;
-        $this->productListing = $listing;
         parent::__construct(new ArrayStruct([
-            'wishlist' => $wishlist,
-            'products' => $listing,
+            'wishlist' => $this->wishlist,
+            'products' => $this->productListing,
         ], 'wishlist_products'));
     }
 

--- a/src/Core/Checkout/Promotion/Cart/Error/AutoPromotionNotFoundError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/AutoPromotionNotFoundError.php
@@ -10,12 +10,8 @@ class AutoPromotionNotFoundError extends Error
 {
     private const KEY = 'auto-promotion-not-found';
 
-    protected string $name;
-
-    public function __construct(string $name)
+    public function __construct(protected string $name)
     {
-        $this->name = $name;
-
         $this->message = \sprintf('Promotion %s was no longer valid!', $this->name);
 
         parent::__construct($this->message);

--- a/src/Core/Checkout/Promotion/Cart/Error/PromotionNotEligibleError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/PromotionNotEligibleError.php
@@ -10,12 +10,8 @@ class PromotionNotEligibleError extends Error
 {
     private const KEY = 'promotion-not-eligible';
 
-    protected string $name;
-
-    public function __construct(string $name)
+    public function __construct(protected string $name)
     {
-        $this->name = $name;
-
         $this->message = \sprintf('Promotion %s not eligible for cart!', $this->name);
 
         parent::__construct($this->message);

--- a/src/Core/Checkout/Promotion/Cart/Error/PromotionNotFoundError.php
+++ b/src/Core/Checkout/Promotion/Cart/Error/PromotionNotFoundError.php
@@ -10,12 +10,8 @@ class PromotionNotFoundError extends Error
 {
     private const KEY = 'promotion-not-found';
 
-    protected string $promotionCode;
-
-    public function __construct(string $promotionCode)
+    public function __construct(protected string $promotionCode)
     {
-        $this->promotionCode = $promotionCode;
-
         $this->message = \sprintf('Promotion with code %s not found!', $this->promotionCode);
 
         parent::__construct($this->message);


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
 While adding native types to all properties in #6559, we discovered that we could use constructor property promotion in many places, and we decided to do so.

### 2. What does this change do, exactly?
Moving all properties to constructor property promotion were possible inside the `src/Core/Checkout` directory. 

### 3. Danger skipped?
Do not want to fix the phpstan error for typing `QuantityPriceDefinition::fromArray` as typing it requires all consumers to be typed correctly - these are not validated and therefore forcing a type would lead to hidden errors.

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
