### PR TITLE
ci: sync issues priority with framework group project

### DIFF
--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -124,3 +124,27 @@ jobs:
           script: |
             const { closeStaleIssues } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
             await closeStaleIssues({github, core, context}, process.env.DRY_RUN)
+
+  priority-sync:
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'issues' && github.event.action == 'labeled' && startsWith(github.event.label.name, 'priority')
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
+      - id: sts
+        continue-on-error: true
+        uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # 1.0.0
+        with:
+          scope: shopware
+          identity: ManageProjects
+      - shell: bash
+        run: npm ci --prefix .github/bin/js/
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        with:
+          github-token: ${{ steps.sts.outputs.token }}
+          script: |
+            const { syncPriorities } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
+            await syncPriorities({github, core, context})


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently we need to manually set the priority in the project cards when we set a `priority/*` label.

### 2. What does this change do, exactly?
Every time a issue gets a `priority/*` label, we sync the priority with the Framework Group project board.

### 3. Describe each step to reproduce the issue or behaviour.
Available after merge:
- Add a `priority/*` label to a issue that is part of the Framework Group board.

### 4. Please link to the relevant issues (if any).
- closes #7258 