### PR TITLE
fix: date picker in date range condition

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/index.js
@@ -59,7 +59,8 @@ Component.extend('sw-condition-date-range', 'sw-condition-base', {
 
                 // eslint-disable-next-line max-len
                 const date =
-                    this.isDateTime === 'datetime' ? fromDate.replace('.000Z', '+00:00') : fromDate.concat('+00:00');
+                    this.isDateTime === 'datetime' ? fromDate.replace('.000Z', '+00:00') : fromDate.split("T")[0];
+
                 this.condition.value = {
                     ...this.condition.value,
                     fromDate: date,
@@ -75,7 +76,9 @@ Component.extend('sw-condition-date-range', 'sw-condition-base', {
             set(toDate) {
                 this.ensureValueExist();
 
-                const date = this.isDateTime === 'datetime' ? toDate.replace('.000Z', '+00:00') : toDate.concat('+00:00');
+                const date =
+                    this.isDateTime === 'datetime' ? toDate.replace('.000Z', '+00:00') : toDate.split("T")[0];
+
                 this.condition.value = {
                     ...this.condition.value,
                     toDate: date,

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.spec.js
@@ -84,6 +84,6 @@ describe('component/rule/sw-condition-date-range', () => {
         expect(getToDate).toBe('2020-01-01T00:00:00');
 
         wrapper.vm.toDate = '2020-01-01T00:00:00';
-        expect(wrapper.vm.toDate).toBe('2020-01-01T00:00:00+00:00');
+        expect(wrapper.vm.toDate).toBe('2020-01-01');
     });
 });

--- a/src/Core/Framework/Rule/DateRangeRule.php
+++ b/src/Core/Framework/Rule/DateRangeRule.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Framework\Rule;
 
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\Validator\Constraints\DateTime as DateTimeConstraint;
+use Symfony\Component\Validator\Constraints\Date as DateConstraint;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
@@ -81,10 +82,20 @@ class DateRangeRule extends Rule
 
     public function getConstraints(): array
     {
-        return [
-            'fromDate' => [new NotBlank(), new DateTimeConstraint(['format' => \DateTime::ATOM])],
-            'toDate' => [new NotBlank(), new DateTimeConstraint(['format' => \DateTime::ATOM])],
-            'useTime' => [new NotNull(), new Type('bool')],
-        ];
+        if($this->useTime===true){
+            return [
+                'fromDate' => [new NotBlank(), new DateTimeConstraint(['format' => \DateTime::ATOM])],
+                'toDate' => [new NotBlank(), new DateTimeConstraint(['format' => \DateTime::ATOM])],
+                'useTime' => [new NotNull(), new Type('bool')],
+            ];
+        }
+        else {
+            return [
+                'fromDate' => [new NotBlank(), new DateConstraint()],
+                'toDate' => [new NotBlank(), new DateConstraint()],
+                'useTime' => [new NotNull(), new Type('bool')],
+            ];
+        }
+
     }
 }

--- a/src/Core/Framework/Rule/DateRangeRule.php
+++ b/src/Core/Framework/Rule/DateRangeRule.php
@@ -29,8 +29,9 @@ class DateRangeRule extends Rule
     public function __construct(
         ?\DateTimeInterface $fromDate = null,
         ?\DateTimeInterface $toDate = null,
-        bool $useTime = false
-    ) {
+        bool                $useTime = false
+    )
+    {
         parent::__construct();
         $this->useTime = $useTime;
         $this->fromDate = $fromDate;
@@ -82,20 +83,18 @@ class DateRangeRule extends Rule
 
     public function getConstraints(): array
     {
-        if($this->useTime===true){
+        if ($this->useTime === true) {
             return [
                 'fromDate' => [new NotBlank(), new DateTimeConstraint(['format' => \DateTime::ATOM])],
                 'toDate' => [new NotBlank(), new DateTimeConstraint(['format' => \DateTime::ATOM])],
                 'useTime' => [new NotNull(), new Type('bool')],
             ];
         }
-        else {
-            return [
-                'fromDate' => [new NotBlank(), new DateConstraint()],
-                'toDate' => [new NotBlank(), new DateConstraint()],
-                'useTime' => [new NotNull(), new Type('bool')],
-            ];
-        }
+        return [
+            'fromDate' => [new NotBlank(), new DateConstraint()],
+            'toDate' => [new NotBlank(), new DateConstraint()],
+            'useTime' => [new NotNull(), new Type('bool')],
+        ];
 
     }
 }

--- a/src/Core/Migration/V6_7/Migration1741596047.php
+++ b/src/Core/Migration/V6_7/Migration1741596047.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1741596047 extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1741596047;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeQuery("
+            UPDATE rule_condition
+            SET value = JSON_SET(
+                value,
+                '$.fromDate', DATE(JSON_UNQUOTE(JSON_EXTRACT(value, '$.fromDate'))),
+                '$.toDate', DATE(JSON_UNQUOTE(JSON_EXTRACT(value, '$.toDate')))
+            )
+            WHERE JSON_UNQUOTE(JSON_EXTRACT(value, '$.useTime')) = 'false'
+        ");
+
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1741596047ChangeDateFormatOfCondition.php
+++ b/src/Core/Migration/V6_7/Migration1741596047ChangeDateFormatOfCondition.php
@@ -9,8 +9,8 @@ use Shopware\Core\Framework\Migration\MigrationStep;
 /**
  * @internal
  */
-#[Package('core')]
-class Migration1741596047 extends MigrationStep
+#[Package('fundamentals@after-sales')]
+class Migration1741596047ChangeDateFormatOfCondition extends MigrationStep
 {
     public function getCreationTimestamp(): int
     {
@@ -19,15 +19,15 @@ class Migration1741596047 extends MigrationStep
 
     public function update(Connection $connection): void
     {
-        $connection->executeQuery("
+        $connection->executeQuery('
             UPDATE rule_condition
             SET value = JSON_SET(
                 value,
-                '$.fromDate', DATE(JSON_UNQUOTE(JSON_EXTRACT(value, '$.fromDate'))),
-                '$.toDate', DATE(JSON_UNQUOTE(JSON_EXTRACT(value, '$.toDate')))
+                \'$.fromDate\', DATE(JSON_UNQUOTE(JSON_EXTRACT(value, \'$.fromDate\'))),
+                \'$.toDate\', DATE(JSON_UNQUOTE(JSON_EXTRACT(value, \'$.toDate\')))
             )
-            WHERE JSON_UNQUOTE(JSON_EXTRACT(value, '$.useTime')) = 'false'
-        ");
+            WHERE JSON_UNQUOTE(JSON_EXTRACT(value, \'$.useTime\')) = \'false\'
+        ');
 
     }
 }

--- a/tests/integration/Core/Checkout/Payment/SalesChannel/PaymentMethodRouteTest.php
+++ b/tests/integration/Core/Checkout/Payment/SalesChannel/PaymentMethodRouteTest.php
@@ -103,7 +103,7 @@ class PaymentMethodRouteTest extends TestCase
                             'value' => [
                                 'fromDate' => '2000-06-07T11:37:51+02:00',
                                 'toDate' => '2099-06-07T11:37:51+02:00',
-                                'useTime' => false,
+                                'useTime' => true,
                             ],
                         ],
                     ],
@@ -125,7 +125,7 @@ class PaymentMethodRouteTest extends TestCase
                             'value' => [
                                 'fromDate' => '2000-06-07T11:37:51+02:00',
                                 'toDate' => '2099-06-07T11:37:51+02:00',
-                                'useTime' => false,
+                                'useTime' => true,
                             ],
                         ],
                     ],
@@ -147,7 +147,7 @@ class PaymentMethodRouteTest extends TestCase
                             'value' => [
                                 'fromDate' => '2000-06-07T11:37:51+02:00',
                                 'toDate' => '2000-06-07T11:37:51+02:00',
-                                'useTime' => false,
+                                'useTime' => true,
                             ],
                         ],
                     ],

--- a/tests/integration/Core/Checkout/Shipping/SalesChannel/ShippingMethodRouteTest.php
+++ b/tests/integration/Core/Checkout/Shipping/SalesChannel/ShippingMethodRouteTest.php
@@ -207,7 +207,7 @@ class ShippingMethodRouteTest extends TestCase
                             'value' => [
                                 'fromDate' => '2000-06-07T11:37:51+02:00',
                                 'toDate' => '2099-06-07T11:37:51+02:00',
-                                'useTime' => false,
+                                'useTime' => true,
                             ],
                         ],
                     ],
@@ -237,7 +237,7 @@ class ShippingMethodRouteTest extends TestCase
                             'value' => [
                                 'fromDate' => '2000-06-07T11:37:51+02:00',
                                 'toDate' => '2099-06-07T11:37:51+02:00',
-                                'useTime' => false,
+                                'useTime' => true,
                             ],
                         ],
                     ],
@@ -267,7 +267,7 @@ class ShippingMethodRouteTest extends TestCase
                             'value' => [
                                 'fromDate' => '2000-06-07T11:37:51+02:00',
                                 'toDate' => '2000-06-07T11:37:51+02:00',
-                                'useTime' => false,
+                                'useTime' => true,
                             ],
                         ],
                     ],


### PR DESCRIPTION
### 1. Why is this change necessary?
The date-picker in the date range can't enter and save a date when "Excluding timestamp" is selected.

### 2. What does this change do, exactly?
Changes how the date is stored when useTime is set to false (When Excluding timestamp is selected) which turns a date: '2020-01-01T00:00:00' to '2020-01-01',and uses the DateConstraint for the rule according to 'useTime'

### 3. Describe each step to reproduce the issue or behaviour.
    1. Go to Settings > Rule builder
    2. Create a new rule
    3. Select “Date range” condition
    4. Open date picker & select a value
    Result: the input field value will not change

### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-40946


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
