### PR TITLE
fix: Ensure that the TestBootstrapper is using the `_test` DB again

### DIFF
--- a/src/Core/TestBootstrapper.php
+++ b/src/Core/TestBootstrapper.php
@@ -150,6 +150,9 @@ class TestBootstrapper
         $dbUrlParts = parse_url($_SERVER['DATABASE_URL'] ?? '') ?: [];
 
         $dbUrlParts['path'] ??= 'root';
+        if (!str_ends_with($dbUrlParts['path'], '_test')) {
+            $dbUrlParts['path'] .= '_test';
+        }
 
         $auth = isset($dbUrlParts['user']) ? ($dbUrlParts['user'] . (isset($dbUrlParts['pass']) ? (':' . $dbUrlParts['pass']) : '') . '@') : '';
 

--- a/tests/unit/Core/TestBootstrapperTest.php
+++ b/tests/unit/Core/TestBootstrapperTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Test\TestCaseBase\EnvTestBehaviour;
+use Shopware\Core\TestBootstrapper;
+
+/**
+ * @internal
+ */
+#[CoversClass(TestBootstrapper::class)]
+class TestBootstrapperTest extends TestCase
+{
+    use EnvTestBehaviour;
+
+    public function testGetDatabaseUrlWithoutSuffix(): void
+    {
+        $this->setEnvVars([
+            'DATABASE_URL' => 'mysql://root:root@localhost:3306/test',
+        ]);
+
+        $testBootstrapper = new TestBootstrapper();
+        static::assertSame('mysql://root:root@localhost:3306/test_test', $testBootstrapper->getDatabaseUrl());
+
+        $this->resetEnvVars();
+    }
+
+    public function testGetDatabaseUrlWithSuffix(): void
+    {
+        $this->setEnvVars([
+            'DATABASE_URL' => 'mysql://root:root@localhost:3306/test_test',
+        ]);
+
+        $testBootstrapper = new TestBootstrapper();
+        static::assertSame('mysql://root:root@localhost:3306/test_test', $testBootstrapper->getDatabaseUrl());
+
+        $this->resetEnvVars();
+    }
+
+    public function testGetDatabaseUrlAlreadySet(): void
+    {
+        $testBootstrapper = new TestBootstrapper();
+        $testBootstrapper->setDatabaseUrl('test');
+
+        static::assertSame('test', $testBootstrapper->getDatabaseUrl());
+    }
+}


### PR DESCRIPTION
### 1. Why is this change necessary?

I removed too much while removing the paratest stuff: https://github.com/shopware/shopware/pull/7373
Currently the TestBoostrapper uses the "production" DB and not the `_test` suffixed one.

Fixes the nightly build, see https://github.com/shopware/shopware/actions/runs/13830653266/job/38694001690

### 2. What does this change do, exactly?

Adding the suffix again

### 3. Describe each step to reproduce the issue or behaviour.

Execute `composer init:testdb` and see how your DB gets destroyed :grimacing: 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
