### PR TITLE
feat: Replace textareas

### DIFF
--- a/src/Administration/Resources/app/administration/.eslintrc.js
+++ b/src/Administration/Resources/app/administration/.eslintrc.js
@@ -213,6 +213,7 @@ module.exports = {
                         'sw-text-field',
                         'sw-card',
                         'sw-switch-field',
+                        'sw-textarea-field',
                     ],
                 }],
                 // @deprecated v.6.7.0.0 - will be error in v.6.7

--- a/src/Administration/Resources/app/administration/code-mods.js
+++ b/src/Administration/Resources/app/administration/code-mods.js
@@ -262,6 +262,7 @@ async function lintFiles(filePaths, fix, shopwareVersion) {
                                         'sw-alert',
                                         'sw-text-field',
                                         'sw-switch-field',
+                                        'sw-textarea-field',
                                     ],
                                 }],
                                 'sw-deprecation-rules/no-deprecated-component-usage': ['error'],
@@ -467,6 +468,11 @@ function removePluginsTsConfigFile() {
 }
 
 function isVersionNewerOrSame(version, compareVersion) {
+    if (!version) {
+        console.error(colors.redBright('Invalid version number. Please specify a version number using "-v". See help for more details.'));
+        process.exit();
+    }
+
     const versionParts = version.split('.');
     const compareVersionParts = compareVersion.split('.');
 

--- a/src/Administration/Resources/app/administration/jest.config.js
+++ b/src/Administration/Resources/app/administration/jest.config.js
@@ -1,5 +1,5 @@
 /**
- * @package admin
+ * @sw-package framework
  */
 
 // For a detailed explanation regarding each configuration property, visit:
@@ -43,7 +43,7 @@ module.exports = {
 
     testRunner: 'jest-jasmine2',
 
-    resolver: '<rootDir>/jest-resolver.js',
+    resolver: '<rootDir>/test/_helper_/jest-resolver.js',
 
     runner: 'groups',
 
@@ -106,6 +106,7 @@ module.exports = {
         }],
     ] : [
         'default',
+        '<rootDir>/test/_helper_/failedSpecFileReporter.js',
     ],
 
     testMatch: [

--- a/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
@@ -93,3 +93,11 @@ a[target="_blank"]:not(.sw-external-link, .sw-internal-link, .mt-button) {
     white-space: nowrap;
     width: 1px;
 }
+
+.mt-textarea {
+    margin-bottom: 24px;
+
+    button.mt-help-text {
+        margin-left: auto;
+    }
+}

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/form/sw-datepicker/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/form/sw-datepicker/index.ts
@@ -5,7 +5,7 @@ import template from './sw-datepicker.html.twig';
  *
  * @private
  * @status ready
- * @description Wrapper component for sw-textarea-field and mt-textarea. Autoswitches between the two components.
+ * @description Wrapper component for sw-datepicker and mt-datepicker. Autoswitches between the two components.
  */
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default Shopware.Component.wrapComponentConfig({
@@ -40,9 +40,9 @@ export default Shopware.Component.wrapComponentConfig({
 
             // Throw warning when deprecated component is used
             Shopware.Utils.debug.warn(
-                'sw-textarea-field',
+                'sw-datepicker',
                 // eslint-disable-next-line max-len
-                'The old usage of "sw-textarea-field" is deprecated and will be removed in v6.7.0.0. Please use "mt-textarea" instead.',
+                'The old usage of "sw-datepicker" is deprecated and will be removed in v6.7.0.0. Please use "mt-datepicker" instead.',
             );
 
             return false;

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/form/sw-datepicker/sw-datepicker.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/form/sw-datepicker/sw-datepicker.html.twig
@@ -1,5 +1,5 @@
 {# v-on="$listeners" needed becaues vue/compat removes them from $attrs #}
-{# New mt-textarea component #}
+{# New mt-datepicker component #}
 {% block sw_datepicker %}
 <mt-datepicker
     v-if="useMeteorComponent"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-snippet-field-edit-modal/sw-snippet-field-edit-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-snippet-field-edit-modal/sw-snippet-field-edit-modal.html.twig
@@ -31,10 +31,10 @@
     </template>
 
     <template v-else-if="textArea">
-        <sw-textarea-field
+        <mt-textarea
             v-for="(snippet, index) in editableSnippets"
             :key="snippet.setId"
-            v-model:value="snippet.value"
+            v-model="snippet.value"
             v-tooltip.bottom="getNoPermissionsTooltip('snippet.editor')"
             class="sw-snippet-field-edit-modal__translation-field"
             :class="`sw-snippet-field-edit-modal__translation-field--${index}`"

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-snippet-field/sw-snippet-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-snippet-field/sw-snippet-field.html.twig
@@ -9,10 +9,10 @@
         disabled
     />
 
-    <sw-textarea-field
+    <mt-textarea
         v-else-if="textareaField"
         v-bind="$attrs"
-        :value="textValue"
+        :model-value="textValue"
         :type="fieldType"
         disabled
     />

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-textarea-field/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-textarea-field/index.ts
@@ -33,40 +33,18 @@ Component.register('sw-textarea-field', {
     },
 
     computed: {
-        useMeteorComponent() {
-            // Use new meteor component in major
-            if (Shopware.Feature.isActive('ENABLE_METEOR_COMPONENTS')) {
-                return true;
-            }
-
-            // Throw warning when deprecated component is used
-            Shopware.Utils.debug.warn(
-                'sw-textarea-field',
-                // eslint-disable-next-line max-len
-                'The old usage of "sw-textarea-field" is deprecated and will be removed in v6.7.0.0. Please use "mt-textarea" instead.',
-            );
-
-            return false;
-        },
-
         realValue: {
             get() {
                 return this.modelValue || this.value;
             },
             set(value: string) {
-                if (this.useMeteorComponent) {
-                    this.$emit('update:value', value);
-                } else {
-                    this.$emit('update:modelValue', value);
-                }
+                this.$emit('update:modelValue', value);
             },
         },
     },
 
     methods: {
         getSlots() {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-
             return this.$slots;
         },
     },

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-textarea-field/sw-textarea-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-textarea-field/sw-textarea-field.html.twig
@@ -2,7 +2,6 @@
 {# New mt-textarea component #}
 {% block sw_textarea_field %}
 <mt-textarea
-    v-if="useMeteorComponent"
     v-bind="$attrs"
     v-model="realValue"
     :placeholder="placeholder"
@@ -20,25 +19,5 @@
 </mt-textarea>
 {% endblock %}
 
-{# v-on="$listeners" needed becaues vue/compat removes them from $attrs #}
-{# Deprecated component #}
 {% block sw_textarea_field_deprecated %}
-<sw-textarea-field-deprecated
-    v-else
-    v-bind="$attrs"
-    v-model:value="realValue"
-    :value="value"
-    :placeholder="placeholder"
->
-    <template
-        v-for="(index, name) in getSlots()"
-        #[name]="data"
-    >
-        <slot
-            :name="name"
-            v-bind="data || {}"
-        >
-        </slot>
-    </template>
-</sw-textarea-field-deprecated>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-textarea-field/sw-textarea-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-textarea-field/sw-textarea-field.spec.js
@@ -8,7 +8,6 @@ async function createWrapper(additionalOptions = {}) {
     return mount(await wrapTestComponent('sw-textarea-field', { sync: true }), {
         global: {
             stubs: {
-                'sw-textarea-field-deprecated': true,
                 'mt-textarea': true,
             },
         },
@@ -23,18 +22,7 @@ describe('src/app/component/base/sw-textarea-field', () => {
         expect(wrapper.vm).toBeTruthy();
     });
 
-    it('should render the deprecated textarea-field when major feature flag is disabled', async () => {
-        global.activeFeatureFlags = [''];
-
-        const wrapper = await createWrapper();
-
-        expect(wrapper.html()).toContain('sw-textarea-field-deprecated');
-        expect(wrapper.html()).not.toContain('mt-textarea');
-    });
-
     it('should render the mt-textarea-field when major feature flag is enabled', async () => {
-        global.activeFeatureFlags = ['ENABLE_METEOR_COMPONENTS'];
-
         const wrapper = await createWrapper();
 
         expect(wrapper.html()).toContain('mt-textarea');

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-not-found/sw-condition-not-found.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-not-found/sw-condition-not-found.html.twig
@@ -8,8 +8,8 @@
 
 {% block sw_condition_value_content %}
 <div class="sw-condition-not-found">
-    <sw-textarea-field
-        v-model:value="value"
+    <mt-textarea
+        v-model="value"
         name="sw-field--value"
         size="medium"
         :disabled="true"

--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-rule-modal/sw-rule-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-rule-modal/sw-rule-modal.html.twig
@@ -36,9 +36,9 @@
     </sw-container>
 
     {% block sw_rule_modal_basic_info_description %}
-    <sw-textarea-field
+    <mt-textarea
         v-if="rule"
-        v-model:value="rule.description"
+        v-model="rule.description"
         name="sw-field--rule-description"
         :label="$tc('sw-rule-modal.labelDescription')"
         :placeholder="$tc('sw-rule-modal.placeholderDescription')"

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-order/sw-bulk-edit-order-documents-generate-invoice/sw-bulk-edit-order-documents-generate-invoice.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-order/sw-bulk-edit-order-documents-generate-invoice/sw-bulk-edit-order-documents-generate-invoice.html.twig
@@ -11,8 +11,8 @@
     {% endblock %}
 
     {% block sw_bulk_edit_order_documents_generate_invoice_textarea %}
-    <sw-textarea-field
-        v-model:value="generateData.documentComment"
+    <mt-textarea
+        v-model="generateData.documentComment"
         :label="$tc('sw-bulk-edit.order.documents.generateInvoice.labelTextarea')"
         :placeholder="$tc('sw-bulk-edit.order.documents.generateInvoice.placeholderTextarea')"
     />

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-entry-point-modal/sw-category-entry-point-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-entry-point-modal/sw-category-entry-point-modal.html.twig
@@ -171,8 +171,8 @@
         {% endblock %}
 
         {% block sw_category_entry_point_modal_selected_sales_channel_seo_meta_description %}
-        <sw-textarea-field
-            v-model:value="selectedSalesChannel.homeMetaDescription"
+        <mt-textarea
+            v-model="selectedSalesChannel.homeMetaDescription"
             class="sw-category-entry-point-modal__meta-description"
             :label="$tc('sw-category.base.entry-point-modal.metaDescriptionLabel')"
             :placeholder="selectedSalesChannel.translated.homeMetaDescription || $tc('sw-category.base.entry-point-modal.metaDescriptionPlaceholder')"

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-entry-point-modal/sw-category-entry-point-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-entry-point-modal/sw-category-entry-point-modal.spec.js
@@ -42,6 +42,7 @@ async function createWrapper() {
                     },
                     'sw-single-select': true,
                     'sw-textarea-field': true,
+                    'mt-textarea': true,
                     'sw-cms-list-item': true,
 
                     'sw-cms-layout-modal': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-seo-form/sw-category-seo-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-seo-form/sw-category-seo-form.html.twig
@@ -13,8 +13,8 @@
     {% endblock %}
 
     {% block sw_category_seo_form_meta_description %}
-    <sw-textarea-field
-        v-model:value="category.metaDescription"
+    <mt-textarea
+        v-model="category.metaDescription"
         maxlength="255"
         :disabled="!acl.can('category.editor')"
         :label="$tc('sw-category.base.seo.labelMetaDescription')"

--- a/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-seo-form/sw-category-seo-form.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/component/sw-category-seo-form/sw-category-seo-form.spec.js
@@ -8,7 +8,7 @@ async function createWrapper() {
         global: {
             stubs: {
                 'sw-text-field': true,
-                'sw-textarea-field': true,
+                'mt-textarea': true,
             },
         },
         props: {

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-base/sw-landing-page-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-base/sw-landing-page-detail-base.html.twig
@@ -94,8 +94,8 @@
             {% endblock %}
 
             {% block sw_landing_page_detail_base_seo_form_meta_description %}
-            <sw-textarea-field
-                v-model:value="landingPage.metaDescription"
+            <mt-textarea
+                v-model="landingPage.metaDescription"
                 maxlength="255"
                 :disabled="!acl.can('landing_page.editor')"
                 :label="$tc('sw-landing-page.base.seo.labelMetaDescription')"

--- a/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-base/sw-landing-page-detail-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/view/sw-landing-page-detail-base/sw-landing-page-detail-base.spec.js
@@ -43,7 +43,7 @@ async function createWrapper({
                 },
                 'sw-entity-multi-select': true,
                 'mt-banner': true,
-                'sw-textarea-field': true,
+                'mt-textarea': true,
                 'sw-custom-field-set-renderer': true,
             },
             computed: {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-contact/sw-cms-el-form-contact.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-contact/sw-cms-el-form-contact.html.twig
@@ -47,9 +47,9 @@
         :model-value="$tc('sw-cms.elements.form.element.placeholder.subject')"
     />
 
-    <sw-textarea-field
+    <mt-textarea
         :label="$tc('sw-cms.elements.form.element.label.message')"
-        :value="$tc('sw-cms.elements.form.element.placeholder.message')"
+        :model-value="$tc('sw-cms.elements.form.element.placeholder.message')"
     />
 
     <h4>{{ $tc('sw-cms.elements.form.element.label.privacy') }}</h4>

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/config/sw-cms-el-config-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/config/sw-cms-el-config-form.html.twig
@@ -68,9 +68,9 @@
             {% endblock %}
 
             {% block sw_cms_el_form_config_content_form_confirmation_text %}
-            <sw-textarea-field
+            <mt-textarea
                 v-if="element.config.type.value === 'contact'"
-                v-model:value="element.config.confirmationText.value"
+                v-model="element.config.confirmationText.value"
                 :label="$tc('sw-cms.elements.form.config.label.confirmationText')"
             />
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-custom-entity-input-field/sw-custom-entity-input-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-custom-entity-input-field/sw-custom-entity-input-field.html.twig
@@ -11,14 +11,14 @@
         @update:model-value="onChange"
     />
 
-    <sw-textarea-field
+    <mt-textarea
         v-else-if="type === 'text'"
         class="sw-custom-entity-input-field__text"
-        :value="currentValue"
+        :model-value="currentValue"
         :label="label"
         :placeholder="placeholder"
         :help-text="helpText"
-        @update:value="onChange"
+        @update:model-value="onChange"
     />
 
     <sw-number-field

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-custom-entity-input-field/sw-custom-entity-input-field.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-custom-entity-input-field/sw-custom-entity-input-field.spec.js
@@ -13,10 +13,10 @@ async function createWrapper(props = { type: 'string' }) {
                         'helpText',
                     ],
                 },
-                'sw-textarea-field': {
+                'mt-textarea': {
                     template: '<input/>',
                     props: [
-                        'value',
+                        'modelValue',
                         'label',
                         'placeholder',
                         'helpText',
@@ -77,7 +77,11 @@ describe('module/sw-custom-entity/component/sw-custom-entity-input-field', () =>
             await wrapper.setProps(mockData);
 
             const inputField = wrapper.getComponent(`.sw-custom-entity-input-field__${type}`);
-            let propType = type === 'string' ? 'modelValue' : 'value';
+            const modelValueTypes = [
+                'text',
+                'string',
+            ];
+            let propType = modelValueTypes.includes(type) ? 'modelValue' : 'value';
 
             if (type === 'boolean') {
                 propType = 'checked';

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/sw-generic-seo-general-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/sw-generic-seo-general-card.html.twig
@@ -23,14 +23,14 @@
         @update:model-value="emitSeoUrl"
     />
 
-    <sw-textarea-field
+    <mt-textarea
         class="sw-generic-seo-general-card__seo-meta-description-input"
-        :value="seoMetaDescription"
+        :model-value="seoMetaDescription"
         maxlength="255"
         :label="$tc('sw-landing-page.base.seo.labelMetaDescription')"
         :help-text="$tc('sw-landing-page.base.seo.helpTextMetaDescription')"
         :placeholder="$tc('sw-landing-page.base.seo.placeholderMetaDescription')"
-        @update:value="emitSeoMetaDescription"
+        @update:model-value="emitSeoMetaDescription"
     />
 
     <div class="sw-generic-seo-general-card__google-preview-container">

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/sw-generic-seo-general-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-seo-general-card/sw-generic-seo-general-card.spec.js
@@ -11,10 +11,10 @@ async function createWrapper() {
                 'mt-card': {
                     template: '<div class="mt-card"><slot></slot></div>',
                 },
-                'sw-textarea-field': {
+                'mt-textarea': {
                     template: '<textarea class="sw-text-field" />',
                     props: [
-                        'value',
+                        'modelValue',
                         'label',
                         'help-text',
                         'placeholder',
@@ -64,10 +64,10 @@ describe('src/module/sw-custom-entity/component/sw-generic-seo-general-card', ()
         expect(seoMetaDescriptionInput.props('label')).toBe('sw-landing-page.base.seo.labelMetaDescription');
         expect(seoMetaDescriptionInput.props('maxlength')).toBe('255');
 
-        expect(seoMetaDescriptionInput.props('value')).toBe('');
+        expect(seoMetaDescriptionInput.props('modelValue')).toBe('');
         expect(seoMetaDescriptionDisplay.text()).toBe('');
 
-        await seoMetaDescriptionInput.vm.$emit('update:value', TEST_SEO_META_DESCRIPTION);
+        await seoMetaDescriptionInput.vm.$emit('update:modelValue', TEST_SEO_META_DESCRIPTION);
         expect(wrapper.emitted('update:seo-meta-description')).toEqual([
             [TEST_SEO_META_DESCRIPTION],
         ]);
@@ -76,7 +76,7 @@ describe('src/module/sw-custom-entity/component/sw-generic-seo-general-card', ()
             seoMetaDescription: TEST_SEO_META_DESCRIPTION,
         });
 
-        expect(seoMetaDescriptionInput.props('value')).toBe(TEST_SEO_META_DESCRIPTION);
+        expect(seoMetaDescriptionInput.props('modelValue')).toBe(TEST_SEO_META_DESCRIPTION);
         expect(seoMetaDescriptionDisplay.text()).toBe(TEST_SEO_META_DESCRIPTION);
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/sw-generic-social-media-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/sw-generic-social-media-card.html.twig
@@ -15,14 +15,14 @@
         @update:model-value="emitOgTitle"
     />
 
-    <sw-textarea-field
+    <mt-textarea
         class="sw-generic-social-media-card__og-description-input"
-        :value="ogDescription"
+        :model-value="ogDescription"
         max-length="255"
         :label="$tc('sw-landing-page.base.seo.labelSocialMediaDescription')"
         :help-text="$tc('sw-landing-page.base.seo.helpTextMetaDescription')"
         :placeholder="$tc('sw-landing-page.base.seo.placeholderSocialMediaDescription')"
-        @update:value="emitOgDescription"
+        @update:model-value="emitOgDescription"
     />
 
     <sw-media-upload-v2

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/sw-generic-social-media-card.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/component/sw-generic-social-media-card/sw-generic-social-media-card.spec.js
@@ -31,12 +31,12 @@ async function createWrapper() {
                         'maxlength',
                     ],
                 },
-                'sw-textarea-field': {
+                'mt-textarea': {
                     // eslint-disable-next-line max-len
                     template:
-                        '<textarea class="sw-text-field" :value="value" @input="$emit(\'update:value\', $event.target.value)" />',
+                        '<textarea class="sw-text-field" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
                     props: [
-                        'value',
+                        'modelValue',
                         'label',
                         'help-text',
                         'placeholder',
@@ -131,19 +131,19 @@ describe('src/module/sw-custom-entity/component/sw-generic-social-media-card', (
         expect(ogDescriptionInput.props().helpText).toBe('sw-landing-page.base.seo.helpTextMetaDescription');
         expect(ogDescriptionInput.props().label).toBe('sw-landing-page.base.seo.labelSocialMediaDescription');
         expect(ogDescriptionInput.props().placeholder).toBe('sw-landing-page.base.seo.placeholderSocialMediaDescription');
-        expect(ogDescriptionInput.props().value).toBe('');
+        expect(ogDescriptionInput.props().modelValue).toBe('');
         expect(ogDescriptionInput.attributes()['max-length']).toBe('255');
 
         expect(ogDescriptionDisplay.text()).toBe('');
 
-        await ogDescriptionInput.vm.$emit('update:value', TEST_OG_DESCRIPTION);
+        await ogDescriptionInput.vm.$emit('update:modelValue', TEST_OG_DESCRIPTION);
         expect(wrapper.emitted('update:og-description')).toEqual([
             [TEST_OG_DESCRIPTION],
         ]);
 
         await wrapper.setProps({ ogDescription: TEST_OG_DESCRIPTION });
 
-        expect(ogDescriptionInput.props('value')).toBe(TEST_OG_DESCRIPTION);
+        expect(ogDescriptionInput.props('modelValue')).toBe(TEST_OG_DESCRIPTION);
         expect(ogDescriptionDisplay.text()).toBe(TEST_OG_DESCRIPTION);
     });
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-review-creation-inputs/sw-extension-review-creation-inputs.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-review-creation-inputs/sw-extension-review-creation-inputs.html.twig
@@ -29,8 +29,8 @@
     {% endblock %}
 
     {% block sw_extension_review_creation_inputs_description_input %}
-    <sw-textarea-field
-        v-model:value="text"
+    <mt-textarea
+        v-model="text"
         :label="$tc('sw-extension-store.component.sw-extension-ratings.sw-extension-review-creation-inputs.labelText')"
     />
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-review-creation-inputs/sw-extension-review-creation-inputs.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-ratings/sw-extension-review-creation-inputs/sw-extension-review-creation-inputs.scss
@@ -15,8 +15,4 @@
             display: flex;
         }
     }
-
-    .sw-textarea-field {
-        margin-bottom: 24px;
-    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-create-mail-template-modal/sw-flow-create-mail-template-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-create-mail-template-modal/sw-flow-create-mail-template-modal.html.twig
@@ -52,8 +52,8 @@
     {% endblock %}
 
     {% block sw_flow_create_mail_template_modal_description %}
-    <sw-textarea-field
-        v-model:value="mailTemplate.description"
+    <mt-textarea
+        v-model="mailTemplate.description"
         name="sw-field--mailTemplate-description"
         class="sw-flow-create-mail-template-modal__description"
         :label="$tc('sw-flow.modals.mail.labelDescription')"

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-rule-modal/sw-flow-rule-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/modals/sw-flow-rule-modal/sw-flow-rule-modal.html.twig
@@ -74,8 +74,8 @@
                     </sw-container>
 
                     {% block sw_flow_rule_modal_detail_description %}
-                    <sw-textarea-field
-                        v-model:value="rule.description"
+                    <mt-textarea
+                        v-model="rule.description"
                         name="sw-field--rule-description"
                         class="sw-flow-rule-modal__description"
                         :label="$tc('sw-flow.modals.rule.labelDescription')"

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-general/sw-flow-detail-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-general/sw-flow-detail-general.html.twig
@@ -37,8 +37,8 @@
         {% endblock %}
 
         {% block sw_flow_detail_general_information_description %}
-        <sw-textarea-field
-            v-model:value="flow.description"
+        <mt-textarea
+            v-model="flow.description"
             name="sw-field--flow-description"
             class="sw-flow-detail-general__general-description"
             :disabled="!acl.can('flow.editor') || undefined"

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-general/sw-flow-detail-general.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/view/detail/sw-flow-detail-general/sw-flow-detail-general.spec.js
@@ -41,7 +41,7 @@ async function createWrapper(privileges = [], query = {}) {
                         template: '<div><slot></slot></div>',
                     },
                     'mt-text-field': true,
-                    'sw-textarea-field': true,
+                    'mt-textarea': true,
                     'sw-container': {
                         template: '<div><slot></slot></div>',
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-header-footer-detail/sw-mail-header-footer-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-header-footer-detail/sw-mail-header-footer-detail.html.twig
@@ -83,8 +83,8 @@
                     {% endblock %}
 
                     {% block sw_mail_header_footer_basic_form_description_field %}
-                    <sw-textarea-field
-                        v-model:value="mailHeaderFooter.description"
+                    <mt-textarea
+                        v-model="mailHeaderFooter.description"
                         name="sw-field--mailHeaderFooter-description"
                         :label="$tc('sw-mail-header-footer.detail.basic.labelDescription')"
                         :placeholder="placeholder(mailHeaderFooter, 'description', $tc('sw-mail-header-footer.detail.basic.placeholderDescription'))"

--- a/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-mail-template/page/sw-mail-template-detail/sw-mail-template-detail.html.twig
@@ -94,8 +94,8 @@
                     {% endblock %}
 
                     {% block sw_mail_template_basic_form_description_field %}
-                    <sw-textarea-field
-                        v-model:value="mailTemplate.description"
+                    <mt-textarea
+                        v-model="mailTemplate.description"
                         name="sw-field--mailTemplate-description"
                         :label="$tc('sw-mail-template.detail.basic.labelDescription')"
                         :placeholder="$tc('sw-mail-template.detail.basic.placeholderDescription')"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-details-body/sw-order-create-details-body.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-details-body/sw-order-create-details-body.html.twig
@@ -33,7 +33,7 @@
             </p>
             <sw-address :address="billingAddress" />
         </div>
-        <sw-textarea-field
+        <mt-textarea
             v-else
             disabled
             class="sw-order-create-details-body__item"
@@ -94,7 +94,7 @@
                 {% endblock %}
             </template>
         </div>
-        <sw-textarea-field
+        <mt-textarea
             v-else
             disabled
             class="sw-order-create-details-body__item"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/sw-order-document-settings-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-settings-modal/sw-order-document-settings-modal.html.twig
@@ -79,8 +79,8 @@
     {% block sw_order_document_settings_modal_form_additional_content %}{% endblock %}
 
     {% block sw_order_document_settings_modal_form_document_comment %}
-    <sw-textarea-field
-        v-model:value="documentConfig.documentComment"
+    <mt-textarea
+        v-model="documentConfig.documentComment"
         name="sw-field--documentConfig-documentComment"
         class="sw-order-document-settings-modal__comment"
         :label="$tc('sw-order.documentModal.labelDocumentComment')"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/view/sw-order-detail-details/sw-order-detail-details.html.twig
@@ -201,8 +201,8 @@
         {% endblock %}
 
         {% block sw_order_detail_details_order_customer_comment %}
-        <sw-textarea-field
-            v-model:value="order.customerComment"
+        <mt-textarea
+            v-model="order.customerComment"
             class="sw-order-detail-details__customer-comment"
             :disabled="!acl.can('order.editor')"
             :label="$tc('sw-order.detailBase.labelCustomerComment')"

--- a/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/sw-product-stream-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product-stream/page/sw-product-stream-detail/sw-product-stream-detail.html.twig
@@ -129,9 +129,9 @@
                     {% endblock %}
 
                     {% block sw_product_basic_form_description_field %}
-                    <sw-textarea-field
+                    <mt-textarea
                         v-if="productStream"
-                        v-model:value="productStream.description"
+                        v-model="productStream.description"
                         v-tooltip.bottom="getNoPermissionsTooltip('product_stream.editor')"
                         name="sw-field--productStream-description"
                         :label="$tc('sw-product-stream.detail.labelDescription')"

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-seo-form/sw-product-seo-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-seo-form/sw-product-seo-form.html.twig
@@ -30,12 +30,12 @@
         :inherited-value="parentProduct.metaDescription"
     >
         <template #content="props">
-            <sw-textarea-field
+            <mt-textarea
                 :placeholder="$tc('sw-product.seoForm.placeholderMetaDescription')"
                 :error="productMetaDescriptionError"
                 :disabled="props.isInherited || !allowEdit"
-                :value="props.currentValue"
-                @update:value="props.updateCurrentValue"
+                :model-value="props.currentValue"
+                @update:model-value="props.updateCurrentValue"
             />
         </template>
     </sw-inherit-wrapper>

--- a/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/sw-property-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-property/component/sw-property-detail-base/sw-property-detail-base.html.twig
@@ -20,8 +20,8 @@
     {% endblock %}
 
     {% block sw_property_detail_base_description %}
-    <sw-textarea-field
-        v-model:value="propertyGroup.description"
+    <mt-textarea
+        v-model="propertyGroup.description"
         name="sw-field--propertyGroup-description"
         :label="$tc('sw-property.detail.labelDescription')"
         :placeholder="placeholder(propertyGroup, 'description', $tc('sw-property.detail.placeholderDescription'))"

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.html.twig
@@ -264,8 +264,8 @@
                 >
 
                     {% block sw_review_detail_basic_info_card_comment %}
-                    <sw-textarea-field
-                        v-model:value="review.comment"
+                    <mt-textarea
+                        v-model="review.comment"
                         name="sw-field--review-comment"
                         class="sw-review__comment-field"
                         :disabled="!acl.can('review.editor') || undefined"

--- a/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-review/page/sw-review-detail/sw-review-detail.spec.js
@@ -76,8 +76,7 @@ async function createWrapper() {
                 'sw-loader': true,
                 'sw-card-section': true,
                 'sw-entity-single-select': true,
-
-                'sw-textarea-field': true,
+                'mt-textarea': true,
                 'sw-language-switch': true,
                 'sw-skeleton': true,
                 'sw-rating-stars': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/sw-settings-customer-group-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/sw-settings-customer-group-detail.html.twig
@@ -155,8 +155,8 @@
                     {% endblock %}
 
                     {% block sw_settings_customer_group_detail_content_registration_card_seo_meta_description %}
-                    <sw-textarea-field
-                        v-model:value="customerGroup.registrationSeoMetaDescription"
+                    <mt-textarea
+                        v-model="customerGroup.registrationSeoMetaDescription"
                         name="sw-field--customerGroup-registrationSeoMetaDescription"
                         :label="$tc('sw-settings-customer-group.registration.seoMetaDescription')"
                         :placeholder="placeholder(customerGroup, 'registrationSeoMetaDescription', $tc('sw-settings-customer-group.registration.placeholderSeoMetaDescription'))"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/sw-settings-customer-group-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-customer-group/page/sw-settings-customer-group-detail/sw-settings-customer-group-detail.spec.js
@@ -57,7 +57,7 @@ async function createWrapper(privileges = []) {
                           <slot></slot>
                         </div>`,
                     },
-                    'sw-textarea-field': true,
+                    'mt-textarea': true,
                     'mt-text-editor': true,
                     'sw-language-info': true,
                     'sw-button-process': true,
@@ -200,7 +200,7 @@ describe('src/module/sw-settings-customer-group/page/sw-settings-customer-group-
             },
             {
                 name: 'seo meta field',
-                selector: 'sw-textarea-field-stub[label="sw-settings-customer-group.registration.seoMetaDescription"]',
+                selector: 'mt-textarea-stub[label="sw-settings-customer-group.registration.seoMetaDescription"]',
             },
             {
                 name: 'sales channel multiple select',
@@ -267,7 +267,7 @@ describe('src/module/sw-settings-customer-group/page/sw-settings-customer-group-
             },
             {
                 name: 'seo meta field',
-                selector: 'sw-textarea-field-stub[label="sw-settings-customer-group.registration.seoMetaDescription"]',
+                selector: 'mt-textarea-stub[label="sw-settings-customer-group.registration.seoMetaDescription"]',
             },
             {
                 name: 'sales channel multiple select',

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-logging/component/sw-settings-logging-entry-info/sw-settings-logging-entry-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-logging/component/sw-settings-logging-entry-info/sw-settings-logging-entry-info.html.twig
@@ -19,9 +19,9 @@
         <template #content>
             {% block sw_settings_logging_entry_info_content %}
             {% block sw_settings_logging_entry_info_raw_content %}
-            <sw-textarea-field
+            <mt-textarea
                 v-if="activeTab === 'raw'"
-                :value="displayString"
+                :model-value="displayString"
             />
             {% endblock %}
             {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/page/sw-settings-payment-detail/sw-settings-payment-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/page/sw-settings-payment-detail/sw-settings-payment-detail.html.twig
@@ -129,11 +129,11 @@
                             gap="0px 30px"
                         >
                             {% block sw_settings_payment_detail_base_content_field_description %}
-                            <sw-textarea-field
-                                v-model:value="paymentMethod.description"
+                            <mt-textarea
+                                v-model="paymentMethod.description"
                                 name="sw-field--paymentMethod-description"
                                 :disabled="!acl.can('payment.editor') || undefined"
-                                :value="paymentMethod.description"
+                                :model-value="paymentMethod.description"
                                 class="sw-settings-payment-detail__description"
                                 :label="$tc('sw-settings-payment.detail.labelDescription')"
                                 :placeholder="placeholder(paymentMethod, 'description', $tc('sw-settings-payment.detail.placeholderDescription'))"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-payment/page/sw-settings-payment-detail/sw-settings-payment-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-payment/page/sw-settings-payment-detail/sw-settings-payment-detail.spec.js
@@ -94,7 +94,7 @@ async function createWrapper(privileges = [], paymentMethod = {}) {
                     'sw-upload-listener': true,
                     'sw-media-upload-v2': true,
                     'sw-plugin-box': true,
-                    'sw-textarea-field': true,
+                    'mt-textarea': true,
                     'sw-select-rule-create': true,
                     'sw-sidebar': true,
                     'sw-sidebar-media-item': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-detail/sw-settings-product-feature-sets-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-detail/sw-settings-product-feature-sets-detail.html.twig
@@ -70,8 +70,8 @@
                     {% endblock %}
 
                     {% block sw_settings_product_feature_set_detail_content_field_description %}
-                    <sw-textarea-field
-                        v-model:value="productFeatureSet.description"
+                    <mt-textarea
+                        v-model="productFeatureSet.description"
                         :label="$tc('sw-settings-product-feature-sets.detail.labelDescription')"
                         class="sw-settings-product-feature-sets-detail__description"
                         :error="productFeatureSetDescriptionError"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-detail/sw-settings-product-feature-sets-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-product-feature-sets/page/sw-settings-product-feature-sets-detail/sw-settings-product-feature-sets-detail.spec.js
@@ -43,12 +43,6 @@ const detailPage = async (additionalOptions = {}, privileges = []) => {
                     'sw-text-field-deprecated': await wrapTestComponent('sw-text-field-deprecated', {
                         sync: true,
                     }),
-                    'sw-textarea-field': await wrapTestComponent('sw-textarea-field', {
-                        sync: true,
-                    }),
-                    'sw-textarea-field-deprecated': await wrapTestComponent('sw-textarea-field-deprecated', {
-                        sync: true,
-                    }),
                     'sw-contextual-field': await wrapTestComponent('sw-contextual-field'),
                     'sw-block-field': await wrapTestComponent('sw-block-field'),
                     'sw-base-field': await wrapTestComponent('sw-base-field'),
@@ -126,8 +120,8 @@ describe('src/module/sw-settings-product-feature-sets/page/sw-settings-product-f
 
     it('should show the description field', async () => {
         const root = wrapper.get(`.${classes.componentRoot}`);
-        const descriptionField = root.findComponent('.sw-field--textarea');
-        const descriptionFieldLabel = descriptionField.get(`.${classes.fieldLabel}`);
+        const descriptionField = root.findComponent('.mt-textarea');
+        const descriptionFieldLabel = descriptionField.get(`label`);
 
         expect(descriptionFieldLabel.text()).toEqual(text.labelDescriptionField);
         expect(descriptionField.props().placeholder).toEqual(text.placeholderDescriptionField);
@@ -154,7 +148,7 @@ describe('src/module/sw-settings-product-feature-sets/page/sw-settings-product-f
 
         expect(saveButton.attributes().disabled).toBe('true');
         expect(fieldName.props().disabled).toBe(true);
-        expect(fieldDescription.vm.$attrs.disabled).toBe(true);
+        expect(fieldDescription.vm.disabled).toBe(true);
         expect(productFeatureSetsValuesCard.attributes()['allow-edit']).toBeUndefined();
     });
 
@@ -183,7 +177,7 @@ describe('src/module/sw-settings-product-feature-sets/page/sw-settings-product-f
 
         expect(saveButton.attributes().disabled).toBeUndefined();
         expect(fieldName.props().disabled).toBe(false);
-        expect(fieldDescription.vm.$attrs.disabled).toBe(false);
+        expect(fieldDescription.vm.disabled).toBe(false);
         expect(productFeatureSetsValuesCard.attributes()['allow-edit']).toBe('true');
     });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/view/sw-settings-rule-detail-base/sw-settings-rule-detail-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/view/sw-settings-rule-detail-base/sw-settings-rule-detail-base.html.twig
@@ -36,8 +36,8 @@
             </div>
 
             {% block sw_settings_rule_detail_base_content_card_field_description %}
-            <sw-textarea-field
-                v-model:value="rule.description"
+            <mt-textarea
+                v-model="rule.description"
                 name="sw-field--rule-description"
                 :label="$tc('sw-settings-rule.detail.labelDescription')"
                 :placeholder="$tc('sw-settings-rule.detail.placeholderDescription')"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-rule/view/sw-settings-rule-detail-base/sw-settings-rule-detail-base.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-rule/view/sw-settings-rule-detail-base/sw-settings-rule-detail-base.spec.js
@@ -45,7 +45,7 @@ async function createWrapper(props = defaultProps, privileges = ['rule.editor'])
                 },
                 'sw-text-field': true,
                 'sw-number-field': true,
-                'sw-textarea-field': true,
+                'mt-textarea': true,
                 'sw-entity-tag-select': true,
                 'sw-loader': true,
                 'sw-custom-field-set-renderer': true,
@@ -98,7 +98,7 @@ describe('src/module/sw-settings-rule/view/sw-settings-rule-detail-base', () => 
 
             const ruleNameField = wrapper.find('input[name=sw-field--rule-name]');
             const rulePriorityField = wrapper.find('sw-number-field-stub[name=sw-field--rule-priority]');
-            const ruleDescriptionField = wrapper.find('sw-textarea-field-stub[name=sw-field--rule-description]');
+            const ruleDescriptionField = wrapper.find('mt-textarea-stub[name=sw-field--rule-description]');
 
             expect(ruleNameField.attributes().disabled).toBeDefined();
             expect(rulePriorityField.attributes().disabled).toBe('true');
@@ -113,7 +113,7 @@ describe('src/module/sw-settings-rule/view/sw-settings-rule-detail-base', () => 
 
             const ruleNameField = wrapper.find('input[name=sw-field--rule-name]');
             const rulePriorityField = wrapper.find('sw-number-field-stub[name=sw-field--rule-priority]');
-            const ruleDescriptionField = wrapper.find('sw-textarea-field-stub[name=sw-field--rule-description]');
+            const ruleDescriptionField = wrapper.find('mt-textarea-stub[name=sw-field--rule-description]');
 
             expect(ruleNameField.attributes().disabled).toBeUndefined();
             expect(rulePriorityField.attributes().disabled).toBeUndefined();

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.html.twig
@@ -127,10 +127,10 @@
                         gap="0px 30px"
                     >
                         {% block sw_settings_shipping_detail_base_content_field_description %}
-                        <sw-textarea-field
-                            v-model:value="shippingMethod.description"
+                        <mt-textarea
+                            v-model="shippingMethod.description"
                             name="sw-field--shippingMethod-description"
-                            :value="shippingMethod.description"
+                            :model-value="shippingMethod.description"
                             class="sw-settings-shipping-detail__description"
                             :disabled="!acl.can('shipping.editor') || undefined"
                             :label="$tc('sw-settings-shipping.detail.labelDescription')"

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-shipping/page/sw-settings-shipping-detail/sw-settings-shipping-detail.spec.js
@@ -72,7 +72,7 @@ async function createWrapper(privileges = [], props = {}) {
                         props: ['disabled'],
                         template: '<input class="sw-field" :disabled="disabled" />',
                     },
-                    'sw-textarea-field': {
+                    'mt-textarea': {
                         props: ['disabled'],
                         template: '<input class="sw-field sw-textarea-field" :disabled="disabled" />',
                     },

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/view/sw-users-permissions-role-view-general/sw-users-permissions-role-view-general.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/view/sw-users-permissions-role-view-general/sw-users-permissions-role-view-general.html.twig
@@ -17,8 +17,8 @@
         {% endblock %}
 
         {% block sw_users_permissions_role_role_view_general_card_view_basic_information_description %}
-        <sw-textarea-field
-            v-model:value="role.description"
+        <mt-textarea
+            v-model="role.description"
             name="sw-field--role-description"
             :error="roleDescriptionError"
             :disabled="!acl.can('users_and_permissions.editor') || undefined"

--- a/src/Administration/Resources/app/administration/src/module/sw-users-permissions/view/sw-users-permissions-role-view-general/sw-users-permissions-role-view-general.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-users-permissions/view/sw-users-permissions-role-view-general/sw-users-permissions-role-view-general.spec.js
@@ -15,7 +15,7 @@ async function createWrapper(privileges = []) {
             global: {
                 renderStubDefaultSlot: true,
                 stubs: {
-                    'sw-textarea-field': true,
+                    'mt-textarea': true,
                     'sw-text-field': true,
                     'sw-number-field': true,
                     'sw-users-permissions-permissions-grid': true,
@@ -48,7 +48,7 @@ describe('module/sw-users-permissions/view/sw-users-permissions-role-view-genera
 
         const fieldRoleName = wrapper.find('input[aria-label="sw-users-permissions.roles.detail.labelName"]');
         const fieldRoleDescription = wrapper.find(
-            'sw-textarea-field-stub[label="sw-users-permissions.roles.detail.labelDescription"]',
+            'mt-textarea-stub[label="sw-users-permissions.roles.detail.labelDescription"]',
         );
         const permissionsGrid = wrapper.find('sw-users-permissions-permissions-grid-stub');
         const additionalPermissionsGrid = wrapper.find('sw-users-permissions-additional-permissions-stub');
@@ -64,7 +64,7 @@ describe('module/sw-users-permissions/view/sw-users-permissions-role-view-genera
 
         const fieldRoleName = wrapper.find('input[aria-label="sw-users-permissions.roles.detail.labelName"]');
         const fieldRoleDescription = wrapper.find(
-            'sw-textarea-field-stub[label="sw-users-permissions.roles.detail.labelDescription"]',
+            'mt-textarea-stub[label="sw-users-permissions.roles.detail.labelDescription"]',
         );
         const permissionsGrid = wrapper.find('sw-users-permissions-permissions-grid-stub');
         const additionalPermissionsGrid = wrapper.find('sw-users-permissions-additional-permissions-stub');

--- a/src/Administration/Resources/app/administration/test/_helper_/failedSpecFileReporter.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/failedSpecFileReporter.js
@@ -1,0 +1,43 @@
+/* eslint-disable no-console */
+
+/**
+ * @sw-package framework
+ */
+class FailedSpecFileReporter {
+    constructor(globalConfig, options) {
+        this._globalConfig = globalConfig;
+        this._options = options;
+        this.failedFiles = new Set();
+    }
+
+    onTestResult(test, testResult) {
+        if (testResult.numFailingTests > 0) {
+            this.failedFiles.add(testResult.testFilePath);
+        }
+    }
+
+    onRunComplete() {
+        if (this.failedFiles.size > 0) {
+            // Using console.error to make output more visible in watch mode
+            console.error('\n\n');
+            console.error('\x1b[41m\x1b[37m FAILED FILES SUMMARY \x1b[0m');
+            console.error('\x1b[31m===================\x1b[0m');
+
+            Array.from(this.failedFiles)
+                .sort()
+                .forEach(file => {
+                    // Using relative path for cleaner output
+                    const relativePath = file.split('/').slice(-3).join('/');
+                    console.error(`\x1b[31m❌ ${relativePath}\x1b[0m`);
+                });
+
+            console.error(`\n\x1b[31mTotal failed files: ${this.failedFiles.size}\x1b[0m`);
+            console.error('\n');
+        }
+
+        // Clear the set for the next run
+        this.failedFiles.clear();
+    }
+}
+
+module.exports = FailedSpecFileReporter;

--- a/src/Administration/Resources/app/administration/test/_helper_/jest-resolver.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/jest-resolver.js
@@ -1,3 +1,7 @@
+/**
+ * @sw-package framework
+ */
+
 const url = require('url')
 
 module.exports = (request, options) => {

--- a/tests/acceptance/package-lock.json
+++ b/tests/acceptance/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@currents/playwright": "^1.5.11",
-        "@shopware-ag/acceptance-test-suite": "^11.7.2",
+        "@shopware-ag/acceptance-test-suite": "^11.8.0",
         "@shopware/api-client": "^0.0.0-canary-20230823113412",
         "lighthouse": "^12.2.2",
         "playwright-lighthouse": "4.0.0"
@@ -673,9 +673,9 @@
       }
     },
     "node_modules/@shopware-ag/acceptance-test-suite": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-11.7.2.tgz",
-      "integrity": "sha512-W4KDbwbDhypsL7zrY4XDr3+wgR5KnMJhKK7fRCQ3SWVK9OracCIw5Qzmoz+hXY12KjB+DIqYScmiSui+KueDtQ==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/acceptance-test-suite/-/acceptance-test-suite-11.8.0.tgz",
+      "integrity": "sha512-S0U6yDNo2HCchsVtPASS5OIMs1LyZW/dN85FoHBB0tAB8YVij5L81PJXCnkHUAgHygyfIDNqdKA361jL/nmZvg==",
       "license": "MIT",
       "dependencies": {
         "@axe-core/playwright": "4.9.1",

--- a/tests/acceptance/package.json
+++ b/tests/acceptance/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@currents/playwright": "^1.5.11",
-    "@shopware-ag/acceptance-test-suite": "^11.7.2",
+    "@shopware-ag/acceptance-test-suite": "^11.8.0",
     "@shopware/api-client": "^0.0.0-canary-20230823113412",
     "lighthouse": "^12.2.2",
     "playwright-lighthouse": "4.0.0"


### PR DESCRIPTION
Background

The current sw-textarea-field is deprecated and needs to be migrated to use the standardized Meteor component library replacements.

Tasks

Migration Steps

Run automatic code modifications

Execute codemods for component replacement

Verify successful execution of automated changes

Code Review

Search for TODOs in all *.html.twig files

Ensure all component instances have been properly replaced

Verify component props and interfaces are correctly mapped

Testing

Run and verify Jest unit tests

Execute Playwright end-to-end tests

Fix any failing tests related to the component change

Quality Checks

Run TypeScript compiler (TSC) and fix any type errors

Execute ESLint and address any linting issues

Run Prettier to ensure consistent code formatting

Acceptance Criteria

All instances of [Component Name] replaced with Meteor equivalent

No remaining TODOs in *.html.twig files

All tests passing (Jest and Playwright)

No TypeScript errors

No ESLint warnings/errors

Code properly formatted according to Prettier rules

Notes

Document any special cases or unexpected behaviors encountered during migration

List any components that required manual intervention

