### PR TITLE
chore: prepare phpstan upgrade domain exceptions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -36,16 +36,6 @@ parameters:
 			path: src/Core/Checkout/Cart/Price/Struct/QuantityPriceDefinition.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Cart\\\\PriceDefinitionFactory\\:\\:factory\\(\\) has parameter \\$priceDefinition with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Cart/PriceDefinitionFactory.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 1
-			path: src/Core/Checkout/Cart/PriceDefinitionFactory.php
-
-		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 1
 			path: src/Core/Checkout/Cart/Rule/CartVolumeRule.php
@@ -139,11 +129,6 @@ parameters:
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 1
 			path: src/Core/Checkout/Customer/Rule/CustomerNumberRule.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 2
-			path: src/Core/Checkout/Customer/Rule/EmailRule.php
 
 		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
@@ -2539,11 +2524,6 @@ parameters:
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 2
 			path: src/Core/Framework/Rule/Container/NotRule.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 1
-			path: src/Core/Framework/Rule/Container/ZipCodeRule.php
 
 		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1421,11 +1421,6 @@ parameters:
 			path: src/Core/Framework/Adapter/Twig/Extension/CategoryUrlExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\ComparisonExtension\\:\\:compareArray\\(\\) has parameter \\$comparable with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\InstanceOfExtension\\:\\:isInstanceOf\\(\\) has parameter \\$class with no type specified\\.$#"
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Extension/InstanceOfExtension.php
@@ -2214,11 +2209,6 @@ parameters:
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 2
 			path: src/Core/Framework/DataAbstractionLayer/Search/IdSearchResult.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\SqlQueryParser\\:\\:parseRanking\\(\\) has parameter \\$queries with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
 
 		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"

--- a/src/Core/Checkout/Cart/CartException.php
+++ b/src/Core/Checkout/Cart/CartException.php
@@ -10,8 +10,10 @@ use Shopware\Core\Checkout\Cart\Exception\LineItemNotFoundException;
 use Shopware\Core\Checkout\Customer\Exception\AddressNotFoundException;
 use Shopware\Core\Checkout\Order\Exception\EmptyCartException;
 use Shopware\Core\Content\Flow\Exception\CustomerDeletedException;
+use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidPriceFieldTypeException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Script\Execution\Hook;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
@@ -189,6 +191,11 @@ class CartException extends HttpException
         );
     }
 
+    public static function invalidPriceFieldType(string $type): InvalidPriceFieldTypeException
+    {
+        return new InvalidPriceFieldTypeException($type);
+    }
+
     public static function invalidQuantity(int $quantity): self
     {
         return new self(
@@ -212,7 +219,7 @@ class CartException extends HttpException
     public static function deliveryDateNotSupportedUnit(string $unit): self
     {
         return new self(
-            Response::HTTP_BAD_REQUEST,
+            Response::HTTP_INTERNAL_SERVER_ERROR,
             self::CART_DELIVERY_DATE_NOT_SUPPORTED_UNIT,
             'Not supported unit {{ unit }}',
             ['unit' => $unit]
@@ -569,5 +576,10 @@ class CartException extends HttpException
             self::UNEXPECTED_VALUE_EXCEPTION,
             $message
         );
+    }
+
+    public static function unsupportedOperator(string $operator, string $class): UnsupportedOperatorException
+    {
+        return new UnsupportedOperatorException($operator, $class);
     }
 }

--- a/src/Core/Checkout/Cart/CartException.php
+++ b/src/Core/Checkout/Cart/CartException.php
@@ -10,10 +10,8 @@ use Shopware\Core\Checkout\Cart\Exception\LineItemNotFoundException;
 use Shopware\Core\Checkout\Customer\Exception\AddressNotFoundException;
 use Shopware\Core\Checkout\Order\Exception\EmptyCartException;
 use Shopware\Core\Content\Flow\Exception\CustomerDeletedException;
-use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidPriceFieldTypeException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Script\Execution\Hook;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
@@ -46,6 +44,7 @@ class CartException extends HttpException
     public const CART_ABSOLUTE_DISCOUNT_MISSING_PRICE_COLLECTION_CODE = 'CHECKOUT__CART_ABSOLUTE_DISCOUNT_MISSING_PRICE_COLLECTION';
     public const CART_DISCOUNT_TYPE_NOT_SUPPORTED_CODE = 'CHECKOUT__CART_DISCOUNT_TYPE_NOT_SUPPORTED';
     public const CART_INVALID_PERCENTAGE_DISCOUNT_CODE = 'CHECKOUT__CART_INVALID_PERCENTAGE_DISCOUNT';
+    public const CART_INVALID_PRICE_FIELD_TYPE = 'CHECKOUT__CART_INVALID_PRICE_FIELD_TYPE';
     public const CART_MISSING_DEFAULT_PRICE_COLLECTION_FOR_SURCHARGE_CODE = 'CHECKOUT__CART_MISSING_DEFAULT_PRICE_COLLECTION_FOR_SURCHARGE';
     public const CART_ABSOLUTE_SURCHARGE_MISSING_PRICE_COLLECTION_CODE = 'CHECKOUT__CART_ABSOLUTE_SURCHARGE_MISSING_PRICE_COLLECTION';
     public const CART_SURCHARGE_TYPE_NOT_SUPPORTED_CODE = 'CHECKOUT__CART_SURCHARGE_TYPE_NOT_SUPPORTED';
@@ -70,6 +69,7 @@ class CartException extends HttpException
     public const LINE_ITEM_GROUP_PACKAGER_NOT_FOUND = 'CHECKOUT__GROUP_PACKAGER_NOT_FOUND';
     public const LINE_ITEM_GROUP_SORTER_NOT_FOUND = 'CHECKOUT__GROUP_SORTER_NOT_FOUND';
     public const UNEXPECTED_VALUE_EXCEPTION = 'CHECKOUT__UNEXPECTED_VALUE_EXCEPTION';
+    public const RULE_OPERATOR_NOT_SUPPORTED = 'CHECKOUT__RULE_OPERATOR_NOT_SUPPORTED';
 
     public static function shippingMethodNotFound(string $id, ?\Throwable $e = null): self
     {
@@ -191,9 +191,14 @@ class CartException extends HttpException
         );
     }
 
-    public static function invalidPriceFieldType(string $type): InvalidPriceFieldTypeException
+    public static function invalidPriceFieldType(string $type): self
     {
-        return new InvalidPriceFieldTypeException($type);
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::CART_INVALID_PRICE_FIELD_TYPE,
+            'The price field does not contain a valid "type" value. Received {{ type }}',
+            ['type' => $type]
+        );
     }
 
     public static function invalidQuantity(int $quantity): self
@@ -578,8 +583,13 @@ class CartException extends HttpException
         );
     }
 
-    public static function unsupportedOperator(string $operator, string $class): UnsupportedOperatorException
+    public static function unsupportedOperator(string $operator, string $class): self
     {
-        return new UnsupportedOperatorException($operator, $class);
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::RULE_OPERATOR_NOT_SUPPORTED,
+            'Unsupported operator {{ operator }} in {{ class }}',
+            ['operator' => $operator, 'class' => $class]
+        );
     }
 }

--- a/src/Core/Checkout/Cart/CartException.php
+++ b/src/Core/Checkout/Cart/CartException.php
@@ -24,6 +24,7 @@ class CartException extends HttpException
     public const CUSTOMER_NOT_LOGGED_IN_CODE = 'CHECKOUT__CUSTOMER_NOT_LOGGED_IN';
     public const INSUFFICIENT_PERMISSION_CODE = 'CHECKOUT__INSUFFICIENT_PERMISSION';
     public const CART_DELIVERY_NOT_FOUND_CODE = 'CHECKOUT__CART_DELIVERY_POSITION_NOT_FOUND';
+    public const CART_DELIVERY_DATE_NOT_SUPPORTED_UNIT = 'CHECKOUT__CART_DELIVERY_DATE_NOT_SUPPORTED_UNIT';
     public const CART_INVALID_CODE = 'CHECKOUT__CART_INVALID';
     public const CART_INVALID_LINE_ITEM_PAYLOAD_CODE = 'CHECKOUT__CART_INVALID_LINE_ITEM_PAYLOAD';
     public const CART_INVALID_LINE_ITEM_QUANTITY_CODE = 'CHECKOUT__CART_INVALID_LINE_ITEM_QUANTITY';
@@ -205,6 +206,16 @@ class CartException extends HttpException
             self::CART_DELIVERY_NOT_FOUND_CODE,
             'Delivery with identifier {{ id }} not found.',
             ['id' => $id]
+        );
+    }
+
+    public static function deliveryDateNotSupportedUnit(string $unit): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::CART_DELIVERY_DATE_NOT_SUPPORTED_UNIT,
+            'Not supported unit {{ unit }}',
+            ['unit' => $unit]
         );
     }
 

--- a/src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
+++ b/src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Cart\Delivery\Struct;
 
+use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
@@ -48,7 +49,7 @@ class DeliveryDate extends Struct
                 self::create('P' . $deliveryTime->getMin() . 'Y'),
                 self::create('P' . $deliveryTime->getMax() . 'Y')
             ),
-            default => throw new \RuntimeException(\sprintf('Not supported unit %s', $deliveryTime->getUnit())),
+            default => throw CartException::deliveryDateNotSupportedUnit($deliveryTime->getUnit()),
         };
     }
 

--- a/src/Core/Checkout/Cart/PriceDefinitionFactory.php
+++ b/src/Core/Checkout/Cart/PriceDefinitionFactory.php
@@ -7,23 +7,25 @@ use Shopware\Core\Checkout\Cart\Price\Struct\PercentagePriceDefinition;
 use Shopware\Core\Checkout\Cart\Price\Struct\PriceDefinitionInterface;
 use Shopware\Core\Checkout\Cart\Price\Struct\QuantityPriceDefinition;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Exception\InvalidPriceFieldTypeException;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('checkout')]
 class PriceDefinitionFactory
 {
+    /**
+     * @param array{type:string, price:float, percentage:float} $priceDefinition
+     */
     public function factory(Context $context, array $priceDefinition, string $lineItemType): PriceDefinitionInterface
     {
         if (!isset($priceDefinition['type'])) {
-            throw new InvalidPriceFieldTypeException('none');
+            throw CartException::invalidPriceFieldType('none');
         }
 
         return match ($priceDefinition['type']) {
             QuantityPriceDefinition::TYPE => QuantityPriceDefinition::fromArray($priceDefinition),
             AbsolutePriceDefinition::TYPE => new AbsolutePriceDefinition((float) $priceDefinition['price']),
             PercentagePriceDefinition::TYPE => new PercentagePriceDefinition($priceDefinition['percentage']),
-            default => throw new InvalidPriceFieldTypeException($priceDefinition['type']),
+            default => throw CartException::invalidPriceFieldType($priceDefinition['type']),
         };
     }
 }

--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Cart\Rule;
 
+use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\CustomFieldRule;
@@ -106,7 +107,7 @@ class LineItemCustomFieldRule extends Rule
             self::OPERATOR_EQ => $actual === $expected,
             self::OPERATOR_GT => $actual > $expected,
             self::OPERATOR_LT => $actual < $expected,
-            default => throw new UnsupportedOperatorException($this->operator, self::class),
+            default => throw CartException::unsupportedOperator($this->operator, self::class),
         };
     }
 }

--- a/src/Core/Checkout/Customer/CustomerException.php
+++ b/src/Core/Checkout/Customer/CustomerException.php
@@ -18,8 +18,6 @@ use Shopware\Core\Checkout\Customer\Exception\InvalidImitateCustomerTokenExcepti
 use Shopware\Core\Checkout\Customer\Exception\PasswordPoliciesUpdatedException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedValueException;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -55,6 +53,8 @@ class CustomerException extends HttpException
     public const CUSTOMER_CHANGE_PAYMENT_ERROR = 'CHECKOUT__CUSTOMER_CHANGE_PAYMENT_METHOD_NOT_FOUND';
     public const CUSTOMER_GUEST_AUTH_INVALID = 'CHECKOUT__CUSTOMER_AUTH_INVALID';
     public const IMITATE_CUSTOMER_INVALID_TOKEN = 'CHECKOUT__IMITATE_CUSTOMER_INVALID_TOKEN';
+    public const RULE_OPERATOR_NOT_SUPPORTED = 'CHECKOUT__RULE_OPERATOR_NOT_SUPPORTED';
+    public const RULE_VALUE_NOT_SUPPORTED = 'CHECKOUT__RULE_VALUE_NOT_SUPPORTED';
 
     public static function customerGroupNotFound(string $id): self
     {
@@ -286,13 +286,23 @@ class CustomerException extends HttpException
         return new InvalidImitateCustomerTokenException($token);
     }
 
-    public static function unsupportedOperator(string $operator, string $class): UnsupportedOperatorException
+    public static function unsupportedOperator(string $operator, string $class): self
     {
-        return new UnsupportedOperatorException($operator, $class);
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::RULE_OPERATOR_NOT_SUPPORTED,
+            'Unsupported operator {{ operator }} in {{ class }}',
+            ['operator' => $operator, 'class' => $class]
+        );
     }
 
-    public static function unsupportedValue(string $value, string $class): UnsupportedValueException
+    public static function unsupportedValue(string $type, string $class): self
     {
-        return new UnsupportedValueException($value, $class);
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::RULE_VALUE_NOT_SUPPORTED,
+            'Unsupported value of type {{ type }} in {{ class }}',
+            ['type' => $type, 'class' => $class]
+        );
     }
 }

--- a/src/Core/Checkout/Customer/CustomerException.php
+++ b/src/Core/Checkout/Customer/CustomerException.php
@@ -18,6 +18,8 @@ use Shopware\Core\Checkout\Customer\Exception\InvalidImitateCustomerTokenExcepti
 use Shopware\Core\Checkout\Customer\Exception\PasswordPoliciesUpdatedException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedValueException;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -282,5 +284,15 @@ class CustomerException extends HttpException
     public static function invalidImitationToken(string $token): InvalidImitateCustomerTokenException
     {
         return new InvalidImitateCustomerTokenException($token);
+    }
+
+    public static function unsupportedOperator(string $operator, string $class): UnsupportedOperatorException
+    {
+        return new UnsupportedOperatorException($operator, $class);
+    }
+
+    public static function unsupportedValue(string $value, string $class): UnsupportedValueException
+    {
+        return new UnsupportedValueException($value, $class);
     }
 }

--- a/src/Core/Checkout/Customer/Rule/EmailRule.php
+++ b/src/Core/Checkout/Customer/Rule/EmailRule.php
@@ -4,9 +4,8 @@ namespace Shopware\Core\Checkout\Customer\Rule;
 
 use Shopware\Core\Checkout\CheckoutRuleScope;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedValueException;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Rule\RuleComparison;
 use Shopware\Core\Framework\Rule\RuleConfig;
@@ -63,7 +62,7 @@ class EmailRule extends Rule
     private function matchPartially(CustomerEntity $customer): bool
     {
         if ($this->email === null) {
-            throw new UnsupportedValueException(\gettype($this->email), self::class);
+            throw CustomerException::unsupportedValue(\gettype($this->email), self::class);
         }
 
         $email = str_replace('\*', '(.*?)', preg_quote($this->email, '/'));
@@ -72,14 +71,14 @@ class EmailRule extends Rule
         return match ($this->operator) {
             Rule::OPERATOR_EQ => preg_match($regex, $customer->getEmail()) === 1,
             Rule::OPERATOR_NEQ => preg_match($regex, $customer->getEmail()) !== 1,
-            default => throw new UnsupportedOperatorException($this->operator, self::class),
+            default => throw CustomerException::unsupportedOperator($this->operator, self::class),
         };
     }
 
     private function matchExact(CustomerEntity $customer): bool
     {
         if ($this->email === null) {
-            throw new UnsupportedValueException(\gettype($this->email), self::class);
+            throw CustomerException::unsupportedValue(\gettype($this->email), self::class);
         }
 
         return RuleComparison::string($customer->getEmail(), $this->email, $this->operator);

--- a/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
@@ -254,7 +254,7 @@ class PromotionCalculator
             PromotionDiscountEntity::SCOPE_CART => $this->cartScopeDiscountPackager,
             PromotionDiscountEntity::SCOPE_SET => $this->setScopeDiscountPackager,
             PromotionDiscountEntity::SCOPE_SETGROUP => $this->setGroupScopeDiscountPackager,
-            default => throw new InvalidScopeDefinitionException($discount->getScope()),
+            default => throw PromotionException::invalidScopeDefinition($discount->getScope()),
         };
 
         $packages = $packager->getMatchingItems($discount, $calculatedCart, $context);
@@ -302,7 +302,7 @@ class PromotionCalculator
             PromotionDiscountEntity::TYPE_PERCENTAGE => new DiscountPercentageCalculator($this->absolutePriceCalculator, $this->percentagePriceCalculator),
             PromotionDiscountEntity::TYPE_FIXED => new DiscountFixedPriceCalculator($this->absolutePriceCalculator),
             PromotionDiscountEntity::TYPE_FIXED_UNIT => new DiscountFixedUnitPriceCalculator($this->absolutePriceCalculator),
-            default => throw new DiscountCalculatorNotFoundException($discount->getType()),
+            default => throw PromotionException::discountCalculatorNotFound($discount->getType()),
         };
 
         $result = $calculator->calculate($discount, $packages, $context);

--- a/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
@@ -36,8 +36,6 @@ use Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\PackageFilter;
 use Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\SetGroupScopeFilter;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionExcludedError;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionNotEligibleError;
-use Shopware\Core\Checkout\Promotion\Exception\DiscountCalculatorNotFoundException;
-use Shopware\Core\Checkout\Promotion\Exception\InvalidScopeDefinitionException;
 use Shopware\Core\Checkout\Promotion\PromotionException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -80,7 +78,7 @@ class PromotionCalculator
      * the different discount line item types (percentage, absolute, ...) and then
      * recalculate the whole cart with these new items.
      *
-     * @throws DiscountCalculatorNotFoundException
+     * @throws PromotionException
      * @throws CartException
      */
     public function calculate(LineItemCollection $discountLineItems, Cart $original, Cart $calculated, SalesChannelContext $context, CartBehavior $behaviour): void
@@ -229,10 +227,8 @@ class PromotionCalculator
      * Calculates and returns the discount based on the settings of
      * the provided discount line item.
      *
-     * @throws DiscountCalculatorNotFoundException
      * @throws FilterSorterNotFoundException
      * @throws PromotionException
-     * @throws InvalidScopeDefinitionException
      * @throws CartException
      */
     private function calculateDiscount(LineItem $item, Cart $calculatedCart, SalesChannelContext $context): DiscountCalculatorResult
@@ -275,9 +271,9 @@ class PromotionCalculator
             $item->setStackable(true);
             $this->splitted[$item->getId()] = $this->lineItemQuantitySplitter->split($item, 1, $context);
         }
-
+        echo 'mini';
         $packages = $this->enrichPackagesWithCartData($packages, $calculatedCart, $context);
-
+        echo 'sas';
         // every scope packager can have an additional
         // list of rules that can be used to filter out items.
         // thus we enrich our current package with items
@@ -296,7 +292,7 @@ class PromotionCalculator
         // that are eligible for our discount by executing our graduation resolver.
         $packages = $this->advancedFilter->filterPackages($discount, $packages, $originalPackageCount);
         $packages = $this->enrichPackagesWithCartData($packages, $calculatedCart, $context);
-
+        echo 'ohou';
         $calculator = match ($discount->getType()) {
             PromotionDiscountEntity::TYPE_ABSOLUTE => new DiscountAbsoluteCalculator($this->absolutePriceCalculator),
             PromotionDiscountEntity::TYPE_PERCENTAGE => new DiscountPercentageCalculator($this->absolutePriceCalculator, $this->percentagePriceCalculator),

--- a/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCalculator.php
@@ -271,9 +271,9 @@ class PromotionCalculator
             $item->setStackable(true);
             $this->splitted[$item->getId()] = $this->lineItemQuantitySplitter->split($item, 1, $context);
         }
-        echo 'mini';
+
         $packages = $this->enrichPackagesWithCartData($packages, $calculatedCart, $context);
-        echo 'sas';
+
         // every scope packager can have an additional
         // list of rules that can be used to filter out items.
         // thus we enrich our current package with items
@@ -292,7 +292,7 @@ class PromotionCalculator
         // that are eligible for our discount by executing our graduation resolver.
         $packages = $this->advancedFilter->filterPackages($discount, $packages, $originalPackageCount);
         $packages = $this->enrichPackagesWithCartData($packages, $calculatedCart, $context);
-        echo 'ohou';
+
         $calculator = match ($discount->getType()) {
             PromotionDiscountEntity::TYPE_ABSOLUTE => new DiscountAbsoluteCalculator($this->absolutePriceCalculator),
             PromotionDiscountEntity::TYPE_PERCENTAGE => new DiscountPercentageCalculator($this->absolutePriceCalculator, $this->percentagePriceCalculator),

--- a/src/Core/Checkout/Promotion/PromotionException.php
+++ b/src/Core/Checkout/Promotion/PromotionException.php
@@ -3,7 +3,9 @@
 namespace Shopware\Core\Checkout\Promotion;
 
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
+use Shopware\Core\Checkout\Promotion\Exception\DiscountCalculatorNotFoundException;
 use Shopware\Core\Checkout\Promotion\Exception\InvalidCodePatternException;
+use Shopware\Core\Checkout\Promotion\Exception\InvalidScopeDefinitionException;
 use Shopware\Core\Checkout\Promotion\Exception\PatternNotComplexEnoughException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
@@ -42,6 +44,11 @@ class PromotionException extends HttpException
         );
     }
 
+    public static function discountCalculatorNotFound(string $type): DiscountCalculatorNotFoundException
+    {
+        return new DiscountCalculatorNotFoundException($type);
+    }
+
     public static function invalidCodePattern(string $codePattern): self
     {
         return new InvalidCodePatternException(
@@ -50,6 +57,11 @@ class PromotionException extends HttpException
             'Invalid code pattern "{{ codePattern }}".',
             ['codePattern' => $codePattern]
         );
+    }
+
+    public static function invalidScopeDefinition(string $scope): InvalidScopeDefinitionException
+    {
+        return new InvalidScopeDefinitionException($scope);
     }
 
     public static function patternNotComplexEnough(): self

--- a/src/Core/Checkout/Promotion/PromotionException.php
+++ b/src/Core/Checkout/Promotion/PromotionException.php
@@ -3,9 +3,7 @@
 namespace Shopware\Core\Checkout\Promotion;
 
 use Shopware\Core\Checkout\Promotion\Aggregate\PromotionDiscount\PromotionDiscountEntity;
-use Shopware\Core\Checkout\Promotion\Exception\DiscountCalculatorNotFoundException;
 use Shopware\Core\Checkout\Promotion\Exception\InvalidCodePatternException;
-use Shopware\Core\Checkout\Promotion\Exception\InvalidScopeDefinitionException;
 use Shopware\Core\Checkout\Promotion\Exception\PatternNotComplexEnoughException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
@@ -34,6 +32,10 @@ class PromotionException extends HttpException
 
     public const PROMOTION_SET_GROUP_NOT_FOUND = 'CHECKOUT__PROMOTION_SETGROUP_NOT_FOUND';
 
+    public const CHECKOUT_DISCOUNT_CALCULATOR_NOT_FOUND = 'CHECKOUT__DISCOUNT_CALCULATOR_NOT_FOUND';
+
+    public const CHECKOUT_INVALID_DISCOUNT_SCOPE_DEFINITION = 'CHECKOUT__INVALID_DISCOUNT_SCOPE_DEFINITION';
+
     public static function codeAlreadyRedeemed(string $code): self
     {
         return new self(
@@ -44,9 +46,14 @@ class PromotionException extends HttpException
         );
     }
 
-    public static function discountCalculatorNotFound(string $type): DiscountCalculatorNotFoundException
+    public static function discountCalculatorNotFound(string $type): self
     {
-        return new DiscountCalculatorNotFoundException($type);
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::CHECKOUT_DISCOUNT_CALCULATOR_NOT_FOUND,
+            'Promotion Discount Calculator "{{ type }}" has not been found!',
+            ['type' => $type]
+        );
     }
 
     public static function invalidCodePattern(string $codePattern): self
@@ -59,9 +66,14 @@ class PromotionException extends HttpException
         );
     }
 
-    public static function invalidScopeDefinition(string $scope): InvalidScopeDefinitionException
+    public static function invalidScopeDefinition(string $scope): self
     {
-        return new InvalidScopeDefinitionException($scope);
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::CHECKOUT_INVALID_DISCOUNT_SCOPE_DEFINITION,
+            'Invalid discount calculator scope definition "{{ label }}"',
+            ['label' => $scope]
+        );
     }
 
     public static function patternNotComplexEnough(): self

--- a/src/Core/Content/Flow/Controller/TriggerFlowController.php
+++ b/src/Core/Content/Flow/Controller/TriggerFlowController.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Core\Content\Flow\Controller;
 
-use Shopware\Core\Content\Flow\Exception\CustomTriggerByNameNotFoundException;
+use Shopware\Core\Content\Flow\FlowException;
 use Shopware\Core\Framework\App\Event\CustomAppEvent;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -50,6 +50,6 @@ class TriggerFlowController extends AbstractController
         $criteria->addFilter(new EqualsFilter('name', $eventName));
         $criteria->addFilter(new EqualsFilter('app.active', 1));
 
-        $this->appFlowEventRepository->search($criteria, $context)->first() ?? throw new CustomTriggerByNameNotFoundException($eventName);
+        $this->appFlowEventRepository->search($criteria, $context)->first() ?? throw FlowException::customTriggerByNameNotFound($eventName);
     }
 }

--- a/src/Core/Content/Flow/FlowException.php
+++ b/src/Core/Content/Flow/FlowException.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Content\Flow;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Shopware\Core\Content\Flow\Dispatching\TransactionFailedException;
-use Shopware\Core\Content\Flow\Exception\CustomTriggerByNameNotFoundException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,10 +15,16 @@ class FlowException extends HttpException
     final public const FLOW_ACTION_TRANSACTION_ABORTED = 'FLOW_ACTION_TRANSACTION_ABORTED';
     final public const FLOW_ACTION_TRANSACTION_COMMIT_FAILED = 'FLOW_ACTION_TRANSACTION_COMMIT_FAILED';
     final public const FLOW_ACTION_TRANSACTION_UNCAUGHT_EXCEPTION = 'FLOW_ACTION_TRANSACTION_UNCAUGHT_EXCEPTION';
+    final public const ADMINISTRATION_CUSTOM_TRIGGER_BY_NAME_NOT_FOUND = 'ADMINISTRATION__CUSTOM_TRIGGER_BY_NAME_NOT_FOUND';
 
-    public static function customTriggerByNameNotFound(string $name): CustomTriggerByNameNotFoundException
+    public static function customTriggerByNameNotFound(string $eventName): self
     {
-        return new CustomTriggerByNameNotFoundException($name);
+        return new self(
+            Response::HTTP_NOT_FOUND,
+            self::ADMINISTRATION_CUSTOM_TRIGGER_BY_NAME_NOT_FOUND,
+            'The provided event name {{ eventName }} is invalid or uninstalled and no custom trigger could be found.',
+            ['eventName' => $eventName]
+        );
     }
 
     public static function methodNotCompatible(string $method, string $class): FlowException

--- a/src/Core/Content/Flow/FlowException.php
+++ b/src/Core/Content/Flow/FlowException.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Flow;
 
 use Doctrine\DBAL\Exception as DBALException;
 use Shopware\Core\Content\Flow\Dispatching\TransactionFailedException;
+use Shopware\Core\Content\Flow\Exception\CustomTriggerByNameNotFoundException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,6 +16,11 @@ class FlowException extends HttpException
     final public const FLOW_ACTION_TRANSACTION_ABORTED = 'FLOW_ACTION_TRANSACTION_ABORTED';
     final public const FLOW_ACTION_TRANSACTION_COMMIT_FAILED = 'FLOW_ACTION_TRANSACTION_COMMIT_FAILED';
     final public const FLOW_ACTION_TRANSACTION_UNCAUGHT_EXCEPTION = 'FLOW_ACTION_TRANSACTION_UNCAUGHT_EXCEPTION';
+
+    public static function customTriggerByNameNotFound(string $name): CustomTriggerByNameNotFoundException
+    {
+        return new CustomTriggerByNameNotFoundException($name);
+    }
 
     public static function methodNotCompatible(string $method, string $class): FlowException
     {

--- a/src/Core/Content/Media/Core/Application/AbstractMediaPathStrategy.php
+++ b/src/Core/Content/Media/Core/Application/AbstractMediaPathStrategy.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Media\Core\Application;
 
 use Shopware\Core\Content\Media\Core\Params\MediaLocationStruct;
 use Shopware\Core\Content\Media\Core\Params\ThumbnailLocationStruct;
+use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 
@@ -37,7 +38,7 @@ abstract class AbstractMediaPathStrategy
             $type = match (true) {
                 $location instanceof MediaLocationStruct => 'media',
                 $location instanceof ThumbnailLocationStruct => 'thumbnail',
-                default => throw new \RuntimeException('Unknown location type'),
+                default => throw MediaException::unknownLocationType(),
             };
 
             $paths[$location->id] = implode('/', \array_filter([

--- a/src/Core/Content/Media/MediaException.php
+++ b/src/Core/Content/Media/MediaException.php
@@ -51,6 +51,7 @@ class MediaException extends HttpException
     public const MEDIA_INVALID_MIME_TYPE = 'CONTENT__MEDIA_INVALID_MIME_TYPE';
 
     public const MEDIA_THUMBNAIL_GENERATION_DISABLED = 'CONTENT__MEDIA_THUMBNAIL_GENERATION_DISABLED';
+    public const MEDIA_UNKNOWN_LOCATION_TYPE = 'CONTENT__MEDIA_UNKNOWN_LOCATION_TYPE';
 
     public static function cannotBanRequest(string $url, string $error, ?\Throwable $e = null): self
     {
@@ -424,6 +425,15 @@ class MediaException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::MEDIA_THUMBNAIL_GENERATION_DISABLED,
             'Remote thumbnails are enabled. Skipping thumbnail generation.'
+        );
+    }
+
+    public static function unknownLocationType(): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::MEDIA_UNKNOWN_LOCATION_TYPE,
+            'Unknown location type'
         );
     }
 }

--- a/src/Core/Framework/Adapter/AdapterException.php
+++ b/src/Core/Framework/Adapter/AdapterException.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Adapter;
 
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Symfony\Component\Asset\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Node\Expression\AbstractExpression;
@@ -33,6 +34,11 @@ class AdapterException extends HttpException
                 'type' => $expression::class,
             ]
         );
+    }
+
+    public static function unsupportedOperator(string $operator, string $class): UnsupportedOperatorException
+    {
+        return new UnsupportedOperatorException($operator, $class);
     }
 
     public static function missingExtendsTemplate(string $template): self

--- a/src/Core/Framework/Adapter/AdapterException.php
+++ b/src/Core/Framework/Adapter/AdapterException.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Framework\Adapter;
 
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Symfony\Component\Asset\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Node\Expression\AbstractExpression;
@@ -23,6 +22,7 @@ class AdapterException extends HttpException
     public const INVALID_ASSET_URL = 'FRAMEWORK__INVALID_ASSET_URL';
     final public const INVALID_ARGUMENT = 'FRAMEWORK__INVALID_ARGUMENT_EXCEPTION';
     final public const STRING_TEMPLATE_RENDERING_FAILED = 'FRAMEWORK__STRING_TEMPLATE_RENDERING_FAILED';
+    public const FRAMEWORK_OPERATOR_NOT_SUPPORTED = 'FRAMEWORK__OPERATOR_NOT_SUPPORTED';
 
     public static function unexpectedTwigExpression(AbstractExpression $expression): self
     {
@@ -36,9 +36,14 @@ class AdapterException extends HttpException
         );
     }
 
-    public static function unsupportedOperator(string $operator, string $class): UnsupportedOperatorException
+    public static function unsupportedOperator(string $operator, string $class): self
     {
-        return new UnsupportedOperatorException($operator, $class);
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::FRAMEWORK_OPERATOR_NOT_SUPPORTED,
+            'Unsupported operator {{ operator }} in {{ class }}',
+            ['operator' => $operator, 'class' => $class]
+        );
     }
 
     public static function missingExtendsTemplate(string $template): self

--- a/src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
@@ -46,6 +46,9 @@ class ComparisonExtension extends AbstractExtension
         return $this->compareMixed($operator, $value, $comparable);
     }
 
+    /**
+     * @param array<mixed> $comparable
+     */
     private function compareArray(string $operator, mixed $value, array $comparable): bool
     {
         if (!\is_array($value)) {

--- a/src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
@@ -2,8 +2,8 @@
 
 namespace Shopware\Core\Framework\Adapter\Twig\Extension;
 
+use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Util\FloatComparator;
 use Twig\Extension\AbstractExtension;
@@ -57,7 +57,7 @@ class ComparisonExtension extends AbstractExtension
         return match ($operator) {
             Rule::OPERATOR_EQ => !empty($matches),
             Rule::OPERATOR_NEQ => empty($matches),
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw AdapterException::unsupportedOperator($operator, self::class),
         };
     }
 
@@ -70,7 +70,7 @@ class ComparisonExtension extends AbstractExtension
             Rule::OPERATOR_LTE => $value <= $comparable,
             Rule::OPERATOR_GT => $value > $comparable,
             Rule::OPERATOR_LT => $value < $comparable,
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw AdapterException::unsupportedOperator($operator, self::class),
         };
     }
 
@@ -83,7 +83,7 @@ class ComparisonExtension extends AbstractExtension
             Rule::OPERATOR_LTE => FloatComparator::lessThanOrEquals($value, $comparable),
             Rule::OPERATOR_GT => FloatComparator::greaterThan($value, $comparable),
             Rule::OPERATOR_LT => FloatComparator::lessThan($value, $comparable),
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw AdapterException::unsupportedOperator($operator, self::class),
         };
     }
 }

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -78,6 +78,7 @@ class DataAbstractionLayerException extends HttpException
     public const INVALID_CHUNK_SIZE = 'FRAMEWORK__INVALID_CHUNK_SIZE';
     public const HOOK_INJECTION_EXCEPTION = 'FRAMEWORK__HOOK_INJECTION_EXCEPTION';
     public const FRAMEWORK_DEPRECATED_DEFINITION_CALL = 'FRAMEWORK__DEPRECATED_DEFINITION_CALL';
+    public const UNSUPPORTED_QUERY_FILTER = 'FRAMEWORK__UNSUPPORTED_QUERY_FILTER';
 
     public static function invalidSerializerField(string $expectedClass, Field $field): self
     {
@@ -192,6 +193,16 @@ class DataAbstractionLayerException extends HttpException
             self::CANNOT_CREATE_NEW_VERSION,
             'Cannot create new version. {{ entity }} by id {{ id }} not found.',
             ['entity' => $entity, 'id' => $id]
+        );
+    }
+
+    public static function unsupportedQueryFilter(string $query): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::UNSUPPORTED_QUERY_FILTER,
+            'Unsupported query {{ query }}',
+            ['query' => $query]
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
@@ -303,7 +303,7 @@ class EntityAggregator implements EntityAggregatorInterface
             DateHistogramAggregation::PER_MONTH => 'DATE_FORMAT(' . $accessor . ', \'%Y-%m\')',
             DateHistogramAggregation::PER_QUARTER => 'CONCAT(DATE_FORMAT(' . $accessor . ', \'%Y\'), \'-\', QUARTER(' . $accessor . '))',
             DateHistogramAggregation::PER_YEAR => 'DATE_FORMAT(' . $accessor . ', \'%Y\')',
-            default => throw new \RuntimeException('Provided date format is not supported'),
+            default => throw DataAbstractionLayerException::invalidDateFormat($aggregation->getInterval(), DateHistogramAggregation::ALLOWED_INTERVALS),
         };
         $query->addGroupBy($groupBy);
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
@@ -40,6 +40,9 @@ class SqlQueryParser
     ) {
     }
 
+    /**
+     * @param list<ScoreQuery> $queries
+     */
     public function parseRanking(
         array $queries,
         EntityDefinition $definition,

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Search\Parser;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
@@ -107,7 +108,7 @@ class SqlQueryParser
             $query instanceof RangeFilter => $this->parseRangeFilter($query, $definition, $root, $context),
             $query instanceof NotFilter => $this->parseNotFilter($query, $definition, $root, $context),
             $query instanceof MultiFilter => $this->parseMultiFilter($query, $definition, $root, $context, $negated),
-            default => throw new \RuntimeException(\sprintf('Unsupported query %s', $query::class)),
+            default => throw DataAbstractionLayerException::unsupportedQueryFilter($query::class),
         };
     }
 

--- a/src/Core/Framework/Rule/Container/ZipCodeRule.php
+++ b/src/Core/Framework/Rule/Container/ZipCodeRule.php
@@ -4,9 +4,8 @@ namespace Shopware\Core\Framework\Rule\Container;
 
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedValueException;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\Framework\Util\FloatComparator;
 use Shopware\Core\Framework\Validation\Constraint\ArrayOfType;
 use Symfony\Component\Validator\Constraints\Choice;
@@ -56,7 +55,7 @@ abstract class ZipCodeRule extends Rule
         $zipCode = $this->sanitizeZipCode($address);
 
         if ($this->zipCodes === null && $this->operator !== self::OPERATOR_EMPTY) {
-            throw new UnsupportedValueException(\gettype($this->zipCodes), self::class);
+            throw RuleException::unsupportedValue(\gettype($this->zipCodes), self::class);
         }
 
         $compareZipCode = \is_array($this->zipCodes) ? $this->zipCodes[0] : null;
@@ -69,7 +68,7 @@ abstract class ZipCodeRule extends Rule
             self::OPERATOR_GT => is_numeric($zipCode) && is_numeric($compareZipCode) && FloatComparator::greaterThan((float) $zipCode, (float) $compareZipCode),
             self::OPERATOR_LT => is_numeric($zipCode) && is_numeric($compareZipCode) && FloatComparator::lessThan((float) $zipCode, (float) $compareZipCode),
             self::OPERATOR_EMPTY => empty($zipCode),
-            default => throw new UnsupportedOperatorException($this->operator, self::class),
+            default => throw RuleException::unsupportedOperator($this->operator, self::class),
         };
     }
 

--- a/src/Core/Framework/Rule/CustomFieldRule.php
+++ b/src/Core/Framework/Rule/CustomFieldRule.php
@@ -5,7 +5,6 @@ namespace Shopware\Core\Framework\Rule;
 use Shopware\Core\Framework\App\Manifest\Xml\CustomField\CustomFieldTypes\MultiEntitySelectField;
 use Shopware\Core\Framework\App\Manifest\Xml\CustomField\CustomFieldTypes\MultiSelectField;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Util\ArrayComparator;
 use Shopware\Core\Framework\Util\FloatComparator;
 use Shopware\Core\System\CustomField\CustomFieldTypes;
@@ -81,7 +80,7 @@ class CustomFieldRule
             Rule::OPERATOR_EQ => $actual === $expected,
             Rule::OPERATOR_GT => $actual > $expected,
             Rule::OPERATOR_LT => $actual < $expected,
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw RuleException::unsupportedOperator($operator, self::class),
         };
     }
 

--- a/src/Core/Framework/Rule/RuleComparison.php
+++ b/src/Core/Framework/Rule/RuleComparison.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Framework\Rule;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Util\FloatComparator;
 
 #[Package('fundamentals@after-sales')]
@@ -30,7 +29,7 @@ class RuleComparison
             Rule::OPERATOR_LT => FloatComparator::lessThan($itemValue, $ruleValue),
             Rule::OPERATOR_EQ => FloatComparator::equals($itemValue, $ruleValue),
             Rule::OPERATOR_NEQ => FloatComparator::notEquals($itemValue, $ruleValue),
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw RuleException::unsupportedOperator($operator, self::class),
         };
     }
 
@@ -44,7 +43,7 @@ class RuleComparison
             Rule::OPERATOR_EQ => strcasecmp($ruleValue, $itemValue) === 0,
             Rule::OPERATOR_NEQ => strcasecmp($ruleValue, $itemValue) !== 0,
             Rule::OPERATOR_EMPTY => empty(trim($itemValue)),
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw RuleException::unsupportedOperator($operator, self::class),
         };
     }
 
@@ -60,7 +59,7 @@ class RuleComparison
         return match ($operator) {
             Rule::OPERATOR_EQ => \in_array(mb_strtolower($itemValue), $ruleValue, true),
             Rule::OPERATOR_NEQ => !\in_array(mb_strtolower($itemValue), $ruleValue, true),
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw RuleException::unsupportedOperator($operator, self::class),
         };
     }
 
@@ -84,7 +83,7 @@ class RuleComparison
             Rule::OPERATOR_EQ => !empty($diff),
             Rule::OPERATOR_NEQ => empty($diff),
             Rule::OPERATOR_EMPTY => empty($itemValue),
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw RuleException::unsupportedOperator($operator, self::class),
         };
     }
 
@@ -97,7 +96,7 @@ class RuleComparison
             Rule::OPERATOR_LT => $itemValue < $ruleValue,
             Rule::OPERATOR_GTE => $itemValue >= $ruleValue,
             Rule::OPERATOR_LTE => $itemValue <= $ruleValue,
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw RuleException::unsupportedOperator($operator, self::class),
         };
     }
 

--- a/src/Core/Framework/Rule/RuleException.php
+++ b/src/Core/Framework/Rule/RuleException.php
@@ -4,6 +4,8 @@ namespace Shopware\Core\Framework\Rule;
 
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedValueException;
 use Shopware\Core\Framework\Script\Exception\ScriptExecutionFailedException;
 use Shopware\Core\Framework\Script\ScriptException;
 
@@ -14,5 +16,15 @@ class RuleException extends HttpException
     {
         // use own exception class so it can be catched properly
         return new ScriptExecutionFailedException($hook, $scriptName, $previous);
+    }
+
+    public static function unsupportedOperator(string $operator, string $class): UnsupportedOperatorException
+    {
+        return new UnsupportedOperatorException($operator, $class);
+    }
+
+    public static function unsupportedValue(string $type, string $class): UnsupportedValueException
+    {
+        return new UnsupportedValueException($type, $class);
     }
 }

--- a/src/Core/Framework/Rule/RuleException.php
+++ b/src/Core/Framework/Rule/RuleException.php
@@ -4,27 +4,39 @@ namespace Shopware\Core\Framework\Rule;
 
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedValueException;
 use Shopware\Core\Framework\Script\Exception\ScriptExecutionFailedException;
 use Shopware\Core\Framework\Script\ScriptException;
+use Symfony\Component\HttpFoundation\Response;
 
 #[Package('fundamentals@after-sales')]
 class RuleException extends HttpException
 {
+    public const FRAMEWORK_RULE_OPERATOR_NOT_SUPPORTED = 'FRAMEWORK__RULE_OPERATOR_NOT_SUPPORTED';
+    public const FRAMEWORK_RULE_VALUE_NOT_SUPPORTED = 'FRAMEWORK__RULE_VALUE_NOT_SUPPORTED';
+
     public static function scriptExecutionFailed(string $hook, string $scriptName, \Throwable $previous): ScriptException
     {
         // use own exception class so it can be catched properly
         return new ScriptExecutionFailedException($hook, $scriptName, $previous);
     }
 
-    public static function unsupportedOperator(string $operator, string $class): UnsupportedOperatorException
+    public static function unsupportedOperator(string $operator, string $class): self
     {
-        return new UnsupportedOperatorException($operator, $class);
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::FRAMEWORK_RULE_OPERATOR_NOT_SUPPORTED,
+            'Unsupported operator {{ operator }} in {{ class }}',
+            ['operator' => $operator, 'class' => $class]
+        );
     }
 
-    public static function unsupportedValue(string $type, string $class): UnsupportedValueException
+    public static function unsupportedValue(string $type, string $class): self
     {
-        return new UnsupportedValueException($type, $class);
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::FRAMEWORK_RULE_VALUE_NOT_SUPPORTED,
+            'Unsupported value of type {{ type }} in {{ class }}',
+            ['type' => $type, 'class' => $class]
+        );
     }
 }

--- a/src/Core/Framework/Store/InAppPurchase/Services/KeyFetcher.php
+++ b/src/Core/Framework/Store/InAppPurchase/Services/KeyFetcher.php
@@ -4,12 +4,12 @@ namespace Shopware\Core\Framework\Store\InAppPurchase\Services;
 
 use GuzzleHttp\ClientInterface;
 use Psr\Log\LoggerInterface;
-use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\JWT\Struct\JWKCollection;
 use Shopware\Core\Framework\JWT\Struct\JWKStruct;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Authentication\AbstractStoreRequestOptionsProvider;
+use Shopware\Core\Framework\Store\StoreException;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
@@ -41,7 +41,7 @@ final class KeyFetcher
             return $key;
         }
 
-        return $this->fetchAndStoreKey($context) ?? $key ?? throw AppException::jwksNotFound();
+        return $this->fetchAndStoreKey($context) ?? $key ?? throw StoreException::jwksNotFound();
     }
 
     private function getStoredKey(): ?JWKCollection

--- a/src/Core/Framework/Store/StoreException.php
+++ b/src/Core/Framework/Store/StoreException.php
@@ -24,7 +24,7 @@ class StoreException extends HttpException
     public const MISSING_INTEGRATION_IN_CONTEXT_SOURCE = 'FRAMEWORK__STORE_MISSING_INTEGRATION_IN_CONTEXT_SOURCE';
     public const MISSING_REQUEST_PARAMETER_CODE = 'FRAMEWORK__STORE_MISSING_REQUEST_PARAMETER';
     public const INVALID_TYPE = 'FRAMEWORK__STORE_INVALID_TYPE';
-    public const JWKS_KEY_NOT_FOUND = 'FRAMEWORK__APP_JWKS_KEY_NOT_FOUND';
+    public const JWKS_KEY_NOT_FOUND = 'FRAMEWORK__STORE_JWKS_NOT_FOUND';
 
     public static function cannotDeleteManaged(string $pluginName): self
     {

--- a/src/Core/Framework/Store/StoreException.php
+++ b/src/Core/Framework/Store/StoreException.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Framework\Store;
 
 use GuzzleHttp\Exception\ClientException;
-use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Exception\ExtensionNotFoundException;
@@ -25,6 +24,7 @@ class StoreException extends HttpException
     public const MISSING_INTEGRATION_IN_CONTEXT_SOURCE = 'FRAMEWORK__STORE_MISSING_INTEGRATION_IN_CONTEXT_SOURCE';
     public const MISSING_REQUEST_PARAMETER_CODE = 'FRAMEWORK__STORE_MISSING_REQUEST_PARAMETER';
     public const INVALID_TYPE = 'FRAMEWORK__STORE_INVALID_TYPE';
+    public const JWKS_KEY_NOT_FOUND = 'FRAMEWORK__APP_JWKS_KEY_NOT_FOUND';
 
     public static function cannotDeleteManaged(string $pluginName): self
     {
@@ -119,9 +119,14 @@ class StoreException extends HttpException
         );
     }
 
-    public static function jwksNotFound(): AppException
+    public static function jwksNotFound(?\Throwable $e = null): self
     {
-        return AppException::jwksNotFound();
+        return new self(
+            statusCode: Response::HTTP_INTERNAL_SERVER_ERROR,
+            errorCode: self::JWKS_KEY_NOT_FOUND,
+            message: 'Unable to retrieve JWKS key',
+            previous: $e
+        );
     }
 
     public static function missingIntegrationInContextSource(string $actualContextSource): StoreException

--- a/src/Core/Framework/Store/StoreException.php
+++ b/src/Core/Framework/Store/StoreException.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Store;
 
 use GuzzleHttp\Exception\ClientException;
+use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Exception\ExtensionNotFoundException;
@@ -116,6 +117,11 @@ class StoreException extends HttpException
                 'actualContextSource' => $actualContextSource,
             ],
         );
+    }
+
+    public static function jwksNotFound(): AppException
+    {
+        return AppException::jwksNotFound();
     }
 
     public static function missingIntegrationInContextSource(string $actualContextSource): StoreException

--- a/src/Core/Framework/Util/ArrayComparator.php
+++ b/src/Core/Framework/Util/ArrayComparator.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Framework\Util;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Exception\ComparatorException;
 
 #[Package('framework')]
 class ArrayComparator
@@ -17,7 +16,7 @@ class ArrayComparator
         return match ($operator) {
             '!=' => self::notEquals($a, $b),
             '=' => self::equals($a, $b),
-            default => throw ComparatorException::operatorNotSupported($operator),
+            default => throw UtilException::operatorNotSupported($operator),
         };
     }
 

--- a/src/Core/Framework/Util/FloatComparator.php
+++ b/src/Core/Framework/Util/FloatComparator.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Framework\Util;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Exception\ComparatorException;
 
 #[Package('framework')]
 class FloatComparator
@@ -19,7 +18,7 @@ class FloatComparator
             '=' => self::equals($a, $b),
             '>' => self::greaterThan($a, $b),
             '<' => self::lessThan($a, $b),
-            default => throw ComparatorException::operatorNotSupported($operator),
+            default => throw UtilException::operatorNotSupported($operator),
         };
     }
 

--- a/src/Core/Framework/Util/UtilException.php
+++ b/src/Core/Framework/Util/UtilException.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Framework\Util;
 
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Util\Exception\ComparatorException;
 use Shopware\Core\Framework\Util\Exception\UtilXmlParsingException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -17,6 +16,7 @@ class UtilException extends HttpException
     public const XML_ELEMENT_NOT_FOUND = 'UTIL__XML_ELEMENT_NOT_FOUND';
     public const FILESYSTEM_FILE_NOT_FOUND = 'UTIL__FILESYSTEM_FILE_NOT_FOUND';
     public const COULD_NOT_HASH_FILE = 'UTIL__COULD_NOT_HASH_FILE';
+    public const OPERATOR_NOT_SUPPORTED = 'UTIL__OPERATOR_NOT_SUPPORTED';
 
     public static function invalidJson(\JsonException $e): self
     {
@@ -73,8 +73,13 @@ class UtilException extends HttpException
         );
     }
 
-    public static function operatorNotSupported(string $operator): ComparatorException
+    public static function operatorNotSupported(string $operator): self
     {
-        return ComparatorException::operatorNotSupported($operator);
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::OPERATOR_NOT_SUPPORTED,
+            'Operator "{{ operator }}" is not supported.',
+            ['operator' => $operator]
+        );
     }
 }

--- a/src/Core/Framework/Util/UtilException.php
+++ b/src/Core/Framework/Util/UtilException.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Util;
 
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Util\Exception\ComparatorException;
 use Shopware\Core\Framework\Util\Exception\UtilXmlParsingException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -70,5 +71,10 @@ class UtilException extends HttpException
             'Could not generate hash for  "{{ file }}"',
             ['file' => $file]
         );
+    }
+
+    public static function operatorNotSupported(string $operator): ComparatorException
+    {
+        return ComparatorException::operatorNotSupported($operator);
     }
 }

--- a/src/Core/System/CustomEntity/CustomEntityException.php
+++ b/src/Core/System/CustomEntity/CustomEntityException.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('framework')]
 class CustomEntityException extends HttpException
 {
+    public const CUSTOM_ENTITY_ON_DELETE_PROPERTY_NOT_SUPPORTED = 'FRAMEWORK__CUSTOM_ENTITY_ON_DELETE_PROPERTY_NOT_SUPPORTED';
     public const CUSTOM_FIELDS_AWARE_NO_LABEL_PROPERTY = 'NO_LABEL_PROPERTY';
     public const CUSTOM_FIELDS_AWARE_LABEL_PROPERTY_NOT_DEFINED = 'LABEL_PROPERTY_NOT_DEFINED';
     public const CUSTOM_FIELDS_AWARE_LABEL_PROPERTY_WRONG_TYPE = 'LABEL_PROPERTY_WRONG_TYPE';
@@ -36,6 +37,11 @@ class CustomEntityException extends HttpException
     public static function notFound(string $entityName): self
     {
         return new self(Response::HTTP_NOT_FOUND, self::NOT_FOUND, 'Custom entity "{{ entityName }}" not found', ['entityName' => $entityName]);
+    }
+
+    public static function unsupportedOnDeletePropertyOnField(string $onDelete, string $name): self
+    {
+        return new self(Response::HTTP_INTERNAL_SERVER_ERROR, self::CUSTOM_ENTITY_ON_DELETE_PROPERTY_NOT_SUPPORTED, 'onDelete property {{ onDelete }} are not supported on field {{ name }}', ['onDelete' => $onDelete, 'name' => $name]);
     }
 
     public static function xmlParsingException(string $file, string $message): self

--- a/src/Core/System/CustomEntity/Schema/DynamicFieldFactory.php
+++ b/src/Core/System/CustomEntity/Schema/DynamicFieldFactory.php
@@ -34,6 +34,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\CustomEntity\CustomEntityException;
 use Shopware\Core\System\CustomEntity\CustomEntityRegistrar;
 use Shopware\Core\System\CustomEntity\Xml\Field\AssociationField;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -424,7 +425,7 @@ class DynamicFieldFactory
             AssociationField::CASCADE => new CascadeDelete(),
             AssociationField::SET_NULL => new SetNullOnDelete(),
             AssociationField::RESTRICT => new RestrictDelete(),
-            default => throw new \RuntimeException(\sprintf('onDelete property %s are not supported on field %s', $field['onDelete'], $field['name'])),
+            default => throw CustomEntityException::unsupportedOnDeletePropertyOnField($field['onDelete'], $field['name']),
         };
     }
 

--- a/src/Elasticsearch/ElasticsearchException.php
+++ b/src/Elasticsearch/ElasticsearchException.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Elasticsearch;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
@@ -16,6 +17,7 @@ class ElasticsearchException extends HttpException
     public const UNSUPPORTED_AGGREGATION = 'ELASTICSEARCH__UNSUPPORTED_AGGREGATION';
     public const UNSUPPORTED_FILTER = 'ELASTICSEARCH__UNSUPPORTED_FILTER';
     public const NESTED_AGGREGATION_PARSE_ERROR = 'ELASTICSEARCH__NESTED_AGGREGATION_PARSE_ERROR';
+    public const OPERATOR_NOT_ALLOWED = 'ELASTICSEARCH__OPERATOR_NOT_ALLOWED';
     public const PARENT_FILTER_ERROR = 'ELASTICSEARCH__PARENT_FILTER_ERROR';
     public const SERVER_NOT_AVAILABLE = 'ELASTICSEARCH__SERVER_NOT_AVAILABLE';
     public const EMPTY_QUERY = 'ELASTICSEARCH__EMPTY_QUERY';
@@ -70,6 +72,23 @@ class ElasticsearchException extends HttpException
             self::NESTED_AGGREGATION_MISSING,
             'Filter aggregation {{ aggregation }} contains no nested aggregation.',
             ['aggregation' => $aggregation]
+        );
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will only return `self` in the future
+     */
+    public static function operatorNotAllowed(string $operator): self|\InvalidArgumentException
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return new \InvalidArgumentException('Operator ' . $operator . ' not allowed');
+        }
+
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::OPERATOR_NOT_ALLOWED,
+            'Operator {{ operator }} not allowed',
+            ['operator' => $operator]
         );
     }
 

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -548,7 +548,7 @@ class CriteriaParser
             $aggregation instanceof TermsAggregation => $this->parseTermsAggregation($aggregation, $fieldName, $definition, $context),
             $aggregation instanceof DateHistogramAggregation => $this->parseDateHistogramAggregation($aggregation, $fieldName, $definition, $context),
             $aggregation instanceof RangeAggregation => $this->parseRangeAggregation($aggregation, $fieldName),
-            default => throw new \RuntimeException(\sprintf('Provided aggregation of class %s not supported', $aggregation::class)),
+            default => throw ElasticsearchException::unsupportedAggregation($aggregation::class),
         };
     }
 
@@ -803,7 +803,7 @@ class CriteriaParser
             MultiFilter::CONNECTION_OR => $this->parseOrMultiFilter($filter, $definition, $root, $context),
             MultiFilter::CONNECTION_AND => $this->parseAndMultiFilter($filter, $definition, $root, $context),
             MultiFilter::CONNECTION_XOR => $this->parseXorMultiFilter($filter, $definition, $root, $context),
-            default => throw new \InvalidArgumentException('Operator ' . $filter->getOperator() . ' not allowed'),
+            default => throw ElasticsearchException::operatorNotAllowed($filter->getOperator()),
         };
     }
 

--- a/tests/integration/Core/Checkout/Cart/Rule/LineItemOfManufacturerRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/LineItemOfManufacturerRuleTest.php
@@ -11,8 +11,8 @@ use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\Cart\Rule\LineItemOfManufacturerRule;
 use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Tests\Unit\Core\Checkout\Cart\SalesChannel\Helper\CartRuleHelperTrait;
@@ -163,7 +163,7 @@ class LineItemOfManufacturerRuleTest extends TestCase
             'operator' => Rule::OPERATOR_LT,
         ]);
 
-        $this->expectException(UnsupportedOperatorException::class);
+        $this->expectException(RuleException::class);
 
         $this->rule->match(new LineItemScope(
             $this->createLineItemWithManufacturer('3'),

--- a/tests/integration/Core/Checkout/Cart/Rule/PaymentMethodRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/PaymentMethodRuleTest.php
@@ -13,8 +13,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -333,7 +333,7 @@ class PaymentMethodRuleTest extends TestCase
             $salesChannelContext
         );
 
-        $this->expectException(UnsupportedOperatorException::class);
+        $this->expectException(RuleException::class);
         $this->expectExceptionMessage('Unsupported operator FOO in Shopware\Core\Framework\Rule\RuleComparison');
 
         $paymentMethodRule->match($ruleScope);

--- a/tests/integration/Core/Checkout/Cart/Rule/ShippingMethodRuleTest.php
+++ b/tests/integration/Core/Checkout/Cart/Rule/ShippingMethodRuleTest.php
@@ -13,8 +13,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\Framework\Test\TestCaseBase\DatabaseTransactionBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -333,7 +333,7 @@ class ShippingMethodRuleTest extends TestCase
             $salesChannelContext
         );
 
-        $this->expectException(UnsupportedOperatorException::class);
+        $this->expectException(RuleException::class);
         $this->expectExceptionMessage('Unsupported operator FOO in Shopware\Core\Framework\Rule\RuleComparison');
 
         $shippingMethodRule->match($ruleScope);

--- a/tests/unit/Core/Checkout/Cart/CartExceptionTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartExceptionTest.php
@@ -16,6 +16,24 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(CartException::class)]
 class CartExceptionTest extends TestCase
 {
+    public function testInvalidPriceFieldType(): void
+    {
+        $e = CartException::invalidPriceFieldType('badType');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(CartException::CART_INVALID_PRICE_FIELD_TYPE, $e->getErrorCode());
+        static::assertSame('The price field does not contain a valid "type" value. Received badType', $e->getMessage());
+    }
+
+    public function testDeliveryDateNotSupportedUnit(): void
+    {
+        $e = CartException::deliveryDateNotSupportedUnit('badUnit');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(CartException::CART_DELIVERY_DATE_NOT_SUPPORTED_UNIT, $e->getErrorCode());
+        static::assertSame('Not supported unit badUnit', $e->getMessage());
+    }
+
     public function testShippingMethodNotFound(): void
     {
         $e = CartException::shippingMethodNotFound('shipping-method-id');
@@ -404,6 +422,15 @@ class CartExceptionTest extends TestCase
         static::assertSame(Response::HTTP_CONFLICT, $e->getStatusCode());
         static::assertSame(CartException::CART_HASH_MISMATCH, $e->getErrorCode());
         static::assertSame('Content hash mismatch for cart token: some-token', $e->getMessage());
+    }
+
+    public function testUnsupportedOperator(): void
+    {
+        $e = CartException::unsupportedOperator('$', 'testClass');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(CartException::RULE_OPERATOR_NOT_SUPPORTED, $e->getErrorCode());
+        static::assertSame('Unsupported operator $ in testClass', $e->getMessage());
     }
 
     public function testWrongCartDataType(): void

--- a/tests/unit/Core/Checkout/Cart/Delivery/DeliveryDateTest.php
+++ b/tests/unit/Core/Checkout/Cart/Delivery/DeliveryDateTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Delivery;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\CartException;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryDate;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryTime;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(DeliveryDate::class)]
+class DeliveryDateTest extends TestCase
+{
+    public function testCreateFromDeliveryDateDoesNotSupportUnit(): void
+    {
+        $deliveryTime = new DeliveryTime();
+        $deliveryTime->setUnit('test');
+
+        $this->expectExceptionObject(CartException::deliveryDateNotSupportedUnit($deliveryTime->getUnit()));
+        DeliveryDate::createFromDeliveryTime($deliveryTime);
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/PriceDefinitionFactoryTest.php
+++ b/tests/unit/Core/Checkout/Cart/PriceDefinitionFactoryTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\CartException;
+use Shopware\Core\Checkout\Cart\PriceDefinitionFactory;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(PriceDefinitionFactory::class)]
+class PriceDefinitionFactoryTest extends TestCase
+{
+    public function testFactoryThrowsAnExceptionWhenTypeIsNotSet(): void
+    {
+        $factory = new PriceDefinitionFactory();
+        $this->expectExceptionObject(CartException::invalidPriceFieldType('none'));
+        /** @phpstan-ignore-next-line for test purpose we do not respect array description, type is missing */
+        $factory->factory(Context::createDefaultContext(), ['price' => 0.0, 'percentage' => 0.0], 'test');
+    }
+
+    public function testFactoryThrowsAnExceptionWhenTypeIsNotSupported(): void
+    {
+        $factory = new PriceDefinitionFactory();
+        $this->expectExceptionObject(CartException::invalidPriceFieldType('unsupported'));
+        $factory->factory(Context::createDefaultContext(), ['type' => 'unsupported', 'price' => 0.0, 'percentage' => 0.0], 'test');
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/Promotion/Cart/PromotionCalculatorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Promotion/Cart/PromotionCalculatorTest.php
@@ -23,6 +23,7 @@ use Shopware\Core\Checkout\Promotion\Cart\Discount\Filter\SetGroupScopeFilter;
 use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionExcludedError;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionCalculator;
 use Shopware\Core\Checkout\Promotion\Cart\PromotionProcessor;
+use Shopware\Core\Checkout\Promotion\PromotionException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 
@@ -89,6 +90,32 @@ class PromotionCalculatorTest extends TestCase
 
         static::assertInstanceOf(PromotionExcludedError::class, $error);
         static::assertEquals('Promotion second-promotion was excluded for cart.', $error->getMessage());
+    }
+
+    public function testThrowsExceptionWhenInvalidScopeDefinition(): void
+    {
+        $this->expectExceptionObject(PromotionException::invalidScopeDefinition('invalid-scope'));
+
+        $lineItems = new LineItem($this->ids->get('line-item-1'), LineItem::PRODUCT_LINE_ITEM_TYPE);
+        $lineItems->setPriceDefinition(new AbsolutePriceDefinition(50.0));
+        $lineItems->setLabel('Product');
+
+        $discountItem = $this->getDiscountItem('first-promotion')
+            ->setPayloadValue('code', 'code-1')
+            ->setPayloadValue('exclusions', ['second-promotion'])
+            ->setPayloadValue('priority', 2)
+            ->setPayloadValue('discountScope', 'invalid-scope');
+
+        $cart = new Cart('promotion-test');
+        $cart->addLineItems(new LineItemCollection([$lineItems]));
+
+        $this->promotionCalculator->calculate(
+            new LineItemCollection([$discountItem]),
+            $cart,
+            $cart,
+            $this->createMock(SalesChannelContext::class),
+            new CartBehavior()
+        );
     }
 
     private function getDiscountItem(string $promotionId): LineItem

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemInCategoryRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemInCategoryRuleTest.php
@@ -12,8 +12,8 @@ use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\Cart\Rule\LineItemInCategoryRule;
 use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\Framework\Validation\Constraint\ArrayOfUuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Tests\Unit\Core\Checkout\Cart\SalesChannel\Helper\CartRuleHelperTrait;
@@ -162,7 +162,7 @@ class LineItemInCategoryRuleTest extends TestCase
             'operator' => Rule::OPERATOR_LT,
         ]);
 
-        $this->expectException(UnsupportedOperatorException::class);
+        $this->expectException(RuleException::class);
 
         $this->rule->match(new LineItemScope(
             $this->createLineItemWithCategories(['3']),

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemInProductStreamRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemInProductStreamRuleTest.php
@@ -12,8 +12,8 @@ use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\Cart\Rule\LineItemInProductStreamRule;
 use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\Framework\Validation\Constraint\ArrayOfUuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Tests\Unit\Core\Checkout\Cart\SalesChannel\Helper\CartRuleHelperTrait;
@@ -172,7 +172,7 @@ class LineItemInProductStreamRuleTest extends TestCase
             'operator' => Rule::OPERATOR_LT,
         ]);
 
-        $this->expectException(UnsupportedOperatorException::class);
+        $this->expectException(RuleException::class);
 
         $this->rule->match(new LineItemScope(
             $this->createLineItemWithProductStreams(['3']),

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemOfTypeRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemOfTypeRuleTest.php
@@ -11,10 +11,10 @@ use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\Cart\Rule\LineItemOfTypeRule;
 use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
 use Shopware\Core\Checkout\CheckoutRuleScope;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Rule\RuleConfig;
 use Shopware\Core\Framework\Rule\RuleConstraints;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -185,7 +185,7 @@ class LineItemOfTypeRuleTest extends TestCase
         $cart->setLineItems(new LineItemCollection([$lineItem]));
         $scope = new CartRuleScope($cart, static::createMock(SalesChannelContext::class));
 
-        static::expectException(UnsupportedOperatorException::class);
+        static::expectException(RuleException::class);
 
         $rule->match($scope);
     }

--- a/tests/unit/Core/Checkout/Cart/Rule/LineItemTaxationRuleTest.php
+++ b/tests/unit/Core/Checkout/Cart/Rule/LineItemTaxationRuleTest.php
@@ -12,8 +12,8 @@ use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\Cart\Rule\LineItemScope;
 use Shopware\Core\Checkout\Cart\Rule\LineItemTaxationRule;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Tests\Unit\Core\Checkout\Cart\SalesChannel\Helper\CartRuleHelperTrait;
 
@@ -153,7 +153,7 @@ class LineItemTaxationRuleTest extends TestCase
             'operator' => Rule::OPERATOR_LT,
         ]);
 
-        $this->expectException(UnsupportedOperatorException::class);
+        $this->expectException(RuleException::class);
 
         $this->rule->match(new LineItemScope(
             $this->createLineItemWithTaxId('3'),

--- a/tests/unit/Core/Checkout/Customer/CustomerExceptionTest.php
+++ b/tests/unit/Core/Checkout/Customer/CustomerExceptionTest.php
@@ -295,4 +295,24 @@ class CustomerExceptionTest extends TestCase
         static::assertSame('Country with id "id-1" not found.', $exception->getMessage());
         static::assertSame(['countryId' => 'id-1'], $exception->getParameters());
     }
+
+    public function testUnsupportedOperator(): void
+    {
+        $exception = CustomerException::unsupportedOperator('$', 'testClass');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::RULE_OPERATOR_NOT_SUPPORTED, $exception->getErrorCode());
+        static::assertSame('Unsupported operator $ in testClass', $exception->getMessage());
+        static::assertSame(['operator' => '$', 'class' => 'testClass'], $exception->getParameters());
+    }
+
+    public function testUnsupportedValue(): void
+    {
+        $exception = CustomerException::unsupportedValue('badType', 'testClass');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::RULE_VALUE_NOT_SUPPORTED, $exception->getErrorCode());
+        static::assertSame('Unsupported value of type badType in testClass', $exception->getMessage());
+        static::assertSame(['type' => 'badType', 'class' => 'testClass'], $exception->getParameters());
+    }
 }

--- a/tests/unit/Core/Checkout/Customer/Rule/EmailRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/EmailRuleTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Customer\Rule;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\CheckoutRuleScope;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\CustomerException;
+use Shopware\Core\Checkout\Customer\Rule\EmailRule;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(EmailRule::class)]
+#[Group('rules')]
+class EmailRuleTest extends TestCase
+{
+    private EmailRule $rule;
+
+    protected function setUp(): void
+    {
+        $this->rule = new EmailRule();
+    }
+
+    public function testRuleMatchThrowsAndExceptionWhenNoCustomerEmailIsProvided(): void
+    {
+        $this->expectExceptionObject(CustomerException::unsupportedValue(\gettype(null), EmailRule::class));
+
+        $customer = new CustomerEntity();
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getCustomer')->willReturn($customer);
+
+        $scope = new CheckoutRuleScope($salesChannelContext);
+        $this->rule->assign(['email' => null, 'operator' => Rule::OPERATOR_EQ]);
+
+        $this->rule->match($scope);
+    }
+
+    public function testRuleMatchThrowsAndExceptionWhenOperatorIsNotSupported(): void
+    {
+        $this->expectExceptionObject(CustomerException::unsupportedOperator(Rule::OPERATOR_LTE, EmailRule::class));
+
+        $customer = new CustomerEntity();
+        $customer->setEmail('*');
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getCustomer')->willReturn($customer);
+
+        $scope = new CheckoutRuleScope($salesChannelContext);
+        $this->rule->assign(['email' => '*', 'operator' => Rule::OPERATOR_LTE]);
+
+        $this->rule->match($scope);
+    }
+}

--- a/tests/unit/Core/Checkout/Promotion/PromotionExceptionTest.php
+++ b/tests/unit/Core/Checkout/Promotion/PromotionExceptionTest.php
@@ -28,6 +28,16 @@ class PromotionExceptionTest extends TestCase
         static::assertSame(['code' => 'code-123'], $exception->getParameters());
     }
 
+    public function testDiscountCalculatorNotFound(): void
+    {
+        $exception = PromotionException::discountCalculatorNotFound('type-123');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(PromotionException::CHECKOUT_DISCOUNT_CALCULATOR_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Promotion Discount Calculator "type-123" has not been found!', $exception->getMessage());
+        static::assertSame(['type' => 'type-123'], $exception->getParameters());
+    }
+
     public function testInvalidCodePattern(): void
     {
         $exception = PromotionException::invalidCodePattern('code-123');
@@ -37,6 +47,16 @@ class PromotionExceptionTest extends TestCase
         static::assertSame(PromotionException::INVALID_CODE_PATTERN, $exception->getErrorCode());
         static::assertSame('Invalid code pattern "code-123".', $exception->getMessage());
         static::assertSame(['codePattern' => 'code-123'], $exception->getParameters());
+    }
+
+    public function testInvalidScopeDefinition(): void
+    {
+        $exception = PromotionException::invalidScopeDefinition('bad-scope');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(PromotionException::CHECKOUT_INVALID_DISCOUNT_SCOPE_DEFINITION, $exception->getErrorCode());
+        static::assertSame('Invalid discount calculator scope definition "bad-scope"', $exception->getMessage());
+        static::assertSame(['label' => 'bad-scope'], $exception->getParameters());
     }
 
     public function testPatternNotComplexEnough(): void

--- a/tests/unit/Core/Checkout/Rule/Rule/Cart/CartAmountRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Cart/CartAmountRuleTest.php
@@ -9,8 +9,8 @@ use Shopware\Core\Checkout\Cart\Rule\CartAmountRule;
 use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\CheckoutRuleScope;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\RuleConfig;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Generator;
 
@@ -144,7 +144,7 @@ class CartAmountRuleTest extends TestCase
     #[DataProvider('unsupportedOperators')]
     public function testUnsupportedOperators(string $operator): void
     {
-        $this->expectException(UnsupportedOperatorException::class);
+        $this->expectException(RuleException::class);
 
         $rule = (new CartAmountRule())->assign(['amount' => 100, 'operator' => $operator]);
 

--- a/tests/unit/Core/Checkout/Rule/Rule/Cart/CartPositionPriceRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Cart/CartPositionPriceRuleTest.php
@@ -9,8 +9,8 @@ use Shopware\Core\Checkout\Cart\Rule\CartPositionPriceRule;
 use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\CheckoutRuleScope;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\RuleConfig;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\Test\Generator;
 
@@ -154,7 +154,7 @@ class CartPositionPriceRuleTest extends TestCase
     #[DataProvider('unsupportedOperators')]
     public function testUnsupportedOperators(string $operator): void
     {
-        $this->expectException(UnsupportedOperatorException::class);
+        $this->expectException(RuleException::class);
 
         $rule = (new CartPositionPriceRule())->assign(['amount' => 100, 'operator' => $operator]);
 

--- a/tests/unit/Core/Checkout/Rule/Rule/Context/ShippingCountryRuleTest.php
+++ b/tests/unit/Core/Checkout/Rule/Rule/Context/ShippingCountryRuleTest.php
@@ -10,8 +10,8 @@ use Shopware\Core\Checkout\Cart\Delivery\Struct\ShippingLocation;
 use Shopware\Core\Checkout\Cart\Rule\CartRuleScope;
 use Shopware\Core\Checkout\Customer\Rule\ShippingCountryRule;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\RuleComparison;
+use Shopware\Core\Framework\Rule\RuleException;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 
@@ -122,7 +122,7 @@ class ShippingCountryRuleTest extends TestCase
             ->method('getShippingLocation')
             ->willReturn(ShippingLocation::createFromCountry($country));
 
-        $this->expectException(UnsupportedOperatorException::class);
+        $this->expectException(RuleException::class);
         $rule->match(new CartRuleScope($cart, $context));
     }
 
@@ -147,9 +147,9 @@ class ShippingCountryRuleTest extends TestCase
 
         try {
             $rule->match(new CartRuleScope($cart, $context));
-        } catch (UnsupportedOperatorException $e) {
-            static::assertSame(ShippingCountryRule::OPERATOR_GTE, $e->getOperator());
-            static::assertSame(RuleComparison::class, $e->getClass());
+        } catch (RuleException $e) {
+            static::assertSame(ShippingCountryRule::OPERATOR_GTE, $e->getParameter('operator'));
+            static::assertSame(RuleComparison::class, $e->getParameter('class'));
         }
     }
 

--- a/tests/unit/Core/Content/Flow/Controller/TriggerFlowControllerTest.php
+++ b/tests/unit/Core/Content/Flow/Controller/TriggerFlowControllerTest.php
@@ -5,7 +5,7 @@ namespace Shopware\Tests\Unit\Core\Content\Flow\Controller;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Flow\Controller\TriggerFlowController;
-use Shopware\Core\Content\Flow\Exception\CustomTriggerByNameNotFoundException;
+use Shopware\Core\Content\Flow\FlowException;
 use Shopware\Core\Framework\App\Aggregate\FlowEvent\AppFlowEventCollection;
 use Shopware\Core\Framework\App\Aggregate\FlowEvent\AppFlowEventEntity;
 use Shopware\Core\Framework\Context;
@@ -56,7 +56,7 @@ class TriggerFlowControllerTest extends TestCase
 
     public function testTriggerWithWrongEventName(): void
     {
-        $this->expectExceptionObject(new CustomTriggerByNameNotFoundException('custom.checkout.event'));
+        $this->expectExceptionObject(FlowException::customTriggerByNameNotFound('custom.checkout.event'));
 
         $request = new Request();
         $request->setMethod('POST');

--- a/tests/unit/Core/Content/Flow/FlowExceptionTest.php
+++ b/tests/unit/Core/Content/Flow/FlowExceptionTest.php
@@ -19,6 +19,15 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(FlowException::class)]
 class FlowExceptionTest extends TestCase
 {
+    public function customTriggerByNameNotFound(): void
+    {
+        $e = FlowException::customTriggerByNameNotFound('myEvent');
+
+        static::assertEquals(Response::HTTP_NOT_FOUND, $e->getStatusCode());
+        static::assertEquals(FlowException::ADMINISTRATION_CUSTOM_TRIGGER_BY_NAME_NOT_FOUND, $e->getErrorCode());
+        static::assertEquals('The provided event name myEvent is invalid or uninstalled and no custom trigger could be found.', $e->getMessage());
+    }
+
     public function testMethodNotCompatible(): void
     {
         $e = FlowException::methodNotCompatible('myMethod', 'myClass');

--- a/tests/unit/Core/Content/Flow/FlowExceptionTest.php
+++ b/tests/unit/Core/Content/Flow/FlowExceptionTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[CoversClass(FlowException::class)]
 class FlowExceptionTest extends TestCase
 {
-    public function customTriggerByNameNotFound(): void
+    public function testCustomTriggerByNameNotFound(): void
     {
         $e = FlowException::customTriggerByNameNotFound('myEvent');
 

--- a/tests/unit/Core/Content/Media/MediaExceptionTest.php
+++ b/tests/unit/Core/Content/Media/MediaExceptionTest.php
@@ -402,4 +402,14 @@ class MediaExceptionTest extends TestCase
         static::assertSame(MediaException::MEDIA_THUMBNAIL_GENERATION_DISABLED, $exception->getErrorCode());
         static::assertSame('Remote thumbnails are enabled. Skipping thumbnail generation.', $exception->getMessage());
     }
+
+    public function testUnknownLocationType(): void
+    {
+        $exception = MediaException::unknownLocationType();
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(MediaException::MEDIA_UNKNOWN_LOCATION_TYPE, $exception->getErrorCode());
+        static::assertSame('Unknown location type', $exception->getMessage());
+        static::assertSame([], $exception->getParameters());
+    }
 }

--- a/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
+++ b/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
@@ -77,4 +77,14 @@ class AdapterExceptionTest extends TestCase
         static::assertSame('test', $exception->getMessage());
         static::assertEmpty($exception->getParameters());
     }
+
+    public function testUnsupportedOperator(): void
+    {
+        $exception = AdapterException::unsupportedOperator('$', 'testClass');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(AdapterException::FRAMEWORK_OPERATOR_NOT_SUPPORTED, $exception->getErrorCode());
+        static::assertSame('Unsupported operator $ in testClass', $exception->getMessage());
+        static::assertSame(['operator' => '$', 'class' => 'testClass'], $exception->getParameters());
+    }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/DataAbstractionLayerExceptionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/DataAbstractionLayerExceptionTest.php
@@ -220,4 +220,13 @@ class DataAbstractionLayerExceptionTest extends TestCase
             $exception->getMessage()
         );
     }
+
+    public function testUnsupportedQueryFilter(): void
+    {
+        $exception = DataAbstractionLayerException::unsupportedQueryFilter('foo');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(DataAbstractionLayerException::UNSUPPORTED_QUERY_FILTER, $exception->getErrorCode());
+        static::assertSame('Unsupported query foo', $exception->getMessage());
+    }
 }

--- a/tests/unit/Core/Framework/Rule/RuleComparisonTest.php
+++ b/tests/unit/Core/Framework/Rule/RuleComparisonTest.php
@@ -6,9 +6,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Rule\RuleComparison;
+use Shopware\Core\Framework\Rule\RuleException;
 
 /**
  * @internal
@@ -147,7 +147,7 @@ class RuleComparisonTest extends TestCase
 
     public function testNumericComparisonThrowsExceptionIfUnsupportedOperatorIsUsed(): void
     {
-        $this->expectException(UnsupportedOperatorException::class);
+        $this->expectException(RuleException::class);
 
         RuleComparison::numeric(1.0, 1.0, 'unsupported');
     }

--- a/tests/unit/Core/Framework/Rule/RuleExceptionTest.php
+++ b/tests/unit/Core/Framework/Rule/RuleExceptionTest.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Rule;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\RuleException;
+use Shopware\Core\Framework\Script\Exception\ScriptExecutionFailedException;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(RuleException::class)]
+#[Group('rules')]
+class RuleExceptionTest extends TestCase
+{
+    public function testScriptExecutionFailed(): void
+    {
+        $previous = new \Exception();
+        $exception = RuleException::scriptExecutionFailed('testHook', 'testScript', $previous);
+
+        static::assertInstanceOf(ScriptExecutionFailedException::class, $exception);
+        static::assertEquals($previous, $exception->getPrevious());
+    }
+
+    public function testUnsupportedOperator(): void
+    {
+        $exception = RuleException::unsupportedOperator('$', 'testClass');
+
+        static::assertEquals(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertEquals('FRAMEWORK__RULE_OPERATOR_NOT_SUPPORTED', $exception->getErrorCode());
+        static::assertEquals('Unsupported operator $ in testClass', $exception->getMessage());
+        static::assertEquals(['operator' => '$', 'class' => 'testClass'], $exception->getParameters());
+    }
+
+    public function testUnsupportedValue(): void
+    {
+        $exception = RuleException::unsupportedValue('testType', 'testClass');
+
+        static::assertEquals(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertEquals('FRAMEWORK__RULE_VALUE_NOT_SUPPORTED', $exception->getErrorCode());
+        static::assertEquals('Unsupported value of type testType in testClass', $exception->getMessage());
+        static::assertEquals(['type' => 'testType', 'class' => 'testClass'], $exception->getParameters());
+    }
+}

--- a/tests/unit/Core/Framework/Store/InAppPurchases/Services/KeyFetcherTest.php
+++ b/tests/unit/Core/Framework/Store/InAppPurchases/Services/KeyFetcherTest.php
@@ -7,11 +7,11 @@ use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Shopware\Core\Framework\App\AppException;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Authentication\StoreRequestOptionsProvider;
 use Shopware\Core\Framework\Store\InAppPurchase\Services\KeyFetcher;
+use Shopware\Core\Framework\Store\StoreException;
 use Shopware\Core\System\SystemConfig\SystemConfigService;
 
 /**
@@ -103,7 +103,7 @@ class KeyFetcherTest extends TestCase
 
     public function testGetKeyReturns400ResponseWithoutExistingKey(): void
     {
-        static::expectException(AppException::class);
+        static::expectException(StoreException::class);
         static::expectExceptionMessage('Unable to retrieve JWKS key');
 
         $systemConfig = $this->createMock(SystemConfigService::class);

--- a/tests/unit/Core/Framework/Store/StoreExceptionTest.php
+++ b/tests/unit/Core/Framework/Store/StoreExceptionTest.php
@@ -69,6 +69,15 @@ class StoreExceptionTest extends TestCase
         static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
     }
 
+    public function testJwksNotFound(): void
+    {
+        $exception = StoreException::jwksNotFound();
+
+        static::assertSame('Unable to retrieve JWKS key', $exception->getMessage());
+        static::assertSame('FRAMEWORK__STORE_JWKS_NOT_FOUND', $exception->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+    }
+
     public function testMissingIntegrationInContextSource(): void
     {
         $exception = StoreException::missingIntegrationInContextSource('context');

--- a/tests/unit/Core/Framework/Util/ArrayComparatorTest.php
+++ b/tests/unit/Core/Framework/Util/ArrayComparatorTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Util\ArrayComparator;
 use Shopware\Core\Framework\Util\Exception\ComparatorException;
+use Shopware\Core\Framework\Util\UtilException;
 
 /**
  * @internal
@@ -47,7 +48,7 @@ class ArrayComparatorTest extends TestCase
 
     public function testCompareThrowException(): void
     {
-        static::expectException(ComparatorException::class);
+        static::expectException(UtilException::class);
         $this->expectExceptionMessage(ComparatorException::operatorNotSupported('>')->getMessage());
 
         ArrayComparator::compare([1], [2], '>');

--- a/tests/unit/Core/Framework/Util/FloatComparatorTest.php
+++ b/tests/unit/Core/Framework/Util/FloatComparatorTest.php
@@ -6,8 +6,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Rule\Rule;
-use Shopware\Core\Framework\Util\Exception\ComparatorException;
 use Shopware\Core\Framework\Util\FloatComparator;
+use Shopware\Core\Framework\Util\UtilException;
 
 /**
  * @internal
@@ -23,8 +23,8 @@ class FloatComparatorTest extends TestCase
 
     public function testCompareThrowException(): void
     {
-        static::expectException(ComparatorException::class);
-        $this->expectExceptionMessage(ComparatorException::operatorNotSupported('empty')->getMessage());
+        static::expectException(UtilException::class);
+        $this->expectExceptionMessage(UtilException::operatorNotSupported('empty')->getMessage());
 
         FloatComparator::compare(1, 2, 'empty');
     }

--- a/tests/unit/Core/Framework/Util/UtilExceptionTest.php
+++ b/tests/unit/Core/Framework/Util/UtilExceptionTest.php
@@ -40,4 +40,12 @@ class UtilExceptionTest extends TestCase
         static::assertEquals('UTIL__FILESYSTEM_FILE_NOT_FOUND', $e->getErrorCode());
         static::assertEquals('The file "some/file" does not exist in the given filesystem "some/folder"', $e->getMessage());
     }
+
+    public function testOperatorNotSupported(): void
+    {
+        $e = UtilException::operatorNotSupported('$');
+        static::assertEquals(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertEquals('UTIL__OPERATOR_NOT_SUPPORTED', $e->getErrorCode());
+        static::assertEquals('Operator "$" is not supported.', $e->getMessage());
+    }
 }

--- a/tests/unit/Core/System/CustomEntity/CustomEntityExceptionTest.php
+++ b/tests/unit/Core/System/CustomEntity/CustomEntityExceptionTest.php
@@ -41,4 +41,15 @@ class CustomEntityExceptionTest extends TestCase
         static::assertSame(CustomEntityException::CUSTOM_FIELDS_AWARE_LABEL_PROPERTY_WRONG_TYPE, $exception->getErrorCode());
         static::assertSame('Entity label_property "some_label" must be a string field', $exception->getMessage());
     }
+
+    public function testUnsupportedOnDeletePropertyOnField(): void
+    {
+        $onDelete = 'some_on_delete';
+        $name = 'some_name';
+        $exception = CustomEntityException::unsupportedOnDeletePropertyOnField($onDelete, $name);
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(CustomEntityException::CUSTOM_ENTITY_ON_DELETE_PROPERTY_NOT_SUPPORTED, $exception->getErrorCode());
+        static::assertSame('onDelete property some_on_delete are not supported on field some_name', $exception->getMessage());
+    }
 }

--- a/tests/unit/Elasticsearch/ElasticsearchExceptionTest.php
+++ b/tests/unit/Elasticsearch/ElasticsearchExceptionTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Elasticsearch;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Feature;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -20,6 +21,20 @@ class ElasticsearchExceptionTest extends TestCase
         static::assertSame('ELASTICSEARCH__DEFINITION_NOT_FOUND', $exception->getErrorCode());
         static::assertSame('Definition product not found', $exception->getMessage());
         static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+    }
+
+    public function testOperatorNotAllowed(): void
+    {
+        $exception = ElasticsearchException::operatorNotAllowed('foo');
+        static::assertSame('Operator foo not allowed', $exception->getMessage());
+
+        if (!Feature::isActive('v6.8.0.0')) {
+            static::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        } else {
+            static::assertInstanceOf(ElasticsearchException::class, $exception);
+            static::assertSame('ELASTICSEARCH__OPERATOR_NOT_ALLOWED', $exception->getErrorCode());
+            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        }
     }
 
     public function testUnsupportedDefinition(): void

--- a/tests/unit/Elasticsearch/ElasticsearchExceptionTest.php
+++ b/tests/unit/Elasticsearch/ElasticsearchExceptionTest.php
@@ -4,7 +4,7 @@ namespace Shopware\Tests\Unit\Elasticsearch;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Core\Framework\Feature;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,14 +27,20 @@ class ElasticsearchExceptionTest extends TestCase
     {
         $exception = ElasticsearchException::operatorNotAllowed('foo');
         static::assertSame('Operator foo not allowed', $exception->getMessage());
+        static::assertInstanceOf(ElasticsearchException::class, $exception);
+        static::assertSame('ELASTICSEARCH__OPERATOR_NOT_ALLOWED', $exception->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+    }
 
-        if (!Feature::isActive('v6.8.0.0')) {
-            static::assertInstanceOf(\InvalidArgumentException::class, $exception);
-        } else {
-            static::assertInstanceOf(ElasticsearchException::class, $exception);
-            static::assertSame('ELASTICSEARCH__OPERATOR_NOT_ALLOWED', $exception->getErrorCode());
-            static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
-        }
+    /**
+     * @deprecated tag:v6.8.0 - reason: see ElasticsearchException::operatorNotAllowed - to be removed
+     */
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testOperatorNotAllowedDeprecated(): void
+    {
+        $exception = ElasticsearchException::operatorNotAllowed('foo');
+        static::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        static::assertSame('Operator foo not allowed', $exception->getMessage());
     }
 
     public function testUnsupportedDefinition(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
Required for https://github.com/shopware/shopware/pull/6280, since `match(` will be inspected by PHPstan 2.0 (that was not the case before)

### 2. What does this change do, exactly?
- Fix various forgotten domain exceptions 

This is a sub branch from https://github.com/shopware/shopware/pull/6280, commits to be extracted (and double check vs Danger job)