### PR TITLE
ci: use octo-sts for backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,8 +7,7 @@ on:
       - labeled
 
 permissions:
-  contents: write
-  pull-requests: write
+  id-token: write
 
 jobs:
   backport:
@@ -24,8 +23,14 @@ jobs:
         )
       )
     steps:
+      - uses: octo-sts/action@v1.0.0
+        id: sts-shopware-backport
+        with:
+          scope: shopware
+          identity: ShopwareBackport
       - name: Backporting
         uses: kiegroup/git-backporting@main
         with:
+          auth: ${{ steps.sts-shopware-backport.outputs.token }}
           target-branch-pattern: "^backport-(?<target>([^ ]+))$"
           pull-request: ${{ github.event.pull_request.url }}


### PR DESCRIPTION
### 1. Why is this change necessary?
When we use the `GITHUB_TOKEN` of the job, the workflows doesn't get triggered on PR creation.
This is a security feature of Github https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

### 2. What does this change do, exactly?
We use a token created by octo-sts.
