### PR TITLE
fix: a11y aria-labelledby filter offcanvas

### DIFF
--- a/changelog/_unreleased/2025-03-04-add-aria-labelledby-for-offcanvas-filter.md
+++ b/changelog/_unreleased/2025-03-04-add-aria-labelledby-for-offcanvas-filter.md
@@ -1,0 +1,13 @@
+---
+title: Add aria-labelledby for offcanvas filter
+issue: NEXT-40818
+author: Björn Meyer
+author_email: b.meyer@shopware.com
+author_github: @BrocksiNet
+---
+# Storefront
+* Changed `offcanvas-filter.plugin.js` to create a virtual wrapper div that is added to the OffCanvas filter template.
+* Added `aria-labelledby` to `cms-element-sidebar-filter.html.twig` template.
+* Removed some useless SCSS rules like `filter-panel-wrapper` and `.btn.filter-panel-wrapper-toggle`.
+
+These changes will improve the accessibility of the filter panel in the OffCanvas.

--- a/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-filter/offcanvas-filter.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/offcanvas-filter/offcanvas-filter.plugin.js
@@ -3,6 +3,13 @@ import Plugin from 'src/plugin-system/plugin.class';
 
 export default class OffCanvasFilter extends Plugin {
 
+    static options = {
+        /**
+         * Classes to remove from the filter wrapper when moved to OffCanvas
+         */
+        classesToRemoveFromWrapperInOffCanvas: ['d-none', 'd-lg-block'],
+    };
+
     init() {
         this._registerEventListeners();
     }
@@ -17,12 +24,13 @@ export default class OffCanvasFilter extends Plugin {
     }
 
     _onCloseOffCanvas(event) {
-        const oldChildNode = event.detail.offCanvasContent[0];
+        const oldChildNode = event.detail.offCanvasContent[0].childNodes[0]; // filterContentWrapper is removed here
 
         const filterContent = document.querySelector('[data-off-canvas-filter-content="true"]');
 
         // move filter back to original place
         filterContent.innerHTML = oldChildNode.innerHTML;
+        filterContent.classList.add(...this.options.classesToRemoveFromWrapperInOffCanvas);
 
         document.$emitter.unsubscribe('onCloseOffcanvas', this._onCloseOffCanvas.bind(this));
         window.PluginManager.getPluginInstances('Listing')[0].refreshRegistry();
@@ -42,21 +50,23 @@ export default class OffCanvasFilter extends Plugin {
         if (!filterContent) {
             throw Error('There was no DOM element with the data attribute "data-offcanvas-filter-content".');
         }
+        // create a virtual wrapper, remove the classes and append content, aria-labelledby is set for offcanvas
+        const filterContentWrapper = document.createElement('div');
+        filterContent.classList.remove(...this.options.classesToRemoveFromWrapperInOffCanvas);
+        filterContentWrapper.appendChild(filterContent.cloneNode(true));
 
         OffCanvas.open(
-            filterContent.innerHTML,
+            filterContentWrapper.innerHTML,
             () => {},
             'bottom',
             true,
-            OffCanvas.REMOVE_OFF_CANVAS_DELAY(),
+            OffCanvas.REMOVE_OFF_CANVAS_DELAY,
             true,
             'offcanvas-filter'
         );
 
-        const filterPanel = filterContent.querySelector('.filter-panel');
-
-        // move filter from original place to offcanvas
-        filterPanel.remove();
+        // remove complete innerHtml from original place to offcanvas
+        filterContent.innerHTML = '';
 
         window.PluginManager.getPluginInstances('Listing')[0].refreshRegistry();
         document.$emitter.subscribe('onCloseOffcanvas', this._onCloseOffCanvas.bind(this));

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_filter-panel.scss
@@ -160,7 +160,6 @@ This file contains the generic styling for all filter items.
     --#{$prefix}btn-hover-color: var(--#{$prefix}primary);
     --#{$prefix}btn-active-bg: var(--#{$prefix}gray-200);
     --#{$prefix}btn-active-color: var(--#{$prefix}primary);
-    display: none;
     width: 100%;
 
     .icon {
@@ -190,16 +189,6 @@ This file contains the generic styling for all filter items.
 
 .filter-panel-offcanvas-close {
     margin-left: auto;
-}
-
-@include media-breakpoint-down(lg) {
-    .btn.filter-panel-wrapper-toggle {
-        display: block;
-    }
-
-    .filter-panel-wrapper {
-        display: none;
-    }
 }
 
 .offcanvas-filter {

--- a/src/Storefront/Resources/app/storefront/test/plugin/offcanvas-filter/offcanvas-filter.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/offcanvas-filter/offcanvas-filter.plugin.test.js
@@ -87,7 +87,9 @@ describe('Offcanvas filter tests', () => {
 
     test('_onCloseOffCanvas replaces the dom innerHTML', () => {
         const sourceDomNode = document.createElement('div');
-        sourceDomNode.appendChild(document.createElement('h1'));
+        const wrapperDomNode = document.createElement('div');
+        wrapperDomNode.appendChild(document.createElement('h1'));
+        sourceDomNode.appendChild(wrapperDomNode);
         sourceDomNode.setAttribute('id', 'itWorksReallyGood');
 
         const targetDomNode = document.createElement('div');

--- a/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/listing/filter-panel.html.twig
@@ -1,7 +1,7 @@
 {% block component_filter_panel %}
     {% block component_filter_panel_header %}
         <div class="filter-panel-offcanvas-header">
-            <h2 class="filter-panel-offcanvas-only filter-panel-offcanvas-title">{{ "listing.filterTitleText"|trans }}</h2>
+            <h2 id="filter-panel-title" class="filter-panel-offcanvas-only filter-panel-offcanvas-title">{{ "listing.filterTitleText"|trans|sw_sanitize }}</h2>
 
             <button type="button" class="btn-close filter-panel-offcanvas-only filter-panel-offcanvas-close js-offcanvas-close" aria-label="{{ 'listing.filterClose'|trans|striptags }}">
             </button>

--- a/src/Storefront/Resources/views/storefront/element/cms-element-sidebar-filter.html.twig
+++ b/src/Storefront/Resources/views/storefront/element/cms-element-sidebar-filter.html.twig
@@ -11,7 +11,7 @@
         <div class="cms-element-sidebar-filter">
             {% block element_product_listing_filter_button %}
                 <button
-                    class="btn btn-outline-primary filter-panel-wrapper-toggle"
+                    class="btn btn-outline-primary filter-panel-wrapper-toggle d-block d-lg-none"
                     type="button"
                     data-off-canvas-filter="true"
                     aria-haspopup="true"
@@ -28,8 +28,9 @@
             {% block element_sidebar_filter_panel %}
                 <div
                     id="filter-panel-wrapper"
-                    class="filter-panel-wrapper"
+                    class="d-none d-lg-block"
                     data-off-canvas-filter-content="true"
+                    aria-labelledby="filter-panel-title"
                 >
                     {% sw_include '@Storefront/storefront/component/listing/filter-panel.html.twig' with {
                         listing: listing,


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
An `aria-labelledby` is currently missing for the filter panel in OffCanvas (mobile).

### 2. What does this change do, exactly?
- Adds the `aria-labelledby` to the Twig template
- Updates the js plugin to add wrapper div only for the offcanvas filter
- Removes some not needed SCSS conditions

### 3. Describe each step to reproduce the issue or behaviour.
- Check the DOM structure for desktop view without OffCanvas
- Check the DOM structure for mobile view with OffCanvas opened

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- closes #7051
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40818

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
