### PR TITLE
chore: Introduce composer require checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -314,6 +314,9 @@
             "@php vendor-bin/roave-backward-compatibility-check/bin/verify-version.php",
             "roave-backward-compatibility-check --install-development-dependencies --from=$(git tag -l --sort -version:refname | head -n 1)"
         ],
+        "require-check": [
+            "php vendor-bin/composer-require-checker/vendor/bin/composer-require-checker check composer.json"
+        ],
         "build:js": [
             "@build:js:admin",
             "@build:js:storefront"

--- a/src/Administration/Framework/Routing/NotFound/AdministrationNotFoundSubscriber.php
+++ b/src/Administration/Framework/Routing/NotFound/AdministrationNotFoundSubscriber.php
@@ -2,8 +2,8 @@
 
 namespace Shopware\Administration\Framework\Routing\NotFound;
 
-use Psr\Container\ContainerInterface;
 use Shopware\Core\Framework\Log\Package;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;

--- a/src/Administration/Snippet/AppAdministrationSnippetCollection.php
+++ b/src/Administration/Snippet/AppAdministrationSnippetCollection.php
@@ -7,14 +7,6 @@ use Shopware\Core\Framework\Log\Package;
 
 /**
  * @extends EntityCollection<AppAdministrationSnippetEntity>
- *
- * @method void add(AppAdministrationSnippetEntity $entity)
- * @method void set(string $key, AppAdministrationSnippetEntity $entity)
- * @method AppAdministrationSnippetEntity[] getIterator()
- * @method AppAdministrationSnippetEntity[] getElements()
- * @method AppAdministrationSnippetEntity|null get(string $key)
- * @method AppAdministrationSnippetEntity|null first()
- * @method AppAdministrationSnippetEntity|null last()
  */
 #[Package('discovery')]
 class AppAdministrationSnippetCollection extends EntityCollection

--- a/src/Administration/composer.json
+++ b/src/Administration/composer.json
@@ -30,11 +30,23 @@
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "doctrine/dbal": "^4.2",
+        "league/flysystem": "^3.10.3",
         "pentatrion/vite-bundle": "^7.0",
         "shopware/core": "*",
+        "symfony/asset": "~7.2.0",
+        "symfony/cache": "~7.2.0",
+        "symfony/console": "~7.2.0",
+        "symfony/dependency-injection": "~7.2.0",
+        "symfony/event-dispatcher": "~7.2.0",
+        "symfony/event-dispatcher-contracts": "~7.2.0",
+        "symfony/filesystem": "~7.2.0",
+        "symfony/finder": "~7.2.0",
         "symfony/framework-bundle": "~7.2.0",
         "symfony/http-foundation": "~7.2.0",
+        "symfony/http-kernel": "~7.2.0",
         "symfony/mime": "~7.2.0",
-        "symfony/routing": "~7.2.0"
+        "symfony/routing": "~7.2.0",
+        "symfony/serializer": "~7.2.0",
+        "symfony/validator": "~7.2.0"
     }
 }

--- a/vendor-bin/composer-require-checker/composer.json
+++ b/vendor-bin/composer-require-checker/composer.json
@@ -1,0 +1,6 @@
+{
+    "require-dev": {
+        "maglnet/composer-require-checker": "^4.16.1"
+    },
+    "sort-packages": true
+}


### PR DESCRIPTION
We are using transitive composer dependencies directly in some places. we should ensure that, we require them directly 