### PR TITLE
fix: settings icon size and settings index background

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.html.twig
@@ -6,7 +6,7 @@
 
     {% block sw_settings_content %}
     <template #content>
-        <sw-card-view>
+        <sw-card-view class="sw-settings-index__card-view">
             {% block sw_settings_content_card_view %}
             <mt-card
                 hero
@@ -47,7 +47,7 @@
                                 <mt-icon
                                     v-else
                                     :name="settingsItem.icon"
-                                    size="18px"
+                                    size="16px"
                                 />
                             </template>
                         </sw-settings-item>

--- a/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings/page/sw-settings-index/sw-settings-index.scss
@@ -1,6 +1,10 @@
 @import "~scss/variables";
 
 .sw-settings-index {
+    &__card-view {
+        background-color: var(--color-elevation-surface-default);
+    }
+
     .sw-settings__card--hero {
         container-type: inline-size;
         color: var(--color-text-primary-default, #2d2e32);


### PR DESCRIPTION
### 1. Why is this change necessary?
The icon size of the settings index must be 16px.
Also the background color should be the token --color-elevation-surface-default


### 2. What does this change do, exactly?
fix the styles


### 3. Describe each step to reproduce the issue or behaviour.
Go to settings and see the right design

### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40966
