### PR TITLE
fix(pinia): SwCategoryDetail store initialization

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/mixin/sw-cms-element.mixin.ts
@@ -1,5 +1,6 @@
 import { defineComponent, type PropType } from 'vue';
 import { type RuntimeSlot } from '../service/cms.service';
+import '../../sw-category/page/sw-category-detail/store';
 
 const { Mixin } = Shopware;
 const { types } = Shopware.Utils;


### PR DESCRIPTION

### 1. Why is this change necessary?
Fixes initialization of the `SwCategoryDetalStore` in the CMS editor

### 2. What does this change do, exactly?
import the store to make sure it is registered


### 3. Describe each step to reproduce the issue or behaviour.
Go to CMS editor and it should work without any console error

