### PR TITLE
fix: disallow 9.2.0 oauth-server to fix auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
             "symfony/runtime": true
         }
     },
+    "conflict": {
+        "league/oauth2-server": "9.2.0"
+    },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-curl": "*",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -47,6 +47,9 @@
         "symfony/polyfill-php82": "*",
         "paragonie/random_compat": "*"
     },
+    "conflict": {
+        "league/oauth2-server": "9.2.0"
+    },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-curl": "*",


### PR DESCRIPTION
Auth is broken with league/oauth-server:9.2.0
