### PR TITLE
fix: Improving bulk edit for b2b toggles

### DIFF
--- a/changelog/_unreleased/2025-03-03-improving-bulk-edit-for-b2b-toggles.md
+++ b/changelog/_unreleased/2025-03-03-improving-bulk-edit-for-b2b-toggles.md
@@ -1,0 +1,6 @@
+---
+title: Improving bulk edit for b2b toggles
+issue: NEXT-40826
+---
+# Administration
+* Changed `onChangeValue`, `onChangeToggle` methods in `src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-change-type-field-renderer/index.js` to add param `changeType` in emit `change-value`. It can distinguish which is `emit` from toggle change or value change. 

--- a/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-change-type-field-renderer/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-bulk-edit/component/sw-bulk-edit-change-type-field-renderer/index.js
@@ -69,7 +69,7 @@ export default {
             );
         },
 
-        onChangeValue(value, fieldName, valueChange = true) {
+        onChangeValue(value, fieldName, valueChange = true, changeType = 'value-change') {
             if (valueChange) {
                 this.entity[fieldName] = value;
             }
@@ -77,11 +77,12 @@ export default {
             if (!this.bulkEditData[fieldName].isInherited) {
                 this.bulkEditData[fieldName].value = value;
             }
-            this.$emit('change-value', fieldName, value);
+
+            this.$emit('change-value', fieldName, value, changeType);
         },
 
         onChangeToggle(value, fieldName) {
-            this.onChangeValue(value, fieldName, false);
+            this.onChangeValue(value, fieldName, false, 'toggle-change');
         },
 
         onInheritanceRestore(item) {


### PR DESCRIPTION
Currently, In the `sw-bulk-edit-change-type-field-renderer` component, when changing the value of the field, for example, it may be the switch or checkbox; we couldn't know where they emit comes from. I would like to add the change type to distinguish them.

In my case, I would like to detect the change from the value (switch component) to make the logic in our component.

If the Order Approval switch is on, the Employee will be automatically activated and disabled fields.

![Screenshot 2025-03-03 at 15 25 01](https://github.com/user-attachments/assets/28fe0f1a-799f-4e7f-8513-e4689346c8e7)

