### PR TITLE
fix: Enable tests again and fix their execution

### DIFF
--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewsWidgetLoadedHook;
 use Shopware\Core\Content\Test\Product\ProductBuilder;
 use Shopware\Core\Defaults;
+use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Feature;
@@ -20,6 +21,7 @@ use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Test\TestCaseBase\SalesChannelApiTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\PlatformRequest;
+use Shopware\Core\SalesChannelRequest;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -292,12 +294,11 @@ class ProductControllerTest extends TestCase
      */
     public static function variantProvider(): iterable
     {
-        // TODO: Executing those cases will lead to a Twig error, caused by the cache_rework. Needs further investigation
-        //        yield 'test color: red - size: xl' => ['a.1', true, false, true, true, true]; // a.1 all options should be normal
-        //        yield 'test color: green - size: xl' => ['a.2', true, false, true, true, false]; // a.2 green and xl should be gray
-        //        yield 'test color: red - size: l' => ['a.3', false, true, true, true, true]; // a.3 all options should be normal except blue
-        //        yield 'test color: green - size: l' => ['a.4', false, true, true, true, false]; // a.4 xl and blue should be gray
-        //        yield 'test color: blue - size: xl' => ['a.5', true, false, true, false, true]; // a.5 l, green should be gray
+        yield 'test color: red - size: xl' => ['a.1', true, false, true, true, true]; // a.1 all options should be normal
+        yield 'test color: green - size: xl' => ['a.2', true, false, true, true, false]; // a.2 green and xl should be gray
+        yield 'test color: red - size: l' => ['a.3', false, true, true, true, true]; // a.3 all options should be normal except blue
+        yield 'test color: green - size: l' => ['a.4', false, true, true, true, false]; // a.4 xl and blue should be gray
+        yield 'test color: blue - size: xl' => ['a.5', true, false, true, false, true]; // a.5 l, green should be gray
         yield 'test color: blue - size: l' => ['a.6', false, false, false, false, false, true]; // a.6 xl should throw exception
         yield 'test color: red - size: m' => ['a.7', false, false, false, false, false, true]; // a.7 m should throw exception
         yield 'test color: green - size: m' => ['a.8', false, false, false, false, false, true]; // a.8 m should throw exception
@@ -362,11 +363,12 @@ class ProductControllerTest extends TestCase
 
     private function createDetailRequest(SalesChannelContext $context, string $productId): Request
     {
-        $request = new Request();
+        $request = Request::create((string) EnvironmentHelper::getVariable('APP_URL'));
         $request->attributes->set(RequestTransformer::STOREFRONT_URL, $_SERVER['APP_URL']);
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $context);
         $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, $context->getSalesChannelId());
         $request->attributes->set('productId', $productId);
+        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST, true);
 
         static::getContainer()->get('request_stack')->push($request);
 

--- a/tests/integration/Storefront/Controller/ProductControllerTest.php
+++ b/tests/integration/Storefront/Controller/ProductControllerTest.php
@@ -364,11 +364,13 @@ class ProductControllerTest extends TestCase
     private function createDetailRequest(SalesChannelContext $context, string $productId): Request
     {
         $request = Request::create((string) EnvironmentHelper::getVariable('APP_URL'));
-        $request->attributes->set(RequestTransformer::STOREFRONT_URL, $_SERVER['APP_URL']);
-        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT, $context);
-        $request->attributes->set(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, $context->getSalesChannelId());
-        $request->attributes->set('productId', $productId);
-        $request->attributes->set(SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST, true);
+        $request->attributes->add([
+            RequestTransformer::STOREFRONT_URL => $_SERVER['APP_URL'],
+            PlatformRequest::ATTRIBUTE_SALES_CHANNEL_CONTEXT_OBJECT => $context,
+            PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID => $context->getSalesChannelId(),
+            'productId' => $productId,
+            SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST => true,
+        ]);
 
         static::getContainer()->get('request_stack')->push($request);
 


### PR DESCRIPTION
Executing `ProductControllerTest::testVariantGrayedOut` (and similar to the two failing test of the CheckoutControllerTest) always failed on the second case of the data provider.

The reason is the creation of the request for the test and the [RequestStackTestBehaviour](https://github.com/shopware/shopware/blob/trunk/src/Core/Framework/Test/TestCaseBase/RequestStackTestBehaviour.php#L43) trait.
Before the change the requests were created quite blank. E.g. host defaults to `localhost`. For the first case, this is no problem, but after the first case the trait sets a new RouterContext with the configured `APP_URL`. 
Now on the second case the value for host in the test request and in the RouterContext **differ**. That causes the subrequests executed for ESI (that is why it is failing in the first place after the removal of the CACHE_REWORK flag), somehow to loose their connection to the parent request. That again causes Symfony after the first ESI call to create a new request(context) without host. that is the reason why the ESI call fails only for the footer, but not for the header. 

So initially creating the test request with the `APP_URL` fixes this problem. 

Additionally the request attribute `SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST` needs to be set to `true`, so `\Shopware\Core\Framework\Routing\RouteScopeListener::checkScope` is validating correctly. 