### PR TITLE
fix: Multi select filter for translated entities

### DIFF
--- a/changelog/_unreleased/2025-02-21-fix-multi-select-filter-for-translated-entities.md
+++ b/changelog/_unreleased/2025-02-21-fix-multi-select-filter-for-translated-entities.md
@@ -1,0 +1,9 @@
+---
+title: Fix multi select filter for translated entities
+issue:
+author: Nicky Gerritsen
+author_email: nicky@letstalk.nl
+author_github: nickygerritsen
+---
+# Administration
+* Changed the multi select filter to show labels of translated entities correctly.

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/index.js
@@ -101,7 +101,7 @@ Component.register('sw-multi-select-filter', {
                       if (!this.filter.displayVariants) {
                           return {
                               id: value.id,
-                              [this.labelProperty]: value?.[this.labelProperty],
+                              [this.labelProperty]: value?.translated?.[this.labelProperty] || value?.[this.labelProperty],
                           };
                       }
 

--- a/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/sw-multi-select-filter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/filter/sw-multi-select-filter/sw-multi-select-filter.spec.js
@@ -10,6 +10,10 @@ const entities = [
     { id: 'id1', name: 'first' },
 ];
 
+const translatedEntities = [
+    { id: 'id1', name: null, translated: { name: 'first' } },
+];
+
 function getCollection() {
     return new EntityCollection(
         '/test-entity',
@@ -96,6 +100,24 @@ describe('src/app/component/filter/sw-multi-select-filter', () => {
         const wrapper = await createWrapper();
 
         await wrapper.getComponent('.sw-entity-multi-select').vm.$emit('update:entity-collection', entities);
+
+        const [
+            name,
+            criteria,
+            value,
+        ] = wrapper.emitted('filter-update')[0];
+
+        expect(name).toBe('category-filter');
+        expect(criteria).toEqual([Criteria.equalsAny('category.id', ['id1'])]);
+        expect(value[0]).toEqual({ id: 'id1', name: 'first' });
+
+        expect(wrapper.emitted('filter-reset')).toBeFalsy();
+    });
+
+    it('should emit `filter-update` event when user chooses translated entity', async () => {
+        const wrapper = await createWrapper();
+
+        await wrapper.getComponent('.sw-entity-multi-select').vm.$emit('update:entity-collection', translatedEntities);
 
         const [
             name,


### PR DESCRIPTION
### 1. Why is this change necessary?
Multi select filters that had entities that were translated (i.e. the base property is `null` but `translated.[property]` is not, where not correctly displayed, see this screenshot:

<img width="380" alt="image" src="https://github.com/user-attachments/assets/ea0b4d14-0621-4e44-8938-97b39a9d2564" />

### 2. What does this change do, exactly?

It first checks for the translated property before getting the normal one.

### 3. Describe each step to reproduce the issue or behaviour.

Pick a filter for an entity that doesn't have a translation in the currently selected language, but does have one in the system language.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
