### PR TITLE
feat: Use real order data for mail preview [6.5.x]

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-send-document-modal/index.js
@@ -128,7 +128,9 @@ export default {
             }
 
             this.subject = mailTemplate.subject;
-            this.mailService.buildRenderPreview(mailTemplate.mailTemplateType, mailTemplate).then((result) => {
+            const mailTemplateType = mailTemplate.mailTemplateType;
+            mailTemplateType.templateData.order = this.order ?? mailTemplateType.templateData.order;
+            this.mailService.buildRenderPreview(mailTemplateType, mailTemplate).then((result) => {
                 this.content = result;
             });
         },


### PR DESCRIPTION
When opening the preview of a mail, use the live order data instead of sample data for order information.

https://shopware.atlassian.net/browse/NEXT-39696