### PR TITLE
fix: typed property error in SalesChannelAnalyticsEntity

### DIFF
--- a/.bc-exclude.php
+++ b/.bc-exclude.php
@@ -19,5 +19,9 @@ return [
         'An enum expression .* is not supported in .*', // Can not be inspected through reflection https://github.com/Roave/BetterReflection/issues/1376
         // major
         'Value of constant Shopware\\\\Core\\\\Kernel::SHOPWARE_FALLBACK_VERSION changed from \'6.6.9999999-dev\' to \'6.7.9999999-dev\'',
+        // wrongly typed (can be removed after merge)
+        'Type of property Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelAnalytics\\\\SalesChannelAnalyticsEntity#$salesChannel changed from Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity to Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity|null',
+        'The return type of Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelAnalytics\\\\SalesChannelAnalyticsEntity#getSalesChannel() changed from Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity to the non-covariant Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity|null',
+        'The return type of Shopware\\\\Core\\\\System\\\\SalesChannel\\\\Aggregate\\\\SalesChannelAnalytics\\\\SalesChannelAnalyticsEntity#getSalesChannel() changed from Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity to Shopware\\\\Core\\\\System\\\\SalesChannel\\\\SalesChannelEntity|null'
     ],
 ];

--- a/src/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsEntity.php
+++ b/src/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsEntity.php
@@ -20,7 +20,7 @@ class SalesChannelAnalyticsEntity extends Entity
 
     protected bool $anonymizeIp;
 
-    protected SalesChannelEntity $salesChannel;
+    protected ?SalesChannelEntity $salesChannel = null;
 
     public function getTrackingId(): string
     {
@@ -62,7 +62,7 @@ class SalesChannelAnalyticsEntity extends Entity
         $this->anonymizeIp = $anonymizeIp;
     }
 
-    public function getSalesChannel(): SalesChannelEntity
+    public function getSalesChannel(): ?SalesChannelEntity
     {
         return $this->salesChannel;
     }

--- a/tests/unit/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsEntityTest.php
+++ b/tests/unit/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsEntityTest.php
@@ -2,10 +2,15 @@
 
 namespace Shopware\Tests\Unit\Core\System\SalesChannel\Aggregate\SalesChannelAnalytics;
 
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelAnalytics\SalesChannelAnalyticsEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 
+/**
+ * @internal
+ */
+#[CoversClass(SalesChannelAnalyticsEntity::class)]
 class SalesChannelAnalyticsEntityTest extends TestCase
 {
     public function testGetSetTrackingId(): void

--- a/tests/unit/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsEntityTest.php
+++ b/tests/unit/Core/System/SalesChannel/Aggregate/SalesChannelAnalytics/SalesChannelAnalyticsEntityTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\System\SalesChannel\Aggregate\SalesChannelAnalytics;
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelAnalytics\SalesChannelAnalyticsEntity;
+use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+
+class SalesChannelAnalyticsEntityTest extends TestCase
+{
+    public function testGetSetTrackingId(): void
+    {
+        $entity = new SalesChannelAnalyticsEntity();
+        $trackingId = 'test-tracking-id';
+        $entity->setTrackingId($trackingId);
+
+        static::assertSame($trackingId, $entity->getTrackingId());
+    }
+
+    public function testGetSetActive(): void
+    {
+        $entity = new SalesChannelAnalyticsEntity();
+        $entity->setActive(true);
+
+        static::assertTrue($entity->isActive());
+    }
+
+    public function testGetSetTrackOrders(): void
+    {
+        $entity = new SalesChannelAnalyticsEntity();
+        $entity->setTrackOrders(true);
+
+        static::assertTrue($entity->isTrackOrders());
+    }
+
+    public function testGetSetAnonymizeIp(): void
+    {
+        $entity = new SalesChannelAnalyticsEntity();
+        $entity->setAnonymizeIp(true);
+
+        static::assertTrue($entity->isAnonymizeIp());
+    }
+
+    public function testGetSetSalesChannel(): void
+    {
+        $entity = new SalesChannelAnalyticsEntity();
+        $salesChannel = new SalesChannelEntity();
+        $entity->setSalesChannel($salesChannel);
+
+        static::assertSame($salesChannel, $entity->getSalesChannel());
+    }
+
+    public function testThatSalesChannelCanBeNull(): void
+    {
+        $entity = new SalesChannelAnalyticsEntity();
+        static::assertNull($entity->getSalesChannel());
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When you activated Google Analytics via Admin and saved a tracking ID you got this error:
```
{
  "errors": [
    {
      "code": "0",
      "status": "500",
      "title": "Internal Server Error",
      "detail": "Typed property Shopware\\Core\\System\\SalesChannel\\Aggregate\\SalesChannelAnalytics\\SalesChannelAnalyticsEntity::$salesChannel must not be accessed before initialization",
      "meta": {
        "trace": [
          {
            "file": "/src\/Core\/Framework\/Api\/Serializer\/JsonApiEncoder.php",
            "line": 93,
            "function": "get",
            "class": "Shopware\\Core\\Framework\\DataAbstractionLayer\\Entity",
            "type": "-\u003E"
          },
          {
            "file": "/src\/Core\/Framework\/Api\/Serializer\/JsonApiEncoder.php",
            "line": 74,
            "function": "serializeRelationships",
            "class": "Shopware\\Core\\Framework\\Api\\Serializer\\JsonApiEncoder",
            "type": "-\u003E"
          },
          {
            "file": "/src\/Core\/Framework\/Api\/Serializer\/JsonApiEncoder.php",
            "line": 110,
            "function": "serializeEntity",
            "class": "Shopware\\Core\\Framework\\Api\\Serializer\\JsonApiEncoder",
            "type": "-\u003E"
          },
          {
            "file": "/src\/Core\/Framework\/Api\/Serializer\/JsonApiEncoder.php",
            "line": 74,
            "function": "serializeRelationships",
            "class": "Shopware\\Core\\Framework\\Api\\Serializer\\JsonApiEncoder",
            "type": "-\u003E"
          },
          {
            "file": "/src\/Core\/Framework\/Api\/Serializer\/JsonApiEncoder.php",
            "line": 141,
            "function": "serializeEntity",
            "class": "Shopware\\Core\\Framework\\Api\\Serializer\\JsonApiEncoder",
            "type": "-\u003E"
          },
          {
            "file": "/src\/Core\/Framework\/Api\/Serializer\/JsonApiEncoder.php",
            "line": 54,
            "function": "encodeData",
            "class": "Shopware\\Core\\Framework\\Api\\Serializer\\JsonApiEncoder",
            "type": "-\u003E"
          },
          {
            "file": "/src\/Core\/Framework\/Api\/Response\/Type\/Api\/JsonApiType.php",
            "line": 105,
            "function": "encode",
            "class": "Shopware\\Core\\Framework\\Api\\Serializer\\JsonApiEncoder",
            "type": "-\u003E"
          },
          {
            "file": "/src\/Core\/Framework\/Api\/Controller\/ApiController.php",
            "line": 266,
            "function": "createListingResponse",
            "class": "Shopware\\Core\\Framework\\Api\\Response\\Type\\Api\\JsonApiType",
            "type": "-\u003E"
          },
          {
            "file": "/vendor\/symfony\/http-kernel\/HttpKernel.php",
            "line": 183,
            "function": "search",
            "class": "Shopware\\Core\\Framework\\Api\\Controller\\ApiController",
            "type": "-\u003E"
          },
          {
            "file": "/vendor\/symfony\/http-kernel\/HttpKernel.php",
            "line": 76,
            "function": "handleRaw",
            "class": "Symfony\\Component\\HttpKernel\\HttpKernel",
            "type": "-\u003E"
          },
          {
            "file": "/src\/Core\/Framework\/Adapter\/Kernel\/HttpKernel.php",
            "line": 72,
            "function": "handle",
            "class": "Symfony\\Component\\HttpKernel\\HttpKernel",
            "type": "-\u003E"
          },
          {
            "file": "/vendor\/symfony\/http-kernel\/HttpCache\/SubRequestHandler.php",
            "line": 86,
            "function": "handle",
            "class": "Shopware\\Core\\Framework\\Adapter\\Kernel\\HttpKernel",
            "type": "-\u003E"
          },
          {
            "file": "/vendor\/symfony\/http-kernel\/HttpCache\/HttpCache.php",
            "line": 460,
            "function": "handle",
            "class": "Symfony\\Component\\HttpKernel\\HttpCache\\SubRequestHandler",
            "type": "::"
          },
          {
            "file": "/vendor\/symfony\/http-kernel\/HttpCache\/HttpCache.php",
            "line": 262,
            "function": "forward",
            "class": "Symfony\\Component\\HttpKernel\\HttpCache\\HttpCache",
            "type": "-\u003E"
          },
          {
            "file": "/vendor\/symfony\/http-kernel\/HttpCache\/HttpCache.php",
            "line": 276,
            "function": "pass",
            "class": "Symfony\\Component\\HttpKernel\\HttpCache\\HttpCache",
            "type": "-\u003E"
          },
          {
            "file": "/vendor\/symfony\/http-kernel\/HttpCache\/HttpCache.php",
            "line": 202,
            "function": "invalidate",
            "class": "Symfony\\Component\\HttpKernel\\HttpCache\\HttpCache",
            "type": "-\u003E"
          },
          {
            "file": "/src\/Core\/Framework\/Adapter\/Kernel\/HttpCacheKernel.php",
            "line": 65,
            "function": "handle",
            "class": "Symfony\\Component\\HttpKernel\\HttpCache\\HttpCache",
            "type": "-\u003E"
          },
          {
            "file": "/src\/Core\/Kernel.php",
            "line": 131,
            "function": "handle",
            "class": "Shopware\\Core\\Framework\\Adapter\\Kernel\\HttpCacheKernel",
            "type": "-\u003E"
          },
          {
            "file": "/vendor\/symfony\/runtime\/Runner\/Symfony\/HttpKernelRunner.php",
            "line": 35,
            "function": "handle",
            "class": "Shopware\\Core\\Kernel",
            "type": "-\u003E"
          },
          {
            "file": "/vendor\/autoload_runtime.php",
            "line": 29,
            "function": "run",
            "class": "Symfony\\Component\\Runtime\\Runner\\Symfony\\HttpKernelRunner",
            "type": "-\u003E"
          },
          {
            "file": "/public\/index.php",
            "line": 10,
            "args": [
              "/vendor\/autoload_runtime.php"
            ],
            "function": "require_once"
          }
        ],
        "file": "/src\/Core\/Framework\/DataAbstractionLayer\/Entity.php",
        "line": 103
      }
    }
  ]
}
```

### 2. What does this change do, exactly?
Fix the typed property error in SalesChannelAnalyticsEntity

### 3. Describe each step to reproduce the issue or behaviour.
I added some elementary unit tests to make sure it can be null.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [X] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [X] I have read the contribution requirements and fulfill them.
