### PR TITLE
fix: sw-tree focusing the wrong item on focusin handler

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/index.js
@@ -357,18 +357,16 @@ Component.register('sw-tree', {
             }
 
             /* Check recursively if any tree item is active, if yes, focus on it.
-             * If no tree item is active, focus on the first tree item
+             * If no tree item is active, focus on the tree item closest to the event target.
              */
             const activeTreeItem = this.$el.querySelector('.sw-tree-item[aria-current="page"]');
 
             if (activeTreeItem) {
                 activeTreeItem.focus();
             } else {
-                const firstTreeItem = this.$el.querySelector('.sw-tree-item');
+                const closestTreeItem = event.target.closest('.sw-tree-item') || this.$el.querySelector('.sw-tree-item');
 
-                if (firstTreeItem) {
-                    firstTreeItem.focus();
-                }
+                closestTreeItem?.focus();
             }
         },
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8f53e9ab-b43e-41fc-865c-d44eaee7abe3)


### 1. Why is this change necessary?

The `sw-tree::handleFocusIn` event handler is covering multiple cases to set the browser focus on the exact `sw-tree-item` you're clicking. The fallback is focusing the root node. This is not considering interactive items inside of nodes except for input tags (expand/collapse toggle, buttons, context menus).

In one weird edge-case, this is also causing the tree to be unusable when the changing focus is scrolling up the tree, blocking you from expanding nested items. This could only be reproduced in SWAG-295075 (I'm quite confident that no extension is responsible for this) and will also be covered by this change. 

### 2. What does this change do, exactly?

Instead of focusing the root node, focus the node closest to the event target (e.g. if you expand/collapse nested items, the parent element will be focused). This way, there's no unintended scrolling and the focus stays on the correct item. 

If there's no "closest" item, the fallback will still be applied.

### 3. Describe each step to reproduce the issue or behaviour.

Use the expand/collapse toggle in any `sw-tree` (categories, product category assignments, etc.). Focus always goes to the root node of the tree.