### PR TITLE
fix: Make off-canvas navigation accessible

### DIFF
--- a/changelog/_unreleased/2025-03-07-make-offcanvas-navigation-accessible.md
+++ b/changelog/_unreleased/2025-03-07-make-offcanvas-navigation-accessible.md
@@ -13,13 +13,19 @@ issue: NEXT-40780
     * Removed `_animateBackward()`.
     * Removed `_getMenuContentFromResponse()`.
     * Removed `_getOverlayContent()`.
-    * Removed `_createOverlayElements()`
-    * Added `_createOverlay()`.
-    * Added `_showOverlay()`.
-    * Added `_hideOverlay()`.
+    * Removed `_createOverlayElements()`.
+    * Renamed `_updateOverlay()` to `_updateContent()`.
+    * Removed option `homeBtnClass`.
+    * Removed option `backBtnClass`.
+    * Removed option `transitionClass`.
+    * Removed option `overlayClass`.
+    * Removed option `placeholderClass`.
+    * Removed option `forwardAnimationType`.
+    * Removed option `backwardAnimationType`.
   * Changed the overlay behaviour so the focus will be correctly set to the overlay and back when navigating between parent and sub-categories.
 * Changed the close button of off-canvas elements to `btn-secondary` and added styling for `:focus-visible`.
 * Removed unnecessary wrapper element in `storefront/layout/navigation/offcanvas/categories.html.twig`.
 * Changed the CSS class naming of `.navigation-offcanvas-container` in `storefront/layout/navigation/offcanvas/navigation.html.twig` to simplify the structure.
 * Added `:focus-visible` styling to `.navigation-offcanvas-link` to support keyboard navigation.
 * Added some margin and padding to `.navigation-offcanvas-actions` to give the layout a bit more space.
+* Added new SCSS variable `$focus-ring-box-shadow-inset` for inner focus outlines.

--- a/changelog/_unreleased/2025-03-07-make-offcanvas-navigation-accessible.md
+++ b/changelog/_unreleased/2025-03-07-make-offcanvas-navigation-accessible.md
@@ -7,6 +7,16 @@ issue: NEXT-40780
   * Removed the animation. The sub-category overlay will now simply be shown, which fixes additional issues like unnecessary scrollbars.
   * Removed some unnecessary wrapper elements to simply the DOM structure.
   * Removed a lot of unnecessary methods according to the simplified behaviour.
+    * Removed `_replaceOffcanvasMenuContent()`.
+    * Removed `_animateInstant()`.
+    * Removed `_animateForward()`.
+    * Removed `_animateBackward()`.
+    * Removed `_getMenuContentFromResponse()`.
+    * Removed `_getOverlayContent()`.
+    * Removed `_createOverlayElements()`
+    * Added `_createOverlay()`.
+    * Added `_showOverlay()`.
+    * Added `_hideOverlay()`.
   * Changed the overlay behaviour so the focus will be correctly set to the overlay and back when navigating between parent and sub-categories.
 * Changed the close button of off-canvas elements to `btn-secondary` and added styling for `:focus-visible`.
 * Removed unnecessary wrapper element in `storefront/layout/navigation/offcanvas/categories.html.twig`.

--- a/changelog/_unreleased/2025-03-07-make-offcanvas-navigation-accessible.md
+++ b/changelog/_unreleased/2025-03-07-make-offcanvas-navigation-accessible.md
@@ -1,0 +1,15 @@
+---
+title: Make off-canvas navigation accessible
+issue: NEXT-40780
+---
+# Storefront
+* Changed the `offcanvas-menu.plugin.js` to fix several issues and make it accessible via keyboard:
+  * Removed the animation. The sub-category overlay will now simply be shown, which fixes additional issues like unnecessary scrollbars.
+  * Removed some unnecessary wrapper elements to simply the DOM structure.
+  * Removed a lot of unnecessary methods according to the simplified behaviour.
+  * Changed the overlay behaviour so the focus will be correctly set to the overlay and back when navigating between parent and sub-categories.
+* Changed the close button of off-canvas elements to `btn-secondary` and added styling for `:focus-visible`.
+* Removed unnecessary wrapper element in `storefront/layout/navigation/offcanvas/categories.html.twig`.
+* Changed the CSS class naming of `.navigation-offcanvas-container` in `storefront/layout/navigation/offcanvas/navigation.html.twig` to simplify the structure.
+* Added `:focus-visible` styling to `.navigation-offcanvas-link` to support keyboard navigation.
+* Added some margin and padding to `.navigation-offcanvas-actions` to give the layout a bit more space.

--- a/src/Storefront/Resources/app/storefront/src/plugin/main-menu/offcanvas-menu.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/main-menu/offcanvas-menu.plugin.js
@@ -18,18 +18,8 @@ export default class OffcanvasMenuPlugin extends Plugin {
         loadingIconSelector: '.js-navigation-offcanvas-loading-icon',
         linkLoadingClass: 'is-loading',
         menuSelector: '.navigation-offcanvas-container',
-        rootSelector: '.navigation-offcanvas-root',
-        overlayHeadlineSelector: '.navigation-offcanvas-headline',
         initialContentSelector: '.js-navigation-offcanvas-initial-content',
-
-        homeBtnClass: 'is-home-link',
-        backBtnClass: 'is-back-link',
-        transitionClass: 'has-transition',
-        overlayClass: '.navigation-offcanvas-overlay',
-        placeholderClass: '.navigation-offcanvas-placeholder',
-
-        forwardAnimationType: 'forwards',
-        backwardAnimationType: 'backwards',
+        currentCategorySelector: 'a.is-current-category',
     };
 
     init() {
@@ -87,11 +77,9 @@ export default class OffcanvasMenuPlugin extends Plugin {
      */
     _getLinkEventHandler(event, link) {
 
-        // Initial root navigation
+        // Initial navigation
         if (!link) {
             const initialContentElement = document.querySelector(this.options.initialContentSelector);
-            this._content = initialContentElement.innerHTML;
-
             const url = `${this.options.navigationUrl}?navigationId=${window.activeNavigationId}`;
 
             return this._fetchMenu(url, (htmlResponse) => {
@@ -117,21 +105,9 @@ export default class OffcanvasMenuPlugin extends Plugin {
             return;
         }
 
-        let showOverlay = true;
-
-        if (link.classList.contains(this.options.homeBtnClass) ||
-            link.classList.contains(this.options.backBtnClass) && !url.includes('navigationId')) {
-            showOverlay = false;
-        }
-
-        // Save the focus of the root menu link
-        if (showOverlay && this._overlay?.classList.contains('d-none')) {
-            window.focusHandler.saveFocusState('offcanvas-menu', link);
-        }
-
         this.$emitter.publish('getLinkEventHandler');
 
-        this._fetchMenu(url, this._updateOverlay.bind(this, showOverlay));
+        this._fetchMenu(url, this._updateContent.bind(this));
     }
 
     /**
@@ -165,72 +141,27 @@ export default class OffcanvasMenuPlugin extends Plugin {
     }
 
     /**
-     * update the overlay content with the
-     * subcategory navigation
+     * Update the content with the current navigation.
      *
-     * @param {boolean} showOverlay
      * @param {string} content
      * @private
      */
-    _updateOverlay(showOverlay, content) {
+    _updateContent(content) {
         this._content = content;
 
         if (OffCanvas.exists()) {
-            this._overlay = this._createOverlay(content);
+            const container = OffcanvasMenuPlugin._getOffcanvasMenu();
 
-            if (showOverlay) {
-                this._showOverlay(this._overlay);
-            } else {
-                this._hideOverlay(this._overlay);
-            }
+            container.innerHTML = content;
+
+            // Focus the current category
+            const currentCategory = container.querySelector(this.options.currentCategorySelector);
+            window.focusHandler.setFocus(currentCategory, { focusVisible: true });
 
             this._registerEvents();
         }
 
-        this.$emitter.publish('updateOverlay');
-    }
-
-    _createOverlay(content) {
-        const offCanvasMenu = OffcanvasMenuPlugin._getOffcanvasMenu();
-
-        let overlay = offCanvasMenu.querySelector(this.options.overlayClass);
-
-        if (!overlay) {
-            overlay = document.createElement('div');
-            overlay.classList.add(this.options.overlayClass.substr(1));
-            overlay.style.minHeight = `${offCanvasMenu.clientHeight}px`;
-            offCanvasMenu.appendChild(overlay);
-        }
-
-        overlay.innerHTML = content;
-
-        return overlay;
-    }
-
-    _showOverlay(overlay) {
-        const offcanvasContainer = OffcanvasMenuPlugin._getOffcanvasMenu();
-        const rootMenu = offcanvasContainer.querySelector(this.options.rootSelector);
-
-        rootMenu.classList.add('d-none');
-        overlay.classList.remove('d-none');
-
-        // Focus the headline with the main category to which the sub-menu belongs.
-        const headline = overlay.querySelector(this.options.overlayHeadlineSelector);
-        window.focusHandler.setFocus(headline);
-
-        this.$emitter.publish('showOverlay');
-    }
-
-    _hideOverlay(overlay) {
-        const offcanvasContainer = OffcanvasMenuPlugin._getOffcanvasMenu();
-        const rootMenu = offcanvasContainer.querySelector(this.options.rootSelector);
-
-        rootMenu.classList.remove('d-none');
-        overlay.classList.add('d-none');
-
-        window.focusHandler.resumeFocusState('offcanvas-menu', { focusVisible: true });
-
-        this.$emitter.publish('hideOverlay');
+        this.$emitter.publish('updateContent');
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/plugin/main-menu/offcanvas-menu.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/main-menu/offcanvas-menu.plugin.js
@@ -17,8 +17,9 @@ export default class OffcanvasMenuPlugin extends Plugin {
         linkSelector: '.js-navigation-offcanvas-link',
         loadingIconSelector: '.js-navigation-offcanvas-loading-icon',
         linkLoadingClass: 'is-loading',
-        menuSelector: '.js-navigation-offcanvas',
-        overlayContentSelector: '.js-navigation-offcanvas-overlay-content',
+        menuSelector: '.navigation-offcanvas-container',
+        rootSelector: '.navigation-offcanvas-root',
+        overlayHeadlineSelector: '.navigation-offcanvas-headline',
         initialContentSelector: '.js-navigation-offcanvas-initial-content',
 
         homeBtnClass: 'is-home-link',
@@ -85,6 +86,8 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * @private
      */
     _getLinkEventHandler(event, link) {
+
+        // Initial root navigation
         if (!link) {
             const initialContentElement = document.querySelector(this.options.initialContentSelector);
             this._content = initialContentElement.innerHTML;
@@ -114,14 +117,21 @@ export default class OffcanvasMenuPlugin extends Plugin {
             return;
         }
 
-        let animationType = this.options.forwardAnimationType;
-        if (link.classList.contains(this.options.homeBtnClass) || link.classList.contains(this.options.backBtnClass)) {
-            animationType = this.options.backwardAnimationType;
+        let showOverlay = true;
+
+        if (link.classList.contains(this.options.homeBtnClass) ||
+            link.classList.contains(this.options.backBtnClass) && !url.includes('navigationId')) {
+            showOverlay = false;
+        }
+
+        // Save the focus of the root menu link
+        if (showOverlay && this._overlay?.classList.contains('d-none')) {
+            window.focusHandler.saveFocusState('offcanvas-menu', link);
         }
 
         this.$emitter.publish('getLinkEventHandler');
 
-        this._fetchMenu(url, this._updateOverlay.bind(this, animationType));
+        this._fetchMenu(url, this._updateOverlay.bind(this, showOverlay));
     }
 
     /**
@@ -158,209 +168,69 @@ export default class OffcanvasMenuPlugin extends Plugin {
      * update the overlay content with the
      * subcategory navigation
      *
-     * @param {string} animationType
+     * @param {boolean} showOverlay
      * @param {string} content
      * @private
      */
-    _updateOverlay(animationType, content) {
+    _updateOverlay(showOverlay, content) {
         this._content = content;
 
         if (OffCanvas.exists()) {
-            const offcanvasMenu = OffcanvasMenuPlugin._getOffcanvasMenu();
+            this._overlay = this._createOverlay(content);
 
-            // if there is no content present
-            // insert the whole response into the offcanvas
-            if (!offcanvasMenu) {
-                this._replaceOffcanvasContent(content);
+            if (showOverlay) {
+                this._showOverlay(this._overlay);
+            } else {
+                this._hideOverlay(this._overlay);
             }
 
-            this._createOverlayElements();
-            const currentContent = OffcanvasMenuPlugin._getOverlayContent(offcanvasMenu);
-            const menuContent = OffcanvasMenuPlugin._getMenuContentFromResponse(content);
-
-            this._replaceOffcanvasMenuContent(animationType, menuContent, currentContent);
             this._registerEvents();
         }
 
         this.$emitter.publish('updateOverlay');
     }
 
-    /**
-     * grab only the menu from the response
-     * and replace it within the created
-     * menu elements
-     *
-     * @param animationType
-     * @param menuContent
-     * @param currentContent
-     * @private
-     */
-    _replaceOffcanvasMenuContent(animationType, menuContent, currentContent) {
+    _createOverlay(content) {
+        const offCanvasMenu = OffcanvasMenuPlugin._getOffcanvasMenu();
 
-        if (animationType === this.options.forwardAnimationType) {
-            this._animateForward(menuContent, currentContent);
-            return;
+        let overlay = offCanvasMenu.querySelector(this.options.overlayClass);
+
+        if (!overlay) {
+            overlay = document.createElement('div');
+            overlay.classList.add(this.options.overlayClass.substr(1));
+            overlay.style.minHeight = `${offCanvasMenu.clientHeight}px`;
+            offCanvasMenu.appendChild(overlay);
         }
 
-        if (animationType === this.options.backwardAnimationType) {
-            this._animateBackward(menuContent, currentContent);
-            return;
-        }
-
-        this._animateInstant(menuContent, currentContent);
-
-        this.$emitter.publish('replaceOffcanvasMenuContent');
-    }
-
-    /**
-     * instantly replaces the ovleray content
-     *
-     * @param menuContent
-     * @private
-     */
-    _animateInstant(menuContent) {
-        this._overlay.innerHTML = menuContent;
-
-        this.$emitter.publish('animateInstant');
-    }
-
-    /**
-     * replaces the content and
-     * animates the overlay to slide in
-     *
-     * @param menuContent
-     * @param currentContent
-     * @private
-     */
-    _animateForward(menuContent, currentContent) {
-        if (this._placeholder.innerHTML === '') {
-            this._placeholder.innerHTML = currentContent;
-        }
-        this._overlay.classList.remove(this.options.transitionClass);
-        this._overlay.style.left = '100%';
-        this._overlay.innerHTML = menuContent;
-        setTimeout(() => {
-            this._overlay.classList.add(this.options.transitionClass);
-            this._overlay.style.left = '0%';
-        }, 1);
-
-        this.$emitter.publish('animateForward');
-    }
-
-    /**
-     * replaces the content and
-     * animates the overlay to slide out
-     *
-     * @param menuContent
-     * @param currentContent
-     * @private
-     */
-    _animateBackward(menuContent, currentContent) {
-        if (this._overlay.innerHTML === '') {
-            this._overlay.innerHTML = currentContent;
-        }
-        this._placeholder.innerHTML = menuContent;
-        this._overlay.classList.remove(this.options.transitionClass);
-        this._overlay.style.left = '0%';
-        setTimeout(() => {
-            this._overlay.classList.add(this.options.transitionClass);
-            this._overlay.style.left = '100%';
-        }, 1);
-
-        this.$emitter.publish('animateBackward');
-    }
-
-    /**
-     * returns the menu content
-     * form the complete offcanvas response
-     *
-     * @param content
-     * @returns {string}
-     * @private
-     */
-    static _getMenuContentFromResponse(content) {
-        const html = new DOMParser().parseFromString(content, 'text/html');
-        return OffcanvasMenuPlugin._getOverlayContent(html);
-    }
-
-    /**
-     * returns the content
-     * from the overlay content container
-     *
-     * @param element
-     * @returns {string}
-     * @private
-     */
-    static _getOverlayContent(element) {
-        if (!element) {
-            return '';
-        }
-
-        const contentElement = element.querySelector(this.options.overlayContentSelector);
-        if (!contentElement) {
-            return '';
-        }
-
-        return contentElement.innerHTML;
-    }
-
-    /**
-     * creates the overlay
-     * elements to be able to animate the menu
-     *
-     * @private
-     */
-    _createOverlayElements() {
-        const offcanvasMenu = OffcanvasMenuPlugin._getOffcanvasMenu();
-
-        if (offcanvasMenu) {
-            this._placeholder = OffcanvasMenuPlugin._createPlaceholder(offcanvasMenu);
-            this._overlay = OffcanvasMenuPlugin._createNavigationOverlay(offcanvasMenu);
-        }
-
-        this.$emitter.publish('createOverlayElements');
-    }
-
-    /**
-     * @param {HTMLElement} container
-     *
-     * @returns {HTMLElement}
-     * @private
-     */
-    static _createNavigationOverlay(container) {
-        const offcanvas = OffcanvasMenuPlugin._getOffcanvas();
-        const currentOverlay = offcanvas.querySelector(this.options.overlayClass);
-        if (currentOverlay) {
-            return currentOverlay;
-        }
-
-        const overlay = document.createElement('div');
-        overlay.classList.add(this.options.overlayClass.substr(1));
-        overlay.style.minHeight = `${offcanvas.clientHeight}px`;
-        container.appendChild(overlay);
+        overlay.innerHTML = content;
 
         return overlay;
     }
 
-    /**
-     * @param {HTMLElement} container
-     *
-     * @returns {HTMLElement}
-     * @private
-     */
-    static _createPlaceholder(container) {
-        const offcanvas = OffcanvasMenuPlugin._getOffcanvas();
-        const currentPlaceholder = offcanvas.querySelector(this.options.placeholderClass);
-        if (currentPlaceholder) {
-            return currentPlaceholder;
-        }
+    _showOverlay(overlay) {
+        const offcanvasContainer = OffcanvasMenuPlugin._getOffcanvasMenu();
+        const rootMenu = offcanvasContainer.querySelector(this.options.rootSelector);
 
-        const placeholder = document.createElement('div');
-        placeholder.classList.add(this.options.placeholderClass.substr(1));
-        placeholder.style.minHeight = `${offcanvas.clientHeight}px`;
-        container.appendChild(placeholder);
+        rootMenu.classList.add('d-none');
+        overlay.classList.remove('d-none');
 
-        return placeholder;
+        // Focus the headline with the main category to which the sub-menu belongs.
+        const headline = overlay.querySelector(this.options.overlayHeadlineSelector);
+        window.focusHandler.setFocus(headline);
+
+        this.$emitter.publish('showOverlay');
+    }
+
+    _hideOverlay(overlay) {
+        const offcanvasContainer = OffcanvasMenuPlugin._getOffcanvasMenu();
+        const rootMenu = offcanvasContainer.querySelector(this.options.rootSelector);
+
+        rootMenu.classList.remove('d-none');
+        overlay.classList.add('d-none');
+
+        window.focusHandler.resumeFocusState('offcanvas-menu', { focusVisible: true });
+
+        this.$emitter.publish('hideOverlay');
     }
 
     /**
@@ -389,20 +259,6 @@ export default class OffcanvasMenuPlugin extends Plugin {
                 cb(res);
             }
         });
-    }
-
-    /**
-     * replaces the offcanvas content
-     *
-     * @param {string} content
-     * @private
-     */
-    _replaceOffcanvasContent(content) {
-        this._content = content;
-        OffCanvas.setContent(this._content);
-        this._registerEvents();
-
-        this.$emitter.publish('replaceOffcanvasContent');
     }
 
     /**

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_icon.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_icon.scss
@@ -217,10 +217,11 @@ Credit: https://github.com/FortAwesome/Font-Awesome
     }
 }
 
-.is-right {
+.is-right,
+.offcanvas-end {
     .offcanvas-close {
         svg {
-            top: 0.3rem;
+            top: 0.25rem;
         }
     }
 }

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_offcanvas.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_offcanvas.scss
@@ -50,13 +50,8 @@ The sliding direction can be left or right.
         padding: $spacer-sm $spacer;
         text-align: left;
 
-        &:focus {
-            box-shadow: none;
-        }
-
-        &,
-        .icon {
-            color: $gray-600;
+        &:focus-visible {
+            box-shadow: inset 0 0 0 0.125rem $focus-ring-color, inset 0 0 0 0.25rem #fff;
         }
     }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/component/_offcanvas.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/component/_offcanvas.scss
@@ -51,7 +51,7 @@ The sliding direction can be left or right.
         text-align: left;
 
         &:focus-visible {
-            box-shadow: inset 0 0 0 0.125rem $focus-ring-color, inset 0 0 0 0.25rem #fff;
+            box-shadow: $focus-ring-box-shadow-inset;
         }
     }
 

--- a/src/Storefront/Resources/app/storefront/src/scss/layout/_navigation-offcanvas.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/layout/_navigation-offcanvas.scss
@@ -31,6 +31,9 @@ Based on custom offcanvas component.
 }
 
 .navigation-offcanvas-actions {
+    padding-top: 1rem;
+    margin-bottom: 0.5rem;
+
     .top-bar-nav-item {
         padding: 0 $spacer;
     }

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/abstract/variables/_bootstrap.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/abstract/variables/_bootstrap.scss
@@ -45,6 +45,7 @@ $focus-ring-opacity: 1 !default;
 $focus-ring-color: rgba($primary, $focus-ring-opacity) !default;
 $focus-ring-blur: 0 !default;
 $focus-ring-box-shadow: (0 0 0 0.125rem $body-bg, 0 0 $focus-ring-blur $focus-ring-width $focus-ring-color) !default;
+$focus-ring-box-shadow-inset: (inset 0 0 0 0.125rem $focus-ring-color, inset 0 0 0 0.25rem $body-bg) !default;
 
 $border-radius: 0 !default;
 $border-radius-lg: 0 !default;

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_navigation-offcanvas.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_navigation-offcanvas.scss
@@ -8,6 +8,10 @@ Based on custom offcanvas component.
 .navigation-offcanvas-headline {
     font-weight: $font-weight-bold;
     color: $secondary;
+
+    &:focus-visible {
+        box-shadow: inset 0 0 $focus-ring-blur 0.125rem $focus-ring-color;
+    }
 }
 
 .navigation-offcanvas-list-item {
@@ -21,6 +25,10 @@ Based on custom offcanvas component.
 
 .navigation-offcanvas-link {
     color: $body-color;
+
+    &:focus-visible {
+        box-shadow: inset 0 0 $focus-ring-blur 0.125rem $focus-ring-color;
+    }
 
     &.is-home-link {
         &,

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_navigation-offcanvas.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/layout/_navigation-offcanvas.scss
@@ -10,7 +10,7 @@ Based on custom offcanvas component.
     color: $secondary;
 
     &:focus-visible {
-        box-shadow: inset 0 0 $focus-ring-blur 0.125rem $focus-ring-color;
+        box-shadow: $focus-ring-box-shadow-inset;
     }
 }
 
@@ -27,7 +27,7 @@ Based on custom offcanvas component.
     color: $body-color;
 
     &:focus-visible {
-        box-shadow: inset 0 0 $focus-ring-blur 0.125rem $focus-ring-color;
+        box-shadow: $focus-ring-box-shadow-inset;
     }
 
     &.is-home-link {

--- a/src/Storefront/Resources/app/storefront/test/plugin/main-menu/offcanvas-menu.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/main-menu/offcanvas-menu.plugin.test.js
@@ -2,8 +2,9 @@ import OffCanvasMenuPlugin from 'src/plugin/main-menu/offcanvas-menu.plugin';
 
 jest.mock('src/service/http-client.service', () => {
     const offCanvasMenuSubCategory = `
-        <div class="navigation-offcanvas-container js-navigation-offcanvas">
-            <div class="navigation-offcanvas-overlay-content js-navigation-offcanvas-overlay-content">
+        <div class="navigation-offcanvas-container">
+            <div class="navigation-offcanvas-content">
+                <div class="navigation-offcanvas-headline">Categories</div>
                 <ul class="list-unstyled navigation-offcanvas-list">
                     <li class="navigation-offcanvas-list-item">
                         <a href="#"
@@ -25,8 +26,9 @@ jest.mock('src/service/http-client.service', () => {
     `;
 
     const offCanvasMenuInitialContent = `
-        <div class="navigation-offcanvas-container js-navigation-offcanvas">
-            <div class="navigation-offcanvas-overlay-content js-navigation-offcanvas-overlay-content">
+        <div class="navigation-offcanvas-container navigation-offcanvas-root">
+            <div class="navigation-offcanvas-content">
+                <div class="navigation-offcanvas-headline">Categories</div>
                 <ul class="list-unstyled navigation-offcanvas-list">
                     <li class="navigation-offcanvas-list-item">
                         <a href="#"
@@ -73,9 +75,7 @@ describe('OffCanvasMenuPlugin tests', () => {
                 <div class="offcanvas-body">
                     <p>Initial content</p>
 
-                    <div class="navigation-offcanvas-container js-navigation-offcanvas">
-                        <div class="navigation-offcanvas-overlay-content js-navigation-offcanvas-overlay-content"></div>
-                    </div>
+                    <div class="navigation-offcanvas-container"></div>
                 </div>
             </div>
         `;
@@ -85,6 +85,7 @@ describe('OffCanvasMenuPlugin tests', () => {
         window.focusHandler = {
             saveFocusState: jest.fn(),
             resumeFocusState: jest.fn(),
+            setFocus: jest.fn(),
         };
 
         plugin = new OffCanvasMenuPlugin(el);
@@ -122,7 +123,7 @@ describe('OffCanvasMenuPlugin tests', () => {
 
         jest.runAllTimers();
 
-        const subCategoryLinks = document.querySelectorAll('.navigation-offcanvas-overlay.has-transition .navigation-offcanvas-link');
+        const subCategoryLinks = document.querySelectorAll('.navigation-offcanvas-overlay .navigation-offcanvas-link');
 
         // Ensure sub-categories are rendered
         expect(subCategoryLinks[0].textContent).toContain('Cars');

--- a/src/Storefront/Resources/app/storefront/test/plugin/main-menu/offcanvas-menu.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/main-menu/offcanvas-menu.plugin.test.js
@@ -123,7 +123,7 @@ describe('OffCanvasMenuPlugin tests', () => {
 
         jest.runAllTimers();
 
-        const subCategoryLinks = document.querySelectorAll('.navigation-offcanvas-overlay .navigation-offcanvas-link');
+        const subCategoryLinks = document.querySelectorAll('.navigation-offcanvas .navigation-offcanvas-link');
 
         // Ensure sub-categories are rendered
         expect(subCategoryLinks[0].textContent).toContain('Cars');

--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/categories.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/categories.html.twig
@@ -5,28 +5,26 @@
 {% set active = navigation.active %}
 
 {% block layout_navigation_offcanvas_navigation_categories %}
-    <div class="navigation-offcanvas-container js-navigation-offcanvas">
-        <div class="navigation-offcanvas-overlay-content js-navigation-offcanvas-overlay-content">
-            {% if not isRoot %}
-                {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/show-all-link.html.twig' %}
+    <div class="navigation-offcanvas-content{% if isRoot %} navigation-offcanvas-root{% endif %}">
+        {% if not isRoot %}
+            {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/show-all-link.html.twig' %}
 
-                {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/active-item-link.html.twig' with { item: active } %}
+            {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/active-item-link.html.twig' with { item: active } %}
 
-                {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/back-link.html.twig' with { item: active } %}
-            {% else %}
-                {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/general-headline.html.twig' %}
+            {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/back-link.html.twig' with { item: active } %}
+        {% else %}
+            {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/general-headline.html.twig' %}
+        {% endif %}
+
+        <ul class="list-unstyled navigation-offcanvas-list">
+            {% if not isRoot and active.type != 'folder' %}
+                {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/show-active-link.html.twig' with { item: active } %}
             {% endif %}
 
-            <ul class="list-unstyled navigation-offcanvas-list">
-                {% if not isRoot and active.type != 'folder' %}
-                    {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/show-active-link.html.twig' with { item: active } %}
-                {% endif %}
-
-                {# @var item \Shopware\Core\Content\Category\Tree\TreeItem #}
-                {% for item in children.tree %}
-                    {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/item-link.html.twig' with { item: item, activeId: activeId } %}
-                {% endfor %}
-            </ul>
-        </div>
+            {# @var item \Shopware\Core\Content\Category\Tree\TreeItem #}
+            {% for item in children.tree %}
+                {% sw_include '@Storefront/storefront/layout/navigation/offcanvas/item-link.html.twig' with { item: item, activeId: activeId } %}
+            {% endfor %}
+        </ul>
     </div>
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/offcanvas/navigation.html.twig
@@ -15,8 +15,6 @@
 
     {# Categories are loaded via OffcanvasMenuPlugin #}
     {% block layout_navigation_offcanvas_navigation_placeholder %}
-        <div class="navigation-offcanvas-container js-navigation-offcanvas">
-            <div class="navigation-offcanvas-overlay-content js-navigation-offcanvas-overlay-content"></div>
-        </div>
+        <div class="navigation-offcanvas-container"></div>
     {% endblock %}
 {% endblock %}

--- a/src/Storefront/Resources/views/storefront/utilities/offcanvas.html.twig
+++ b/src/Storefront/Resources/views/storefront/utilities/offcanvas.html.twig
@@ -18,7 +18,7 @@
     {% block utilities_offcanvas_header %}
         <div class="offcanvas-header">
             {% block utilities_offcanvas_close %}
-                <button class="btn btn-light offcanvas-close js-offcanvas-close">
+                <button class="btn btn-secondary offcanvas-close js-offcanvas-close">
                     {% block utilities_offcanvas_close_icon %}
                         {% sw_icon 'x' style { size: 'sm' } %}
                     {% endblock %}


### PR DESCRIPTION
fixes #6998
fixes #7041
fixes #7092
fixes #5091
fixes #4576

### 1. Why is this change necessary?
The off-canvas menu lacks accessibility best-practices, especially keyboard navigation and focus handling. In addition, there are some minor issues with the current implementation.

### 2. What does this change do, exactly?

* Remove the animation from the sub-category navigation.
* Add proper keyboard and focus handling to the category navigation
* Fix some styling issues of the close button and other focus states.
* Simplify the HTML structure and logic of the off-canvas navigation plugin.


![image](https://github.com/user-attachments/assets/69e88f0f-8e15-4f67-bd8e-d6888a18d722)

