### PR TITLE
fix: download e-invoice

### DIFF
--- a/changelog/_unreleased/2025-02-24-fix-add-file-type-to-download-open-e-invoice.md
+++ b/changelog/_unreleased/2025-02-24-fix-add-file-type-to-download-open-e-invoice.md
@@ -1,0 +1,10 @@
+---
+title: Add file type to download and open e-invoices
+issue: https://github.com/shopware/shopware/issues/6969
+author_github: @En0Ma1259
+---
+# Core
+* Added check `companyCountry` key inside `mergeConfiguration` for `Shopware\Core\Checkout\Document\DocumentConfigurationFactory` 
+___
+# Administration
+* Added `fileExtension` to `onDownload` and `onOpenDocument` method in `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig` 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -191,26 +191,6 @@ parameters:
 			path: src/Core/Checkout/Customer/Validation/Constraint/CustomerZipCodeValidator.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfigurationFactory\\:\\:cleanConfig\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Document/DocumentConfigurationFactory.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfigurationFactory\\:\\:cleanConfig\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Document/DocumentConfigurationFactory.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfigurationFactory\\:\\:createConfiguration\\(\\) has parameter \\$specificConfig with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Document/DocumentConfigurationFactory.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\DocumentConfigurationFactory\\:\\:mergeConfiguration\\(\\) has parameter \\$additionalConfig with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Checkout/Document/DocumentConfigurationFactory.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Checkout\\\\Document\\\\Event\\\\DocumentTemplateRendererParameterEvent\\:\\:__construct\\(\\) has parameter \\$parameters with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Checkout/Document/Event/DocumentTemplateRendererParameterEvent.php

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
@@ -117,7 +117,7 @@
                 <sw-context-menu-item
                     :disabled="!acl.can('document.viewer')"
                     class="sw-order-document-card__context-button-open-pdf"
-                    @click="onOpenDocument(item.id, item.deepLinkCode)"
+                    @click="onOpenDocument(item.id, item.deepLinkCode, item.documentMediaFile?.fileExtension)"
                 >
                     {% block sw_order_document_card_grid_action_open_label %}
                     {{ $tc('sw-order.documentCard.labelOpenDocument') }}
@@ -129,7 +129,7 @@
                 <sw-context-menu-item
                     :disabled="!acl.can('document.viewer')"
                     class="sw-order-document-card__context-button-download-pdf"
-                    @click="onDownload(item.id, item.deepLinkCode)"
+                    @click="onDownload(item.id, item.deepLinkCode, item.documentMediaFile?.fileExtension)"
                 >
                     {% block sw_order_document_card_grid_action_download_label %}
                     {{ $tc('sw-order.documentCard.labelDownloadPdf') }}

--- a/src/Core/Checkout/Document/DocumentConfigurationFactory.php
+++ b/src/Core/Checkout/Document/DocumentConfigurationFactory.php
@@ -14,6 +14,9 @@ class DocumentConfigurationFactory
         // Factory is Static
     }
 
+    /**
+     * @param array<string, bool|int|string|array<array-key, mixed>|null> $specificConfig
+     */
     public static function createConfiguration(array $specificConfig, ?DocumentBaseConfigEntity ...$configs): DocumentConfiguration
     {
         $configs = array_filter($configs);
@@ -25,6 +28,9 @@ class DocumentConfigurationFactory
         return static::mergeConfiguration($documentConfiguration, $specificConfig);
     }
 
+    /**
+     * @param DocumentBaseConfigEntity|DocumentConfiguration|array<string, bool|int|string|array<array-key, mixed>|null> $additionalConfig
+     */
     public static function mergeConfiguration(DocumentConfiguration $baseConfig, DocumentBaseConfigEntity|DocumentConfiguration|array $additionalConfig): DocumentConfiguration
     {
         $additionalConfigArray = [];
@@ -43,7 +49,7 @@ class DocumentConfigurationFactory
                 } elseif (str_starts_with($key, 'custom.')) {
                     $customKey = mb_substr($key, 7);
                     $baseConfig->__set('custom', array_merge((array) $baseConfig->__get('custom'), [$customKey => $value]));
-                } elseif ($key === 'companyCountry') {
+                } elseif ($key === 'companyCountry' && \is_array($value)) {
                     $baseConfig->setCompanyCountry((new CountryEntity())->assign($value));
                 } else {
                     $baseConfig->__set($key, $value);
@@ -54,9 +60,14 @@ class DocumentConfigurationFactory
         return $baseConfig;
     }
 
+    /**
+     * @param array<bool|int|string|array<array-key, mixed>|null> $config
+     *
+     * @return array<bool|int|string|array<array-key, mixed>|null>
+     */
     private static function cleanConfig(array $config): array
     {
-        if (isset($config['config'])) {
+        if (isset($config['config']) && \is_array($config['config'])) {
             $config = array_merge($config, $config['config']);
             unset($config['config']);
         }

--- a/src/Core/Checkout/Document/DocumentConfigurationFactory.php
+++ b/src/Core/Checkout/Document/DocumentConfigurationFactory.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Checkout\Document;
 
 use Shopware\Core\Checkout\Document\Aggregate\DocumentBaseConfig\DocumentBaseConfigEntity;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Country\CountryEntity;
 
 #[Package('after-sales')]
 class DocumentConfigurationFactory
@@ -20,9 +21,8 @@ class DocumentConfigurationFactory
         foreach ($configs as $config) {
             $documentConfiguration = static::mergeConfiguration($documentConfiguration, $config);
         }
-        $documentConfiguration = static::mergeConfiguration($documentConfiguration, $specificConfig);
 
-        return $documentConfiguration;
+        return static::mergeConfiguration($documentConfiguration, $specificConfig);
     }
 
     public static function mergeConfiguration(DocumentConfiguration $baseConfig, DocumentBaseConfigEntity|DocumentConfiguration|array $additionalConfig): DocumentConfiguration
@@ -43,6 +43,8 @@ class DocumentConfigurationFactory
                 } elseif (str_starts_with($key, 'custom.')) {
                     $customKey = mb_substr($key, 7);
                     $baseConfig->__set('custom', array_merge((array) $baseConfig->__get('custom'), [$customKey => $value]));
+                } elseif ($key === 'companyCountry') {
+                    $baseConfig->setCompanyCountry((new CountryEntity())->assign($value));
                 } else {
                     $baseConfig->__set($key, $value);
                 }


### PR DESCRIPTION
### 1. Why is this change necessary?
The filetype is necessary to download or open the e-invoice.

### 2. What does this change do, exactly?
Added fileType method argument

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/6969

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
