### PR TITLE
fix: server-timing header to be set only when elements is not empty

### DIFF
--- a/src/Core/Profiling/Integration/ServerTiming.php
+++ b/src/Core/Profiling/Integration/ServerTiming.php
@@ -47,9 +47,10 @@ class ServerTiming implements ProfilerInterface
 
     public function onResponseEvent(ResponseEvent $event): void
     {
-        $response = $event->getResponse();
-
-        $response->headers->set('Server-Timing', implode(', ', $this->elements));
+        if (!empty($this->elements)) {
+            $response = $event->getResponse();
+            $response->headers->set('Server-Timing', implode(', ', $this->elements));
+        }
         $this->elements = [];
         $this->watch->reset();
     }


### PR DESCRIPTION
Add a check to set the 'Server-Timing' header only when elements are not empty in `src/Core/Profiling/Integration/ServerTiming.php`.

* Add a condition in the `onResponseEvent` method to verify if `elements` is not empty before setting the 'Server-Timing' header
* Skip setting the 'Server-Timing' header if `elements` is empty
* Reset the `elements` array after the header is set or skipped
* Reset `watch` after the header is set or skipped

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/shopware/shopware/pull/7464?shareId=4d0fbfec-5c68-416e-b884-e06f17607c5f).