### PR TITLE
feat: split date and datetime rule operators

### DIFF
--- a/src/Core/Checkout/Customer/Rule/CustomerBirthdayRule.php
+++ b/src/Core/Checkout/Customer/Rule/CustomerBirthdayRule.php
@@ -29,14 +29,14 @@ class CustomerBirthdayRule extends Rule
     public function getConstraints(): array
     {
         $constraints = [
-            'operator' => RuleConstraints::datetimeOperators(),
+            'operator' => RuleConstraints::dateOperators(),
         ];
 
         if ($this->operator === self::OPERATOR_EMPTY) {
             return $constraints;
         }
 
-        $constraints['birthday'] = RuleConstraints::datetime();
+        $constraints['birthday'] = RuleConstraints::date();
 
         return $constraints;
     }
@@ -74,13 +74,13 @@ class CustomerBirthdayRule extends Rule
 
         $birthdayValue = new \DateTime($this->birthday);
 
-        return RuleComparison::datetime($customerBirthday, $birthdayValue, $this->operator);
+        return RuleComparison::date($customerBirthday, $birthdayValue, $this->operator);
     }
 
     public function getConfig(): RuleConfig
     {
         return (new RuleConfig())
             ->operatorSet(RuleConfig::OPERATOR_SET_NUMBER, true)
-            ->dateTimeField('birthday');
+            ->dateField('birthday');
     }
 }

--- a/src/Core/Framework/Rule/RuleComparison.php
+++ b/src/Core/Framework/Rule/RuleComparison.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Rule;
 
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Util\FloatComparator;
@@ -9,9 +10,6 @@ use Shopware\Core\Framework\Util\FloatComparator;
 #[Package('fundamentals@after-sales')]
 class RuleComparison
 {
-    public const FORMAT_DATE = 'Y-m-d';
-    public const FORMAT_DATETIME = 'Y-m-d H:i:s';
-
     public static function numeric(?float $itemValue, ?float $ruleValue, string $operator): bool
     {
         if ($itemValue === null) {
@@ -93,12 +91,12 @@ class RuleComparison
 
     public static function date(\DateTime $itemValue, \DateTime $ruleValue, string $operator): bool
     {
-        return self::compareDate(self::FORMAT_DATE, $itemValue, $ruleValue, $operator);
+        return self::compareDate(Defaults::STORAGE_DATE_FORMAT, $itemValue, $ruleValue, $operator);
     }
 
     public static function datetime(\DateTime $itemValue, \DateTime $ruleValue, string $operator): bool
     {
-        return self::compareDate(self::FORMAT_DATETIME, $itemValue, $ruleValue, $operator);
+        return self::compareDate(Defaults::STORAGE_DATE_TIME_FORMAT, $itemValue, $ruleValue, $operator);
     }
 
     public static function isNegativeOperator(string $operator): bool

--- a/src/Core/Framework/Rule/RuleComparison.php
+++ b/src/Core/Framework/Rule/RuleComparison.php
@@ -9,6 +9,9 @@ use Shopware\Core\Framework\Util\FloatComparator;
 #[Package('fundamentals@after-sales')]
 class RuleComparison
 {
+    public const FORMAT_DATE = 'Y-m-d';
+    public const FORMAT_DATETIME = 'Y-m-d H:i:s';
+
     public static function numeric(?float $itemValue, ?float $ruleValue, string $operator): bool
     {
         if ($itemValue === null) {
@@ -88,17 +91,14 @@ class RuleComparison
         };
     }
 
+    public static function date(\DateTime $itemValue, \DateTime $ruleValue, string $operator): bool
+    {
+        return self::compareDate(self::FORMAT_DATE, $itemValue, $ruleValue, $operator);
+    }
+
     public static function datetime(\DateTime $itemValue, \DateTime $ruleValue, string $operator): bool
     {
-        return match ($operator) {
-            Rule::OPERATOR_EQ => $itemValue->format('Y-m-d H:i:s') === $ruleValue->format('Y-m-d H:i:s'),
-            Rule::OPERATOR_NEQ => $itemValue->format('Y-m-d H:i:s') !== $ruleValue->format('Y-m-d H:i:s'),
-            Rule::OPERATOR_GT => $itemValue > $ruleValue,
-            Rule::OPERATOR_LT => $itemValue < $ruleValue,
-            Rule::OPERATOR_GTE => $itemValue >= $ruleValue,
-            Rule::OPERATOR_LTE => $itemValue <= $ruleValue,
-            default => throw new UnsupportedOperatorException($operator, self::class),
-        };
+        return self::compareDate(self::FORMAT_DATETIME, $itemValue, $ruleValue, $operator);
     }
 
     public static function isNegativeOperator(string $operator): bool
@@ -107,5 +107,18 @@ class RuleComparison
             Rule::OPERATOR_EMPTY,
             Rule::OPERATOR_NEQ,
         ], true);
+    }
+
+    private static function compareDate(string $format, \DateTime $itemValue, \DateTime $ruleValue, string $operator): bool
+    {
+        return match ($operator) {
+            Rule::OPERATOR_EQ => $itemValue->format($format) === $ruleValue->format($format),
+            Rule::OPERATOR_NEQ => $itemValue->format($format) !== $ruleValue->format($format),
+            Rule::OPERATOR_GT => $itemValue > $ruleValue,
+            Rule::OPERATOR_LT => $itemValue < $ruleValue,
+            Rule::OPERATOR_GTE => $itemValue >= $ruleValue,
+            Rule::OPERATOR_LTE => $itemValue <= $ruleValue,
+            default => throw new UnsupportedOperatorException($operator, self::class),
+        };
     }
 }

--- a/src/Core/Framework/Rule/RuleConfig.php
+++ b/src/Core/Framework/Rule/RuleConfig.php
@@ -116,6 +116,14 @@ final class RuleConfig extends Struct
     /**
      * @param array<string, mixed> $config
      */
+    public function dateField(string $name, array $config = []): self
+    {
+        return $this->field($name, 'date', $config);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     */
     public function dateTimeField(string $name, array $config = []): self
     {
         return $this->field($name, 'datetime', $config);

--- a/src/Core/Framework/Rule/RuleConstraints.php
+++ b/src/Core/Framework/Rule/RuleConstraints.php
@@ -73,6 +73,14 @@ class RuleConstraints
     /**
      * @return array<int, Constraint>
      */
+    public static function date(): array
+    {
+        return [new NotBlank(), new Type('string')];
+    }
+
+    /**
+     * @return array<int, Constraint>
+     */
     public static function datetime(): array
     {
         return [new NotBlank(), new Type('string')];
@@ -155,7 +163,7 @@ class RuleConstraints
     /**
      * @return array<int, Constraint>
      */
-    public static function datetimeOperators(bool $emptyAllowed = true): array
+    public static function dateOperators(bool $emptyAllowed = true): array
     {
         $operators = [
             Rule::OPERATOR_NEQ,
@@ -174,5 +182,13 @@ class RuleConstraints
             new NotBlank(),
             new Choice($operators),
         ];
+    }
+
+    /**
+     * @return array<int, Constraint>
+     */
+    public static function datetimeOperators(bool $emptyAllowed = true): array
+    {
+        return self::dateOperators($emptyAllowed);
     }
 }

--- a/tests/unit/Core/Framework/Rule/RuleComparisonTest.php
+++ b/tests/unit/Core/Framework/Rule/RuleComparisonTest.php
@@ -20,7 +20,7 @@ class RuleComparisonTest extends TestCase
     #[DataProvider('valuesForNumericEqualComparison')]
     public function testNumericComparisonWithEqualOperator(?float $itemValue, ?float $ruleValue, bool $result): void
     {
-        static::assertEquals($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_EQ));
+        static::assertSame($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_EQ));
     }
 
     public static function valuesForNumericEqualComparison(): \Generator
@@ -38,7 +38,7 @@ class RuleComparisonTest extends TestCase
     #[DataProvider('valuesForNumericNotEqualComparison')]
     public function testNumericComparisonWithNotEqualOperator(?float $itemValue, ?float $ruleValue, bool $result): void
     {
-        static::assertEquals($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_NEQ));
+        static::assertSame($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_NEQ));
     }
 
     public static function valuesForNumericNotEqualComparison(): \Generator
@@ -55,7 +55,7 @@ class RuleComparisonTest extends TestCase
     #[DataProvider('valuesForNumericGreaterThanComparison')]
     public function testNumericComparisonWithGreaterThanOperator(?float $itemValue, ?float $ruleValue, bool $result): void
     {
-        static::assertEquals($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_GT));
+        static::assertSame($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_GT));
     }
 
     public static function valuesForNumericGreaterThanComparison(): \Generator
@@ -75,7 +75,7 @@ class RuleComparisonTest extends TestCase
     #[DataProvider('valuesForLessThanOrEqualComparison')]
     public function testNumericComparisonWithLessThanOrEqualOperator(?float $itemValue, ?float $ruleValue, bool $result): void
     {
-        static::assertEquals($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_LTE));
+        static::assertSame($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_LTE));
     }
 
     public static function valuesForLessThanOrEqualComparison(): \Generator
@@ -95,7 +95,7 @@ class RuleComparisonTest extends TestCase
     #[DataProvider('valuesForGreaterThanOrEqualComparison')]
     public function testNumericComparisonWithGreaterThanOrEqualOperator(?float $itemValue, ?float $ruleValue, bool $result): void
     {
-        static::assertEquals($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_GTE));
+        static::assertSame($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_GTE));
     }
 
     public static function valuesForGreaterThanOrEqualComparison(): \Generator
@@ -115,7 +115,7 @@ class RuleComparisonTest extends TestCase
     #[DataProvider('valuesForLessThanComparison')]
     public function testNumericComparisonWithLessThanOperator(?float $itemValue, ?float $ruleValue, bool $result): void
     {
-        static::assertEquals($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_LT));
+        static::assertSame($result, RuleComparison::numeric($itemValue, $ruleValue, Rule::OPERATOR_LT));
     }
 
     public static function valuesForLessThanComparison(): \Generator
@@ -135,7 +135,7 @@ class RuleComparisonTest extends TestCase
     #[DataProvider('valuesForNumericEmptyComparison')]
     public function testNumericComparisonWithEmptyOperator(?float $itemValue, bool $result): void
     {
-        static::assertEquals($result, RuleComparison::numeric($itemValue, null, Rule::OPERATOR_EMPTY));
+        static::assertSame($result, RuleComparison::numeric($itemValue, null, Rule::OPERATOR_EMPTY));
     }
 
     public static function valuesForNumericEmptyComparison(): \Generator
@@ -155,7 +155,7 @@ class RuleComparisonTest extends TestCase
     #[DataProvider('valuesForDateTimeComparison')]
     public function testDateTimeComparison(\DateTime $itemValue, \DateTime $ruleValue, bool $result, string $operator): void
     {
-        static::assertEquals($result, RuleComparison::datetime($itemValue, $ruleValue, $operator));
+        static::assertSame($result, RuleComparison::datetime($itemValue, $ruleValue, $operator));
     }
 
     public static function valuesForDateTimeComparison(): \Generator
@@ -254,7 +254,7 @@ class RuleComparisonTest extends TestCase
     #[DataProvider('valuesForDateComparison')]
     public function testDateComparison(\DateTime $itemValue, \DateTime $ruleValue, bool $result, string $operator): void
     {
-        static::assertEquals($result, RuleComparison::date($itemValue, $ruleValue, $operator));
+        static::assertSame($result, RuleComparison::date($itemValue, $ruleValue, $operator));
     }
 
     public static function valuesForDateComparison(): \Generator

--- a/tests/unit/Core/Framework/Rule/RuleComparisonTest.php
+++ b/tests/unit/Core/Framework/Rule/RuleComparisonTest.php
@@ -151,4 +151,202 @@ class RuleComparisonTest extends TestCase
 
         RuleComparison::numeric(1.0, 1.0, 'unsupported');
     }
+
+    #[DataProvider('valuesForDateTimeComparison')]
+    public function testDateTimeComparison(\DateTime $itemValue, \DateTime $ruleValue, bool $result, string $operator): void
+    {
+        static::assertEquals($result, RuleComparison::datetime($itemValue, $ruleValue, $operator));
+    }
+
+    public static function valuesForDateTimeComparison(): \Generator
+    {
+        yield 'datetime equal - true' => [
+            new \DateTime('2025-02-27 10:00:00'),
+            new \DateTime('2025-02-27 10:00:00'),
+            true,
+            Rule::OPERATOR_EQ,
+        ];
+        yield 'datetime equal - false' => [
+            new \DateTime('2025-02-27 10:00:00'),
+            new \DateTime('2025-02-27 12:00:00'),
+            false,
+            Rule::OPERATOR_EQ,
+        ];
+
+        yield 'datetime not equal - true' => [
+            new \DateTime('2025-02-27 10:00:00'),
+            new \DateTime('2025-02-27 11:00:00'),
+            true,
+            Rule::OPERATOR_NEQ,
+        ];
+        yield 'datetime not equal - false' => [
+            new \DateTime('2025-02-27 10:00:00'),
+            new \DateTime('2025-02-27 10:00:00'),
+            false,
+            Rule::OPERATOR_NEQ,
+        ];
+
+        yield 'datetime greater than - true' => [
+            new \DateTime('2025-02-28 18:00:00'),
+            new \DateTime('2025-02-28 10:00:00'),
+            true,
+            Rule::OPERATOR_GT,
+        ];
+        yield 'datetime greater than - false' => [
+            new \DateTime('2025-02-28 10:00:00'),
+            new \DateTime('2025-02-28 10:00:00'),
+            false,
+            Rule::OPERATOR_GT,
+        ];
+
+        yield 'datetime less then - true' => [
+            new \DateTime('2025-02-27 09:00:00'),
+            new \DateTime('2025-02-27 10:00:00'),
+            true,
+            Rule::OPERATOR_LT,
+        ];
+        yield 'datetime less then - false' => [
+            new \DateTime('2025-02-27 10:00:00'),
+            new \DateTime('2025-02-27 10:00:00'),
+            false,
+            Rule::OPERATOR_LT,
+        ];
+
+        yield 'datetime greater then equal - true' => [
+            new \DateTime('2025-02-27 10:00:00'),
+            new \DateTime('2025-02-27 09:00:00'),
+            true,
+            Rule::OPERATOR_GTE,
+        ];
+        yield 'datetime greater then equal - true (equal)' => [
+            new \DateTime('2025-02-27 10:00:00'),
+            new \DateTime('2025-02-27 10:00:00'),
+            true,
+            Rule::OPERATOR_GTE,
+        ];
+        yield 'datetime greater then equal - false' => [
+            new \DateTime('2025-02-27 09:00:00'),
+            new \DateTime('2025-02-27 10:00:00'),
+            false,
+            Rule::OPERATOR_GTE,
+        ];
+
+        yield 'datetime less then equal - true' => [
+            new \DateTime('2025-02-27 10:00:00'),
+            new \DateTime('2025-02-27 11:00:00'),
+            true,
+            Rule::OPERATOR_LTE,
+        ];
+        yield 'datetime less then equal - true (equal)' => [
+            new \DateTime('2025-02-27 10:00:00'),
+            new \DateTime('2025-02-27 10:00:00'),
+            true,
+            Rule::OPERATOR_LTE,
+        ];
+        yield 'datetime less then equal - false' => [
+            new \DateTime('2025-02-27 11:00:00'),
+            new \DateTime('2025-02-27 10:00:00'),
+            false,
+            Rule::OPERATOR_LTE,
+        ];
+    }
+
+    #[DataProvider('valuesForDateComparison')]
+    public function testDateComparison(\DateTime $itemValue, \DateTime $ruleValue, bool $result, string $operator): void
+    {
+        static::assertEquals($result, RuleComparison::date($itemValue, $ruleValue, $operator));
+    }
+
+    public static function valuesForDateComparison(): \Generator
+    {
+        yield 'date equal - true' => [
+            new \DateTime('2025-02-27'),
+            new \DateTime('2025-02-27'),
+            true,
+            Rule::OPERATOR_EQ,
+        ];
+        yield 'date equal - false' => [
+            new \DateTime('2025-02-27'),
+            new \DateTime('2025-02-28'),
+            false,
+            Rule::OPERATOR_EQ,
+        ];
+
+        yield 'date not equal - true' => [
+            new \DateTime('2025-02-27'),
+            new \DateTime('2025-02-28'),
+            true,
+            Rule::OPERATOR_NEQ,
+        ];
+        yield 'date not equal - false' => [
+            new \DateTime('2025-02-27'),
+            new \DateTime('2025-02-27'),
+            false,
+            Rule::OPERATOR_NEQ,
+        ];
+
+        yield 'date greater than - true' => [
+            new \DateTime('2025-02-29'),
+            new \DateTime('2025-02-28'),
+            true,
+            Rule::OPERATOR_GT,
+        ];
+        yield 'date greater than - false' => [
+            new \DateTime('2025-02-28'),
+            new \DateTime('2025-02-28'),
+            false,
+            Rule::OPERATOR_GT,
+        ];
+
+        yield 'date less then - true' => [
+            new \DateTime('2025-02-26'),
+            new \DateTime('2025-02-27'),
+            true,
+            Rule::OPERATOR_LT,
+        ];
+        yield 'date less then - false' => [
+            new \DateTime('2025-02-27'),
+            new \DateTime('2025-02-27'),
+            false,
+            Rule::OPERATOR_LT,
+        ];
+
+        yield 'date greater then equal - true' => [
+            new \DateTime('2025-02-28'),
+            new \DateTime('2025-02-27'),
+            true,
+            Rule::OPERATOR_GTE,
+        ];
+        yield 'date greater then equal - true (equal)' => [
+            new \DateTime('2025-02-27'),
+            new \DateTime('2025-02-27'),
+            true,
+            Rule::OPERATOR_GTE,
+        ];
+        yield 'date greater then equal - false' => [
+            new \DateTime('2025-02-26'),
+            new \DateTime('2025-02-27'),
+            false,
+            Rule::OPERATOR_GTE,
+        ];
+
+        yield 'date less then equal - true' => [
+            new \DateTime('2025-02-26'),
+            new \DateTime('2025-02-27'),
+            true,
+            Rule::OPERATOR_LTE,
+        ];
+        yield 'date less then equal - true (equal)' => [
+            new \DateTime('2025-02-27'),
+            new \DateTime('2025-02-27'),
+            true,
+            Rule::OPERATOR_LTE,
+        ];
+        yield 'date less then equal - false' => [
+            new \DateTime('2025-02-28'),
+            new \DateTime('2025-02-27'),
+            false,
+            Rule::OPERATOR_LTE,
+        ];
+    }
 }

--- a/tests/unit/Core/Framework/Rule/RuleConfigTest.php
+++ b/tests/unit/Core/Framework/Rule/RuleConfigTest.php
@@ -79,4 +79,36 @@ class RuleConfigTest extends TestCase
         static::assertEquals('float', $field['type']);
         static::assertEquals(5, $field['config']['digits']);
     }
+
+    public function testDateFieldConfig(): void
+    {
+        $ruleConfig = new RuleConfig();
+
+        $ruleConfig->dateField('foo', [
+            'someConfig' => 'bar',
+        ]);
+
+        $field = $ruleConfig->getField('foo');
+
+        static::assertNotNull($field);
+        static::assertEquals('foo', $field['name']);
+        static::assertEquals('date', $field['type']);
+        static::assertEquals('bar', $field['config']['someConfig']);
+    }
+
+    public function testDateTimeFieldConfig(): void
+    {
+        $ruleConfig = new RuleConfig();
+
+        $ruleConfig->dateTimeField('foo', [
+            'someConfig' => 'bar',
+        ]);
+
+        $field = $ruleConfig->getField('foo');
+
+        static::assertNotNull($field);
+        static::assertEquals('foo', $field['name']);
+        static::assertEquals('datetime', $field['type']);
+        static::assertEquals('bar', $field['config']['someConfig']);
+    }
 }

--- a/tests/unit/Core/Framework/Rule/RuleConstraintsTest.php
+++ b/tests/unit/Core/Framework/Rule/RuleConstraintsTest.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Rule;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\Framework\Rule\RuleConstraints;
+use Symfony\Component\Validator\Constraints\Choice;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Type;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(RuleConstraints::class)]
+class RuleConstraintsTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private array $defaultOperators = [
+        Rule::OPERATOR_NEQ,
+        Rule::OPERATOR_GTE,
+        Rule::OPERATOR_LTE,
+        Rule::OPERATOR_EQ,
+        Rule::OPERATOR_GT,
+        Rule::OPERATOR_LT,
+    ];
+
+    public function testDateConstraints(): void
+    {
+        $constraints = RuleConstraints::date();
+
+        static::assertCount(2, $constraints);
+        static::assertInstanceOf(NotBlank::class, $constraints[0]);
+        static::assertInstanceOf(Type::class, $constraints[1]);
+    }
+
+    public function testDateTimeConstraints(): void
+    {
+        $constraints = RuleConstraints::datetime();
+
+        static::assertCount(2, $constraints);
+        static::assertInstanceOf(NotBlank::class, $constraints[0]);
+        static::assertInstanceOf(Type::class, $constraints[1]);
+    }
+
+    public function testDateOperators(): void
+    {
+        $operators = RuleConstraints::dateOperators(false);
+
+        static::assertCount(2, $operators);
+        static::assertInstanceOf(NotBlank::class, $operators[0]);
+        static::assertInstanceOf(Choice::class, $operators[1]);
+        static::assertEquals(new Choice($this->defaultOperators), $operators[1]);
+
+        $operators = RuleConstraints::dateOperators();
+
+        static::assertCount(2, $operators);
+        static::assertInstanceOf(NotBlank::class, $operators[0]);
+        static::assertInstanceOf(Choice::class, $operators[1]);
+        static::assertEquals(
+            new Choice([...$this->defaultOperators, Rule::OPERATOR_EMPTY]),
+            $operators[1],
+        );
+    }
+
+    public function testDateTimeOperators(): void
+    {
+        $operators = RuleConstraints::datetimeOperators(false);
+
+        static::assertCount(2, $operators);
+        static::assertInstanceOf(NotBlank::class, $operators[0]);
+        static::assertInstanceOf(Choice::class, $operators[1]);
+        static::assertEquals(new Choice($this->defaultOperators), $operators[1]);
+
+        $operators = RuleConstraints::datetimeOperators();
+
+        static::assertCount(2, $operators);
+        static::assertInstanceOf(NotBlank::class, $operators[0]);
+        static::assertInstanceOf(Choice::class, $operators[1]);
+        static::assertEquals(
+            new Choice([...$this->defaultOperators, Rule::OPERATOR_EMPTY]),
+            $operators[1],
+        );
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

The administration relies on the field type configuration to determine which component to render in the rule builder (`sw-generic-condition`). Previously, all date (also non time) fields were displayed with a time selection. However, in cases like the `CustomerBirthdayRule`, this is not appropriate.

### 2. What does this change do, exactly?

I have added the `date` field option to separate `date` from `datetime` fields. The administration already handles this change automatically, so no further adjustments are needed.

### 3. Describe each step to reproduce the issue or behaviour.

1. Go to Settings > Rule Builder > Create Rule
2. Fill in general config
3. Select "Customer date of birth" as condition
4. Open "Select date" field
Result: There you will see a selection of date and time.

### 4. Please link to the relevant issues (if any).
- closes #7123
- jira: https://shopware.atlassian.net/browse/NEXT-37534

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
