### PR TITLE
ci: use one worker for ats again

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,7 +51,7 @@ jobs:
           php-version: ${{ matrix.php-version }}
           shard: ${{ matrix.shard }}
           shard-count: ${{ matrix.shard-count }}
-          workers: ${{ matrix.name != 'Install' && '2' || '1' }}
+          workers: 1
           install: ${{ matrix.name != 'Install' && 'true' || 'false' }}
           extra-options: ${{ matrix.name != 'Install' && '' || '--trace=on' }}
           use-currents: ${{ inputs.nightly == 'true' && matrix.php-version == '8.4' && !matrix.major && 'true' || '' }}


### PR DESCRIPTION
Too many tests are running into timeouts, because the execution got slower.

We should reduce the workers to 2 again, until we've improved the general performance