### PR TITLE
fix: Do not rely on the languages of the sales channel in template

### DIFF
--- a/changelog/_unreleased/2025-01-07-introduce-global-template-data-for-language-and-navigation.md
+++ b/changelog/_unreleased/2025-01-07-introduce-global-template-data-for-language-and-navigation.md
@@ -21,7 +21,7 @@ ___
     * `context.currency` instead of `page.header.activeCurrency`
     * `shopware.navigation.id` instead of `page.header.navigation.active.id`
     * `shopware.navigation.pathIdList` instead of `page.header.navigation.active.path`
-    * `context.saleschannel.languages.first` instead of `page.header.activeLanguage`
+    * `context.languageInfo` instead of `page.header.activeLanguage`
 * Added new optional parameter `serviceMenu` of type `\Shopware\Core\Content\Category\CategoryCollection` to `\Shopware\Storefront\Pagelet\Footer\FooterPagelet`. It will be required in the next major version.
 ___
 

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block base_html %}
-<html lang="{{ context.saleschannel.languages.first.translationCode.code }}"
+<html lang="{{ context.languageInfo.localeCode }}"
       itemscope="itemscope"
       itemtype="https://schema.org/WebPage">
 {% endblock %}


### PR DESCRIPTION
The `languageInfo` of the `context` could be improved. 

As the first small step, we should not rely any longer on the availability of languages in the salesChannel object of the context. This was introduced here https://github.com/shopware/shopware/commit/973fe076db9de7478f6940d9a812229aa85def02#diff-87def97e495ae0faabd6d72f11e4c65447e3a0eb8b12c9f35cbf4e96733ac759R80-R83 and misused in this case. 

In a follow up PR, the `languageInfo` will be extended and improved. 