### PR TITLE
fix: NEXT-40652 - fix field visibility for entities [6.6.10.0] 

### DIFF
--- a/src/Core/Framework/Adapter/Twig/SwTwigFunction.php
+++ b/src/Core/Framework/Adapter/Twig/SwTwigFunction.php
@@ -42,8 +42,9 @@ class SwTwigFunction
     public static function getAttribute(Environment $env, Source $source, mixed $object, mixed $item, array $arguments = [], $type = /* Template::ANY_CALL */ 'any', $isDefinedTest = false, $ignoreStrictCheck = false, bool $sandboxed = false, int $lineno = -1)
     {
         try {
-            FieldVisibility::$isInTwigRenderingContext = true;
             if ($object instanceof Struct) {
+                FieldVisibility::$isInTwigRenderingContext = true;
+
                 if ($type === Template::METHOD_CALL) {
                     // @phpstan-ignore-next-line
                     return $object->$item(...$arguments);


### PR DESCRIPTION
We get following exception "Access to property "mediaTypeRaw" not allowed on entity "Shopware\Core\Content\Media\MediaEntity"."This happens with a script hook, which is calling the product repository with associated media entities for example.

After deep digging, the error was introduced [here](https://github.com/shopware/shopware/commit/4dc8d7d9db39964e572aab2d2d8c8b5250eb71f0#diff-1b292f24d3ee694052dea3e22f4802d7957f792bde8c417dd304da5063d55739R45), as the FieldVisibility::$isInTwigRenderingContext = true; was moved outside of an if clause. This breaks all entities in script hooks with non ApiAware fields for example.