### PR TITLE
fix: make sender name required (#6443)

### DIFF
--- a/changelog/_unreleased/2025-02-18-make-sender-name-required.md
+++ b/changelog/_unreleased/2025-02-18-make-sender-name-required.md
@@ -1,0 +1,14 @@
+---
+title: Make sender name required for email templates 
+author: Melvin Achterhuis
+author_email: melvin@achterhuis.work
+author_github: @MelvinAchterhuis
+---
+# Core
+* Changed definition `\Shopware\Core\Content\MailTemplate\Aggregate\MailTemplateTranslation\MailTemplateTranslationDefinition` to require `sender_name`.
+* Added migration `\Shopware\Core\Migration\V6_7\Migration1739916340SenderNameRequired` to fix existing mail templates without a sender name.
+
+# Administration
+* Added prop `required` to `sw-text-field` element in `src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig`.
+* Added prop `required` to `sw-text-field` element in `src/module/sw-flow/component/modals/sw-flow-create-mail-template-modal/sw-flow-create-mail-template-modal.html.twig`.
+

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-create-mail-template-modal/sw-flow-create-mail-template-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-create-mail-template-modal/sw-flow-create-mail-template-modal.html.twig
@@ -42,8 +42,10 @@
             v-model:value="mailTemplate.senderName"
             name="sw-field--mailTemplate-senderName"
             class="sw-flow-create-mail-template-modal__sender-name"
+            required
             :label="$tc('sw-flow.modals.mail.labelSenderName')"
             :placeholder="$tc('sw-flow.modals.mail.placeholderSenderName')"
+            :error="mailTemplateSenderNameError"
         />
         {% endblock %}
     </sw-container>

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -134,9 +134,11 @@
                         <sw-text-field
                             v-model:value="mailTemplate.senderName"
                             name="sw-field--mailTemplate-senderName"
+                            required
                             :label="$tc('sw-mail-template.detail.options.labelSenderName')"
                             :placeholder="placeholder(mailTemplate, 'senderName', $tc('sw-mail-template.detail.options.placeholderSenderName'))"
                             :disabled="!acl.can('mail_templates.editor') || undefined"
+                            :error="mailTemplateSenderNameError"
                         />
                         {% endblock %}
                     </sw-container>

--- a/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
+++ b/src/Core/Content/MailTemplate/Aggregate/MailTemplateTranslation/MailTemplateTranslationDefinition.php
@@ -46,7 +46,7 @@ class MailTemplateTranslationDefinition extends EntityTranslationDefinition
     protected function defineFields(): FieldCollection
     {
         return new FieldCollection([
-            (new StringField('sender_name', 'senderName'))->addFlags(new ApiAware()),
+            (new StringField('sender_name', 'senderName'))->addFlags(new Required, new ApiAware()),
             (new LongTextField('description', 'description'))->addFlags(new ApiAware()),
             (new StringField('subject', 'subject'))->addFlags(new Required(), new AllowHtml(false)),
             (new LongTextField('content_html', 'contentHtml'))->addFlags(new Required(), new AllowHtml(false)),

--- a/src/Core/Migration/V6_7/Migration1739916340SenderNameRequired.php
+++ b/src/Core/Migration/V6_7/Migration1739916340SenderNameRequired.php
@@ -9,7 +9,7 @@ use Shopware\Core\Framework\Migration\MigrationStep;
 /**
  * @internal
  */
-#[Package('core')]
+#[Package('after-sales')]
 class Migration1739916340SenderNameRequired extends MigrationStep
 {
     public function getCreationTimestamp(): int

--- a/src/Core/Migration/V6_7/Migration1739916340SenderNameRequired.php
+++ b/src/Core/Migration/V6_7/Migration1739916340SenderNameRequired.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1739916340SenderNameRequired extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1739916340;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement(
+            'UPDATE mail_template_translation
+            SET sender_name = :defaultSenderName
+            WHERE sender_name IS NULL OR sender_name = ""',
+            ['defaultSenderName' => '{{ salesChannel.name }}']
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently it is possible to remove the sender name from the default language which will prevent emails from being sent

### 2. What does this change do, exactly?

- Added the required props to elements in the administration
- Added required flag to the senderName in the definition
- Added migration to fix empty / null values in database and add sales channel name as default

### 3. Describe each step to reproduce the issue or behaviour.

- Clean trunk install
- Go to email templates
- Go for example to order confirmation mail
- Empty sender name for default language (en-GB) and save
- Place order with domain language en-GB
- No order confirmation received

Error:
`[2025-02-18T22:36:48.731810+00:00] app.ERROR: Could not send mail: Caught 1 violation errors. Error Code:0 Template data:  {"recipients":{"test@trunk.com":"Test Trunk"},"senderName":null,"salesChannelId":"0195070984357317b300f3571bccef80","languageId":null,"templateId":"0195070934017231a6d7a0785465f786","customFields":null,"contentHtml":"Test HTML","contentPlain":"Test plain","subject":"Order confirmation","mediaIds":[],"attachmentsConfig":{}}  [] []`


### 4. Please link to the relevant issues (if any).
- closes #6443

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
