### PR TITLE
chore: Use dev branch for conflicts package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         "scssphp/scssphp": "v1.12.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/conflicts": "0.4.0",
+        "shopware/conflicts": "6.7.x-dev",
         "shyim/opensearch-php-dsl": "^1.0.5",
         "squirrelphp/twig-php-syntax": "^1.8.0",
         "symfony/asset": "~7.2.0",


### PR DESCRIPTION
Instead of using specific versions of the conflicts package, we use a specific branch for each major version