### PR TITLE
feat: defer cart errors

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -212,6 +212,8 @@ jobs:
           shopware-version: ${{ github.ref }}
           shopware-repository: ${{ github.repository }}
 
+      # do not remove
+      # This is required for the test `tests/unit/Core/Checkout/Cart/Error/ErrorTest.php` to work properly
       - name: Dump composer autoloader
         run: php vendor/bin/composer dump-autoload -o
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -212,6 +212,9 @@ jobs:
           shopware-version: ${{ github.ref }}
           shopware-repository: ${{ github.repository }}
 
+      - name: Dump composer autoloader
+        run: php vendor/bin/composer dump-autoload -o
+
       - name: Start Webserver
         run: symfony server:start -d
 

--- a/changelog/_unreleased/2025-02-24-deferred-cart-errors.md
+++ b/changelog/_unreleased/2025-02-24-deferred-cart-errors.md
@@ -1,0 +1,14 @@
+---
+title: deferred-cart-errors
+issue: Ocarthon
+flag: DEFERRED_CART_ERRORS
+author: Philip Standt
+author_email: philip.standt@strix.net
+author_github: @Philip Standt
+---
+# Core
+* Added method `withPermissions` to the `SalesChannelContext` to execute code with specific permissions set
+* Added the feature of deferred cart errors with the feature flag `DEFERRED_CART_ERRORS`
+  * Cart errors that happen during the construction of the `SalesChannelContext` are persisted with the cart and will only be removed with the next load of a cart
+  * This ensures cart errors are deferred until a Store-API call related to the cart is made
+___

--- a/changelog/_unreleased/2025-02-24-deferred-cart-errors.md
+++ b/changelog/_unreleased/2025-02-24-deferred-cart-errors.md
@@ -15,6 +15,7 @@ author_github: @Philip Standt
 
 ___
 # Next Major Version Changes
+## Persisted cart errors
 * Changed persistence of cart errors. Cart errors are persisted with the cart when the `SalesChannelContext` is constructed
     * If a temporary cart error happens during the initial cart evaluation (i.e. a product is no longer available and is removed from the cart), that error is now persisted until the cart is processed again.
     * This prevents temporary errors from being removed without ever being shown to the user (especially when using the Store-API)

--- a/changelog/_unreleased/2025-02-24-deferred-cart-errors.md
+++ b/changelog/_unreleased/2025-02-24-deferred-cart-errors.md
@@ -6,14 +6,16 @@ author: Philip Standt
 author_email: philip.standt@strix.net
 author_github: @Philip Standt
 ---
-# Next Major Version Changes
-* Cart errors are persisted with the cart when the `SalesChannelContext` is constructed
-  * If a temporary cart error happens during the initial cart evaluation (i.e. a product is no longer available and is removed from the cart), that error is now persisted until the cart is processed again.
-  * This prevents temporary errors from being removed without ever being shown to the user (especially when using the Store-API)
 
 # Core
 * Added method `withPermissions` to the `SalesChannelContext` to execute code with specific permissions set
 * Added the feature of deferred cart errors with the feature flag `DEFERRED_CART_ERRORS`
   * Cart errors that happen during the construction of the `SalesChannelContext` are persisted with the cart and will only be removed with the next load of a cart
   * This ensures cart errors are deferred until a Store-API call related to the cart is made
+
+___
+# Next Major Version Changes
+* Changed persistence of cart errors. Cart errors are persisted with the cart when the `SalesChannelContext` is constructed
+    * If a temporary cart error happens during the initial cart evaluation (i.e. a product is no longer available and is removed from the cart), that error is now persisted until the cart is processed again.
+    * This prevents temporary errors from being removed without ever being shown to the user (especially when using the Store-API)
 

--- a/changelog/_unreleased/2025-02-24-deferred-cart-errors.md
+++ b/changelog/_unreleased/2025-02-24-deferred-cart-errors.md
@@ -6,6 +6,11 @@ author: Philip Standt
 author_email: philip.standt@strix.net
 author_github: @Philip Standt
 ---
+# Next Major Version Changes
+* Cart errors are persisted with the cart when the `SalesChannelContext` is constructed
+  * If a temporary cart error happens during the initial cart evaluation (i.e. a product is no longer available and is removed from the cart), that error is now persisted until the cart is processed again.
+  * This prevents temporary errors from being removed without ever being shown to the user (especially when using the Store-API)
+
 # Core
 * Added method `withPermissions` to the `SalesChannelContext` to execute code with specific permissions set
 * Added the feature of deferred cart errors with the feature flag `DEFERRED_CART_ERRORS`

--- a/changelog/_unreleased/2025-02-24-deferred-cart-errors.md
+++ b/changelog/_unreleased/2025-02-24-deferred-cart-errors.md
@@ -11,4 +11,4 @@ author_github: @Philip Standt
 * Added the feature of deferred cart errors with the feature flag `DEFERRED_CART_ERRORS`
   * Cart errors that happen during the construction of the `SalesChannelContext` are persisted with the cart and will only be removed with the next load of a cart
   * This ensures cart errors are deferred until a Store-API call related to the cart is made
-___
+

--- a/src/Core/Checkout/Cart/AbstractCartPersister.php
+++ b/src/Core/Checkout/Cart/AbstractCartPersister.php
@@ -10,7 +10,7 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 #[Package('checkout')]
 abstract class AbstractCartPersister
 {
-    public const DEFER_CART_ERRORS_PERMISSION = 'defer-cart-errors';
+    public const PERSIST_CART_ERROR_PERMISSION = 'persist-cart-errors';
 
     abstract public function getDecorated(): AbstractCartPersister;
 
@@ -33,7 +33,7 @@ abstract class AbstractCartPersister
     protected function shouldPersist(Cart $cart): bool
     {
         return $cart->getLineItems()->count() > 0
-            || ($cart->getErrors()->count() > 0 && $cart->getBehavior()?->hasPermission(static::DEFER_CART_ERRORS_PERMISSION))
+            || ($cart->getErrors()->count() > 0 && $cart->getBehavior()?->hasPermission(static::PERSIST_CART_ERROR_PERMISSION))
             || $cart->getAffiliateCode() !== null
             || $cart->getCampaignCode() !== null
             || $cart->getCustomerComment() !== null

--- a/src/Core/Checkout/Cart/AbstractCartPersister.php
+++ b/src/Core/Checkout/Cart/AbstractCartPersister.php
@@ -10,6 +10,8 @@ use Shopware\Core\System\SalesChannel\SalesChannelContext;
 #[Package('checkout')]
 abstract class AbstractCartPersister
 {
+    public const DEFER_CART_ERRORS_PERMISSION = 'defer-cart-errors';
+
     abstract public function getDecorated(): AbstractCartPersister;
 
     abstract public function load(string $token, SalesChannelContext $context): Cart;
@@ -31,6 +33,7 @@ abstract class AbstractCartPersister
     protected function shouldPersist(Cart $cart): bool
     {
         return $cart->getLineItems()->count() > 0
+            || ($cart->getErrors()->count() > 0 && $cart->getBehavior()?->hasPermission(static::DEFER_CART_ERRORS_PERMISSION))
             || $cart->getAffiliateCode() !== null
             || $cart->getCampaignCode() !== null
             || $cart->getCustomerComment() !== null

--- a/src/Core/Checkout/Cart/Address/Error/AddressValidationError.php
+++ b/src/Core/Checkout/Cart/Address/Error/AddressValidationError.php
@@ -12,8 +12,8 @@ class AddressValidationError extends Error
     private const KEY = 'address-invalid';
 
     public function __construct(
-        private readonly bool $isBillingAddress,
-        private readonly ConstraintViolationList $violations
+        protected readonly bool $isBillingAddress,
+        protected readonly ConstraintViolationList $violations
     ) {
         $this->message = \sprintf(
             'Please check your %s address for missing or invalid values.',

--- a/src/Core/Checkout/Cart/Address/Error/BillingAddressBlockedError.php
+++ b/src/Core/Checkout/Cart/Address/Error/BillingAddressBlockedError.php
@@ -10,7 +10,7 @@ class BillingAddressBlockedError extends Error
 {
     private const KEY = 'billing-address-blocked';
 
-    public function __construct(private readonly string $name)
+    public function __construct(protected readonly string $name)
     {
         $this->message = \sprintf(
             'Billings to billing address %s are not possible.',

--- a/src/Core/Checkout/Cart/Address/Error/ShippingAddressBlockedError.php
+++ b/src/Core/Checkout/Cart/Address/Error/ShippingAddressBlockedError.php
@@ -10,7 +10,7 @@ class ShippingAddressBlockedError extends Error
 {
     private const KEY = 'shipping-address-blocked';
 
-    public function __construct(private readonly string $name)
+    public function __construct(protected readonly string $name)
     {
         $this->message = \sprintf(
             'Shippings to shipping address %s are not possible.',

--- a/src/Core/Checkout/Cart/CartPersister.php
+++ b/src/Core/Checkout/Cart/CartPersister.php
@@ -149,9 +149,11 @@ class CartPersister extends AbstractCartPersister
     private function serializeCart(Cart $cart): array
     {
         $errors = $cart->getErrors();
-        $data = $cart->getData();
+        if (!$cart->getBehavior()?->hasPermission(static::DEFER_CART_ERRORS_PERMISSION)) {
+            $cart->setErrors(new ErrorCollection());
+        }
 
-        $cart->setErrors(new ErrorCollection());
+        $data = $cart->getData();
         $cart->setData(null);
 
         $this->cartSerializationCleaner->cleanupCart($cart);

--- a/src/Core/Checkout/Cart/CartPersister.php
+++ b/src/Core/Checkout/Cart/CartPersister.php
@@ -60,6 +60,7 @@ class CartPersister extends AbstractCartPersister
 
         $cart->setToken($token);
         $cart->setRuleIds(json_decode((string) $content['rule_ids'], true, 512, \JSON_THROW_ON_ERROR) ?? []);
+        $cart->setErrorHash($cart->getErrors()->getUniqueHash());
 
         $this->eventDispatcher->dispatch(new CartLoadedEvent($cart, $context));
 
@@ -149,7 +150,7 @@ class CartPersister extends AbstractCartPersister
     private function serializeCart(Cart $cart): array
     {
         $errors = $cart->getErrors();
-        if (!$cart->getBehavior()?->hasPermission(static::DEFER_CART_ERRORS_PERMISSION)) {
+        if (!$cart->getBehavior()?->hasPermission(static::PERSIST_CART_ERROR_PERMISSION)) {
             $cart->setErrors(new ErrorCollection());
         }
 

--- a/src/Core/Checkout/Cart/CartRuleLoader.php
+++ b/src/Core/Checkout/Cart/CartRuleLoader.php
@@ -81,6 +81,10 @@ class CartRuleLoader implements ResetInterface
     private function load(SalesChannelContext $context, Cart $cart, CartBehavior $behaviorContext, bool $new): RuleLoaderResult
     {
         return Profiler::trace('cart-rule-loader', function () use ($context, $cart, $behaviorContext, $new) {
+            // If the processing starts with deferred errors already in the cart, the cart MUST be persisted
+            // to remove the errors from the stored cart
+            $hasDeferredErrors = $cart->getErrors()->count() > 0;
+
             $rules = $this->loadRules($context->getContext());
 
             // save all rules for later usage
@@ -154,7 +158,10 @@ class CartRuleLoader implements ResetInterface
             $context->setAreaRuleIds($rules->getIdsByArea());
 
             // save the cart if errors exist, so the errors get persisted
-            if ($this->updated($cart, $timestamps, $dataHashes) || $cart->getErrorHash() !== $cart->getErrors()->getUniqueHash()) {
+            if ($this->updated($cart, $timestamps, $dataHashes)
+                || $cart->getErrorHash() !== $cart->getErrors()->getUniqueHash()
+                || $hasDeferredErrors
+            ) {
                 $cart->setErrorHash($cart->getErrors()->getUniqueHash());
                 $this->cartPersister->save($cart, $context);
             }

--- a/src/Core/Checkout/Cart/CartRuleLoader.php
+++ b/src/Core/Checkout/Cart/CartRuleLoader.php
@@ -84,12 +84,11 @@ class CartRuleLoader implements ResetInterface
         return Profiler::trace('cart-rule-loader', function () use ($context, $cart, $behaviorContext, $new) {
             // If the processing starts with deferred errors already in the cart, the cart MUST be persisted
             // to remove the errors from the stored cart
-            if (Feature::isActive('DEFERRED_CART_ERRORS')) {
-                $hasDeferredErrors = $cart->getErrors()->count() > 0;
-            } else {
+            $hasDeferredErrors = $cart->getErrors()->count() > 0;
+
+            if (!Feature::isActive('DEFERRED_CART_ERRORS')) {
                 $hasDeferredErrors = false;
             }
-
 
             $rules = $this->loadRules($context->getContext());
 

--- a/src/Core/Checkout/Cart/CartRuleLoader.php
+++ b/src/Core/Checkout/Cart/CartRuleLoader.php
@@ -12,6 +12,7 @@ use Shopware\Core\Content\Rule\RuleCollection;
 use Shopware\Core\Content\Rule\RuleEntity;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\FloatComparator;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -83,7 +84,12 @@ class CartRuleLoader implements ResetInterface
         return Profiler::trace('cart-rule-loader', function () use ($context, $cart, $behaviorContext, $new) {
             // If the processing starts with deferred errors already in the cart, the cart MUST be persisted
             // to remove the errors from the stored cart
-            $hasDeferredErrors = $cart->getErrors()->count() > 0;
+            if (Feature::isActive('DEFERRED_CART_ERRORS')) {
+                $hasDeferredErrors = $cart->getErrors()->count() > 0;
+            } else {
+                $hasDeferredErrors = false;
+            }
+
 
             $rules = $this->loadRules($context->getContext());
 

--- a/src/Core/Checkout/Cart/CartSerializationCleaner.php
+++ b/src/Core/Checkout/Cart/CartSerializationCleaner.php
@@ -33,6 +33,10 @@ class CartSerializationCleaner
         foreach ($cart->getDeliveries() as $delivery) {
             $this->cleanupLineItems($delivery->getPositions()->getLineItems(), $event->getCustomFieldAllowList());
         }
+
+        foreach ($cart->getErrors() as $error) {
+            $this->cleanupCartError($error);
+        }
     }
 
     /**
@@ -87,5 +91,16 @@ class CartSerializationCleaner
                 )
             )
         );
+    }
+
+    private function cleanupCartError(\Exception $error): void
+    {
+        $traces = $error->getTrace();
+        foreach ($traces as &$trace) {
+            $trace['args'] = [];
+        }
+
+        $traceProperty = new \ReflectionProperty(\Exception::class, 'trace');
+        $traceProperty->setValue($error, $traces);
     }
 }

--- a/src/Core/Checkout/Cart/CartSerializationCleaner.php
+++ b/src/Core/Checkout/Cart/CartSerializationCleaner.php
@@ -33,10 +33,6 @@ class CartSerializationCleaner
         foreach ($cart->getDeliveries() as $delivery) {
             $this->cleanupLineItems($delivery->getPositions()->getLineItems(), $event->getCustomFieldAllowList());
         }
-
-        foreach ($cart->getErrors() as $error) {
-            $this->cleanupCartError($error);
-        }
     }
 
     /**
@@ -91,16 +87,5 @@ class CartSerializationCleaner
                 )
             )
         );
-    }
-
-    private function cleanupCartError(\Exception $error): void
-    {
-        $traces = $error->getTrace();
-        foreach ($traces as &$trace) {
-            $trace['args'] = [];
-        }
-
-        $traceProperty = new \ReflectionProperty(\Exception::class, 'trace');
-        $traceProperty->setValue($error, $traces);
     }
 }

--- a/src/Core/Checkout/Cart/Error/Error.php
+++ b/src/Core/Checkout/Cart/Error/Error.php
@@ -25,6 +25,13 @@ abstract class Error extends \Exception implements \JsonSerializable
 
     final public const LEVEL_ERROR = 20;
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function __serialize(): array {
+        return get_object_vars($this);
+    }
+
     abstract public function getId(): string;
 
     abstract public function getMessageKey(): string;

--- a/src/Core/Checkout/Cart/Error/Error.php
+++ b/src/Core/Checkout/Cart/Error/Error.php
@@ -26,11 +26,27 @@ abstract class Error extends \Exception implements \JsonSerializable
     final public const LEVEL_ERROR = 20;
 
     /**
+     * The trace has to be cleaned up to remove service references that are not serializable.
+     *
      * @return array<string, mixed>
      */
     public function __serialize(): array
     {
-        return get_object_vars($this);
+        $ref = new \ReflectionClass($this);
+
+        $data = [];
+        foreach ($ref->getProperties() as $property) {
+            $data[$property->getName()] = $property->getValue($this);
+        }
+
+        $traces = $this->getTrace();
+        foreach ($traces as &$trace) {
+            $trace['args'] = [];
+        }
+
+        $data['trace'] = $traces;
+
+        return $data;
     }
 
     abstract public function getId(): string;

--- a/src/Core/Checkout/Cart/Error/Error.php
+++ b/src/Core/Checkout/Cart/Error/Error.php
@@ -28,7 +28,8 @@ abstract class Error extends \Exception implements \JsonSerializable
     /**
      * @return array<string, mixed>
      */
-    public function __serialize(): array {
+    public function __serialize(): array
+    {
         return get_object_vars($this);
     }
 

--- a/src/Core/Checkout/Cart/Error/Error.php
+++ b/src/Core/Checkout/Cart/Error/Error.php
@@ -39,12 +39,7 @@ abstract class Error extends \Exception implements \JsonSerializable
             $data[$property->getName()] = $property->getValue($this);
         }
 
-        $traces = $this->getTrace();
-        foreach ($traces as &$trace) {
-            $trace['args'] = [];
-        }
-
-        $data['trace'] = $traces;
+        unset($data['trace']);
 
         return $data;
     }

--- a/src/Core/Checkout/Cart/Error/IncompleteLineItemError.php
+++ b/src/Core/Checkout/Cart/Error/IncompleteLineItemError.php
@@ -9,8 +9,8 @@ use Shopware\Core\Framework\Log\Package;
 class IncompleteLineItemError extends Error
 {
     public function __construct(
-        private string $key,
-        private readonly string $property
+        protected string $key,
+        protected readonly string $property
     ) {
         $this->message = \sprintf('Line item "%s" incomplete. Property "%s" missing.', $key, $property);
 

--- a/src/Core/Checkout/Cart/RedisCartPersister.php
+++ b/src/Core/Checkout/Cart/RedisCartPersister.php
@@ -131,9 +131,11 @@ class RedisCartPersister extends AbstractCartPersister
     private function serializeCart(Cart $cart, SalesChannelContext $context): string
     {
         $errors = $cart->getErrors();
-        $data = $cart->getData();
+        if (!$cart->getBehavior()?->hasPermission(static::DEFER_CART_ERRORS_PERMISSION)) {
+            $cart->setErrors(new ErrorCollection());
+        }
 
-        $cart->setErrors(new ErrorCollection());
+        $data = $cart->getData();
         $cart->setData(null);
 
         $this->cartSerializationCleaner->cleanupCart($cart);

--- a/src/Core/Checkout/Cart/RedisCartPersister.php
+++ b/src/Core/Checkout/Cart/RedisCartPersister.php
@@ -131,7 +131,7 @@ class RedisCartPersister extends AbstractCartPersister
     private function serializeCart(Cart $cart, SalesChannelContext $context): string
     {
         $errors = $cart->getErrors();
-        if (!$cart->getBehavior()?->hasPermission(static::DEFER_CART_ERRORS_PERMISSION)) {
+        if (!$cart->getBehavior()?->hasPermission(static::PERSIST_CART_ERROR_PERMISSION)) {
             $cart->setErrors(new ErrorCollection());
         }
 

--- a/src/Core/Checkout/Gateway/Error/CheckoutGatewayError.php
+++ b/src/Core/Checkout/Gateway/Error/CheckoutGatewayError.php
@@ -12,9 +12,9 @@ class CheckoutGatewayError extends Error
     private const KEY = 'checkout-gateway-error';
 
     public function __construct(
-        private readonly string $reason,
-        private readonly int $level,
-        private readonly bool $blockOrder,
+        protected readonly string $reason,
+        protected readonly int $level,
+        protected readonly bool $blockOrder,
     ) {
         parent::__construct($this->reason);
     }

--- a/src/Core/Checkout/Payment/Cart/Error/PaymentMethodBlockedError.php
+++ b/src/Core/Checkout/Payment/Cart/Error/PaymentMethodBlockedError.php
@@ -11,7 +11,7 @@ class PaymentMethodBlockedError extends Error
     private const KEY = 'payment-method-blocked';
 
     public function __construct(
-        private readonly string $name,
+        protected readonly string $name,
         ?string $reason = null
     ) {
         $this->message = \sprintf(

--- a/src/Core/Checkout/Promotion/Cart/PromotionCartAddedInformationError.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCartAddedInformationError.php
@@ -11,9 +11,9 @@ class PromotionCartAddedInformationError extends Error
 {
     private const KEY = 'promotion-discount-added';
 
-    private string $name;
+    protected string $name;
 
-    private readonly string $discountLineItemId;
+    protected readonly string $discountLineItemId;
 
     public function __construct(LineItem $discountLineItem)
     {

--- a/src/Core/Checkout/Promotion/Cart/PromotionCartDeletedInformationError.php
+++ b/src/Core/Checkout/Promotion/Cart/PromotionCartDeletedInformationError.php
@@ -11,9 +11,9 @@ class PromotionCartDeletedInformationError extends Error
 {
     private const KEY = 'promotion-discount-deleted';
 
-    private string $name;
+    protected string $name;
 
-    private readonly string $discountLineItemId;
+    protected readonly string $discountLineItemId;
 
     public function __construct(LineItem $discountLineItem)
     {

--- a/src/Core/Checkout/Shipping/Cart/Error/ShippingMethodBlockedError.php
+++ b/src/Core/Checkout/Shipping/Cart/Error/ShippingMethodBlockedError.php
@@ -10,7 +10,7 @@ class ShippingMethodBlockedError extends Error
 {
     private const KEY = 'shipping-method-blocked';
 
-    public function __construct(private readonly string $name)
+    public function __construct(protected readonly string $name)
     {
         $this->message = \sprintf(
             'Shipping method %s not available',

--- a/src/Core/Content/Product/Cart/ProductStockReachedError.php
+++ b/src/Core/Content/Product/Cart/ProductStockReachedError.php
@@ -10,10 +10,10 @@ use Shopware\Core\Framework\Log\Package;
 class ProductStockReachedError extends Error
 {
     public function __construct(
-        private readonly string $id,
-        private readonly string $name,
-        private readonly int $quantity,
-        private bool $resolved = true
+        protected readonly string $id,
+        protected readonly string $name,
+        protected readonly int $quantity,
+        protected bool $resolved = true
     ) {
         $this->message = \sprintf(
             'The product %s is only available %d times',

--- a/src/Core/Content/Product/Cart/PurchaseStepsError.php
+++ b/src/Core/Content/Product/Cart/PurchaseStepsError.php
@@ -9,9 +9,9 @@ use Shopware\Core\Framework\Log\Package;
 class PurchaseStepsError extends Error
 {
     public function __construct(
-        private readonly string $id,
-        private readonly string $name,
-        private readonly int $quantity
+        protected readonly string $id,
+        protected readonly string $name,
+        protected readonly int $quantity
     ) {
         $this->message = \sprintf(
             'Your input quantity does not match with the setup of the %s. The quantity was changed to %d',

--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -41,3 +41,8 @@ shopware:
         major: false
         toggleable: true
         description: "Experimental! Contains Performance Tweaks for future changes"
+      - name: DEFERRED_CART_ERRORS
+        default: true
+        major: false
+        toggleable: true
+        description: "Defers cart errors that happen during SalesChannelContext creation"

--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -42,7 +42,7 @@ shopware:
         toggleable: true
         description: "Experimental! Contains Performance Tweaks for future changes"
       - name: DEFERRED_CART_ERRORS
-        default: true
+        default: false
         major: false
         toggleable: true
         description: "Defers cart errors that happen during SalesChannelContext creation"

--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -45,4 +45,4 @@ shopware:
         default: false
         major: false
         toggleable: true
-        description: "Defers cart errors that happen during SalesChannelContext creation"
+        description: "Defers cart errors that happen during SalesChannelContext creation\nThis feature will be standard as of v6.8.0"

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -99,7 +99,7 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
 
             if (Feature::isActive('DEFERRED_CART_ERRORS')) {
                 $result = $context->withPermissions(
-                    [AbstractCartPersister::DEFER_CART_ERRORS_PERMISSION => true],
+                    [AbstractCartPersister::PERSIST_CART_ERROR_PERMISSION => true],
                     function (SalesChannelContext $context) use ($token): RuleLoaderResult {
                         return $this->ruleLoader->loadByToken($context, $token);
                     },

--- a/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
+++ b/src/Core/System/SalesChannel/Context/SalesChannelContextService.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\System\SalesChannel\Context;
 
 use Shopware\Core\Checkout\Cart\AbstractCartPersister;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
-use Shopware\Core\Checkout\Cart\RuleLoaderResult;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
@@ -100,9 +99,7 @@ class SalesChannelContextService implements SalesChannelContextServiceInterface
             if (Feature::isActive('DEFERRED_CART_ERRORS')) {
                 $result = $context->withPermissions(
                     [AbstractCartPersister::PERSIST_CART_ERROR_PERMISSION => true],
-                    function (SalesChannelContext $context) use ($token): RuleLoaderResult {
-                        return $this->ruleLoader->loadByToken($context, $token);
-                    },
+                    fn (SalesChannelContext $context) => $this->ruleLoader->loadByToken($context, $token),
                 );
             } else {
                 $result = $this->ruleLoader->loadByToken($context, $token);

--- a/src/Core/System/SalesChannel/SalesChannelContext.php
+++ b/src/Core/System/SalesChannel/SalesChannelContext.php
@@ -379,6 +379,35 @@ class SalesChannelContext extends Struct
         return $result;
     }
 
+    /**
+     * Executed the callback function with the given permissions set in the SalesChannelContext. If the
+     * permissions are locked, the callback is called with the original permissions of the SalesChannelContext.
+     *
+     * @template TReturn of mixed
+     *
+     * @param array<string, bool> $permissions
+     * @param callable(SalesChannelContext): TReturn $callback
+     *
+     * @return TReturn the return value of the provided callback function
+     */
+    public function withPermissions(array $permissions, callable $callback): mixed
+    {
+        if ($this->permisionsLocked) {
+            return $callback($this);
+        }
+
+        $originalPermissions = $this->getPermissions();
+        $permissions = array_merge($originalPermissions, $permissions);
+
+        $this->setPermissions($permissions);
+
+        $result = $callback($this);
+
+        $this->setPermissions($originalPermissions);
+
+        return $result;
+    }
+
     public function getCountryId(): string
     {
         return $this->shippingLocation->getCountry()->getId();

--- a/src/Storefront/Checkout/Cart/Error/PaymentMethodChangedError.php
+++ b/src/Storefront/Checkout/Cart/Error/PaymentMethodChangedError.php
@@ -11,8 +11,8 @@ class PaymentMethodChangedError extends Error
     private const KEY = 'payment-method-changed';
 
     public function __construct(
-        private readonly string $oldPaymentMethodName,
-        private readonly string $newPaymentMethodName
+        protected readonly string $oldPaymentMethodName,
+        protected readonly string $newPaymentMethodName
     ) {
         $this->message = \sprintf(
             '%s payment is not available for your current cart, the payment was changed to %s',

--- a/src/Storefront/Checkout/Cart/Error/ShippingMethodChangedError.php
+++ b/src/Storefront/Checkout/Cart/Error/ShippingMethodChangedError.php
@@ -11,8 +11,8 @@ class ShippingMethodChangedError extends Error
     private const KEY = 'shipping-method-changed';
 
     public function __construct(
-        private readonly string $oldShippingMethodName,
-        private readonly string $newShippingMethodName
+        protected readonly string $oldShippingMethodName,
+        protected readonly string $newShippingMethodName
     ) {
         $this->message = \sprintf(
             '%s shipping is not available for your current cart, the shipping was changed to %s',

--- a/tests/integration/Core/Checkout/Cart/SalesChannel/CartLoadRouteTest.php
+++ b/tests/integration/Core/Checkout/Cart/SalesChannel/CartLoadRouteTest.php
@@ -17,6 +17,7 @@ use Shopware\Core\Content\Product\ProductCollection;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
@@ -170,5 +171,73 @@ class CartLoadRouteTest extends TestCase
                 1,
             ],
         ];
+    }
+
+    public function testDeferredCartErrors(): void
+    {
+        Feature::skipTestIfInActive('DEFERRED_CART_ERRORS', $this);
+
+        $this->productRepository->create([
+            [
+                'id' => $this->ids->create('productId'),
+                'productNumber' => $this->ids->create('productNumber'),
+                'stock' => 1,
+                'isCloseout' => true,
+                'name' => 'Test',
+                'price' => [['currencyId' => Defaults::CURRENCY, 'gross' => 10, 'net' => 9, 'linked' => false]],
+                'manufacturer' => ['id' => $this->ids->create('manufacturerId'), 'name' => 'test'],
+                'tax' => ['id' => $this->ids->create('tax'), 'taxRate' => 17, 'name' => 'with id'],
+                'active' => true,
+                'visibilities' => [
+                    ['salesChannelId' => $this->ids->get('sales-channel'), 'visibility' => ProductVisibilityDefinition::VISIBILITY_ALL],
+                ],
+            ],
+        ], Context::createDefaultContext());
+
+        $this->login($this->browser);
+
+        // Add product to cart
+        $this->browser->request(
+            'POST',
+            '/store-api/checkout/cart/line-item',
+            [
+                'items' => [
+                    ['type' => LineItem::PRODUCT_LINE_ITEM_TYPE, 'referencedId' => $this->ids->get('productId')],
+                ],
+            ],
+        );
+
+        // Check that product was added to cart
+        $cartResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertCount(1, $cartResponse['lineItems']);
+        static::assertEmpty($cartResponse['errors']);
+
+        // Set product out of stock (to force a temporary cart error)
+        $this->productRepository->update([
+            [
+                'id' => $this->ids->create('productId'),
+                'stock' => 0,
+            ],
+        ], Context::createDefaultContext());
+
+        // Fetch context to simulate a non cart related request
+        $this->browser->request('GET', '/store-api/context');
+        static::assertEquals(200, $this->browser->getResponse()->getStatusCode());
+
+        // Fetch cart, make sure the product is no longer in cart and an error is set
+        $this->browser->request('GET', '/store-api/checkout/cart');
+        static::assertEquals(200, $this->browser->getResponse()->getStatusCode());
+
+        $cartResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertEmpty($cartResponse['lineItems']);
+        static::assertCount(1, $cartResponse['errors']);
+
+        // Fetch cart again, error should not be present anymore
+        $this->browser->request('GET', '/store-api/checkout/cart');
+        static::assertEquals(200, $this->browser->getResponse()->getStatusCode());
+
+        $cartResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
+        static::assertEmpty($cartResponse['lineItems']);
+        static::assertEmpty($cartResponse['errors']);
     }
 }

--- a/tests/integration/Core/Checkout/Cart/SalesChannel/CartLoadRouteTest.php
+++ b/tests/integration/Core/Checkout/Cart/SalesChannel/CartLoadRouteTest.php
@@ -222,11 +222,11 @@ class CartLoadRouteTest extends TestCase
 
         // Fetch context to simulate a non cart related request
         $this->browser->request('GET', '/store-api/context');
-        static::assertEquals(200, $this->browser->getResponse()->getStatusCode());
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode());
 
         // Fetch cart, make sure the product is no longer in cart and an error is set
         $this->browser->request('GET', '/store-api/checkout/cart');
-        static::assertEquals(200, $this->browser->getResponse()->getStatusCode());
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode());
 
         $cartResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertEmpty($cartResponse['lineItems']);
@@ -234,7 +234,7 @@ class CartLoadRouteTest extends TestCase
 
         // Fetch cart again, error should not be present anymore
         $this->browser->request('GET', '/store-api/checkout/cart');
-        static::assertEquals(200, $this->browser->getResponse()->getStatusCode());
+        static::assertSame(200, $this->browser->getResponse()->getStatusCode());
 
         $cartResponse = json_decode((string) $this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
         static::assertEmpty($cartResponse['lineItems']);

--- a/tests/unit/Core/Checkout/Cart/Error/ErrorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Error/ErrorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Error;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Error\Error;
+use Shopware\Core\Checkout\Shipping\Cart\Error\ShippingMethodBlockedError;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[CoversClass(Error::class)]
+#[Package('checkout')]
+class ErrorTest extends TestCase
+{
+    public function testSerialization(): void
+    {
+        $error = new ShippingMethodBlockedError('foo');
+
+        static::assertEquals('foo', $error->getName());
+        dump($error->getTrace());
+
+        $serialized = serialize($error);
+
+        $unserialized = unserialize($serialized);
+        static::assertInstanceOf(ShippingMethodBlockedError::class, $unserialized);
+
+        static::assertEquals('foo', $unserialized->getName());
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/Error/ErrorTest.php
+++ b/tests/unit/Core/Checkout/Cart/Error/ErrorTest.php
@@ -4,11 +4,42 @@ declare(strict_types=1);
 
 namespace Shopware\Tests\Unit\Core\Checkout\Cart\Error;
 
+use Composer\Autoload\ClassLoader;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\Address\Error\AddressValidationError;
+use Shopware\Core\Checkout\Cart\Address\Error\BillingAddressBlockedError;
+use Shopware\Core\Checkout\Cart\Address\Error\BillingAddressCountryRegionMissingError;
+use Shopware\Core\Checkout\Cart\Address\Error\BillingAddressSalutationMissingError;
+use Shopware\Core\Checkout\Cart\Address\Error\ShippingAddressBlockedError;
+use Shopware\Core\Checkout\Cart\Address\Error\ShippingAddressCountryRegionMissingError;
+use Shopware\Core\Checkout\Cart\Address\Error\ShippingAddressSalutationMissingError;
 use Shopware\Core\Checkout\Cart\Error\Error;
+use Shopware\Core\Checkout\Cart\Error\GenericCartError;
+use Shopware\Core\Checkout\Cart\Error\IncompleteLineItemError;
+use Shopware\Core\Checkout\Cart\LineItem\LineItem;
+use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
+use Shopware\Core\Checkout\Gateway\Error\CheckoutGatewayError;
+use Shopware\Core\Checkout\Payment\Cart\Error\PaymentMethodBlockedError;
+use Shopware\Core\Checkout\Promotion\Cart\Error\AutoPromotionNotFoundError;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionExcludedError;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionNotEligibleError;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionNotFoundError;
+use Shopware\Core\Checkout\Promotion\Cart\Error\PromotionsOnCartPriceZeroError;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionCartAddedInformationError;
+use Shopware\Core\Checkout\Promotion\Cart\PromotionCartDeletedInformationError;
 use Shopware\Core\Checkout\Shipping\Cart\Error\ShippingMethodBlockedError;
+use Shopware\Core\Content\Product\Cart\MinOrderQuantityError;
+use Shopware\Core\Content\Product\Cart\ProductNotFoundError;
+use Shopware\Core\Content\Product\Cart\ProductOutOfStockError;
+use Shopware\Core\Content\Product\Cart\ProductStockReachedError;
+use Shopware\Core\Content\Product\Cart\PurchaseStepsError;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Storefront\Checkout\Cart\Error\PaymentMethodChangedError;
+use Shopware\Storefront\Checkout\Cart\Error\ShippingMethodChangedError;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 /**
  * @internal
@@ -17,18 +48,131 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('checkout')]
 class ErrorTest extends TestCase
 {
-    public function testSerialization(): void
+    public function testShippingMethodBlockedErrorSerialization(): void
     {
         $error = new ShippingMethodBlockedError('foo');
 
-        static::assertEquals('foo', $error->getName());
-        dump($error->getTrace());
+        static::assertSame('foo', $error->getName());
 
         $serialized = serialize($error);
 
         $unserialized = unserialize($serialized);
         static::assertInstanceOf(ShippingMethodBlockedError::class, $unserialized);
 
-        static::assertEquals('foo', $unserialized->getName());
+        static::assertSame('foo', $unserialized->getName());
+    }
+
+    #[DataProvider('serializationDataProvider')]
+    public function testErrorSerialization(Error $error): void
+    {
+        $serialized = serialize($error);
+
+        $unserialized = unserialize($serialized);
+        static::assertInstanceOf($error::class, $unserialized);
+
+        // Call all public methods without parameters (i.e. getters) to make sure the don't throw an exception
+        $refClass = new \ReflectionClass($error);
+        $refMethods = $refClass->getMethods(\ReflectionMethod::IS_PUBLIC);
+        foreach ($refMethods as $method) {
+            if ($method->getNumberOfParameters() !== 0) {
+                continue;
+            }
+
+            $method->invoke($error);
+        }
+    }
+
+    /**
+     * @return iterable<class-string<Error>, array{0: Error}>
+     */
+    public static function serializationDataProvider(): iterable
+    {
+        yield AddressValidationError::class => [new AddressValidationError(true, new ConstraintViolationList())];
+        yield BillingAddressBlockedError::class => [new BillingAddressBlockedError('foo')];
+        yield BillingAddressCountryRegionMissingError::class => [new BillingAddressCountryRegionMissingError(self::createCustomerAddress())];
+        yield BillingAddressSalutationMissingError::class => [new BillingAddressSalutationMissingError(self::createCustomerAddress())];
+        yield ShippingAddressBlockedError::class => [new ShippingAddressBlockedError('foo')];
+        yield ShippingAddressCountryRegionMissingError::class => [new ShippingAddressCountryRegionMissingError(self::createCustomerAddress())];
+        yield ShippingAddressSalutationMissingError::class => [new ShippingAddressSalutationMissingError(self::createCustomerAddress())];
+        yield GenericCartError::class => [new GenericCartError('foo', 'bar', [], Error::LEVEL_ERROR, false, false, false)];
+        yield IncompleteLineItemError::class => [new IncompleteLineItemError('foo', 'bar')];
+        yield CheckoutGatewayError::class => [new CheckoutGatewayError('foo', Error::LEVEL_NOTICE, true)];
+        yield PaymentMethodBlockedError::class => [new PaymentMethodBlockedError('foo', 'reason')];
+        yield AutoPromotionNotFoundError::class => [new AutoPromotionNotFoundError('foo')];
+        yield PromotionExcludedError::class => [new PromotionExcludedError('foo')];
+        yield PromotionNotEligibleError::class => [new PromotionNotEligibleError('foo')];
+        yield PromotionNotFoundError::class => [new PromotionNotFoundError('foo')];
+        yield PromotionsOnCartPriceZeroError::class => [new PromotionsOnCartPriceZeroError(['foo', 'bar'])];
+        yield PromotionCartAddedInformationError::class => [new PromotionCartAddedInformationError(self::createLineItem())];
+        yield PromotionCartDeletedInformationError::class => [new PromotionCartDeletedInformationError(self::createLineItem())];
+        yield ShippingMethodBlockedError::class => [new ShippingMethodBlockedError('foo')];
+        yield MinOrderQuantityError::class => [new MinOrderQuantityError(Uuid::randomHex(), 'foo', 5)];
+        yield ProductNotFoundError::class => [new ProductNotFoundError(Uuid::randomHex())];
+        yield ProductOutOfStockError::class => [new ProductOutOfStockError(Uuid::randomHex(), 'foo')];
+        yield ProductStockReachedError::class => [new ProductStockReachedError(Uuid::randomHex(), 'foo', 1)];
+        yield PurchaseStepsError::class => [new PurchaseStepsError(Uuid::randomHex(), 'foo', 5)];
+        yield PaymentMethodChangedError::class => [new PaymentMethodChangedError('foo', 'bar')];
+        yield ShippingMethodChangedError::class => [new ShippingMethodChangedError('foo', 'bar')];
+    }
+
+    public function testAllErrorsCovered(): void
+    {
+        $testedErrors = \array_keys(\iterator_to_array(self::serializationDataProvider()));
+
+        $classLoader = require __DIR__ . '/../../../../../../vendor/autoload.php';
+        static::assertInstanceOf(ClassLoader::class, $classLoader);
+
+        $loadedErrors = [];
+
+        foreach ($classLoader->getClassMap() as $class => $_) {
+            if (!str_starts_with($class, 'Shopware\\')) {
+                continue;
+            }
+
+            if ($class !== Error::class && !\is_subclass_of($class, Error::class)) {
+                continue;
+            }
+
+            $refClass = new \ReflectionClass($class);
+            if ($refClass->isAbstract()) {
+                continue;
+            }
+
+            $loadedErrors[] = $class;
+        }
+
+        if (empty($loadedErrors)) {
+            static::fail('composer autoloader has not been optimized. Run `composer dump-autoload --optimize` to fix this.');
+        }
+
+        $missing = array_diff($loadedErrors, $testedErrors);
+        static::assertEmpty(
+            $missing,
+            'The following cart errors have not been added to the serialization Test: ' . \implode(', ', $missing),
+        );
+    }
+
+    private static function createCustomerAddress(): CustomerAddressEntity
+    {
+        $address = new CustomerAddressEntity();
+        $address->setId(Uuid::randomHex());
+
+        $address->setCustomerId(Uuid::randomHex());
+        $address->setCountryId(Uuid::randomHex());
+        $address->setFirstName('John');
+        $address->setLastName('Doe');
+        $address->setZipcode('12345');
+        $address->setCity('Testcity');
+        $address->setStreet('Teststreet 1');
+
+        return $address;
+    }
+
+    private static function createLineItem(): LineItem
+    {
+        $lineItem = new LineItem(Uuid::randomHex(), LineItem::PRODUCT_LINE_ITEM_TYPE, Uuid::randomHex(), 2);
+        $lineItem->setLabel('LineItem label');
+
+        return $lineItem;
     }
 }

--- a/tests/unit/Core/Checkout/Cart/Order/TestError.php
+++ b/tests/unit/Core/Checkout/Cart/Order/TestError.php
@@ -15,9 +15,9 @@ class TestError extends Error
     final public const LEVEL_UNKNOWN = \PHP_INT_MAX;
 
     public function __construct(
-        private readonly int $level,
-        private readonly bool $blockOrderVal = true,
-        private readonly bool $blockResubmitVal = true
+        protected readonly int $level,
+        protected readonly bool $blockOrderVal = true,
+        protected readonly bool $blockResubmitVal = true
     ) {
     }
 

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
@@ -46,7 +46,6 @@ class SalesChannelContextServiceTest extends TestCase
         $context = $this->createMock(SalesChannelContext::class);
         $context->method('withPermissions')->willReturn($this->createMock(RuleLoaderResult::class));
 
-
         $factory->expects($this->once())
             ->method('create')
             ->with(

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextServiceTest.php
@@ -5,6 +5,7 @@ namespace Shopware\Tests\Unit\Core\System\SalesChannel\Context;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
+use Shopware\Core\Checkout\Cart\RuleLoaderResult;
 use Shopware\Core\Checkout\Cart\SalesChannel\CartService;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
@@ -42,6 +43,10 @@ class SalesChannelContextServiceTest extends TestCase
 
         $expiredToken = Uuid::randomHex();
 
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('withPermissions')->willReturn($this->createMock(RuleLoaderResult::class));
+
+
         $factory->expects($this->once())
             ->method('create')
             ->with(
@@ -52,7 +57,7 @@ class SalesChannelContextServiceTest extends TestCase
                     'expired' => true,
                 ]
             )
-            ->willReturn($this->createMock(SalesChannelContext::class));
+            ->willReturn($context);
 
         $service->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $expiredToken, Defaults::LANGUAGE_SYSTEM));
     }
@@ -74,6 +79,9 @@ class SalesChannelContextServiceTest extends TestCase
         $persister->method('load')->willReturn(['expired' => false, SalesChannelContextService::CUSTOMER_ID => $customerId]);
         $noneExpiringToken = Uuid::randomHex();
 
+        $context = $this->createMock(SalesChannelContext::class);
+        $context->method('withPermissions')->willReturn($this->createMock(RuleLoaderResult::class));
+
         $factory->expects($this->once())
             ->method('create')
             ->with(
@@ -85,7 +93,7 @@ class SalesChannelContextServiceTest extends TestCase
                     'expired' => false,
                 ]
             )
-            ->willReturn($this->createMock(SalesChannelContext::class));
+            ->willReturn($context);
 
         $service->get(new SalesChannelContextServiceParameters(TestDefaults::SALES_CHANNEL, $noneExpiringToken, Defaults::LANGUAGE_SYSTEM));
     }
@@ -94,6 +102,7 @@ class SalesChannelContextServiceTest extends TestCase
     {
         $token = 'test-token';
         $context = $this->createMock(SalesChannelContext::class);
+        $context->method('withPermissions')->willReturn($this->createMock(RuleLoaderResult::class));
         $session = [
             'foo' => 'bar',
         ];

--- a/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
+++ b/tests/unit/Core/System/SalesChannel/SalesChannelContextTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\System\SalesChannel;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\AbstractCartPersister;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
@@ -41,5 +42,44 @@ class SalesChannelContextTest extends TestCase
         static::assertEquals([$idA, $idB], $salesChannelContext->getRuleIdsByAreas(['a', 'c']));
         static::assertEquals([$idC], $salesChannelContext->getRuleIdsByAreas(['d']));
         static::assertEquals([], $salesChannelContext->getRuleIdsByAreas(['f']));
+    }
+
+    public function testWithPermissions(): void
+    {
+        $salesChannelContext = Generator::generateSalesChannelContext();
+        static::assertEmpty($salesChannelContext->getPermissions());
+
+        $called = false;
+        $salesChannelContext->withPermissions(
+            [AbstractCartPersister::PERSIST_CART_ERROR_PERMISSION => true],
+            function (SalesChannelContext $context) use (&$called): void {
+                $called = true;
+
+                static::assertTrue($context->hasPermission(AbstractCartPersister::PERSIST_CART_ERROR_PERMISSION));
+            },
+        );
+
+        static::assertTrue($called);
+        static::assertEmpty($salesChannelContext->getPermissions());
+    }
+
+    public function testWithPermissionsWithLockedPermissions(): void
+    {
+        $salesChannelContext = Generator::generateSalesChannelContext();
+        $salesChannelContext->lockPermissions();
+        static::assertEmpty($salesChannelContext->getPermissions());
+
+        $called = false;
+        $salesChannelContext->withPermissions(
+            [AbstractCartPersister::PERSIST_CART_ERROR_PERMISSION => true],
+            function (SalesChannelContext $context) use (&$called): void {
+                $called = true;
+
+                static::assertEmpty($context->getPermissions());
+            },
+        );
+
+        static::assertTrue($called);
+        static::assertEmpty($salesChannelContext->getPermissions());
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

* This change introduces the concept of deferred cart error
* during the construction of the `SalesChannelContext`, the cart is evaluated
* If a temporary cart error happens (i.e. a product is out of stock and has been removed from the cart), this cart error may never be shown when using the Store-API when other calls are made to the API (and especially if the cart is empty afterwards)

### 2. What does this change do, exactly?

* this change adds the mechanism of deferred cart errors (currently behind the feature flag `DEFERRED_CART_ERRORS`)
* during the construction of the `SalesChannelContext`, the `CartRuleLoader` is now called with the permissions `defer-cart-errors`
* with this permissions set, the cart persistors will also persist the errors of a cart, even if the cart is empty
* the errors are stripped of any argument information to prevent serialization issues

### 3. Describe each step to reproduce the issue or behaviour.

* See also `CartLoadRouteTest::testDeferredCartErrors`
* Add available product to cart
* Make product unavailable (set stock to zero)
* Fetch the context
* Fetch the cart

Without the `DEFERRED_CART_ERRORS` flag, the cart will be empty without any errors

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
