### PR TITLE
feat!: Change default margin of CMS blocks

### DIFF
--- a/changelog/_unreleased/2025-02-10-change-cms-block-default-margin.md
+++ b/changelog/_unreleased/2025-02-10-change-cms-block-default-margin.md
@@ -1,0 +1,36 @@
+---
+title: Changed the default CMS block margin for default listing pages to be aligned
+issue: NEXT-39528
+---
+# Core
+* Changed the left and right margin of CMS blocks within the default listing pages to `null` so the layout is aligned with the rest of the page.
+___
+# Storefront
+* Added new inner wrapping `<div>` within `.cms-section-sidebar` in `storefront/section/cms-section-sidebar.html.twig` and moved the Bootstrap `.row` class to the new inner `<div>` element. This makes the sidebar layout compliant with Bootstrap native grid system.
+* Added new block `page_content_section_sidebar_row` in `storefront/section/cms-section-sidebar.html.twig` for the new inner row.
+* Added the gutter size variable `--#{$prefix}gutter-x` to `.cms-section-sidebar > row` within `storefront/src/scss/component/_cms-sections.scss` to control the gutter size between sidebar and listing. It is set to `60px` to maintain the original gap size.
+* Added styles for the CMS layout option class `.full-width` by extending the native Bootstrap class `.container-fluid` in `storefront/src/scss/component/_cms-sections.scss` to use regular Bootstrap styling for the container settings.
+___
+# Administration
+* Changed the general default value of CMS blocks for left and right margin to `null` so they don't cause layout issues by default.
+___
+# Upgrade Information
+
+## CMS block margins
+
+### Default settings for blocks within the Administration
+We updated the default values for the left and right margin of blocks within the Shopping Experience module. Previously, the setting within the "Layout" tab of each block was set to `20px` which led to an additional outer margin of the content that made the inner content of the page to be not aligned with the rest of the page layout. The top and bottom margin default values will stay at `20px` so blocks have a white space between each other. You can always change these settings in the "Layout" tab of your block settings. Existing pages are not affected. But, if you add new blocks to any new or existing page the new default settings will be used.
+
+### Block margins of default templates
+The locked default templates for listing pages in Shopware were also updated, so that the standard blocks don't have that margin. If you duplicated the standard templates to do your own customization, your pages won't be affected.
+
+### Bootstrap grid in sidebar sections
+We also tweaked the template of CMS sections with a sidebar to make it compliant with the Bootstrap grid system and to properly handle the margin settings. You can control the space between the sidebar and the content by simply setting the gutter variable on `.cms-section-sidebar > .row`. The current gap is `60px` wide.
+
+**Example:**
+```SCSS
+.cms-section-sidebar > .row {
+    --#{$prefix}gutter-x: 80px;
+}
+```
+

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/cross-selling/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/cross-selling/index.ts
@@ -21,8 +21,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/gallery-buybox/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/gallery-buybox/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-description-reviews/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-description-reviews/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-heading/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-heading/index.ts
@@ -21,9 +21,9 @@ Shopware.Service('cmsService').registerCmsBlock({
     previewComponent: 'sw-cms-preview-product-heading',
     defaultConfig: {
         marginTop: '20px',
-        marginLeft: '20px',
+        marginLeft: null,
         marginBottom: '20px',
-        marginRight: '20px',
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-listing/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-listing/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-slider/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-slider/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-three-column/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/commerce/product-three-column/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/form/form/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/form/form/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/html/html/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/html/html/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-bubble-row/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-bubble-row/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-four-column/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-four-column/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-gallery/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-gallery/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-highlight-row/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-highlight-row/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '40px',
         marginTop: '40px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
         backgroundColor: '#e9e9e9',
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-simple-grid/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-simple-grid/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-slider/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-slider/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-three-column/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-three-column/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-two-column/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image-two-column/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/image/image/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/sidebar/category-navigation/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/sidebar/category-navigation/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/sidebar/sidebar-filter/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/sidebar/sidebar-filter/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/center-text/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/center-text/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-bubble/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-bubble/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-gallery/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-gallery/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-row/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text-row/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/image-text/index.ts
@@ -24,8 +24,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/text-on-image/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text-image/text-on-image/index.ts
@@ -29,8 +29,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
         backgroundMedia: {
             url: '/administration/static/img/cms/preview_mountain_large.jpg',

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-hero/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-hero/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-teaser-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-teaser-section/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-teaser/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-teaser/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-three-column/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-three-column/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-two-column/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text-two-column/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/text/text/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/video/vimeo-video/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/video/vimeo-video/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/video/youtube-video/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/video/youtube-video/index.ts
@@ -22,8 +22,8 @@ Shopware.Service('cmsService').registerCmsBlock({
     defaultConfig: {
         marginBottom: '20px',
         marginTop: '20px',
-        marginLeft: '20px',
-        marginRight: '20px',
+        marginLeft: null,
+        marginRight: null,
         sizingMode: 'boxed',
     },
     slots: {

--- a/src/Core/Migration/V6_7/Migration1739197440ChangeCmsBlockDefaultMargin.php
+++ b/src/Core/Migration/V6_7/Migration1739197440ChangeCmsBlockDefaultMargin.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+class Migration1739197440ChangeCmsBlockDefaultMargin extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1739197440;
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function update(Connection $connection): void
+    {
+        $this->updateDefaultLayout($connection, 'Default listing layout');
+        $this->updateDefaultLayout($connection, 'Default listing layout with sidebar');
+        $this->updateDefaultLayout($connection, 'Default shop page layout with contact form');
+        $this->updateDefaultLayout($connection, 'Default shop page layout with newsletter form');
+    }
+
+    /**
+     * Searches for the default layout with the given translated name
+     * and updates each of its blocks with the new default margins.
+     *
+     * @param string $layoutName - The translated name of the CMS layout.
+     *
+     * @throws Exception
+     */
+    private function updateDefaultLayout(Connection $connection, string $layoutName): void
+    {
+        $layoutId = $this->findDefaultLayoutId($connection, $layoutName);
+
+        if ($layoutId) {
+            $this->updateBlockDefaultMargin($connection, $layoutId);
+        }
+    }
+
+    /**
+     * Updates all blocks within the sections of given CMS page.
+     *
+     * @throws Exception
+     */
+    private function updateBlockDefaultMargin(Connection $connection, string $cmsPageId): void
+    {
+        $sectionIds = $connection->fetchFirstColumn(
+            'SELECT LOWER(HEX(id))
+            FROM cms_section
+            WHERE cms_page_id = :cms_page_id',
+            ['cms_page_id' => $cmsPageId]
+        );
+
+        $connection->executeStatement(
+            'UPDATE cms_block
+            SET margin_left = null, margin_right = null
+            WHERE cms_section_id IN (:ids)',
+            ['ids' => Uuid::fromHexToBytesList($sectionIds)],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+    }
+
+    /**
+     * Retrieves a locked standard layout given by its translated name.
+     *
+     * @throws Exception
+     */
+    private function findDefaultLayoutId(Connection $connection, string $name): ?string
+    {
+        $result = $connection->fetchOne(
+            'SELECT cms_page_id
+            FROM cms_page_translation
+            INNER JOIN cms_page ON cms_page.id = cms_page_translation.cms_page_id
+            WHERE cms_page.locked
+            AND name = :name',
+            ['name' => $name]
+        );
+
+        return $result ?: null;
+    }
+}

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
@@ -16,8 +16,16 @@ General styling for cms sections
         @extend .container;
     }
 
+    .full-width {
+        @extend .container-fluid;
+    }
+
     .cms-section-sidebar {
         display: flex;
+
+        & > .row {
+            --#{$prefix}gutter-x: 60px;
+        }
     }
 }
 

--- a/src/Storefront/Resources/views/storefront/section/cms-section-sidebar.html.twig
+++ b/src/Storefront/Resources/views/storefront/section/cms-section-sidebar.html.twig
@@ -3,30 +3,35 @@
     {# ludtwig-ignore twig-hash-key-no-quotes #}
     {% set layout = section.sizingMode ? section.sizingMode|replace({'_': '-'}) : 'container' %}
 
-    <div class="cms-section-sidebar {{ sectionMobileBehaviorClass }} {{ layout }} row">
+    <div class="cms-section-sidebar {{ sectionMobileBehaviorClass }} {{ layout }}">
 
-        {% set sidebarBlocks = section.blocks.filterBySectionPosition('sidebar') %}
-        {% set mainContentBlocks = section.blocks.filterBySectionPosition('main') %}
+        {% block page_content_section_sidebar_row %}
+            <div class="row">
 
-        {% block section_sidebar_content %}
-            <div class="cms-section-sidebar-sidebar-content col-lg-4 col-xl-3">
+                {% set sidebarBlocks = section.blocks.filterBySectionPosition('sidebar') %}
+                {% set mainContentBlocks = section.blocks.filterBySectionPosition('main') %}
 
-                {% for block in sidebarBlocks %}
-                    {% block section_sidebar_content_block %}
-                        {% sw_include '@Storefront/storefront/section/cms-section-block-container.html.twig' %}
-                    {% endblock %}
-                {% endfor %}
-            </div>
-        {% endblock %}
+                {% block section_sidebar_content %}
+                    <div class="cms-section-sidebar-sidebar-content col-lg-4 col-xl-3">
 
-        {% block section_main_content %}
-            <div class="cms-section-sidebar-main-content col-lg-8 col-xl-9">
+                        {% for block in sidebarBlocks %}
+                            {% block section_sidebar_content_block %}
+                                {% sw_include '@Storefront/storefront/section/cms-section-block-container.html.twig' %}
+                            {% endblock %}
+                        {% endfor %}
+                    </div>
+                {% endblock %}
 
-                {% for block in mainContentBlocks %}
-                    {% block section_main_content_block %}
-                        {% sw_include '@Storefront/storefront/section/cms-section-block-container.html.twig' %}
-                    {% endblock %}
-                {% endfor %}
+                {% block section_main_content %}
+                    <div class="cms-section-sidebar-main-content col-lg-8 col-xl-9">
+
+                        {% for block in mainContentBlocks %}
+                            {% block section_main_content_block %}
+                                {% sw_include '@Storefront/storefront/section/cms-section-block-container.html.twig' %}
+                            {% endblock %}
+                        {% endfor %}
+                    </div>
+                {% endblock %}
             </div>
         {% endblock %}
     </div>

--- a/tests/migration/Core/V6_7/Migration1739197440ChangeCmsBlockDefaultMarginTest.php
+++ b/tests/migration/Core/V6_7/Migration1739197440ChangeCmsBlockDefaultMarginTest.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1739197440ChangeCmsBlockDefaultMargin;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1739197440ChangeCmsBlockDefaultMargin::class)]
+class Migration1739197440ChangeCmsBlockDefaultMarginTest extends TestCase
+{
+    use DatabaseTransactionBehaviour;
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    protected function setUp(): void
+    {
+        $this->connection = $this->getContainer()->get(Connection::class);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testChangeCmsBlockDefaultMargin(): void
+    {
+        $migration = new Migration1739197440ChangeCmsBlockDefaultMargin();
+
+        $migration->update($this->connection);
+        $migration->update($this->connection);
+
+        $this->checkLayout($this->connection, 'Default listing layout');
+        $this->checkLayout($this->connection, 'Default listing layout with sidebar');
+        $this->checkLayout($this->connection, 'Default shop page layout with contact form');
+        $this->checkLayout($this->connection, 'Default shop page layout with newsletter form');
+    }
+
+    /**
+     * Validates the blocks of the CMS page with the given translated name.
+     *
+     * @param string $layoutName - The translated name of the CMS page layout.
+     *
+     * @throws Exception
+     */
+    private function checkLayout(Connection $connection, string $layoutName): void
+    {
+        $layoutId = $this->findDefaultLayoutId($connection, $layoutName);
+        static::assertNotNull($layoutId);
+
+        $defaultListingBlocks = $this->getCmsPageBlocks($this->connection, $layoutId);
+        static::assertNotEmpty($defaultListingBlocks);
+
+        foreach ($defaultListingBlocks as $block) {
+            static::assertNull($block['margin_left']);
+            static::assertNull($block['margin_right']);
+        }
+    }
+
+    /**
+     * @throws Exception
+     */
+    private function findDefaultLayoutId(Connection $connection, string $name): ?string
+    {
+        $result = $connection->fetchOne(
+            'SELECT cms_page_id
+            FROM cms_page_translation
+            INNER JOIN cms_page ON cms_page.id = cms_page_translation.cms_page_id
+            WHERE cms_page.locked
+            AND name = :name',
+            ['name' => $name]
+        );
+
+        return $result ?: null;
+    }
+
+    /**
+     * @throws Exception
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function getCmsPageBlocks(Connection $connection, string $cmsPageId): array
+    {
+        $sectionIds = $connection->fetchFirstColumn(
+            'SELECT LOWER(HEX(id))
+            FROM cms_section
+            WHERE cms_page_id = :cms_page_id',
+            ['cms_page_id' => $cmsPageId]
+        );
+
+        return $connection->fetchAllAssociative(
+            'SELECT id, margin_left, margin_right
+            FROM cms_block
+            WHERE cms_section_id IN (:ids)',
+            ['ids' => Uuid::fromHexToBytesList($sectionIds)],
+            ['ids' => ArrayParameterType::BINARY]
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
The default layout settings of CMS blocks cause the pages to not align with the rest of the page. Currently, a value of `20px` is set as the default for left and right margins. This creates an inner gap between the inner page content and the rest of the shop layout.

### 2. What does this change do, exactly?
* The default value of blocks added to a page within the Administration will have no value for left and right margins. Users can still configure this in the "Layout" tab of the block settings.
* The block settings of the default page templates for listing, listing with sidebar, contact form, and newsletter form are adjusted to not have the `20px` left and right margin. Product detail page layouts are already correct.
* The template for the listing with a sidebar layout was slightly adjusted to correctly use the Bootstrap grid system and handle the grid gutter in association with the block changes.


![image](https://github.com/user-attachments/assets/eb1ee638-0c6d-4892-b0df-c7675e250384)



