### PR TITLE
fix: sw-tree focusing the wrong item on focusin handler

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/index.js
@@ -365,18 +365,16 @@ Component.register('sw-tree', {
             }
 
             /* Check recursively if any tree item is active, if yes, focus on it.
-             * If no tree item is active, focus on the first tree item
+             * If no tree item is active, focus on the tree item closest to the event target.
              */
             const activeTreeItem = this.$el.querySelector('.sw-tree-item[aria-current="page"]');
 
             if (activeTreeItem) {
                 activeTreeItem.focus();
             } else {
-                const firstTreeItem = this.$el.querySelector('.sw-tree-item');
+                const closestTreeItem = event.target.closest('.sw-tree-item') || this.$el.querySelector('.sw-tree-item');
 
-                if (firstTreeItem) {
-                    firstTreeItem.focus();
-                }
+                closestTreeItem?.focus();
             }
         },
 


### PR DESCRIPTION
Backport of https://github.com/shopware/shopware/pull/6758