### PR TITLE
fix: Remove an unrelated change from backport again

### DIFF
--- a/src/Core/Content/Mail/MailerConfigurationCompilerPass.php
+++ b/src/Core/Content/Mail/MailerConfigurationCompilerPass.php
@@ -27,11 +27,5 @@ class MailerConfigurationCompilerPass implements CompilerPassInterface
             new Reference(MailerTransportLoader::class),
             'fromStrings',
         ]);
-
-        $mailer = $container->getDefinition(MailSender::class);
-        // use the same message bus from symfony/mailer configuration.
-        // matching: https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue.html#sending-mails-over-the-message-queue
-        $originalMailer = $container->getDefinition('mailer.mailer');
-        $mailer->replaceArgument(4, $originalMailer->getArgument(1));
     }
 }


### PR DESCRIPTION
the [backport](https://github.com/shopware/shopware/pull/7133/files#diff-ab214a60b3884dee2608b2ba8c97ffc9c2a89103b5e1b0400d042c9c8a7c873cR31-R35) added an unrelated change. This removes it again