### PR TITLE
fix: updated ProductSearchTermInterpreter for better search ux

### DIFF
--- a/changelog/_unreleased/2025-02-12-fix-the-number-slops-to-find-numbers-between-non-digits.md
+++ b/changelog/_unreleased/2025-02-12-fix-the-number-slops-to-find-numbers-between-non-digits.md
@@ -1,0 +1,9 @@
+---
+title: Fix the number slops to find numbers between non-digits
+issue: NEXT-40382
+author: Björn Meyer
+author_email: b.meyer@shopware.com
+author_github: @BrocksiNet
+---
+# Core
+* Changed `\Shopware\Core\Content\Product\SearchKeyword\ProductSearchTermInterpreter::slop` to also find the number between non-digits.

--- a/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
+++ b/src/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreter.php
@@ -105,12 +105,11 @@ class ProductSearchTermInterpreter implements ProductSearchTermInterpreterInterf
                 'normal' => [],
                 'reversed' => [],
             ];
-            $token = (string) $token;
             $slopSize = mb_strlen($token) > 4 ? 2 : 1;
             $length = mb_strlen($token);
 
             // is too short
-            if (mb_strlen($token) <= 2) {
+            if ($length <= 2) {
                 $slops['normal'][] = $token . '%';
                 $slops['reversed'][] = $token . '%';
                 $tokenSlops[$token] = $slops;
@@ -120,7 +119,7 @@ class ProductSearchTermInterpreter implements ProductSearchTermInterpreterInterf
 
             // looks like a number
             if (\preg_match('/\d/', $token) === 1) {
-                $slops['normal'][] = $token . '%';
+                $slops['normal'][] = '%' . $token . '%';
                 $tokenSlops[$token] = $slops;
 
                 continue;

--- a/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
+++ b/tests/integration/Core/Content/Product/SearchKeyword/ProductSearchTermInterpreterTest.php
@@ -179,6 +179,10 @@ class ProductSearchTermInterpreterTest extends TestCase
                 '1000',
                 ['10000', '10001', '10002', '10007'],
             ],
+            [
+                '9000',
+                ['SW-9000'],
+            ],
             'test it uses only first 8 keywords' => [
                 '10',
                 ['10', '100', '101', '102', '103', '10000', '10001', '10002'],
@@ -447,6 +451,7 @@ class ProductSearchTermInterpreterTest extends TestCase
             'netzwerkspieler',
             'schwarzweiß',
             'netzwerkprotokolle',
+            'SW-9000',
             '10100',
             '10000',
             '10001',


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, you cannot find numbers if they are between other non-digits.

### 2. What does this change do, exactly?
The number was only found at the start of some string.
Changed the slop condition so it is also found if the number is at the end or between.

### 3. Describe each step to reproduce the issue or behaviour.
Please take a look at the newly added Unit-Test case.

### 4. Please link to the relevant issues (if any).
- closes #6354
- Other [related commit](https://github.com/shopware/shopware/commit/0e891e4203dff72694faa1c50ec7cf0c64d9e53e) to that.

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
