### PR TITLE
fix: Restore previous block name in configurator template

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/buy-widget/configurator.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/buy-widget/configurator.html.twig
@@ -118,7 +118,7 @@
                                                                     {% if displayType == 'media' and media or displayType == 'color' and option.colorHexCode %}
                                                                         <span class="visually-hidden">{{ option.translated.name }}</span>
                                                                     {% else %}
-                                                                        {% block page_product_detail_configurator_option_radio_label_text %}
+                                                                        {% block buy_widget_configurator_option_radio_label_text %}
                                                                             {{ option.translated.name }}
                                                                         {% endblock %}
                                                                     {% endif %}


### PR DESCRIPTION
Block name was changed by accident to `page_product_detail_configurator_option_radio_label_text` in `buy-widget/configurator.html.twig` which is a BC.

Change it back to `buy_widget_configurator_option_radio_label_text` 