### PR TITLE
fix: shortcut to payment methods

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/init/shortcut.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/shortcut.init.ts
@@ -64,7 +64,7 @@ function defaultShortcutMap() {
         { combination: 'GN', path: '/sw/newsletter/recipient/index' },
         { combination: 'GS', path: '/sw/settings/index' },
         { combination: 'GSN', path: '/sw/settings/snippet/index' },
-        { combination: 'GSP', path: '/sw/settings/payment/index' },
+        { combination: 'GSP', path: '/sw/settings/payment/overview' },
         { combination: 'GSS', path: '/sw/settings/shipping/index' },
         { combination: 'GSR', path: '/sw/settings/rule/index' },
         { combination: 'GA', path: '/sw/extension/my-extensions/listing/app' },


### PR DESCRIPTION
### 1. Why is this change necessary?
Documentation lead users to use shortcut which ended up taking them to the incorrect page

### 2. What does this change do, exactly?
just updated the target url for `GSP` shortcut

### 3. Describe each step to reproduce the issue or behaviour.
Press keys G+S+P in quick succession and see nothing.

### 4. Please link to the relevant issues (if any).
Closes #5340 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
