### PR TITLE
chore: Remove paratest dependency and all related code places as it is unused

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -402,7 +402,7 @@ jobs:
 
       - name: Run integration tests
         if: inputs.nightly == 'true'
-        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --exclude-group=needsWebserver,skip-paratest,not-deterministic --stop-on-error --stop-on-failure
+        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --exclude-group=needsWebserver,not-deterministic --stop-on-error --stop-on-failure
 
       - name: Install Shopware in previous major version
         if: inputs.nightly != 'true'
@@ -485,7 +485,7 @@ jobs:
 
       - name: Run integration tests in previous major version
         if: inputs.nightly == 'true'
-        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --exclude-group=needsWebserver,skip-paratest,not-deterministic --stop-on-error --stop-on-failure
+        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --exclude-group=needsWebserver,not-deterministic --stop-on-error --stop-on-failure
 
       - name: Run blue-green check
         if: inputs.nightly != 'true'

--- a/.gitlab/stages/22-blue-green.yml
+++ b/.gitlab/stages/22-blue-green.yml
@@ -41,7 +41,7 @@ PHP blue green 6.6->6.7->6.6:
       if [[ $CI_PIPELINE_SOURCE == "schedule" ]]; then
         composer init:testdb
         DATABASE_URL="$TEST_DB_URL" bin/console database:migrate --all core.V6_7
-        php vendor/bin/phpunit --testsuite integration --exclude-group=needsWebserver,skip-paratest,not-deterministic --stop-on-error --stop-on-failure
+        php vendor/bin/phpunit --testsuite integration --exclude-group=needsWebserver,not-deterministic --stop-on-error --stop-on-failure
       else
         bin/console system:install --basic-setup --create-database --skip-assets-install
         bin/console database:migrate --all core.V6_7

--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,7 @@
         "scssphp/scssphp": "v1.12.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
+        "shopware/commercial": "7.0.0",
         "shopware/conflicts": "0.5.0",
         "shyim/opensearch-php-dsl": "^1.0.5",
         "squirrelphp/twig-php-syntax": "^1.8.0",
@@ -176,7 +177,6 @@
         "ext-tokenizer": "*",
         "ext-xmlwriter": "*",
         "bamarni/composer-bin-plugin": "^1.8.2",
-        "brianium/paratest": "^7.3",
         "dominikb/composer-license-checker": "^2.5",
         "ergebnis/phpunit-slow-test-detector": "^2.4",
         "friendsofphp/php-cs-fixer": "3.64.0",
@@ -266,7 +266,6 @@
         "npm:storefront": " ",
         "npm:storefront:bin": " ",
         "npm:storefront:check-license": "Check thrid-party dependency licenses for storefront",
-        "paratest": " ",
         "phpbench": " ",
         "phpstan": "Launches the PHP static analysis tool",
         "phpstan-errors-by-area": "Shows the ignored errors defined in the phpstan-baseline.neon by area",
@@ -397,9 +396,6 @@
         "npm:storefront": "@npm:storefront:bin npm",
         "npm:storefront:bin": "export PROJECT_ROOT=\"$PWD\"; cd src/Storefront/Resources/app/storefront; export PATH=\"$PWD/node_modules/.bin/:$PATH\"; \"$PROJECT_ROOT\"/bin/exec-with-env ",
         "npm:storefront:check-license": "export ALLOWED_LICENSES=\"$(sed -z 's/\\n/;/g' .allowed-licenses)\"; cd src/Storefront/Resources/app/storefront; bash -c \"node_modules/.bin/license-checker-rseidelsohn --onlyAllow \\\"$ALLOWED_LICENSES\\\" --excludePrivatePackages\"",
-        "paratest": [
-            "paratest --configuration phpunit.xml.dist --testsuite=paratest --exclude-group=skip-paratest,needsWebserver --processes $(getconf _NPROCESSORS_ONLN)"
-        ],
         "phpbench": "phpbench run --report=compressed",
         "phpstan": [
             "Composer\\Config::disableProcessTimeout",

--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,6 @@
         "scssphp/scssphp": "v1.12.0",
         "setasign/fpdi": "^2.3.7",
         "setasign/tfpdf": "^1.33",
-        "shopware/commercial": "7.0.0",
         "shopware/conflicts": "0.5.0",
         "shyim/opensearch-php-dsl": "^1.0.5",
         "squirrelphp/twig-php-syntax": "^1.8.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -116,12 +116,6 @@
         <testsuite name="migration">
             <directory>tests/migration</directory>
         </testsuite>
-        <!-- Paratest -->
-        <testsuite name="paratest">
-            <directory>src/Core/*/Test</directory>
-            <directory>src/*/Test</directory>
-            <directory>tests/unit</directory>
-        </testsuite>
     </testsuites>
     <extensions>
         <bootstrap class="Ergebnis\PHPUnit\SlowTestDetector\Extension"/>

--- a/src/Core/Framework/Adapter/Cache/CacheClearer.php
+++ b/src/Core/Framework/Adapter/Cache/CacheClearer.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Framework\Adapter\Cache;
 
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Log\LoggerInterface;
-use Shopware\Core\DevOps\Environment\EnvironmentHelper;
 use Shopware\Core\Framework\Adapter\AdapterException;
 use Shopware\Core\Framework\Adapter\Cache\Message\CleanupOldCacheFolders;
 use Shopware\Core\Framework\Adapter\Cache\ReverseProxy\AbstractReverseProxyGateway;
@@ -119,10 +118,6 @@ class CacheClearer
 
     public function cleanupOldContainerCacheDirectories(): void
     {
-        // Don't delete other folders while paratest is running
-        if (EnvironmentHelper::getVariable('TEST_TOKEN')) {
-            return;
-        }
         if ($this->clusterMode) {
             // In cluster mode we can't delete caches on the filesystem
             // because this only runs on one node in the cluster

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -177,11 +177,10 @@ class Kernel extends HttpKernel
     public function getCacheDir(): string
     {
         return \sprintf(
-            '%s/var/cache/%s_h%s%s',
+            '%s/var/cache/%s_h%s',
             EnvironmentHelper::getVariable('APP_CACHE_DIR', $this->getProjectDir()),
             $this->getEnvironment(),
             $this->getCacheHash(),
-            EnvironmentHelper::getVariable('TEST_TOKEN') ?? ''
         );
     }
 

--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -149,13 +149,7 @@ class TestBootstrapper
 
         $dbUrlParts = parse_url($_SERVER['DATABASE_URL'] ?? '') ?: [];
 
-        $testToken = getenv('TEST_TOKEN');
         $dbUrlParts['path'] ??= 'root';
-
-        // allows using the same database during development, by setting TEST_TOKEN=none
-        if ($testToken !== 'none' && !str_ends_with($dbUrlParts['path'], 'test')) {
-            $dbUrlParts['path'] .= '_' . ($testToken ?: 'test');
-        }
 
         $auth = isset($dbUrlParts['user']) ? ($dbUrlParts['user'] . (isset($dbUrlParts['pass']) ? (':' . $dbUrlParts['pass']) : '') . '@') : '';
 

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -167,7 +167,6 @@
         "symfony/phpunit-bridge": "~7.2.0",
         "symfony/var-dumper": "~7.2.0",
         "symfony/dom-crawler": "~7.2.0",
-        "brianium/paratest": "^7.3",
         "shopware/dev-tools": "^1.3"
     },
     "suggest": {

--- a/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
+++ b/tests/integration/Core/Checkout/Cart/Order/RecalculationServiceTest.php
@@ -69,7 +69,6 @@ use Symfony\Component\HttpFoundation\Response;
  * @internal
  */
 #[Group('slow')]
-#[Group('skip-paratest')]
 class RecalculationServiceTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaFolderRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaFolderRepositoryTest.php
@@ -18,7 +18,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
  * @internal
  */
 #[Group('slow')]
-#[Group('skip-paratest')]
 class MediaFolderRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
@@ -39,7 +39,6 @@ use Shopware\Core\Test\TestDefaults;
  * @internal
  */
 #[Group('slow')]
-#[Group('skip-paratest')]
 class MediaRepositoryTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Api/ApiAliasTest.php
+++ b/tests/integration/Core/Framework/Api/ApiAliasTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\Api;
 
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Entity;
@@ -15,7 +14,6 @@ use Shopware\Core\Kernel;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class ApiAliasTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Api/ApiAwareTest.php
+++ b/tests/integration/Core/Framework/Api/ApiAwareTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\Api;
 
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Administration\Notification\NotificationDefinition;
 use Shopware\Administration\Snippet\AppAdministrationSnippetDefinition;
@@ -18,7 +17,6 @@ use Shopware\Storefront\Theme\ThemeDefinition;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class ApiAwareTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour;

--- a/tests/integration/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Test.php
+++ b/tests/integration/Core/Framework/Api/ApiDefinition/Generator/OpenApi3Test.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\Api\ApiDefinition\Generator;
 
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\System\SalesChannel\SalesChannel\StoreApiInfoController;
@@ -11,7 +10,6 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class OpenApi3Test extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
+++ b/tests/integration/Core/Framework/Api/Controller/CacheControllerTest.php
@@ -17,7 +17,6 @@ use Symfony\Component\Messenger\TraceableMessageBus;
  * @internal
  */
 #[Package('framework')]
-#[Group('skip-paratest')]
 class CacheControllerTest extends TestCase
 {
     use AdminFunctionalTestBehaviour;

--- a/tests/integration/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandlerTest.php
+++ b/tests/integration/Core/Framework/App/ScheduledTask/DeleteCascadeAppsHandlerTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Integration\Core\Framework\App\ScheduledTask;
 
 use Doctrine\DBAL\Connection;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Defaults;
@@ -19,7 +18,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class DeleteCascadeAppsHandlerTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Cache/CacheClearerTest.php
+++ b/tests/integration/Core/Framework/Cache/CacheClearerTest.php
@@ -27,7 +27,6 @@ use Symfony\Component\Messenger\MessageBusInterface;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 #[Group('slow')]
 class CacheClearerTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Changelog/ChangelogCommandTest.php
+++ b/tests/integration/Core/Framework/Changelog/ChangelogCommandTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Integration\Core\Framework\Changelog;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Changelog\Command\ChangelogChangeCommand;
 use Shopware\Core\Framework\Changelog\Command\ChangelogCheckCommand;
@@ -20,7 +19,6 @@ use Symfony\Component\Console\Output\NullOutput;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class ChangelogCommandTest extends TestCase
 {
     use ChangelogTestBehaviour;

--- a/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionRegisterTest.php
+++ b/tests/integration/Core/Framework/DataAbstractionLayer/EntityExtensionRegisterTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\DataAbstractionLayer;
 
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition;
 use Shopware\Core\Content\Product\ProductDefinition;
@@ -21,7 +20,6 @@ use Shopware\Core\System\SalesChannel\Entity\SalesChannelDefinitionInstanceRegis
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class EntityExtensionRegisterTest extends TestCase
 {
     use DataAbstractionLayerFieldTestBehaviour {

--- a/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
+++ b/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Integration\Core\Framework\FeatureFlag;
 
 use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\Extension\FeatureFlagExtension;
 use Shopware\Core\Framework\Feature;
@@ -17,7 +16,6 @@ use Twig\Loader\FilesystemLoader;
  *
  * @phpstan-import-type FeatureFlagConfig from Feature
  */
-#[Group('skip-paratest')]
 class FeatureTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
@@ -39,7 +39,6 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
  * @internal
  */
 #[Group('slow')]
-#[Group('skip-paratest')]
 class KernelPluginIntegrationTest extends TestCase
 {
     use PluginIntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceMigrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceMigrationTest.php
@@ -38,7 +38,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @internal
  */
 #[Group('slow')]
-#[Group('skip-paratest')]
 class PluginLifecycleServiceMigrationTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -47,7 +47,6 @@ use Symfony\Component\Filesystem\Filesystem;
  * @internal
  */
 #[Group('slow')]
-#[Group('skip-paratest')]
 class PluginLifecycleServiceTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginManagementServiceTest.php
@@ -28,7 +28,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  * @internal
  */
 #[Group('slow')]
-#[Group('skip-paratest')]
 class PluginManagementServiceTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
+++ b/tests/integration/Core/Framework/Plugin/PluginServiceTest.php
@@ -29,7 +29,6 @@ use SwagTestPlugin\SwagTestPlugin;
  * @internal
  */
 #[Group('slow')]
-#[Group('skip-paratest')]
 class PluginServiceTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Core/Framework/Store/Services/ExtensionDataProviderTest.php
+++ b/tests/integration/Core/Framework/Store/Services/ExtensionDataProviderTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Integration\Core\Framework\Store\Services;
 
 use GuzzleHttp\Psr7\Response;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Shopware\Core\Framework\Api\Context\AdminApiSource;
@@ -23,7 +22,6 @@ use Shopware\Core\System\SystemConfig\SystemConfigService;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 #[Package('checkout')]
 class ExtensionDataProviderTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Store/Services/ExtensionLifecycleServiceTest.php
+++ b/tests/integration/Core/Framework/Store/Services/ExtensionLifecycleServiceTest.php
@@ -2,7 +2,6 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\Store\Services;
 
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Api\Context\SystemSource;
@@ -26,7 +25,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 #[Package('checkout')]
 class ExtensionLifecycleServiceTest extends TestCase
 {

--- a/tests/integration/Core/Framework/Store/Services/ExtensionLoaderTest.php
+++ b/tests/integration/Core/Framework/Store/Services/ExtensionLoaderTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Integration\Core\Framework\Store\Services;
 
 use Composer\IO\NullIO;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\App\AppCollection;
 use Shopware\Core\Framework\App\AppEntity;
@@ -27,7 +26,6 @@ use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 #[Package('checkout')]
 class ExtensionLoaderTest extends TestCase
 {

--- a/tests/integration/Core/Framework/TestCaseBase/KernelLifecycleManagerTest.php
+++ b/tests/integration/Core/Framework/TestCaseBase/KernelLifecycleManagerTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Integration\Core\Framework\TestCaseBase;
 
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Kernel;
@@ -11,7 +10,6 @@ use Shopware\Core\Kernel;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class KernelLifecycleManagerTest extends TestCase
 {
     public function testARebootIsPossible(): void

--- a/tests/integration/Core/System/CustomEntity/Xml/Config/CmsAwareAndAdminUiTest.php
+++ b/tests/integration/Core/System/CustomEntity/Xml/Config/CmsAwareAndAdminUiTest.php
@@ -26,7 +26,6 @@ use Shopware\Core\Framework\Uuid\Uuid;
  * @internal
  */
 #[Group('slow')]
-#[Group('skip-paratest')]
 class CmsAwareAndAdminUiTest extends TestCase
 {
     use KernelTestBehaviour;

--- a/tests/integration/Elasticsearch/Admin/AdminSearchControllerTest.php
+++ b/tests/integration/Elasticsearch/Admin/AdminSearchControllerTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Integration\Elasticsearch\Admin;
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Promotion\PromotionCollection;
 use Shopware\Core\Framework\Context;
@@ -20,7 +19,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class AdminSearchControllerTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Elasticsearch/Admin/AdminSearchRegistryTest.php
+++ b/tests/integration/Elasticsearch/Admin/AdminSearchRegistryTest.php
@@ -4,7 +4,6 @@ namespace Shopware\Tests\Integration\Elasticsearch\Admin;
 
 use Doctrine\DBAL\Connection;
 use OpenSearch\Client;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Shopware\Core\Framework\Context;
@@ -28,7 +27,6 @@ use Symfony\Component\Messenger\MessageBusInterface;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class AdminSearchRegistryTest extends TestCase
 {
     use AdminApiTestBehaviour;

--- a/tests/integration/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
+++ b/tests/integration/Elasticsearch/Framework/Indexing/ElasticsearchIndexerTest.php
@@ -3,7 +3,6 @@
 namespace Shopware\Tests\Integration\Elasticsearch\Framework\Indexing;
 
 use Doctrine\DBAL\Connection;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Test\TestCaseBase\BasicTestDataBehaviour;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
@@ -14,7 +13,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class ElasticsearchIndexerTest extends TestCase
 {
     use BasicTestDataBehaviour;

--- a/tests/integration/Elasticsearch/Product/CustomFieldUpdaterTest.php
+++ b/tests/integration/Elasticsearch/Product/CustomFieldUpdaterTest.php
@@ -5,7 +5,6 @@ namespace Shopware\Tests\Integration\Elasticsearch\Product;
 use Doctrine\DBAL\Connection;
 use OpenSearch\Client;
 use PHPUnit\Framework\Attributes\Depends;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
@@ -24,7 +23,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class CustomFieldUpdaterTest extends TestCase
 {
     use ElasticsearchTestTestBehaviour;

--- a/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
+++ b/tests/integration/Elasticsearch/Product/ElasticsearchProductTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\Attributes\AfterClass;
 use PHPUnit\Framework\Attributes\BeforeClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Depends;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Product\Aggregate\ProductManufacturer\ProductManufacturerDefinition;
 use Shopware\Core\Content\Product\Aggregate\ProductVisibility\ProductVisibilityDefinition;
@@ -96,7 +95,6 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 class ElasticsearchProductTest extends TestCase
 {
     use CacheTestBehaviour;

--- a/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
+++ b/tests/integration/Storefront/Framework/Cache/HttpCacheIntegrationTest.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * @internal
  */
-#[Group('skip-paratest')]
 #[Group('cache')]
 class HttpCacheIntegrationTest extends TestCase
 {

--- a/tests/integration/Storefront/Framework/Seo/NavigationPageSeoUrlTest.php
+++ b/tests/integration/Storefront/Framework/Seo/NavigationPageSeoUrlTest.php
@@ -26,7 +26,6 @@ use Shopware\Storefront\Framework\Seo\SeoUrlRoute\NavigationPageSeoUrlRoute;
  */
 #[Package('inventory')]
 #[Group('slow')]
-#[Group('skip-paratest')]
 class NavigationPageSeoUrlTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/integration/Storefront/Framework/Seo/SeoUrl/SeoUrlTest.php
+++ b/tests/integration/Storefront/Framework/Seo/SeoUrl/SeoUrlTest.php
@@ -33,7 +33,6 @@ use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
  */
 #[Package('inventory')]
 #[Group('slow')]
-#[Group('skip-paratest')]
 class SeoUrlTest extends TestCase
 {
     use IntegrationTestBehaviour;

--- a/tests/unit/Core/KernelTest.php
+++ b/tests/unit/Core/KernelTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Plugin\KernelPluginLoader\StaticKernelPluginLoader;
+use Shopware\Core\Kernel;
+
+/**
+ * @internal
+ */
+#[CoversClass(Kernel::class)]
+class KernelTest extends TestCase
+{
+    public function testGetCacheDir(): void
+    {
+        $kernel = new Kernel(
+            'fooBar',
+            true,
+            $this->createMock(StaticKernelPluginLoader::class),
+            'cacheId',
+            '6.6.6',
+            $this->createMock(Connection::class),
+            'www/shopware'
+        );
+
+        static::assertStringStartsWith('www/shopware/var/cache/fooBar_h', $kernel->getCacheDir());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

After the update of PHPUnit the command `composer init:testdb` didn't work anymore. See e.g. https://github.com/shopware/shopware/actions/runs/13711815770/job/38349629667


### 2. What does this change do, exactly?

Remove `brianium/paratest` dependency and all related code places as it is unused anyway

### 3. Describe each step to reproduce the issue or behaviour.

Execute `composer init:testdb`

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
