### PR TITLE
[Epic] Create CMS Popup Builder

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/component/component.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/component/component.spec.js
@@ -1,0 +1,9 @@
+/**
+ * @sw-package discovery
+ */
+import { runGenericCmsTest } from 'src/module/sw-cms/test-utils';
+import component from './index';
+
+describe('src/module/sw-cms/blocks/popup/component', () => {
+    runGenericCmsTest(component);
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/component/index.js
@@ -1,0 +1,9 @@
+import template from './sw-cms-block-popup.html.twig';
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+export default {
+    template,
+};

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/component/sw-cms-block-popup.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/component/sw-cms-block-popup.html.twig
@@ -1,0 +1,6 @@
+<!-- File: src/module/sw-cms/blocks/popup/component/sw-cms-block-popup.html.twig -->
+{% block sw_cms_block_popup %}
+    <div class="sw-cms-block-popup">
+        <slot name="content">{% block sw_cms_block_popup_slot_content %}{% endblock %}</slot>
+    </div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/component/sw-cms-block-popup.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/component/sw-cms-block-popup.scss
@@ -1,0 +1,7 @@
+/* File: src/module/sw-cms/blocks/popup/sw-cms-block-popup.scss */
+.sw-cms-block-popup {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 20px;
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/index.ts
@@ -1,0 +1,62 @@
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-block-popup', () => import('./component'));
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-preview-popup', () => import('./preview'));
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Service('cmsService').registerCmsBlock({
+    name: 'popup',
+    label: 'sw-cms.blocks.popup.popup.label', // Changed from form to popup
+    category: 'form', // Could be changed to 'custom' or another relevant category
+    component: 'sw-cms-block-popup',
+    previewComponent: 'sw-cms-preview-popup',
+    defaultConfig: {
+        marginBottom: '20px',
+        marginTop: '20px',
+        marginLeft: null,
+        marginRight: null,
+        sizingMode: 'boxed',
+    },
+    slots: {
+        content: {
+            type: 'popup-element',
+            default: {
+                config: {
+                    title: {
+                        source: 'static',
+                        value: 'Popup Title',
+                    },
+                    content: {
+                        source: 'static',
+                        value: 'This is a popup content',
+                    },
+                    buttonText: {
+                        source: 'static',
+                        value: 'Open Popup',
+                    },
+                    width: {
+                        source: 'static',
+                        value: '400px',
+                    },
+                    height: {
+                        source: 'static',
+                        value: 'auto',
+                    },
+                    trigger: {
+                        source: 'static',
+                        value: 'click',
+                    },
+                },
+            },
+        },
+    },
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/preview/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/preview/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @private
+ * @sw-package discovery
+ */
+import template from './sw-cms-preview-popup.html.twig';
+import './sw-cms-preview-popup.scss';
+
+Shopware.Component.register('sw-cms-preview-popup', {
+    template,
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/preview/sw-cms-preview-popup.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/preview/sw-cms-preview-popup.html.twig
@@ -1,0 +1,10 @@
+<!-- File: src/module/sw-cms/blocks/popup/preview/sw-cms-preview-popup.html.twig -->
+{% block sw_cms_preview_popup %}
+    <div class="sw-cms-preview-popup">
+        <div class="sw-cms-preview-popup-button">Popup Button</div>
+        <div class="sw-cms-preview-popup-container">
+            <h2>Popup Title</h2>
+            <p>Popup Content</p>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/preview/sw-cms-preview-popup.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/blocks/popup/preview/sw-cms-preview-popup.scss
@@ -1,0 +1,35 @@
+/* File: src/module/sw-cms/blocks/popup/preview/sw-cms-preview-popup.scss */
+.sw-cms-preview-popup {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    
+    .sw-cms-preview-popup-button {
+        padding: 5px 10px;
+        background-color: #189eff;
+        color: white;
+        border-radius: 4px;
+        margin-bottom: 10px;
+        cursor: pointer;
+    }
+    
+    .sw-cms-preview-popup-container {
+        background-color: white;
+        border: 1px solid #d1d9e0;
+        padding: 10px;
+        width: 80%;
+        box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);
+        
+        h2 {
+            font-size: 16px;
+            margin-bottom: 8px;
+        }
+        
+        p {
+            font-size: 12px;
+        }
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-age-verification/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-age-verification/index.js
@@ -1,0 +1,30 @@
+import { Mixin } from 'src/core/shopware';
+import AgeVerification from './sw-cms-el-form-age-verification';
+
+export default {
+    template,
+
+    mixins: [
+        Mixin.getByName('cms-element'),
+    ],
+
+    components: {
+        'sw-cms-el-form-age-verification': AgeVerification
+    },
+
+    computed: {
+        selectedForm() {
+            return this.element.config.type.value;
+        },
+    },
+
+    created() {
+        this.createdComponent();
+    },
+
+    methods: {
+        createdComponent() {
+            this.initElementConfig('age-verification');
+        },
+    },
+};

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-age-verification/sw-cms-el-form-age-verification.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/form/component/templates/form-age-verification/sw-cms-el-form-age-verification.html.twig
@@ -1,0 +1,36 @@
+{% block sw_cms_el_form_age_verification %}
+<div class="sw-cms-el-form-age-verification">
+    <h3 v-if="formSettings.title.value.length > 0" class="sw-cms-el-form-headline">
+        {{ formSettings.title.value }}
+    </h3>
+
+    <mt-text-field
+        :label="$tc('sw-cms.elements.form.element.ageVerification.placeholder.age')"
+        :model-value="$tc('sw-cms.elements.form.element.placeholder.age')"
+    />
+
+    <div class="sw-cms-el-form-contact-form-group three-items">
+        <mt-text-field
+            :label="$tc('sw-cms.elements.form.element.ageVerification.placeholder.firstName')"
+            :model-value="$tc('sw-cms.elements.form.element.placeholder.firstName')"
+        />
+
+        <mt-text-field
+            :label="$tc('sw-cms.elements.form.element.ageVerification.placeholder.lastName')"
+            :model-value="$tc('sw-cms.elements.form.element.placeholder.lastName')"
+        />
+    </div>
+
+    <h4>{{ $tc('sw-cms.elements.form.element.label.privacy') }}</h4>
+
+    <mt-checkbox :label="$tc('sw-cms.elements.form.element.helpText.privacy')" />
+
+    <p class="sw-cms-el-form-note">
+        {{ $tc('sw-cms.elements.form.element.helpText.requiredFields') }}
+    </p>
+
+    <div class="sw-cms-el-form__action">
+        {{ $tc('sw-cms.elements.form.element.label.submit') }}
+    </div>
+</div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/index.ts
@@ -21,3 +21,4 @@ import './product-description-reviews';
 import './buy-box';
 import './cross-selling';
 import './html';
+import './popup';

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/component/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/component/index.js
@@ -1,0 +1,55 @@
+/**
+ * @private
+ * @sw-package discovery
+ */
+import template from './sw-cms-el-popup.html.twig';
+import '../sw-cms-el-popup.scss';
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-el-popup', {
+    template,
+
+    mixins: [
+        Shopware.Mixin.getByName('cms-element')
+    ],
+    
+    inject: ['cmsService'],
+    
+    data() {
+        return {
+            showPopup: false
+        };
+    },
+
+    computed: {
+        popupStyles() {
+            return {
+                width: this.element.config.width.value,
+                height: this.element.config.height.value
+            };
+        }
+    },
+
+    methods: {
+        togglePopup() {
+            this.showPopup = !this.showPopup;
+        },
+        
+        closePopup() {
+            this.showPopup = false;
+        },
+        
+        createdComponent() {
+            // Initialize the CMS element
+            this.initElementConfig('popup-element');
+            this.initElementData('popup-element');
+        }
+    },
+
+    created() {
+        this.createdComponent();
+    }
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/component/sw-cms-el-popup.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/component/sw-cms-el-popup.html.twig
@@ -1,0 +1,30 @@
+{% block sw_cms_element_popup %}
+    <div class="sw-cms-el-popup">
+        <!-- Button display in admin -->
+        <div class="sw-cms-el-popup-admin">
+            <p class="sw-cms-el-popup-admin-title">{{ element.config.title.value || 'Popup Title' }}</p>
+            <div class="sw-cms-el-popup-admin-button">{{ element.config.buttonText.value || 'Open Popup' }}</div>
+            <p class="sw-cms-el-popup-admin-info">Popup content: {{ element.config.content.value || 'Popup content will display here' }}</p>
+        </div>
+        
+        <!-- This will be used on the actual storefront -->
+        <div v-show="false">
+            <button class="sw-cms-el-popup-button" @click="togglePopup">
+                {{ element.config.buttonText.value }}
+            </button>
+
+            <div class="sw-cms-el-popup-overlay" v-if="showPopup" @click="closePopup">
+                <div class="sw-cms-el-popup-container" @click.stop
+                     :style="popupStyles">
+                    <div class="sw-cms-el-popup-header">
+                        <h2>{{ element.config.title.value }}</h2>
+                        <button class="sw-cms-el-popup-close" @click="closePopup">×</button>
+                    </div>
+                    <div class="sw-cms-el-popup-content">
+                        {{ element.config.content.value }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/config/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/config/index.js
@@ -1,0 +1,46 @@
+/**
+ * @private
+ * @sw-package discovery
+ */
+import template from './sw-cms-el-config-popup.html.twig';
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-el-config-popup', {
+    template,
+
+    mixins: [
+        Shopware.Mixin.getByName('cms-element')
+    ],
+
+    data() {
+        return {
+            triggerOptions: [
+                { 
+                    label: this.$tc('sw-cms.elements.popup.config.options.click'), 
+                    value: 'click' 
+                },
+                { 
+                    label: this.$tc('sw-cms.elements.popup.config.options.hover'), 
+                    value: 'hover' 
+                },
+                { 
+                    label: this.$tc('sw-cms.elements.popup.config.options.auto'), 
+                    value: 'auto' 
+                }
+            ]
+        };
+    },
+
+    created() {
+        this.createdComponent();
+    },
+
+    methods: {
+        createdComponent() {
+            this.initElementConfig('popup-element');
+        }
+    }
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/config/sw-cms-el-config-popup.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/config/sw-cms-el-config-popup.html.twig
@@ -1,0 +1,39 @@
+{% block sw_cms_element_popup_config %}
+    <div class="sw-cms-el-config-popup">
+        <sw-text-field
+            :label="$tc('sw-cms.elements.popup.config.labelTitle')"
+            :placeholder="$tc('sw-cms.elements.popup.config.placeholderTitle')"
+            v-model="element.config.title.value">
+        </sw-text-field>
+        
+        <sw-textarea-field
+            :label="$tc('sw-cms.elements.popup.config.labelContent')"
+            :placeholder="$tc('sw-cms.elements.popup.config.placeholderContent')"
+            v-model="element.config.content.value">
+        </sw-textarea-field>
+        
+        <sw-text-field
+            :label="$tc('sw-cms.elements.popup.config.labelButtonText')"
+            :placeholder="$tc('sw-cms.elements.popup.config.placeholderButtonText')"
+            v-model="element.config.buttonText.value">
+        </sw-text-field>
+        
+        <sw-text-field
+            :label="$tc('sw-cms.elements.popup.config.labelWidth')"
+            :placeholder="$tc('sw-cms.elements.popup.config.placeholderWidth')"
+            v-model="element.config.width.value">
+        </sw-text-field>
+        
+        <sw-text-field
+            :label="$tc('sw-cms.elements.popup.config.labelHeight')"
+            :placeholder="$tc('sw-cms.elements.popup.config.placeholderHeight')"
+            v-model="element.config.height.value">
+        </sw-text-field>
+        
+        <sw-single-select
+            :label="$tc('sw-cms.elements.popup.config.labelTrigger')"
+            :options="triggerOptions"
+            v-model="element.config.trigger.value">
+        </sw-single-select>
+    </div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/index.js
@@ -1,0 +1,35 @@
+/**
+ * @private
+ * @sw-package discovery
+ */
+import './component';
+import './config';
+import './preview';
+
+Shopware.Service('cmsService').registerCmsElement({
+    name: 'popup-element',
+    label: {
+        'de-DE': 'Popup',
+        'en-GB': 'Popup'
+    },
+    component: 'sw-cms-el-popup',
+    configComponent: 'sw-cms-el-config-popup',
+    previewComponent: 'sw-cms-el-preview-popup',
+    defaultConfig: {
+        title: { source: 'static', value: 'Popup Title' },
+        content: { source: 'static', value: 'Popup Content' },
+        buttonText: { source: 'static', value: 'Open Popup' },
+        width: { source: 'static', value: '400px' },
+        height: { source: 'static', value: 'auto' },
+        trigger: { source: 'static', value: 'click' }
+    },
+    collect: function collect(elem) {
+        const context = {
+            title: elem.config.title.value,
+            content: elem.config.content.value,
+            buttonText: elem.config.buttonText.value
+        };
+
+        return context;
+    }
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/preview/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/preview/index.js
@@ -1,0 +1,14 @@
+/**
+ * @private
+ * @sw-package discovery
+ */
+import template from './sw-cms-el-preview-popup.html.twig';
+import './sw-cms-el-preview-popup.scss';
+
+/**
+ * @private
+ * @sw-package discovery
+ */
+Shopware.Component.register('sw-cms-el-preview-popup', {
+    template
+});

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/preview/sw-cms-el-preview-popup.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/preview/sw-cms-el-preview-popup.html.twig
@@ -1,0 +1,7 @@
+{% block sw_cms_element_popup_preview %}
+    <div class="sw-cms-el-preview-popup">
+        <div class="sw-cms-el-preview-popup-button">
+            Open Popup
+        </div>
+    </div>
+{% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/preview/sw-cms-el-preview-popup.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/preview/sw-cms-el-preview-popup.scss
@@ -1,0 +1,37 @@
+.sw-cms-preview-popup {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    
+    .sw-cms-preview-popup-button {
+        padding: 5px 10px;
+        background-color: #189eff;
+        color: white;
+        border-radius: 4px;
+        margin-bottom: 10px;
+        cursor: pointer;
+        font-size: 11px;
+    }
+    
+    .sw-cms-preview-popup-container {
+        background-color: white;
+        border: 1px solid #d1d9e0;
+        padding: 5px 10px;
+        width: 80%;
+        box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16);
+        
+        h2 {
+            font-size: 12px;
+            margin-bottom: 2px;
+            font-weight: bold;
+        }
+        
+        p {
+            font-size: 10px;
+            margin: 0;
+        }
+    }
+}

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/sw-cms-el-popup.scss
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/elements/popup/sw-cms-el-popup.scss
@@ -1,0 +1,100 @@
+.sw-cms-el-popup {
+    &-admin {
+        border: 1px dashed #d8dde6;
+        border-radius: 4px;
+        padding: 10px;
+        text-align: center;
+        min-height: 100px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        
+        &-title {
+            font-weight: bold;
+            margin-bottom: 8px;
+            font-size: 14px;
+        }
+        
+        &-button {
+            display: inline-block;
+            padding: 6px 12px;
+            background-color: #189eff;
+            color: white;
+            border-radius: 4px;
+            margin: 8px 0;
+            font-size: 12px;
+        }
+        
+        &-info {
+            font-size: 11px;
+            color: #71758a;
+            margin-top: 8px;
+            max-width: 200px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    }
+
+    &-button {
+        padding: 8px 16px;
+        background-color: #189eff;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        
+        &:hover {
+            background-color: #0080dc;
+        }
+    }
+    
+    &-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: rgba(0, 0, 0, 0.5);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        z-index: 1000;
+    }
+    
+    &-container {
+        background-color: white;
+        border-radius: 4px;
+        box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+        max-width: 90%;
+        max-height: 90%;
+        overflow: auto;
+    }
+    
+    &-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 16px;
+        border-bottom: 1px solid #d1d9e0;
+        
+        h2 {
+            margin: 0;
+            font-size: 18px;
+        }
+    }
+    
+    &-close {
+        background: none;
+        border: none;
+        font-size: 24px;
+        cursor: pointer;
+        padding: 0;
+        line-height: 1;
+    }
+    
+    &-content {
+        padding: 16px;
+    }
+}

--- a/src/Core/Migration/V6_7/Migration1741702041AddAgeVerificationPage.php
+++ b/src/Core/Migration/V6_7/Migration1741702041AddAgeVerificationPage.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('core')]
+class Migration1741702041AddAgeVerificationPage extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1741702041;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $layoutId = Uuid::randomBytes();
+        $sectionId = Uuid::randomBytes();
+        $blockId = Uuid::randomBytes();
+        $slotTextId = Uuid::randomBytes();
+        $slotButtonId = Uuid::randomBytes();
+        $languageId = Uuid::fromHexToBytes('2fbb5fe2e29a4d70aa5854ce7ce3e20b'); 
+        $versionId = Uuid::fromHexToBytes('0fa91ce3e96a4bc2be4bd9ce752c3425'); 
+
+        $connection->executeStatement('
+            INSERT INTO cms_page (id, version_id, type, locked, created_at)
+            VALUES (:id, :versionId, :type, :locked, NOW())
+        ', [
+            'id' => $layoutId,
+            'versionId' => $versionId,
+            'type' => 'landingpage', 
+            'locked' => 0
+        ]);
+
+        $connection->executeStatement('
+            INSERT INTO cms_page_translation (cms_page_id, cms_page_version_id, language_id, name, created_at)
+            VALUES (:cmsPageId, :cmsPageVersionId, :languageId, :name, NOW())
+        ', [
+            'cmsPageId' => $layoutId,
+            'cmsPageVersionId' => $versionId,
+            'languageId' => $languageId,
+            'name' => 'Altersverifikation'
+        ]);
+
+        $connection->executeStatement('
+            INSERT INTO cms_section (id, version_id, cms_page_id, cms_page_version_id, position, type, sizing_mode, created_at)
+            VALUES (:id, :versionId, :pageId, :pageVersionId, 0, :type, :sizingMode, NOW())
+        ', [
+            'id' => $sectionId,
+            'versionId' => $versionId,
+            'pageId' => $layoutId,
+            'pageVersionId' => $versionId,
+            'type' => 'default',
+            'sizingMode' => 'boxed'
+        ]);
+
+        $connection->executeStatement('
+            INSERT INTO cms_block (id, version_id, cms_section_id, cms_section_version_id, position, type, name, locked, created_at)
+            VALUES (:id, :versionId, :sectionId, :sectionVersionId, 0, :type, :name, :locked, NOW())
+        ', [
+            'id' => $blockId,
+            'versionId' => $versionId,
+            'sectionId' => $sectionId,
+            'sectionVersionId' => $versionId,
+            'type' => 'text',
+            'name' => 'Altersverifikation Block',
+            'locked' => 0
+        ]);
+
+        $connection->executeStatement('
+            INSERT INTO cms_slot (id, version_id, cms_block_id, cms_block_version_id, type, slot, locked, created_at)
+            VALUES (:id, :versionId, :blockId, :blockVersionId, :type, :slot, :locked, NOW())
+        ', [
+            'id' => $slotTextId,
+            'versionId' => $versionId,
+            'blockId' => $blockId,
+            'blockVersionId' => $versionId,
+            'type' => 'text',
+            'slot' => 'content',
+            'locked' => 0
+        ]);
+
+        $connection->executeStatement('
+            INSERT INTO cms_slot (id, version_id, cms_block_id, cms_block_version_id, type, slot, locked, created_at)
+            VALUES (:id, :versionId, :blockId, :blockVersionId, :type, :slot, :locked, NOW())
+        ', [
+            'id' => $slotButtonId,
+            'versionId' => $versionId,
+            'blockId' => $blockId,
+            'blockVersionId' => $versionId,
+            'type' => 'button',
+            'slot' => 'buttons',
+            'locked' => 0
+        ]);
+    }
+
+    public function updateDestructive(Connection $connection): void
+    {
+
+    }
+}

--- a/src/Core/System/Resources/config/basicInformation.xml
+++ b/src/Core/System/Resources/config/basicInformation.xml
@@ -154,6 +154,16 @@
             <placeholder lang="de-DE">Layout zuweisen ...</placeholder>
         </component>
 
+        <component name="sw-cms-page-select">
+            <name>ageVerificationPage</name>
+            <entity>cms_page</entity>
+            <pageType>page</pageType>
+            <label>Shop page layout for age verification</label>
+            <label lang="de-DE">Shopseiten-Layout für Altersverifikation</label>
+            <placeholder>Assign layout...</placeholder>
+            <placeholder lang="de-DE">Layout zuweisen ...</placeholder>
+        </component>
+
     </card>
 
     <card>


### PR DESCRIPTION
### Problem we must solve

Merchants require a customizable and integrated solution for age verification to comply with legal requirements and enhance user experience.

### WHY we need to solve it

As a final project for Silas, we decided to integrate the improved functionalities of the SwagCustomNotification App into the Shopware Core.

During this process, we identified the Popup Builder as a great starting point.

Here is the link to our mock-up: [Miro Board](https://miro.com/app/board/uXjVL2Rjmpo=/?share_link_id=960847955900) 

### Solution to the problem

Our idea is to introduce a new shop page layout called **“Default Popup Layout for Age Verification”**. This layout will be automatically created by the system and locked by default. However, it can be duplicated and customized as needed.

Additionally, we want to add a new **CMS category “Popup”,** which will contain a new CMS element “Age Verification”. This element includes a template featuring a title, content, and button text, which will be displayed in the popup and is part of the new shop page layout.

By implementing this into the CMS, we enable flexible handling and customization of the popup. This is particularly beneficial because the original app was very restrictive in terms of possibilities. Thanks to the CMS, customers can expand the new layout, add more CMS elements, and customize the popup to meet their individual needs.

### WHO benefits

With this integration, the Popup Builder becomes seamlessly embedded into Shopware’s existing tools and fits organically into the system.

### WHERE will we do it

The new layout can be assigned in two ways:

1. **Directly in Shopping Experiences:** In the Layout Assignment section, users can select the “Shop Pages” tab, set the sales channel, and assign the new Age Verification Popup Layout to the shop page.

2. **In the Admin Settings:** Under “Basic Information,” the “Shop Pages” card includes all globally available layouts, such as those for 404 pages, imprint pages, or newsletters. A new field will be added here to assign a layout for the Age Verification Popup.

### Out of scope

_No response_

### Acceptance criteria

- Release as Blueprint via Insider Previews
- Include a feedback link (for example, create an idea in UserVoice)

