### PR TITLE
fix: removed deprecated pluralization parameter from $tc calls

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/tree/sw-tree/sw-tree.html.twig
@@ -32,7 +32,7 @@
             v-if="checkedElementsCount > 0"
             class="sw-tree-actions__headline"
         >
-            <span> {{ $tc(`${translationContext}.general.treeHeadSelected`, 0, { count: checkedElementsCount }) }}:</span>
+            <span> {{ $tc(`${translationContext}.general.treeHeadSelected`, { count: checkedElementsCount }) }}:</span>
             <mt-button
                 class="sw-tree-actions__delete_categories"
                 :disabled="!allowDeleteCategories || undefined"
@@ -110,14 +110,14 @@
                 v-if="toDeleteItem.childCount > 0"
                 class="sw_tree__confirm-delete-text"
             >
-                {{ $tc(`${translationContext}.modal.textDeleteConfirm`, 0, { name: toDeleteItem.data.name || toDeleteItem.data.translated.name }) }}<br>
+                {{ $tc(`${translationContext}.modal.textDeleteConfirm`, { name: toDeleteItem.data.name || toDeleteItem.data.translated.name }) }}<br>
                 <b>{{ $tc(`${translationContext}.modal.textDeleteChildrenConfirm`) }}</b>
             </p>
             <p
                 v-else
                 class="sw_tree__confirm-delete-text"
             >
-                {{ $tc(`${translationContext}.modal.textDeleteConfirm`, 0, { name: toDeleteItem.data.name || toDeleteItem.data.translated.name }) }}
+                {{ $tc(`${translationContext}.modal.textDeleteConfirm`, { name: toDeleteItem.data.name || toDeleteItem.data.translated.name }) }}
             </p>
         </div>
         <div v-else>
@@ -125,14 +125,14 @@
                 v-if="checkedElementsChildCount > 0"
                 class="sw_tree__confirm-delete-text"
             >
-                {{ $tc(`${translationContext}.modal.textDeleteMultipleConfirm`, 0, { count: checkedElementsCount }) }}<br>
+                {{ $tc(`${translationContext}.modal.textDeleteMultipleConfirm`, { count: checkedElementsCount }) }}<br>
                 <b>{{ $tc(`${translationContext}.modal.textDeleteChildrenConfirm`) }}</b>
             </p>
             <p
                 v-else
                 class="sw_tree__confirm-delete-text"
             >
-                {{ $tc(`${translationContext}.modal.textDeleteMultipleConfirm`, 0, { count: checkedElementsCount }) }}
+                {{ $tc(`${translationContext}.modal.textDeleteMultipleConfirm`, { count: checkedElementsCount }) }}
             </p>
         </div>
         {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/sw-category-detail.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-category/page/sw-category-detail/sw-category-detail.html.twig
@@ -103,7 +103,7 @@
                     v-if="categoryCheckedItem > 0"
                     class="sw-category-detail__collapse-selected-count"
                 >
-                    {{ $tc(`sw-category.general.treeHeadSelected`, 0, { count: categoryCheckedItem }) }}:
+                    {{ $tc(`sw-category.general.treeHeadSelected`, { count: categoryCheckedItem }) }}:
                 </div>
                 <div
                     v-else
@@ -163,7 +163,7 @@
                     v-if="landingPageCheckedItem > 0"
                     class="sw-category-detail__collapse-selected-count"
                 >
-                    {{ $tc(`sw-landing-page.general.treeHeadSelected`, 0, { count: landingPageCheckedItem }) }}:
+                    {{ $tc(`sw-landing-page.general.treeHeadSelected`, { count: landingPageCheckedItem }) }}:
                 </div>
                 <div
                     v-else


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The category tree is still using a deprecated (or by now non-existing) `$tc` pluralization parameter.

### 2. What does this change do, exactly?

Remove the pluralization parameter. 

### 3. Describe each step to reproduce the issue or behaviour.

 In the category tree for categories and landing pages
- displayed counts of selected items are always 0
- displayed name in delete modal is empty

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
- https://shopware.atlassian.net/browse/NEXT-40825

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
