### PR TITLE
fix: initialize empty properties on cms section and block config

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/index.ts
@@ -144,9 +144,8 @@ export default Shopware.Component.wrapComponentConfig({
 
     methods: {
         createdComponent() {
-            if (!this.block.backgroundMediaMode) {
-                this.block.backgroundMediaMode = 'cover';
-            }
+            this.block.backgroundMediaMode ??= 'cover';
+            this.block.backgroundColor ??= '';
         },
 
         onBlockOverlayClick() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-block/sw-cms-block.spec.js
@@ -43,6 +43,8 @@ describe('module/sw-cms/component/sw-cms-block', () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.vm).toBeTruthy();
+        expect(wrapper.vm.block.backgroundMediaMode).toBe('cover');
+        expect(wrapper.vm.block.backgroundColor).toBe('');
     });
 
     it('should have the overlay by default', async () => {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/index.ts
@@ -216,9 +216,8 @@ export default Shopware.Component.wrapComponentConfig({
 
     methods: {
         createdComponent() {
-            if (!this.section.backgroundMediaMode) {
-                this.section.backgroundMediaMode = 'cover';
-            }
+            this.section.backgroundMediaMode ??= 'cover';
+            this.section.backgroundColor ??= '';
         },
 
         openBlockBar() {

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-section/sw-cms-section.spec.js
@@ -96,6 +96,8 @@ describe('module/sw-cms/component/sw-cms-section', () => {
         const wrapper = await createWrapper();
 
         expect(wrapper.vm).toBeTruthy();
+        expect(wrapper.vm.section.backgroundMediaMode).toBe('cover');
+        expect(wrapper.vm.section.backgroundColor).toBe('');
     });
 
     it('should not disable all sub components', async () => {


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When working with new content, the CMS is leaving some properties uninitialized, like a some background related properties. This is leading to some runtime exceptions where strings are expceted and null is given.

### 2. What does this change do, exactly?
Add a default value to the `backgroundColor` properties of said configs.

### 3. Describe each step to reproduce the issue or behaviour.
In the CMs, open the section or block settings. This should lead to the CMS running into an exception and the sidebar not working properly.

![image](https://github.com/user-attachments/assets/380366a3-c412-417e-8f46-801c0b7162d2)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
