### PR TITLE
chore: prepare phpstan upgrade domain exception CartException

### DIFF
--- a/src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
+++ b/src/Core/Checkout/Cart/Delivery/Struct/DeliveryDate.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Cart\Delivery\Struct;
 
+use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
@@ -48,7 +49,7 @@ class DeliveryDate extends Struct
                 self::create('P' . $deliveryTime->getMin() . 'Y'),
                 self::create('P' . $deliveryTime->getMax() . 'Y')
             ),
-            default => throw new \RuntimeException(\sprintf('Not supported unit %s', $deliveryTime->getUnit())),
+            default => throw CartException::deliveryDateNotSupportedUnit($deliveryTime->getUnit()),
         };
     }
 

--- a/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
+++ b/src/Core/Checkout/Cart/Rule/LineItemCustomFieldRule.php
@@ -2,10 +2,10 @@
 
 namespace Shopware\Core\Checkout\Cart\Rule;
 
+use Shopware\Core\Checkout\Cart\CartException;
 use Shopware\Core\Checkout\Cart\LineItem\LineItem;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Rule\CustomFieldRule;
-use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
 use Shopware\Core\Framework\Rule\Rule;
 use Shopware\Core\Framework\Rule\RuleComparison;
 use Shopware\Core\Framework\Rule\RuleScope;
@@ -40,9 +40,6 @@ class LineItemCustomFieldRule extends Rule
         parent::__construct();
     }
 
-    /**
-     * @throws UnsupportedOperatorException
-     */
     public function match(RuleScope $scope): bool
     {
         if ($scope instanceof LineItemScope) {
@@ -70,9 +67,6 @@ class LineItemCustomFieldRule extends Rule
         return CustomFieldRule::getConstraints($this->renderedField);
     }
 
-    /**
-     * @throws UnsupportedOperatorException
-     */
     private function isCustomFieldValid(LineItem $lineItem): bool
     {
         $customFields = $lineItem->getPayloadValue('customFields');
@@ -106,7 +100,7 @@ class LineItemCustomFieldRule extends Rule
             self::OPERATOR_EQ => $actual === $expected,
             self::OPERATOR_GT => $actual > $expected,
             self::OPERATOR_LT => $actual < $expected,
-            default => throw new UnsupportedOperatorException($this->operator, self::class),
+            default => throw CartException::unsupportedOperator($this->operator, self::class),
         };
     }
 }

--- a/tests/unit/Core/Checkout/Cart/CartExceptionTest.php
+++ b/tests/unit/Core/Checkout/Cart/CartExceptionTest.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\CartException;
+use Shopware\Core\Framework\Rule\Exception\UnsupportedOperatorException;
+use Shopware\Core\Test\Annotation\DisabledFeatures;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * @internal
+ */
+#[CoversClass(CartException::class)]
+class CartExceptionTest extends TestCase
+{
+    public function testInvalidPriceFieldType(): void
+    {
+        $e = CartException::invalidPriceFieldTypeException('badType');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(CartException::INVALID_PRICE_FIELD_TYPE, $e->getErrorCode());
+        static::assertSame('The price field does not contain a valid "type" value. Received badType', $e->getMessage());
+    }
+
+    public function testDeliveryDateNotSupportedUnit(): void
+    {
+        $e = CartException::deliveryDateNotSupportedUnit('badUnit');
+
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $e->getStatusCode());
+        static::assertSame(CartException::CART_DELIVERY_DATE_NOT_SUPPORTED_UNIT, $e->getErrorCode());
+        static::assertSame('Not supported unit badUnit', $e->getMessage());
+    }
+
+    public function testShippingMethodNotFound(): void
+    {
+        $e = CartException::shippingMethodNotFound('shipping-method-id');
+        static::assertSame('Could not find shipping method with id "shipping-method-id"', $e->getMessage());
+    }
+
+    public function testUnsupportedOperator(): void
+    {
+        $e = CartException::unsupportedOperator('$', 'testClass');
+
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(CartException::RULE_OPERATOR_NOT_SUPPORTED, $e->getErrorCode());
+        static::assertSame('Unsupported operator $ in testClass', $e->getMessage());
+    }
+
+    #[DisabledFeatures(['v6.8.0.0'])]
+    public function testUnsupportedOperatorDeprecated(): void
+    {
+        $e = CartException::unsupportedOperator('$', 'testClass');
+
+        static::assertInstanceOf(UnsupportedOperatorException::class, $e);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame('CONTENT__RULE_OPERATOR_NOT_SUPPORTED', $e->getErrorCode());
+        static::assertSame('Unsupported operator $ in testClass', $e->getMessage());
+    }
+
+    public function testWrongCartDataType(): void
+    {
+        $fieldKey = 'some-field';
+        $expectedType = 'string';
+        $e = CartException::wrongCartDataType($fieldKey, $expectedType);
+        static::assertSame(Response::HTTP_BAD_REQUEST, $e->getStatusCode());
+        static::assertSame(CartException::CART_WRONG_DATA_TYPE, $e->getErrorCode());
+        static::assertSame('Cart data some-field does not match expected type "string"', $e->getMessage());
+    }
+}

--- a/tests/unit/Core/Checkout/Cart/Delivery/Struct/DeliveryDateTest.php
+++ b/tests/unit/Core/Checkout/Cart/Delivery/Struct/DeliveryDateTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Checkout\Cart\Delivery\Struct;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Cart\CartException;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryDate;
+use Shopware\Core\Checkout\Cart\Delivery\Struct\DeliveryTime;
+use Shopware\Core\Framework\Log\Package;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(DeliveryDate::class)]
+class DeliveryDateTest extends TestCase
+{
+    public function testCreateFromDeliveryTimeThrowsExceptionWhenUnsupportedUnit(): void
+    {
+        $deliveryTime = new DeliveryTime();
+        $deliveryTime->setUnit('$unsupportedUnit');
+
+        static::expectExceptionObject(CartException::deliveryDateNotSupportedUnit($deliveryTime->getUnit()));
+
+        DeliveryDate::createFromDeliveryTime($deliveryTime);
+    }
+}


### PR DESCRIPTION
Prepare phpstan upgrade with fixing domain exception previously not detected inside `match(` (phpstan 2.0 will detect it)