### PR TITLE
fix: disable delivery was not set

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/index.js
@@ -122,6 +122,7 @@ export default {
                 this.mailerSettings = {
                     ...defaultMailerSettings,
                     'core.mailerSettings.emailAgent': 'local',
+                    'core.mailerSettings.disableDelivery': this.mailerSettings['core.mailerSettings.disableDelivery'],
                 };
             }
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-mailer/page/sw-settings-mailer/sw-settings-mailer.spec.js
@@ -175,4 +175,59 @@ describe('src/module/sw-settings-mailer/page/sw-settings-mailer', () => {
             'core.mailerSettings.disableDelivery': false,
         });
     });
+
+    it('should be possible to set disableDelivery to true', async () => {
+        const wrapper = await new CreateSettingsMailer();
+
+        await wrapper.setData({
+            mailerSettings: {
+                'core.mailerSettings.emailAgent': 'local',
+                'core.mailerSettings.sendMailOptions': '-bs',
+                'core.mailerSettings.disableDelivery': true,
+            },
+        });
+
+        const spySaveValues = jest.spyOn(wrapper.vm.systemConfigApiService, 'saveValues');
+
+        wrapper.vm.saveMailerSettings();
+
+        expect(spySaveValues).toHaveBeenCalledWith({
+            'core.mailerSettings.emailAgent': 'local',
+            'core.mailerSettings.host': null,
+            'core.mailerSettings.port': null,
+            'core.mailerSettings.username': null,
+            'core.mailerSettings.password': null,
+            'core.mailerSettings.encryption': 'null',
+            'core.mailerSettings.senderAddress': null,
+            'core.mailerSettings.deliveryAddress': null,
+            'core.mailerSettings.disableDelivery': true,
+        });
+    });
+
+    it('should display and allow selection of email sendmail options', async () => {
+        const wrapper = await new CreateSettingsMailer();
+
+        // Verify options are correct
+        expect(wrapper.vm.emailSendmailOptions).toEqual([
+            {
+                value: '-bs',
+                name: 'sw-settings-mailer.sendmail.sync'
+            },
+            {
+                value: '-t -i',
+                name: 'sw-settings-mailer.sendmail.async'
+            }
+        ]);
+
+        // Set the mailer settings directly
+        await wrapper.setData({
+            mailerSettings: {
+                'core.mailerSettings.emailAgent': 'local',
+                'core.mailerSettings.sendMailOptions': '-bs'
+            }
+        });
+
+        // Verify the value was set correctly
+        expect(wrapper.vm.mailerSettings['core.mailerSettings.sendMailOptions']).toBe('-bs');
+    });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
It was not possible to disable mail when the local agent was selected.

### 2. What does this change do, exactly?
Merge the correct object with `disableDelivery`.
Adding two more jest test to prevent this error in the future.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes: #6983 
- Related commit: https://github.com/shopware/shopware/commit/cab034ecc3fa0baf3f7cfe365b8dc216becc4352#diff-0b25c0d57464d1278ef7b844ad1cee3307e93ad190486e0f7bc5ac76d107362aL122

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
