### PR TITLE
fix: require with minimum-stability stable (fixes: #6912)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
         "scssphp/scssphp": "v1.12.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/conflicts": "6.6.x-dev",
+        "shopware/conflicts": "0.4.0",
         "shyim/opensearch-php-dsl": "^1.0.5",
         "squirrelphp/twig-php-syntax": "^1.8.0",
         "symfony/asset": "~7.2.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -93,7 +93,7 @@
         "ramsey/uuid": "^4.7",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/conflicts": ">=0.2.0",
+        "shopware/conflicts": "0.4.0",
         "squirrelphp/twig-php-syntax": "^1.8.0",
         "symfony/asset": "~7.2.0",
         "symfony/cache": "~7.2.0",


### PR DESCRIPTION
- we can't use a branch because this requires a minimum stability of dev to work