### PR TITLE
Add possibility to call lifecycle commands for all plugins

### DIFF
--- a/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
+++ b/src/Core/Framework/Plugin/Command/Lifecycle/AbstractPluginLifecycleCommand.php
@@ -42,8 +42,8 @@ abstract class AbstractPluginLifecycleCommand extends Command
             ->setDescription(\sprintf('%ss given plugins', ucfirst($lifecycleMethod)))
             ->addArgument(
                 'plugins',
-                InputArgument::REQUIRED | InputArgument::IS_ARRAY,
-                'List of plugins'
+                InputArgument::IS_ARRAY,
+                'List of plugins. Leave empty for all available plugins.'
             )
             ->addOption(
                 'refresh',
@@ -166,7 +166,8 @@ abstract class AbstractPluginLifecycleCommand extends Command
         /** @var PluginCollection $pluginCollection */
         $pluginCollection = $this->pluginRepo->search($criteria, $context)->getEntities();
 
-        if ($pluginCollection->count() <= 1) {
+        // if no arguments were given and only one plugin is present, still ask
+        if ($pluginCollection->count() === 0 || (count($arguments) > 0 && $pluginCollection->count() === 1)) {
             return $pluginCollection;
         }
 
@@ -176,7 +177,7 @@ abstract class AbstractPluginLifecycleCommand extends Command
         $choice = $io->askQuestion(
             new ChoiceQuestion(
                 \sprintf(
-                    '%d plugins were found. How do you want to continue?',
+                    '%d plugin(s) found. How do you want to continue?',
                     $pluginCollection->count()
                 ),
                 [


### PR DESCRIPTION
### 1. Why is this change necessary?

Inspired by https://stackoverflow.com/questions/76574773/how-to-deploy-plugin-updates-in-a-scripted-workflow-for-shopware-6-5

### 2. What does this change do, exactly?

Let us iterate via all plugins.

### 3. Describe each step to reproduce the issue or behaviour.

For example:

```
bin/console plugin:install --activate --no-interaction
```

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
