### PR TITLE
fix: empty row on add snippet set

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid-row/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid-row/index.js
@@ -61,6 +61,8 @@ Component.register('sw-grid-row', {
         },
     },
 
+    expose: ['startInlineEditing'],
+
     data() {
         return {
             columns: [],
@@ -132,6 +134,10 @@ Component.register('sw-grid-row', {
         onInlineEditFinish() {
             this.isEditingActive = false;
             this.$emit('inline-edit-finish', this.item);
+        },
+
+        startInlineEditing() {
+            this.onInlineEditStart();
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid-row/sw-grid-row.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid-row/sw-grid-row.scss
@@ -85,7 +85,7 @@ $sw-grid-row-border-radius: $border-radius-default;
         display: none;
         position: absolute;
         left: 50%;
-        bottom: -53px;
+        top: 100%;
         transform: translate(-50%, 0);
         z-index: 10;
         padding: 10px 16px;

--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/index.js
@@ -114,6 +114,8 @@ Component.register('sw-grid', {
         },
     },
 
+    expose: ['startInlineEditing', 'selectAll', 'selectItem'],
+
     data() {
         return {
             columns: [],
@@ -122,6 +124,7 @@ Component.register('sw-grid', {
             editing: null,
             allSelectedChecked: false,
             swGridDisableInlineEditListener: [],
+            rowRefs: [],
         };
     },
 
@@ -325,6 +328,10 @@ Component.register('sw-grid', {
             }
 
             return item.id;
+        },
+
+        startInlineEditing() {
+            this.$refs.rowRefs.at(-1).startInlineEditing();
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/sw-grid.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/sw-grid.html.twig
@@ -104,6 +104,7 @@
                     >
                         {% block sw_grid_body_slot_items %}
                         <sw-grid-row
+                            ref="rowRefs"
                             :style="columnFlex"
                             :item="item"
                             :index="index"
@@ -120,7 +121,6 @@
                             >
                                 <div class="sw-grid__cell-content">
                                     <mt-checkbox
-
                                         :checked="isSelected(item.id)"
                                         @update:checked="selectItem($event, item)"
                                     />

--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/sw-grid.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid/sw-grid.scss
@@ -160,4 +160,8 @@ $sw-grid-table-row-color-background: $color-white;
             margin-bottom: 15px;
         }
     }
+
+    .mt-field {
+        margin-bottom: 0;
+    }
 }

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/index.js
@@ -113,25 +113,7 @@ export default {
             }
 
             this.$nextTick(() => {
-                let foundRow = this.$refs.snippetSetList.$children.find((vueComponent) => {
-                    if (vueComponent.$options.name === 'AsyncComponentWrapper') {
-                        vueComponent = vueComponent?.$children[0];
-                    }
-
-                    return vueComponent?.item !== undefined && vueComponent.item.id === newSnippetSet.id;
-                });
-
-                if (!foundRow) {
-                    return false;
-                }
-
-                if (foundRow.$options.name === 'AsyncComponentWrapper') {
-                    foundRow = foundRow.$children[0];
-                }
-
-                foundRow.isEditingActive = true;
-
-                return true;
+                this.$refs.snippetSetList?.startInlineEditing();
             });
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/sw-settings-snippet-set-list.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-snippet/page/sw-settings-snippet-set-list/sw-settings-snippet-set-list.spec.js
@@ -45,6 +45,7 @@ function getSnippetSetData() {
 }
 
 describe('module/sw-settings-snippet/page/sw-settings-snippet-set-list', () => {
+    const saveSpy = jest.fn(() => Promise.resolve());
     async function createWrapper(privileges = []) {
         return mount(
             await wrapTestComponent('sw-settings-snippet-set-list', {
@@ -78,6 +79,7 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-set-list', () => {
                         repositoryFactory: {
                             create: () => ({
                                 search: () => Promise.resolve(getSnippetSetData()),
+                                save: saveSpy,
                             }),
                         },
                         searchRankingService: {},
@@ -269,5 +271,20 @@ describe('module/sw-settings-snippet/page/sw-settings-snippet-set-list', () => {
         }
 
         expect(duplicateButton.classes()).toContain('is--disabled');
+    });
+
+    it('adds a new snippet', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+        const createSetButton = wrapper.findByText('button', 'sw-settings-snippet.setList.buttonAddSet');
+        await createSetButton.trigger('click');
+        await flushPromises();
+
+        const nameInput = wrapper.findByPlaceholder('sw-settings-snippet.setList.placeholderName');
+        await nameInput.setValue('test');
+        await wrapper.findByText('button', 'global.default.save').trigger('click');
+        await flushPromises();
+
+        expect(saveSpy).toHaveBeenCalledWith(expect.objectContaining({ name: 'test' }));
     });
 });


### PR DESCRIPTION
### 1. Why is this change necessary?
The adding of a new snippets set does not work, as an error is raised


### 2. What does this change do, exactly?
- It removes the use of `$children` as it is not longer available after the remove of vue compact.
- It exposes internal methods in `sw-grid` and `sw-grid-row`


### 3. Describe each step to reproduce the issue or behaviour.
1. Go to settings -> Snippets
2. Click on `Add snippet set`
3. After fix the row is added in editing mode
4. Before fix an error is thrown and an empty row (without inputs) is added.


### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40850


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
