### PR TITLE
refactor(schema): bump OpenAPI version to 3.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -144,7 +144,7 @@ jobs:
         run: |
           echo "PATH=${{ env.NPM_CONFIG_PREFIX }}/bin:$PATH" >> $GITHUB_ENV
           curl localhost:8000/
-          npm i -g @redocly/cli@1.31.3 @shopware/api-gen
+          npm i -g @redocly/cli@1.32.1 @shopware/api-gen
           export STOREFRONT_ID=$(bin/console sales-channel:list --output json | jq -r '.[] | select(.name == "Storefront") | .id')
           export OPENAPI_ACCESS_KEY=$(mysql -u root -h 127.0.0.1 shopware -se "SELECT access_key FROM sales_channel WHERE id = UNHEX(\"${STOREFRONT_ID}\")";)
           echo -e "OPENAPI_JSON_URL=http://localhost:8000\nSHOPWARE_ADMIN_USERNAME=admin\nSHOPWARE_ADMIN_PASSWORD=shopware\nOPENAPI_ACCESS_KEY=${OPENAPI_ACCESS_KEY}" > .env
@@ -154,10 +154,12 @@ jobs:
         run: |
           api-gen loadSchema --apiType=store && api-gen generate --apiType=store
 
-      - uses: actions/upload-artifact@v4.6.1
+      - name: Upload OpenApi StoreAPI schema
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: storeApiSchema.json
           path: ./api-types/storeApiSchema.json
+          retention-days: 1
 
       - name: Lint OpenApi StoreAPI schema
         run: |
@@ -168,10 +170,12 @@ jobs:
           api-gen loadSchema --apiType=admin && api-gen generate --apiType=admin
           redocly lint --skip-rule operation-4xx-response --skip-rule no-server-example.com --skip-rule no-unused-components ./api-types/adminApiSchema.json
 
-      - uses: actions/upload-artifact@v4.6.1
+      - name: Upload OpenApi AdminAPI schema
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: adminApiSchema.json
           path: ./api-types/adminApiSchema.json
+          retention-days: 1
 
       - name: Lint OpenApi AdminAPI schema
         run: |

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -112,16 +112,16 @@ jobs:
           git remote add bc-checker-upstream https://github.com/shopware/platform.git
           git fetch bc-checker-upstream
       - name: BC Checker PR
-#       temporarily run against trunk, until we have a RC release tag
+        #       temporarily run against trunk, until we have a RC release tag
         if: github.event_name == 'pull_request' && !contains(github.base_ref, '/feature/')
         run: composer run bc-check -- --from="origin/${{ github.base_ref }}"
-#       ToDo: Activate BC checker for latest tag after RC release again
-#       - name: BC Checker lastest tag
-#         if: github.event_name != 'pull_request'
-#         run: composer run bc-check
-#       - name: BC Checker PR
-#         if: github.event_name == 'pull_request' && !contains(github.base_ref, '/feature/')
-#         run: composer run bc-check -- --from="origin/${{ github.base_ref }}"
+  #       ToDo: Activate BC checker for latest tag after RC release again
+  #       - name: BC Checker lastest tag
+  #         if: github.event_name != 'pull_request'
+  #         run: composer run bc-check
+  #       - name: BC Checker PR
+  #         if: github.event_name == 'pull_request' && !contains(github.base_ref, '/feature/')
+  #         run: composer run bc-check -- --from="origin/${{ github.base_ref }}"
 
   openapi-lint:
     runs-on: ubuntu-24.04
@@ -150,14 +150,31 @@ jobs:
           echo -e "OPENAPI_JSON_URL=http://localhost:8000\nSHOPWARE_ADMIN_USERNAME=admin\nSHOPWARE_ADMIN_PASSWORD=shopware\nOPENAPI_ACCESS_KEY=${OPENAPI_ACCESS_KEY}" > .env
           cat .env
 
-      - name: Generate & Lint OpenApi StoreAPI schema
+      - name: Generate OpenApi StoreAPI schema
         run: |
           api-gen loadSchema --apiType=store && api-gen generate --apiType=store
+
+      - uses: actions/upload-artifact@v4.6.1
+        with:
+          name: storeApiSchema.json
+          path: ./api-types/storeApiSchema.json
+
+      - name: Lint OpenApi StoreAPI schema
+        run: |
           redocly lint --skip-rule operation-4xx-response --skip-rule no-server-example.com --skip-rule no-unused-components ./api-types/storeApiSchema.json
 
       - name: Generate & Lint OpenApi API schema
         run: |
           api-gen loadSchema --apiType=admin && api-gen generate --apiType=admin
+          redocly lint --skip-rule operation-4xx-response --skip-rule no-server-example.com --skip-rule no-unused-components ./api-types/adminApiSchema.json
+
+      - uses: actions/upload-artifact@v4.6.1
+        with:
+          name: adminApiSchema.json
+          path: ./api-types/adminApiSchema.json
+
+      - name: Lint OpenApi AdminAPI schema
+        run: |
           redocly lint --skip-rule operation-4xx-response --skip-rule no-server-example.com --skip-rule no-unused-components ./api-types/adminApiSchema.json
 
   phpunit:
@@ -265,19 +282,19 @@ jobs:
   php-check:
     if: always()
     needs:
-    - lint
-    - phpstan
-    - openapi-lint
-    - phpunit
-    - license-check
-    - composer-audit
-    - bc-checker
+      - lint
+      - phpstan
+      - openapi-lint
+      - phpunit
+      - license-check
+      - composer-audit
+      - bc-checker
 
     runs-on: Ubuntu-latest
     steps:
-    - name: Decide whether the needed jobs succeeded or failed
-      uses: re-actors/alls-green@release/v1
-      with:
-        # allowed-failures: docs, linters
-        # allowed-skips: non-voting-flaky-job
-        jobs: ${{ toJSON(needs) }}
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          # allowed-failures: docs, linters
+          # allowed-skips: non-voting-flaky-job
+          jobs: ${{ toJSON(needs) }}

--- a/src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Generator.php
@@ -54,7 +54,9 @@ class OpenApi3Generator implements ApiDefinitionGeneratorInterface
     {
         $forSalesChannel = $this->containsSalesChannelDefinition($definitions);
 
-        $openApi = new OpenApi([]);
+        $openApi = new OpenApi([
+            'openapi' => '3.1.0',
+        ]);
         $this->openApiBuilder->enrich($openApi, $api);
 
         ksort($definitions);

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/responses/OpenApi3Response.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/responses/OpenApi3Response.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/Criteria.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/Criteria.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/OAuthScopes.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/OAuthScopes.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/Price.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/Price.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/businessEventsResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/businessEventsResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/flowBuilderActionsResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/flowBuilderActionsResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/infoConfigResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/infoConfigResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cache.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cache.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/cache": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cache_info.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cache_info.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/cache_info": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cleanup.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/cleanup.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/cleanup": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/config.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/config.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_info\/config": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/container_cache.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/container_cache.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/container_cache": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/customer_impersonation.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/customer_impersonation.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_proxy\/generate-imitate-customer-token": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/document.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/document.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/document\/{documentId}\/{deepLinkCode}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/events.json.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/events.json.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_info\/events.json": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/flow-actions.json.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/flow-actions.json.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_info\/flow-actions.json": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/health_check.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/health_check.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_info\/health-check": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/index-products.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/index-products.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/index-products": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/index.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/index.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": [],
   "paths": {
     "\/_action\/index": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/indexing.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/indexing.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/indexing": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/info.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/info.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": {
         "title": "API Info Routes",
         "version": "1.0.0"

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/mail-template.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/mail-template.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/mail-template\/send": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/media.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/media.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/media\/{mediaId}\/upload": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/message-queue.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/message-queue.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/message-queue\/consume": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/number-range.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/number-range.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/number-range\/reserve\/{type}\/{saleschannel}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/openapi3.json.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/openapi3.json.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_info\/openapi3.json": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": [],
   "paths": {
     "/_action/order/document/download": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order_address.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order_address.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/order\/{orderId}\/order-address": {
@@ -42,9 +42,15 @@
                                                     "description": "The type of the address"
                                                 },
                                                 "deliveryId": {
-                                                    "type": "string",
                                                     "description": "The ID of the delivery (optional)",
-                                                    "nullable": true
+                                                    "oneOf": [
+                                                        {
+                                                            "type": "string"
+                                                        },
+                                                        {
+                                                            "type": "null"
+                                                        }
+                                                    ]
                                                 }
                                             },
                                             "required": ["customerAddressId", "type"]

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order_delivery.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order_delivery.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/order_delivery\/{orderDeliveryId}\/state\/{transition}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order_transaction.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order_transaction.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/order_transaction\/{orderTransactionId}\/state\/{transition}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order_transaction_capture_refund.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order_transaction_capture_refund.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/order_transaction_capture_refund\/{refundId}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/scheduled-task.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/scheduled-task.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/scheduled-task\/run": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sync.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/sync.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/sync": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/token.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/token.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/oauth/token": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/version.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/paths/version.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_info\/version": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/tags/tags.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/AdminApi/tags/tags.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "tags": [

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/responses/ContextTokenResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/responses/ContextTokenResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/responses/OpenApi3Response.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/responses/OpenApi3Response.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/AccountNewsletterRecipient.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/AccountNewsletterRecipient.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/AggregationBuckets.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/AggregationBuckets.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/AggregationMetrics.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/AggregationMetrics.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Breadcrumb.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Breadcrumb.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CalculatedPrice.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CalculatedPrice.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {
@@ -69,25 +69,39 @@
                         "type": "number"
                     },
                     "regulationPrice": {
-                        "type": "object",
-                        "properties": {
-                            "price": {
-                                "type": "number"
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "price": {
+                                        "type": "number"
+                                    },
+                                    "apiAlias": {
+                                        "type": "string",
+                                        "enum": [
+                                            "cart_regulation_price"
+                                        ]
+                                    }
+                                }
                             },
-                            "apiAlias": {
-                                "type": "string",
-                                "enum": ["cart_regulation_price"]
+                            {
+                                "type": "null"
                             }
-                        },
-                        "nullable": true
+                        ]
                     },
                     "hasRange": {
                         "type": "boolean"
                     },
                     "variantId": {
-                        "type": "string",
-                        "format": "^[0-9a-f]{32}$",
-                        "nullable": true
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "^[0-9a-f]{32}$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     },
                     "apiAlias": {
                         "type": "string",

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Cart.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Cart.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {
@@ -57,19 +57,37 @@
                         "type": "boolean"
                     },
                     "customerComment": {
-                        "type": "string",
                         "description": "A comment that can be added to the cart.",
-                        "nullable": true
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     },
                     "affiliateCode": {
-                        "type": "string",
                         "description": "An affiliate tracking code",
-                        "nullable": true
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     },
                     "campaignCode": {
-                        "type": "string",
                         "description": "A campaign tracking code",
-                        "nullable": true
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     }
                 }
             }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartDelivery.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartDelivery.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartDeliveryInformation.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartDeliveryInformation.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartDeliveryPosition.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartDeliveryPosition.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartError.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartError.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartItems.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartItems.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartListPrice.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartListPrice.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartPriceQuantity.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartPriceQuantity.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartPriceReference.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CartPriceReference.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {
@@ -34,25 +34,39 @@
                         ]
                     },
                     "regulationPrice": {
-                        "type": "object",
-                        "properties": {
-                            "price": {
-                                "type": "number"
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "price": {
+                                        "type": "number"
+                                    },
+                                    "apiAlias": {
+                                        "type": "string",
+                                        "enum": [
+                                            "cart_regulation_price"
+                                        ]
+                                    }
+                                }
                             },
-                            "apiAlias": {
-                                "type": "string",
-                                "enum": ["cart_regulation_price"]
+                            {
+                                "type": "null"
                             }
-                        },
-                        "nullable": true
+                        ]
                     },
                     "hasRange": {
                         "type": "boolean"
                     },
                     "variantId": {
-                        "type": "string",
-                        "format": "^[0-9a-f]{32}$",
-                        "nullable": true
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "^[0-9a-f]{32}$"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     }
                 },
                 "required": [

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Category.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Category.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CmsBlock.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CmsBlock.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CmsPage.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CmsPage.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CmsSection.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CmsSection.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Criteria.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Criteria.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CrossSellingElement.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CrossSellingElement.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CrossSellingElementCollection.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CrossSellingElementCollection.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Customer.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Customer.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CustomerAddress.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CustomerAddress.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CustomerAddressBody.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CustomerAddressBody.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CustomerAddressRead.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CustomerAddressRead.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {
@@ -22,16 +22,28 @@
                         "format": "date-time"
                     },
                     "updatedAt": {
-                        "type": "string",
-                        "format": "date-time",
-                        "nullable": true
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     },
                     "country": {
                         "$ref": "#/components/schemas/Country"
                     },
                     "countryState": {
-                        "$ref": "#/components/schemas/CountryState",
-                        "nullable": true
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/CountryState"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     },
                     "salutation": {
                         "$ref": "#/components/schemas/Salutation"

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CustomerGroup.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/CustomerGroup.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Document.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Document.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/EntitySearchResult.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/EntitySearchResult.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/FindProductVariantRouteResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/FindProductVariantRouteResponse.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": [],
   "paths": [],
   "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/LandingPage.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/LandingPage.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/LineItem.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/LineItem.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {
@@ -114,17 +114,25 @@
                                 ]
                             },
                             "regulationPrice": {
-                                "type": "object",
-                                "properties": {
-                                    "price": {
-                                        "type": "number"
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "price": {
+                                                "type": "number"
+                                            },
+                                            "apiAlias": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "cart_regulation_price"
+                                                ]
+                                            }
+                                        }
                                     },
-                                    "apiAlias": {
-                                        "type": "string",
-                                        "enum": ["cart_regulation_price"]
+                                    {
+                                        "type": "null"
                                     }
-                                },
-                                "nullable": true
+                                ]
                             },
                             "totalPrice": {
                                 "type": "number"

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Media.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Media.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/MediaThumbnail.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/MediaThumbnail.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/NavigationRouteResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/NavigationRouteResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/NavigationType.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/NavigationType.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Order.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Order.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/OrderLineItem.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/OrderLineItem.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/OrderLineItemDownload.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/OrderLineItemDownload.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/OrderRouteResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/OrderRouteResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Price.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Price.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Product.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Product.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {
@@ -16,13 +16,19 @@
                         "$ref": "#/components/schemas/Category"
                     },
                     "variantListingConfig": {
-                        "nullable": true,
-                        "type": "object",
-                        "properties": {
-                            "displayParent": {
-                                "type": "boolean"
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "displayParent": {
+                                        "type": "boolean"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "null"
                             }
-                        }
+                        ]
                     },
                     "calculatedPrice": {
                         "$ref": "#/components/schemas/CalculatedPrice"
@@ -75,24 +81,37 @@
                                         ]
                                     },
                                     "regulationPrice": {
-                                        "type": "object",
-                                        "properties": {
-                                            "price": {
-                                                "type": "number"
+                                        "oneOf": [
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "price": {
+                                                        "type": "number"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "price"
+                                                ]
+                                            },
+                                            {
+                                                "type": "null"
                                             }
-                                        },
-                                        "required": ["price"],
-                                        "nullable": true
+                                        ]
                                     },
                                     "hasRange": {
                                         "type": "boolean"
                                     },
                                     "variantId": {
-                                        "type": "string",
-                                        "format": "",
-                                        "nullable": true
+                                        "oneOf": [
+                                            {
+                                                "type": "string",
+                                                "format": ""
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
                                     },
-
                                     "apiAlias": {
                                         "type": "string",
                                         "enum": ["calculated_cheapest_price"]

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductDetailResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductDetailResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductListingCriteria.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductListingCriteria.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {
@@ -87,8 +87,14 @@
                             },
                             "reduce-aggregations": {
                                 "description": "By sending the parameter `reduce-aggregations` , the post-filters that were applied by the customer, are also applied to the aggregations. This has the consequence that only values are returned in the aggregations that would lead to further filter results. This parameter is a flag, the value has no effect.",
-                                "type": "string",
-                                "nullable": true
+                                "oneOf": [
+                                    {
+                                        "type": "string"
+                                    },
+                                    {
+                                        "type": "null"
+                                    }
+                                ]
                             }
                         }
                     }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductListingFlags.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductListingFlags.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {
@@ -10,13 +10,25 @@
                 "properties": {
                     "no-aggregations": {
                         "description": "Resets all aggregations in the criteria. This parameter is a flag, the value has no effect.",
-                        "type": "string",
-                        "nullable": true
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     },
                     "only-aggregations": {
                         "description": "If this flag is set, no products are fetched. Sorting and associations are also ignored. This parameter is a flag, the value has no effect.",
-                        "type": "string",
-                        "nullable": true
+                        "oneOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
                     }
                 }
             }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductListingResult.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductListingResult.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {
@@ -41,8 +41,14 @@
                                         "required": ["min", "max"]
                                     },
                                     "rating": {
-                                        "type": "integer",
-                                        "nullable": true
+                                        "oneOf": [
+                                            {
+                                                "type": "integer"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ]
                                     },
                                     "shipping-free": {
                                         "type": "boolean",

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductMedia.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductMedia.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductReview.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ProductReview.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/PropertyGroupOption.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/PropertyGroupOption.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/SalesChannelContext.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/SalesChannelContext.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/SeoUrl.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/SeoUrl.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ShippingMethodPageRouteResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/ShippingMethodPageRouteResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Sitemap.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/Sitemap.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/SuccessResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/SuccessResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/WishlistLoadRouteResponse.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/WishlistLoadRouteResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/account.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/account.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/account/newsletter-recipient": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/app.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/app.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/app-system/{name}/generate-token": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/breadcrumb.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/breadcrumb.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "components": {
         "schemas": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/category.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/category.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/category": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/checkout.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/checkout.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/checkout/cart": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/cms.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/cms.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/cms/{id}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/contact-form.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/contact-form.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/contact-form": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/context.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/context.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/context": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/country-state.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/country-state.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/country-state/{countryId}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/country.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/country.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/country": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/currency.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/currency.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/currency": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/customer-group-registration.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/customer-group-registration.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/customer-group-registration/config/{customerGroupId}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/customer.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/customer.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/customer/wishlist/add/{productId}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/document.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/document.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/document/download/{documentId}/{deepLinkCode}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/handle-payment.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/handle-payment.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/handle-payment": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/info.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/info.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": {
         "title": "API Info Routes",
         "version": "1.0.0"

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/landing-page.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/landing-page.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/landing-page/{landingPageId}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/language.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/language.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/language": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/media.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/media.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/media": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/navigation.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/navigation.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/navigation/{activeId}/{rootId}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/newsletter.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/newsletter.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/newsletter/confirm": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/openapi3.json.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/openapi3.json.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_info\/openapi3.json": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/order.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/order.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/order/state/cancel": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/payment-method.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/payment-method.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/payment-method": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product-export.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product-export.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/product-export/{accessKey}/{fileName}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product-listing.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product-listing.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/product-listing/{categoryId}": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/product/{productId}/cross-selling": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/salutation.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/salutation.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/salutation": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/script.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/script.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/script/{hook}": {
@@ -24,16 +24,28 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "nullable": true
+                                    "oneOf": [
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ]
                                 }
                             },
                             "application/vnd.api+json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "nullable": true
+                                    "oneOf": [
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ]
                                 }
                             }
                         }
@@ -69,16 +81,28 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "nullable": true
+                                    "oneOf": [
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ]
                                 }
                             },
                             "application/vnd.api+json": {
                                 "schema": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "nullable": true
+                                    "oneOf": [
+                                        {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ]
                                 }
                             }
                         }

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/script.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/script.json
@@ -27,7 +27,7 @@
                                     "oneOf": [
                                         {
                                             "type": "object",
-                                            "additionalProperties": true,
+                                            "additionalProperties": true
                                         },
                                         {
                                             "type": "null"

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/search-suggest.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/search-suggest.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/search-suggest": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/search.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/search.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/search": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/seo-url.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/seo-url.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/seo-url": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/shipping-method.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/shipping-method.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/shipping-method": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/sitemap.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/sitemap.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "/sitemap": {

--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/tags/tags.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/tags/tags.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "tags": [

--- a/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/StoreApiGenerator.php
@@ -57,7 +57,9 @@ class StoreApiGenerator implements ApiDefinitionGeneratorInterface
 
     public function generate(array $definitions, string $api, string $apiType, ?string $bundleName): array
     {
-        $openApi = new OpenApi([]);
+        $openApi = new OpenApi([
+            'openapi' => '3.1.0',
+        ]);
         $this->openApiBuilder->enrich($openApi, $api);
 
         $forSalesChannel = $api === DefinitionService::STORE_API;

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/infoConfigResponse.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/AdminApi/components/schemas/infoConfigResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order_delivery.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/AdminApi/paths/order_delivery.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/order_delivery\/{orderDeliveryId}\/state\/{transition}": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/AdminApi/tags/tags.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/AdminApi/tags/tags.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "tags": [

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/infoConfigResponse.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/infoConfigResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/infoConfigResponse2.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/StoreApi/components/schemas/infoConfigResponse2.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/StoreApi/paths/order_delivery.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/StoreApi/paths/order_delivery.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/order_delivery\/{orderDeliveryId}\/state\/{transition}": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/StoreApi/tags/tags.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/Api/ApiDefinition/Generator/Schema/StoreApi/tags/tags.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "tags": [

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithApiSchema/Resources/Schema/AdminApi/components/schemas/infoConfigResponse.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithApiSchema/Resources/Schema/AdminApi/components/schemas/infoConfigResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithApiSchema/Resources/Schema/AdminApi/paths/order_delivery.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithApiSchema/Resources/Schema/AdminApi/paths/order_delivery.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/order_delivery\/{orderDeliveryId}\/state\/{transition}": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/infoConfigResponse.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/infoConfigResponse.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/infoConfigResponse2.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/infoConfigResponse2.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithApiSchema/Resources/Schema/StoreApi/paths/order_delivery.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithApiSchema/Resources/Schema/StoreApi/paths/order_delivery.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/order_delivery\/{orderDeliveryId}\/state\/{transition}": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithOverride/Resources/Schema/StoreApi/paths/order_delivery.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/BundleWithOverride/Resources/Schema/StoreApi/paths/order_delivery.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": {
         "\/_action\/order_delivery\/{orderDeliveryId}\/state\/{transition}": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/AdminApi/components/schemas/GetListBodyRequest.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/AdminApi/components/schemas/GetListBodyRequest.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/AdminApi/components/schemas/Presentation.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/AdminApi/components/schemas/Presentation.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/AdminApi/paths/presentation.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/AdminApi/paths/presentation.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": [],
   "paths": {
     "/search/guided-shopping-presentation": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/GetListBodyRequest.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/GetListBodyRequest.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/Presentation.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/Presentation.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
     "info": [],
     "paths": [],
     "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/Simple.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi/components/schemas/Simple.json
@@ -1,6 +1,6 @@
 
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": [],
   "paths": [],
   "components": {

--- a/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi/paths/presentation.json
+++ b/tests/unit/Core/Framework/Api/ApiDefinition/Generator/_fixtures/CustomBundleWithApiSchema/Resources/Schema/StoreApi/paths/presentation.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.0",
+  "openapi": "3.1.0",
   "info": [],
   "paths": {
     "/search/guided-shopping-presentation": {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

Bumping OpenAPI schema to 3.1 for proper linting

- Refactored old `nullable` definitions to `null` types.
- Bumping schema definitions in files (most of the file changes)
- bumping schema definition in generators
- upgraded redocly CLI to 1.32.1
- related downstream: https://github.com/shopware/SwagCommercial/pull/278