### PR TITLE
chore: Removed deprecated Twig filter

### DIFF
--- a/changelog/_unreleased/2025-02-24-remove-spaceless-twig-filter.md
+++ b/changelog/_unreleased/2025-02-24-remove-spaceless-twig-filter.md
@@ -1,0 +1,12 @@
+---
+title: Removed deprecated Twig filter "spaceless".
+issue: NEXT-40293
+---
+# Storefront
+* Removed all occurrences of the deprecated Twig filter `spaceless`. Affected files are:
+  * Removed spaceless filter in `component/product/properties.html.twig`. 
+  * Removed spaceless filter in `component/product/listing.html.twig`.
+  * Removed spaceless filter in `layout/meta.html.twig`.
+  * Removed spaceless filter in `layout/footer/footer.html.twig`.
+  * Removed spaceless filter in `page/account/order-history/order-detail.html.twig`.
+  * Removed spaceless filter in `utilities/thumbnail.html.twig`.

--- a/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/listing.html.twig
@@ -52,15 +52,16 @@
                 {% endif %}
 
                 {% block element_product_listing_row %}
-                    {% set ariaLiveText %}{% apply spaceless %}
-                        {% if searchResult.total > searchResult.limit %}
-                            {{ 'listing.filterPanelAriaLivePaginated'|trans({'%count%': searchResult.elements|length, '%total%': searchResult.total})|sw_sanitize }}
-                        {% else %}
-                            {{ 'listing.filterPanelAriaLive'|trans({'%count%': searchResult.total})|sw_sanitize }}
-                        {% endif %}
-                    {% endapply %}{% endset %}
+                    {% if searchResult.total > searchResult.limit %}
+                        {% set ariaLiveText = 'listing.filterPanelAriaLivePaginated'|trans({
+                            '%count%': searchResult.elements|length,
+                            '%total%': searchResult.total}
+                        )|sw_sanitize %}
+                    {% else %}
+                        {% set ariaLiveText = 'listing.filterPanelAriaLive'|trans({'%count%': searchResult.total})|sw_sanitize %}
+                    {% endif %}
 
-                    <div class="row cms-listing-row js-listing-wrapper" data-aria-live-text="{{ ariaLiveText }}"{% if searchResult.total > 0 %} role="list"{% endif %}>
+                    <div class="row cms-listing-row js-listing-wrapper" data-aria-live-text="{{- ariaLiveText -}}"{% if searchResult.total > 0 %} role="list"{% endif %}>
                         {% if searchResult.total > 0 %}
                             {% block element_product_listing_col %}
                                 {% for product in searchResult %}

--- a/src/Storefront/Resources/views/storefront/component/product/properties.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/product/properties.html.twig
@@ -16,12 +16,7 @@
 
                                         {% block component_product_properties_item_value %}
                                             <td class="properties-value">
-                                                {% apply spaceless %}
-                                                    {% for option in group.options %}
-                                                        {% set i = ( i | default(0) ) + 1 %}
-                                                        <span>{% if i > 1 %}, {% endif %}{{ option.translated.name|e }}</span>
-                                                    {% endfor %}
-                                                {% endapply %}
+                                                <span>{{ group.options|map(option => "#{option.translated.name}")|join(', ') }}</span>
                                             </td>
                                         {% endblock %}
                                     </tr>

--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -190,22 +190,20 @@
             {% block layout_footer_service_menu %}
                 <div class="container">
                     {% block layout_footer_service_menu_content %}
-                        {% apply spaceless %}
-                            <ul class="footer-service-menu-list list-unstyled">
-                                {% for serviceMenuItem in footer.serviceMenu %}
-                                    {% block layout_footer_service_menu_item %}
-                                        <li class="footer-service-menu-item">
-                                            <a class="footer-service-menu-link"
-                                               href="{{ category_url(serviceMenuItem) }}"
-                                               {% if category_linknewtab(serviceMenuItem) %}target="_blank"{% endif %}
-                                               title="{{ serviceMenuItem.translated.name }}">
-                                                {{ serviceMenuItem.translated.name }}
-                                            </a>
-                                        </li>
-                                    {% endblock %}
-                                {% endfor %}
-                            </ul>
-                        {% endapply %}
+                        <ul class="footer-service-menu-list list-unstyled d-flex justify-content-center">
+                            {% for serviceMenuItem in footer.serviceMenu %}
+                                {% block layout_footer_service_menu_item %}
+                                    <li class="footer-service-menu-item">
+                                        <a class="footer-service-menu-link"
+                                           href="{{ category_url(serviceMenuItem) }}"
+                                           {% if category_linknewtab(serviceMenuItem) %}target="_blank"{% endif %}
+                                           title="{{ serviceMenuItem.translated.name }}">
+                                            {{ serviceMenuItem.translated.name }}
+                                        </a>
+                                    </li>
+                                {% endblock %}
+                            {% endfor %}
+                        </ul>
                     {% endblock %}
                 </div>
             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/meta.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/meta.html.twig
@@ -105,11 +105,7 @@
         {% endblock %}
 
         {% block layout_head_title %}
-            <title itemprop="name">{% apply spaceless %}
-                {% block layout_head_title_inner %}
-                    {{ metaTitle }}
-                {% endblock %}
-            {% endapply %}</title>
+            <title itemprop="name">{% block layout_head_title_inner %}{{- metaTitle -}}{% endblock %}</title>
         {% endblock %}
 
         {% block layout_head_stylesheet %}

--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
@@ -125,36 +125,33 @@
                                                     {% endblock %}
 
                                                     {% block page_account_order_item_detail_tracking_code_label_value %}
-                                                        {% apply spaceless %}
-                                                            <dd class="col-6 col-md-7">
-                                                                {% set totalOutput = 0 %}
+                                                        <dd class="col-6 col-md-7">
+                                                            {% for delivery in order.deliveries %}
+                                                                {% set trackingCodes = delivery.trackingCodes %}
+                                                                {% set trackingUrl = delivery.shippingMethod.translated.trackingUrl %}
 
-                                                                {% for delivery in order.deliveries %}
-                                                                    {% set trackingCodes = delivery.trackingCodes %}
-                                                                    {% set trackingUrl = delivery.shippingMethod.translated.trackingUrl %}
+                                                                {% if trackingCodes|length > 0 %}
 
-                                                                    {% if trackingCodes|length > 0 %}
-                                                                        {% for trackingCode in trackingCodes %}
-                                                                            {% if trackingUrl %}
-                                                                                {% set output %}
-                                                                                    <a href="{{ trackingUrl|format(trackingCode) }}" target="_blank" rel="noopener">{{ trackingCode }}</a>
-                                                                                {% endset %}
-                                                                            {% else %}
-                                                                                {% set output %}
-                                                                                    <span>{{ trackingCode }}</span>
-                                                                                {% endset %}
-                                                                            {% endif %}
+                                                                    {% set trackingCodesOutput = [] %}
 
-                                                                            {% set totalOutput = totalOutput + 1 %}
+                                                                    {% for trackingCode in trackingCodes %}
+                                                                        {% if trackingUrl %}
+                                                                            {% set trackingCodesOutput = trackingCodesOutput|merge(
+                                                                                ['<a href="' ~ trackingUrl|format(trackingCode) ~ '" target="_blank" rel="noopener">' ~ trackingCode ~ '</a>']
+                                                                            ) %}
+                                                                        {% else %}
+                                                                            {% set trackingCodesOutput = trackingCodesOutput|merge(
+                                                                                ['<span>' ~ trackingCode ~ '</span>']
+                                                                            ) %}
+                                                                        {% endif %}
+                                                                    {% endfor %}
 
-                                                                            {% if totalOutput > 1 %}<span>, </span>{% endif %}{{ output }}
-                                                                        {% endfor %}
-                                                                    {% else %}
-                                                                        {{ 'account.orderTrackingNotAvailable'|trans|sw_sanitize }}
-                                                                    {% endif %}
-                                                                {% endfor %}
-                                                            </dd>
-                                                        {% endapply %}
+                                                                    {{- trackingCodesOutput|join(', ')|raw -}}
+                                                                {% else %}
+                                                                    {{ 'account.orderTrackingNotAvailable'|trans|sw_sanitize }}
+                                                                {% endif %}
+                                                            {% endfor %}
+                                                        </dd>
                                                     {% endblock %}
                                                 {% endif %}
                                             {% endblock %}

--- a/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/thumbnail.html.twig
@@ -63,39 +63,49 @@
         {% set thumbnails = media.thumbnails|sort|reverse %}
 
         {# generate srcset with all available thumbnails #}
-        {% set srcsetValue %}{% apply spaceless %}
-            {% if loadOriginalImage %}{{ media|sw_encode_media_url }} {{ thumbnails|first.width + 1 }}w, {% endif %}{% for thumbnail in thumbnails %}{{ thumbnail.url|sw_encode_url }} {{ thumbnail.width }}w{% if not loop.last %}, {% endif %}{% endfor %}
-        {% endapply %}{% endset %}
+        {% set srcsetValues = [] %}
+
+        {% if loadOriginalImage %}
+            {% set srcsetValues = srcsetValues|merge([media|sw_encode_media_url ~ ' ' ~ (thumbnails|first.width + 1) ~ 'w']) %}
+        {% endif %}
+
+        {% for thumbnail in thumbnails %}
+            {% set srcsetValues = srcsetValues|merge([thumbnail.url|sw_encode_url ~ ' ' ~ thumbnail.width ~ 'w']) %}
+        {% endfor %}
 
         {# generate sizes #}
-        {% set sizesValue %}{% apply spaceless %}
-            {% set sizeFallback = 100 %}
+        {% set sizeFallback = 100 %}
 
-            {# set largest size depending on column count of cms block #}
-            {% if autoColumnSizes and columns %}
-                {% set sizeFallback = (sizeFallback / columns)|round(0, 'ceil') %}
-            {% endif %}
+        {# set largest size depending on column count of cms block #}
+        {% if autoColumnSizes and columns %}
+            {% set sizeFallback = (sizeFallback / columns)|round(0, 'ceil') %}
+        {% endif %}
 
-            {% set breakpoint = {
-                xs: theme_config('breakpoint.xs'),
-                sm: theme_config('breakpoint.sm'),
-                md: theme_config('breakpoint.md'),
-                lg: theme_config('breakpoint.lg'),
-                xl: theme_config('breakpoint.xl')
-            } %}
+        {% set breakpoint = {
+            xs: theme_config('breakpoint.xs'),
+            sm: theme_config('breakpoint.sm'),
+            md: theme_config('breakpoint.md'),
+            lg: theme_config('breakpoint.lg'),
+            xl: theme_config('breakpoint.xl')
+        } %}
 
-            {% for key, value in breakpoint|reverse %}(min-width: {{ value }}px) {{ sizes[key] }}{% if not loop.last %}, {% endif %}{% endfor %}, {{ sizeFallback }}vw
-        {% endapply %}{% endset %}
+        {% set sizesValues = [] %}
+
+        {% for key, value in breakpoint|reverse %}
+            {% set sizesValues = sizesValues|merge(['(min-width: ' ~ value ~ 'px) ' ~ sizes[key]]) %}
+        {% endfor %}
+
+        {% set sizesValues = sizesValues|merge([sizeFallback ~ 'vw']) %}
     {% endif %}
 
     {% block thumbnail_utility_img %}
         <img {% if load %}src="{{ media|sw_encode_media_url }}" {% else %}data-src="{{ media|sw_encode_media_url }}" {% endif %}
             {% if media.thumbnails|length > 0 %}
-                {% if load %}srcset="{{ srcsetValue }}" {% else %}data-srcset="{{ srcsetValue }}" {% endif %}
+                {% if load %}srcset="{{ srcsetValues|join(', ') }}" {% else %}data-srcset="{{ srcsetValues|join(', ') }}" {% endif %}
                 {% if sizes['default'] %}
                 sizes="{{ sizes['default'] }}"
                 {% elseif sizes|length > 0 %}
-                sizes="{{ sizesValue }}"
+                sizes="{{ sizesValues|join(', ') }}"
                 {% endif %}
             {% endif %}
             {% for key, value in attributes %}{% if value != '' %} {{ key }}="{{ value }}"{% endif %}{% endfor %}


### PR DESCRIPTION
Removed all occurrences of the deprecated [spaceless](https://twig.symfony.com/doc/3.x/filters/spaceless.html) Twig filter.
