### PR TITLE
fix: Remove root navigation category ID from path list

### DIFF
--- a/src/Storefront/Framework/Twig/TemplateDataExtension.php
+++ b/src/Storefront/Framework/Twig/TemplateDataExtension.php
@@ -90,14 +90,10 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
 
     private function minSearchLength(SalesChannelContext $context): int
     {
-        $query = $this->connection->createQueryBuilder();
-
-        $query->select('min_search_length')
-            ->from('product_search_config')
-            ->where('language_id = :id')
-            ->setParameter('id', Uuid::fromHexToBytes($context->getLanguageId()));
-
-        $min = (int) $query->executeQuery()->fetchOne();
+        $min = (int) $this->connection->fetchOne(
+            'SELECT `min_search_length` FROM `product_search_config` WHERE `language_id` = :id',
+            ['id' => Uuid::fromHexToBytes($context->getLanguageId())]
+        );
 
         return $min ?: AbstractTokenFilter::DEFAULT_MIN_SEARCH_TERM_LENGTH;
     }
@@ -113,6 +109,7 @@ class TemplateDataExtension extends AbstractExtension implements GlobalsInterfac
         ) ?: '';
 
         $navigationPathIdList = array_filter(explode('|', $path));
+        $navigationPathIdList = array_diff($navigationPathIdList, [$context->getSalesChannel()->getNavigationCategoryId()]);
 
         return array_values($navigationPathIdList);
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

Before this change, the root navigation category ID was part of the path, but this leads to wrong shown active categories. 

### 2. What does this change do, exactly?

Remove the root ID from the path list. 

### 3. Describe each step to reproduce the issue or behaviour.

Create some categories and navigate to a child category. the "Home" category is always shown as active.

### 4. Please link to the relevant issues (if any).
n/a

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
