### PR TITLE
fix: search bar item hover style stays after mouse out

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/structure/sw-search-bar/index.js
@@ -706,6 +706,12 @@ Component.register('sw-search-bar', {
                 index: this.activeResultIndex,
                 column: this.activeResultColumn,
             });
+            this.activeItemIndexSelectHandler.forEach((callback) =>
+                callback({
+                    index: this.activeResultIndex,
+                    column: this.activeResultColumn,
+                }),
+            );
         },
 
         navigateUpResults() {
@@ -789,6 +795,8 @@ Component.register('sw-search-bar', {
 
         onKeyUpEnter() {
             this.$emit('keyup-enter', this.activeResultIndex, this.activeResultColumn);
+
+            this.keyupEnterHandler.forEach((callback) => callback(this.activeResultIndex, this.activeResultColumn));
 
             if (this.showTypeSelectContainer) {
                 if (this.typeSelectResults.length > 0) {


### PR DESCRIPTION
### 1. Why is this change necessary?
The issue is when user hovers the search bar dropdown items, all of the keep in active style


### 2. What does this change do, exactly?
fix the missing callbacks that restores the active state


### 3. Describe each step to reproduce the issue or behaviour.
1. click in the main search bar in any page
2. hover mouse over all the dropdown items
3. Before the fix all hovered items keep in active style


### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40960
