### PR TITLE
chore: extract permission helpers

### DIFF
--- a/src/Core/Framework/App/Delta/PermissionsDeltaProvider.php
+++ b/src/Core/Framework/App/Delta/PermissionsDeltaProvider.php
@@ -2,12 +2,11 @@
 
 namespace Shopware\Core\Framework\App\Delta;
 
-use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Manifest\Manifest;
+use Shopware\Core\Framework\App\Privileges\Utils;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Store\Struct\PermissionCollection;
-use Shopware\Core\Framework\Store\Struct\PermissionStruct;
 
 /**
  * @internal only for use by the app-system
@@ -33,7 +32,7 @@ class PermissionsDeltaProvider extends AbstractAppDeltaProvider
             return [];
         }
 
-        return $this->makeCategorizedPermissions($permissions->asParsedPrivileges());
+        return Utils::makeCategorizedPermissions($permissions->asParsedPrivileges());
     }
 
     public function hasDelta(Manifest $manifest, AppEntity $app): bool
@@ -56,56 +55,5 @@ class PermissionsDeltaProvider extends AbstractAppDeltaProvider
         $privilegesDelta = array_diff($newPrivileges, $currentPrivileges);
 
         return \count($privilegesDelta) > 0;
-    }
-
-    /**
-     * @param array<string> $appPrivileges
-     *
-     * @return list<array<'entity'|'operation', string>>
-     */
-    private function makePermissions(array $appPrivileges): array
-    {
-        $permissions = [];
-
-        foreach ($appPrivileges as $privilege) {
-            if ($this->isCrudPrivilege($privilege)) {
-                $entityAndOperation = explode(':', $privilege);
-                if (\array_key_exists($entityAndOperation[1], AclRoleDefinition::PRIVILEGE_DEPENDENCE)) {
-                    $permissions[] = array_combine(['entity', 'operation'], $entityAndOperation);
-
-                    continue;
-                }
-            }
-
-            $permissions[] = ['entity' => 'additional_privileges', 'operation' => $privilege];
-        }
-
-        return $permissions;
-    }
-
-    private function isCrudPrivilege(string $privilege): bool
-    {
-        return substr_count($privilege, ':') === 1;
-    }
-
-    /**
-     * @param array<string> $privilegesDelta
-     *
-     * @return array<string, PermissionCollection>
-     */
-    private function makeCategorizedPermissions(array $privilegesDelta): array
-    {
-        $permissions = $this->makePermissions($privilegesDelta);
-
-        $permissionCollection = new PermissionCollection();
-
-        foreach ($permissions as $permission) {
-            $permissionCollection->add(PermissionStruct::fromArray([
-                'entity' => $permission['entity'],
-                'operation' => $permission['operation'],
-            ]));
-        }
-
-        return $permissionCollection->getCategorizedPermissions();
     }
 }

--- a/src/Core/Framework/App/Privileges/Utils.php
+++ b/src/Core/Framework/App/Privileges/Utils.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\App\Privileges;
+
+use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Store\Struct\PermissionCollection;
+use Shopware\Core\Framework\Store\Struct\PermissionStruct;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Utils
+{
+    /**
+     * @param array<string> $appPrivileges
+     *
+     * @return list<array<'entity'|'operation', string>>
+     */
+    public static function makePermissions(array $appPrivileges): array
+    {
+        $permissions = [];
+
+        foreach ($appPrivileges as $privilege) {
+            if (self::isCrudPrivilege($privilege)) {
+                $entityAndOperation = explode(':', $privilege);
+                if (\array_key_exists($entityAndOperation[1], AclRoleDefinition::PRIVILEGE_DEPENDENCE)) {
+                    $permissions[] = array_combine(['entity', 'operation'], $entityAndOperation);
+
+                    continue;
+                }
+            }
+
+            $permissions[] = ['entity' => 'additional_privileges', 'operation' => $privilege];
+        }
+
+        return $permissions;
+    }
+
+    /**
+     * @param array<string> $privileges
+     *
+     * @return array<string, PermissionCollection>
+     */
+    public static function makeCategorizedPermissions(array $privileges): array
+    {
+        $permissions = self::makePermissions($privileges);
+
+        $permissionCollection = new PermissionCollection();
+
+        foreach ($permissions as $permission) {
+            $permissionCollection->add(PermissionStruct::fromArray([
+                'entity' => $permission['entity'],
+                'operation' => $permission['operation'],
+            ]));
+        }
+
+        return $permissionCollection->getCategorizedPermissions();
+    }
+
+    private static function isCrudPrivilege(string $privilege): bool
+    {
+        return substr_count($privilege, ':') === 1;
+    }
+}

--- a/src/Core/Framework/Store/Services/ExtensionLoader.php
+++ b/src/Core/Framework/Store/Services/ExtensionLoader.php
@@ -2,11 +2,11 @@
 
 namespace Shopware\Core\Framework\Store\Services;
 
-use Shopware\Core\Framework\Api\Acl\Role\AclRoleDefinition;
 use Shopware\Core\Framework\App\Aggregate\AppTranslation\AppTranslationCollection;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
 use Shopware\Core\Framework\App\Lifecycle\AppLoader;
+use Shopware\Core\Framework\App\Privileges\Utils;
 use Shopware\Core\Framework\App\Source\SourceResolver;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
@@ -286,7 +286,7 @@ class ExtensionLoader
             'privacyPolicyLink' => $app->getPrivacy(),
             'iconRaw' => $app->getIcon(),
             'installedAt' => $app->getCreatedAt(),
-            'permissions' => $app->getAclRole() !== null ? $this->makePermissionArray($app->getAclRole()->getPrivileges()) : [],
+            'permissions' => $app->getAclRole() !== null ? Utils::makePermissions($app->getAclRole()->getPrivileges()) : [],
             'active' => $app->isActive(),
             'languages' => [],
             'type' => ExtensionStruct::EXTENSION_TYPE_APP,
@@ -328,33 +328,6 @@ class ExtensionLoader
         }
 
         return $data;
-    }
-
-    /**
-     * @param array<string> $appPrivileges
-     *
-     * @return array<array<string, string>>
-     */
-    private function makePermissionArray(array $appPrivileges): array
-    {
-        $permissions = [];
-
-        foreach ($appPrivileges as $privilege) {
-            if (substr_count($privilege, ':') === 1) {
-                $entityAndOperation = explode(':', $privilege);
-                if (\array_key_exists($entityAndOperation[1], AclRoleDefinition::PRIVILEGE_DEPENDENCE)) {
-                    /** @var array<string, string> $permission */
-                    $permission = array_combine(['entity', 'operation'], $entityAndOperation);
-                    $permissions[] = $permission;
-
-                    continue;
-                }
-            }
-
-            $permissions[] = ['operation' => $privilege, 'entity' => 'additional_privileges'];
-        }
-
-        return $permissions;
     }
 
     /**

--- a/tests/unit/Core/Framework/App/Permission/UtilsTest.php
+++ b/tests/unit/Core/Framework/App/Permission/UtilsTest.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\App\Permission;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\App\Privileges\Utils;
+use Shopware\Core\Framework\Store\Struct\PermissionCollection;
+use Shopware\Core\Framework\Store\Struct\PermissionStruct;
+
+/**
+ * @internal
+ */
+#[CoversClass(Utils::class)]
+class UtilsTest extends TestCase
+{
+    public function testMakePermissions(): void
+    {
+        $permissions = [
+            'product:create',
+            'product:update',
+            'product:delete',
+            'category:delete',
+            'product_manufacturer:create',
+            'product_manufacturer:delete',
+            'tax:create',
+            'language:read',
+            'custom_field_set:update',
+            'order:read',
+            'user_change_me:permission',
+        ];
+
+        $result = Utils::makePermissions($permissions);
+
+        static::assertSame(
+            [
+                ['entity' => 'product', 'operation' => 'create'],
+                ['entity' => 'product', 'operation' => 'update'],
+                ['entity' => 'product', 'operation' => 'delete'],
+                ['entity' => 'category', 'operation' => 'delete'],
+                ['entity' => 'product_manufacturer', 'operation' => 'create'],
+                ['entity' => 'product_manufacturer', 'operation' => 'delete'],
+                ['entity' => 'tax', 'operation' => 'create'],
+                ['entity' => 'language', 'operation' => 'read'],
+                ['entity' => 'custom_field_set', 'operation' => 'update'],
+                ['entity' => 'order', 'operation' => 'read'],
+                ['entity' => 'additional_privileges', 'operation' => 'user_change_me:permission'],
+            ],
+            $result
+        );
+    }
+
+    public function testMakeCategorized(): void
+    {
+        $permissions = [
+            'product:create',
+            'product:update',
+            'product:delete',
+            'category:delete',
+            'product_manufacturer:create',
+            'product_manufacturer:delete',
+            'tax:create',
+            'language:read',
+            'custom_field_set:update',
+            'order:read',
+            'user_change_me:permission',
+        ];
+
+        $result = Utils::makeCategorizedPermissions($permissions);
+
+        static::assertCount(6, $result);
+        static::assertSame(
+            ['category', 'custom_fields', 'order', 'product', 'settings', 'additional_privileges'],
+            array_keys($result)
+        );
+
+        static::assertInstanceOf(PermissionCollection::class, $result['category']);
+        static::assertInstanceOf(PermissionCollection::class, $result['custom_fields']);
+        static::assertInstanceOf(PermissionCollection::class, $result['order']);
+        static::assertInstanceOf(PermissionCollection::class, $result['product']);
+        static::assertInstanceOf(PermissionCollection::class, $result['settings']);
+        static::assertInstanceOf(PermissionCollection::class, $result['additional_privileges']);
+
+        $mapper = fn (PermissionStruct $p) => ['entity' => $p->getEntity(), 'op' => $p->getOperation()];
+
+        static::assertCount(1, $result['category']->getElements());
+        static::assertSame(
+            [['entity' => 'category', 'op' => 'delete']],
+            $result['category']->map($mapper)
+        );
+
+        static::assertCount(1, $result['custom_fields']->getElements());
+        static::assertSame(
+            [['entity' => 'custom_field_set', 'op' => 'update']],
+            $result['custom_fields']->map($mapper)
+        );
+
+        static::assertCount(1, $result['order']->getElements());
+        static::assertSame(
+            [['entity' => 'order', 'op' => 'read']],
+            $result['order']->map($mapper)
+        );
+
+        static::assertCount(5, $result['product']->getElements());
+        static::assertSame(
+            [
+                ['entity' => 'product', 'op' => 'create'],
+                ['entity' => 'product', 'op' => 'update'],
+                ['entity' => 'product', 'op' => 'delete'],
+                ['entity' => 'product_manufacturer', 'op' => 'create'],
+                ['entity' => 'product_manufacturer', 'op' => 'delete'],
+            ],
+            $result['product']->map($mapper)
+        );
+
+        static::assertCount(2, $result['settings']->getElements());
+        static::assertSame(
+            [
+                ['entity' => 'tax', 'op' => 'create'],
+                ['entity' => 'language', 'op' => 'read'],
+            ],
+            $result['settings']->map($mapper)
+        );
+
+        static::assertCount(1, $result['additional_privileges']->getElements());
+        static::assertSame(
+            [['entity' => 'additional_privileges', 'op' => 'user_change_me:permission']],
+            $result['additional_privileges']->map($mapper)
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Some code is duplicated and will be needed in some other places in the future

### 2. What does this change do, exactly?

Extract some duplicated code and make some helpers
