### PR TITLE
fix: Rename wrongly named block name in header template

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/header.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/header.html.twig
@@ -1,5 +1,5 @@
 {% block header %}
-    {% block header_header %}
+    {% block base_header %}
         {% sw_include '@Storefront/storefront/utilities/staging-info.html.twig' %}
 
         <header class="header-main">


### PR DESCRIPTION
Somehow the block was named wrong. `header_header` didn't exist before and `base_header` would be gone, without this change. 