### PR TITLE
chore(ci): enable repo split for protected branches

### DIFF
--- a/.github/bin/check_workflow.bash
+++ b/.github/bin/check_workflow.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ -n "${DEBUG:-}" ]]; then
+if [ -n "${DEBUG:-}" ] || [ -n "${ACTIONS_STEP_DEBUG:-}" ]; then
   set -x
 fi
 

--- a/.github/bin/compile_deployment_info.sh
+++ b/.github/bin/compile_deployment_info.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-if [ -n "${DEBUG:-}" ]; then
+if [ -n "${DEBUG:-}" ] || [ -n "${ACTIONS_STEP_DEBUG:-}" ]; then
   set -x
 fi
 

--- a/.github/bin/create_github_release.bash
+++ b/.github/bin/create_github_release.bash
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-if [ -n "${DEBUG:-}" ]; then
+if [ -n "${DEBUG:-}" ] || [ -n "${ACTIONS_STEP_DEBUG:-}" ]; then
     set -x
 fi
 

--- a/.github/bin/sbp_release.bash
+++ b/.github/bin/sbp_release.bash
@@ -3,7 +3,7 @@ set -eu
 
 set -o pipefail
 
-if [ -n "${DEBUG:-}" ]; then
+if [ -n "${DEBUG:-}" ] || [ -n "${ACTIONS_STEP_DEBUG:-}" ]; then
     set -x
 fi
 

--- a/.github/bin/split.bash
+++ b/.github/bin/split.bash
@@ -111,7 +111,7 @@ require_core_version() {
   if [ "${package_lower}" != "core" ]; then
     if [[ $type != "tag" ]]; then
       # version like add dev at the end
-      if grep -q -E '^[0-9]'; then
+      if echo -n "${version}" | grep -q -E '^[0-9]'; then
         version="${version}-dev"
       else
         version="dev-${version}"
@@ -219,7 +219,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     set -o errexit
     set -o pipefail
 
-    if [ -n "${DEBUG:-}" ]; then
+    if [ -n "${DEBUG:-}" ] || [ -n "${ACTIONS_STEP_DEBUG:-}" ]; then
         set -x
     fi
 

--- a/.github/workflows/05-prepare-release.yml
+++ b/.github/workflows/05-prepare-release.yml
@@ -132,6 +132,10 @@ jobs:
         if: github.ref_type != 'tag' && !github.ref_protected
         run: |
           bash .github/bin/split.bash branch "${{ matrix.package }}" "tmp-${{ github.sha }}"
+      - name: Create named branch
+        if: github.ref_type != 'tag' && github.ref_protected
+        run: |
+          bash .github/bin/split.bash branch "${{ matrix.package }}" "${{ github.ref_name }}"
       - name: Push
         if: github.ref_type == 'tag' || github.ref_protected
         run: |


### PR DESCRIPTION
- **chore(ci): support protected branches in repo split**
- **chore(ci): take GitHub Actions debug indicator into account**
---

The repo split is [currently failing](https://github.com/shopware/shopware/actions/runs/13320848055/job/37220402735#step:14:68) in the `6.6.x` nightly, since we're trying to push `refs/heads/6.6.x`, while the local split repository only has `refs/heads/main` (or whatever comes out of `git config --global init.defaultBranch` with `trunk` as a fallback). This additional step will explicitly create a branch named after the git ref, when running for protected branches.