### PR TITLE
fix: change document configuration logo type

### DIFF
--- a/src/Core/Checkout/Document/DocumentConfiguration.php
+++ b/src/Core/Checkout/Document/DocumentConfiguration.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Checkout\Document;
 
+use Shopware\Core\Content\Media\MediaEntity;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\Struct;
 use Shopware\Core\System\Country\CountryEntity;
@@ -22,10 +23,7 @@ class DocumentConfiguration extends Struct
 
     protected ?bool $displayPrices = null;
 
-    /**
-     * @var array<string, mixed>|null
-     */
-    protected ?array $logo = null;
+    protected ?MediaEntity $logo = null;
 
     protected ?string $filenamePrefix = null;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently it is impossible to create a document where a logo is assigned.


### 2. What does this change do, exactly?

This change changes the expected type of `$logo` in `DocumentConfiguration` from `array|null` to `MediaEntity|null` as there is no known case where the `DocumentConfiguration` should contain more than one logo.

### 3. Describe each step to reproduce the issue or behaviour.

1. Add a logo to the `Invoice` document configuration (Settings > Documents > Invoice > Logo)
2. Create a new order
3. Open your order and try to create a new invoice (Order > Documents > Create new document > Invoice > Create)

Without the change you will see the following error message:  
> Error
> Cannot assign Shopware\Core\Content\Media\MediaEntity to property
> Shopware\Core\Checkout\Document\DocumentConfiguration::$logo of type ?array

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
https://shopware.atlassian.net/browse/NEXT-40920

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
