### PR TITLE
chore: prepare phpstan upgrade domain exception DataAbstractionLayerException

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1901,11 +1901,6 @@ parameters:
 			path: src/Core/Framework/DataAbstractionLayer/Search/IdSearchResult.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\DataAbstractionLayer\\\\Search\\\\Parser\\\\SqlQueryParser\\:\\:parseRanking\\(\\) has parameter \\$queries with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
-
-		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 1
 			path: src/Core/Framework/DataAbstractionLayer/Search/RequestCriteriaBuilder.php

--- a/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
+++ b/src/Core/Framework/DataAbstractionLayer/DataAbstractionLayerException.php
@@ -78,6 +78,7 @@ class DataAbstractionLayerException extends HttpException
     public const INVALID_CHUNK_SIZE = 'FRAMEWORK__INVALID_CHUNK_SIZE';
     public const HOOK_INJECTION_EXCEPTION = 'FRAMEWORK__HOOK_INJECTION_EXCEPTION';
     public const FRAMEWORK_DEPRECATED_DEFINITION_CALL = 'FRAMEWORK__DEPRECATED_DEFINITION_CALL';
+    public const UNSUPPORTED_QUERY_FILTER = 'FRAMEWORK__UNSUPPORTED_QUERY_FILTER';
 
     public static function invalidSerializerField(string $expectedClass, Field $field): self
     {
@@ -686,6 +687,16 @@ class DataAbstractionLayerException extends HttpException
             self::INVALID_CHUNK_SIZE,
             'Parameter $chunkSize needs to be a positive integer starting with 1, "{{ size }}" given',
             ['size' => $size]
+        );
+    }
+
+    public static function unsupportedQueryFilter(string $query): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::UNSUPPORTED_QUERY_FILTER,
+            'Unsupported query {{ query }}',
+            ['query' => $query]
         );
     }
 

--- a/src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
+++ b/src/Core/Framework/DataAbstractionLayer/Dbal/EntityAggregator.php
@@ -303,7 +303,7 @@ class EntityAggregator implements EntityAggregatorInterface
             DateHistogramAggregation::PER_MONTH => 'DATE_FORMAT(' . $accessor . ', \'%Y-%m\')',
             DateHistogramAggregation::PER_QUARTER => 'CONCAT(DATE_FORMAT(' . $accessor . ', \'%Y\'), \'-\', QUARTER(' . $accessor . '))',
             DateHistogramAggregation::PER_YEAR => 'DATE_FORMAT(' . $accessor . ', \'%Y\')',
-            default => throw new \RuntimeException('Provided date format is not supported'),
+            default => throw throw DataAbstractionLayerException::invalidDateFormat($aggregation->getInterval(), DateHistogramAggregation::ALLOWED_INTERVALS),
         };
         $query->addGroupBy($groupBy);
 

--- a/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
+++ b/src/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParser.php
@@ -5,6 +5,7 @@ namespace Shopware\Core\Framework\DataAbstractionLayer\Search\Parser;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
@@ -39,6 +40,9 @@ class SqlQueryParser
     ) {
     }
 
+    /**
+     * @param list<ScoreQuery> $queries
+     */
     public function parseRanking(
         array $queries,
         EntityDefinition $definition,
@@ -107,7 +111,7 @@ class SqlQueryParser
             $query instanceof RangeFilter => $this->parseRangeFilter($query, $definition, $root, $context),
             $query instanceof NotFilter => $this->parseNotFilter($query, $definition, $root, $context),
             $query instanceof MultiFilter => $this->parseMultiFilter($query, $definition, $root, $context, $negated),
-            default => throw new \RuntimeException(\sprintf('Unsupported query %s', $query::class)),
+            default => throw DataAbstractionLayerException::unsupportedQueryFilter($query::class),
         };
     }
 

--- a/tests/unit/Core/Framework/DataAbstractionLayer/DataAbstractionLayerExceptionTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/DataAbstractionLayerExceptionTest.php
@@ -220,4 +220,13 @@ class DataAbstractionLayerExceptionTest extends TestCase
             $exception->getMessage()
         );
     }
+
+    public function testUnsupportedQueryFilter(): void
+    {
+        $exception = DataAbstractionLayerException::unsupportedQueryFilter('foo');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(DataAbstractionLayerException::UNSUPPORTED_QUERY_FILTER, $exception->getErrorCode());
+        static::assertSame('Unsupported query foo', $exception->getMessage());
+    }
 }

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Search/Parser/SqlQueryParserTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\DataAbstractionLayer\Search\Parser;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\DataAbstractionLayerException;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\EntityDefinitionQueryHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\SqlQueryParser;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery;
+use Shopware\Core\System\Unit\UnitDefinition;
+
+/**
+ * @internal
+ */
+#[CoversClass(SqlQueryParser::class)]
+class SqlQueryParserTest extends TestCase
+{
+    public function testParseUnsupportedQueryFilter(): void
+    {
+        $this->expectException(DataAbstractionLayerException::class);
+
+        $parser = new SqlQueryParser(new EntityDefinitionQueryHelper(), $this->createMock(Connection::class));
+
+        $parser->parse(
+            new ScoreQuery(new ContainsFilter('description', 'test'), 250),
+            new UnitDefinition(),
+            Context::createDefaultContext(),
+        );
+    }
+}


### PR DESCRIPTION
Prepare phpstan upgrade with fixing domain exception previously not detected inside `match(` (phpstan 2.0 will detect it)