### PR TITLE
fix: missing mt-url-field import

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
@@ -272,6 +272,7 @@ export default class VueAdapter extends ViewAdapter {
             'MtModal',
             'MtModalRoot',
             'MtModalClose',
+            'MtUrlField',
         ];
 
         meteorComponents.forEach((componentName) => {

--- a/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
+++ b/src/Administration/Resources/app/administration/src/app/assets/scss/global.scss
@@ -110,3 +110,10 @@ a[target="_blank"]:not(.sw-external-link, .sw-internal-link, .mt-button) {
         min-height: 45px !important;
     }
 }
+
+// TODO: remove when the issue is fixed https://github.com/shopware/meteor/issues/563
+.mt-url-field {
+    &__protocol-toggle * {
+        white-space: nowrap;
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?
The `mt-url-field` is not imported so it is not rendered properly.

### 2. What does this change do, exactly?
- Add the import of the missing component
- Also fixes some issue with the CSS of the component


### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Storefront -> Domains
2. Add a new Domain
3. In the modal the first input is a URL field
