### PR TITLE
fix: Fix CMS background NEXT-39997 #5794 [6.6.x]

### DIFF
--- a/changelog/_unreleased/2025-01-28-fix-cms-section-background.md
+++ b/changelog/_unreleased/2025-01-28-fix-cms-section-background.md
@@ -1,0 +1,10 @@
+---
+title: Fix CMS-Section background
+issue: NEXT-39997
+author: Rune Laenen
+author_email: rune@laenen.me
+author_github: @runelaenen
+---
+
+# Storefront
+* Changed `cms-section-block-container.html.twig` to support display of hero media image of `text-on-image` CMS-element in storefront

--- a/src/Storefront/Resources/views/storefront/section/cms-section-block-container.html.twig
+++ b/src/Storefront/Resources/views/storefront/section/cms-section-block-container.html.twig
@@ -53,11 +53,15 @@
          style="{% if blockBgColor %} background-color: {{ blockBgColor }};{% endif %};">
 
         {% block section_content_block_background_image %}
-            {% set backgroundImageUrl = null %}
-
             {% if block.backgroundMedia %}
-                {% set backgroundImageUrl = block.backgroundMedia.url %}
-            {% else %}
+                {% sw_thumbnails 'cms-block-background' with {
+                    media: block.backgroundMedia,
+                    autoColumnSizes: false,
+                    attributes: {
+                        class: 'cms-block-background media-mode--' ~ block.backgroundMediaMode
+                    }
+                } %}
+            {% elseif (block.type == 'text-on-image') %}
                 {% set defaultMediaUrl = null %}
 
                 {% for slot in block.slots.elements %}
@@ -67,11 +71,11 @@
                         {% break %}
                     {% endif %}
                 {% endfor %}
-            {% endif %}
 
-            {% if backgroundImageUrl %}
-                <img src="{{ backgroundImageUrl }}"
-                     class="cms-block-background media-mode--{{ block.backgroundMediaMode|default('cover') }}">
+                {% if backgroundImageUrl %}
+                    <img src="{{ backgroundImageUrl }}"
+                         class="cms-block-background media-mode--{{ block.backgroundMediaMode|default('cover') }}">
+                {% endif %}
             {% endif %}
         {% endblock %}
 


### PR DESCRIPTION
Backport: https://github.com/shopware/shopware/pull/6453

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
https://github.com/shopware/shopware/issues/5794

Additionaly, no thumbnails are used anymore and the full fat image is always loaded.

### 2. What does this change do, exactly?
Make the change made in 6.6.9.0 more strict, and revert to the original working for the normal behaviour so thumbnails are used.

### 3. Describe each step to reproduce the issue or behaviour.
https://github.com/shopware/shopware/issues/5794

### 4. Please link to the relevant issues (if any).
- closes #5794

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
