### PR TITLE
fix: user language change does not change ui lang until reload

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.spec.js
@@ -753,7 +753,7 @@ describe('ASYNC app/adapter/view/vue.adapter.js', () => {
 
             await flushPromises();
 
-            expect(vueAdapter.i18n.global.locale).toEqual(expectedLocale);
+            expect(vueAdapter.i18n.global.locale.value).toEqual(expectedLocale);
         });
     });
 });

--- a/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
+++ b/src/Administration/Resources/app/administration/src/app/adapter/view/vue.adapter.ts
@@ -61,7 +61,7 @@ export default class VueAdapter extends ViewAdapter {
 
         const vuexRoot = State._store;
         // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-        const i18n = this.initLocales() as I18n<{}, {}, {}, string, true>;
+        const i18n = this.initLocales();
 
         // add router to View
         this.router = router;
@@ -533,7 +533,7 @@ export default class VueAdapter extends ViewAdapter {
             sync: true,
             messages,
             allowComposition: true,
-        };
+        } as const;
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         const i18n = createI18n(options);
@@ -541,7 +541,7 @@ export default class VueAdapter extends ViewAdapter {
         Shopware.Vue.watch(
             useSession().currentLocale,
             (currentLocale: string | null) => {
-                i18n.global.locale = currentLocale ?? '';
+                i18n.global.locale.value = currentLocale ?? '';
             },
             { immediate: true },
         );

--- a/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-product/component/sw-product-variants/sw-product-variants-overview/sw-product-variants-overview.html.twig
@@ -28,7 +28,10 @@
                     @click="filterWindowOpen = !filterWindowOpen"
                 >
                     {{ $tc('sw-product.variations.generatedFilterList') }}
-                    <mt-icon name="regular-filter" size="12px" />
+                    <mt-icon
+                        name="regular-filter"
+                        size="12px"
+                    />
                 </mt-button>
                 {% endblock %}
 


### PR DESCRIPTION
### 1. Why is this change necessary?
When the user changes the language in the User Profile, the UI language was not updated until reloads the page


### 2. What does this change do, exactly?
Change the assignment of the new lang in the i18n lib.
As we are not longer using the legacy mode of vue-i18n, the locale is a ref so we have to change its `.value`
https://vue-i18n.intlify.dev/guide/essentials/scope.html#locale-changing


### 3. Describe each step to reproduce the issue or behaviour.
1. go Settings > Users & Permissions
2. edit the current user
3. Change the `User Interface language`
4. Save user changes introducing the password when required
5. Before fix, the UI lang is not change unless user reloads the page
6. After fix, the UI lang is automatically without reloading

- Jira issue: https://shopware.atlassian.net/browse/NEXT-41070