### PR TITLE
fix(media): issues with media module after removing vue compat

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-entity-mapper/index.js
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-entity-mapper/index.js
@@ -1,23 +1,16 @@
 /**
- * @private
  * @sw-package discovery
  */
+
+const ENTITY_MAPPING = {
+    media: 'sw-media-media-item',
+    media_folder: 'sw-media-folder-item',
+};
+/**
+ * @private
+ */
 export default {
-    functional: true,
-
-    render(createElement, context) {
-        function mapEntity() {
-            const entityMapping = {
-                media: 'sw-media-media-item',
-                media_folder: 'sw-media-folder-item',
-            };
-            return entityMapping[context.props.item.getEntityName()];
-        }
-
-        Object.assign(context.data, context.props);
-
-        return createElement(mapEntity(), context.data, context.slots().default);
-    },
+    template: `<component :is="mapEntity" v-bind="$props"><slot/></component>`,
 
     props: {
         item: {
@@ -26,6 +19,12 @@ export default {
             validator(value) {
                 return !!value.getEntityName();
             },
+        },
+    },
+
+    computed: {
+        mapEntity() {
+            return ENTITY_MAPPING[this.item.getEntityName()];
         },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-metadata-item/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sidebar/sw-media-quickinfo-metadata-item/index.js
@@ -1,45 +1,18 @@
 import './sw-media-quickinfo-metadata-item.scss';
-import { h } from 'vue';
 
 /**
  * @sw-package discovery
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
-    functional: true,
-
-    render(createElement, context) {
-        const title = h(
-            'dt',
-            {
-                class: [
-                    context.data.class,
-                    {
-                        'sw-media-quickinfo-metadata-item__term': true,
-                    },
-                ],
-            },
-            `${context.props.labelName}:`,
-        );
-
-        const description = h(
-            'dd',
-            {
-                class: [
-                    context.data.class,
-                    {
-                        'sw-media-quickinfo-metadata-item__description': true,
-                    },
-                ],
-            },
-            context.children.default(),
-        );
-
-        return [
-            title,
-            description,
-        ];
-    },
+    template: `
+        <dt :class="$attrs.class" class="sw-media-quickinfo-metadata-item__term">
+            {{ this.labelName }}:
+        </dt>
+        <dd :class="$attrs.class"  class="sw-media-quickinfo-metadata-item__description">
+            <slot/>
+        </dd>
+    `,
 
     props: {
         labelName: {

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-grid/index.js
@@ -82,9 +82,7 @@ export default {
         },
 
         isEmittedFromChildren(target) {
-            return this.$children.some((child) => {
-                return child.$el === target || child.$el.contains(target);
-            });
+            return this.$refs.componentRef?.contains(target) ?? false;
         },
 
         emitSelectionCleared(originalDomEvent) {

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-grid/sw-media-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-grid/sw-media-grid.html.twig
@@ -1,5 +1,5 @@
 {% block sw_media_grid %}
-<div class="sw-media-grid">
+<div ref="componentRef" class="sw-media-grid" >
     <slot name="content">
         {% block sw_media_grid_slot_content %}
         <div


### PR DESCRIPTION
### 1. Why is this change necessary?
There were some issues in the Media module caused by the removal of vue compat

### 2. What does this change do, exactly?
- Refactors `se-media-quickinfo-metadata-item` and `sw-media-entity-mapper` to a simpler components without render function.
- Change the use of `$children` in `sw-media-grid`


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes [#6878](https://github.com/shopware/shopware/issues/6878)
