### PR TITLE
fix: varibles missing in 2 twig blocks

### DIFF
--- a/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/privacy-notice.html.twig
@@ -39,6 +39,8 @@
 
                     {# @deprecated tag:v6.7.0 - Block will be removed. Form field is replaced by a central component. #}
                     {% block component_privacy_dpi_label %}
+                        {% set cmsPath = 'frontend.cms.page' %}
+                        {% set privacyNoticeSnippet = 'general.privacyNoticeText' %}
                         <label class="custom-control-label no-validation"
                                for="acceptedDataProtection">
 
@@ -55,6 +57,8 @@
             {% else %}
                 <div class="data-protection-information">
                     {% block component_privacy_label %}
+                        {% set cmsPath = 'frontend.cms.page' %}
+                        {% set privacyNoticeSnippet = 'general.privacyNoticeText' %}
 
                         <div>
                             {{ privacyNoticeSnippet|trans({


### PR DESCRIPTION
This is a follow up to https://github.com/shopware/shopware/pull/6856/

In 6.6.x there are two blocks that are not used in 6.7 anymore, but can potentially lead to the fixed error again, if any derivation uses these blocks directly instead of the parent block.