### PR TITLE
fix: translation scope issue in i18n-t component

### DIFF
--- a/changelog/_unreleased/2025-02-26-fix-translation-scope-issue-in-i18n-t-component.md
+++ b/changelog/_unreleased/2025-02-26-fix-translation-scope-issue-in-i18n-t-component.md
@@ -1,0 +1,11 @@
+---
+title: Fix translation scope issue in i18n-t component
+issue: NEXT-40830
+---
+# Administration
+* Changed `i18n-t` usage in the following component templates to set the correct translation scope.
+  * `sw-usage-data-consent-banner`
+  * `sw-customer-imitate-customer-modal`
+  * `sw-extension-adding-failed`
+  * `sw-order-details-state-card`
+  * `sw-product-feature-set-form`

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.html.twig
@@ -10,6 +10,7 @@
         <i18n-t
             keypath="sw-customer.imitateCustomerModal.modalInfo"
             tag="p"
+            scope="local"
         >
             <template #logout>
                 <b>{{ $tc('sw-customer.imitateCustomerModal.modalInfoLogout') }}</b>

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/component/sw-customer-imitate-customer-modal/sw-customer-imitate-customer-modal.spec.js
@@ -40,7 +40,9 @@ async function createWrapper() {
                     }),
                     'sw-container': await wrapTestComponent('sw-container'),
                     'sw-context-menu-item': await wrapTestComponent('sw-context-menu-item'),
-                    'i18n-t': true,
+                    'i18n-t': {
+                        template: '<div class="i18n-stub"><slot></slot></div>',
+                    },
                     'sw-loader': true,
                     'router-link': true,
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/sw-extension-adding-failed.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/sw-extension-adding-failed.html.twig
@@ -30,6 +30,7 @@
         <i18n-t
             tag="p"
             keypath="sw-extension-store.component.sw-extension-adding-failed.installationFailed.textSupport"
+            scope="local"
         >
             <template #mail>
                 <a :href="`mailto:${$tc('sw-extension-store.component.sw-extension-adding-failed.installationFailed.supportEmail')}`">

--- a/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/sw-extension-adding-failed.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-extension/component/sw-extension-adding-failed/sw-extension-adding-failed.spec.js
@@ -8,7 +8,9 @@ async function createWrapper() {
         global: {
             stubs: {
                 'sw-circle-icon': await wrapTestComponent('sw-circle-icon', { sync: true }),
-                'i18n-t': true,
+                'i18n-t': {
+                    template: '<div class="i18n-stub"><slot></slot></div>',
+                },
                 'sw-label': true,
                 'router-link': true,
                 'sw-loader': true,

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-details-state-card/sw-order-details-state-card.html.twig
@@ -40,6 +40,7 @@
             >
                 <i18n-t
                     keypath="sw-order.stateCard.labelHistory"
+                    scope="local"
                 >
                     <template #time>
                         <sw-time-ago :date="lastStateChange.createdAt" />

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-feature-set-form/sw-product-feature-set-form.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-feature-set-form/sw-product-feature-set-form.html.twig
@@ -24,6 +24,7 @@
         <i18n-t
             tag="p"
             keypath="sw-product.featureSets.configInformation"
+            scope="local"
             class="sw-product-feature-set-form__description-config-info"
         >
             <span class="sw-product-feature-set-form__description-link">

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-general/sw-settings-usage-data-general.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-settings-usage-data-general/sw-settings-usage-data-general.spec.js
@@ -26,7 +26,9 @@ async function createWrapper() {
                     'sw-usage-data-consent-banner': await wrapTestComponent('sw-usage-data-consent-banner'),
                     'sw-extension-component-section': true,
                     'sw-internal-link': true,
-                    'i18n-t': true,
+                    'i18n-t': {
+                        template: '<div class="i18n-stub"><slot></slot></div>',
+                    },
                     'sw-help-text': true,
                     'sw-external-link': true,
                 },

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-usage-data-consent-banner/sw-usage-data-consent-banner.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-usage-data-consent-banner/sw-usage-data-consent-banner.html.twig
@@ -12,6 +12,7 @@
     <i18n-t
         tag="p"
         :keypath="showThankYouBanner ? 'sw-usage-data-consent-banner.thankYouMessage' : 'sw-usage-data-consent-banner.rejectedMessage'"
+        scope="local"
     >
         <template
             #thanksForParticipation
@@ -169,6 +170,7 @@
         <i18n-t
             tag="p"
             keypath="sw-usage-data-consent-banner.fullDetailsDescription"
+            scope="local"
             class="sw-usage-data-consent-banner__content-details-description"
         >
             <template #link>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-usage-data-consent-banner/sw-usage-data-consent-banner.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-usage-data/component/sw-usage-data-consent-banner/sw-usage-data-consent-banner.spec.js
@@ -25,7 +25,9 @@ async function createWrapper(canBeHidden = false, isPrivileged = true) {
                     'sw-internal-link': true,
                     'sw-help-text': true,
                     i18n: true,
-                    'i18n-t': true,
+                    'i18n-t': {
+                        template: '<div class="i18n-stub"><slot></slot></div>',
+                    },
                     'router-link': true,
                     'sw-loader': true,
                 },


### PR DESCRIPTION
Some translations inside <i18n-t> do not resolve correctly due to Vue I18n's default global scope behavior. This causes issues when translations are defined locally within a component.

<img width="883" alt="Screenshot 2025-02-26 at 15 30 22" src="https://github.com/user-attachments/assets/70bd9d72-c197-41df-9ca4-73b71e665c52" />

https://vue-i18n.intlify.dev/guide/advanced/component#scope-resolving
