### PR TITLE
fix: Remove customer after closing create order modal

### DIFF
--- a/changelog/_unreleased/2025-03-13-reset-customer-on-cancel-order-create-modal.md
+++ b/changelog/_unreleased/2025-03-13-reset-customer-on-cancel-order-create-modal.md
@@ -4,4 +4,4 @@ issue: https://github.com/shopware/shopware/issues/7454
 author_github: @En0Ma1259
 ---
 # Administration
-* Changed `cancelCart` method in `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/index.ts`. Will remove customer and not emit "clone-modal" anymore
+* Changed `cancelCart` method in `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/index.ts`. Will remove customer and not emit "modal-close" anymore

--- a/changelog/_unreleased/2025-03-13-reset-customer-on-cancel-order-create-modal.md
+++ b/changelog/_unreleased/2025-03-13-reset-customer-on-cancel-order-create-modal.md
@@ -1,0 +1,7 @@
+---
+title: Reset customer on cancel order create modal
+issue: https://github.com/shopware/shopware/issues/7454
+author_github: @En0Ma1259
+---
+# Administration
+* Changed `cancelCart` method in `src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/index.ts`. Will remove customer and not emit "clone-modal" anymore

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/index.ts
@@ -245,7 +245,7 @@ export default Component.wrapComponentConfig({
                     contextToken: this.cart.token,
                 })
                 .then(() => {
-                    this.$emit('modal-close');
+                    Store.get('swOrder').setCustomer(null);
                 });
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/sw-order-create-initial-modal.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/sw-order-create-initial-modal.spec.js
@@ -169,8 +169,12 @@ describe('src/module/sw-order/view/sw-order-create-initial-modal', () => {
         const wrapper = await createWrapper();
         const spyCancelCart = jest.spyOn(wrapper.vm, 'cancelCart');
 
+        expect(Shopware.Store.get('swOrder').customer).not.toBeNull();
+
         const buttonCancel = wrapper.find('.sw-order-create-initial-modal__button-cancel');
         await buttonCancel.trigger('click');
+
+        expect(Shopware.Store.get('swOrder').customer).toBeNull();
 
         expect(spyCancelCart).toHaveBeenCalled();
     });
@@ -249,6 +253,9 @@ describe('src/module/sw-order/view/sw-order-create-initial-modal', () => {
     });
 
     it('should able to preview order', async () => {
+        Shopware.Store.get('swOrder').setCustomer({
+            id: '1234',
+        });
         Shopware.Store.get('swOrder').setCart({
             token: cartToken,
             lineItems: [],

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/index.ts
@@ -83,8 +83,8 @@ export default Component.wrapComponentConfig({
 
         addressRepository(): Repository<'customer_address'> {
             return this.repositoryFactory.create(
-                this.customer.addresses?.entity ?? 'customer_address',
-                this.customer.addresses?.source,
+                this.customer?.addresses?.entity ?? 'customer_address',
+                this.customer?.addresses?.source,
             );
         },
 


### PR DESCRIPTION
### 1. Why is this change necessary?
If you click the Add Order button to open the Add Order modal, once you have selected a customer and their respective sales channel, that customer is selected by default the next time you open the modal (and forcing you to first pick a sales channel for them) even if you didn’t create an order.

Expected Behaviour
Search field is empty and no customer is selected

Actual Behaviour
You are forced to reselect a Sales Channel, then you can see the last customer is selected with their customer number in the search bar.

### 2. What does this change do, exactly?
Will set customer null when closing "create order" modal

### 3. Describe each step to reproduce the issue or behaviour.
- Create multiple customers
- Go to Orders Overview and click Add Order button
- Select a Customer
- Select a Sales Channel
- Cancel the Order/close the modal
- Click Add Order button again


### 4. Please link to the relevant issues (if any).
https://github.com/shopware/shopware/issues/7454