### PR TITLE
feat: Add possibility to use the Google Tag Manager in the storefront

### DIFF
--- a/changelog/_unreleased/2025-02-08-add-possibility-to-use-the-google-tag-manager.md
+++ b/changelog/_unreleased/2025-02-08-add-possibility-to-use-the-google-tag-manager.md
@@ -1,0 +1,8 @@
+---
+title: Add possibility to use the Google Tag Manager
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Storefront
+* Changed the `@Storefront/storefront/component/analytics.html.twig` template to include the Google Tag Manager, if the tracking id starts with `GTM-`

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
@@ -253,7 +253,7 @@
           "trackingId": {
             "label": "Tracking-ID",
             "placeHolder": "Tracking-ID eingeben ...",
-            "helpText": "Nach der Anmeldung in Deinem Google-Analytics-Konto erhältst Du eine Tracking-ID. Tracking-IDs können wie folgt aussehen: G-XXXXXXXXXX"
+            "helpText": "Nach der Anmeldung in Deinem Google-Analytics-Konto erhältst Du eine Tracking-ID. Tracking-IDs können wie folgt aussehen `G-XXXXXXXXXX`. Beginnt die ID mit `GTM-`, wird im Storefront automatisch das Google Tag Manager-Skript eingebunden: `https://www.googletagmanager.com/gtm.js?id=...`. Andernfalls wird `https://www.googletagmanager.com/gtag/js?id=...` verwendet."
           },
           "active": {
             "label": "Google Analytics aktivieren"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/de-DE.json
@@ -253,7 +253,7 @@
           "trackingId": {
             "label": "Tracking-ID",
             "placeHolder": "Tracking-ID eingeben ...",
-            "helpText": "Nach der Anmeldung in Deinem Google-Analytics-Konto erhältst Du eine Tracking-ID. Tracking-IDs können wie folgt aussehen `G-XXXXXXXXXX`. Beginnt die ID mit `GTM-`, wird im Storefront automatisch das Google Tag Manager-Skript eingebunden: `https://www.googletagmanager.com/gtm.js?id=...`. Andernfalls wird `https://www.googletagmanager.com/gtag/js?id=...` verwendet."
+            "helpText": "Nach der Anmeldung in Deinem Google-Analytics-Konto erhältst Du eine Tracking-ID. Tracking-IDs können wie folgt aussehen `G-XXXXXXXXXX`. Beginnt die ID mit `GTM-`, wird in der Storefront automatisch das Google Tag Manager-Skript eingebunden: `https://www.googletagmanager.com/gtm.js?id=...`. Andernfalls wird `https://www.googletagmanager.com/gtag/js?id=...` verwendet."
           },
           "active": {
             "label": "Google Analytics aktivieren"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
@@ -253,7 +253,7 @@
           "trackingId": {
             "label": "Tracking ID",
             "placeHolder": "Enter tracking ID...",
-            "helpText": "When logged in to your Google Analytics account, you will be given access to a tracking ID, which should look like this: G-XXXXXXXXXX"
+            "helpText": "When logged into your Google Analytics account, you will receive a tracking ID in the format `G-XXXXXXXXXX`. If the you want to use the Google Tag Manager, then use an ID which starts with `GTM-`, the storefront then automatically includes the Google Tag Manager script: `https://www.googletagmanager.com/gtm.js?id=...`. Otherwise, it uses `https://www.googletagmanager.com/gtag/js?id=...`."
           },
           "active": {
             "label": "Activate Google Analytics"

--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/snippet/en-GB.json
@@ -253,7 +253,7 @@
           "trackingId": {
             "label": "Tracking ID",
             "placeHolder": "Enter tracking ID...",
-            "helpText": "When logged into your Google Analytics account, you will receive a tracking ID in the format `G-XXXXXXXXXX`. If the you want to use the Google Tag Manager, then use an ID which starts with `GTM-`, the storefront then automatically includes the Google Tag Manager script: `https://www.googletagmanager.com/gtm.js?id=...`. Otherwise, it uses `https://www.googletagmanager.com/gtag/js?id=...`."
+            "helpText": "When logged into your Google Analytics account, you will receive a tracking ID in the format `G-XXXXXXXXXX`. If you want to use the Google Tag Manager, then use an ID which starts with `GTM-`. The storefront then automatically includes the Google Tag Manager script: `https://www.googletagmanager.com/gtm.js?id=...`. Otherwise, it uses `https://www.googletagmanager.com/gtag/js?id=...`."
           },
           "active": {
             "label": "Activate Google Analytics"

--- a/src/Storefront/Resources/views/storefront/component/analytics.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/analytics.html.twig
@@ -2,11 +2,12 @@
     {% block component_head_analytics_gtag %}
         {% if storefrontAnalytics and storefrontAnalytics.isActive() %}
             {% set trackingId = storefrontAnalytics.getTrackingId() %}
+            {% set trackingUrl = 'https://www.googletagmanager.com/' ~ (trackingId starts with 'GTM-' ? 'gtm.js?id=' : 'gtag/js?id=') %}
 
             <script>
                 {% block component_head_analytics_gtag_config %}
                     window.gtagActive = true;
-                    window.gtagURL = 'https://www.googletagmanager.com/gtag/js?id={{ trackingId }}';
+                    window.gtagURL = '{{ trackingUrl }}{{ trackingId }}';
                     window.controllerName = '{{ controllerName|lower }}';
                     window.actionName = '{{ controllerAction|lower }}';
                     window.trackOrders = '{{ storefrontAnalytics.isTrackOrders() }}';


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently it is not possible to use the Google Tag Manager, with an tracking ID that starts with `GTM-`, although technically all events can be used inside of the Google Tag Manager.

### 2. What does this change do, exactly?
Use the "correct" URL to include the Google Tag Manager.

### 3. Describe each step to reproduce the issue or behaviour.
Use an tracking ID like `GTM-XXXXXXXXX`

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
