### PR TITLE
feat: support traversing pagination for service registry client

### DIFF
--- a/src/Core/Service/AppInfo.php
+++ b/src/Core/Service/AppInfo.php
@@ -15,7 +15,9 @@ readonly class AppInfo
         public string $version,
         public string $hash,
         public string $revision,
-        public string $zipUrl
+        public string $zipUrl,
+        public ?string $hashAlgorithm = null,
+        public ?string $minShopSupportedVersion = null
     ) {
     }
 
@@ -34,11 +36,13 @@ readonly class AppInfo
             $appInfo['app-hash'],
             $appInfo['app-revision'],
             $appInfo['app-zip-url'],
+            $appInfo['app-hash-algorithm'] ?? null,
+            $appInfo['app-min-shop-supported-version'] ?? null,
         );
     }
 
     /**
-     * @return array{version: string, hash: string, revision: string, zip-url: string}
+     * @return array{version: string, hash: string, revision: string, zip-url: string, hash-algorithm: string|null, min-shop-supported-version: string|null}
      */
     public function toArray(): array
     {
@@ -47,6 +51,8 @@ readonly class AppInfo
             'hash' => $this->hash,
             'revision' => $this->revision,
             'zip-url' => $this->zipUrl,
+            'hash-algorithm' => $this->hashAlgorithm,
+            'min-shop-supported-version' => $this->minShopSupportedVersion,
         ];
     }
 }

--- a/src/Core/Service/ServiceRegistryClient.php
+++ b/src/Core/Service/ServiceRegistryClient.php
@@ -57,7 +57,7 @@ class ServiceRegistryClient implements ResetInterface
 
             $rawServices = array_merge($rawServices, $response['services']);
             ++$page;
-        } while ($page <= ($response['pagination']['pages'] ?? 1));
+        } while ($page <= ($response['pagination']['total-pages'] ?? 1));
 
         $this->services = array_map(
             static fn (array $service) => new ServiceRegistryEntry(

--- a/src/Core/Service/ServiceRegistryClient.php
+++ b/src/Core/Service/ServiceRegistryClient.php
@@ -46,42 +46,69 @@ class ServiceRegistryClient implements ResetInterface
             return $this->services;
         }
 
-        try {
-            $response = $this->client->request('GET', $this->registryUrl, [
-                'headers' => [
-                    'Accept' => 'application/json',
-                ],
-            ]);
+        $rawServices = [];
+        $page = 1;
 
-            if ($response->getStatusCode() !== 200) {
-                return [];
+        do {
+            $response = $this->fetchServices($page);
+            if ($response === null) {
+                break;
             }
 
-            $content = $response->toArray();
+            $rawServices = array_merge($rawServices, $response['services']);
+            ++$page;
+        } while ($page <= ($response['pagination']['pages'] ?? 1));
 
-            if (!$this->validateResponse($content)) {
-                return [];
-            }
+        $this->services = array_map(
+            static fn (array $service) => new ServiceRegistryEntry(
+                $service['name'],
+                $service['label'],
+                $service['host'],
+                $service['app-endpoint'],
+                (bool) ($service['activate-on-install'] ?? true),
+                $service['license-sync-endpoint'] ?? null
+            ),
+            $rawServices
+        );
 
-            return $this->services = array_map(
-                static fn (array $service) => new ServiceRegistryEntry(
-                    $service['name'],
-                    $service['label'],
-                    $service['host'],
-                    $service['app-endpoint'],
-                    (bool) ($service['activate-on-install'] ?? true),
-                    $service['license-sync-endpoint'] ?? null
-                ),
-                $content['services']
-            );
-        } catch (ExceptionInterface $e) {
-            return [];
-        }
+        return $this->services;
     }
 
     public function reset(): void
     {
         $this->services = null;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function fetchServices(int $page): ?array
+    {
+        try {
+            $response = $this->client->request('GET', $this->registryUrl, [
+                'headers' => [
+                    'Accept' => 'application/json',
+                ],
+                'query' => [
+                    'page' => $page,
+                    'limit' => 10,
+                ],
+            ]);
+
+            if ($response->getStatusCode() !== 200) {
+                return null;
+            }
+
+            $content = $response->toArray();
+
+            if (!$this->validateResponse($content)) {
+                return null;
+            }
+
+            return $content;
+        } catch (ExceptionInterface $e) {
+            return null;
+        }
     }
 
     /**

--- a/tests/unit/Core/Service/AppInfoTest.php
+++ b/tests/unit/Core/Service/AppInfoTest.php
@@ -38,20 +38,70 @@ class AppInfoTest extends TestCase
 
     public function testFromArray(): void
     {
-        $appInfo = AppInfo::fromNameAndArray('TestApp', ['app-version' => '1.0.0', 'app-hash' => 'a453f', 'app-revision' => '1.0.0-a453f', 'app-zip-url' => 'https://website.com/zip']);
+        $appInfo = AppInfo::fromNameAndArray('TestApp', [
+            'app-version' => '1.0.0',
+            'app-hash' => 'a453f',
+            'app-revision' => '1.0.0-a453f',
+            'app-zip-url' => 'https://website.com/zip',
+            'app-hash-algorithm' => 'xxh128',
+            'app-min-shop-supported-version' => '6.7.0.0'
+        ]);
+
+        static::assertSame('1.0.0', $appInfo->version);
+        static::assertSame('a453f', $appInfo->hash);
+        static::assertSame('1.0.0-a453f', $appInfo->revision);
+        static::assertSame('https://website.com/zip', $appInfo->zipUrl);
+        static::assertSame('xxh128', $appInfo->hashAlgorithm);
+        static::assertSame('6.7.0.0', $appInfo->minShopSupportedVersion);
+    }
+
+    public function testFromArrayWithNullableFields(): void
+    {
+        $appInfo = AppInfo::fromNameAndArray('TestApp', [
+            'app-version' => '1.0.0',
+            'app-hash' => 'a453f',
+            'app-revision' => '1.0.0-a453f',
+            'app-zip-url' => 'https://website.com/zip'
+        ]);
 
         static::assertEquals('1.0.0', $appInfo->version);
         static::assertEquals('a453f', $appInfo->hash);
         static::assertEquals('1.0.0-a453f', $appInfo->revision);
         static::assertEquals('https://website.com/zip', $appInfo->zipUrl);
+        static::assertNull($appInfo->hashAlgorithm);
+        static::assertNull($appInfo->minShopSupportedVersion);
     }
 
     public function testToArray(): void
     {
+        $appInfo = new AppInfo('TestApp', '1.0.0', 'a453f', '1.0.0-a453f', 'https://website.com/zip', 'xxh128', '6.7.0.0');
+
+        static::assertSame(
+            [
+                'version' => '1.0.0',
+                'hash' => 'a453f',
+                'revision' => '1.0.0-a453f',
+                'zip-url' => 'https://website.com/zip',
+                'hash-algorithm' => 'xxh128',
+                'min-shop-supported-version' => '6.7.0.0'
+            ],
+            $appInfo->toArray()
+        );
+    }
+
+    public function testToArrayWithNullableFields(): void
+    {
         $appInfo = new AppInfo('TestApp', '1.0.0', 'a453f', '1.0.0-a453f', 'https://website.com/zip');
 
-        static::assertEquals(
-            ['version' => '1.0.0', 'hash' => 'a453f', 'revision' => '1.0.0-a453f', 'zip-url' => 'https://website.com/zip'],
+        static::assertSame(
+            [
+                'version' => '1.0.0',
+                'hash' => 'a453f',
+                'revision' => '1.0.0-a453f',
+                'zip-url' => 'https://website.com/zip',
+                'hash-algorithm' => null,
+                'min-shop-supported-version' => null
+            ],
             $appInfo->toArray()
         );
     }

--- a/tests/unit/Core/Service/ServiceRegistryClientTest.php
+++ b/tests/unit/Core/Service/ServiceRegistryClientTest.php
@@ -160,12 +160,12 @@ class ServiceRegistryClientTest extends TestCase
     {
         $servicesPage1 = [
             'services' => [['name' => 'MyCoolService1', 'host' => 'https://coolservice1.com', 'label' => 'My Cool Service 1', 'app-endpoint' => '/app-endpoint']],
-            'pagination' => ['page' => 1, 'pages' => 2, 'total' => 2, 'limit' => 10],
+            'pagination' => ['page' => 1, 'pages' => 2, 'total-pages' => 2, 'limit' => 10],
         ];
 
         $servicesPage2 = [
             'services' => [['name' => 'MyCoolService2', 'host' => 'https://coolservice2.com', 'label' => 'My Cool Service 2', 'app-endpoint' => '/app-endpoint']],
-            'pagination' => ['page' => 2, 'pages' => 2, 'total' => 2, 'limit' => 10],
+            'pagination' => ['page' => 2, 'pages' => 2, 'total-pages' => 2, 'limit' => 10],
         ];
 
         $client = new MockHttpClient([

--- a/tests/unit/Core/Service/ServiceRegistryClientTest.php
+++ b/tests/unit/Core/Service/ServiceRegistryClientTest.php
@@ -50,7 +50,7 @@ class ServiceRegistryClientTest extends TestCase
         $registryClient = new ServiceRegistryClient('https://www.shopware.com/services.json', $client);
 
         static::assertEquals([], $registryClient->getAll());
-        static::assertEquals('https://www.shopware.com/services.json', $response->getRequestUrl());
+        static::assertEquals('https://www.shopware.com/services.json?page=1&limit=10', $response->getRequestUrl());
     }
 
     public function testFailRequestReturnsEmptyListOfServices(): void
@@ -62,7 +62,7 @@ class ServiceRegistryClientTest extends TestCase
         $registryClient = new ServiceRegistryClient('https://www.shopware.com/services.json', $client);
 
         static::assertEquals([], $registryClient->getAll());
-        static::assertEquals('https://www.shopware.com/services.json', $response->getRequestUrl());
+        static::assertEquals('https://www.shopware.com/services.json?page=1&limit=10', $response->getRequestUrl());
     }
 
     public function testSuccessfulRequestReturnsListOfServices(): void
@@ -93,7 +93,7 @@ class ServiceRegistryClientTest extends TestCase
         static::assertEquals('My Cool Service 2', $entries[1]->description);
         static::assertEquals('https://coolservice2.com', $entries[1]->host);
         static::assertEquals('/app-endpoint', $entries[1]->appEndpoint);
-        static::assertEquals('https://www.shopware.com/services.json', $response->getRequestUrl());
+        static::assertEquals('https://www.shopware.com/services.json?page=1&limit=10', $response->getRequestUrl());
         static::assertEquals('/license-sync-endpoint', $entries[1]->licenseSyncEndPoint);
     }
 
@@ -154,5 +154,38 @@ class ServiceRegistryClientTest extends TestCase
 
         $entries2 = $registryClient->getAll();
         static::assertCount(3, $entries2);
+    }
+
+    public function testPaginationWorks(): void
+    {
+        $servicesPage1 = [
+            'services' => [['name' => 'MyCoolService1', 'host' => 'https://coolservice1.com', 'label' => 'My Cool Service 1', 'app-endpoint' => '/app-endpoint']],
+            'pagination' => ['page' => 1, 'pages' => 2, 'total' => 2, 'limit' => 10],
+        ];
+
+        $servicesPage2 = [
+            'services' => [['name' => 'MyCoolService2', 'host' => 'https://coolservice2.com', 'label' => 'My Cool Service 2', 'app-endpoint' => '/app-endpoint']],
+            'pagination' => ['page' => 2, 'pages' => 2, 'total' => 2, 'limit' => 10],
+        ];
+
+        $client = new MockHttpClient([
+            $response1 = new MockResponse((string) json_encode($servicesPage1)),
+            $response2 = new MockResponse((string) json_encode($servicesPage2)),
+        ]);
+
+        $registryClient = new ServiceRegistryClient('https://www.shopware.com/services.json', $client);
+        $entries = $registryClient->getAll();
+
+        static::assertCount(2, $entries);
+        static::assertEquals('MyCoolService1', $entries[0]->name);
+        static::assertEquals('My Cool Service 1', $entries[0]->description);
+        static::assertEquals('https://coolservice1.com', $entries[0]->host);
+        static::assertEquals('/app-endpoint', $entries[0]->appEndpoint);
+        static::assertEquals('MyCoolService2', $entries[1]->name);
+        static::assertEquals('My Cool Service 2', $entries[1]->description);
+        static::assertEquals('https://coolservice2.com', $entries[1]->host);
+        static::assertEquals('/app-endpoint', $entries[1]->appEndpoint);
+        static::assertEquals('https://www.shopware.com/services.json?page=1&limit=10', $response1->getRequestUrl());
+        static::assertEquals('https://www.shopware.com/services.json?page=2&limit=10', $response2->getRequestUrl());
     }
 }


### PR DESCRIPTION
If the API response includes pagination, traverse it till the end.