### PR TITLE
fix: Only change mailer transport definition if it is present in container

### DIFF
--- a/src/Core/Content/Mail/MailerConfigurationCompilerPass.php
+++ b/src/Core/Content/Mail/MailerConfigurationCompilerPass.php
@@ -17,10 +17,12 @@ class MailerConfigurationCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        $container->getDefinition('mailer.default_transport')->setFactory([
-            new Reference(MailerTransportLoader::class),
-            'fromString',
-        ]);
+        if ($container->hasDefinition('mailer.default_transport')) {
+            $container->getDefinition('mailer.default_transport')->setFactory([
+                new Reference(MailerTransportLoader::class),
+                'fromString',
+            ]);
+        }
 
         $container->getDefinition('mailer.transports')->setFactory([
             new Reference(MailerTransportLoader::class),
@@ -28,7 +30,8 @@ class MailerConfigurationCompilerPass implements CompilerPassInterface
         ]);
 
         $mailer = $container->getDefinition(MailSender::class);
-        // use the same message bus from symfony/mailer configuration. matching: https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue.html#sending-mails-over-the-message-queue
+        // use the same message bus from symfony/mailer configuration.
+        // matching: https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue.html#sending-mails-over-the-message-queue
         $originalMailer = $container->getDefinition('mailer.mailer');
         $mailer->replaceArgument(4, $originalMailer->getArgument(1));
     }


### PR DESCRIPTION
With https://github.com/symfony/symfony/pull/59781/files the definition `mailer.default_transport` was removed and set as a simply alias. Therefore it could not be accessed anymore in a compiler pass. But this should also be not necessary anymore. 