### PR TITLE
feat: add post deleted app event

### DIFF
--- a/src/Core/Framework/App/Event/PostAppDeletedEvent.php
+++ b/src/Core/Framework/App/Event/PostAppDeletedEvent.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Event\ShopwareEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Contracts\EventDispatcher\Event;
 
+/**
+ * @final
+ */
 #[Package('framework')]
 class PostAppDeletedEvent extends Event implements ShopwareEvent
 {

--- a/src/Core/Framework/App/Event/PostAppDeletedEvent.php
+++ b/src/Core/Framework/App/Event/PostAppDeletedEvent.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Event;
+
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\Event\ShopwareEvent;
+use Shopware\Core\Framework\Log\Package;
+use Symfony\Contracts\EventDispatcher\Event;
+
+#[Package('framework')]
+class PostAppDeletedEvent extends Event implements ShopwareEvent
+{
+    final public const NAME = 'app.deleted.post';
+
+    public function __construct(
+        public readonly string $appName,
+        public readonly string $sourceType,
+        private readonly Context $context,
+        public readonly bool $keepUserData = false
+    ) {
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    public function getName(): string
+    {
+        return self::NAME;
+    }
+}

--- a/src/Core/Framework/App/Lifecycle/AppLifecycle.php
+++ b/src/Core/Framework/App/Lifecycle/AppLifecycle.php
@@ -20,6 +20,7 @@ use Shopware\Core\Framework\App\Event\AppUpdatedEvent;
 use Shopware\Core\Framework\App\Event\Hooks\AppDeletedHook;
 use Shopware\Core\Framework\App\Event\Hooks\AppInstalledHook;
 use Shopware\Core\Framework\App\Event\Hooks\AppUpdatedHook;
+use Shopware\Core\Framework\App\Event\PostAppDeletedEvent;
 use Shopware\Core\Framework\App\Exception\AppRegistrationException;
 use Shopware\Core\Framework\App\Flow\Action\Action;
 use Shopware\Core\Framework\App\Flow\Event\Event;
@@ -170,6 +171,9 @@ class AppLifecycle extends AbstractAppLifecycle
         $this->removeAppAndRole($appEntity, $context, $keepUserData, true);
         $this->assetService->removeAssets($appEntity->getName());
         $this->customEntitySchemaUpdater->update();
+
+        $event = new PostAppDeletedEvent($appEntity->getName(), $appEntity->getSourceType(), $context, $keepUserData);
+        $this->eventDispatcher->dispatch($event);
     }
 
     public function ensureIsCompatible(Manifest $manifest): void


### PR DESCRIPTION
### 1. Why is this change necessary?

To allow us to hook in to when an app is fully removed.

### 2. What does this change do, exactly?

Dispatches an event after app is deleted.

See also https://github.com/shopware/Rufus/pull/66
