### PR TITLE
fix: Fix MessengerMiddlewareCompilerPass when middlewares are not defined

### DIFF
--- a/changelog/_unreleased/2025-02-19-fix-messenger-middleware-compiler-path.md
+++ b/changelog/_unreleased/2025-02-19-fix-messenger-middleware-compiler-path.md
@@ -1,0 +1,11 @@
+---
+title: Fix MessengerMiddlewareCompilerPass
+issue: #6911
+---
+# Core
+* Changed `\Shopware\Core\Framework\DependencyInjection\CompilerPass\MessengerMiddlewareCompilerPass` to handle cases when middlewares are not defined yet
+___
+# Upgrade Information
+## Fix `MessengerMiddlewareCompilerPass` middleware assertion
+
+The `MessengerMiddlewareCompilerPass` now handles cases when middlewares are not defined yet. This change ensures that the middleware is correctly registered in the application.

--- a/src/Core/Framework/DependencyInjection/CompilerPass/MessengerMiddlewareCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/MessengerMiddlewareCompilerPass.php
@@ -20,14 +20,22 @@ class MessengerMiddlewareCompilerPass implements CompilerPassInterface
 
         $middlewares = $messageBus->getArgument(0);
 
-        \assert($middlewares instanceof IteratorArgument);
+        if ($middlewares instanceof IteratorArgument) {
+            $messageBus->replaceArgument(
+                0,
+                new IteratorArgument([
+                    new Reference(RoutingOverwriteMiddleware::class),
+                    ...$middlewares->getValues(),
+                ])
+            );
+        } else {
+            $messageBus->replaceArgument(
+                0,
+                new IteratorArgument([
+                    new Reference(RoutingOverwriteMiddleware::class),
+                ])
+            );
+        }
 
-        $messageBus->replaceArgument(
-            0,
-            new IteratorArgument([
-                new Reference(RoutingOverwriteMiddleware::class),
-                ...$middlewares->getValues(),
-            ])
-        );
     }
 }

--- a/src/Core/Framework/DependencyInjection/CompilerPass/MessengerMiddlewareCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/MessengerMiddlewareCompilerPass.php
@@ -36,6 +36,5 @@ class MessengerMiddlewareCompilerPass implements CompilerPassInterface
                 ])
             );
         }
-
     }
 }

--- a/tests/unit/Core/Framework/DependencyInjection/CompilerPass/MessengerMiddlewareCompilerPassTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/CompilerPass/MessengerMiddlewareCompilerPassTest.php
@@ -10,6 +10,7 @@ use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\ValidationMiddleware;
 
 /**
  * @internal
@@ -26,7 +27,39 @@ class MessengerMiddlewareCompilerPassTest extends TestCase
         $container->addCompilerPass(new MessengerMiddlewareCompilerPass());
 
         $busDefinition = new Definition(MessageBusInterface::class);
-        $busDefinition->setArguments([new IteratorArgument([]), []]);
+        $busDefinition->setArguments([new IteratorArgument([new Definition(ValidationMiddleware::class)]), []]);
+
+        $middlewareDefinition = new Definition(RoutingOverwriteMiddleware::class);
+        $middlewareDefinition->setArguments([[], []]);
+
+        $container->setDefinitions([
+            'messenger.bus.default' => $busDefinition,
+            RoutingOverwriteMiddleware::class => $middlewareDefinition,
+        ]);
+
+        // disable removing passes because the alias will not be used
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->getCompilerPassConfig()->setAfterRemovingPasses([]);
+
+        $container->compile();
+
+        $argument = $busDefinition->getArgument(0);
+        static::assertInstanceOf(IteratorArgument::class, $argument);
+        static::assertSame(RoutingOverwriteMiddleware::class, (string) $argument->getValues()[0]);
+        static::assertSame(ValidationMiddleware::class, (string) $argument->getValues()[1]);
+
+    }
+
+    public function testMiddlewareIsRegisteredWithoutMiddlewares(): void
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('messenger.default_transport_name', 'test');
+        $container->setParameter('kernel.debug', true);
+
+        $container->addCompilerPass(new MessengerMiddlewareCompilerPass());
+
+        $busDefinition = new Definition(MessageBusInterface::class);
+        $busDefinition->setArguments([[], []]);
 
         $middlewareDefinition = new Definition(RoutingOverwriteMiddleware::class);
         $middlewareDefinition->setArguments([[], []]);

--- a/tests/unit/Core/Framework/DependencyInjection/CompilerPass/MessengerMiddlewareCompilerPassTest.php
+++ b/tests/unit/Core/Framework/DependencyInjection/CompilerPass/MessengerMiddlewareCompilerPassTest.php
@@ -9,6 +9,7 @@ use Shopware\Core\Framework\MessageQueue\Middleware\RoutingOverwriteMiddleware;
 use Symfony\Component\DependencyInjection\Argument\IteratorArgument;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Messenger\Middleware\ValidationMiddleware;
 
@@ -45,9 +46,15 @@ class MessengerMiddlewareCompilerPassTest extends TestCase
 
         $argument = $busDefinition->getArgument(0);
         static::assertInstanceOf(IteratorArgument::class, $argument);
-        static::assertSame(RoutingOverwriteMiddleware::class, (string) $argument->getValues()[0]);
-        static::assertSame(ValidationMiddleware::class, (string) $argument->getValues()[1]);
 
+        $routingMiddleware = $argument->getValues()[0];
+        $validationMiddleware = $argument->getValues()[1];
+
+        static::assertInstanceOf(Reference::class, $routingMiddleware);
+        static::assertSame(RoutingOverwriteMiddleware::class, $routingMiddleware->__toString());
+
+        static::assertInstanceOf(Definition::class, $validationMiddleware);
+        static::assertSame(ValidationMiddleware::class, $validationMiddleware->getClass());
     }
 
     public function testMiddlewareIsRegisteredWithoutMiddlewares(): void


### PR DESCRIPTION
FIx issues like this:
![image (1)](https://github.com/user-attachments/assets/8fb71a80-cefb-492d-b2f8-7d2da54a4601)
