### PR TITLE
fix: PHPStan array type hint errors in Script and Debug classes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,9 +20,6 @@ Please create a second pull request at https://github.com/shopware/docs
 <!-- Examples:
 - closes #123  - closes the issue #123 when the PR is merged
 - relates #123 - relates to the issue #123
-
-In case of issue existing only on Jira, link to the Jira issue.
-- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
 -->
 
 ### 5. Checklist

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,9 @@ Please create a second pull request at https://github.com/shopware/docs
 <!-- Examples:
 - closes #123  - closes the issue #123 when the PR is merged
 - relates #123 - relates to the issue #123
+
+In case of issue existing only on Jira, link to the Jira issue.
+- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
 -->
 
 ### 5. Checklist

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2206,31 +2206,6 @@ parameters:
 			path: src/Core/Framework/Rule/Rule.php
 
 		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Script\\\\Debugging\\\\Debug\\:\\:all\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/Script/Debugging/Debug.php
-
-		-
-			message: "#^Property Shopware\\\\Core\\\\Framework\\\\Script\\\\Debugging\\\\Debug\\:\\:\\$dumps type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/Script/Debugging/Debug.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Script\\\\Execution\\\\Script\\:\\:__construct\\(\\) has parameter \\$includes with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/Script/Execution/Script.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Script\\\\Execution\\\\Script\\:\\:__construct\\(\\) has parameter \\$twigOptions with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/Script/Execution/Script.php
-
-		-
-			message: "#^Method Shopware\\\\Core\\\\Framework\\\\Script\\\\Execution\\\\Script\\:\\:getTwigOptions\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Core/Framework/Script/Execution/Script.php
-
-		-
 			message: "#^Expected domain exception class Shopware\\\\Core\\\\Framework\\\\Store\\\\StoreException, got Shopware\\\\Core\\\\Framework\\\\Routing\\\\RoutingException$#"
 			count: 1
 			path: src/Core/Framework/Store/Api/ExtensionStoreActionsController.php

--- a/src/Core/Framework/Script/Debugging/Debug.php
+++ b/src/Core/Framework/Script/Debugging/Debug.php
@@ -7,6 +7,9 @@ use Shopware\Core\Framework\Log\Package;
 #[Package('framework')]
 class Debug
 {
+    /**
+     * @var array<string|int, mixed>
+     */
     protected array $dumps = [];
 
     public function dump(mixed $value, ?string $key = null): void
@@ -18,6 +21,9 @@ class Debug
         }
     }
 
+    /**
+     * @return array<string|int, mixed>
+     */
     public function all(): array
     {
         return $this->dumps;

--- a/src/Core/Framework/Script/Execution/Script.php
+++ b/src/Core/Framework/Script/Execution/Script.php
@@ -11,6 +11,10 @@ use Shopware\Core\Framework\Struct\Struct;
 #[Package('framework')]
 class Script extends Struct
 {
+    /**
+     * @param array<string, mixed> $twigOptions
+     * @param array<Script> $includes
+     */
     public function __construct(
         protected string $name,
         protected string $script,
@@ -32,6 +36,9 @@ class Script extends Struct
         return $this->script;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getTwigOptions(): array
     {
         return $this->twigOptions;
@@ -43,7 +50,7 @@ class Script extends Struct
     }
 
     /**
-     * @return Script[]
+     * @return array<Script>
      */
     public function getIncludes(): array
     {


### PR DESCRIPTION
### Description
This PR fixes PHPStan errors related to missing array type hints in the Script and Debug classes. The changes add proper type specifications for array properties and methods.

### Changes
- Added proper array type hints in `Debug.php`:
  - Added `@var array<string|int, mixed>` for `$dumps` property
  - Added `@return array<string|int, mixed>` for `all()` method

- Added proper array type hints in `Script.php`:
  - Added `@param array<string, mixed>` for `$twigOptions` constructor parameter
  - Added `@param array<Script>` for `$includes` constructor parameter
  - Added `@return array<string, mixed>` for `getTwigOptions()` method
  - Updated return type hint for `getIncludes()` to use modern array syntax

### How to verify
1. Run PHPStan on the modified files:
```bash
vendor/bin/phpstan analyse src/Core/Framework/Script/Debugging/Debug.php src/Core/Framework/Script/Execution/Script.php --level max
```
2. Verify that no errors are reported for these files

### Additional Information
- The changes are purely type-related and do not affect runtime behavior
- The baseline file has been updated to remove the fixed errors