### PR TITLE
fix: rule builder switch hidden behind filter modal

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/sw-condition-unit-menu.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-condition-unit-menu/sw-condition-unit-menu.html.twig
@@ -26,7 +26,7 @@
 
     <sw-popover
         v-if="showMenu && defaultUnit"
-        :z-index="10"
+        :z-index="1001"
     >
         <!-- eslint-disable-next-line vuejs-accessibility/mouse-events-have-key-events -->
         <div


### PR DESCRIPTION
### 1. Why is this change necessary?
![e1681169-c6c1-4d21-9843-0638a4f5d6f9](https://github.com/user-attachments/assets/df825e27-6bcd-4367-b6e3-49db2e14fafa)

### 2. What does this change do, exactly?
Increase the z index of the popover

### 4. Please link to the relevant issues (if any).
- relates: https://shopware.atlassian.net/browse/NEXT-40732