### PR TITLE
fix: HttpCacheTagDataCollectorSubscriber now collects HTTP cache tags correctly

### DIFF
--- a/src/Core/Profiling/Subscriber/HttpCacheTagDataCollectorSubscriber.php
+++ b/src/Core/Profiling/Subscriber/HttpCacheTagDataCollectorSubscriber.php
@@ -38,15 +38,6 @@ class HttpCacheTagDataCollectorSubscriber extends AbstractDataCollector implemen
         ];
     }
 
-    public function store(HttpCacheStoreEvent $event): void
-    {
-        $uri = $this->uri($event->request);
-
-        foreach ($event->tags as $tag) {
-            self::$tags[$uri][$tag] = [];
-        }
-    }
-
     public function reset(): void
     {
     }

--- a/src/Core/Profiling/Subscriber/HttpCacheTagDataCollectorSubscriber.php
+++ b/src/Core/Profiling/Subscriber/HttpCacheTagDataCollectorSubscriber.php
@@ -11,7 +11,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\LateDataCollectorInterface;
-use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -21,12 +20,15 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class HttpCacheTagDataCollectorSubscriber extends AbstractDataCollector implements EventSubscriberInterface, LateDataCollectorInterface
 {
     /**
-     * @var array<string, mixed>
+     * [uri => [tag => [caller => count]]]
+     *
+     * @var array<string, array<string, array<string, int>>>
      */
     public static array $tags = [];
 
-    public function __construct(private readonly RequestStack $stack)
-    {
+    public function __construct(
+        private readonly RequestStack $stack,
+    ) {
     }
 
     public static function getSubscribedEvents(): array
@@ -40,7 +42,9 @@ class HttpCacheTagDataCollectorSubscriber extends AbstractDataCollector implemen
     {
         $uri = $this->uri($event->request);
 
-        self::$tags[$uri] = $event->tags;
+        foreach ($event->tags as $tag) {
+            self::$tags[$uri][$tag] = [];
+        }
     }
 
     public function reset(): void
@@ -48,17 +52,18 @@ class HttpCacheTagDataCollectorSubscriber extends AbstractDataCollector implemen
     }
 
     /**
-     * @return array<string, mixed>|Data
+     * @return array<string, array<string, array<string, int>>>
      */
-    public function getData(): array|Data
+    public function getData(): array
     {
+        \assert(\is_array($this->data));
+
         return $this->data;
     }
 
     public function getTotal(): int
     {
-        // @phpstan-ignore-next-line
-        return array_sum(array_map('count', $this->data));
+        return array_sum(array_map('count', $this->getData()));
     }
 
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void
@@ -116,8 +121,8 @@ class HttpCacheTagDataCollectorSubscriber extends AbstractDataCollector implemen
         array_shift($source);
         array_shift($source);
         foreach ($source as $index => $element) {
-            /** @var class-string $class */
             $class = $element['class'] ?? '';
+            \assert(class_exists($class));
 
             $instance = new \ReflectionClass($class);
             // skip dispatcher chain
@@ -151,7 +156,7 @@ class HttpCacheTagDataCollectorSubscriber extends AbstractDataCollector implemen
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string, array<string, array<string, int>>>
      */
     private function buildTags(): array
     {
@@ -161,23 +166,25 @@ class HttpCacheTagDataCollectorSubscriber extends AbstractDataCollector implemen
             return $tags;
         }
 
-        $keys = array_keys($tags);
+        $uris = array_keys($tags);
 
-        if (\count($keys) <= 1) {
+        if (\count($uris) <= 1) {
             return $tags;
         }
 
-        $na = $tags['n/a'];
+        $tagsWithoutValidUri = $tags['n/a'];
         unset($tags['n/a']);
 
-        $second = $keys[1];
+        $firstValidUri = $uris[1];
 
-        foreach ($na as $caller => $count) {
-            if (!isset($tags[$second][$caller])) {
-                $tags[$second][$caller] = 0;
+        foreach ($tagsWithoutValidUri as $tag => $callerCountArray) {
+            foreach ($callerCountArray as $caller => $count) {
+                if (!isset($tags[$firstValidUri][$tag][$caller])) {
+                    $tags[$firstValidUri][$tag][$caller] = 0;
+                }
+
+                $tags[$firstValidUri][$tag][$caller] += $count;
             }
-
-            $tags[$second][$caller] += $count;
         }
 
         return $tags;

--- a/src/Core/Profiling/Subscriber/HttpCacheTagDataCollectorSubscriber.php
+++ b/src/Core/Profiling/Subscriber/HttpCacheTagDataCollectorSubscriber.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Profiling\Subscriber;
 
 use Shopware\Core\Framework\Adapter\Cache\Event\AddCacheTagEvent;
-use Shopware\Core\Framework\Adapter\Cache\Event\HttpCacheStoreEvent;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Bundle\FrameworkBundle\DataCollector\AbstractDataCollector;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/tests/unit/Core/Profiling/Subscriber/HttpCacheTagDataCollectorSubscriberTest.php
+++ b/tests/unit/Core/Profiling/Subscriber/HttpCacheTagDataCollectorSubscriberTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Profiling\Subscriber;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Profiling\Subscriber\HttpCacheTagDataCollectorSubscriber;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @internal
+ */
+#[CoversClass(HttpCacheTagDataCollectorSubscriber::class)]
+class HttpCacheTagDataCollectorSubscriberTest extends TestCase
+{
+    public function testLateCollectSameTagInValidAndInvalidURIs(): void
+    {
+        HttpCacheTagDataCollectorSubscriber::$tags = [
+            'n/a' => [
+                'system.config-' => [
+                    'SystemConfigService::get | CanonicalRedirectService::getRedirect' => 1,
+                ],
+            ],
+            '/widgets/checkout/info' => [
+                'system.config-' => [
+                    'SystemConfigService::get | StorefrontSubscriber::shouldRenewToken' => 1,
+                ],
+            ],
+        ];
+
+        $data = $this->getProcessedTags();
+        static::assertSame([
+            '/widgets/checkout/info' => [
+                'system.config-' => [
+                    'SystemConfigService::get | StorefrontSubscriber::shouldRenewToken' => 1,
+                    'SystemConfigService::get | CanonicalRedirectService::getRedirect' => 1,
+                ],
+            ],
+        ], $data);
+    }
+
+    public function testLateCollectWithDifferentTagsInValidAndInvalidURIs(): void
+    {
+        HttpCacheTagDataCollectorSubscriber::$tags = [
+            'n/a' => [
+                'system.config-' => [
+                    'SystemConfigService::get | CanonicalRedirectService::getRedirect' => 1,
+                ],
+            ],
+            '/api/rule' => [
+                'translator-01956aa1d58f729d8f7cb8643a16c708' => [
+                    'Translator::trans | DataCollectorTranslator::trans' => 1,
+                ],
+            ],
+        ];
+
+        $data = $this->getProcessedTags();
+        static::assertSame([
+            '/api/rule' => [
+                'translator-01956aa1d58f729d8f7cb8643a16c708' => [
+                    'Translator::trans | DataCollectorTranslator::trans' => 1,
+                ],
+                'system.config-' => [
+                    'SystemConfigService::get | CanonicalRedirectService::getRedirect' => 1,
+                ],
+            ],
+        ], $data);
+    }
+
+    /**
+     * @return array<string, array<string, array<string, int>>>
+     */
+    private function getProcessedTags(): array
+    {
+        $subscriber = new HttpCacheTagDataCollectorSubscriber(new RequestStack());
+
+        $subscriber->lateCollect();
+
+        return $subscriber->getData();
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

In dev mode the collector does not work correctly in some cases. 

### 2. What does this change do, exactly?

Change the internals of putting cache tags to valid URIs. 

### 3. Describe each step to reproduce the issue or behaviour.

- Go to Settings >Rule Builder
- Click "Create rule"
- Click "Save"

### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40686

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
