### PR TITLE
feat: Add support for html div wrappers in component sections

### DIFF
--- a/changelog/_unreleased/2025-03-06-add-div-wrapper-support-to-component-sections.md
+++ b/changelog/_unreleased/2025-03-06-add-div-wrapper-support-to-component-sections.md
@@ -1,0 +1,17 @@
+---
+title: Add div wrapper support for extensions api
+---
+# Administration
+* Added support for rendering the extension iframe inside a html div element using component sections.
+
+```
+import { ui } from '@shopware-ag/meteor-admin-sdk';
+
+ui.componentSection.add({
+    component: 'div',
+    positionId: 'sw-help-sidebar__navigation',
+    props: {
+    locationId: 'my-custom-location-id',
+    },
+  });
+```

--- a/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/extension-api/sw-extension-component-section/sw-extension-component-section.html.twig
@@ -43,5 +43,12 @@
             :location-id="componentSection.props.locationId"
         />
     </mt-card>
+    <div v-else-if="componentSection.component === 'div'">
+        <sw-iframe-renderer
+            v-if="componentSection.props?.locationId"
+            :src="componentSection.src"
+            :location-id="componentSection.props.locationId"
+        />
+    </div>
 </template>
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
To let extension developers to render extension iframes inside their choice of component.

### 2. What does this change do, exactly?
Currently when using component sections, the iframe is rendered inside mt-card component. With these changes the developer can define what element is going to be wrapper.

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
