### PR TITLE
fix(form-validator): Escape snippets to prevent symbols like apostrophes to break the storefront

### DIFF
--- a/src/Storefront/Resources/views/storefront/utilities/form-validation-config.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/form-validation-config.html.twig
@@ -1,10 +1,12 @@
 {% block form_validation_config %}
-<script>
-    window.validationMessages = {
-        'required': '{{ "error.VIOLATION::IS_BLANK_ERROR"|trans|sw_sanitize }}',
-        'email': '{{ "error.VIOLATION::INVALID_EMAIL_FORMAT_ERROR"|trans|sw_sanitize }}',
-        'confirmation': '{{ "error.VIOLATION::NOT_EQUAL_ERROR"|trans|sw_sanitize }}',
-        'minLength': '{{ "error.VIOLATION::TOO_SHORT_ERROR"|trans|sw_sanitize }}',
-    };
-</script>
+    {% set validationMessages = {
+        required: "error.VIOLATION::IS_BLANK_ERROR"|trans|sw_sanitize,
+        email: "error.VIOLATION::INVALID_EMAIL_FORMAT_ERROR"|trans|sw_sanitize,
+        confirmation: "error.VIOLATION::NOT_EQUAL_ERROR"|trans|sw_sanitize,
+        minLength: "error.VIOLATION::TOO_SHORT_ERROR"|trans|sw_sanitize,
+    } %}
+
+    <script>
+        window.validationMessages = {{ validationMessages|json_encode|raw }};
+    </script>
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
In languages, which use Apostrophes a lot (like french), the storefront broke because escaping was missing.
![image](https://github.com/user-attachments/assets/7dd18177-f328-43c7-b968-b28856fb74c9)



### 2. What does this change do, exactly?
Escape them

### 3. Describe each step to reproduce the issue or behaviour.
- Configure a storefront with multiple domains and snippet sets (e.g. english and french from the language pack)
- Try to use the validator (e.g. register form) in french
- Immediately submit and see error messages
- Standard HTML-Validator kicked in
- In 6.6.x, the language switch itself even breaks

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
