### PR TITLE
refactor: move layout assignment disabled value to computed property

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
@@ -310,6 +310,10 @@ export default Shopware.Component.wrapComponentConfig({
             return result.filter((block) => block && block.category === this.currentBlockCategory);
         },
 
+        isLayoutAssignmentDisabled() {
+            return this.disabled || this.page.locked;
+        },
+
         ...mapPropertyErrors('page', ['name']),
     },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.html.twig
@@ -509,7 +509,7 @@
         class="sw-cms-sidebar__layout-assignment"
         icon="regular-share"
         :title="$tc('sw-cms.detail.sidebar.titleLayoutAssignment')"
-        :disabled="page.locked || disabled"
+        :disabled="isLayoutAssignmentDisabled"
     >
 
         {% block sw_cms_sidebar_layout_assignment_content %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/sw-cms-sidebar.spec.js
@@ -483,7 +483,7 @@ describe('module/sw-cms/component/sw-cms-sidebar', () => {
         expect(sidebarItems).toHaveLength(5);
 
         sidebarItems.forEach((sidebarItem) => {
-            expect(sidebarItem.props('disabled')).toBe(false);
+            expect(sidebarItem.props('disabled')).toBeFalsy();
         });
     });
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently we are disabling the layout assignment for draft layouts in the publisher plugin via. template overrides. This makes it more difficult to extend the sidebar for other extensions.
By adding this computed property we can disable draft assignments without overriding the template.
