### PR TITLE
chore: prepare phpstan upgrade domain exception MediaException

### DIFF
--- a/src/Core/Content/Media/Core/Application/AbstractMediaPathStrategy.php
+++ b/src/Core/Content/Media/Core/Application/AbstractMediaPathStrategy.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Media\Core\Application;
 
 use Shopware\Core\Content\Media\Core\Params\MediaLocationStruct;
 use Shopware\Core\Content\Media\Core\Params\ThumbnailLocationStruct;
+use Shopware\Core\Content\Media\MediaException;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Util\Hasher;
 
@@ -37,7 +38,7 @@ abstract class AbstractMediaPathStrategy
             $type = match (true) {
                 $location instanceof MediaLocationStruct => 'media',
                 $location instanceof ThumbnailLocationStruct => 'thumbnail',
-                default => throw new \RuntimeException('Unknown location type'),
+                default => throw MediaException::unknownLocationType(),
             };
 
             $paths[$location->id] = implode('/', \array_filter([

--- a/src/Core/Content/Media/MediaException.php
+++ b/src/Core/Content/Media/MediaException.php
@@ -51,6 +51,7 @@ class MediaException extends HttpException
     public const MEDIA_INVALID_MIME_TYPE = 'CONTENT__MEDIA_INVALID_MIME_TYPE';
 
     public const MEDIA_THUMBNAIL_GENERATION_DISABLED = 'CONTENT__MEDIA_THUMBNAIL_GENERATION_DISABLED';
+    public const MEDIA_UNKNOWN_LOCATION_TYPE = 'CONTENT__MEDIA_UNKNOWN_LOCATION_TYPE';
 
     public static function cannotBanRequest(string $url, string $error, ?\Throwable $e = null): self
     {
@@ -424,6 +425,15 @@ class MediaException extends HttpException
             Response::HTTP_BAD_REQUEST,
             self::MEDIA_THUMBNAIL_GENERATION_DISABLED,
             'Remote thumbnails are enabled. Skipping thumbnail generation.'
+        );
+    }
+
+    public static function unknownLocationType(): self
+    {
+        return new self(
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+            self::MEDIA_UNKNOWN_LOCATION_TYPE,
+            'Unknown location type'
         );
     }
 }

--- a/tests/unit/Core/Content/Media/MediaExceptionTest.php
+++ b/tests/unit/Core/Content/Media/MediaExceptionTest.php
@@ -402,4 +402,14 @@ class MediaExceptionTest extends TestCase
         static::assertSame(MediaException::MEDIA_THUMBNAIL_GENERATION_DISABLED, $exception->getErrorCode());
         static::assertSame('Remote thumbnails are enabled. Skipping thumbnail generation.', $exception->getMessage());
     }
+
+    public function testUnknownLocationType(): void
+    {
+        $exception = MediaException::unknownLocationType();
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame(MediaException::MEDIA_UNKNOWN_LOCATION_TYPE, $exception->getErrorCode());
+        static::assertSame('Unknown location type', $exception->getMessage());
+        static::assertSame([], $exception->getParameters());
+    }
 }


### PR DESCRIPTION
Prepare phpstan upgrade with fixing domain exception previously not detected inside `match(` (phpstan 2.0 will detect it)