### PR TITLE
chore: prepare phpstan upgrade domain exception CustomEntityException

### DIFF
--- a/src/Core/System/CustomEntity/CustomEntityException.php
+++ b/src/Core/System/CustomEntity/CustomEntityException.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 #[Package('framework')]
 class CustomEntityException extends HttpException
 {
+    public const CUSTOM_ENTITY_ON_DELETE_PROPERTY_NOT_SUPPORTED = 'FRAMEWORK__CUSTOM_ENTITY_ON_DELETE_PROPERTY_NOT_SUPPORTED';
     public const CUSTOM_FIELDS_AWARE_NO_LABEL_PROPERTY = 'NO_LABEL_PROPERTY';
     public const CUSTOM_FIELDS_AWARE_LABEL_PROPERTY_NOT_DEFINED = 'LABEL_PROPERTY_NOT_DEFINED';
     public const CUSTOM_FIELDS_AWARE_LABEL_PROPERTY_WRONG_TYPE = 'LABEL_PROPERTY_WRONG_TYPE';
@@ -41,5 +42,10 @@ class CustomEntityException extends HttpException
     public static function xmlParsingException(string $file, string $message): self
     {
         return new CustomEntityXmlParsingException($file, $message);
+    }
+
+    public static function unsupportedOnDeletePropertyOnField(string $onDelete, string $name): self
+    {
+        return new self(Response::HTTP_INTERNAL_SERVER_ERROR, self::CUSTOM_ENTITY_ON_DELETE_PROPERTY_NOT_SUPPORTED, 'onDelete property {{ onDelete }} are not supported on field {{ name }}', ['onDelete' => $onDelete, 'name' => $name]);
     }
 }

--- a/src/Core/System/CustomEntity/CustomEntityException.php
+++ b/src/Core/System/CustomEntity/CustomEntityException.php
@@ -46,6 +46,11 @@ class CustomEntityException extends HttpException
 
     public static function unsupportedOnDeletePropertyOnField(string $onDelete, string $name): self
     {
-        return new self(Response::HTTP_INTERNAL_SERVER_ERROR, self::CUSTOM_ENTITY_ON_DELETE_PROPERTY_NOT_SUPPORTED, 'onDelete property {{ onDelete }} are not supported on field {{ name }}', ['onDelete' => $onDelete, 'name' => $name]);
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::CUSTOM_ENTITY_ON_DELETE_PROPERTY_NOT_SUPPORTED,
+            'onDelete property {{ onDelete }} are not supported on field {{ name }}',
+            ['onDelete' => $onDelete, 'name' => $name]
+        );
     }
 }

--- a/src/Core/System/CustomEntity/Schema/DynamicFieldFactory.php
+++ b/src/Core/System/CustomEntity/Schema/DynamicFieldFactory.php
@@ -34,6 +34,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslatedField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\TranslationsAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\CustomEntity\CustomEntityException;
 use Shopware\Core\System\CustomEntity\CustomEntityRegistrar;
 use Shopware\Core\System\CustomEntity\Xml\Field\AssociationField;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -424,7 +425,7 @@ class DynamicFieldFactory
             AssociationField::CASCADE => new CascadeDelete(),
             AssociationField::SET_NULL => new SetNullOnDelete(),
             AssociationField::RESTRICT => new RestrictDelete(),
-            default => throw new \RuntimeException(\sprintf('onDelete property %s are not supported on field %s', $field['onDelete'], $field['name'])),
+            default => throw CustomEntityException::unsupportedOnDeletePropertyOnField($field['onDelete'], $field['name']),
         };
     }
 

--- a/tests/unit/Core/System/CustomEntity/CustomEntityExceptionTest.php
+++ b/tests/unit/Core/System/CustomEntity/CustomEntityExceptionTest.php
@@ -41,4 +41,15 @@ class CustomEntityExceptionTest extends TestCase
         static::assertSame(CustomEntityException::CUSTOM_FIELDS_AWARE_LABEL_PROPERTY_WRONG_TYPE, $exception->getErrorCode());
         static::assertSame('Entity label_property "some_label" must be a string field', $exception->getMessage());
     }
+
+    public function testUnsupportedOnDeletePropertyOnField(): void
+    {
+        $onDelete = 'some_on_delete';
+        $name = 'some_name';
+        $exception = CustomEntityException::unsupportedOnDeletePropertyOnField($onDelete, $name);
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(CustomEntityException::CUSTOM_ENTITY_ON_DELETE_PROPERTY_NOT_SUPPORTED, $exception->getErrorCode());
+        static::assertSame('onDelete property some_on_delete are not supported on field some_name', $exception->getMessage());
+    }
 }

--- a/tests/unit/Core/System/CustomEntity/Schema/DynamicFieldFactoryTest.php
+++ b/tests/unit/Core/System/CustomEntity/Schema/DynamicFieldFactoryTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\CustomEntity\Schema;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\CustomEntity\CustomEntityException;
+use Shopware\Core\System\CustomEntity\Schema\DynamicFieldFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(DynamicFieldFactory::class)]
+class DynamicFieldFactoryTest extends TestCase
+{
+    private ContainerInterface&MockObject $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = $this->createMock(ContainerInterface::class);
+    }
+
+    public function testCreateThrowsAnExceptionWhenTheServiceIsNotFound(): void
+    {
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage('You have requested a non-existent service "Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry".');
+
+        $factory = new DynamicFieldFactory();
+
+        $factory->create($this->container, 'test', [
+            ['name' => 'test', 'type' => '', 'reference' => '', 'onDelete' => ''],
+        ]);
+    }
+
+    public function testGetDeletedFlagThrowsAnExceptionWhenTheFieldIsUnmatched(): void
+    {
+        $this->expectExceptionObject(CustomEntityException::unsupportedOnDeletePropertyOnField('INVALID', 'test'));
+
+        $factory = new DynamicFieldFactory();
+
+        $this->container->expects(static::once())
+            ->method('get')
+            ->willReturn($this->createMock(DefinitionInstanceRegistry::class));
+
+        $factory->create($this->container, 'test', [
+            ['name' => 'test', 'type' => 'many-to-one', 'reference' => 'unit', 'onDelete' => 'INVALID'],
+        ]);
+    }
+}


### PR DESCRIPTION
Prepare phpstan upgrade with fixing domain exception previously not detected inside `match(` (phpstan 2.0 will detect it)
