### PR TITLE
chore(ci): checkout new branch, resetting it to current HEAD if it exists

### DIFF
--- a/.github/bin/split.bash
+++ b/.github/bin/split.bash
@@ -133,9 +133,8 @@ branch() {
   local package_lower; package_lower=$(lowercase "${1}")
   local package; package="$(uppercase_first "${package_lower}")"
   local name; name="${2}"
-  local commit_id; commit_id=$(git -C "${PLATFORM_DIR}/repos/${package_lower}" log -n1 --format="%H")
 
-  git -C "${PLATFORM_DIR}/repos/${package_lower}" branch -f "${name}" "${commit_id}"
+  git -C "${PLATFORM_DIR}/repos/${package_lower}" checkout -B "${name}"
 }
 
 # Commits additional files in a split repository of a subpackage of platform.


### PR DESCRIPTION
In my recent PR, I've fixed the split workflow for branches with non-default names, but overlooked the case of `trunk` 🤦
This is the correction for that.

Since we've used the current `HEAD` to determine a commit ID beforehand, I've just removed that variable and use `git checkout -B` now. This will take care of splitting off a new branch, without failing if the branch name already exists (branch will be reset to HEAD, [as intended](https://github.com/shopware/shopware/compare/split-20250220-1157?expand=1#diff-3646fc722cb5caa30d70e01aa9af156640a20f85d270d88e66351aca84536093R127), in that case).