### PR TITLE
fix: Improve media queries by adding indices

### DIFF
--- a/changelog/_unreleased/2025-02-07-improve-db-queries-on-media-files.md
+++ b/changelog/_unreleased/2025-02-07-improve-db-queries-on-media-files.md
@@ -1,0 +1,9 @@
+---
+title: Improve db queries on media files
+issue: NEXT-40408
+---
+# Core
+* Changed performance for media files by indexing the columns `file_name` and parts of `meta_data` for relevant queries. This change is especially noticeable when working with a large number of media files.
+___
+# API
+* Changed writing performance for `api/_action/media/{mediaId}/upload`

--- a/src/Core/Content/Media/File/FileFetcher.php
+++ b/src/Core/Content/Media/File/FileFetcher.php
@@ -46,6 +46,7 @@ class FileFetcher
             FileInfoHelper::getMimeType($fileName, $extension),
             $extension,
             $bytesWritten,
+            // Change length of db field `media`.`file_hash` if algorithm is changed
             Hasher::hashFile($fileName, 'md5')
         );
     }
@@ -85,6 +86,7 @@ class FileFetcher
             $mimeType,
             $extension,
             $writtenBytes,
+            // Change length of db field `media`.`file_hash` if algorithm is changed
             Hasher::hashFile($fileName, 'md5')
         );
     }

--- a/src/Core/Content/Media/MediaDefinition.php
+++ b/src/Core/Content/Media/MediaDefinition.php
@@ -133,6 +133,7 @@ class MediaDefinition extends EntityDefinition
             (new OneToManyAssociationField('documents', DocumentDefinition::class, 'document_media_file_id'))->addFlags(new RestrictDelete()),
             (new OneToManyAssociationField('appPaymentMethods', AppPaymentMethodDefinition::class, 'original_media_id', 'id'))->addFlags(new SetNullOnDelete()),
             (new OneToManyAssociationField('appShippingMethods', AppShippingMethodDefinition::class, 'original_media_id', 'id'))->addFlags(new SetNullOnDelete()),
+            (new StringField('file_hash', 'fileHash'))->addFlags(new Computed()),
         ]);
 
         return $fields;

--- a/src/Core/Content/Media/MediaEntity.php
+++ b/src/Core/Content/Media/MediaEntity.php
@@ -843,13 +843,24 @@ class MediaEntity extends Entity
         return $this->mediaType instanceof SpatialObjectType;
     }
 
+    /**
+     * @internal
+     */
     public function getFileHash(): ?string
     {
         return $this->fileHash;
     }
 
-    private function setFileHash(): never
+    /**
+     * @internal
+     */
+    protected function setFileHash(?string $fileHash): void
     {
-        throw new \BadMethodCallException('The file hash is a computed field and cannot be set');
+        if ($fileHash === null) {
+            unset($this->metaData['file_hash']);
+        } else {
+            $this->metaData['file_hash'] = $fileHash;
+        }
+        $this->fileHash = $fileHash;
     }
 }

--- a/src/Core/Content/Media/MediaEntity.php
+++ b/src/Core/Content/Media/MediaEntity.php
@@ -330,6 +330,11 @@ class MediaEntity extends Entity
      */
     protected ?array $config;
 
+    /**
+     * @internal
+     */
+    protected ?string $fileHash = null;
+
     public function get(string $property)
     {
         if ($property === 'hasFile') {
@@ -836,5 +841,15 @@ class MediaEntity extends Entity
     public function isSpatialObject(): bool
     {
         return $this->mediaType instanceof SpatialObjectType;
+    }
+
+    public function getFileHash(): ?string
+    {
+        return $this->fileHash;
+    }
+
+    private function setFileHash(): never
+    {
+        throw new \BadMethodCallException('The file hash is a computed field and cannot be set');
     }
 }

--- a/src/Core/Migration/V6_6/Migration1738661307AddMediaIndices.php
+++ b/src/Core/Migration/V6_6/Migration1738661307AddMediaIndices.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_6;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1738661307AddMediaIndices extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1738661307;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->dropIndexIfExists($connection, 'media', 'idx.media.file_extension');
+        $connection->executeStatement(/** @lang MySQL */ 'CREATE INDEX `idx.media.file_extension` ON `media` (`file_extension`);');
+
+        $this->dropIndexIfExists($connection, 'media', 'idx.media.file_name');
+        $connection->executeStatement(/** @lang MySQL */ 'CREATE INDEX `idx.media.file_name` ON `media` (`file_name`(768));');
+
+        if (!$this->columnExists($connection, 'media', 'file_hash')) {
+            $connection->executeStatement(
+                <<<SQL
+                ALTER TABLE `media` ADD COLUMN `file_hash` VARCHAR(32) GENERATED ALWAYS AS (
+                    JSON_UNQUOTE(meta_data->"$.hash")
+                    ) STORED;
+                SQL
+            );
+        }
+
+        $this->dropIndexIfExists($connection, 'media', 'idx.media.file_hash');
+        $connection->executeStatement(/** @lang MySQL */ 'CREATE INDEX `idx.media.file_hash` ON `media` (`file_hash`);');
+    }
+}

--- a/src/Core/Migration/V6_6/Migration1738661307AddMediaIndices.php
+++ b/src/Core/Migration/V6_6/Migration1738661307AddMediaIndices.php
@@ -20,10 +20,20 @@ class Migration1738661307AddMediaIndices extends MigrationStep
     public function update(Connection $connection): void
     {
         $this->dropIndexIfExists($connection, 'media', 'idx.media.file_extension');
-        $connection->executeStatement(/** @lang MySQL */ 'CREATE INDEX `idx.media.file_extension` ON `media` (`file_extension`);');
+        $connection->executeStatement(
+            <<<SQL
+            CREATE INDEX `idx.media.file_extension`
+                ON `media` (`file_extension`);
+            SQL
+        );
 
         $this->dropIndexIfExists($connection, 'media', 'idx.media.file_name');
-        $connection->executeStatement(/** @lang MySQL */ 'CREATE INDEX `idx.media.file_name` ON `media` (`file_name`(768));');
+        $connection->executeStatement(
+            <<<'SQL'
+            CREATE INDEX `idx.media.file_name`
+                ON `media` (`file_name`(768));
+            SQL
+        );
 
         if (!$this->columnExists($connection, 'media', 'file_hash')) {
             $connection->executeStatement(

--- a/src/Core/Migration/V6_6/Migration1738661307AddMediaIndices.php
+++ b/src/Core/Migration/V6_6/Migration1738661307AddMediaIndices.php
@@ -46,6 +46,11 @@ class Migration1738661307AddMediaIndices extends MigrationStep
         }
 
         $this->dropIndexIfExists($connection, 'media', 'idx.media.file_hash');
-        $connection->executeStatement(/** @lang MySQL */ 'CREATE INDEX `idx.media.file_hash` ON `media` (`file_hash`);');
+        $connection->executeStatement(
+            <<<SQL
+            CREATE INDEX `idx.media.file_hash`
+                ON `media` (`file_hash`);
+            SQL
+        );
     }
 }

--- a/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
+++ b/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
@@ -56,6 +56,16 @@ class Migration1738661307AddMediaIndicesTest extends TestCase
                 SQL
             );
         }
+
+        foreach (['idx.media.file_extension', 'idx.media.file_name', 'idx.media.file_hash'] as $indexName) {
+            if ($this->hasIndex($indexName)) {
+                $this->connection->executeStatement(
+                    <<<SQL
+                    ALTER TABLE `media` DROP INDEX `$indexName`;
+                    SQL
+                );
+            }
+        }
     }
 
     /**

--- a/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
+++ b/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
@@ -26,9 +26,9 @@ class Migration1738661307AddMediaIndicesTest extends TestCase
         $this->connection = static::getContainer()->get(Connection::class);
     }
 
-    public function testTimestamp()
+    public function testTimestamp(): void
     {
-        self::assertSame(1738661307, (new Migration1738661307AddMediaIndices())->getCreationTimestamp());
+        static::assertSame(1738661307, (new Migration1738661307AddMediaIndices())->getCreationTimestamp());
     }
 
     public function testMigration(): void

--- a/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
+++ b/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_6;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Migration\V6_6\Migration1738661307AddMediaIndices;
+
+/**
+ * @internal
+ */
+#[CoversClass(Migration1738661307AddMediaIndices::class)]
+class Migration1738661307AddMediaIndicesTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    private Connection $connection;
+
+    private string $tableName = 'media';
+
+    protected function setUp(): void
+    {
+        $this->connection = static::getContainer()->get(Connection::class);
+    }
+
+    public function testMigration(): void
+    {
+        // Test multiple execution
+        $this->migrate();
+        $this->migrate();
+
+        static::assertTrue($this->hasIndex('idx.media.file_extension', ['file_extension']));
+        static::assertTrue($this->hasIndex('idx.media.file_name', ['file_name']));
+        static::assertTrue($this->hasColumn('file_hash'));
+        static::assertTrue($this->hasIndex('idx.media.file_hash', ['file_hash']));
+    }
+
+    private function migrate(): void
+    {
+        (new Migration1738661307AddMediaIndices())->update($this->connection);
+    }
+
+    /**
+     * @param list<string> $spansColumns Also test if the index covers the given columns
+     */
+    private function hasIndex(string $indexName, array $spansColumns = []): bool
+    {
+        $manager = $this->connection->createSchemaManager();
+        $indices = $manager->listTableIndexes($this->tableName);
+
+        return \array_key_exists($indexName, $indices)
+            && $indices[$indexName]->spansColumns($spansColumns);
+    }
+
+    private function hasColumn(string $columnName): bool
+    {
+        $manager = $this->connection->createSchemaManager();
+        $columns = $manager->listTableColumns($this->tableName);
+
+        return \array_key_exists($columnName, $columns);
+    }
+}

--- a/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
+++ b/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
@@ -19,8 +19,6 @@ class Migration1738661307AddMediaIndicesTest extends TestCase
 
     private Connection $connection;
 
-    private string $tableName = 'media';
-
     protected function setUp(): void
     {
         $this->connection = static::getContainer()->get(Connection::class);
@@ -54,7 +52,7 @@ class Migration1738661307AddMediaIndicesTest extends TestCase
         if ($this->hasColumn('file_hash')) {
             $this->connection->executeStatement(
                 <<<SQL
-                ALTER TABLE `{$this->tableName}` DROP COLUMN `file_hash`;
+                ALTER TABLE `media` DROP COLUMN `file_hash`;
                 SQL
             );
         }
@@ -66,7 +64,7 @@ class Migration1738661307AddMediaIndicesTest extends TestCase
     private function hasIndex(string $indexName, array $spansColumns = []): bool
     {
         $manager = $this->connection->createSchemaManager();
-        $indices = $manager->listTableIndexes($this->tableName);
+        $indices = $manager->listTableIndexes('media');
 
         return \array_key_exists($indexName, $indices)
             && $indices[$indexName]->spansColumns($spansColumns);
@@ -74,6 +72,6 @@ class Migration1738661307AddMediaIndicesTest extends TestCase
 
     private function hasColumn(string $columnName): bool
     {
-        return EntityDefinitionQueryHelper::columnExists($this->connection, $this->tableName, $columnName);
+        return EntityDefinitionQueryHelper::columnExists($this->connection, 'media', $columnName);
     }
 }

--- a/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
+++ b/tests/migration/Core/V6_6/Migration1738661307AddMediaIndicesTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Migration\Core\V6_6;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Migration\V6_6\Migration1738661307AddMediaIndices;
 
@@ -25,8 +26,14 @@ class Migration1738661307AddMediaIndicesTest extends TestCase
         $this->connection = static::getContainer()->get(Connection::class);
     }
 
+    public function testTimestamp()
+    {
+        self::assertSame(1738661307, (new Migration1738661307AddMediaIndices())->getCreationTimestamp());
+    }
+
     public function testMigration(): void
     {
+        $this->undoMigration();
         // Test multiple execution
         $this->migrate();
         $this->migrate();
@@ -40,6 +47,17 @@ class Migration1738661307AddMediaIndicesTest extends TestCase
     private function migrate(): void
     {
         (new Migration1738661307AddMediaIndices())->update($this->connection);
+    }
+
+    private function undoMigration(): void
+    {
+        if ($this->hasColumn('file_hash')) {
+            $this->connection->executeStatement(
+                <<<SQL
+                ALTER TABLE `{$this->tableName}` DROP COLUMN `file_hash`;
+                SQL
+            );
+        }
     }
 
     /**
@@ -56,9 +74,6 @@ class Migration1738661307AddMediaIndicesTest extends TestCase
 
     private function hasColumn(string $columnName): bool
     {
-        $manager = $this->connection->createSchemaManager();
-        $columns = $manager->listTableColumns($this->tableName);
-
-        return \array_key_exists($columnName, $columns);
+        return EntityDefinitionQueryHelper::columnExists($this->connection, $this->tableName, $columnName);
     }
 }


### PR DESCRIPTION
NEXT-40408

Add indices to improve checks for existing media files when adding or modifying media. This improves performance when working with many media files.