### PR TITLE
fix: Accessibility of keyboard navigation on mobile

### DIFF
--- a/changelog/_unreleased/2025-03-04-accessibility-via-mobile-keyboard-navigation.md
+++ b/changelog/_unreleased/2025-03-04-accessibility-via-mobile-keyboard-navigation.md
@@ -1,5 +1,5 @@
 ---
-title: Removed deprecated Twig filter "spaceless".
+title: Accessibility of keyboard navigation on mobile
 issue: NEXT-40778
 ---
 # Storefront

--- a/changelog/_unreleased/2025-03-04-accessibility-via-mobile-keyboard-navigation.md
+++ b/changelog/_unreleased/2025-03-04-accessibility-via-mobile-keyboard-navigation.md
@@ -1,0 +1,7 @@
+---
+title: Removed deprecated Twig filter "spaceless".
+issue: NEXT-40778
+---
+# Storefront
+* Changed `search-widget.plugin.js` to not add a `tabindex="-1"` to the search input on mobile, so it can be reached via keyboard.
+* Changed the `offcanvas.plugin.js` to always use the `click` event for close buttons, even on mobile, so keyboard navigation is possible.

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -204,7 +204,6 @@ export default class SearchWidgetPlugin extends Plugin {
     _focusInput() {
         if (this._toggleButton && !this._toggleButton.classList.contains(this.options.searchWidgetCollapseClass)) {
             this._toggleButton.blur(); // otherwise iOS won't focus the field.
-            this._inputField.setAttribute('tabindex', '-1');
             this._inputField.focus();
         }
 

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/offcanvas.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas/offcanvas.plugin.js
@@ -1,4 +1,3 @@
-import DeviceDetection from 'src/helper/device-detection.helper';
 import NativeEventEmitter from 'src/helper/emitter.helper';
 
 const OFF_CANVAS_CLASS = 'offcanvas';
@@ -134,7 +133,7 @@ class OffCanvasSingleton {
      * @private
      */
     _registerEvents(delay) {
-        const event = (DeviceDetection.isTouchDevice()) ? 'touchend' : 'click';
+        const event = 'click';
         const offCanvasElements = this.getOffCanvas();
 
         // Ensure OffCanvas is removed from the DOM and events are published.


### PR DESCRIPTION
### 1. Why is this change necessary?

Keyboard navigation also applies to mobile devices according to accessibility best practices. This change fixes two issues with mobile navigation. The first one addresses that the search is not accessible via keyboard (NEXT-40778). The second addresses the close button of the offcanvas menu, which did not work on touch devices via keyboard (NEXT-40779).

### 2. What does this change do, exactly?

* Changed `search-widget.plugin.js` to not add a `tabindex="-1"` to the search input on mobile, so it can be reached via keyboard.
* Changed the `offcanvas.plugin.js` to always use the `click` event for close buttons, even on mobile, so keyboard navigation is possible.

