### PR TITLE
fix: Twig map filter with key value

### DIFF
--- a/src/Core/Framework/Adapter/Twig/SecurityExtension.php
+++ b/src/Core/Framework/Adapter/Twig/SecurityExtension.php
@@ -40,12 +40,8 @@ class SecurityExtension extends AbstractExtension
      */
     public function map(?iterable $array, string|callable|\Closure $function): ?array
     {
-        if ($array === null) {
+        if ($array === null || !\is_callable($function)) {
             return null;
-        }
-
-        if (\is_array($function)) {
-            $function = implode('::', $function);
         }
 
         if (\is_string($function) && !\in_array($function, $this->allowedPHPFunctions, true)) {
@@ -56,10 +52,10 @@ class SecurityExtension extends AbstractExtension
         foreach ($array as $key => $value) {
             if (\is_string($function)) {
                 // Custom functions
-                // @phpstan-ignore-next-line
+                // @phpstan-ignore-next-line (Dynamic function name allowed)
                 $result[$key] = $function($value);
             } else {
-                // @phpstan-ignore-next-line
+                // @phpstan-ignore-next-line (Dynamic function name allowed)
                 $result[$key] = $function($value, $key);
             }
         }

--- a/src/Core/Framework/Adapter/Twig/SecurityExtension.php
+++ b/src/Core/Framework/Adapter/Twig/SecurityExtension.php
@@ -54,8 +54,14 @@ class SecurityExtension extends AbstractExtension
 
         $result = [];
         foreach ($array as $key => $value) {
-            // @phpstan-ignore-next-line
-            $result[$key] = $function($value, $key);
+            if (\is_string($function)) {
+                // Custom functions
+                // @phpstan-ignore-next-line
+                $result[$key] = $function($value);
+            } else {
+                // @phpstan-ignore-next-line
+                $result[$key] = $function($value, $key);
+            }
         }
 
         return $result;

--- a/src/Core/Framework/Adapter/Twig/SecurityExtension.php
+++ b/src/Core/Framework/Adapter/Twig/SecurityExtension.php
@@ -55,7 +55,7 @@ class SecurityExtension extends AbstractExtension
         $result = [];
         foreach ($array as $key => $value) {
             // @phpstan-ignore-next-line
-            $result[$key] = $function($value);
+            $result[$key] = $function($value, $key);
         }
 
         return $result;

--- a/tests/unit/Core/Framework/Adapter/Twig/SecurityExtensionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/SecurityExtensionTest.php
@@ -80,6 +80,11 @@ class SecurityExtensionTest extends TestCase
         static::assertSame('a-testb-testc-test', $this->runTwig('{{ ["a", "b", "c"]|map(v => (v ~ "-test"))|join }}'));
     }
 
+    public function testMapWithKeyValue(): void
+    {
+        static::assertSame('jon doe', $this->runTwig('{{ { "jon": "doe" }|map((value, key) => "#{key} #{value}")|join }}'));
+    }
+
     public function testReduceAllowedFunction(): void
     {
         static::assertSame('6', $this->runTwig('{{ [1 , 5]|reduce((a, b) => a + b)|json_encode|raw }}'));


### PR DESCRIPTION
### 1. Why is this change necessary?

The current implementation of the `map` Twig filter in `SecurityExtension.php` does not comply with the [official API](https://twig.symfony.com/doc/3.x/filters/map.html) to support the key within the map function.

### 2. What does this change do, exactly?

Passing the missing `key` parameter into the map function.

