### PR TITLE
refactor: align styling of import-export

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-exporter/sw-import-export-exporter.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-exporter/sw-import-export-exporter.html.twig
@@ -1,8 +1,6 @@
 {% block sw_import_export_exporter %}
 <div class="sw-import-export-exporter">
-    {% block sw_import_export_exporter_header %}
-    <h2>{{ $tc('sw-import-export.importer.selectProfileLabel') }}</h2>
-    {% endblock %}
+    {% block sw_import_export_exporter_header %}{% endblock %}
 
     {% block sw_import_export_exporter_profile_select %}
     <sw-entity-single-select

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-exporter/sw-import-export-exporter.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-exporter/sw-import-export-exporter.scss
@@ -1,6 +1,10 @@
 @import "~scss/variables";
 
 .sw-import-export-exporter {
+    &__title {
+        font-weight: $font-weight-semi-bold;
+    }
+
     .sw-import-export-exporter__link {
         text-decoration: underline;
         color: $color-darkgray-200;

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-importer/sw-import-export-importer.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-importer/sw-import-export-importer.html.twig
@@ -1,11 +1,15 @@
 {% block sw_import_export_importer %}
 <div class="sw-import-export-importer">
     {% block sw_import_export_importer_upload_csv_label %}
-    <h2>{{ $tc('sw-import-export.importer.uploadCsvLabel') }}</h2>
+    <span class="sw-import-export-importer__title">
+        {{ $tc('sw-import-export.importer.uploadCsvLabel') }}
+    </span>
     {% endblock %}
 
     {% block sw_import_export_importer_warning_block %}
-    <p><span v-html="$tc('sw-import-export.importer.warningBlock')"></span></p>
+    <p class="sw-import-export-importer__text">
+        <span v-html="$tc('sw-import-export.importer.warningBlock')"></span>
+    </p>
     {% endblock %}
 
     {% block sw_import_export_importer_file_input %}
@@ -19,9 +23,7 @@
     </sw-file-input>
     {% endblock %}
 
-    {% block sw_import_export_importer_select_profile_label %}
-    <h2>{{ $tc('sw-import-export.importer.selectProfileLabel') }}</h2>
-    {% endblock %}
+    {% block sw_import_export_importer_select_profile_label %}{% endblock %}
 
     {% block sw_import_export_importer_profile_select %}
     <sw-entity-single-select

--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-importer/sw-import-export-importer.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/component/sw-import-export-importer/sw-import-export-importer.scss
@@ -1,6 +1,17 @@
 @import "~scss/variables";
 
 .sw-import-export-importer {
+    &__title {
+        font-weight: $font-weight-semi-bold;
+    }
+
+    &__text {
+        margin-top: 8px;
+        font-size: $font-size-xs;
+        line-height: $line-height-sm;
+        color: $color-darkgray-200;
+    }
+
     .sw-file-input {
         margin-bottom: 32px;
 


### PR DESCRIPTION
### 1. Why is this change necessary?

The styling of the `import-export` pages looked pretty unfimiliar and not like the other shopware modules,  because of their headline styling

### 2. What does this change do, exactly?

Aligned styling with rest of shopware. Used the `product-detail-page` as an example.

### Before

![Screenshot From 2025-03-06 08-11-29](https://github.com/user-attachments/assets/d1dc2bf3-c7f2-4a01-b8a8-ee6933264dcf)

![Screenshot From 2025-03-06 08-11-38](https://github.com/user-attachments/assets/25bf87bb-1cef-4aa0-85db-4d4488015468)

### After

![Screenshot From 2025-03-06 08-12-21](https://github.com/user-attachments/assets/03fe25eb-70f4-4501-b11b-23aabb4ca7c0)

![Screenshot From 2025-03-06 08-12-27](https://github.com/user-attachments/assets/76384b73-301d-40c4-96ee-b8e597ff07de)