### PR TITLE
chore: Add possibility to validate snippets of any bundle

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2776,17 +2776,7 @@ parameters:
 			path: src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFileHandler\\:\\:findAdministrationSnippetFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/System/Snippet/SnippetFileHandler.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFileHandler\\:\\:findSnippetFilesByPath\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/System/Snippet/SnippetFileHandler.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFileHandler\\:\\:findStorefrontSnippetFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/System/Snippet/SnippetFileHandler.php
 
@@ -2824,11 +2814,6 @@ parameters:
 			message: "#^Parameter \\#2 \\$translation of method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetFixer\\:\\:addTranslationUsingSnippetKey\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Core/System/Snippet/SnippetFixer.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\System\\\\Snippet\\\\SnippetValidatorInterface\\:\\:validate\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/System/Snippet/SnippetValidatorInterface.php
 
 		-
 			message: "#^Method Shopware\\\\Core\\\\System\\\\StateMachine\\\\Loader\\\\InitialStateIdLoader\\:\\:load\\(\\) return type has no value type specified in iterable type array\\.$#"

--- a/src/Core/System/DependencyInjection/snippet.xml
+++ b/src/Core/System/DependencyInjection/snippet.xml
@@ -17,6 +17,7 @@
             <argument type="service" id="Shopware\Core\System\Snippet\Files\SnippetFileCollection" />
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetFileHandler" />
             <argument>%kernel.project_dir%/</argument>
+            <argument type="service" id="kernel"/>
         </service>
 
         <service id="Shopware\Core\System\Snippet\SnippetFixer">

--- a/src/Core/System/DependencyInjection/snippet.xml
+++ b/src/Core/System/DependencyInjection/snippet.xml
@@ -20,12 +20,19 @@
             <argument type="service" id="kernel"/>
         </service>
 
+        <service id="Shopware\Core\System\Snippet\BundleSnippetValidatorInterface" class="Shopware\Core\System\Snippet\SnippetValidator">
+            <argument type="service" id="Shopware\Core\System\Snippet\Files\SnippetFileCollection" />
+            <argument type="service" id="Shopware\Core\System\Snippet\SnippetFileHandler" />
+            <argument>%kernel.project_dir%/</argument>
+            <argument type="service" id="kernel"/>
+        </service>
+
         <service id="Shopware\Core\System\Snippet\SnippetFixer">
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetFileHandler" />
         </service>
 
         <service id="Shopware\Core\System\Snippet\Command\ValidateSnippetsCommand">
-            <argument type="service" id="Shopware\Core\System\Snippet\SnippetValidatorInterface" />
+            <argument type="service" id="Shopware\Core\System\Snippet\BundleSnippetValidatorInterface" />
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetFixer" />
 
             <tag name="console.command"/>

--- a/src/Core/System/DependencyInjection/snippet.xml
+++ b/src/Core/System/DependencyInjection/snippet.xml
@@ -14,7 +14,7 @@
         </service>
 
         <service id="Shopware\Core\System\Snippet\SnippetValidatorInterface" class="Shopware\Core\System\Snippet\SnippetValidator">
-            <deprecated package="core" version="6.7.0.0">The %service_id% service is deprecated. Use Shopware\Core\System\Snippet\BundleSnippetValidatorInterface instead</deprecated>
+            <deprecated package="core" version="6.8.0.0">The %service_id% service is deprecated. Use Shopware\Core\System\Snippet\BundleSnippetValidatorInterface instead</deprecated>
 
             <argument type="service" id="Shopware\Core\System\Snippet\Files\SnippetFileCollection" />
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetFileHandler" />

--- a/src/Core/System/DependencyInjection/snippet.xml
+++ b/src/Core/System/DependencyInjection/snippet.xml
@@ -14,13 +14,14 @@
         </service>
 
         <service id="Shopware\Core\System\Snippet\SnippetValidatorInterface" class="Shopware\Core\System\Snippet\SnippetValidator">
+            <deprecated package="core" version="6.7.0.0">The %service_id% service is deprecated. Use Shopware\Core\System\Snippet\BundleSnippetValidatorInterface instead</deprecated>
+
             <argument type="service" id="Shopware\Core\System\Snippet\Files\SnippetFileCollection" />
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetFileHandler" />
             <argument>%kernel.project_dir%/</argument>
-            <argument type="service" id="kernel"/>
         </service>
 
-        <service id="Shopware\Core\System\Snippet\BundleSnippetValidatorInterface" class="Shopware\Core\System\Snippet\SnippetValidator">
+        <service id="Shopware\Core\System\Snippet\BundleSnippetValidatorInterface" class="Shopware\Core\System\Snippet\BundleSnippetValidator">
             <argument type="service" id="Shopware\Core\System\Snippet\Files\SnippetFileCollection" />
             <argument type="service" id="Shopware\Core\System\Snippet\SnippetFileHandler" />
             <argument>%kernel.project_dir%/</argument>

--- a/src/Core/System/Snippet/BundleSnippetValidator.php
+++ b/src/Core/System/Snippet/BundleSnippetValidator.php
@@ -5,9 +5,10 @@ namespace Shopware\Core\System\Snippet;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Files\GenericSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
+use Symfony\Component\HttpKernel\KernelInterface;
 
-#[Package('framework')]
-class SnippetValidator implements SnippetValidatorInterface
+#[Package('discovery')]
+class BundleSnippetValidator implements BundleSnippetValidatorInterface
 {
     /**
      * @internal
@@ -15,16 +16,14 @@ class SnippetValidator implements SnippetValidatorInterface
     public function __construct(
         private readonly SnippetFileCollection $deprecatedSnippetFiles,
         private readonly SnippetFileHandler $snippetFileHandler,
-        private readonly string $projectDir
+        private readonly string $projectDir,
+        private readonly KernelInterface $kernel
     ) {
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function validate(): array
+    public function validateForBundles(array $bundles = []): array
     {
-        $files = $this->getAllFiles();
+        $files = $this->getFileFromBundles($bundles);
 
         $snippetFileMappings = [];
         $availableISOs = [];
@@ -48,13 +47,23 @@ class SnippetValidator implements SnippetValidatorInterface
         return $this->findMissingSnippets($snippetFileMappings, $availableISOs);
     }
 
-    protected function getAllFiles(): SnippetFileCollection
+    /**
+     * @param array<int, string> $bundles
+     */
+    protected function getFileFromBundles(array $bundles = []): SnippetFileCollection
     {
-        $deprecatedFiles = $this->findDeprecatedSnippetFiles();
-        $administrationFiles = $this->snippetFileHandler->findAdministrationSnippetFiles();
-        $storefrontSnippetFiles = $this->snippetFileHandler->findStorefrontSnippetFiles();
+        if ($bundles !== []) {
+            $bundles = array_map(fn (string $bundle) => $this->kernel->getBundle($bundle), $bundles);
+        }
 
-        return $this->hydrateFiles(array_merge($deprecatedFiles, $administrationFiles, $storefrontSnippetFiles));
+        $files = [];
+        foreach ($bundles as $bundle) {
+            $files[] = $this->snippetFileHandler->findBundleSnippetFiles($bundle);
+        }
+
+        $files = array_merge($this->findDeprecatedSnippetFiles(), ...$files);
+
+        return $this->hydrateFiles($files);
     }
 
     /**

--- a/src/Core/System/Snippet/BundleSnippetValidator.php
+++ b/src/Core/System/Snippet/BundleSnippetValidator.php
@@ -48,9 +48,9 @@ class BundleSnippetValidator implements BundleSnippetValidatorInterface
     }
 
     /**
-     * @param array<int, string> $bundles
+     * @param list<string> $bundles
      */
-    protected function getFileFromBundles(array $bundles = []): SnippetFileCollection
+    private function getFileFromBundles(array $bundles = []): SnippetFileCollection
     {
         if ($bundles !== []) {
             $bundles = array_map(fn (string $bundle) => $this->kernel->getBundle($bundle), $bundles);

--- a/src/Core/System/Snippet/BundleSnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/BundleSnippetValidatorInterface.php
@@ -5,10 +5,12 @@ namespace Shopware\Core\System\Snippet;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('discovery')]
-interface SnippetValidatorInterface
+interface BundleSnippetValidatorInterface extends SnippetValidatorInterface
 {
     /**
+     * @param array<int, string> $bundles
+     *
      * @return array<string, mixed>
      */
-    public function validate(): array;
+    public function validate(array $bundles = []): array;
 }

--- a/src/Core/System/Snippet/BundleSnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/BundleSnippetValidatorInterface.php
@@ -5,12 +5,12 @@ namespace Shopware\Core\System\Snippet;
 use Shopware\Core\Framework\Log\Package;
 
 #[Package('discovery')]
-interface BundleSnippetValidatorInterface extends SnippetValidatorInterface
+interface BundleSnippetValidatorInterface
 {
     /**
      * @param array<int, string> $bundles
      *
      * @return array<string, mixed>
      */
-    public function validate(array $bundles = []): array;
+    public function validateForBundles(array $bundles = []): array;
 }

--- a/src/Core/System/Snippet/BundleSnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/BundleSnippetValidatorInterface.php
@@ -8,7 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 interface BundleSnippetValidatorInterface
 {
     /**
-     * @param array<int, string> $bundles
+     * @param list<string> $bundles
      *
      * @return array<string, mixed>
      */

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -35,12 +35,17 @@ class ValidateSnippetsCommand extends Command
 
     protected function configure(): void
     {
-        $this->addOption('fix', 'f', InputOption::VALUE_NONE, 'Use this option to start a wizard to fix the snippets comfortably');
+        $this
+            ->addOption('fix', 'f', InputOption::VALUE_NONE, 'Use this option to start a wizard to fix the snippets comfortably')
+            ->addOption('bundle', 'b', InputOption::VALUE_OPTIONAL, 'The bundle name where to load the snippets. Multiple bundles can be passed separated by a comma', 'Storefront, Administration')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $missingSnippetsArray = $this->snippetValidator->validate();
+        $bundles = array_map('trim', array_filter(explode(',', $input->getOption('bundle'))));
+
+        $missingSnippetsArray = $this->snippetValidator->validate($bundles);
         $missingSnippetsCollection = $this->hydrateMissingSnippets($missingSnippetsArray);
 
         $io = new ShopwareStyle($input, $output);

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -44,7 +44,7 @@ class ValidateSnippetsCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var list<string> $bundles */
-        $bundles = array_map('trim', array_filter(explode(',', (string) $input->getOption('bundle'))));
+        $bundles = array_values(array_map('trim', array_filter(explode(',', (string) $input->getOption('bundle')))));
 
         $missingSnippetsArray = $this->snippetValidator->validateForBundles($bundles);
         $missingSnippetsCollection = $this->hydrateMissingSnippets($missingSnippetsArray);

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\System\Snippet\Command;
 
 use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Snippet\BundleSnippetValidatorInterface;
 use Shopware\Core\System\Snippet\SnippetFixer;
 use Shopware\Core\System\Snippet\SnippetValidatorInterface;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
@@ -27,7 +28,7 @@ class ValidateSnippetsCommand extends Command
      * @internal
      */
     public function __construct(
-        private readonly SnippetValidatorInterface $snippetValidator,
+        private readonly BundleSnippetValidatorInterface $snippetValidator,
         private readonly SnippetFixer $snippetFixer
     ) {
         parent::__construct();

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -43,7 +43,6 @@ class ValidateSnippetsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        /** @var list<string> $bundles */
         $bundles = array_values(array_map('trim', array_filter(explode(',', (string) $input->getOption('bundle')))));
 
         $missingSnippetsArray = $this->snippetValidator->validateForBundles($bundles);

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -43,7 +43,7 @@ class ValidateSnippetsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $bundles = array_map('trim', array_filter(explode(',', $input->getOption('bundle'))));
+        $bundles = array_map('trim', array_filter(explode(',', (string) $input->getOption('bundle'))));
 
         $missingSnippetsArray = $this->snippetValidator->validate($bundles);
         $missingSnippetsCollection = $this->hydrateMissingSnippets($missingSnippetsArray);

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -45,7 +45,7 @@ class ValidateSnippetsCommand extends Command
     {
         $bundles = array_map('trim', array_filter(explode(',', (string) $input->getOption('bundle'))));
 
-        $missingSnippetsArray = $this->snippetValidator->validate($bundles);
+        $missingSnippetsArray = $this->snippetValidator->validateForBundles($bundles);
         $missingSnippetsCollection = $this->hydrateMissingSnippets($missingSnippetsArray);
 
         $io = new ShopwareStyle($input, $output);

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -6,7 +6,6 @@ use Shopware\Core\Framework\Adapter\Console\ShopwareStyle;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\BundleSnippetValidatorInterface;
 use Shopware\Core\System\Snippet\SnippetFixer;
-use Shopware\Core\System\Snippet\SnippetValidatorInterface;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetCollection;
 use Shopware\Core\System\Snippet\Struct\MissingSnippetStruct;
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
+++ b/src/Core/System/Snippet/Command/ValidateSnippetsCommand.php
@@ -43,6 +43,7 @@ class ValidateSnippetsCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        /** @var list<string> $bundles */
         $bundles = array_map('trim', array_filter(explode(',', (string) $input->getOption('bundle'))));
 
         $missingSnippetsArray = $this->snippetValidator->validateForBundles($bundles);

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -6,6 +6,7 @@ use Shopware\Administration\Administration;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Storefront;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 #[Package('discovery')]
 class SnippetFileHandler
@@ -27,6 +28,21 @@ class SnippetFileHandler
         $json = json_encode($content, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
 
         file_put_contents($path, $json);
+    }
+
+    public function findBundleSnippetFiles(BundleInterface $bundle): array
+    {
+        $storefrontSnippets = [];
+        if(is_dir($bundle->getPath() . '/Resources/snippet/')) {
+            $storefrontSnippets =  $this->findSnippetFilesByPath($bundle->getPath() . '/Resources/snippet/');
+        }
+
+        $administrationSnippets = [];
+        if(is_dir($bundle->getPath() . '/Resources/app/*/src/')) {
+            $administrationSnippets = $this->findSnippetFilesByPath($bundle->getPath() . '/Resources/app/*/src/');
+        }
+
+        return array_merge($storefrontSnippets, $administrationSnippets);
     }
 
     public function findAdministrationSnippetFiles(): array

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -48,6 +48,9 @@ class SnippetFileHandler
         return array_merge($storefrontSnippets, $administrationSnippets);
     }
 
+    /**
+     * @return array<int, string>
+     */
     public function findAdministrationSnippetFiles(): array
     {
         if (!($bundleDir = $this->getBundleDir(Administration::class))) {
@@ -57,6 +60,9 @@ class SnippetFileHandler
         return $this->findSnippetFilesByPath($bundleDir . '/Resources/app/*/src/');
     }
 
+    /**
+     * @return array<int, string>
+     */
     public function findStorefrontSnippetFiles(): array
     {
         if (!($bundleDir = $this->getBundleDir(Storefront::class))) {

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -49,6 +49,8 @@ class SnippetFileHandler
     }
 
     /**
+     * @deprecated
+     *
      * @return array<int, string>
      */
     public function findAdministrationSnippetFiles(): array
@@ -61,6 +63,8 @@ class SnippetFileHandler
     }
 
     /**
+     * @deprecated
+     *
      * @return array<int, string>
      */
     public function findStorefrontSnippetFiles(): array

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -2,9 +2,7 @@
 
 namespace Shopware\Core\System\Snippet;
 
-use Shopware\Administration\Administration;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Storefront\Storefront;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
@@ -30,46 +28,22 @@ class SnippetFileHandler
         file_put_contents($path, $json);
     }
 
+    /**
+     * @return array<int, string>
+     */
     public function findBundleSnippetFiles(BundleInterface $bundle): array
     {
         $storefrontSnippets = [];
-        if(is_dir($bundle->getPath() . '/Resources/snippet/')) {
-            $storefrontSnippets =  $this->findSnippetFilesByPath($bundle->getPath() . '/Resources/snippet/');
+        if (is_dir($bundle->getPath() . '/Resources/snippet/')) {
+            $storefrontSnippets = $this->findSnippetFilesByPath($bundle->getPath() . '/Resources/snippet/');
         }
 
         $administrationSnippets = [];
-        if(is_dir($bundle->getPath() . '/Resources/app/*/src/')) {
+        if (is_dir($bundle->getPath() . '/Resources/app/*/src/')) {
             $administrationSnippets = $this->findSnippetFilesByPath($bundle->getPath() . '/Resources/app/*/src/');
         }
 
-        return array_merge($storefrontSnippets, $administrationSnippets);
-    }
-
-    public function findAdministrationSnippetFiles(): array
-    {
-        if (!($bundleDir = $this->getBundleDir(Administration::class))) {
-            return [];
-        }
-
-        return $this->findSnippetFilesByPath($bundleDir . '/Resources/app/*/src/');
-    }
-
-    public function findStorefrontSnippetFiles(): array
-    {
-        if (!($bundleDir = $this->getBundleDir(Storefront::class))) {
-            return [];
-        }
-
-        return $this->findSnippetFilesByPath($bundleDir . '/Resources/snippet/');
-    }
-
-    private function getBundleDir(string $bundleClass): ?string
-    {
-        if (!class_exists($bundleClass)) {
-            return null;
-        }
-
-        return \dirname((string) (new \ReflectionClass($bundleClass))->getFileName());
+        return array_merge(...$storefrontSnippets, ...$administrationSnippets);
     }
 
     private function findSnippetFilesByPath(string $path): array

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -43,7 +43,7 @@ class SnippetFileHandler
             $administrationSnippets = $this->findSnippetFilesByPath($bundle->getPath() . '/Resources/app/*/src/');
         }
 
-        return array_merge(...$storefrontSnippets, ...$administrationSnippets);
+        return array_merge($storefrontSnippets, $administrationSnippets);
     }
 
     private function findSnippetFilesByPath(string $path): array

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -2,7 +2,9 @@
 
 namespace Shopware\Core\System\Snippet;
 
+use Shopware\Administration\Administration;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Storefront\Storefront;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
@@ -44,6 +46,33 @@ class SnippetFileHandler
         }
 
         return array_merge($storefrontSnippets, $administrationSnippets);
+    }
+
+    public function findAdministrationSnippetFiles(): array
+    {
+        if (!($bundleDir = $this->getBundleDir(Administration::class))) {
+            return [];
+        }
+
+        return $this->findSnippetFilesByPath($bundleDir . '/Resources/app/*/src/');
+    }
+
+    public function findStorefrontSnippetFiles(): array
+    {
+        if (!($bundleDir = $this->getBundleDir(Storefront::class))) {
+            return [];
+        }
+
+        return $this->findSnippetFilesByPath($bundleDir . '/Resources/snippet/');
+    }
+
+    private function getBundleDir(string $bundleClass): ?string
+    {
+        if (!class_exists($bundleClass)) {
+            return null;
+        }
+
+        return \dirname((string) (new \ReflectionClass($bundleClass))->getFileName());
     }
 
     private function findSnippetFilesByPath(string $path): array

--- a/src/Core/System/Snippet/SnippetFileHandler.php
+++ b/src/Core/System/Snippet/SnippetFileHandler.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\System\Snippet;
 
 use Shopware\Administration\Administration;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Storefront\Storefront;
 use Symfony\Component\Finder\Finder;
@@ -49,12 +50,17 @@ class SnippetFileHandler
     }
 
     /**
-     * @deprecated
+     * @deprecated tag:v6.8.0 - Will be removed. Use `SnippetFileHandler::findBundleSnippetFiles(['administration'])` instead
      *
      * @return array<int, string>
      */
     public function findAdministrationSnippetFiles(): array
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0', 'SnippetFileHandler::findBundleSnippetFiles([\'administration\'])'),
+        );
+
         if (!($bundleDir = $this->getBundleDir(Administration::class))) {
             return [];
         }
@@ -63,12 +69,17 @@ class SnippetFileHandler
     }
 
     /**
-     * @deprecated
+     * @deprecated tag:v6.8.0 - Will be removed. Use `SnippetFileHandler::findBundleSnippetFiles(['storefront'])` instead
      *
      * @return array<int, string>
      */
     public function findStorefrontSnippetFiles(): array
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0', 'SnippetFileHandler::findBundleSnippetFiles([\'storefront\'])'),
+        );
+
         if (!($bundleDir = $this->getBundleDir(Storefront::class))) {
             return [];
         }

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -2,11 +2,15 @@
 
 namespace Shopware\Core\System\Snippet;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Files\GenericSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 
-#[Package('framework')]
+/**
+ * @deprecated tag:v6.8.0 - Will be removed. Use `Shopware\Core\System\Snippet\BundleSnippetValidator` instead
+ */
+#[Package('discovery')]
 class SnippetValidator implements SnippetValidatorInterface
 {
     /**
@@ -24,6 +28,11 @@ class SnippetValidator implements SnippetValidatorInterface
      */
     public function validate(): array
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+        );
+
         $files = $this->getAllFiles();
 
         $snippetFileMappings = [];
@@ -50,6 +59,11 @@ class SnippetValidator implements SnippetValidatorInterface
 
     protected function getAllFiles(): SnippetFileCollection
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0'),
+        );
+
         $deprecatedFiles = $this->findDeprecatedSnippetFiles();
         $administrationFiles = $this->snippetFileHandler->findAdministrationSnippetFiles();
         $storefrontSnippetFiles = $this->snippetFileHandler->findStorefrontSnippetFiles();

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -21,7 +21,7 @@ class SnippetValidator implements SnippetValidatorInterface
     ) {
     }
 
-    public function validate(array $bundles): array
+    public function validate(array $bundles = []): array
     {
         $files = $this->getAllFiles($bundles);
 
@@ -50,7 +50,7 @@ class SnippetValidator implements SnippetValidatorInterface
     /**
      * @param array<int, string> $bundles
      */
-    protected function getAllFiles(array $bundles): SnippetFileCollection
+    protected function getAllFiles(array $bundles = []): SnippetFileCollection
     {
         if ($bundles !== []) {
             $bundles = array_map(fn (string $bundle) => $this->kernel->getBundle($bundle), $bundles);

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -3,9 +3,9 @@
 namespace Shopware\Core\System\Snippet;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Kernel;
 use Shopware\Core\System\Snippet\Files\GenericSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 #[Package('discovery')]
 class SnippetValidator implements SnippetValidatorInterface
@@ -17,7 +17,7 @@ class SnippetValidator implements SnippetValidatorInterface
         private readonly SnippetFileCollection $deprecatedSnippetFiles,
         private readonly SnippetFileHandler $snippetFileHandler,
         private readonly string $projectDir,
-        private readonly Kernel $kernel
+        private readonly KernelInterface $kernel
     ) {
     }
 
@@ -48,11 +48,11 @@ class SnippetValidator implements SnippetValidatorInterface
     }
 
     /**
-     * @param array<string, class-string> $bundles
+     * @param array<int, string> $bundles
      */
     protected function getAllFiles(array $bundles): SnippetFileCollection
     {
-        if($bundles !== []) {
+        if ($bundles !== []) {
             $bundles = array_map(fn (string $bundle) => $this->kernel->getBundle($bundle), $bundles);
         }
 

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -8,7 +8,7 @@ use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 #[Package('discovery')]
-class SnippetValidator implements SnippetValidatorInterface
+class SnippetValidator implements BundleSnippetValidatorInterface
 {
     /**
      * @internal

--- a/src/Core/System/Snippet/SnippetValidator.php
+++ b/src/Core/System/Snippet/SnippetValidator.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\System\Snippet;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Kernel;
 use Shopware\Core\System\Snippet\Files\GenericSnippetFile;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 
@@ -15,16 +16,14 @@ class SnippetValidator implements SnippetValidatorInterface
     public function __construct(
         private readonly SnippetFileCollection $deprecatedSnippetFiles,
         private readonly SnippetFileHandler $snippetFileHandler,
-        private readonly string $projectDir
+        private readonly string $projectDir,
+        private readonly Kernel $kernel
     ) {
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function validate(): array
+    public function validate(array $bundles): array
     {
-        $files = $this->getAllFiles();
+        $files = $this->getAllFiles($bundles);
 
         $snippetFileMappings = [];
         $availableISOs = [];
@@ -48,13 +47,23 @@ class SnippetValidator implements SnippetValidatorInterface
         return $this->findMissingSnippets($snippetFileMappings, $availableISOs);
     }
 
-    protected function getAllFiles(): SnippetFileCollection
+    /**
+     * @param array<string, class-string> $bundles
+     */
+    protected function getAllFiles(array $bundles): SnippetFileCollection
     {
-        $deprecatedFiles = $this->findDeprecatedSnippetFiles();
-        $administrationFiles = $this->snippetFileHandler->findAdministrationSnippetFiles();
-        $storefrontSnippetFiles = $this->snippetFileHandler->findStorefrontSnippetFiles();
+        if($bundles !== []) {
+            $bundles = array_map(fn (string $bundle) => $this->kernel->getBundle($bundle), $bundles);
+        }
 
-        return $this->hydrateFiles(array_merge($deprecatedFiles, $administrationFiles, $storefrontSnippetFiles));
+        $files = [];
+        foreach ($bundles as $bundle) {
+            $files[] = $this->snippetFileHandler->findBundleSnippetFiles($bundle);
+        }
+
+        $files = array_merge($this->findDeprecatedSnippetFiles(), ...$files);
+
+        return $this->hydrateFiles($files);
     }
 
     /**

--- a/src/Core/System/Snippet/SnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/SnippetValidatorInterface.php
@@ -12,5 +12,5 @@ interface SnippetValidatorInterface
      *
      * @return array<string, mixed>
      */
-    public function validate(array $bundles): array;
+    public function validate(array $bundles = []): array;
 }

--- a/src/Core/System/Snippet/SnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/SnippetValidatorInterface.php
@@ -8,7 +8,8 @@ use Shopware\Core\Framework\Log\Package;
 interface SnippetValidatorInterface
 {
     /**
-     * @param array<string, class-string> $bundles
+     * @param array<int, string> $bundles
+     *
      * @return array<string, mixed>
      */
     public function validate(array $bundles): array;

--- a/src/Core/System/Snippet/SnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/SnippetValidatorInterface.php
@@ -7,5 +7,9 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('discovery')]
 interface SnippetValidatorInterface
 {
-    public function validate(): array;
+    /**
+     * @param array<string, class-string> $bundles
+     * @return array<string, mixed>
+     */
+    public function validate(array $bundles): array;
 }

--- a/src/Core/System/Snippet/SnippetValidatorInterface.php
+++ b/src/Core/System/Snippet/SnippetValidatorInterface.php
@@ -4,6 +4,9 @@ namespace Shopware\Core\System\Snippet;
 
 use Shopware\Core\Framework\Log\Package;
 
+/**
+ * @deprecated tag:v6.8.0 - Will be removed. Use `Shopware\Core\System\Snippet\BundleSnippetValidatorInterface` instead
+ */
 #[Package('discovery')]
 interface SnippetValidatorInterface
 {

--- a/tests/unit/Core/System/Snippet/BundleSnippetValidatorTest.php
+++ b/tests/unit/Core/System/Snippet/BundleSnippetValidatorTest.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\Snippet;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Administration\Administration;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\Snippet\BundleSnippetValidator;
+use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
+use Shopware\Core\System\Snippet\SnippetFileHandler;
+use Shopware\Storefront\Storefront;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(BundleSnippetValidator::class)]
+class BundleSnippetValidatorTest extends TestCase
+{
+    public function testValidateShouldFindMissingSnippets(): void
+    {
+        $snippetFileHandler = $this->getMockBuilder(SnippetFileHandler::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $firstPath = 'irrelevant.de-DE.json';
+        $secondPath = 'irrelevant.en-GB.json';
+
+        $matcher = static::exactly(2);
+        $snippetFileHandler->expects($matcher)
+            ->method('findBundleSnippetFiles')
+            ->willReturnOnConsecutiveCalls()
+            ->willReturnCallback(function () use ($matcher, $firstPath, $secondPath) {
+                return match ($matcher->numberOfInvocations()) {
+                    1 => [$firstPath],
+                    2 => [$secondPath],
+                    default => null,
+                };
+            });
+
+        $snippetFileHandler->method('openJsonFile')
+            ->willReturnCallback(function ($path) use ($firstPath) {
+                if ($path === $firstPath) {
+                    return ['german' => 'exampleGerman'];
+                }
+
+                return ['english' => 'exampleEnglish'];
+            });
+
+        $matcher = static::exactly(2);
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->expects($matcher)
+            ->method('getBundle')
+            ->willReturnOnConsecutiveCalls()
+            ->willReturnCallback(function () use ($matcher) {
+                return match ($matcher->numberOfInvocations()) {
+                    1 => new Storefront(),
+                    2 => new Administration(),
+                    default => null,
+                };
+            })
+        ;
+
+        $snippetValidator = new BundleSnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '', $kernel);
+        $missingSnippets = $snippetValidator->validateForBundles(['Storefront', 'Administration']);
+
+        static::assertCount(2, $missingSnippets);
+        static::assertArrayHasKey('german', $missingSnippets['en-GB']);
+        static::assertSame('german', $missingSnippets['en-GB']['german']['keyPath']);
+        static::assertSame('exampleGerman', $missingSnippets['en-GB']['german']['availableValue']);
+
+        static::assertArrayHasKey('english', $missingSnippets['de-DE']);
+        static::assertSame('english', $missingSnippets['de-DE']['english']['keyPath']);
+        static::assertSame('exampleEnglish', $missingSnippets['de-DE']['english']['availableValue']);
+    }
+
+    public function testValidateShouldNotFindAnyMissingSnippets(): void
+    {
+        $snippetFileHandler = $this->getMockBuilder(SnippetFileHandler::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $firstPath = 'irrelevant.de-DE.json';
+        $secondPath = 'irrelevant.en-GB.json';
+        $snippetFileHandler->method('findBundleSnippetFiles')
+            ->with(new Storefront())
+            ->willReturn([$firstPath, $secondPath]);
+
+        $snippetFileHandler->method('openJsonFile')
+            ->willReturnCallback(fn () => ['foo' => 'bar']);
+
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->expects(static::once())
+            ->method('getBundle')
+            ->with('Storefront')
+            ->willReturn(new Storefront());
+
+        $snippetValidator = new BundleSnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '', $kernel);
+        $missingSnippets = $snippetValidator->validateForBundles(['Storefront']);
+
+        static::assertCount(0, $missingSnippets);
+    }
+}

--- a/tests/unit/Core/System/Snippet/SnippetFileHandlerTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetFileHandlerTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\Snippet;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Administration\Administration;
+use Shopware\Core\System\Snippet\SnippetFileHandler;
+use Shopware\Storefront\Storefront;
+
+/**
+ * @internal
+ */
+#[CoversClass(SnippetFileHandler::class)]
+class SnippetFileHandlerTest extends TestCase
+{
+    public function testFindBundleSnippetFiles(): void
+    {
+        $handler = new SnippetFileHandler();
+        $files = $handler->findBundleSnippetFiles(new Storefront());
+        static::assertCount(2, $files);
+
+        $files = $handler->findBundleSnippetFiles(new Administration());
+        static::assertCount(0, $files);
+    }
+}

--- a/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
@@ -12,7 +12,7 @@ use Shopware\Core\System\Snippet\SnippetValidator;
 /**
  * @internal
  */
-#[Package('framework')]
+#[Package('discovery')]
 #[CoversClass(SnippetValidator::class)]
 class SnippetValidatorTest extends TestCase
 {

--- a/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
@@ -4,10 +4,13 @@ namespace Shopware\Tests\Unit\Core\System\Snippet;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Administration\Administration;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Shopware\Core\System\Snippet\SnippetFileHandler;
 use Shopware\Core\System\Snippet\SnippetValidator;
+use Shopware\Storefront\Storefront;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * @internal
@@ -24,10 +27,18 @@ class SnippetValidatorTest extends TestCase
 
         $firstPath = 'irrelevant.de-DE.json';
         $secondPath = 'irrelevant.en-GB.json';
-        $snippetFileHandler->method('findAdministrationSnippetFiles')
-            ->willReturn([$firstPath]);
-        $snippetFileHandler->method('findStorefrontSnippetFiles')
-            ->willReturn([$secondPath]);
+
+        $matcher = static::exactly(2);
+        $snippetFileHandler->expects($matcher)
+            ->method('findBundleSnippetFiles')
+            ->willReturnOnConsecutiveCalls()
+            ->willReturnCallback(function () use ($matcher, $firstPath, $secondPath) {
+                return match ($matcher->numberOfInvocations()) {
+                    1 => [$firstPath],
+                    2 => [$secondPath],
+                    default => null,
+                };
+            });
 
         $snippetFileHandler->method('openJsonFile')
             ->willReturnCallback(function ($path) use ($firstPath) {
@@ -38,8 +49,22 @@ class SnippetValidatorTest extends TestCase
                 return ['english' => 'exampleEnglish'];
             });
 
-        $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
-        $missingSnippets = $snippetValidator->validate();
+        $matcher = static::exactly(2);
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->expects($matcher)
+            ->method('getBundle')
+            ->willReturnOnConsecutiveCalls()
+            ->willReturnCallback(function () use ($matcher) {
+                return match ($matcher->numberOfInvocations()) {
+                    1 => new Storefront(),
+                    2 => new Administration(),
+                    default => null,
+                };
+            })
+        ;
+
+        $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '', $kernel);
+        $missingSnippets = $snippetValidator->validate(['Storefront', 'Administration']);
 
         static::assertCount(2, $missingSnippets);
         static::assertArrayHasKey('german', $missingSnippets['en-GB']);
@@ -59,16 +84,21 @@ class SnippetValidatorTest extends TestCase
 
         $firstPath = 'irrelevant.de-DE.json';
         $secondPath = 'irrelevant.en-GB.json';
-        $snippetFileHandler->method('findAdministrationSnippetFiles')
-            ->willReturn([$firstPath]);
-        $snippetFileHandler->method('findStorefrontSnippetFiles')
-            ->willReturn([$secondPath]);
+        $snippetFileHandler->method('findBundleSnippetFiles')
+            ->with(new Storefront())
+            ->willReturn([$firstPath, $secondPath]);
 
         $snippetFileHandler->method('openJsonFile')
             ->willReturnCallback(fn () => ['foo' => 'bar']);
 
-        $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
-        $missingSnippets = $snippetValidator->validate();
+        $kernel = $this->createMock(KernelInterface::class);
+        $kernel->expects(static::once())
+            ->method('getBundle')
+            ->with('Storefront')
+            ->willReturn(new Storefront());
+
+        $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '', $kernel);
+        $missingSnippets = $snippetValidator->validate(['Storefront']);
 
         static::assertCount(0, $missingSnippets);
     }

--- a/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Shopware\Core\System\Snippet\SnippetFileHandler;
 use Shopware\Core\System\Snippet\SnippetValidator;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 
 /**
  * @internal
@@ -16,6 +17,7 @@ use Shopware\Core\System\Snippet\SnippetValidator;
 #[CoversClass(SnippetValidator::class)]
 class SnippetValidatorTest extends TestCase
 {
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateShouldFindMissingSnippets(): void
     {
         $snippetFileHandler = $this->getMockBuilder(SnippetFileHandler::class)
@@ -51,6 +53,7 @@ class SnippetValidatorTest extends TestCase
         static::assertSame('exampleEnglish', $missingSnippets['de-DE']['english']['availableValue']);
     }
 
+    #[DisabledFeatures(['v6.8.0.0'])]
     public function testValidateShouldNotFindAnyMissingSnippets(): void
     {
         $snippetFileHandler = $this->getMockBuilder(SnippetFileHandler::class)

--- a/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
+++ b/tests/unit/Core/System/Snippet/SnippetValidatorTest.php
@@ -4,18 +4,15 @@ namespace Shopware\Tests\Unit\Core\System\Snippet;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
-use Shopware\Administration\Administration;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\Snippet\Files\SnippetFileCollection;
 use Shopware\Core\System\Snippet\SnippetFileHandler;
 use Shopware\Core\System\Snippet\SnippetValidator;
-use Shopware\Storefront\Storefront;
-use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * @internal
  */
-#[Package('discovery')]
+#[Package('framework')]
 #[CoversClass(SnippetValidator::class)]
 class SnippetValidatorTest extends TestCase
 {
@@ -27,18 +24,10 @@ class SnippetValidatorTest extends TestCase
 
         $firstPath = 'irrelevant.de-DE.json';
         $secondPath = 'irrelevant.en-GB.json';
-
-        $matcher = static::exactly(2);
-        $snippetFileHandler->expects($matcher)
-            ->method('findBundleSnippetFiles')
-            ->willReturnOnConsecutiveCalls()
-            ->willReturnCallback(function () use ($matcher, $firstPath, $secondPath) {
-                return match ($matcher->numberOfInvocations()) {
-                    1 => [$firstPath],
-                    2 => [$secondPath],
-                    default => null,
-                };
-            });
+        $snippetFileHandler->method('findAdministrationSnippetFiles')
+            ->willReturn([$firstPath]);
+        $snippetFileHandler->method('findStorefrontSnippetFiles')
+            ->willReturn([$secondPath]);
 
         $snippetFileHandler->method('openJsonFile')
             ->willReturnCallback(function ($path) use ($firstPath) {
@@ -49,22 +38,8 @@ class SnippetValidatorTest extends TestCase
                 return ['english' => 'exampleEnglish'];
             });
 
-        $matcher = static::exactly(2);
-        $kernel = $this->createMock(KernelInterface::class);
-        $kernel->expects($matcher)
-            ->method('getBundle')
-            ->willReturnOnConsecutiveCalls()
-            ->willReturnCallback(function () use ($matcher) {
-                return match ($matcher->numberOfInvocations()) {
-                    1 => new Storefront(),
-                    2 => new Administration(),
-                    default => null,
-                };
-            })
-        ;
-
-        $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '', $kernel);
-        $missingSnippets = $snippetValidator->validate(['Storefront', 'Administration']);
+        $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
+        $missingSnippets = $snippetValidator->validate();
 
         static::assertCount(2, $missingSnippets);
         static::assertArrayHasKey('german', $missingSnippets['en-GB']);
@@ -84,21 +59,16 @@ class SnippetValidatorTest extends TestCase
 
         $firstPath = 'irrelevant.de-DE.json';
         $secondPath = 'irrelevant.en-GB.json';
-        $snippetFileHandler->method('findBundleSnippetFiles')
-            ->with(new Storefront())
-            ->willReturn([$firstPath, $secondPath]);
+        $snippetFileHandler->method('findAdministrationSnippetFiles')
+            ->willReturn([$firstPath]);
+        $snippetFileHandler->method('findStorefrontSnippetFiles')
+            ->willReturn([$secondPath]);
 
         $snippetFileHandler->method('openJsonFile')
             ->willReturnCallback(fn () => ['foo' => 'bar']);
 
-        $kernel = $this->createMock(KernelInterface::class);
-        $kernel->expects(static::once())
-            ->method('getBundle')
-            ->with('Storefront')
-            ->willReturn(new Storefront());
-
-        $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '', $kernel);
-        $missingSnippets = $snippetValidator->validate(['Storefront']);
+        $snippetValidator = new SnippetValidator(new SnippetFileCollection(), $snippetFileHandler, '');
+        $missingSnippets = $snippetValidator->validate();
 
         static::assertCount(0, $missingSnippets);
     }


### PR DESCRIPTION
Add bundle-specific snippet validation and handling (Storefront and Administration by default)

This update allows snippet validation and retrieval to be scoped to specific bundles via a new `--bundle` option. It introduces methods for processing bundle-specific snippet files and updates the validator interface and implementation to support this feature.