### PR TITLE
feat: support og:video meta tag

### DIFF
--- a/changelog/_unreleased/2025-02-23-support-og-video-meta-tag.md
+++ b/changelog/_unreleased/2025-02-23-support-og-video-meta-tag.md
@@ -1,0 +1,8 @@
+---
+title: Support og:video meta tag
+author: Elias Lackner
+author_email: lackner.elias@gmail.com
+author_github: @lacknere
+---
+# Storefront
+* Changed `og:image` meta tag in `views/storefront/page/product-detail/meta.html.twig` to `og:video` if product cover is a video.

--- a/src/Storefront/Resources/views/storefront/page/product-detail/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/product-detail/meta.html.twig
@@ -12,7 +12,7 @@
 
     <meta property="og:description"
           content="{{ metaDescription }}">
-    <meta property="og:image"
+    <meta property="og:{{ page.product.cover.media.getMediaType().getName() === 'VIDEO' ? 'video' : 'image' }}"
           content="{{ page.product.cover.media.url }}">
 
     {% if page.product.manufacturer %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Currently, if a product uses a video as cover, the `og:image` meta tag is used.

### 2. What does this change do, exactly?
* Changing `og:image` meta tag in `views/storefront/page/product-detail/meta.html.twig` to `og:video` if product cover is a video.

### 3. Describe each step to reproduce the issue or behaviour.
Use a video as product cover and inspect the og meta tags on the product detail page.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
