### PR TITLE
fix: issues with sw-entity-multiselect collapse and expand when there are multiple instances

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/base/sw-select-base/sw-select-base.html.twig
@@ -12,7 +12,7 @@
             class="sw-select__selection"
             tabindex="0"
             :aria-expanded="expanded ? 'true' : 'false'"
-            @click.stop="expand"
+            @click="expand"
             @focus="expand"
             @keydown.tab="collapse"
             @keydown.esc="collapse"
@@ -54,7 +54,7 @@
         </div>
 
         <template v-if="expanded">
-            <transition name="sw-select-result-list-fade-down">
+            <transition name="sw-select-result-list-fade-down" @click.stop>
                 <slot
                     name="results-list"
                     v-bind="{ collapse }"


### PR DESCRIPTION
### 1. Why is this change necessary?
The `sw-entity-multi-select` component has issues when there are multiple instances, interfering the selection with each other.

### 2. What does this change do, exactly?
The problem was the dropdown element is now using the new `mt-popover` which is rendered in the `body`.
Because of that, the component can not handle properly the click outside it to close it.
Rearranging the click events in the component and stopping the blubbing of it only in the dropdown fixes the issue.

### 3. Describe each step to reproduce the issue or behaviour.
1. go to Storefront channel
2. Scroll to `Payment and shipping`
3. click on `shipping methods` to expand the dropdown
4. Without clicking anywhere else, click in the next select of `currencies`
5. Select and deselect some currencies
6. Without the fix, the `shipping methods` will receive the currency selection ❌ 
7. With the fix, it works normally selecting the currencies in the right select ✅ 


### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40829


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
