### PR TITLE
chore: remove! implementations of EntityExtension::getDefinitionClass

### DIFF
--- a/src/Administration/Notification/Extension/IntegrationExtension.php
+++ b/src/Administration/Notification/Extension/IntegrationExtension.php
@@ -26,13 +26,6 @@ class IntegrationExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        Feature::triggerDeprecationOrThrow('v6.7.0.0', 'This class will be removed as it is unused');
-
-        return IntegrationDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         Feature::triggerDeprecationOrThrow('v6.7.0.0', 'This class will be removed as it is unused');

--- a/src/Administration/Notification/Extension/UserExtension.php
+++ b/src/Administration/Notification/Extension/UserExtension.php
@@ -26,13 +26,6 @@ class UserExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        Feature::triggerDeprecationOrThrow('v6.7.0.0', 'This class will be removed as it is unused');
-
-        return UserDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         Feature::triggerDeprecationOrThrow('v6.7.0.0', 'This class will be removed as it is unused');

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -708,18 +708,4 @@ class DataAbstractionLayerException extends HttpException
             ['class' => $class, 'required' => $required, 'hook' => $hook]
         );
     }
-
-    /**
-     * @internal
-     *
-     * @deprecated tag:v6.7.0 - reason:remove-subscriber - remove method completely not used anymore
-     */
-    public static function deprecatedDefinitionCall(): self
-    {
-        return new self(
-            Response::HTTP_INTERNAL_SERVER_ERROR,
-            self::FRAMEWORK_DEPRECATED_DEFINITION_CALL,
-            'Method getDefinitionClass is deprecated. Use getEntityName instead.'
-        );
-    }
 }

--- a/src/Core/Framework/DataAbstractionLayer/EntityExtension.php
+++ b/src/Core/Framework/DataAbstractionLayer/EntityExtension.php
@@ -28,13 +28,5 @@ abstract class EntityExtension
     {
     }
 
-    /**
-     * @deprecated tag:v6.7.0 - Implement `getEntityName` instead or use `BulkEntityExtension`
-     * Defines which entity definition should be extended by this class.
-     *
-     * When removing this method. Make sure to remove all child implementations
-     */
-    abstract public function getDefinitionClass(): string;
-
     abstract public function getEntityName(): string;
 }

--- a/src/Core/Framework/DataAbstractionLayer/ExtensionRegistry.php
+++ b/src/Core/Framework/DataAbstractionLayer/ExtensionRegistry.php
@@ -87,11 +87,11 @@ class ExtensionRegistry
             return null;
         }
 
-        return new class($fields, $definition->getClass(), $entity) extends EntityExtension {
+        return new class($fields, $entity) extends EntityExtension {
             /**
              * @param list<Field> $fields
              */
-            public function __construct(private readonly array $fields, private readonly string $class, private readonly string $entity)
+            public function __construct(private readonly array $fields, private readonly string $entity)
             {
             }
 
@@ -100,11 +100,6 @@ class ExtensionRegistry
                 foreach ($this->fields as $field) {
                     $collection->add($field);
                 }
-            }
-
-            public function getDefinitionClass(): string
-            {
-                return $this->class;
             }
 
             public function getEntityName(): string

--- a/src/Core/Framework/DataAbstractionLayer/FilteredBulkEntityExtension.php
+++ b/src/Core/Framework/DataAbstractionLayer/FilteredBulkEntityExtension.php
@@ -33,9 +33,4 @@ class FilteredBulkEntityExtension extends EntityExtension
     {
         return $this->entityName;
     }
-
-    public function getDefinitionClass(): string
-    {
-        throw DataAbstractionLayerException::deprecatedDefinitionCall();
-    }
 }

--- a/src/Core/Framework/Test/DataAbstractionLayer/EntityProtection/_fixtures/PluginProtectionExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/EntityProtection/_fixtures/PluginProtectionExtension.php
@@ -14,14 +14,6 @@ use Shopware\Core\Framework\Plugin\PluginDefinition;
  */
 class PluginProtectionExtension extends EntityExtension
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefinitionClass(): string
-    {
-        return PluginDefinition::class;
-    }
-
     public function extendProtections(EntityProtectionCollection $protections): void
     {
         $protections->add(new ReadProtection(Context::SYSTEM_SCOPE, Context::USER_SCOPE));

--- a/src/Core/Framework/Test/DataAbstractionLayer/EntityProtection/_fixtures/SystemConfigExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/EntityProtection/_fixtures/SystemConfigExtension.php
@@ -13,14 +13,6 @@ use Shopware\Core\System\SystemConfig\SystemConfigDefinition;
  */
 class SystemConfigExtension extends EntityExtension
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefinitionClass(): string
-    {
-        return SystemConfigDefinition::class;
-    }
-
     public function extendProtections(EntityProtectionCollection $protections): void
     {
         $protections->add(new WriteProtection(Context::SYSTEM_SCOPE, Context::USER_SCOPE));

--- a/src/Core/Framework/Test/DataAbstractionLayer/EntityProtection/_fixtures/UserAccessKeyExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/EntityProtection/_fixtures/UserAccessKeyExtension.php
@@ -14,14 +14,6 @@ use Shopware\Core\System\User\Aggregate\UserAccessKey\UserAccessKeyDefinition;
  */
 class UserAccessKeyExtension extends EntityExtension
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefinitionClass(): string
-    {
-        return UserAccessKeyDefinition::class;
-    }
-
     public function extendProtections(EntityProtectionCollection $protections): void
     {
         $protections->add(new ReadProtection(Context::SYSTEM_SCOPE, Context::USER_SCOPE));

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/DataAbstractionLayerFieldTestBehaviour.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/DataAbstractionLayerFieldTestBehaviour.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Test\DataAbstractionLayer\Field;
 
+use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityExtension;
@@ -150,9 +151,8 @@ trait DataAbstractionLayerFieldTestBehaviour
     {
         foreach ($extensionsClasses as $extensionsClass) {
             $extension = new $extensionsClass();
-            if (!isset($this->extensionDefinitionMap[$extensionsClass])) {
-                throw new \RuntimeException(\sprintf('Trying to remove not registered extension "%s".', $extensionsClass));
-            }
+            TestCase::assertArrayHasKey($extensionsClass, $this->extensionDefinitionMap, \sprintf('Trying to remove not registered extension "%s".', $extensionsClass));
+
             $definitionClass = $this->extensionDefinitionMap[$extensionsClass];
             if (static::getContainer()->has($definitionClass)) {
                 /** @var EntityDefinition $definition */

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/DataAbstractionLayerFieldTestBehaviour.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/DataAbstractionLayerFieldTestBehaviour.php
@@ -32,6 +32,11 @@ trait DataAbstractionLayerFieldTestBehaviour
      */
     private array $addedExtensions = [];
 
+    /**
+     * @var array<class-string<EntityExtension>, class-string<EntityDefinition>>
+     */
+    private array $extensionDefinitionMap = [];
+
     protected function tearDown(): void
     {
         $this->removeExtension(...$this->addedExtensions);
@@ -41,6 +46,7 @@ trait DataAbstractionLayerFieldTestBehaviour
         $this->addedDefinitions = [];
         $this->addedSalesChannelDefinitions = [];
         $this->addedExtensions = [];
+        $this->extensionDefinitionMap = [];
     }
 
     abstract protected static function getContainer(): ContainerInterface;
@@ -95,7 +101,7 @@ trait DataAbstractionLayerFieldTestBehaviour
      */
     protected function registerSalesChannelDefinition(string $definitionClass): EntityDefinition
     {
-        $serviceId = 'sales_channel_definition.' . $definitionClass;
+        $serviceId = $this->getSalesChannelDefinitionServiceId($definitionClass);
 
         if (static::getContainer()->has($serviceId)) {
             /** @var EntityDefinition $definition */
@@ -120,19 +126,7 @@ trait DataAbstractionLayerFieldTestBehaviour
     protected function registerDefinitionWithExtensions(string $definitionClass, string ...$extensionsClasses): EntityDefinition
     {
         $definition = $this->registerDefinition($definitionClass);
-        foreach ($extensionsClasses as $extensionsClass) {
-            $this->addedExtensions[] = $extensionsClass;
-
-            if (static::getContainer()->has($extensionsClass)) {
-                /** @var EntityExtension $extension */
-                $extension = static::getContainer()->get($extensionsClass);
-            } else {
-                $extension = new $extensionsClass();
-                static::getContainer()->set($extensionsClass, $extension);
-            }
-
-            $definition->addExtension($extension);
-        }
+        $this->registerDefinitionExtensions($extensionsClasses, $definitionClass, $definition);
 
         return $definition;
     }
@@ -144,19 +138,7 @@ trait DataAbstractionLayerFieldTestBehaviour
     protected function registerSalesChannelDefinitionWithExtensions(string $definitionClass, string ...$extensionsClasses): EntityDefinition
     {
         $definition = static::getContainer()->get(SalesChannelDefinitionInstanceRegistry::class)->get($definitionClass);
-        foreach ($extensionsClasses as $extensionsClass) {
-            $this->addedExtensions[] = $extensionsClass;
-
-            if (static::getContainer()->has($extensionsClass)) {
-                /** @var EntityExtension $extension */
-                $extension = static::getContainer()->get($extensionsClass);
-            } else {
-                $extension = new $extensionsClass();
-                static::getContainer()->set($extensionsClass, $extension);
-            }
-
-            $definition->addExtension($extension);
-        }
+        $this->registerDefinitionExtensions($extensionsClasses, $definitionClass, $definition);
 
         return $definition;
     }
@@ -168,17 +150,21 @@ trait DataAbstractionLayerFieldTestBehaviour
     {
         foreach ($extensionsClasses as $extensionsClass) {
             $extension = new $extensionsClass();
-            if (static::getContainer()->has($extension->getDefinitionClass())) {
+            if (!isset($this->extensionDefinitionMap[$extensionsClass])) {
+                throw new \RuntimeException(\sprintf('Trying to remove not registered extension "%s".', $extensionsClass));
+            }
+            $definitionClass = $this->extensionDefinitionMap[$extensionsClass];
+            if (static::getContainer()->has($definitionClass)) {
                 /** @var EntityDefinition $definition */
-                $definition = static::getContainer()->get($extension->getDefinitionClass());
+                $definition = static::getContainer()->get($definitionClass);
 
                 $definition->removeExtension($extension);
 
-                $salesChannelDefinitionId = 'sales_channel_definition.' . $extension->getDefinitionClass();
+                $salesChannelDefinitionId = $this->getSalesChannelDefinitionServiceId($definitionClass);
 
                 if (static::getContainer()->has($salesChannelDefinitionId)) {
                     /** @var EntityDefinition $definition */
-                    $definition = static::getContainer()->get('sales_channel_definition.' . $extension->getDefinitionClass());
+                    $definition = static::getContainer()->get($salesChannelDefinitionId);
 
                     $definition->removeExtension($extension);
                 }
@@ -225,6 +211,38 @@ trait DataAbstractionLayerFieldTestBehaviour
                     $this->entityClassMapping[$definition->getEntityClass()],
                 );
             }, $registry, $registry)();
+        }
+    }
+
+    /**
+     * @param class-string<EntityDefinition> $definitionClass
+     */
+    private function getSalesChannelDefinitionServiceId(string $definitionClass): string
+    {
+        return 'sales_channel_definition.' . $definitionClass;
+    }
+
+    /**
+     * @internal
+     *
+     * @param array<class-string<EntityExtension>> $extensionsClasses
+     * @param class-string<EntityDefinition> $definitionClass
+     */
+    private function registerDefinitionExtensions(array $extensionsClasses, string $definitionClass, EntityDefinition $definition): void
+    {
+        foreach ($extensionsClasses as $extensionsClass) {
+            $this->addedExtensions[] = $extensionsClass;
+            $this->extensionDefinitionMap[$extensionsClass] = $definitionClass;
+
+            if (static::getContainer()->has($extensionsClass)) {
+                /** @var EntityExtension $extension */
+                $extension = static::getContainer()->get($extensionsClass);
+            } else {
+                $extension = new $extensionsClass();
+                static::getContainer()->set($extensionsClass, $extension);
+            }
+
+            $definition->addExtension($extension);
         }
     }
 }

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/AssociationExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/AssociationExtension.php
@@ -31,11 +31,6 @@ class AssociationExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ExtendableDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return 'extendable';

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/FkFieldExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/FkFieldExtension.php
@@ -23,11 +23,6 @@ class FkFieldExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ExtendableDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return 'extendable';

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/InvalidReferenceExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/InvalidReferenceExtension.php
@@ -18,11 +18,6 @@ class InvalidReferenceExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ExtendableDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return 'extendable';

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/OneToOneInheritedProductExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/OneToOneInheritedProductExtension.php
@@ -29,11 +29,6 @@ class OneToOneInheritedProductExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ProductDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return ProductDefinition::ENTITY_NAME;

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ProductExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ProductExtension.php
@@ -25,11 +25,6 @@ class ProductExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ProductDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return ProductDefinition::ENTITY_NAME;

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ProductExtensionSelfReferenced.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ProductExtensionSelfReferenced.php
@@ -42,11 +42,6 @@ class ProductExtensionSelfReferenced extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ProductDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return 'product';

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ProductManufacturerExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ProductManufacturerExtension.php
@@ -25,11 +25,6 @@ class ProductManufacturerExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ProductManufacturerDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return ProductManufacturerDefinition::ENTITY_NAME;

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ReferenceVersionExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ReferenceVersionExtension.php
@@ -23,11 +23,6 @@ class ReferenceVersionExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ExtendableDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return 'extendable';

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ScalarExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ScalarExtension.php
@@ -18,11 +18,6 @@ class ScalarExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ExtendableDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return 'extendable';

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ScalarRuntimeExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ScalarRuntimeExtension.php
@@ -20,11 +20,6 @@ class ScalarRuntimeExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ExtendableDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return 'extendable';

--- a/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ToOneProductExtension.php
+++ b/src/Core/Framework/Test/DataAbstractionLayer/Field/TestDefinition/ToOneProductExtension.php
@@ -25,11 +25,6 @@ class ToOneProductExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ProductDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return ProductDefinition::ENTITY_NAME;

--- a/src/Storefront/Theme/Extension/LanguageExtension.php
+++ b/src/Storefront/Theme/Extension/LanguageExtension.php
@@ -20,11 +20,6 @@ class LanguageExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return LanguageDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return LanguageDefinition::ENTITY_NAME;

--- a/src/Storefront/Theme/Extension/MediaExtension.php
+++ b/src/Storefront/Theme/Extension/MediaExtension.php
@@ -25,11 +25,6 @@ class MediaExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return MediaDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return MediaDefinition::ENTITY_NAME;

--- a/src/Storefront/Theme/Extension/SalesChannelExtension.php
+++ b/src/Storefront/Theme/Extension/SalesChannelExtension.php
@@ -20,11 +20,6 @@ class SalesChannelExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return SalesChannelDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return SalesChannelDefinition::ENTITY_NAME;

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/EntitySerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/EntitySerializerTest.php
@@ -369,11 +369,6 @@ class TestExtension extends EntityExtension
         );
     }
 
-    public function getDefinitionClass(): string
-    {
-        return ProductDefinition::class;
-    }
-
     public function getEntityName(): string
     {
         return ProductDefinition::ENTITY_NAME;

--- a/tests/unit/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPassTest.php
+++ b/tests/unit/Core/System/DependencyInjection/CompilerPass/SalesChannelEntityCompilerPassTest.php
@@ -83,11 +83,6 @@ class SalesChannelEntityCompilerPassTest extends TestCase
  */
 class ProductEntityExtension extends EntityExtension
 {
-    public function getDefinitionClass(): string
-    {
-        return ProductDefinition::class;
-    }
-
     public function extendFields(FieldCollection $collection): void
     {
         $collection->add(


### PR DESCRIPTION
### 1. Why is this change necessary?

This PR removes implementations of EntityExtension::getDefinitionClass (deprecated) as a part of v6.7 preparation.

Separated from https://github.com/shopware/shopware/pull/6561 to reduce scope.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40450

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
