### PR TITLE
fix: Ignore tables with enums in definition validator as DBAL 3.x does not support enums

### DIFF
--- a/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\DataAbstractionLayer;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Shopware\Core\Framework\DataAbstractionLayer\Exception\DefinitionNotFoundException;
@@ -225,8 +226,17 @@ class DefinitionValidator
             }
         }
 
-        $tableSchemas = $this->connection->createSchemaManager()->listTables();
-        $violations = array_merge_recursive($violations, $this->findNotRegisteredTables($tableSchemas));
+        try {
+            $tableSchemas = $this->connection->createSchemaManager()->listTables();
+            $violations = array_merge_recursive($violations, $this->findNotRegisteredTables($tableSchemas));
+        } catch (Exception $e) {
+            // DBAL 3.x does not support enum types, we need to skip validation for now
+            // will be fixed with DBAL 4 in shopware 6.7
+            if (!str_contains($e->getMessage(), 'Unknown database type enum requested')) {
+                throw $e;
+            }
+
+        }
 
         return array_filter($violations);
     }
@@ -468,7 +478,17 @@ class DefinitionValidator
     {
         $violations = [];
 
-        $columns = $this->connection->createSchemaManager()->listTableColumns($translationDefinition->getEntityName());
+        try {
+            $columns=  $this->connection->createSchemaManager()->listTableColumns($translationDefinition->getEntityName());
+        } catch (Exception $e) {
+            // DBAL 3.x does not support enum types, we need to skip validation for now
+            // will be fixed with DBAL 4 in shopware 6.7
+            if (str_contains($e->getMessage(), 'Unknown database type enum requested')) {
+                return [];
+            }
+
+            throw $e;
+        }
 
         $translatedFields = $translationDefinition->getParentDefinition()
             ->getFields()
@@ -896,7 +916,17 @@ class DefinitionValidator
      */
     private function validateSchema(EntityDefinition $definition): array
     {
-        $columns = $this->connection->createSchemaManager()->listTableColumns($definition->getEntityName());
+        try {
+            $columns=  $this->connection->createSchemaManager()->listTableColumns($definition->getEntityName());
+        } catch (Exception $e) {
+            // DBAL 3.x does not support enum types, we need to skip validation for now
+            // will be fixed with DBAL 4 in shopware 6.7
+            if (str_contains($e->getMessage(), 'Unknown database type enum requested')) {
+                return [];
+            }
+
+            throw $e;
+        }
 
         $violations = [];
         $mappedFieldNames = [];
@@ -941,7 +971,17 @@ class DefinitionValidator
      */
     private function validateColumn(EntityDefinition $definition): array
     {
-        $columns = $this->connection->createSchemaManager()->listTableColumns($definition->getEntityName());
+        try {
+            $columns=  $this->connection->createSchemaManager()->listTableColumns($definition->getEntityName());
+        } catch (Exception $e) {
+            // DBAL 3.x does not support enum types, we need to skip validation for now
+            // will be fixed with DBAL 4 in shopware 6.7
+            if (str_contains($e->getMessage(), 'Unknown database type enum requested')) {
+                return [];
+            }
+
+            throw $e;
+        }
 
         $notices = [];
 

--- a/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
@@ -235,7 +235,6 @@ class DefinitionValidator
             if (!str_contains($e->getMessage(), 'Unknown database type enum requested')) {
                 throw $e;
             }
-
         }
 
         return array_filter($violations);
@@ -479,7 +478,7 @@ class DefinitionValidator
         $violations = [];
 
         try {
-            $columns=  $this->connection->createSchemaManager()->listTableColumns($translationDefinition->getEntityName());
+            $columns = $this->connection->createSchemaManager()->listTableColumns($translationDefinition->getEntityName());
         } catch (Exception $e) {
             // DBAL 3.x does not support enum types, we need to skip validation for now
             // will be fixed with DBAL 4 in shopware 6.7
@@ -917,7 +916,7 @@ class DefinitionValidator
     private function validateSchema(EntityDefinition $definition): array
     {
         try {
-            $columns=  $this->connection->createSchemaManager()->listTableColumns($definition->getEntityName());
+            $columns = $this->connection->createSchemaManager()->listTableColumns($definition->getEntityName());
         } catch (Exception $e) {
             // DBAL 3.x does not support enum types, we need to skip validation for now
             // will be fixed with DBAL 4 in shopware 6.7
@@ -972,7 +971,7 @@ class DefinitionValidator
     private function validateColumn(EntityDefinition $definition): array
     {
         try {
-            $columns=  $this->connection->createSchemaManager()->listTableColumns($definition->getEntityName());
+            $columns = $this->connection->createSchemaManager()->listTableColumns($definition->getEntityName());
         } catch (Exception $e) {
             // DBAL 3.x does not support enum types, we need to skip validation for now
             // will be fixed with DBAL 4 in shopware 6.7

--- a/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
+++ b/src/Core/Framework/DataAbstractionLayer/DefinitionValidator.php
@@ -231,7 +231,7 @@ class DefinitionValidator
             $violations = array_merge_recursive($violations, $this->findNotRegisteredTables($tableSchemas));
         } catch (Exception $e) {
             // DBAL 3.x does not support enum types, we need to skip validation for now
-            // will be fixed with DBAL 4 in shopware 6.7
+            // will be fixed with DBAL >= 4.2 in shopware 6.7
             if (!str_contains($e->getMessage(), 'Unknown database type enum requested')) {
                 throw $e;
             }
@@ -481,7 +481,7 @@ class DefinitionValidator
             $columns = $this->connection->createSchemaManager()->listTableColumns($translationDefinition->getEntityName());
         } catch (Exception $e) {
             // DBAL 3.x does not support enum types, we need to skip validation for now
-            // will be fixed with DBAL 4 in shopware 6.7
+            // will be fixed with DBAL >= 4.2 in shopware 6.7
             if (str_contains($e->getMessage(), 'Unknown database type enum requested')) {
                 return [];
             }
@@ -919,7 +919,7 @@ class DefinitionValidator
             $columns = $this->connection->createSchemaManager()->listTableColumns($definition->getEntityName());
         } catch (Exception $e) {
             // DBAL 3.x does not support enum types, we need to skip validation for now
-            // will be fixed with DBAL 4 in shopware 6.7
+            // will be fixed with DBAL >= 4.2 in shopware 6.7
             if (str_contains($e->getMessage(), 'Unknown database type enum requested')) {
                 return [];
             }
@@ -974,7 +974,7 @@ class DefinitionValidator
             $columns = $this->connection->createSchemaManager()->listTableColumns($definition->getEntityName());
         } catch (Exception $e) {
             // DBAL 3.x does not support enum types, we need to skip validation for now
-            // will be fixed with DBAL 4 in shopware 6.7
+            // will be fixed with DBAL >= 4.2 in shopware 6.7
             if (str_contains($e->getMessage(), 'Unknown database type enum requested')) {
                 return [];
             }


### PR DESCRIPTION
fixes https://github.com/shopware/shopware/issues/7119


