### PR TITLE
fix: Removed the total count mode when selecting products during order creation in the administration

### DIFF
--- a/changelog/_unreleased/2024-12-26-removed-the-total-count-mode-when-selecting-products-during-order-creation-in-the-administration.md
+++ b/changelog/_unreleased/2024-12-26-removed-the-total-count-mode-when-selecting-products-during-order-creation-in-the-administration.md
@@ -1,0 +1,6 @@
+---
+title: Removed the total count mode when selecting products during order creation in the administration.
+issue: NEXT-40175
+---
+# Administration
+* Changed component `sw-order-product-select` to remove the total count mode from `productCriteria` when selecting products.

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-product-select/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-product-select/index.js
@@ -80,6 +80,7 @@ export default {
 
             criteria.addFilter(Criteria.equals('visibilities.salesChannelId', this.salesChannelId));
             criteria.addFilter(Criteria.equals('active', true));
+            criteria.setTotalCountMode(0);
 
             return criteria;
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-product-select/sw-order-product-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-product-select/sw-order-product-select.spec.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import {mount} from '@vue/test-utils';
 
 /**
  * @sw-package checkout
@@ -214,5 +214,12 @@ describe('src/module/sw-order/component/sw-order-product-select', () => {
         expect(criteria.filters[2].type).toBe('equals');
         expect(criteria.filters[2].field).toBe('active');
         expect(criteria.filters[2].value).toBe(true);
+    });
+
+    it('has correct criteria with total count mode is zero', async () => {
+        const wrapper = await createWrapper();
+        const criteria = wrapper.vm.productCriteria;
+
+        expect(criteria.totalCountMode).toBe(0);
     });
 });


### PR DESCRIPTION
Cherry-picked from https://github.com/shopware/shopware/pull/5964