### PR TITLE
chore: prepare phpstan upgrade domain exception  AdapterException

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1111,11 +1111,6 @@ parameters:
 			path: src/Core/Framework/Adapter/Twig/Extension/CategoryUrlExtension.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\ComparisonExtension\\:\\:compareArray\\(\\) has parameter \\$comparable with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Adapter\\\\Twig\\\\Extension\\\\InstanceOfExtension\\:\\:isInstanceOf\\(\\) has parameter \\$class with no type specified\\.$#"
 			count: 1
 			path: src/Core/Framework/Adapter/Twig/Extension/InstanceOfExtension.php

--- a/src/Core/Framework/Adapter/AdapterException.php
+++ b/src/Core/Framework/Adapter/AdapterException.php
@@ -2,8 +2,10 @@
 
 namespace Shopware\Core\Framework\Adapter;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Symfony\Component\Asset\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Node\Expression\AbstractExpression;
@@ -22,6 +24,24 @@ class AdapterException extends HttpException
     public const INVALID_ASSET_URL = 'FRAMEWORK__INVALID_ASSET_URL';
     final public const INVALID_ARGUMENT = 'FRAMEWORK__INVALID_ARGUMENT_EXCEPTION';
     final public const STRING_TEMPLATE_RENDERING_FAILED = 'FRAMEWORK__STRING_TEMPLATE_RENDERING_FAILED';
+    public const OPERATOR_NOT_SUPPORTED = 'FRAMEWORK__OPERATOR_NOT_SUPPORTED';
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self
+     */
+    public static function unsupportedOperator(string $operator, string $class): self|UnsupportedOperatorException
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return new UnsupportedOperatorException($operator, $class);
+        }
+
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::OPERATOR_NOT_SUPPORTED,
+            'Unsupported operator {{ operator }} in {{ class }}',
+            ['operator' => $operator, 'class' => $class]
+        );
+    }
 
     public static function unexpectedTwigExpression(AbstractExpression $expression): self
     {

--- a/src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
+++ b/src/Core/Framework/Adapter/Twig/Extension/ComparisonExtension.php
@@ -2,8 +2,8 @@
 
 namespace Shopware\Core\Framework\Adapter\Twig\Extension;
 
+use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Util\FloatComparator;
 use Twig\Extension\AbstractExtension;
@@ -46,6 +46,9 @@ class ComparisonExtension extends AbstractExtension
         return $this->compareMixed($operator, $value, $comparable);
     }
 
+    /**
+     * @param array<mixed> $comparable
+     */
     private function compareArray(string $operator, mixed $value, array $comparable): bool
     {
         if (!\is_array($value)) {
@@ -57,7 +60,7 @@ class ComparisonExtension extends AbstractExtension
         return match ($operator) {
             Rule::OPERATOR_EQ => !empty($matches),
             Rule::OPERATOR_NEQ => empty($matches),
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw throw AdapterException::unsupportedOperator($operator, self::class),
         };
     }
 
@@ -70,7 +73,7 @@ class ComparisonExtension extends AbstractExtension
             Rule::OPERATOR_LTE => $value <= $comparable,
             Rule::OPERATOR_GT => $value > $comparable,
             Rule::OPERATOR_LT => $value < $comparable,
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw throw AdapterException::unsupportedOperator($operator, self::class),
         };
     }
 
@@ -83,7 +86,7 @@ class ComparisonExtension extends AbstractExtension
             Rule::OPERATOR_LTE => FloatComparator::lessThanOrEquals($value, $comparable),
             Rule::OPERATOR_GT => FloatComparator::greaterThan($value, $comparable),
             Rule::OPERATOR_LT => FloatComparator::lessThan($value, $comparable),
-            default => throw new UnsupportedOperatorException($operator, self::class),
+            default => throw throw AdapterException::unsupportedOperator($operator, self::class),
         };
     }
 }

--- a/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
+++ b/tests/unit/Core/Framework/Adapter/AdapterExceptionTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\AdapterException;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Node\Expression\AbstractExpression;
 
@@ -15,6 +17,29 @@ use Twig\Node\Expression\AbstractExpression;
 #[CoversClass(AdapterException::class)]
 class AdapterExceptionTest extends TestCase
 {
+    public function testUnsupportedOperator(): void
+    {
+        $exception = AdapterException::unsupportedOperator('$', 'testClass');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(AdapterException::OPERATOR_NOT_SUPPORTED, $exception->getErrorCode());
+        static::assertSame('Unsupported operator $ in testClass', $exception->getMessage());
+        static::assertSame(['operator' => '$', 'class' => 'testClass'], $exception->getParameters());
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testUnsupportedOperatorDeprecated(): void
+    {
+        $exception = AdapterException::unsupportedOperator('$', 'testClass');
+
+        static::assertInstanceOf(UnsupportedOperatorException::class, $exception);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame('CONTENT__RULE_OPERATOR_NOT_SUPPORTED', $exception->getErrorCode());
+        static::assertSame('Unsupported operator $ in testClass', $exception->getMessage());
+        static::assertSame('$', $exception->getOperator());
+        static::assertSame('testClass', $exception->getClass());
+    }
+
     public function testUnexpectedTwigExpression(): void
     {
         /** @var AbstractExpression&MockObject $expression */

--- a/tests/unit/Core/Framework/Adapter/Twig/Extension/ComparisonExtensionTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/Extension/ComparisonExtensionTest.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Framework\Adapter\Twig\Extension;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Adapter\AdapterException;
+use Shopware\Core\Framework\Adapter\Twig\Extension\ComparisonExtension;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+
+/**
+ * @internal
+ */
+#[CoversClass(ComparisonExtension::class)]
+class ComparisonExtensionTest extends TestCase
+{
+    public function testCompareNumericThrowsAnExceptionWhenOperatorIsUnsupported(): void
+    {
+        $this->expectExceptionObject(AdapterException::unsupportedOperator('$', ComparisonExtension::class));
+        $extension = new ComparisonExtension();
+
+        $extension->compare('$', 2, 0);
+    }
+
+    public function testCompareMixedThrowsAnExceptionWhenOperatorIsUnsupported(): void
+    {
+        $this->expectExceptionObject(AdapterException::unsupportedOperator('$', ComparisonExtension::class));
+        $extension = new ComparisonExtension();
+
+        $extension->compare('$', '5', 0);
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testCompareNumericThrowsAnExceptionWhenOperatorIsUnsupportedDeprecated(): void
+    {
+        $this->expectExceptionObject(new UnsupportedOperatorException('$', ComparisonExtension::class));
+        $extension = new ComparisonExtension();
+
+        $extension->compare('$', 2, 0);
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testCompareMixedThrowsAnExceptionWhenOperatorIsUnsupportedDeprecated(): void
+    {
+        $this->expectExceptionObject(AdapterException::unsupportedOperator('$', ComparisonExtension::class));
+        $extension = new ComparisonExtension();
+
+        $extension->compare('$', '5', 0);
+    }
+}


### PR DESCRIPTION
Prepare phpstan upgrade with fixing domain exception previously not detected inside `match(` (phpstan 2.0 will detect it)
