### PR TITLE
fix: disabled context menu item allowed parent click listener to execute

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/index.js
@@ -63,4 +63,13 @@ Component.register('sw-context-menu-item', {
             };
         },
     },
+
+    methods: {
+        // the listener has the `capture` modifier in the template to prevent parent listeners from being called
+        handleClick(event) {
+            if (this.disabled) {
+                event.stopPropagation();
+            }
+        },
+    },
 });

--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/sw-context-menu-item.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/sw-context-menu-item.html.twig
@@ -36,11 +36,12 @@
 {% endblock %}
 
 {% block sw_context_menu_item_entry %}
-<div
+<button
     v-else
     class="sw-context-menu-item"
     :class="contextMenuItemStyles"
     v-bind="$attrs"
+    @click.capture="handleClick"
 >
     {% block sw_context_menu_item_entry_icon %}
     <slot name="icon">
@@ -64,6 +65,6 @@
         </slot>
     </span>
     {% endblock %}
-</div>
+</button>
 {% endblock %}
 {% endblock %}

--- a/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/sw-context-menu-item.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/context-menu/sw-context-menu-item/sw-context-menu-item.scss
@@ -12,6 +12,8 @@ $sw-context-menu-color-warning: $color-pumpkin-spice-500;
     position: relative;
     border-radius: $border-radius-default;
     margin: 0;
+    width: 100%;
+    text-align: start;
     line-height: $line-height-xs;
     padding: 4px 14px;
     text-decoration: none;


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
When a `sw-context-menu-item` is disabled, it allows click listeners added from the parent to execute.

### 2. What does this change do, exactly?
This change makes the `sw-context-menu-item` to prevent parent click listeners to execute adding a click listener with `stopPropagation` in case the item is disabled. It also has the `capture` modifier to prevent the parents listeners to execute.


### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Settings > Languages
2. click in the context menu of the current default language:
![image](https://github.com/user-attachments/assets/1321446d-2507-48b7-be22-c75e06918b3f)

3. Click in the disabled Delete button
4. Before fix, the delete dialog is shown anyway
5. After fix, the dialog is not shown
