### PR TITLE
fix(css): fix collapsing columns on sidebar layout with empty content

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_cms-sections.scss
@@ -21,8 +21,6 @@ General styling for cms sections
     }
 
     .cms-section-sidebar {
-        display: flex;
-
         & > .row {
             --#{$prefix}gutter-x: 60px;
         }


### PR DESCRIPTION
### 1. Why is this change necessary?

The columns for sidebar layouts with empty content are collapsing

### 2. What does this change do, exactly?

Remove the `display: flex` from the `.cms-section-sidebar` because since [6716](https://github.com/shopware/shopware/pull/6716) its direct child is now a `.row` - which already applies the flex-layout for the columns.

The elements inside `.row` are collapsing because the row is no longer stretched over 100% width (depending on the content), because the parent also has `display: flex`.

### 3. Describe each step to reproduce the issue or behaviour.

Go to any category with a sidebar layout and without products in it.

### 4. Please link to the relevant issues (if any).
- relates https://github.com/shopware/shopware/pull/6716

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.

### Before

![image](https://github.com/user-attachments/assets/3f4803a8-e2f1-4bd5-b307-48cc040c18bf)

![image](https://github.com/user-attachments/assets/9a72b020-19e3-4def-aaea-126bdcd117d0)

### After

![image](https://github.com/user-attachments/assets/972f273d-c2ec-4f72-aa76-4a8af283c709)

