### PR TITLE
fix: NEXT-40874 - order document empty state

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-document-card/sw-order-document-card.html.twig
@@ -183,7 +183,6 @@
 
     {% block sw_order_document_card_grid_column_modal %}
     <div v-if="showModal">
-        <h1>huhu</h1>
         <component
             :is="documentModal"
             :current-document-type="currentDocumentType"
@@ -223,6 +222,7 @@
         v-if="documentsEmpty"
         :title="emptyStateTitle"
         :show-description="false"
+        :absolute="false"
     >/
         <template #icon>
             <img


### PR DESCRIPTION
Before: 
![image](https://github.com/user-attachments/assets/18362a92-3dfa-4c30-8628-342068176ba2)

After:
![image](https://github.com/user-attachments/assets/62ffb06e-0cf5-43a4-a404-efaf4fbf227a)
