### PR TITLE
feat: enable ios ar quick look for chrome

### DIFF
--- a/changelog/_unreleased/2025-02-17-ios-quick-look-chrome.md
+++ b/changelog/_unreleased/2025-02-17-ios-quick-look-chrome.md
@@ -1,0 +1,9 @@
+---
+title:              iOS Quick Look Chrome
+issue:              NEXT-37218
+author:             Dennis Höllmann
+author_email:       d.hoellmann@shopware.com
+author_github:      @Deristes
+---
+# Storefront
+*  Changed method `supportQuickLook` to return true for supported browsers on iOS

--- a/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/arSupportChecker.ts
+++ b/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/arSupportChecker.ts
@@ -26,13 +26,16 @@ export function supportQuickLook(): boolean {
 
     // Other Browser support
     const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
-
+    const iosVersion = navigator.userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
+    if (!isIos || !iosVersion) { return false; }
+    if (parseInt(iosVersion[1], 10) < 12) { return false; }
+    
     // These browsers currently support AR Quick Look on iOS
     const isChromeOrVivaldi = /CriOS/.test(navigator.userAgent);
     const isEdge = /EdgiOS/.test(navigator.userAgent);
     const isDuckDuckGo = /Ddg/.test(navigator.userAgent);
 
-    if(isIos && (isChromeOrVivaldi || isEdge || isDuckDuckGo)) {
+    if(isChromeOrVivaldi || isEdge || isDuckDuckGo) {
         return true;
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/arSupportChecker.ts
+++ b/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/arSupportChecker.ts
@@ -35,9 +35,7 @@ export function supportQuickLook(): boolean {
     const isEdge = /EdgiOS/.test(navigator.userAgent);
     const isDuckDuckGo = /Ddg/.test(navigator.userAgent);
 
-    if(isChromeOrVivaldi || isEdge || isDuckDuckGo) {
-        return true;
-    }
+    return isChromeOrVivaldi || isEdge || isDuckDuckGo;
 }
 
 /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/arSupportChecker.ts
+++ b/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/arSupportChecker.ts
@@ -20,7 +20,7 @@ export async function supportsAr(): Promise<boolean> {
 export function supportQuickLook(): boolean {
     // Native IOS Support (Safari)
     const a = document.createElement('a');
-    if(a.relList.supports('ar')) {
+    if (a.relList.supports('ar')) {
         return true;
     }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/arSupportChecker.ts
+++ b/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/arSupportChecker.ts
@@ -29,7 +29,7 @@ export function supportQuickLook(): boolean {
     const iosVersion = navigator.userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
     if (!isIos || !iosVersion) { return false; }
     if (parseInt(iosVersion[1], 10) < 12) { return false; }
-    
+
     // These browsers currently support AR Quick Look on iOS
     const isChromeOrVivaldi = /CriOS/.test(navigator.userAgent);
     const isEdge = /EdgiOS/.test(navigator.userAgent);

--- a/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/arSupportChecker.ts
+++ b/src/Storefront/Resources/app/storefront/src/plugin/spatial/utils/ar/arSupportChecker.ts
@@ -18,8 +18,23 @@ export async function supportsAr(): Promise<boolean> {
  * @returns {boolean}
  */
 export function supportQuickLook(): boolean {
+    // Native IOS Support (Safari)
     const a = document.createElement('a');
-    return a.relList.supports('ar');
+    if(a.relList.supports('ar')) {
+        return true;
+    }
+
+    // Other Browser support
+    const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+
+    // These browsers currently support AR Quick Look on iOS
+    const isChromeOrVivaldi = /CriOS/.test(navigator.userAgent);
+    const isEdge = /EdgiOS/.test(navigator.userAgent);
+    const isDuckDuckGo = /Ddg/.test(navigator.userAgent);
+
+    if(isIos && (isChromeOrVivaldi || isEdge || isDuckDuckGo)) {
+        return true;
+    }
 }
 
 /**

--- a/src/Storefront/Resources/app/storefront/test/plugin/spatial/utils/ar/arSupportChecker.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/spatial/utils/ar/arSupportChecker.test.js
@@ -35,6 +35,80 @@ describe('arSupportChecker', () => {
             supportsMock = jest.spyOn(anchor.relList, 'supports').mockReturnValue(false);
             expect(supportQuickLook()).toBe(false);
         });
+
+        test('should return true on quick look enabled browsers', () => {
+            jest.spyOn(anchor.relList, 'supports').mockReturnValue(false);
+
+            // These are real user agents that support QuickLook
+            // These are supported browsers
+            const validAgents = [
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 16_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/118.0.5993.69 Mobile/15E148 Safari/604.1", // Chrome
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 16_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/126.0.2592.106 Version/16.0 Mobile/15E148 Safari/604.1", // Edge
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 16_1_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/132.0.6834.208 Mobile/15E148 Safari/604.1", // Vivaldi
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 16_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Mobile/15E148 Safari/604.1 Ddg/16.1", // DuckDuckGo
+            ];
+
+            validAgents.forEach((ua) => {
+                jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua.replace('[DEVICE]', 'iPhone'));
+                expect(supportQuickLook()).toBe(true);
+
+                jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua.replace('[DEVICE]', 'iPad'));
+                expect(supportQuickLook()).toBe(true);
+
+                jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua.replace('[DEVICE]', 'iPod'));
+                expect(supportQuickLook()).toBe(true);
+
+                jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua.replace('[DEVICE]', 'Mac'));
+                expect(supportQuickLook()).toBe(false);
+            });
+        });
+
+        test('should return false on quick look un enabled browsers', () => {
+            jest.spyOn(anchor.relList, 'supports').mockReturnValue(false);
+
+            // These are real user agents that support QuickLook
+            const invalidAgents = [
+                // unsupported browsers
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 16_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Mobile/15E148 Safari/604.1", // Safari - note that this will have the relList.supports return true normally, if not we should not try to open the quick look
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 16_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/128.3 Mobile/15E148 Safari/605.1.15", // Firefox
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 16_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Mobile/15E148 Safari/604.1 OPT/5.4.1", // Opera
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 16_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148", // Brave
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 16_1_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) GSA/356.0.726653311 Mobile/15E148 Safari/604.1", // Google
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 16_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.1 Mobile/15E148 Safari/605.1.15 (Ecosia ios@10.6.0.2082)", // Ecosia
+
+                // andriod browsers
+                "Mozilla/5.0 (Linux; Android 10; Pixel 3 XL Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36",
+                "Mozilla/5.0 (Android 9; Pixel 2 XL; rv:68.0) Gecko/68.0 Firefox/68.0",
+                "Mozilla/5.0 (Linux; Android 11; SM-G998B Build/RP1A.200720.012; Samsung; Galaxy S21 Ultra 5G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/14.0 Chrome/89.0.4389.90 Mobile Safari/537.36",
+
+                // pre ios 12 - but supported browsers
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 10_3_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/118.0.5993.69 Mobile/14E277 Safari/602.1", // Chrome
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 10_3_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) EdgiOS/40.10.0.0.0 Version/10.0 Mobile/14E277 Safari/602.1", // Edge
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 10_3_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/132.0.6834.208 Mobile/14E277 Safari/602.1", // Vivaldi
+                "Mozilla/5.0 ([DEVICE]; CPU [DEVICE] OS 10_3_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14E277 Safari/602.1 Ddg/10.0", // DuckDuckGo
+
+                // other
+                "",
+                "Mozilla/5.0",
+                "[DEVICE]",
+                "OS 16_1 like Mac OS X",
+                "CriOS/118.0.5993.69 Mobile/15E148 Safari/604.1",
+            ];
+
+            invalidAgents.forEach((ua) => {
+                jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua.replace('[DEVICE]', 'iPhone'));
+                expect(supportQuickLook()).toBe(false);
+
+                jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua.replace('[DEVICE]', 'iPad'));
+                expect(supportQuickLook()).toBe(false);
+
+                jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua.replace('[DEVICE]', 'iPod'));
+                expect(supportQuickLook()).toBe(false);
+
+                jest.spyOn(navigator, 'userAgent', 'get').mockReturnValue(ua.replace('[DEVICE]', 'Mac'));
+                expect(supportQuickLook()).toBe(false);
+            });
+        });
     });
 
     describe('supportWebXR', () => {


### PR DESCRIPTION
### 1. Why is this change necessary?
We want to enable IOS Quick-look AR for more browsers than Safari on IOS based devices.
Not all browsers currently support this feature. 

### 2. What does this change do, exactly?
We add some user agent checks additionally to the default check, to support other browsers, that are capable of opening quick look but do not return true on the default check.

### 3. Describe each step to reproduce the issue or behavior.
1. Open a product with AR enabled 3D-Model in all respective Browsers.
2. Click on AR Icon to open Quick-view.
3. If supported, it opens, otherwise it will display the unsupported device modal
 

### 4. Please link to the relevant issues.
- relates #4405 - relates to the issue #4405
- Jira issue: https://shopware.atlassian.net/browse/NEXT-37218

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
