### PR TITLE
chore: set primary image of page for products (#6827)

### DIFF
--- a/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-image-gallery.html.twig
@@ -267,7 +267,11 @@
                                                                                 {% endif %}
 
                                                                                 {% if isProduct %}
-                                                                                    {% set attributes = attributes|merge({ itemprop: 'image' }) %}
+                                                                                    {% if loop.first %}
+                                                                                        {% set attributes = attributes|merge({ itemprop: 'image primaryImageOfPage' }) %}
+                                                                                    {% else %}
+                                                                                        {% set attributes = attributes|merge({ itemprop: 'image' }) %}
+                                                                                    {% endif %}
                                                                                 {% endif %}
 
                                                                                 {% if loop.first %}
@@ -412,7 +416,11 @@
                                                                 {% endif %}
 
                                                                 {% if isProduct %}
-                                                                    {% set attributes = attributes|merge({ itemprop: 'image' }) %}
+                                                                    {% if loop.first %}
+                                                                        {% set attributes = attributes|merge({ itemprop: 'image primaryImageOfPage' }) %}
+                                                                    {% else %}
+                                                                        {% set attributes = attributes|merge({ itemprop: 'image' }) %}
+                                                                    {% endif %}
                                                                 {% endif %}
 
                                                                 {% sw_thumbnails 'gallery-slider-image-thumbnails' with {
@@ -500,7 +508,11 @@
                                                                             }) %}
 
                                                                             {% if isProduct %}
-                                                                                {% set attributes = attributes|merge({ itemprop: 'image' }) %}
+                                                                                {% if loop.first %}
+                                                                                    {% set attributes = attributes|merge({ itemprop: 'image primaryImageOfPage' }) %}
+                                                                                {% else %}
+                                                                                    {% set attributes = attributes|merge({ itemprop: 'image' }) %}
+                                                                                {% endif %}
                                                                             {% endif %}
 
                                                                             {% sw_thumbnails 'gallery-slider-thumbnails-image-thumbnails' with {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Setting the `primaryImageOfPage` property will enable search engines to display the correct thumbnail.

### 2. What does this change do, exactly?

Set the `primaryImageOfPage` property for the first image in the product gallery.

### 3. Describe each step to reproduce the issue or behaviour.

-

### 4. Please link to the relevant issues (if any).

- closes #6827
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
