### PR TITLE
fix: matching of flow scope rules in promotions

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.spec.js
@@ -11,6 +11,26 @@ describe('entity-collection.data.ts', () => {
         });
     });
 
+    it('should configure rule awareness configurations', async () => {
+        const expectedConfigs = [
+            'shippingMethodPrices',
+            'shippingMethodPriceCalculations',
+            'promotionDiscounts',
+            'promotionSetGroups',
+            'cartPromotions',
+            'orderPromotions',
+            'personaPromotions',
+        ];
+
+        const ruleAwareness = Shopware.Service('ruleConditionDataProviderService').awarenessConfiguration
+
+        expect(Object.keys(ruleAwareness)).toHaveLength(expectedConfigs.length);
+
+        expectedConfigs.forEach((config) => {
+            expect(ruleAwareness).toHaveProperty(config);
+        });
+    });
+
     it('should register conditions with correct scope', async () => {
         const condition = Shopware.Service('ruleConditionDataProviderService').getByType('language');
 

--- a/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.ts
+++ b/src/Administration/Resources/app/administration/src/app/decorator/condition-type-data-provider.decorator.ts
@@ -659,6 +659,7 @@ Application.addServiceProviderDecorator('ruleConditionDataProviderService', (rul
         notEquals: [
             'cartCartAmount',
             'cartShippingCost',
+            ...ruleConditionService.getRestrictionsByGroup('order'),
         ],
         snippet: 'sw-restricted-rules.restrictedAssignment.orderPromotions',
     });
@@ -667,6 +668,7 @@ Application.addServiceProviderDecorator('ruleConditionDataProviderService', (rul
         notEquals: [
             'cartCartAmount',
             'cartShippingCost',
+            ...ruleConditionService.getRestrictionsByGroup('order'),
         ],
         snippet: 'sw-restricted-rules.restrictedAssignment.cartPromotions',
     });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/index.js
@@ -4,7 +4,6 @@ import template from './sw-order-promotion-field.html.twig';
 /**
  * @sw-package checkout
  */
-
 const { Store } = Shopware;
 const { ChangesetGenerator } = Shopware.Data;
 
@@ -40,8 +39,8 @@ export default {
     },
 
     emits: [
-        'loading-change',
         'error',
+        'loading-change',
         'reload-entity-data',
     ],
 
@@ -65,16 +64,20 @@ export default {
     },
 
     computed: {
-        order: () => Store.get('swOrderDetail').order,
+        order() {
+            return Store.get('swOrderDetail').order;
+        },
 
-        versionContext: () => Store.get('swOrderDetail').versionContext,
+        versionContext() {
+            return Store.get('swOrderDetail').versionContext;
+        },
 
         orderLineItemRepository() {
             return this.repositoryFactory.create('order_line_item');
         },
 
         hasLineItem() {
-            return this.order.lineItems.filter((item) => item.hasOwnProperty('id')).length > 0;
+            return this.order.lineItems.some((item) => item.hasOwnProperty('id'));
         },
 
         currency() {
@@ -135,7 +138,9 @@ export default {
         // Validate if switch can be toggled
         disabledAutoPromotions(newState, oldState) {
             // To prevent recursion when value is set in next tick
-            if (oldState === this.hasAutomaticPromotions) return;
+            if (oldState === this.hasAutomaticPromotions) {
+                return;
+            }
 
             this.toggleAutomaticPromotions(newState);
         },
@@ -155,124 +160,103 @@ export default {
             this.disabledAutoPromotions = !this.hasAutomaticPromotions;
         },
 
+        emitEntityData() {
+            this.$emit('reload-entity-data');
+
+            if (this.swOrderDetailOnReloadEntityData) {
+                this.swOrderDetailOnReloadEntityData();
+            }
+        },
+
+        emitLoadingChange(state) {
+            this.$emit('loading-change', state);
+
+            if (this.swOrderDetailOnLoadingChange) {
+                this.swOrderDetailOnLoadingChange(state);
+            }
+        },
+
+        handleUnsavedOrderChangesResponse() {
+            this.createNotificationWarning({
+                message: this.$tc('sw-order.detailBase.textUnsavedChanges', 0),
+            });
+        },
+
+        handleError(error) {
+            this.emitLoadingChange(false);
+            this.$emit('error', error);
+
+            if (this.swOrderDetailOnError) {
+                this.swOrderDetailOnError(error);
+            }
+        },
+
         deleteAutomaticPromotions() {
             if (this.automaticPromotions.length === 0) {
                 return Promise.resolve();
             }
 
-            const deletionPromises = [];
-
-            this.automaticPromotions.forEach((promotion) => {
-                deletionPromises.push(this.orderLineItemRepository.delete(promotion.id, this.versionContext));
+            const deletionPromises = this.automaticPromotions.map((promotion) => {
+                return this.orderLineItemRepository.delete(promotion.id, this.versionContext);
             });
 
             return Promise.all(deletionPromises)
                 .then(() => {
                     this.automaticPromotions.forEach((promotion) => {
                         this.createNotificationSuccess({
-                            message: this.$tc(
-                                'sw-order.detailBase.textPromotionRemoved',
-                                {
-                                    promotion: promotion.label,
-                                },
-                                0,
-                            ),
+                            message: this.$tc('sw-order.detailBase.textPromotionRemoved', { promotion: promotion.label }, 0),
                         });
                     });
                 })
-                .catch((error) => {
-                    this.$emit('loading-change', false);
-                    if (this.swOrderDetailOnLoadingChange) {
-                        this.swOrderDetailOnLoadingChange(false);
-                    }
-
-                    this.$emit('error', error);
-                    if (this.swOrderDetailOnError) {
-                        this.swOrderDetailOnError(error);
-                    }
-                });
+                .catch(this.handleError);
         },
 
         toggleAutomaticPromotions(state) {
-            this.$emit('loading-change', true);
-            if (this.swOrderDetailOnLoadingChange) {
-                this.swOrderDetailOnLoadingChange(true);
-            }
+            this.emitLoadingChange(true);
 
-            // Throw notification warning and reset switch state
             if (this.hasOrderUnsavedChanges) {
-                this.$emit('loading-change', false);
-                if (this.swOrderDetailOnLoadingChange) {
-                    this.swOrderDetailOnLoadingChange(false);
-                }
+                this.emitLoadingChange(false);
+
                 this.handleUnsavedOrderChangesResponse();
                 this.$nextTick(() => {
                     this.disabledAutoPromotions = !state;
                 });
+
                 return;
             }
 
             this.deleteAutomaticPromotions()
                 .then(() => {
-                    return this.orderService.toggleAutomaticPromotions(this.order.id, this.order.versionId, state);
+                    this.orderService.toggleAutomaticPromotions(this.order.id, this.order.versionId, state);
                 })
-                .then((response) => {
-                    this.handlePromotionResponse(response);
-                    this.$emit('reload-entity-data');
-                    if (this.swOrderDetailOnReloadEntityData) {
-                        this.swOrderDetailOnReloadEntityData();
-                    }
-                })
-                .catch((error) => {
-                    this.$emit('loading-change', false);
-                    if (this.swOrderDetailOnLoadingChange) {
-                        this.swOrderDetailOnLoadingChange(false);
-                    }
-                    this.$emit('error', error);
-                    if (this.swOrderDetailOnError) {
-                        this.swOrderDetailOnError(error);
-                    }
-                });
+                .then(this.handlePromotionResponse)
+                .catch(this.handleError);
         },
 
         onSubmitCode(code) {
-            this.$emit('loading-change', true);
-            if (this.swOrderDetailOnLoadingChange) {
-                this.swOrderDetailOnLoadingChange(true);
-            }
+            this.emitLoadingChange(true);
 
             if (this.hasOrderUnsavedChanges) {
-                this.$emit('loading-change', false);
-                if (this.swOrderDetailOnLoadingChange) {
-                    this.swOrderDetailOnLoadingChange(false);
-                }
+                this.emitLoadingChange(false);
                 this.handleUnsavedOrderChangesResponse();
+
                 return;
             }
 
             this.orderService
                 .addPromotionToOrder(this.order.id, this.order.versionId, code)
-                .then((response) => {
-                    this.handlePromotionResponse(response);
-                    this.$emit('reload-entity-data');
-                    if (this.swOrderDetailOnReloadEntityData) {
-                        this.swOrderDetailOnReloadEntityData();
-                    }
-                })
-                .catch((error) => {
-                    this.$emit('loading-change', false);
-                    if (this.swOrderDetailOnLoadingChange) {
-                        this.swOrderDetailOnLoadingChange(false);
-                    }
-                    this.$emit('error', error);
-                    if (this.swOrderDetailOnError) {
-                        this.swOrderDetailOnError(error);
-                    }
-                });
+                .then(this.handlePromotionResponse)
+                .catch(this.handleError);
         },
 
         handlePromotionResponse(response) {
-            Object.values(response.data.errors).forEach((value) => {
+            this.emitEntityData();
+
+            if (!response?.data?.errors) {
+                return;
+            }
+
+            Object.values(response?.data?.errors).forEach((value) => {
                 switch (value.level) {
                     case 0: {
                         this.createNotificationInfo({
@@ -298,21 +282,13 @@ export default {
             });
         },
 
-        handleUnsavedOrderChangesResponse() {
-            this.createNotificationWarning({
-                message: this.$tc('sw-order.detailBase.textUnsavedChanges', 0),
-            });
-        },
-
         onRemoveExistingCode(removedItem) {
-            this.$emit('loading-change', true);
+            this.emitLoadingChange(true);
 
             if (this.hasOrderUnsavedChanges) {
-                this.$emit('loading-change', false);
-                if (this.swOrderDetailOnLoadingChange) {
-                    this.swOrderDetailOnLoadingChange(false);
-                }
+                this.emitLoadingChange(false);
                 this.handleUnsavedOrderChangesResponse();
+
                 return;
             }
 
@@ -322,22 +298,8 @@ export default {
 
             this.orderLineItemRepository
                 .delete(lineItem.id, this.versionContext)
-                .then(() => {
-                    this.$emit('reload-entity-data');
-                    if (this.swOrderDetailOnReloadEntityData) {
-                        this.swOrderDetailOnReloadEntityData();
-                    }
-                })
-                .catch((error) => {
-                    this.$emit('loading-change', false);
-                    if (this.swOrderDetailOnLoadingChange) {
-                        this.swOrderDetailOnLoadingChange(false);
-                    }
-                    this.$emit('error', error);
-                    if (this.swOrderDetailOnError) {
-                        this.swOrderDetailOnError(error);
-                    }
-                });
+                .then(this.emitEntityData)
+                .catch(this.handleError);
         },
 
         getLineItemByPromotionCode(code) {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-promotion-field/sw-order-promotion-field.html.twig
@@ -1,6 +1,5 @@
 {% block sw_order_promotion_field %}
 <div class="sw-order-promotion-field">
-
     {% block sw_order_promotion_field_codes %}
     <sw-order-promotion-tag-field
         v-model:value="promotionCodeTags"
@@ -21,6 +20,5 @@
         :label="$tc('sw-order.detailsTab.promotionsField.labelToggleAutomaticPromotions')"
     />
     {% endblock %}
-
 </div>
 {% endblock %}


### PR DESCRIPTION
### 1. Why is this change necessary?

When submitting a promotion code to an order in the past, all rules were executed using `CartScopeRule`. This led to incorrect evaluations for rules utilizing `FlowScopeRule`, as they check the scope immediately and always return false.

Additionally, I noticed missing error and info messages in the administration, which were caused by cart incomplete data translation within the Cart processor. I created a ticket for that bug: https://shopware.atlassian.net/browse/NEXT-40798

Lastly, I refactored the admin component responsible for adding promotions to an order.

### 2. What does this change do, exactly?

I added rule-awareness configurations for order- and cart promotions. So that the flow/order conditions are not assignable anymore for promotions.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).

- closes #6587
- jira: https://shopware.atlassian.net/browse/NEXT-40565

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
