### PR TITLE
feat: add route scope specific request events

### DIFF
--- a/src/Core/Framework/Routing/RouteEventSubscriber.php
+++ b/src/Core/Framework/Routing/RouteEventSubscriber.php
@@ -3,6 +3,7 @@
 namespace Shopware\Core\Framework\Routing;
 
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\PlatformRequest;
 use Shopware\Storefront\Event\StorefrontRenderEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
@@ -15,12 +16,12 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  * @internal
  */
 #[Package('framework')]
-class RouteEventSubscriber implements EventSubscriberInterface
+readonly class RouteEventSubscriber implements EventSubscriberInterface
 {
     /**
      * @internal
      */
-    public function __construct(private readonly EventDispatcherInterface $dispatcher)
+    public function __construct(private EventDispatcherInterface $dispatcher)
     {
     }
 
@@ -42,44 +43,44 @@ class RouteEventSubscriber implements EventSubscriberInterface
     public function request(RequestEvent $event): void
     {
         $request = $event->getRequest();
-        if (!$request->attributes->has('_route')) {
-            return;
+        if ($request->attributes->has('_route')) {
+            $this->dispatcher->dispatch($event, $request->attributes->get('_route') . '.request');
         }
 
-        $name = $request->attributes->get('_route') . '.request';
-        $this->dispatcher->dispatch($event, $name);
+        foreach ($request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []) as $scope) {
+            $this->dispatcher->dispatch($event, $scope . '.scope.request');
+        }
     }
 
     public function render(StorefrontRenderEvent $event): void
     {
         $request = $event->getRequest();
-        if (!$request->attributes->has('_route')) {
-            return;
+        if ($request->attributes->has('_route')) {
+            $this->dispatcher->dispatch($event, $request->attributes->get('_route') . '.render');
         }
 
-        $name = $request->attributes->get('_route') . '.render';
-        $this->dispatcher->dispatch($event, $name);
+        foreach ($request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []) as $scope) {
+            $this->dispatcher->dispatch($event, $scope . '.scope.render');
+        }
     }
 
     public function response(ResponseEvent $event): void
     {
         $request = $event->getRequest();
-        if (!$request->attributes->has('_route')) {
-            return;
+        if ($request->attributes->has('_route')) {
+            $this->dispatcher->dispatch($event, $request->attributes->get('_route') . '.response');
         }
-
-        $name = $request->attributes->get('_route') . '.response';
-        $this->dispatcher->dispatch($event, $name);
     }
 
     public function controller(ControllerEvent $event): void
     {
         $request = $event->getRequest();
-        if (!$request->attributes->has('_route')) {
-            return;
+        if ($request->attributes->has('_route')) {
+            $this->dispatcher->dispatch($event, $request->attributes->get('_route') . '.controller');
         }
 
-        $name = $request->attributes->get('_route') . '.controller';
-        $this->dispatcher->dispatch($event, $name);
+        foreach ($request->attributes->get(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, []) as $scope) {
+            $this->dispatcher->dispatch($event, $scope . '.scope.controller');
+        }
     }
 }

--- a/tests/unit/Core/Framework/Routing/RouteEventSubscriberTest.php
+++ b/tests/unit/Core/Framework/Routing/RouteEventSubscriberTest.php
@@ -7,11 +7,13 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Routing\RouteEventSubscriber;
 use Shopware\Core\Framework\Test\TestCaseHelper\CallableClass;
 use Shopware\Core\Kernel;
+use Shopware\Core\PlatformRequest;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Event\StorefrontRenderEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -76,5 +78,149 @@ class RouteEventSubscriberTest extends TestCase
 
         $subscriber = new RouteEventSubscriber($dispatcher);
         $subscriber->render($event);
+    }
+
+    public function testRequestScopeEvent(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'frontend.home.page');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, ['storefront', 'api']);
+
+        $event = new RequestEvent($this->createMock(Kernel::class), $request, HttpKernelInterface::MAIN_REQUEST);
+
+        $storefrontListener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $storefrontListener->expects(static::once())->method('__invoke');
+
+        $apiListener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $apiListener->expects(static::once())->method('__invoke');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('storefront.scope.request', $storefrontListener);
+        $dispatcher->addListener('api.scope.request', $apiListener);
+
+        $subscriber = new RouteEventSubscriber($dispatcher);
+        $subscriber->request($event);
+    }
+
+    public function testControllerEvent(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'frontend.home.page');
+
+        $event = new ControllerEvent(
+            $this->createMock(Kernel::class),
+            [CallableClassFoo::class, 'test'],
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $listener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $listener->expects(static::once())->method('__invoke');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('frontend.home.page.controller', $listener);
+
+        $subscriber = new RouteEventSubscriber($dispatcher);
+        $subscriber->controller($event);
+    }
+
+    public function testControllerScopeEvent(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_route', 'frontend.home.page');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, ['storefront', 'api']);
+
+        $event = new ControllerEvent(
+            $this->createMock(Kernel::class),
+            [CallableClassFoo::class, 'test'],
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+
+        $storefrontListener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $storefrontListener->expects(static::once())->method('__invoke');
+
+        $apiListener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $apiListener->expects(static::once())->method('__invoke');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('storefront.scope.controller', $storefrontListener);
+        $dispatcher->addListener('api.scope.controller', $apiListener);
+
+        $subscriber = new RouteEventSubscriber($dispatcher);
+        $subscriber->controller($event);
+    }
+
+    public function testRenderScopeEvent(): void
+    {
+        if (!\class_exists(StorefrontRenderEvent::class)) {
+            // storefront dependency not installed
+            return;
+        }
+
+        $request = new Request();
+        $request->attributes->set('_route', 'frontend.home.page');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, ['storefront', 'api']);
+
+        $event = new StorefrontRenderEvent('', [], $request, $this->createMock(SalesChannelContext::class));
+
+        $storefrontListener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $storefrontListener->expects(static::once())->method('__invoke');
+
+        $apiListener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $apiListener->expects(static::once())->method('__invoke');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('storefront.scope.render', $storefrontListener);
+        $dispatcher->addListener('api.scope.render', $apiListener);
+
+        $subscriber = new RouteEventSubscriber($dispatcher);
+        $subscriber->render($event);
+    }
+
+    public function testResponseScopeEvent(): void
+    {
+        // Note: The current implementation of RouteEventSubscriber::response()
+        // does not dispatch scope events for responses
+        // This test is added to document this behavior
+
+        $request = new Request();
+        $request->attributes->set('_route', 'frontend.home.page');
+        $request->attributes->set(PlatformRequest::ATTRIBUTE_ROUTE_SCOPE, ['storefront', 'api']);
+
+        $event = new ResponseEvent(
+            $this->createMock(Kernel::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST,
+            new Response()
+        );
+
+        $routeListener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $routeListener->expects(static::once())->method('__invoke');
+
+        // These listeners should not be called as per current implementation
+        $storefrontListener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $storefrontListener->expects(static::never())->method('__invoke');
+
+        $apiListener = $this->getMockBuilder(CallableClass::class)->getMock();
+        $apiListener->expects(static::never())->method('__invoke');
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('frontend.home.page.response', $routeListener);
+        $dispatcher->addListener('storefront.response', $storefrontListener);
+        $dispatcher->addListener('api.response', $apiListener);
+
+        $subscriber = new RouteEventSubscriber($dispatcher);
+        $subscriber->response($event);
+    }
+}
+
+/**
+ * @internal
+ */
+class CallableClassFoo
+{
+    public static function test(): void
+    {
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

In plugins I can listen on `api.scope.request`, to get called on all API calls. similar to route what we already have

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
