### PR TITLE
chore: Refactor migration compiler passes

### DIFF
--- a/src/Administration/DependencyInjection/AdministrationMigrationCompilerPass.php
+++ b/src/Administration/DependencyInjection/AdministrationMigrationCompilerPass.php
@@ -10,11 +10,11 @@ class AdministrationMigrationCompilerPass extends AbstractMigrationReplacementCo
 {
     protected function getMigrationPath(): string
     {
-        return \dirname(__DIR__) . '/Migration';
+        return \dirname(__DIR__);
     }
 
-    protected function getMigrationNamespace(): string
+    protected function getMigrationNamespacePart(): string
     {
-        return 'Shopware\Administration\Migration';
+        return 'Administration';
     }
 }

--- a/src/Administration/DependencyInjection/AdministrationMigrationCompilerPass.php
+++ b/src/Administration/DependencyInjection/AdministrationMigrationCompilerPass.php
@@ -2,30 +2,19 @@
 
 namespace Shopware\Administration\DependencyInjection;
 
+use Shopware\Core\Framework\DependencyInjection\CompilerPass\AbstractMigrationReplacementCompilerPass;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Migration\MigrationSource;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 #[Package('framework')]
-class AdministrationMigrationCompilerPass implements CompilerPassInterface
+class AdministrationMigrationCompilerPass extends AbstractMigrationReplacementCompilerPass
 {
-    public function process(ContainerBuilder $container): void
+    protected function getMigrationPath(): string
     {
-        $migrationPath = \dirname(__DIR__) . '/Migration';
+        return \dirname(__DIR__) . '/Migration';
+    }
 
-        // configure migration directories
-        $migrationSourceV4 = $container->getDefinition(MigrationSource::class . '.core.V6_4');
-        $migrationSourceV4->addMethodCall('addDirectory', [$migrationPath . '/V6_4', 'Shopware\Administration\Migration\V6_4']);
-
-        $majors = ['V6_5', 'V6_6'];
-        foreach ($majors as $major) {
-            $migrationPathV5 = $migrationPath . '/' . $major;
-
-            if (\is_dir($migrationPathV5)) {
-                $migrationSource = $container->getDefinition(MigrationSource::class . '.core.' . $major);
-                $migrationSource->addMethodCall('addDirectory', [$migrationPathV5, 'Shopware\Administration\Migration\\' . $major]);
-            }
-        }
+    protected function getMigrationNamespace(): string
+    {
+        return 'Shopware\Administration\Migration';
     }
 }

--- a/src/Core/Framework/DependencyInjection/CompilerPass/AbstractMigrationReplacementCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/AbstractMigrationReplacementCompilerPass.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DependencyInjection\CompilerPass;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationSource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+#[Package('framework')]
+abstract class AbstractMigrationReplacementCompilerPass implements CompilerPassInterface
+{
+    private const MAJOR_VERSIONS = ['V6_3', 'V6_4', 'V6_5', 'V6_6', 'V6_7', 'V6_8'];
+
+    public function process(ContainerBuilder $container): void
+    {
+        $migrationPath = $this->getMigrationPath();
+        // configure migration directories
+        foreach (self::MAJOR_VERSIONS as $major) {
+            $versionedMigrationPath = $migrationPath . '/' . $major;
+
+            if (\is_dir($versionedMigrationPath)) {
+                $migrationSource = $container->getDefinition(MigrationSource::class . '.core.' . $major);
+                $migrationSource->addMethodCall('addDirectory', [$versionedMigrationPath, $this->getMigrationNamespace() . '\\' . $major]);
+            }
+        }
+    }
+
+    abstract protected function getMigrationPath(): string;
+
+    abstract protected function getMigrationNamespace(): string;
+}

--- a/src/Core/Framework/DependencyInjection/CompilerPass/AbstractMigrationReplacementCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/AbstractMigrationReplacementCompilerPass.php
@@ -17,18 +17,18 @@ abstract class AbstractMigrationReplacementCompilerPass implements CompilerPassI
     public function process(ContainerBuilder $container): void
     {
         $migrationPath = $this->getMigrationPath();
-        // configure migration directories
+
         foreach (self::MAJOR_VERSIONS as $major) {
-            $versionedMigrationPath = $migrationPath . '/' . $major;
+            $versionedMigrationPath = $migrationPath . '/Migration/' . $major;
 
             if (\is_dir($versionedMigrationPath)) {
                 $migrationSource = $container->getDefinition(MigrationSource::class . '.core.' . $major);
-                $migrationSource->addMethodCall('addDirectory', [$versionedMigrationPath, $this->getMigrationNamespace() . '\\' . $major]);
+                $migrationSource->addMethodCall('addDirectory', [$versionedMigrationPath, 'Shopware\\' . $this->getMigrationNamespacePart() . '\Migration\\' . $major]);
             }
         }
     }
 
     abstract protected function getMigrationPath(): string;
 
-    abstract protected function getMigrationNamespace(): string;
+    abstract protected function getMigrationNamespacePart(): string;
 }

--- a/src/Core/Framework/DependencyInjection/CompilerPass/FrameworkMigrationReplacementCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/FrameworkMigrationReplacementCompilerPass.php
@@ -3,33 +3,17 @@
 namespace Shopware\Core\Framework\DependencyInjection\CompilerPass;
 
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Migration\MigrationSource;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 #[Package('framework')]
-class FrameworkMigrationReplacementCompilerPass implements CompilerPassInterface
+class FrameworkMigrationReplacementCompilerPass extends AbstractMigrationReplacementCompilerPass
 {
-    public function process(ContainerBuilder $container): void
+    protected function getMigrationPath(): string
     {
-        $bundleRoot = \dirname(__DIR__, 3);
+        return \dirname(__DIR__, 3) . '/Migration';
+    }
 
-        $migrationSourceV3 = $container->getDefinition(MigrationSource::class . '.core.V6_3');
-        $migrationSourceV3->addMethodCall('addDirectory', [$bundleRoot . '/Migration/V6_3', 'Shopware\Core\Migration\V6_3']);
-
-        $migrationSourceV4 = $container->getDefinition(MigrationSource::class . '.core.V6_4');
-        $migrationSourceV4->addMethodCall('addDirectory', [$bundleRoot . '/Migration/V6_4', 'Shopware\Core\Migration\V6_4']);
-
-        $migrationSourceV5 = $container->getDefinition(MigrationSource::class . '.core.V6_5');
-        $migrationSourceV5->addMethodCall('addDirectory', [$bundleRoot . '/Migration/V6_5', 'Shopware\Core\Migration\V6_5']);
-
-        $migrationSourceV6 = $container->getDefinition(MigrationSource::class . '.core.V6_6');
-        $migrationSourceV6->addMethodCall('addDirectory', [$bundleRoot . '/Migration/V6_6', 'Shopware\Core\Migration\V6_6']);
-
-        $migrationSourceV6 = $container->getDefinition(MigrationSource::class . '.core.V6_7');
-        $migrationSourceV6->addMethodCall('addDirectory', [$bundleRoot . '/Migration/V6_7', 'Shopware\Core\Migration\V6_7']);
-
-        $migrationSourceV6 = $container->getDefinition(MigrationSource::class . '.core.V6_8');
-        $migrationSourceV6->addMethodCall('addDirectory', [$bundleRoot . '/Migration/V6_8', 'Shopware\Core\Migration\V6_8']);
+    protected function getMigrationNamespace(): string
+    {
+        return 'Shopware\Core\Migration';
     }
 }

--- a/src/Core/Framework/DependencyInjection/CompilerPass/FrameworkMigrationReplacementCompilerPass.php
+++ b/src/Core/Framework/DependencyInjection/CompilerPass/FrameworkMigrationReplacementCompilerPass.php
@@ -9,11 +9,11 @@ class FrameworkMigrationReplacementCompilerPass extends AbstractMigrationReplace
 {
     protected function getMigrationPath(): string
     {
-        return \dirname(__DIR__, 3) . '/Migration';
+        return \dirname(__DIR__, 3);
     }
 
-    protected function getMigrationNamespace(): string
+    protected function getMigrationNamespacePart(): string
     {
-        return 'Shopware\Core\Migration';
+        return 'Core';
     }
 }

--- a/src/Elasticsearch/DependencyInjection/ElasticsearchMigrationCompilerPass.php
+++ b/src/Elasticsearch/DependencyInjection/ElasticsearchMigrationCompilerPass.php
@@ -10,11 +10,11 @@ class ElasticsearchMigrationCompilerPass extends AbstractMigrationReplacementCom
 {
     protected function getMigrationPath(): string
     {
-        return \dirname(__DIR__) . '/Migration';
+        return \dirname(__DIR__);
     }
 
-    protected function getMigrationNamespace(): string
+    protected function getMigrationNamespacePart(): string
     {
-        return 'Shopware\Elasticsearch\Migration';
+        return 'Elasticsearch';
     }
 }

--- a/src/Elasticsearch/DependencyInjection/ElasticsearchMigrationCompilerPass.php
+++ b/src/Elasticsearch/DependencyInjection/ElasticsearchMigrationCompilerPass.php
@@ -2,27 +2,19 @@
 
 namespace Shopware\Elasticsearch\DependencyInjection;
 
+use Shopware\Core\Framework\DependencyInjection\CompilerPass\AbstractMigrationReplacementCompilerPass;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Migration\MigrationSource;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 #[Package('framework')]
-class ElasticsearchMigrationCompilerPass implements CompilerPassInterface
+class ElasticsearchMigrationCompilerPass extends AbstractMigrationReplacementCompilerPass
 {
-    public function process(ContainerBuilder $container): void
+    protected function getMigrationPath(): string
     {
-        $migrationPath = \dirname(__DIR__) . '/Migration';
+        return \dirname(__DIR__) . '/Migration';
+    }
 
-        // configure migration directories
-        $majors = ['V6_5', 'V6_6'];
-        foreach ($majors as $major) {
-            $migrationPathV5 = $migrationPath . '/' . $major;
-
-            if (\is_dir($migrationPathV5)) {
-                $migrationSource = $container->getDefinition(MigrationSource::class . '.core.' . $major);
-                $migrationSource->addMethodCall('addDirectory', [$migrationPathV5, 'Shopware\Elasticsearch\Migration\\' . $major]);
-            }
-        }
+    protected function getMigrationNamespace(): string
+    {
+        return 'Shopware\Elasticsearch\Migration';
     }
 }

--- a/src/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPass.php
+++ b/src/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPass.php
@@ -2,32 +2,19 @@
 
 namespace Shopware\Storefront\DependencyInjection;
 
+use Shopware\Core\Framework\DependencyInjection\CompilerPass\AbstractMigrationReplacementCompilerPass;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Migration\MigrationSource;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 #[Package('framework')]
-class StorefrontMigrationReplacementCompilerPass implements CompilerPassInterface
+class StorefrontMigrationReplacementCompilerPass extends AbstractMigrationReplacementCompilerPass
 {
-    public function process(ContainerBuilder $container): void
+    protected function getMigrationPath(): string
     {
-        $migrationPath = \dirname(__DIR__) . '/Migration';
+        return \dirname(__DIR__) . '/Migration';
+    }
 
-        $migrationSourceV3 = $container->getDefinition(MigrationSource::class . '.core.V6_3');
-        $migrationSourceV3->addMethodCall('addDirectory', [$migrationPath . '/V6_3', 'Shopware\Storefront\Migration\V6_3']);
-
-        $migrationSourceV4 = $container->getDefinition(MigrationSource::class . '.core.V6_4');
-        $migrationSourceV4->addMethodCall('addDirectory', [$migrationPath . '/V6_4', 'Shopware\Storefront\Migration\V6_4']);
-
-        $majors = ['V6_5', 'V6_6'];
-        foreach ($majors as $major) {
-            $migrationPathV5 = $migrationPath . '/' . $major;
-
-            if (\is_dir($migrationPathV5)) {
-                $migrationSource = $container->getDefinition(MigrationSource::class . '.core.' . $major);
-                $migrationSource->addMethodCall('addDirectory', [$migrationPathV5, 'Shopware\Storefront\Migration\\' . $major]);
-            }
-        }
+    protected function getMigrationNamespace(): string
+    {
+        return 'Shopware\Storefront\Migration';
     }
 }

--- a/src/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPass.php
+++ b/src/Storefront/DependencyInjection/StorefrontMigrationReplacementCompilerPass.php
@@ -10,11 +10,11 @@ class StorefrontMigrationReplacementCompilerPass extends AbstractMigrationReplac
 {
     protected function getMigrationPath(): string
     {
-        return \dirname(__DIR__) . '/Migration';
+        return \dirname(__DIR__);
     }
 
-    protected function getMigrationNamespace(): string
+    protected function getMigrationNamespacePart(): string
     {
-        return 'Shopware\Storefront\Migration';
+        return 'Storefront';
     }
 }


### PR DESCRIPTION
@DennisGarding approached me, because he added a new migration to the "Administration" package and wondered, why the new migration was not considered. After some debugging we found those compiler passes. 

To reduce hassle for future us, we thought about an abstraction. This is the result. Looking for feedback. 