### PR TITLE
fix: copy twig variables into each block

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
@@ -1,6 +1,3 @@
-{% set cmsPath = 'frontend.cms.page' %}
-{% set privacyNoticeSnippet = 'general.privacyNoticeText' %}
-
 {% block component_privacy_notice %}
     <fieldset class="form-text privacy-notice">
         {% block component_privacy_title %}
@@ -10,7 +7,10 @@
             <br>
         {% endblock %}
 
+
         {% block component_privacy_dpi %}
+            {% set cmsPath = 'frontend.cms.page' %}
+            {% set privacyNoticeSnippet = 'general.privacyNoticeText' %}
             {% if config('core.loginRegistration.requireDataProtectionCheckbox') == 1 %}
                 {% if feature('ACCESSIBILITY_TWEAKS') %}
                     {% set dataProtectionLabel = privacyNoticeSnippet|trans({

--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -1,5 +1,3 @@
-{% set cmsPath = feature('ACCESSIBILITY_TWEAKS') ? 'frontend.cms.page.full' : 'frontend.cms.page' %}
-
 {% block layout_footer_inner_container %}
     <div class="container">
         {% block layout_footer_navigation %}
@@ -38,6 +36,7 @@
                         {% endblock %}
 
                         {% block layout_footer_navigation_hotline_content %}
+                            {% set cmsPath = feature('ACCESSIBILITY_TWEAKS') ? 'frontend.cms.page.full' : 'frontend.cms.page' %}
                             <div id="collapseFooterHotline"
                                  class="footer-column-content collapse js-footer-column-content footer-contact"
                                  aria-labelledby="collapseFooterHotlineTitle"
@@ -211,6 +210,7 @@
             {% endblock %}
 
             {% block layout_footer_vat %}
+                {% set cmsPath = feature('ACCESSIBILITY_TWEAKS') ? 'frontend.cms.page.full' : 'frontend.cms.page' %}
                 {% if showVatNotice or showVatNotice is not defined %}
                     <div class="footer-vat">
                         {%- if feature('ACCESSIBILITY_TWEAKS') -%}

--- a/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/checkout/confirm/index.html.twig
@@ -42,7 +42,6 @@
             <div class="confirm-tos">
                 <div class="card checkout-card">
                     <div class="card-body">
-                        {% set cmsPath = 'frontend.cms.page' %}
 
                         {% block page_checkout_confirm_tos_header %}
                             <div class="card-title">
@@ -51,6 +50,7 @@
                         {% endblock %}
 
                         {% block page_checkout_confirm_revocation_notice %}
+                            {% set cmsPath = 'frontend.cms.page' %}
                             <p class="revocation-notice">
                                 {% set revocationSnippetKey = 'checkout.confirmRevocationNotice' %}
 
@@ -73,6 +73,7 @@
 
                                 {% block page_checkout_confirm_tos_control_label %}
                                     {% set tosSnippetKey = 'checkout.confirmTermsText' %}
+                                    {% set cmsPath = 'frontend.cms.page' %}
                                     <label for="tos"
                                            class="checkout-confirm-tos-label custom-control-label">
                                         {{ tosSnippetKey|trans({


### PR DESCRIPTION
Copy used variables into each block that uses the variables. This ensures that other Twig templates can import an individual block without having to either set the variable themselves or having the variable being interpreted as null.

This is the 6.7 port of https://github.com/shopware/shopware/pull/6856/