### PR TITLE
chore: fix devenv process manager deprecation

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -21,7 +21,7 @@ in {
   ];
 
   # Fix .env loading
-  process.implementation = lib.mkDefault "honcho";
+  process.manager.implementation = lib.mkDefault "honcho";
 
   dotenv.disableHint = true;
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The current devenv.nix triggers a deprecation because it uses the old `process.manager` option.

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
