### PR TITLE
fix: document download if customer not logged in

### DIFF
--- a/src/Core/Checkout/Document/SalesChannel/DocumentRoute.php
+++ b/src/Core/Checkout/Document/SalesChannel/DocumentRoute.php
@@ -54,7 +54,7 @@ final class DocumentRoute extends AbstractDocumentRoute
 
         /** @var CustomerEntity $customer */
         $customer = $context->getCustomer();
-        if ($customer->getGuest() && $deepLinkCode === '') {
+        if ($customer?->getGuest() && $deepLinkCode === '') {
             throw DocumentException::customerNotLoggedIn();
         }
 


### PR DESCRIPTION
If customer is not logged in, $customer is always null.

### 1. Why is this change necessary?
You cannot retrieve the document without being logged in. We are currently getting an error.

### 2. What does this change do, exactly?
Verifies that the client is logged in, which allows the document to be downloaded.

### 3. Describe each step to reproduce the issue or behaviour.
#### 1. Create an order as a guest.
#### 2. Generate the document and send a link to it via email.
#### 3. Open the document link in a new window to ensure you are not in the guest session.
#### 4. You will receive an error: Call to a member function getGuest() on null.