### PR TITLE
fix: replacing feedback link on dashboard

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/snippet/de-DE.json
@@ -63,7 +63,7 @@
       "headline": "Der erste Eindruck zählt.",
       "text": "Berichte uns von Deinen ersten Erfahrungen und hilf uns, Shopware besser zu machen.",
       "feedback": "Feedback geben",
-      "feedbackLink": "https://github.com/shopware/shopware/issues"
+      "feedbackLink": "https://feedback.shopware.com"
     },
     "todayStats": {
       "headline": "Statistik des Tages",

--- a/src/Administration/Resources/app/administration/src/module/sw-dashboard/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/module/sw-dashboard/snippet/en-GB.json
@@ -63,7 +63,7 @@
       "headline": "First impressions count.",
       "text": "Share your first impressions and help us improve the overall Shopware experience.",
       "feedback": "Give feedback",
-      "feedbackLink": "https://github.com/shopware/shopware/issues"
+      "feedbackLink": "https://feedback.shopware.com"
     },
     "todayStats": {
       "headline": "Today's statistics",


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

The current link of the feedback button on the dashboard leads to our issue board (https://github.com/shopware/shopware/issues) but instead should link to our `Product Feedback & Ideas` forum (https://feedback.shopware.com).

### 2. What does this change do, exactly?
This change replaces the mentioned links.

### 3. Describe each step to reproduce the issue or behaviour.
Click on the mentioned button on the dashboard.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
https://shopware.atlassian.net/browse/NEXT-28589

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
