### PR TITLE
fix: usageKey needs to be be type of string

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-promotion-v2/component/sw-promotion-discount-component/index.js
@@ -287,7 +287,7 @@ export default {
             let i;
             for (i = 1; i < 10; i += 1) {
                 counts.push({
-                    key: i,
+                    key: i.toString(),
                     name: this.$tc('sw-promotion-v2.detail.conditions.filter.counter.SELECT', { count: i }, 0),
                 });
             }


### PR DESCRIPTION
`usageKey` needs to be type of string
https://github.com/shopware/shopware/blob/trunk/src/Core/Checkout/Promotion/Aggregate/PromotionDiscount/PromotionDiscountDefinition.php#L74