### PR TITLE
fix: flow builder crashing when saving an invalid flow (#6844)

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-detail/sw-flow-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/page/sw-flow-detail/sw-flow-detail.spec.js
@@ -580,4 +580,20 @@ describe('module/sw-flow/page/sw-flow-detail', () => {
         expect(sequences[0]).toHaveProperty('rule');
         expect(sequences[0].rule).toEqual({ id: '1111', name: 'test rule' });
     });
+
+    it('should display an error when trying to save an empty flow', async () => {
+        global.activeAclRoles = ['flow.editor'];
+
+        const wrapper = await createWrapper();
+        const notificationSpy = jest.spyOn(wrapper.vm, 'createNotificationWarning');
+        await flushPromises();
+
+        const saveButton = wrapper.find('.sw-flow-detail__save');
+        await saveButton.trigger('click');
+        await flushPromises();
+
+        expect(notificationSpy).toHaveBeenNthCalledWith(1, {
+            message: 'sw-flow.flowNotification.emptyFields.general',
+        });
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/de-DE.json
@@ -77,13 +77,16 @@
       "tabFlow": "Flow"
     },
     "flowNotification": {
+      "emptyFields": {
+        "general": "Bitte fülle alle Pflichtfelder aus.",
+        "sequences": "Wähle vor dem Speichern eine Regel oder Aktion aus."
+      },
       "messageDeleteSuccess": "Flow gelöscht.",
       "messageDeleteError": "Flow konnte nicht gelöscht werden.",
       "messageSaveError": "Flow konnte nicht gespeichert werden.",
       "messageWarningSave": "Flow Templates können nicht bearbeitet werden.",
       "messageError": "Ein Fehler ist aufgetreten.",
       "messageRequiredEventName": "Wähle vor dem Speichern ein Auslöser-Ereignis aus.",
-      "messageRequiredEmptyFields": "Wähle vor dem Speichern eine Regel oder Aktion aus.",
       "messageDuplicateSuccess": "Flow dupliziert.",
       "messageDuplicateError": "Flow konnte nicht dupliziert werden.",
       "messageCreateSuccess": "Flow erstellt.",

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/snippet/en-GB.json
@@ -77,13 +77,16 @@
       "tabFlow": "Flow"
     },
     "flowNotification": {
+      "emptyFields": {
+        "general": "Please fill all required fields before saving",
+        "sequences": "Please enter a rule or action name before saving"
+      },
       "messageDeleteSuccess": "Flow deleted.",
       "messageDeleteError": "Flow could not be deleted.",
       "messageSaveError": "Flow could not be saved.",
       "messageWarningSave": "Flow templates cannot be edited.",
       "messageError": "An error occurred.",
       "messageRequiredEventName": "Please choose a trigger event before saving.",
-      "messageRequiredEmptyFields": "Please enter a rule or action name before saving.",
       "messageDuplicateSuccess": "Flow duplicated.",
       "messageDuplicateError": "Flow could not be duplicated.",
       "messageCreateSuccess": "Flow created.",


### PR DESCRIPTION
### 1. Why is this change necessary?  
Saving an invalid or empty flow causes the page to crash due to missing validation on required fields. Created a follow-up ticket, as this appears to be a broader issue with field validation: [NEXT-40686](https://shopware.atlassian.net/browse/NEXT-40686).  

### 2. What does this change do?  
Introduces a fallback check before saving a flow to prevent crashes, even if the validation is incorrect.  

### 3. Steps to reproduce the issue:  
1. Navigate to **Settings > Flow Builder**  
2. Click **"Create flow"**  
3. Click **"Save"** without entering any values.

### 4. Please link to the relevant issues (if any).
- closes #6844
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40684

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.


[NEXT-40686]: https://shopware.atlassian.net/browse/NEXT-40686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ