### PR TITLE
fix: Double form submit from reCaptcha plugin

### DIFF
--- a/changelog/_unreleased/2025-02-28-fix-google-recaptcha-with-guest-orders.md
+++ b/changelog/_unreleased/2025-02-28-fix-google-recaptcha-with-guest-orders.md
@@ -1,0 +1,6 @@
+---
+title: Fixed double form submit with reCaptcha plugin
+issue: NEXT-40865
+---
+# Storefront
+* Changed the `google-re-captcha-base.plugin.js` to only subscribe to the proper form submit event and call an `event.preventDefault()` to prevent double form submits, which lead to empty carts for guest orders.

--- a/changelog/_unreleased/2025-02-28-fix-google-recaptcha-with-guest-orders.md
+++ b/changelog/_unreleased/2025-02-28-fix-google-recaptcha-with-guest-orders.md
@@ -4,3 +4,4 @@ issue: NEXT-40865
 ---
 # Storefront
 * Changed the `google-re-captcha-base.plugin.js` to only subscribe to the proper form submit event and call an `event.preventDefault()` to prevent double form submits, which lead to empty carts for guest orders.
+* Changed the `google-re-captcha-v2.plugin.js` to properly handle the submit in association with the reCaptcha callback.

--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
@@ -58,6 +58,7 @@ export default class GoogleReCaptchaBasePlugin extends Plugin {
 
     _submitInvisibleForm() {
         if (!this._form.checkValidity()) {
+            this._formSubmitting = false;
             return;
         }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.js
@@ -53,13 +53,7 @@ export default class GoogleReCaptchaBasePlugin extends Plugin {
     }
 
     _registerEvents() {
-        if (!this.formPluginInstances) {
-            this._form.addEventListener('submit', this._onFormSubmitCallback.bind(this));
-        } else {
-            this.formPluginInstances.forEach(plugin => {
-                plugin.$emitter.subscribe('beforeSubmit', this._onFormSubmitCallback.bind(this));
-            });
-        }
+        this._form.addEventListener('submit', this._onFormSubmitCallback.bind(this));
     }
 
     _submitInvisibleForm() {
@@ -88,10 +82,12 @@ export default class GoogleReCaptchaBasePlugin extends Plugin {
         this._form.submit();
     }
 
-    _onFormSubmitCallback() {
+    _onFormSubmitCallback(event) {
         if (this._formSubmitting) {
             return;
         }
+
+        event.preventDefault();
 
         this._formSubmitting = true;
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-v2.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/captcha/google-re-captcha/google-re-captcha-v2.plugin.js
@@ -18,6 +18,8 @@ export default class GoogleReCaptchaV2Plugin extends GoogleReCaptchaBasePlugin
         this.grecaptchaContainerIframe = null;
         this.grecaptchaWidgetId = null;
 
+        this.currentToken = null;
+
         this._renderV2Captcha();
     }
 
@@ -36,19 +38,30 @@ export default class GoogleReCaptchaV2Plugin extends GoogleReCaptchaBasePlugin
 
             this.grecaptcha.execute(this.grecaptchaWidgetId).then(() => {
                 this._formSubmitting = false;
+
+                /**
+                 * If the form was not valid on a first submit because of other fields the captcha callback won't be called again by reCaptcha.
+                 * So if a valid token is already present we can proceed with submitting the form.
+                 * Otherwise, the form submit will be called by the captcha callback.
+                 */
+                if (this.currentToken !== null && this.grecaptchaInput.value === this.currentToken) {
+                    this._submitInvisibleForm();
+                }
             });
         } else {
-            if (!this.grecaptchaInput.value) {
-                this.grecaptchaContainerIframe = DomAccess.querySelector(this.el, 'iframe');
-                this.grecaptchaContainerIframe.classList.add(this.options.grecaptchaIframeHasErrorClassSelector);
-            }
-
-            this._formSubmitting = false;
 
             this.$emitter.publish('beforeGreCaptchaFormSubmit', {
                 info: this.getGreCaptchaInfo(),
                 token: this.grecaptchaInput.value,
             });
+
+            if (!this.grecaptchaInput.value) {
+                this._formSubmitting = false;
+                this.grecaptchaContainerIframe = DomAccess.querySelector(this.el, 'iframe');
+                this.grecaptchaContainerIframe.classList.add(this.options.grecaptchaIframeHasErrorClassSelector);
+            } else {
+                this._submitInvisibleForm();
+            }
         }
     }
 
@@ -68,15 +81,15 @@ export default class GoogleReCaptchaV2Plugin extends GoogleReCaptchaBasePlugin
             token,
         });
 
-        this._formSubmitting = false;
+        this.currentToken = token;
         this.grecaptchaInput.value = token;
 
         if (!this.options.invisible) {
             this.grecaptchaContainerIframe.classList.remove(this.options.grecaptchaIframeHasErrorClassSelector);
-            return;
+        } else {
+            // If the captcha is invisible it is validated on submit and therefore the callback has to trigger the submit.
+            this._submitInvisibleForm();
         }
-
-        this._submitInvisibleForm();
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/captcha/google-re-captcha/google-re-captcha-base.plugin.test.js
@@ -6,7 +6,7 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
     beforeEach(() => {
         window.grecaptcha = {
             ready: () => {},
-            execute: () => {}
+            execute: () => {},
         };
 
         const mockElement = document.createElement('form');
@@ -15,7 +15,7 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
         mockElement.appendChild(inputField);
 
         googleReCaptchaBasePlugin = new GoogleReCaptchaBasePlugin(mockElement, {
-            grecaptchaInputSelector: '.grecaptcha-input'
+            grecaptchaInputSelector: '.grecaptcha-input',
         });
     });
 
@@ -37,7 +37,7 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
         mockForm.appendChild(inputField);
 
         googleReCaptchaBasePlugin = new GoogleReCaptchaBasePlugin(mockForm, {
-            grecaptchaInputSelector: '.grecaptcha-input'
+            grecaptchaInputSelector: '.grecaptcha-input',
         });
 
         expect(typeof googleReCaptchaBasePlugin).toBe('object');
@@ -48,26 +48,28 @@ describe('GoogleReCaptchaBasePlugin tests', () => {
 
         googleReCaptchaBasePlugin._formSubmitting = true;
 
-        googleReCaptchaBasePlugin._onFormSubmitCallback();
+        const submitEvent = new Event('submit');
+
+        googleReCaptchaBasePlugin._onFormSubmitCallback(submitEvent);
 
         expect(googleReCaptchaBasePlugin.onFormSubmit).not.toHaveBeenCalled();
         expect(googleReCaptchaBasePlugin._formSubmitting).toEqual(true);
 
         googleReCaptchaBasePlugin._formSubmitting = false;
 
-        googleReCaptchaBasePlugin._onFormSubmitCallback();
+        googleReCaptchaBasePlugin._onFormSubmitCallback(submitEvent);
         expect(googleReCaptchaBasePlugin.onFormSubmit).toHaveBeenCalled();
     });
 
     test('form is not submitted is not validated', () => {
         googleReCaptchaBasePlugin._form.submit = jest.fn();
-        googleReCaptchaBasePlugin._form.checkValidity = () => { return false };
+        googleReCaptchaBasePlugin._form.checkValidity = () => { return false; };
 
         googleReCaptchaBasePlugin._submitInvisibleForm();
 
         expect(googleReCaptchaBasePlugin._form.submit).not.toHaveBeenCalled();
 
-        googleReCaptchaBasePlugin._form.checkValidity = () => { return true };
+        googleReCaptchaBasePlugin._form.checkValidity = () => { return true; };
 
         googleReCaptchaBasePlugin._submitInvisibleForm();
 


### PR DESCRIPTION
### 1. Why is this change necessary?
In a specific case, while using Google reCaptcha, you end up with an empty cart during a guest order because the registration form is submitted twice. 

### 2. What does this change do, exactly?
It changes the `google-re-captcha-base.plugin.js` to subscribe only to the proper `submit` event and do an `event.preventDefault()` to handle the submit by the captcha plugin properly.

