### PR TITLE
fix: request structure of find product variant endpoint

### DIFF
--- a/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product.json
+++ b/src/Core/Framework/Api/ApiDefinition/Generator/Schema/StoreApi/paths/product.json
@@ -387,11 +387,22 @@
                                 ],
                                 "properties": {
                                     "options": {
-                                        "description": "The options parameter for the variant to find.",
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
+                                        "oneOf": [
+                                            {
+                                                "description": "The options parameter for the variant to find.",
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            {
+                                                "description": "The options parameter as a map of groupId => optionId.",
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        ]
                                     },
                                     "switchedGroup": {
                                         "description": "The id of the option group that has been switched.",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

because of the raised [issue](https://github.com/shopware/frontends/issues/1630) which says that body payload is not described properly.

### 2. What does this change do, exactly?

changes the structure of openapi schema for this specific endpoint

### 3. Describe each step to reproduce the issue or behaviour.

play on with https://shopware.stoplight.io/docs/store-api/89d0e268cd663-search-for-a-matching-variant-by-product-options

### 4. Please link to the relevant issues (if any).

closes: https://github.com/shopware/frontends/issues/1630



### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
