### PR TITLE
feat: extract column exists trait

### DIFF
--- a/src/Core/Framework/Migration/AddColumnTrait.php
+++ b/src/Core/Framework/Migration/AddColumnTrait.php
@@ -6,6 +6,8 @@ use Doctrine\DBAL\Connection;
 
 trait AddColumnTrait
 {
+    use ColumnExistsTrait;
+
     /**
      * @return bool true if the column was created, false if it already exists
      */
@@ -27,15 +29,5 @@ trait AddColumnTrait
         );
 
         return true;
-    }
-
-    protected function columnExists(Connection $connection, string $table, string $column): bool
-    {
-        $exists = $connection->fetchOne(
-            'SHOW COLUMNS FROM `' . $table . '` WHERE `Field` LIKE :column',
-            ['column' => $column]
-        );
-
-        return !empty($exists);
     }
 }

--- a/src/Core/Framework/Migration/ColumnExistsTrait.php
+++ b/src/Core/Framework/Migration/ColumnExistsTrait.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Connection;
 
 trait ColumnExistsTrait
 {
-    public function columnExists(Connection $connection, string $table, string $column): bool
+    protected function columnExists(Connection $connection, string $table, string $column): bool
     {
         $exists = $connection->fetchOne(
             'SHOW COLUMNS FROM `' . $table . '` WHERE `Field` LIKE :column',

--- a/src/Core/Framework/Migration/ColumnExistsTrait.php
+++ b/src/Core/Framework/Migration/ColumnExistsTrait.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Migration;
+
+use Doctrine\DBAL\Connection;
+
+trait ColumnExistsTrait
+{
+    public function columnExists(Connection $connection, string $table, string $column): bool
+    {
+        $exists = $connection->fetchOne(
+            'SHOW COLUMNS FROM `' . $table . '` WHERE `Field` LIKE :column',
+            ['column' => $column]
+        );
+
+        return !empty($exists);
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

Lots of migration tests copy + paste this or a similar method

### 2. What does this change do, exactly?

Extracts the code to a separate trait so it can be imported wherever needed