### PR TITLE
fix: custom field rule value comparision with datetime and date fields

### DIFF
--- a/src/Core/Framework/Rule/CustomFieldRule.php
+++ b/src/Core/Framework/Rule/CustomFieldRule.php
@@ -120,6 +120,10 @@ class CustomFieldRule
             return $renderedFieldValue ?? false; // those fields are initialized with null in the rule builder
         }
 
+        if (self::isDatetimeOrDateField($renderedField) && \is_string($renderedFieldValue)) {
+            return (new \DateTimeImmutable($renderedFieldValue))->format(\DATE_ATOM);
+        }
+
         return $renderedFieldValue;
     }
 
@@ -185,5 +189,13 @@ class CustomFieldRule
     private static function isSwitchOrBoolField(array $renderedField): bool
     {
         return \in_array($renderedField['type'], [CustomFieldTypes::BOOL, CustomFieldTypes::SWITCH], true);
+    }
+
+    /**
+     * @param array<string, string|array<string, string>> $renderedField
+     */
+    private static function isDatetimeOrDateField(array $renderedField): bool
+    {
+        return \in_array($renderedField['type'], [CustomFieldTypes::DATETIME, CustomFieldTypes::DATE], true);
     }
 }

--- a/tests/unit/Core/Framework/Rule/CustomFieldRuleTest.php
+++ b/tests/unit/Core/Framework/Rule/CustomFieldRuleTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\CustomFieldRule;
+use Shopware\Core\Framework\Rule\Rule;
 
 /**
  * @internal
@@ -38,12 +39,12 @@ class CustomFieldRuleTest extends TestCase
     }
 
     /**
-     * @param array<string, mixed> $customFields
+     * @param array<string, array<string>|string|bool|float> $customFields
      * @param array<string>|bool|string|int|null $renderedFieldValue
      * @param array<string, string> $config
      */
-    #[DataProvider('customFieldRuleData')]
-    public function testMatch(
+    #[DataProvider('customFieldRuleMatchDataProvider')]
+    public function testCustomFieldRuleMatchesValues(
         array $customFields,
         array|bool|string|int|null $renderedFieldValue,
         string $type,
@@ -57,334 +58,633 @@ class CustomFieldRuleTest extends TestCase
             'config' => $config,
         ];
 
-        static::assertEquals(CustomFieldRule::match($renderedField, $renderedFieldValue, $operator, $customFields), $isMatching);
+        static::assertSame($isMatching, CustomFieldRule::match($renderedField, $renderedFieldValue, $operator, $customFields));
     }
 
     /**
-     * @return array<string, array<int, mixed>>
+     * @return iterable<string, array<array<string|int, array<string>|string|bool|float|null>|bool|string|int|null>>
      */
-    public static function customFieldRuleData(): array
+    public static function customFieldRuleMatchDataProvider(): iterable
     {
-        return [
-            'custom field null / rendered field value true/ bool type/ EQ operator / not matching' => [
-                [],
-                true,
-                'bool',
-                '=',
-                false,
-            ],
-            'custom field null / rendered field value false/ bool type/ EQ operator / matching' => [
-                [],
-                false,
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field false value / rendered field value true/ bool type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                true,
-                'bool',
-                '=',
-                false,
-            ],
-            'custom field false value / rendered field value false/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                false,
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field true value / rendered field value false/ bool type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => true],
-                false,
-                'bool',
-                '=',
-                false,
-            ],
-            'custom field true value / rendered field value true/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => true],
-                true,
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field true value / rendered field value string "yes"/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => true],
-                'yes',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field true value / rendered field value string "yes "/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => true],
-                'yes ',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field true value / rendered field value string "True"/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => true],
-                'True',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field true value / rendered field value string "true"/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => true],
-                'true',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field true value / rendered field value string "1"/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => true],
-                '1',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field false value / rendered field value string "yes"/ bool type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                'yes',
-                'bool',
-                '=',
-                false,
-            ],
-            'custom field false value / rendered field value string "yes "/ bool type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                'yes ',
-                'bool',
-                '=',
-                false,
-            ],
-            'custom field false value / rendered field value string "True"/ bool type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                'True',
-                'bool',
-                '=',
-                false,
-            ],
-            'custom field false value / rendered field value string "true"/ bool type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                'true',
-                'bool',
-                '=',
-                false,
-            ],
-            'custom field false value / rendered field value string "1"/ bool type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                '1',
-                'bool',
-                '=',
-                false,
-            ],
-            'custom field false value / rendered field value string "no"/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                'no',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field false value / rendered field value string "no "/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                'no ',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field false value / rendered field value string "False"/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                'False',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field false value / rendered field value string "false"/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                'false',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field false value / rendered field value string "0"/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                '0',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field false value / rendered field value string "some string"/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                'some string',
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field false value / rendered field null/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                null,
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field null value / rendered field string value "testValue"/ text type/ NEQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => null],
-                'testValue',
-                'text',
-                '!=',
-                true,
-            ],
-            'custom field empty value / rendered field string value "testValue"/ text type/ EQ operator / not matching' => [
-                [],
-                'testValue',
-                'text',
-                '=',
-                false,
-            ],
-            'custom field string value / rendered field string value "my_test_value"/ string type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => 'my_test_value'],
-                'my_test_value',
-                'string',
-                '=',
-                true,
-            ],
-            'custom field string value / rendered field string value "my_test_value"/ string type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => 'my_invalid_value'],
-                'my_test_value',
-                'string',
-                '=',
-                false,
-            ],
-            'custom field false value / rendered field string value false/ bool type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                false,
-                'bool',
-                '=',
-                true,
-            ],
-            'custom field false value / rendered field string value true/ bool type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => false],
-                true,
-                'bool',
-                '=',
-                false,
-            ],
-            'custom field "my_test_value" value / rendered field string value "my_test_value"/ string type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => 'my_test_value'],
-                'my_test_value',
-                'string',
-                '=',
-                true,
-            ],
-            'custom field "my_test_value" value / rendered field string value "my_invalid_value"/ string type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => 'my_test_value'],
-                'my_invalid_value',
-                'string',
-                '=',
-                false,
-            ],
-            'custom field "123.0" value / rendered field float value "123"/ string type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => 123.0],
-                123,
-                'float',
-                '=',
-                true,
-            ],
-            'custom field null / rendered field multi select value ["option_1", "option_2"]/ select type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
-                null,
-                'select',
-                '=',
-                false,
-            ],
-            'custom field "[option_1, option_2]" value / rendered field multi select value "[option_1]"/ select type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
-                ['option_1'],
-                'select',
-                '=',
-                true,
-                ['componentName' => 'sw-multi-select'],
-            ],
-            'custom field "[option_2, option_3]" value / rendered field multi select value "[option_1, option_2]"/ select type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_2', 'option_3']],
-                ['option_1', 'option_2'],
-                'select',
-                '=',
-                true,
-                ['componentName' => 'sw-multi-select'],
-            ],
-            'custom field "[option_1, option_2]" value / rendered field multi select value "[option_3]"/ select type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
-                ['option_3'],
-                'select',
-                '=',
-                false,
-                ['componentName' => 'sw-multi-select'],
-            ],
-            'custom field "[option_1, option_2]" value / rendered field multi select value "[option_3, option_4]"/ select type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
-                ['option_3', 'option_4'],
-                'select',
-                '=',
-                false,
-                ['componentName' => 'sw-multi-select'],
-            ],
-            'custom field "[option_1, option_2]" value / rendered field multi select value "[option_1]"/ select type/ NEQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
-                ['option_1'],
-                'select',
-                '!=',
-                false,
-                ['componentName' => 'sw-multi-select'],
-            ],
-            'custom field "[option_1, option_2]" value / rendered field multi select value "[option_3]"/ select type/ NEQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
-                ['option_3'],
-                'select',
-                '!=',
-                true,
-                ['componentName' => 'sw-multi-select'],
-            ],
-            'custom field ["option_1", "option_2"] / rendered field multi select value null/ select type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
-                null,
-                'select',
-                '=',
-                false,
-                ['componentName' => 'sw-multi-select'],
-            ],
-            'custom field "[option_2, option_3]" value / rendered field entity multi id select value "[option_1, option_2]"/ select type/ EQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_2', 'option_3']],
-                ['option_1', 'option_2'],
-                'select',
-                '=',
-                true,
-                ['componentName' => 'sw-entity-multi-id-select'],
-            ],
-            'custom field "[option_1, option_2]" value / rendered field entity multi id select value "[option_3, option_4]"/ select type/ EQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
-                ['option_3', 'option_4'],
-                'select',
-                '=',
-                false,
-                ['componentName' => 'sw-entity-multi-id-select'],
-            ],
-            'custom field "[option_1, option_2]" value / rendered field entity multi id select value "[option_1]"/ select type/ NEQ operator / not matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
-                ['option_1'],
-                'select',
-                '!=',
-                false,
-                ['componentName' => 'sw-entity-multi-id-select'],
-            ],
-            'custom field "[option_1, option_2]" value / rendered field entity multi id select value "[option_3]"/ select type/ NEQ operator / matching' => [
-                [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
-                ['option_3'],
-                'select',
-                '!=',
-                true,
-                ['componentName' => 'sw-entity-multi-id-select'],
-            ],
+        yield from self::boolTypeDataProvider();
+        yield from self::textTypeDataProvider();
+        yield from self::stringTypeDataProvider();
+        yield from self::floatTypeDataProvider();
+        yield from self::selectTypeDataProvider();
+        yield from self::datetimeTypeDataProvider();
+        yield from self::dateTypeDataProvider();
+    }
+
+    /**
+     * @return iterable<string, array<array<string, bool>|bool|string|null>>
+     */
+    private static function boolTypeDataProvider(): iterable
+    {
+        yield 'does not match missing value equals bool true' => [
+            [],
+            true,
+            'bool',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does match missing value equals bool false' => [
+            [],
+            false,
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does not match bool false equals bool true' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            true,
+            'bool',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does match bool false equals bool false' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            false,
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does not match bool true equals bool false' => [
+            [self::CUSTOM_FIELD_NAME => true],
+            false,
+            'bool',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does match bool true equals bool true' => [
+            [self::CUSTOM_FIELD_NAME => true],
+            true,
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool true equals "yes"' => [
+            [self::CUSTOM_FIELD_NAME => true],
+            'yes',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool true equals "yes "' => [
+            [self::CUSTOM_FIELD_NAME => true],
+            'yes ',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool true equals "True"' => [
+            [self::CUSTOM_FIELD_NAME => true],
+            'True',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool true equals "true"' => [
+            [self::CUSTOM_FIELD_NAME => true],
+            'true',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool true equals "1"' => [
+            [self::CUSTOM_FIELD_NAME => true],
+            '1',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does not match bool false equals "yes"' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            'yes',
+            'bool',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does not match bool false with "yes "' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            'yes ',
+            'bool',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does not match bool false with "True"' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            'True',
+            'bool',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does not match bool false with "true"' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            'true',
+            'bool',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does not match bool false with "1"' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            '1',
+            'bool',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does match bool false equals "no"' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            'no',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool false equals "no "' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            'no ',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool false equals "False"' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            'False',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool false equals "false"' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            'false',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool false equals "0"' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            '0',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool false equals "some string"' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            'some string',
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does match bool false equals null' => [
+            [self::CUSTOM_FIELD_NAME => false],
+            null,
+            'bool',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+    }
+
+    /**
+     * @return iterable<string, array<array<string, null>|bool|string>>
+     */
+    private static function textTypeDataProvider(): iterable
+    {
+        yield 'does match null not equals "testValue"' => [
+            [self::CUSTOM_FIELD_NAME => null],
+            'testValue',
+            'text',
+            Rule::OPERATOR_NEQ,
+            true,
+        ];
+
+        yield 'does match missing value equals "testValue"' => [
+            [],
+            'testValue',
+            'text',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+    }
+
+    /**
+     * @return iterable<string, array<array<string, string>|bool|string>>
+     */
+    private static function stringTypeDataProvider(): iterable
+    {
+        yield 'does match same strings on equals' => [
+            [self::CUSTOM_FIELD_NAME => 'my_test_value'],
+            'my_test_value',
+            'string',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does not match different strings on equals' => [
+            [self::CUSTOM_FIELD_NAME => 'my_test_value'],
+            'my_invalid_value',
+            'string',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+    }
+
+    /**
+     * @return iterable<string, array<array<string, float>|bool|string|int>>
+     */
+    private static function floatTypeDataProvider(): iterable
+    {
+        yield 'does match same float on equals' => [
+            [self::CUSTOM_FIELD_NAME => 123.0],
+            123,
+            'float',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+    }
+
+    /**
+     * @return iterable<string, array<array<string|int, array<string>|string>|bool|string|null>>
+     */
+    private static function selectTypeDataProvider(): iterable
+    {
+        yield 'does not match selected options equals null' => [
+            [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+            null,
+            'select',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does match selected options include certain option in multi-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+            ['option_1'],
+            'select',
+            Rule::OPERATOR_EQ,
+            true,
+            ['componentName' => 'sw-multi-select'],
+        ];
+
+        yield 'does match selected options partially include certain options in multi-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_2', 'option_3']],
+            ['option_1', 'option_2'],
+            'select',
+            Rule::OPERATOR_EQ,
+            true,
+            ['componentName' => 'sw-multi-select'],
+        ];
+
+        yield 'does not match selected options include different option in multi-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+            ['option_3'],
+            'select',
+            Rule::OPERATOR_EQ,
+            false,
+            ['componentName' => 'sw-multi-select'],
+        ];
+
+        yield 'does not match selected options include different options in multi-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+            ['option_3', 'option_4'],
+            'select',
+            Rule::OPERATOR_EQ,
+            false,
+            ['componentName' => 'sw-multi-select'],
+        ];
+
+        yield 'does not match selected options do not include certain option in multi-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+            ['option_1'],
+            'select',
+            Rule::OPERATOR_NEQ,
+            false,
+            ['componentName' => 'sw-multi-select'],
+        ];
+
+        yield 'does match selected options do not include different option in multi-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+            ['option_3'],
+            'select',
+            Rule::OPERATOR_NEQ,
+            true,
+            ['componentName' => 'sw-multi-select'],
+        ];
+
+        yield 'does not match selected options include null in multi-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+            null,
+            'select',
+            Rule::OPERATOR_EQ,
+            false,
+            ['componentName' => 'sw-multi-select'],
+        ];
+
+        yield 'does match selected options partially include certain options in entity-multi-id-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_2', 'option_3']],
+            ['option_1', 'option_2'],
+            'select',
+            Rule::OPERATOR_EQ,
+            true,
+            ['componentName' => 'sw-entity-multi-id-select'],
+        ];
+
+        yield 'does not match selected options include different options in entity-multi-id-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+            ['option_3', 'option_4'],
+            'select',
+            Rule::OPERATOR_EQ,
+            false,
+            ['componentName' => 'sw-entity-multi-id-select'],
+        ];
+
+        yield 'does not match selected options do not include certain option in entity-multi-id-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+            ['option_1'],
+            'select',
+            Rule::OPERATOR_NEQ,
+            false,
+            ['componentName' => 'sw-entity-multi-id-select'],
+        ];
+
+        yield 'does match selected options do not include different option in entity-multi-id-select component' => [
+            [self::CUSTOM_FIELD_NAME => ['option_1', 'option_2']],
+            ['option_3'],
+            'select',
+            Rule::OPERATOR_NEQ,
+            true,
+            ['componentName' => 'sw-entity-multi-id-select'],
+        ];
+    }
+
+    /**
+     * @return iterable<string, array<array<string,string>|bool|string>>
+     */
+    private static function datetimeTypeDataProvider(): iterable
+    {
+        yield 'does not match missing value equals datetime' => [
+            [],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does match missing value not equals datetime' => [
+            [],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_NEQ,
+            true,
+        ];
+
+        yield 'does match different datetimes on not equals' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T11:20:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_NEQ,
+            true,
+        ];
+
+        yield 'does match same datetimes on greater then/equals' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T11:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_GTE,
+            true,
+        ];
+
+        yield 'does match greater datetime bigger then/equals smaller datetime' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T12:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_GTE,
+            true,
+        ];
+
+        yield 'does not match smaller datetime greater then/equals bigger datetime' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T10:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_GTE,
+            false,
+        ];
+
+        yield 'does match same datetimes on less then/equals' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T11:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_LTE,
+            true,
+        ];
+
+        yield 'does not match bigger datetime less then/equals smaller datetime' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T12:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_LTE,
+            false,
+        ];
+
+        yield 'does match smaller datetime less then/equals bigger datetime' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T10:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_LTE,
+            true,
+        ];
+
+        yield 'does match same datetimes on equals' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T11:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does not match different datetimes on equals' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T10:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does match bigger datetime greater then smaller datetime' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T12:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_GT,
+            true,
+        ];
+
+        yield 'does not match smaller datetime greater then bigger datetime' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T10:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_GT,
+            false,
+        ];
+
+        yield 'does not match bigger datetime less then smaller datetime' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T12:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_LT,
+            false,
+        ];
+
+        yield 'does match smaller datetime less then bigger datetime' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T10:00:00+00:00'],
+            '2025-02-25T11:00:00.000Z',
+            'datetime',
+            Rule::OPERATOR_LT,
+            true,
+        ];
+    }
+
+    /**
+     * @return iterable<string, array<array<string, string>|bool|string>>
+     */
+    private static function dateTypeDataProvider(): iterable
+    {
+        yield 'does not match missing value equals date' => [
+            [],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does match missing value not equals date' => [
+            [],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_NEQ,
+            true,
+        ];
+
+        yield 'does match different dates on not equals' => [
+            [self::CUSTOM_FIELD_NAME => '2024-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_NEQ,
+            true,
+        ];
+
+        yield 'does match same dates on greater then/equals' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_GTE,
+            true,
+        ];
+
+        yield 'does match greater date bigger then/equals smaller date' => [
+            [self::CUSTOM_FIELD_NAME => '2026-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_GTE,
+            true,
+        ];
+
+        yield 'does not match smaller date greater then/equals bigger date' => [
+            [self::CUSTOM_FIELD_NAME => '2024-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_GTE,
+            false,
+        ];
+
+        yield 'does match same dates on less then/equals' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_LTE,
+            true,
+        ];
+
+        yield 'does not match bigger date less then/equals smaller date' => [
+            [self::CUSTOM_FIELD_NAME => '2026-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_LTE,
+            false,
+        ];
+
+        yield 'does match smaller date less then/equals bigger date' => [
+            [self::CUSTOM_FIELD_NAME => '2024-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_LTE,
+            true,
+        ];
+
+        yield 'does match same dates on equals' => [
+            [self::CUSTOM_FIELD_NAME => '2025-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_EQ,
+            true,
+        ];
+
+        yield 'does not match different dates on equals' => [
+            [self::CUSTOM_FIELD_NAME => '2024-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_EQ,
+            false,
+        ];
+
+        yield 'does match bigger date greater then smaller date' => [
+            [self::CUSTOM_FIELD_NAME => '2026-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_GT,
+            true,
+        ];
+
+        yield 'does not match smaller date greater then bigger date' => [
+            [self::CUSTOM_FIELD_NAME => '2024-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_GT,
+            false,
+        ];
+
+        yield 'does not match bigger date less then smaller date' => [
+            [self::CUSTOM_FIELD_NAME => '2026-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_LT,
+            false,
+        ];
+
+        yield 'does match smaller date less then bigger date' => [
+            [self::CUSTOM_FIELD_NAME => '2024-02-25T00:00:00+00:00'],
+            '2025-02-25T00:00:00',
+            'date',
+            Rule::OPERATOR_LT,
+            true,
         ];
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently the rules regarding `datetime` or `date` custom fields aren't correctly evaluated which results in unwanted results (e.g. wrongly triggered flows, ...).

### 2. What does this change do, exactly?

This change makes sure that during the comparison between two different dates they both have the same format, according to the [php `ATOM` format](https://www.php.net/manual/en/datetime.constants.php#constant.date-atom), which is already used, when decoding time information in the `JsonFieldSerializer`, which is used when loading the custom field values from the database, when comparing them.  
At the moment this wasn't the case so the rule could not evaluate the differences between the two dates accordingly. 

### 3. Describe each step to reproduce the issue or behavior.

1. Create a custom field set with an custom field of the `Date/time field` and one with the `Date` type
2. Attach them to Customers, Products (you also have to activate the `Available in shopping carts` option) and/or Orders
3. Configure the custom fields on one of the above mentioned
4. Configure two rules, where you test on the value of the custom fields
5. Configure e.g. a flow that you can trigger, that uses the rules as conditions and that you know the definite results (e.g. attaching the tags `True` and `False` to an entity according to the evaluation)
6. The actual result should only sometimes match with what one would expect

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

- Jira issue: https://shopware.atlassian.net/browse/NEXT-40047

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
