### PR TITLE
fix: progress bar showing NaN%

### DIFF
--- a/changelog/_unreleased/2025-03-12-fix-progress-bar-showing-nan.md
+++ b/changelog/_unreleased/2025-03-12-fix-progress-bar-showing-nan.md
@@ -1,0 +1,7 @@
+---
+title: Fix progress bar showing NaN
+issue: NEXT-41038
+---
+# Administration
+* Deprecated `progressInPercentage` computed property in `sw-product-clone-modal` component
+* Changed `sw_product_clone_modal_progress_bar` block in `sw-product-clone-modal` component template to correct the usage of `mt-progress-bar` component

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/index.js
@@ -34,6 +34,7 @@ export default {
     },
 
     computed: {
+        // @deprecated tag:v6.8.0 - Will be removed, no longer needed
         progressInPercentage() {
             return 100 / (this.cloneMaxProgress * this.cloneProgress);
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/sw-product-clone-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-clone-modal/sw-product-clone-modal.html.twig
@@ -15,7 +15,8 @@
     {% block sw_product_clone_modal_progress_bar %}
     <mt-progress-bar
         class="clone-variant-progress-bar"
-        :model-value="progressInPercentage"
+        :max-value="cloneMaxProgress"
+        :model-value="cloneProgress"
     />
     {% endblock %}
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

There is a NaN% displayed in the progress bar when duplicating a product that has variants.

### 2. What does this change do, exactly?

Passing down the correct data to the progress bar

### 3. Describe each step to reproduce the issue or behaviour.

Duplicating a product that has variants.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

Jira issue: https://shopware.atlassian.net/browse/NEXT-40986

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
