### PR TITLE
fix: add accessible menu to folder navigation [6.6.x]

### DIFF
--- a/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/navigation/navigation.html.twig
@@ -48,6 +48,21 @@
                                                 <span itemprop="name">{{ name }}</span>
                                             </div>
                                         </div>
+                                        {% if feature('ACCESSIBILITY_TWEAKS') and (treeItem.children|length > 0) %}
+                                            <div class="navigation-flyouts position-absolute w-100 start-0">
+                                                <div class="navigation-flyout"
+                                                     data-flyout-menu-id="{{ treeItem.category.id }}">
+                                                    <div class="container">
+                                                        {% sw_include '@Storefront/storefront/layout/navigation/flyout.html.twig' with {
+                                                            themeIconConfig: themeIconConfig,
+                                                            navigationTree: treeItem,
+                                                            level: level+1,
+                                                            page: page
+                                                        } only %}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        {% endif %}
                                     {% else %}
                                         {% set active = '' %}
                                         {% if category.id == shopware.navigation.id or category.id in activePath %}


### PR DESCRIPTION
Add the fly-out menu to the new location within the `<div>` element that contains the menu entry instead of using the off-canvas for menu entries of type `folder`. This fixes menus not being shown when the **ACCESSIBILITY_TWEAKS** flag is enabled.

https://shopware.atlassian.net/browse/NEXT-40641