### PR TITLE
fix: tax-free status was ignored on order history page

### DIFF
--- a/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
+++ b/src/Storefront/Resources/views/storefront/page/account/order-history/order-detail.html.twig
@@ -174,7 +174,7 @@
                                                 {% endblock %}
 
                                                 {% block page_account_order_item_detail_vat %}
-                                                    {% if not order.isTaxFree %}
+                                                    {% if order.taxStatus !== constant('Shopware\\Core\\Checkout\\Cart\\Price\\Struct\\CartPrice::TAX_STATE_FREE') %}
                                                         {% for calculatedTax in order.price.calculatedTaxes %}
                                                             {% block page_account_order_item_detail_vat_label %}
                                                                 <dt class="col-6 col-md-8">
@@ -196,7 +196,7 @@
                                                 {% block page_account_order_item_detail_amount %}
                                                     {% block page_account_order_item_detail_amount_label %}
                                                         <dt class="col-6 col-md-8">
-                                                            {% if order.isTaxFree %}
+                                                            {% if order.taxStatus === constant('Shopware\\Core\\Checkout\\Cart\\Price\\Struct\\CartPrice::TAX_STATE_FREE') %}
                                                                 {{ 'account.orderItemNetTotal'|trans|sw_sanitize }}
                                                             {% else %}
                                                                 {{ 'account.orderItemTotal'|trans|sw_sanitize }}
@@ -206,7 +206,7 @@
 
                                                     {% block page_account_order_item_detail_amount_value %}
                                                         <dd class="col-6 col-md-4">
-                                                            {% if order.isTaxFree %}
+                                                            {% if order.taxStatus === constant('Shopware\\Core\\Checkout\\Cart\\Price\\Struct\\CartPrice::TAX_STATE_FREE') %}
                                                                 {{ order.amountNet|currency(order.currency.isoCode) }}
                                                             {% else %}
                                                                 {{ order.amountTotal|currency(order.currency.isoCode) }}


### PR DESCRIPTION
### 1. Why is this change necessary?
The tax free status on the order history page in the storefront is ignored.

### 2. What does this change do, exactly?
It listens to the order taxStatus and determines what text to use for the total

### 3. Describe each step to reproduce the issue or behaviour.
Set your country to a tax free country
create an order in storefront
go to order history in storefront and look at the totals

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
