### PR TITLE
fix(accessibility): Increase contrast for slider UI

### DIFF
--- a/changelog/_unreleased/2025-03-05-increase-contrast-for-slider-ui.md
+++ b/changelog/_unreleased/2025-03-05-increase-contrast-for-slider-ui.md
@@ -1,0 +1,9 @@
+---
+title: Increase contrast for slider UI
+issue: #6311
+---
+# Storefront
+* Changed CSS of the following slider controls and increase their contrast when `ACCESSIBILITY_TWEAKS` is active.
+    * `.base-slider-controls-prev`
+    * `.base-slider-controls-next` 
+    * `.base-slider-dot`

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_base-slider.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_base-slider.scss
@@ -20,7 +20,7 @@ based on: https://github.com/ganlanyuan/tiny-slider
 
         .base-slider-dot,
         button {
-            background-color: $gray-300;
+            background-color: if(feature('ACCESSIBILITY_TWEAKS'), $gray-800, $gray-300);
             border: 0;
             height: 8px;
             width: 8px;
@@ -76,30 +76,51 @@ based on: https://github.com/ganlanyuan/tiny-slider
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    color: $gray-600;
-    background: rgba($white, 0.5);
-    border: 1px solid rgba($white, 0.5);
     line-height: 68px;
-    opacity: 0.5;
     transition: opacity 0.15s ease;
     cursor: pointer;
     padding: 0;
 
-    &:hover {
-        border-color: rgba($primary, 0.5);
-        color: $primary;
-        opacity: 1;
-    }
+    @if feature('ACCESSIBILITY_TWEAKS') {
+        color: $body-color;
+        background: $body-bg;
+        border: 1px solid $body-bg;
 
-    &.is-nav-prev-outside,
-    &.is-nav-next-outside {
-        border: 0;
-        background-color: rgba($white, 0.8);
-    }
+        .icon {
+            color: currentColor;
+        }
 
-    &[disabled] {
-        opacity: 0.2;
-        cursor: default;
+        &:hover {
+            border-color: $primary;
+            color: $primary;
+        }
+
+        &[disabled] {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+    } @else {
+        color: $gray-600;
+        background: rgba($white, 0.5);
+        border: 1px solid rgba($white, 0.5);
+        opacity: 0.5;
+
+        &:hover {
+            border-color: rgba($primary, 0.5);
+            color: $primary;
+            opacity: 1;
+        }
+
+        &.is-nav-prev-outside,
+        &.is-nav-next-outside {
+            border: 0;
+            background-color: rgba($white, 0.8);
+        }
+
+        &[disabled] {
+            opacity: 0.2;
+            cursor: default;
+        }
     }
 }
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The slider controls (arrows and slider dots) do not have optimal contrast and can be hard to see.

### 2. What does this change do, exactly?

To improve the accessibility, the slider controls get better contrast with colors that fulfil the contrast requirements.

### 3. Describe each step to reproduce the issue or behaviour.

Go to any product detail page and look at the image gallery.

### 4. Please link to the relevant issues (if any).

closes [#6311](https://github.com/shopware/shopware/issues/6311)


![image](https://github.com/user-attachments/assets/5ec1177c-5bbf-4171-9b03-dbbce41bbeec)

