### PR TITLE
chore: Update deprecations

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/index.ts
@@ -27,7 +27,7 @@ Component.register('sw-tabs', {
     computed: {
         useMeteorComponent() {
             // Use new meteor component in major
-            if (Shopware.Feature.isActive('ENABLE_METEOR_COMPONENTS')) {
+            if (Shopware.Feature.isActive('V6_8_0_0')) {
                 return true;
             }
 
@@ -35,7 +35,7 @@ Component.register('sw-tabs', {
             Shopware.Utils.debug.warn(
                 'sw-tabs',
                 // eslint-disable-next-line max-len
-                'The old usage of "sw-tabs" is deprecated and will be removed in v6.7.0.0. Please use "mt-tabs" instead.',
+                'The old usage of "sw-tabs" is deprecated and will be removed in v6.8.0.0. Please use "mt-tabs" instead.',
             );
 
             return false;

--- a/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/base/sw-tabs/sw-tabs.spec.js
@@ -33,7 +33,7 @@ describe('src/app/component/base/sw-tabs', () => {
     });
 
     it('should render the mt-tabs when major feature flag is enabled', async () => {
-        global.activeFeatureFlags = ['ENABLE_METEOR_COMPONENTS'];
+        global.activeFeatureFlags = ['V6_8_0_0'];
 
         const wrapper = await createWrapper();
 

--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/index.js
@@ -114,7 +114,11 @@ Component.register('sw-grid', {
         },
     },
 
-    expose: ['startInlineEditing', 'selectAll', 'selectItem'],
+    expose: [
+        'startInlineEditing',
+        'selectAll',
+        'selectItem',
+    ],
 
     data() {
         return {

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.spec.js
@@ -11,7 +11,7 @@ async function createWrapper(useTime) {
         propsData: {
             condition: {
                 value: {
-                    useTime: useTime
+                    useTime: useTime,
                 },
 
                 getEntityName: () => 'rule_condition',
@@ -60,11 +60,11 @@ describe('component/rule/sw-condition-date-range', () => {
         const wrapper = await createWrapper();
         await flushPromises();
 
-        const datepickerCollection  = wrapper.findAll('.wrapper .dp__main');
+        const datepickerCollection = wrapper.findAll('.wrapper .dp__main');
 
         expect(datepickerCollection).toHaveLength(2);
 
-        datepickerCollection.forEach(datepicker => {
+        datepickerCollection.forEach((datepicker) => {
             expect(datepicker.attributes('type')).toBe('date');
         });
 
@@ -74,9 +74,9 @@ describe('component/rule/sw-condition-date-range', () => {
         await wrapper.find('.sw-select-option--true').trigger('click');
         await flushPromises();
 
-        datepickerCollection.forEach(datepicker => {
+        datepickerCollection.forEach((datepicker) => {
             expect(datepicker.attributes('type')).toBe('datetime');
-        })
+        });
     });
 
     it('should select a fromDate without time', async () => {

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/index.ts
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/index.ts
@@ -23,7 +23,7 @@ Component.register('sw-popover', {
     computed: {
         useMeteorComponent() {
             // Use new meteor component in major
-            if (Shopware.Feature.isActive('ENABLE_METEOR_COMPONENTS')) {
+            if (Shopware.Feature.isActive('V6_8_0_0')) {
                 return true;
             }
 
@@ -31,7 +31,7 @@ Component.register('sw-popover', {
             Shopware.Utils.debug.warn(
                 'sw-popover',
                 // eslint-disable-next-line max-len
-                'The old usage of "sw-popover" is deprecated and will be removed in v6.7.0.0. Please use "mt-floating-ui" instead.',
+                'The old usage of "sw-popover" is deprecated and will be removed in v6.8.0.0. Please use "mt-floating-ui" instead.',
             );
 
             return false;

--- a/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/utils/sw-popover/sw-popover.spec.js
@@ -33,7 +33,7 @@ describe('src/app/component/base/sw-popover', () => {
     });
 
     it('should render the mt-floating-ui when major feature flag is enabled', async () => {
-        global.activeFeatureFlags = ['ENABLE_METEOR_COMPONENTS'];
+        global.activeFeatureFlags = ['V6_8_0_0'];
 
         const wrapper = await createWrapper();
 

--- a/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.spec.js
@@ -22,7 +22,7 @@ describe('entity-collection.data.ts', () => {
             'personaPromotions',
         ];
 
-        const ruleAwareness = Shopware.Service('ruleConditionDataProviderService').awarenessConfiguration
+        const ruleAwareness = Shopware.Service('ruleConditionDataProviderService').awarenessConfiguration;
 
         expect(Object.keys(ruleAwareness)).toHaveLength(expectedConfigs.length);
 

--- a/src/Administration/Resources/app/administration/src/app/init/context.init.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/init/context.init.spec.js
@@ -227,5 +227,5 @@ describe('src/app/init/context.init.ts', () => {
 
         expect(Shopware.Store.get('context').windowId).not.toBeNull();
         expect(windowId).toBe(Shopware.Store.get('context').app.windowId);
-    })
+    });
 });

--- a/src/Administration/Resources/app/administration/src/app/init/extension-data-handling.init.ts
+++ b/src/Administration/Resources/app/administration/src/app/init/extension-data-handling.init.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/prefer-promise-reject-errors */
 /**
  * @sw-package framework
  */
@@ -34,7 +35,6 @@ function getRepository(
 }
 
 function rejectRepositoryCreation(entityName: string): unknown {
-    // eslint-disable-next-line prefer-promise-reject-errors
     return Promise.reject(`Could not create repository for entity "${entityName}"`);
 }
 

--- a/src/Administration/Resources/app/administration/src/app/mixin/user-settings.mixin.ts
+++ b/src/Administration/Resources/app/administration/src/app/mixin/user-settings.mixin.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/prefer-promise-reject-errors */
 /**
  * @sw-package framework
  */

--- a/src/Administration/Resources/app/administration/src/core/application.ts
+++ b/src/Administration/Resources/app/administration/src/core/application.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/prefer-promise-reject-errors */
 import type Bottle from 'bottlejs';
 import type { App } from 'vue';
 import { reactive } from 'vue';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-create-wizard/sw-cms-create-wizard.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-create-wizard/sw-cms-create-wizard.spec.js
@@ -159,7 +159,9 @@ describe('module/sw-cms/component/sw-cms-create-wizard', () => {
 
     it('should generate the correct pagePreviewMedia tag', async () => {
         const wrapper = await createWrapper();
-        expect(wrapper.vm.pagePreviewMedia).toBe('url(administration/administration/static/img/cms/preview_landingpage_default.png)');
+        expect(wrapper.vm.pagePreviewMedia).toBe(
+            'url(administration/administration/static/img/cms/preview_landingpage_default.png)',
+        );
     });
 
     it('should not generate any pagePreviewMedia, when no sections are set', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-layout-assignment-modal/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/prefer-promise-reject-errors */
 import EntityCollection from '@shopware-ag/meteor-admin-sdk/es/_internals/data/EntityCollection';
 import { difference } from 'lodash';
 import { type PropType } from 'vue';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/sw-cms-list-item.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-list-item/sw-cms-list-item.spec.js
@@ -104,7 +104,8 @@ describe('module/sw-cms/component/sw-cms-list-item', () => {
                 ],
             },
             {
-                'background-image': 'url(administration/administration/static/img/cms/preview_product_list_product_listing.png)',
+                'background-image':
+                    'url(administration/administration/static/img/cms/preview_product_list_product_listing.png)',
                 'background-size': 'cover',
             },
         ],

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/image-slider/component/component.spec.js
@@ -98,7 +98,9 @@ describe('src/module/sw-cms/elements/image-slider/component', () => {
 
         const image = wrapper.get('.sw-cms-el-image-slider__image');
 
-        expect(image.attributes('src')).toBe(`${MOCK_ASSET_PATH}administration/administration/static/img/cms/preview_mountain_large.jpg`);
+        expect(image.attributes('src')).toBe(
+            `${MOCK_ASSET_PATH}administration/administration/static/img/cms/preview_mountain_large.jpg`,
+        );
     });
 
     it('setSliderArrowItem should work correctly', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-detail/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-custom-entity/page/sw-generic-custom-entity-detail/index.ts
@@ -150,6 +150,7 @@ export default Shopware.Component.wrapComponentConfig({
             this.isLoading = true;
 
             if (!this.customEntityData) {
+                // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
                 return Promise.reject();
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-my-extensions-listing-controls/sw-extension-my-extensions-listing-controls.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-my-extensions-listing-controls/sw-extension-my-extensions-listing-controls.spec.js
@@ -28,7 +28,11 @@ describe('src/module/sw-extension/component/sw-extension-my-extensions-listing-c
         const wrapper = await createWrapper();
         expect(wrapper.vm.selectedSortingOption).toBe('updated-at');
 
-        await selectMtSelectOptionByText(wrapper, 'sw-extension.my-extensions.listing.controls.filterOptions.name-asc', '.mt-select__selection');
+        await selectMtSelectOptionByText(
+            wrapper,
+            'sw-extension.my-extensions.listing.controls.filterOptions.name-asc',
+            '.mt-select__selection',
+        );
 
         expect(wrapper.vm.selectedSortingOption).toBe('name-asc');
         expect(wrapper.emitted()).toHaveProperty('update:sorting-option');

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-config/sw-extension-config.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-config/sw-extension-config.spec.js
@@ -125,7 +125,9 @@ describe('src/module/sw-extension/page/sw-extension-config.spec', () => {
         const wrapper = await createWrapper();
 
         const iconComponent = wrapper.get('.sw-extension-config__extension-icon img');
-        expect(iconComponent.attributes().src).toBe('administration/administration/static/img/theme/default_theme_preview.jpg');
+        expect(iconComponent.attributes().src).toBe(
+            'administration/administration/static/img/theme/default_theme_preview.jpg',
+        );
         expect(iconComponent.attributes().alt).toBe('sw-extension-store.component.sw-extension-config.imageDescription');
 
         const title = wrapper.get('.sw-meteor-page__smart-bar-title');

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/page/sw-extension-my-extensions-listing/sw-extension-my-extensions-listing.spec.js
@@ -362,7 +362,11 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
 
         await wrapper.vm.$nextTick();
 
-        await selectMtSelectOptionByText(wrapper, 'sw-extension.my-extensions.listing.controls.filterOptions.name-desc', '.mt-select__selection');
+        await selectMtSelectOptionByText(
+            wrapper,
+            'sw-extension.my-extensions.listing.controls.filterOptions.name-desc',
+            '.mt-select__selection',
+        );
 
         const correctOrder = [
             'very smart plugin',
@@ -397,7 +401,11 @@ describe('src/module/sw-extension/page/sw-extension-my-extensions-listing', () =
 
         Shopware.Store.get('shopwareExtensions').setMyExtensions(extensions);
 
-        await selectMtSelectOptionByText(wrapper, 'sw-extension.my-extensions.listing.controls.filterOptions.name-asc', '.mt-select__selection');
+        await selectMtSelectOptionByText(
+            wrapper,
+            'sw-extension.my-extensions.listing.controls.filterOptions.name-asc',
+            '.mt-select__selection',
+        );
 
         const correctOrder = [
             '#1 best plugin',

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-display-options/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-display-options/index.js
@@ -108,13 +108,15 @@ export default {
         },
 
         presentationOptions() {
-            return this.previewOptions?.map((item) => {
-                return {
-                    id: item.value,
-                    value: item.value,
-                    label: item.name,
-                };
-            }) ?? [];
+            return (
+                this.previewOptions?.map((item) => {
+                    return {
+                        id: item.value,
+                        value: item.value,
+                        label: item.name,
+                    };
+                }) ?? []
+            );
         },
 
         sortOptionsSelect() {

--- a/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-display-options/sw-media-display-options.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-media/component/sw-media-display-options/sw-media-display-options.spec.js
@@ -3,11 +3,11 @@ import { mount } from '@vue/test-utils';
 const createWrapper = async (customOptions) => {
     return mount(await wrapTestComponent('sw-media-display-options', { sync: true }), {
         global: {
-            stubs: {}
+            stubs: {},
         },
         ...customOptions,
     });
-}
+};
 
 describe('src/module/sw-media/component/sw-media-display-options', () => {
     it('should be a Vue.JS component', async () => {
@@ -32,4 +32,4 @@ describe('src/module/sw-media/component/sw-media-display-options', () => {
         expect(selectResults[2].text()).toBe('sw-media.presentation.labelPresentationLarge');
         expect(selectResults[3].text()).toBe('sw-media.presentation.labelPresentationList');
     });
-})
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/view/sw-product-detail-context-prices/index.js
@@ -522,7 +522,7 @@ export default {
             newPriceRule.price = [];
 
             referencePrice.price.forEach((price, index) => {
-                newPriceRule.price[index] = { ...price }
+                newPriceRule.price[index] = { ...price };
             });
 
             this.product.prices.add(newPriceRule);

--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-empty-state-hero/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-v2-empty-state-hero/index.js
@@ -35,8 +35,9 @@ export default {
 
     computed: {
         imagePath() {
-            return this.assetPath ||
-                '/administration/administration/static/img/empty-states/promotion-v2-empty-state-hero.svg';
+            return (
+                this.assetPath || '/administration/administration/static/img/empty-states/promotion-v2-empty-state-hero.svg'
+            );
         },
 
         showDescription() {

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-detail/sw-settings-tax-detail.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-tax/page/sw-settings-tax-detail/sw-settings-tax-detail.spec.js
@@ -149,14 +149,14 @@ describe('module/sw-settings-tax/page/sw-settings-tax-detail', () => {
         ]);
         await wrapper.setProps({
             taxId: '12345',
-        })
+        });
         await flushPromises();
 
         // Look for defaultTaxRate switch
         const defaultTaxRateSwitch = wrapper.find('.sw-settings-tax-detail__default-tax-rate');
-        await defaultTaxRateSwitch.find('input').setValue(true)
+        await defaultTaxRateSwitch.find('input').setValue(true);
 
         // Check if config value is set to the default tax id
         expect(wrapper.vm.config['core.tax.defaultTaxRate']).toBe('12345');
-    })
+    });
 });

--- a/src/Administration/Resources/app/administration/test/_helper_/allowedErrors.js
+++ b/src/Administration/Resources/app/administration/test/_helper_/allowedErrors.js
@@ -16,3 +16,25 @@ export const sendTimeoutExpired = {
     msg: 'Send timeout expired. It could be possible that no handler for the postMessage request exists or that the handler freezed.',
     method: 'error',
 };
+
+export const deprecatedTabComponent = {
+    method: 'warn',
+    msgCheck: (_, msg1) => {
+        if (typeof msg1 !== 'string') {
+            return false;
+        }
+
+        return msg1.includes('The old usage of "sw-tabs" is deprecated');
+    },
+};
+
+export const deprecatedPopoverComponent = {
+    method: 'warn',
+    msgCheck: (_, msg1) => {
+        if (typeof msg1 !== 'string') {
+            return false;
+        }
+
+        return msg1.includes('The old usage of "sw-popover" is deprecated');
+    },
+};

--- a/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
+++ b/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
@@ -46,7 +46,7 @@ import repositoryFactory from './_mocks_/repositoryFactory.service.mock';
 import flushPromises from '../_helper_/flushPromises';
 import wrapTestComponent from '../_helper_/componentWrapper';
 import 'blob-polyfill';
-import { sendTimeoutExpired } from '../_helper_/allowedErrors';
+import { sendTimeoutExpired, deprecatedTabComponent, deprecatedPopoverComponent } from '../_helper_/allowedErrors';
 import findByText from '../_helper_/find-by-text';
 import findByLabel from '../_helper_/find-by-label';
 import findByPlaceholder from '../_helper_/find-by-placeholder';
@@ -407,6 +407,8 @@ global.allowedErrors = [
     },
 
     sendTimeoutExpired,
+    deprecatedTabComponent,
+    deprecatedPopoverComponent,
 ];
 
 global.flushPromises = flushPromises;

--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -31,10 +31,6 @@ shopware:
         major: false
         toggleable: true
         description: "Experimental! Enable OpenTelemetry metrics"
-      - name: ENABLE_METEOR_COMPONENTS
-        default: false
-        major: false
-        toggleable: false
       - name: FLOW_EXECUTION_AFTER_BUSINESS_PROCESS
         default: false
         major: false


### PR DESCRIPTION
The `sw-tabs` and `sw-popover` components won't be replaced by meteor components this release. Therefore updating the deprecations and the used feature flag.