### PR TITLE
chore: prepare phpstan upgrade domain exception CustomerException

### DIFF
--- a/src/Core/Checkout/Customer/CustomerException.php
+++ b/src/Core/Checkout/Customer/CustomerException.php
@@ -20,14 +20,12 @@ use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
 use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Exception\UnsupportedValueException;
 use Shopware\Core\Framework\ShopwareHttpException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Validator\Exception\MissingOptionsException;
 
-/**
- * @codeCoverageIgnore
- */
 #[Package('checkout')]
 class CustomerException extends HttpException
 {
@@ -62,6 +60,7 @@ class CustomerException extends HttpException
     public const IMITATE_CUSTOMER_INVALID_TOKEN = 'CHECKOUT__IMITATE_CUSTOMER_INVALID_TOKEN';
     public const MISSING_ROUTE_ANNOTATION = 'CHECKOUT__MISSING_ROUTE_ANNOTATION';
     public const MISSING_ROUTE_SALES_CHANNEL = 'CHECKOUT__MISSING_ROUTE_SALES_CHANNEL';
+    public const OPERATOR_NOT_SUPPORTED = 'CHECKOUT__CUSTOMER_RULE_OPERATOR_NOT_SUPPORTED';
     public const VALUE_NOT_SUPPORTED = 'CONTENT__RULE_VALUE_NOT_SUPPORTED';
     public const MISSING_REQUEST_PARAMETER_CODE = 'CONTENT__MISSING_REQUEST_PARAMETER_CODE';
     public const MISSING_OPTIONS = 'CONTENT__MISSING_OPTIONS';
@@ -313,6 +312,23 @@ class CustomerException extends HttpException
             self::MISSING_ROUTE_SALES_CHANNEL,
             'Missing sales channel context for route {{ route }}',
             ['route' => $route]
+        );
+    }
+
+    /**
+     * @deprecated tag:v6.8.0 - reason:return-type-change - Will return self
+     */
+    public static function unsupportedOperator(string $operator, string $class): self|UnsupportedOperatorException
+    {
+        if (!Feature::isActive('v6.8.0.0')) {
+            return new UnsupportedOperatorException($operator, $class);
+        }
+
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::OPERATOR_NOT_SUPPORTED,
+            'Unsupported operator {{ operator }} in {{ class }}',
+            ['operator' => $operator, 'class' => $class]
         );
     }
 

--- a/src/Core/Checkout/Customer/Rule/EmailRule.php
+++ b/src/Core/Checkout/Customer/Rule/EmailRule.php
@@ -6,7 +6,6 @@ use Shopware\Core\Checkout\CheckoutRuleScope;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\CustomerException;
 use Shopware\Core\Framework\Log\Package;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Rule\RuleComparison;
 use Shopware\Core\Framework\Rule\RuleConfig;
@@ -72,7 +71,7 @@ class EmailRule extends Rule
         return match ($this->operator) {
             Rule::OPERATOR_EQ => preg_match($regex, $customer->getEmail()) === 1,
             Rule::OPERATOR_NEQ => preg_match($regex, $customer->getEmail()) !== 1,
-            default => throw new UnsupportedOperatorException($this->operator, self::class),
+            default => throw CustomerException::unsupportedOperator($this->operator, self::class),
         };
     }
 

--- a/tests/unit/Core/Checkout/Customer/CustomerExceptionTest.php
+++ b/tests/unit/Core/Checkout/Customer/CustomerExceptionTest.php
@@ -1,0 +1,317 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Customer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedValueException;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[Package('checkout')]
+#[CoversClass(CustomerException::class)]
+class CustomerExceptionTest extends TestCase
+{
+    public function testCustomerGroupNotFound(): void
+    {
+        $exception = CustomerException::customerGroupNotFound('id-1');
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_GROUP_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Could not find customer group with id "id-1"', $exception->getMessage());
+        static::assertSame(['entity' => 'customer group', 'field' => 'id', 'value' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testGroupRequestNotFound(): void
+    {
+        $exception = CustomerException::groupRequestNotFound('id-1');
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_GROUP_REQUEST_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Group request for customer "id-1" is not found', $exception->getMessage());
+        static::assertSame(['id' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testCustomersNotFound(): void
+    {
+        $exception = CustomerException::customersNotFound(['id-1', 'id-2']);
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMERS_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('These customers "id-1, id-2" are not found', $exception->getMessage());
+        static::assertSame(['ids' => 'id-1, id-2'], $exception->getParameters());
+    }
+
+    public function testCustomerNotLoggedIn(): void
+    {
+        $exception = CustomerException::customerNotLoggedIn();
+        static::assertSame(Response::HTTP_FORBIDDEN, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_NOT_LOGGED_IN, $exception->getErrorCode());
+        static::assertSame('Customer is not logged in.', $exception->getMessage());
+        static::assertEmpty($exception->getParameters());
+    }
+
+    public function testDownloadFileNotFound(): void
+    {
+        $exception = CustomerException::downloadFileNotFound('id-1');
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(CustomerException::LINE_ITEM_DOWNLOAD_FILE_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Line item download file with id "id-1" not found.', $exception->getMessage());
+        static::assertSame(['downloadId' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testCustomerIdsParameterIsMissing(): void
+    {
+        $exception = CustomerException::customerIdsParameterIsMissing();
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_IDS_PARAMETER_IS_MISSING, $exception->getErrorCode());
+        static::assertSame('Parameter "customerIds" is missing.', $exception->getMessage());
+        static::assertEmpty($exception->getParameters());
+    }
+
+    public function testUnknownPaymentMethod(): void
+    {
+        $exception = CustomerException::unknownPaymentMethod('id-1');
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_CHANGE_PAYMENT_ERROR, $exception->getErrorCode());
+        static::assertSame('Change Payment to method id-1 not possible.', $exception->getMessage());
+        static::assertSame(['paymentMethodId' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testProductIdsParameterIsMissing(): void
+    {
+        $exception = CustomerException::productIdsParameterIsMissing();
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::PRODUCT_IDS_PARAMETER_IS_MISSING, $exception->getErrorCode());
+        static::assertSame('Parameter "productIds" is missing.', $exception->getMessage());
+        static::assertEmpty($exception->getParameters());
+    }
+
+    public function testAddressNotFound(): void
+    {
+        $exception = CustomerException::addressNotFound('id-1');
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_ADDRESS_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Customer address with id "id-1" not found.', $exception->getMessage());
+        static::assertSame(['addressId' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testBadCredentials(): void
+    {
+        $exception = CustomerException::badCredentials();
+        static::assertSame(Response::HTTP_UNAUTHORIZED, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_AUTH_BAD_CREDENTIALS, $exception->getErrorCode());
+        static::assertSame('Invalid username and/or password.', $exception->getMessage());
+        static::assertEmpty($exception->getParameters());
+    }
+
+    public function testCannotDeleteActiveAddress(): void
+    {
+        $exception = CustomerException::cannotDeleteActiveAddress('id-1');
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_ADDRESS_IS_ACTIVE, $exception->getErrorCode());
+        static::assertSame('Customer address with id "id-1" is an active address and cannot be deleted.', $exception->getMessage());
+        static::assertSame(['addressId' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testCannotDeleteDefaultAddress(): void
+    {
+        $exception = CustomerException::cannotDeleteDefaultAddress('id-1');
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_ADDRESS_IS_DEFAULT, $exception->getErrorCode());
+        static::assertSame('Customer address with id "id-1" is a default address and cannot be deleted.', $exception->getMessage());
+        static::assertSame(['addressId' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testCustomerAlreadyConfirmed(): void
+    {
+        $exception = CustomerException::customerAlreadyConfirmed('id-1');
+        static::assertSame(Response::HTTP_PRECONDITION_FAILED, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_IS_ALREADY_CONFIRMED, $exception->getErrorCode());
+        static::assertSame('The customer with the id "id-1" is already confirmed.', $exception->getMessage());
+        static::assertSame(['customerId' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testCustomerGroupRegistrationConfigurationNotFound(): void
+    {
+        $exception = CustomerException::customerGroupRegistrationConfigurationNotFound('id-1');
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_GROUP_REGISTRATION_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Customer group registration for id id-1 not found.', $exception->getMessage());
+        static::assertSame(['customerGroupId' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testCustomerNotFoundByHash(): void
+    {
+        $exception = CustomerException::customerNotFoundByHash('e9c8985e0b0f8ec20a16ac9ffd0m');
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_NOT_FOUND_BY_HASH, $exception->getErrorCode());
+        static::assertSame('No matching customer for the hash "e9c8985e0b0f8ec20a16ac9ffd0m" was found.', $exception->getMessage());
+        static::assertSame(['hash' => 'e9c8985e0b0f8ec20a16ac9ffd0m'], $exception->getParameters());
+    }
+
+    public function testCustomerNotFoundByIdException(): void
+    {
+        $exception = CustomerException::customerNotFoundByIdException('id-1');
+        static::assertSame(Response::HTTP_UNAUTHORIZED, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_NOT_FOUND_BY_ID, $exception->getErrorCode());
+        static::assertSame('No matching customer for the id "id-1" was found.', $exception->getMessage());
+        static::assertSame(['id' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testCustomerNotFound(): void
+    {
+        $exception = CustomerException::customerNotFound('abc@com');
+        static::assertSame(Response::HTTP_UNAUTHORIZED, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('No matching customer for the email "abc@com" was found.', $exception->getMessage());
+        static::assertSame(['email' => 'abc@com'], $exception->getParameters());
+    }
+
+    public function testCustomerRecoveryHashExpired(): void
+    {
+        $exception = CustomerException::customerRecoveryHashExpired('e9c8985e0b0f8ec20a16ac9ffd0m');
+        static::assertSame(Response::HTTP_GONE, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_RECOVERY_HASH_EXPIRED, $exception->getErrorCode());
+        static::assertSame('The hash "e9c8985e0b0f8ec20a16ac9ffd0m" is expired.', $exception->getMessage());
+        static::assertSame(['hash' => 'e9c8985e0b0f8ec20a16ac9ffd0m'], $exception->getParameters());
+    }
+
+    public function testCustomerWishlistNotActivated(): void
+    {
+        $exception = CustomerException::customerWishlistNotActivated();
+        static::assertSame(Response::HTTP_FORBIDDEN, $exception->getStatusCode());
+        static::assertSame(CustomerException::WISHLIST_IS_NOT_ACTIVATED, $exception->getErrorCode());
+        static::assertSame('Wishlist is not activated!', $exception->getMessage());
+        static::assertEmpty($exception->getParameters());
+    }
+
+    public function testCustomerWishlistNotFound(): void
+    {
+        $exception = CustomerException::customerWishlistNotFound();
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(CustomerException::WISHLIST_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Wishlist for this customer was not found.', $exception->getMessage());
+        static::assertEmpty($exception->getParameters());
+    }
+
+    public function testDuplicateWishlistProduct(): void
+    {
+        $exception = CustomerException::duplicateWishlistProduct();
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::DUPLICATE_WISHLIST_PRODUCT, $exception->getErrorCode());
+        static::assertSame('Product already added in wishlist', $exception->getMessage());
+        static::assertEmpty($exception->getParameters());
+    }
+
+    public function testLegacyPasswordEncoderNotFound(): void
+    {
+        $exception = CustomerException::legacyPasswordEncoderNotFound('encoder');
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::LEGACY_PASSWORD_ENCODER_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Could not find encoder with name "encoder"', $exception->getMessage());
+        static::assertSame(['entity' => 'encoder', 'field' => 'name', 'value' => 'encoder'], $exception->getParameters());
+    }
+
+    public function testNoHashProvided(): void
+    {
+        $exception = CustomerException::noHashProvided();
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(CustomerException::NO_HASH_PROVIDED, $exception->getErrorCode());
+        static::assertSame('The given hash is empty.', $exception->getMessage());
+        static::assertEmpty($exception->getParameters());
+    }
+
+    public function testWishlistProductNotFound(): void
+    {
+        $exception = CustomerException::wishlistProductNotFound('id-1');
+        static::assertSame(Response::HTTP_NOT_FOUND, $exception->getStatusCode());
+        static::assertSame(CustomerException::WISHLIST_PRODUCT_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Could not find wishlist product with id "id-1"', $exception->getMessage());
+        static::assertSame(['entity' => 'wishlist product', 'field' => 'id', 'value' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testCustomerOptinNotCompleted(): void
+    {
+        $exception = CustomerException::customerOptinNotCompleted('id-1');
+        static::assertSame(Response::HTTP_UNAUTHORIZED, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_OPTIN_NOT_COMPLETED, $exception->getErrorCode());
+        static::assertSame('The customer with the id "id-1" has not completed the opt-in.', $exception->getMessage());
+        static::assertSame(['customerId' => 'id-1'], $exception->getParameters());
+        static::assertSame('account.doubleOptinAccountAlert', $exception->getSnippetKey());
+    }
+
+    public function testCustomerAuthThrottledException(): void
+    {
+        $exception = CustomerException::customerAuthThrottledException(100);
+        static::assertSame(Response::HTTP_TOO_MANY_REQUESTS, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_AUTH_THROTTLED, $exception->getErrorCode());
+        static::assertSame('Customer auth throttled for 100 seconds.', $exception->getMessage());
+        static::assertSame(100, $exception->getWaitTime());
+    }
+
+    public function testGuestAccountInvalidAuth(): void
+    {
+        $exception = CustomerException::guestAccountInvalidAuth();
+        static::assertSame(Response::HTTP_FORBIDDEN, $exception->getStatusCode());
+        static::assertSame(CustomerException::CUSTOMER_GUEST_AUTH_INVALID, $exception->getErrorCode());
+        static::assertSame('Guest account is not allowed to login', $exception->getMessage());
+        static::assertEmpty($exception->getParameters());
+    }
+
+    public function testCountryNotFound(): void
+    {
+        $exception = CustomerException::countryNotFound('id-1');
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::COUNTRY_NOT_FOUND, $exception->getErrorCode());
+        static::assertSame('Country with id "id-1" not found.', $exception->getMessage());
+        static::assertSame(['countryId' => 'id-1'], $exception->getParameters());
+    }
+
+    public function testUnsupportedOperator(): void
+    {
+        $exception = CustomerException::unsupportedOperator('$', 'testClass');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::OPERATOR_NOT_SUPPORTED, $exception->getErrorCode());
+        static::assertSame('Unsupported operator $ in testClass', $exception->getMessage());
+        static::assertSame(['operator' => '$', 'class' => 'testClass'], $exception->getParameters());
+    }
+
+    public function testUnsupportedValue(): void
+    {
+        $exception = CustomerException::unsupportedValue('badType', 'testClass');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame(CustomerException::VALUE_NOT_SUPPORTED, $exception->getErrorCode());
+        static::assertSame('Unsupported value of type badType in testClass', $exception->getMessage());
+        static::assertSame(['type' => 'badType', 'class' => 'testClass'], $exception->getParameters());
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testUnsupportedOperatorDeprecated(): void
+    {
+        $exception = CustomerException::unsupportedOperator('$', 'testClass');
+
+        static::assertInstanceOf(UnsupportedOperatorException::class, $exception);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame('CONTENT__RULE_OPERATOR_NOT_SUPPORTED', $exception->getErrorCode());
+        static::assertSame('Unsupported operator $ in testClass', $exception->getMessage());
+        static::assertSame(['operator' => '$', 'class' => 'testClass'], $exception->getParameters());
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testUnsupportedValueDeprecated(): void
+    {
+        $exception = CustomerException::unsupportedValue('badType', 'testClass');
+
+        static::assertInstanceOf(UnsupportedValueException::class, $exception);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame('CONTENT__RULE_VALUE_NOT_SUPPORTED', $exception->getErrorCode());
+        static::assertSame('Unsupported value of type badType in testClass', $exception->getMessage());
+        static::assertSame(['type' => 'badType', 'class' => 'testClass'], $exception->getParameters());
+    }
+}

--- a/tests/unit/Core/Checkout/Customer/Rule/EmailRuleTest.php
+++ b/tests/unit/Core/Checkout/Customer/Rule/EmailRuleTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Customer\Rule;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\CheckoutRuleScope;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Checkout\Customer\CustomerException;
+use Shopware\Core\Checkout\Customer\Rule\EmailRule;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Rule\Rule;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+
+/**
+ * @internal
+ */
+#[Package('fundamentals@after-sales')]
+#[CoversClass(EmailRule::class)]
+#[Group('rules')]
+class EmailRuleTest extends TestCase
+{
+    private EmailRule $rule;
+
+    protected function setUp(): void
+    {
+        $this->rule = new EmailRule();
+    }
+
+    public function testRuleMatchThrowsAndExceptionWhenNoCustomerEmailIsProvided(): void
+    {
+        $this->expectExceptionObject(CustomerException::unsupportedValue(\gettype(null), EmailRule::class));
+
+        $customer = new CustomerEntity();
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getCustomer')->willReturn($customer);
+
+        $scope = new CheckoutRuleScope($salesChannelContext);
+        $this->rule->assign(['email' => null, 'operator' => Rule::OPERATOR_EQ]);
+
+        $this->rule->match($scope);
+    }
+
+    public function testRuleMatchThrowsAndExceptionWhenOperatorIsNotSupported(): void
+    {
+        $this->expectExceptionObject(CustomerException::unsupportedOperator(Rule::OPERATOR_LTE, EmailRule::class));
+
+        $customer = new CustomerEntity();
+        $customer->setEmail('*');
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getCustomer')->willReturn($customer);
+
+        $scope = new CheckoutRuleScope($salesChannelContext);
+        $this->rule->assign(['email' => '*', 'operator' => Rule::OPERATOR_LTE]);
+
+        $this->rule->match($scope);
+    }
+}


### PR DESCRIPTION
Prepare phpstan upgrade with fixing domain exception previously not detected inside `match(` (phpstan 2.0 will detect it)