### PR TITLE
chore: Update conflicts package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,7 @@
         "scssphp/scssphp": "v1.12.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/conflicts": "0.4.0",
+        "shopware/conflicts": "0.5.0",
         "shyim/opensearch-php-dsl": "^1.0.5",
         "squirrelphp/twig-php-syntax": "^1.8.0",
         "symfony/asset": "~7.2.0",


### PR DESCRIPTION
Update of the conflict package to enable the excluded `symfony/framework-bundle` again