### PR TITLE
fix: Import of customer with custom profile which uses identifiers

### DIFF
--- a/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/LanguageSerializer.php
+++ b/src/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/LanguageSerializer.php
@@ -45,7 +45,7 @@ class LanguageSerializer extends EntitySerializer implements ResetInterface
             }
 
             if ($language) {
-                $deserialized = array_merge_recursive($deserialized, $language);
+                $deserialized = array_merge($deserialized, $language);
             }
         }
 

--- a/src/Core/Content/ImportExport/ImportExportProfileEntity.php
+++ b/src/Core/Content/ImportExport/ImportExportProfileEntity.php
@@ -43,14 +43,14 @@ class ImportExportProfileEntity extends Entity
      */
     protected ?array $updateBy = [];
 
-    protected ?ImportExportLogCollection $importExportLogs;
+    protected ?ImportExportLogCollection $importExportLogs = null;
 
     /**
      * @var array<string, mixed>
      */
     protected array $config;
 
-    protected ?ImportExportProfileTranslationCollection $translations;
+    protected ?ImportExportProfileTranslationCollection $translations = null;
 
     public function getTechnicalName(): string
     {

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationEntity.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationEntity.php
@@ -24,7 +24,7 @@ class MailTemplateTranslationEntity extends TranslationEntity
 
     protected ?string $contentPlain = null;
 
-    protected ?MailTemplateEntity $mailTemplate;
+    protected ?MailTemplateEntity $mailTemplate = null;
 
     public function getMailTemplateId(): string
     {

--- a/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/LanguageSerializerTest.php
+++ b/tests/integration/Core/Content/ImportExport/DataAbstractionLayer/Serializer/Entity/LanguageSerializerTest.php
@@ -39,12 +39,14 @@ class LanguageSerializerTest extends TestCase
 
     public function testSimple(): void
     {
-        $this->createCountry();
+        $localeId = Uuid::randomHex();
+        $this->createCountry($localeId);
 
         $config = new Config([], [], []);
         $language = [
             'locale' => [
                 'code' => 'xx-XX',
+                'id' => $localeId,
             ],
         ];
 
@@ -53,6 +55,7 @@ class LanguageSerializerTest extends TestCase
         $deserialized = iterator_to_array($this->serializer->deserialize($config, $this->languageRepository->getDefinition(), $serialized));
 
         static::assertSame($this->languageId, $deserialized['id']);
+        static::assertSame($localeId, $deserialized['locale']['id']);
     }
 
     public function testSupportsOnlyCountry(): void
@@ -74,9 +77,8 @@ class LanguageSerializerTest extends TestCase
         }
     }
 
-    private function createCountry(): void
+    private function createCountry(string $localeId): void
     {
-        $localeId = Uuid::randomHex();
         $this->languageRepository->upsert([
             [
                 'id' => $this->languageId,


### PR DESCRIPTION
### array_merge vs array_merge_recursive

```PHP
$arrayOne = [
    'locale' => [
        'code' => 'xx-XX',
        'id' => 1,
    ],
];

$arrayTwo = [
    'locale' => [
        'code' => 'xx-XX',
        'id' => 1,
    ],
];
```



**RESULT OF: array_merge_recursive**
```PHP
array (
  'locale' => 
  array (
    'code' => 
    array (
      0 => 'xx-XX',
      1 => 'xx-XX',
    ),
    'id' => 
    array (
      0 => 1,
      1 => 1,
    ),
  ),
)
```


**RESULT OF: array_merge:** 
```PHP
array (
  'locale' => 
  array (
    'code' => 'xx-XX',
    'id' => 1,
  ),
)
```


In our case, we expect a string as id of the locale, and not an array