### PR TITLE
fix: sw-tree selecting a value when other value is selected issue

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/index.js
@@ -345,7 +345,7 @@ Component.register('sw-tree', {
 
         handleFocusIn(event) {
             // Check if focus in already in the tree on any tree item
-            if (event.target.classList.contains('sw-tree-item')) {
+            if (event.target.classList.contains('sw-tree-item') || event.target.classList.contains('sw-tree-item__toggle')) {
                 // If focus is already on a tree item, do nothing
                 return;
             }


### PR DESCRIPTION

### 1. Why is this change necessary?
We are currently using the sw-tree component to select the trigger in our Flow Builder feature.  
The problem is, that when trying to interact with the component again after selecting an item, the focus stays on the selected item until another option is selected. This leads to a jump to the currently focused item when the user tries to interact with something in the sw-tree and the currently focused item isn’t on the screen anymore. 

### 2. What does this change do, exactly?
Fixing the check if the element is already selected and adding a new element to check

### 3. Describe each step to reproduce the issue or behavior.
1. Go to Settings > Flow Builder
2. Add a new Flow
3. Select the Flow card next to General
4. Select the trigger State leave > Order transaction capture refund > State > Open
5. Open the trigger selection again and try to open the Checkout option

### 4. Please link to the relevant issues (if any).

- Jira issue: https://shopware.atlassian.net/browse/NEXT-40701

