### PR TITLE
feat: add app-version to query-signer

### DIFF
--- a/src/Core/Framework/App/Hmac/QuerySigner.php
+++ b/src/Core/Framework/App/Hmac/QuerySigner.php
@@ -35,20 +35,21 @@ class QuerySigner
             throw AppException::appSecretMissing($app->getName());
         }
 
-        $uri = Uri::withQueryValues(new Uri($uri), [
+        $unsignedUri = Uri::withQueryValues(new Uri($uri), [
             'shop-id' => $this->shopIdProvider->getShopId(),
             'shop-url' => $this->shopUrl,
             'timestamp' => (string) (new \DateTime())->getTimestamp(),
             'sw-version' => $this->shopwareVersion,
+            'app-version' => $app->getVersion(),
             'in-app-purchases' => \urlencode($this->inAppPurchase->getJWTByExtension($app->getName()) ?? ''),
             AuthMiddleware::SHOPWARE_CONTEXT_LANGUAGE => $context->getLanguageId(),
             AuthMiddleware::SHOPWARE_USER_LANGUAGE => $this->localeProvider->getLocaleFromContext($context),
         ]);
 
         return Uri::withQueryValue(
-            $uri,
+            $unsignedUri,
             'shopware-shop-signature',
-            (new RequestSigner())->signPayload($uri->getQuery(), $secret)
+            (new RequestSigner())->signPayload($unsignedUri->getQuery(), $secret)
         );
     }
 }

--- a/tests/integration/Core/Framework/App/ActionButton/Response/ActionButtonResponseFactoryTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/Response/ActionButtonResponseFactoryTest.php
@@ -35,6 +35,8 @@ class ActionButtonResponseFactoryTest extends TestCase
         $app->setName('TestApp');
         $app->setId(Uuid::randomHex());
         $app->setAppSecret('app-secret');
+        $app->setVersion('1.0.0');
+
         $this->action = new AppAction(
             $app,
             new Source('http://shop.url', 'shop-id', '1.0.0'),

--- a/tests/integration/Core/Framework/App/ActionButton/Response/OpenModalResponseFactoryTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/Response/OpenModalResponseFactoryTest.php
@@ -35,6 +35,8 @@ class OpenModalResponseFactoryTest extends TestCase
         $app->setName('TestApp');
         $app->setId(Uuid::randomHex());
         $app->setAppSecret('app-secret');
+        $app->setVersion('1.0.0');
+
         $this->action = new AppAction(
             $app,
             new Source('http://shop.url', 'shop-id', '1.0.0'),

--- a/tests/integration/Core/Framework/App/ActionButton/Response/OpenNewTabResponseFactoryTest.php
+++ b/tests/integration/Core/Framework/App/ActionButton/Response/OpenNewTabResponseFactoryTest.php
@@ -35,6 +35,7 @@ class OpenNewTabResponseFactoryTest extends TestCase
         $app->setName('TestApp');
         $app->setId(Uuid::randomHex());
         $app->setAppSecret('app-secret');
+        $app->setVersion('1.0.0');
 
         $this->action = new AppAction(
             $app,

--- a/tests/integration/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/integration/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -34,6 +34,7 @@ class QuerySignerTest extends TestCase
         $this->app->setName('TestApp');
         $this->app->setId('app-id');
         $this->app->setAppSecret('lksf#$osck$FSFDSF#$#F43jjidjsfisj-333');
+        $this->app->setVersion('1.0.0');
 
         $this->querySigner = static::getContainer()->get(QuerySigner::class);
         $this->systemConfigService = static::getContainer()->get(SystemConfigService::class);
@@ -68,6 +69,9 @@ class QuerySignerTest extends TestCase
 
         static::assertArrayHasKey('sw-user-language', $signedQuery);
         static::assertSame('en-GB', $signedQuery['sw-user-language']);
+
+        static::assertArrayHasKey('app-version', $signedQuery);
+        static::assertSame('1.0.0', $signedQuery['app-version']);
 
         static::assertNotNull($this->app->getAppSecret());
 

--- a/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
+++ b/tests/unit/Core/Framework/App/Hmac/QuerySignerTest.php
@@ -46,6 +46,7 @@ class QuerySignerTest extends TestCase
         $app->setName('extension-1');
         $app->setAppSecret('devSecret');
         $app->setId(Uuid::randomHex());
+        $app->setVersion('1.0.0');
 
         $querySigner = new QuerySigner('http://shop.url', '1.0.0', $localeProvider, $shopIdProvider, $inAppPurchase);
         $signedQuery = $querySigner->signUri('http://app.url/?foo=bar', $app, $context);
@@ -60,6 +61,7 @@ class QuerySignerTest extends TestCase
         static::assertArrayHasKey('sw-context-language', $url);
         static::assertArrayHasKey('sw-user-language', $url);
         static::assertArrayHasKey('shopware-shop-signature', $url);
+        static::assertArrayHasKey('app-version', $url);
 
         static::assertSame('shopId', $url['shop-id']);
         static::assertSame('http://shop.url', $url['shop-url']);
@@ -68,6 +70,7 @@ class QuerySignerTest extends TestCase
         static::assertSame('a6a4063ffda65516983ad40e8dc91db6', $url['in-app-purchases']);
         static::assertSame(Defaults::LANGUAGE_SYSTEM, $url['sw-context-language']);
         static::assertSame('en-GB', $url['sw-user-language']);
+        static::assertSame('1.0.0', $url['app-version']);
     }
 
     public function testThrowsWithoutAppSecret(): void


### PR DESCRIPTION
### 1. Why is this change necessary?
- Add the app-version  to the context created for e.g `/api/_action/extension-sdk/sign-uri`
- This context can be used for further api calls to the app backend without resign the params
- For WebHook`s the app-version is already in the payload

### 2. What does this change do, exactly?
- This will add the `app-version` to query-params (e.g. iframe of the app)

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- Jira issue: https://shopware.atlassian.net/browse/NEXT-41110


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
