### PR TITLE
fix: remove invalid association from rule-modal (#7004)

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/rule/sw-rule-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/sw-rule-modal/index.js
@@ -113,7 +113,6 @@ Component.register('sw-rule-modal', {
                 languageId: Shopware.Store.get('session').languageId,
             };
             const criteria = new Criteria(1, 500);
-            criteria.addAssociation('appScriptCondition');
 
             return Promise.all([
                 this.appScriptConditionRepository.search(criteria, context),


### PR DESCRIPTION
### 1. Why is this change necessary?

The `sw-rule-modal` could not load, because of invalid association to the `app_script_condition` entity.

### 2. What does this change do, exactly?

Remove the invalid association.

### 3. Describe each step to reproduce the issue or behaviour.

1. Go to a product page
2. Go to advanced pricing
3. Select “Create new Rule…” in dropdown

### 4. Please link to the relevant issues (if any).
- closes: #7004
- jira: https://shopware.atlassian.net/browse/NEXT-40782

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
