### PR TITLE
chore: prepare phpstan upgrade domain exception ElasticSearchException

### DIFF
--- a/src/Elasticsearch/ElasticsearchException.php
+++ b/src/Elasticsearch/ElasticsearchException.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Elasticsearch;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,6 +23,8 @@ class ElasticsearchException extends HttpException
     public const EMPTY_INDEXING_REQUEST = 'ELASTICSEARCH__EMPTY_INDEXING_REQUEST';
 
     public const AWS_CREDENTIALS_NOT_FOUND = 'ELASTICSEARCH__AWS_CREDENTIALS_NOT_FOUND';
+
+    public const OPERATOR_NOT_ALLOWED = 'ELASTICSEARCH__OPERATOR_NOT_ALLOWED';
 
     public static function definitionNotFound(string $definition): self
     {
@@ -146,6 +149,23 @@ class ElasticsearchException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::EMPTY_INDEXING_REQUEST,
             'Empty indexing request provided'
+        );
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will only return `self` in the future
+     */
+    public static function operatorNotAllowed(string $operator): self|\InvalidArgumentException
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return new \InvalidArgumentException('Operator ' . $operator . ' not allowed');
+        }
+
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::OPERATOR_NOT_ALLOWED,
+            'Operator {{ operator }} not allowed',
+            ['operator' => $operator]
         );
     }
 }

--- a/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
+++ b/src/Elasticsearch/Framework/DataAbstractionLayer/CriteriaParser.php
@@ -548,7 +548,7 @@ class CriteriaParser
             $aggregation instanceof TermsAggregation => $this->parseTermsAggregation($aggregation, $fieldName, $definition, $context),
             $aggregation instanceof DateHistogramAggregation => $this->parseDateHistogramAggregation($aggregation, $fieldName, $definition, $context),
             $aggregation instanceof RangeAggregation => $this->parseRangeAggregation($aggregation, $fieldName),
-            default => throw new \RuntimeException(\sprintf('Provided aggregation of class %s not supported', $aggregation::class)),
+            default => throw ElasticsearchException::unsupportedAggregation($aggregation::class),
         };
     }
 
@@ -803,7 +803,7 @@ class CriteriaParser
             MultiFilter::CONNECTION_OR => $this->parseOrMultiFilter($filter, $definition, $root, $context),
             MultiFilter::CONNECTION_AND => $this->parseAndMultiFilter($filter, $definition, $root, $context),
             MultiFilter::CONNECTION_XOR => $this->parseXorMultiFilter($filter, $definition, $root, $context),
-            default => throw new \InvalidArgumentException('Operator ' . $filter->getOperator() . ' not allowed'),
+            default => throw ElasticsearchException::operatorNotAllowed($filter->getOperator()),
         };
     }
 

--- a/tests/unit/Elasticsearch/ElasticsearchExceptionTest.php
+++ b/tests/unit/Elasticsearch/ElasticsearchExceptionTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Elasticsearch;
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Shopware\Elasticsearch\ElasticsearchException;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -125,5 +126,25 @@ class ElasticsearchExceptionTest extends TestCase
         static::assertSame('ELASTICSEARCH__AWS_CREDENTIALS_NOT_FOUND', $exception->getErrorCode());
         static::assertSame('Could not get AWS credentials', $exception->getMessage());
         static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+    }
+
+    public function testOperatorNotAllowed(): void
+    {
+        $exception = ElasticsearchException::operatorNotAllowed('foo');
+        static::assertSame('Operator foo not allowed', $exception->getMessage());
+        static::assertInstanceOf(ElasticsearchException::class, $exception);
+        static::assertSame('ELASTICSEARCH__OPERATOR_NOT_ALLOWED', $exception->getErrorCode());
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - reason: see ElasticsearchException::operatorNotAllowed - to be removed
+     */
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testOperatorNotAllowedDeprecated(): void
+    {
+        $exception = ElasticsearchException::operatorNotAllowed('foo');
+        static::assertInstanceOf(\InvalidArgumentException::class, $exception);
+        static::assertSame('Operator foo not allowed', $exception->getMessage());
     }
 }


### PR DESCRIPTION
Prepare phpstan upgrade with fixing domain exception previously not detected inside `match(` (phpstan 2.0 will detect it)