### PR TITLE
fix: Adjust date format in date range rule

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/index.js
@@ -34,7 +34,6 @@ Component.extend('sw-condition-date-range', 'sw-condition-base', {
             get() {
                 this.ensureValueExist();
                 if (typeof this.condition.value.useTime === 'undefined') {
-                    // eslint-disable-next-line vue/no-side-effects-in-computed-properties
                     this.condition.value = {
                         ...this.condition.value,
                         useTime: false,
@@ -46,6 +45,8 @@ Component.extend('sw-condition-date-range', 'sw-condition-base', {
             set(useTime) {
                 this.ensureValueExist();
                 this.condition.value = { ...this.condition.value, useTime };
+                this.fromDate = this.condition.value.fromDate;
+                this.toDate = this.condition.value.toDate;
             },
         },
 
@@ -57,12 +58,9 @@ Component.extend('sw-condition-date-range', 'sw-condition-base', {
             set(fromDate) {
                 this.ensureValueExist();
 
-                // eslint-disable-next-line max-len
-                const date =
-                    this.isDateTime === 'datetime' ? fromDate.replace('.000Z', '+00:00') : fromDate.concat('+00:00');
                 this.condition.value = {
                     ...this.condition.value,
-                    fromDate: date,
+                    fromDate: this.formatDate(fromDate, '00:00:00+00:00'),
                 };
             },
         },
@@ -75,10 +73,9 @@ Component.extend('sw-condition-date-range', 'sw-condition-base', {
             set(toDate) {
                 this.ensureValueExist();
 
-                const date = this.isDateTime === 'datetime' ? toDate.replace('.000Z', '+00:00') : toDate.concat('+00:00');
                 this.condition.value = {
                     ...this.condition.value,
-                    toDate: date,
+                    toDate: this.formatDate(toDate, '23:59:59+00:00'),
                 };
             },
         },
@@ -95,6 +92,20 @@ Component.extend('sw-condition-date-range', 'sw-condition-base', {
 
         currentError() {
             return this.conditionValueUseTimeError || this.conditionValueFromDateError || this.conditionValueToDateError;
+        },
+    },
+
+    methods: {
+        formatDate(date, dateModifier) {
+            if (!date) {
+                return null;
+            }
+
+            if (this.isDateTime === 'datetime') {
+                return date.replace('.000Z', '+00:00');
+            }
+
+            return date.split('T')[0].concat('T'.concat(dateModifier));
         },
     },
 });

--- a/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.spec.js
+++ b/src/Administration/Resources/app/administration/src/app/component/rule/condition-type/sw-condition-date-range/sw-condition-date-range.spec.js
@@ -6,16 +6,32 @@ import ConditionDataProviderService from 'src/app/service/rule-condition.service
 import 'src/app/component/rule/condition-type/sw-condition-date-range';
 import 'src/app/component/rule/sw-condition-base';
 
-async function createWrapper(condition = {}) {
-    condition.getEntityName = () => 'rule_condition';
-
+async function createWrapper(useTime) {
     return mount(await wrapTestComponent('sw-condition-date-range', { sync: true }), {
         propsData: {
-            condition,
+            condition: {
+                value: {
+                    useTime: useTime
+                },
+
+                getEntityName: () => 'rule_condition',
+            },
         },
         global: {
             stubs: {
-                'sw-single-select': true,
+                'sw-single-select': await wrapTestComponent('sw-single-select'),
+                'sw-select-base': await wrapTestComponent('sw-select-base'),
+                'sw-block-field': await wrapTestComponent('sw-block-field'),
+                'sw-base-field': await wrapTestComponent('sw-base-field'),
+                'sw-inheritance-switch': true,
+                'sw-ai-copilot-badge': true,
+                'sw-help-text': true,
+                'sw-loader': true,
+                'sw-select-result-list': await wrapTestComponent('sw-select-result-list'),
+                'sw-popover': await wrapTestComponent('sw-popover'),
+                'sw-popover-deprecated': await wrapTestComponent('sw-popover-deprecated'),
+                'sw-select-result': await wrapTestComponent('sw-select-result'),
+                'sw-highlight-text': true,
                 'sw-condition-base': true,
                 'sw-condition-type-select': true,
                 'sw-context-button': true,
@@ -40,50 +56,166 @@ async function createWrapper(condition = {}) {
 }
 
 describe('component/rule/sw-condition-date-range', () => {
-    let wrapper;
+    it('should toggle selection without and with time', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
 
-    beforeEach(async () => {
-        wrapper = await createWrapper();
-    });
+        const datepickerCollection  = wrapper.findAll('.wrapper .dp__main');
 
-    it('should be a Vue.JS component', async () => {
-        wrapper = await createWrapper();
-        expect(wrapper.vm).toBeTruthy();
-    });
+        expect(datepickerCollection).toHaveLength(2);
 
-    it('should fromDate format have a suffix timezone', async () => {
-        wrapper = await createWrapper();
-        await wrapper.setProps({
-            condition: {
-                value: {
-                    useTime: true,
-                    fromDate: '2020-01-01T00:00:00.000Z',
-                },
-            },
+        datepickerCollection.forEach(datepicker => {
+            expect(datepicker.attributes('type')).toBe('date');
         });
 
-        const getFromDate = wrapper.vm.fromDate;
-        expect(getFromDate).toBe('2020-01-01T00:00:00.000Z');
+        await wrapper.find('.sw-single-select input').trigger('click');
+        await flushPromises();
 
-        wrapper.vm.fromDate = '2020-01-01T00:00:00+00:00';
-        expect(wrapper.vm.fromDate).toBe('2020-01-01T00:00:00+00:00');
+        await wrapper.find('.sw-select-option--true').trigger('click');
+        await flushPromises();
+
+        datepickerCollection.forEach(datepicker => {
+            expect(datepicker.attributes('type')).toBe('datetime');
+        })
     });
 
-    it('should toDate format have a suffix timezone', async () => {
-        wrapper = await createWrapper();
-        await wrapper.setProps({
-            condition: {
-                value: {
-                    useTime: false,
-                    toDate: '2020-01-01T00:00:00',
-                },
-            },
-        });
+    it('should select a fromDate without time', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
 
-        const getToDate = wrapper.vm.toDate;
-        expect(getToDate).toBe('2020-01-01T00:00:00');
+        const fromDateInput = wrapper.find('.wrapper[name="sw-field--fromDate"] input');
 
-        wrapper.vm.toDate = '2020-01-01T00:00:00';
-        expect(wrapper.vm.toDate).toBe('2020-01-01T00:00:00+00:00');
+        expect(fromDateInput.attributes('value')).toBe('');
+        await fromDateInput.trigger('click');
+        await flushPromises();
+
+        document.querySelector('[data-test-id="year-toggle-overlay-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="1900"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="month-toggle-overlay-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="Jan"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[id="1900-01-01"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        expect(fromDateInput.attributes('value')).toBe('1900/01/01');
+        expect(wrapper.vm.fromDate).toBe('1900-01-01T00:00:00+00:00');
+    });
+
+    it('should select a fromDate with time', async () => {
+        const wrapper = await createWrapper(true);
+        await flushPromises();
+
+        const fromDateInput = wrapper.find('.wrapper[name="sw-field--fromDate"] input');
+
+        expect(fromDateInput.attributes('value')).toBe('');
+        await fromDateInput.trigger('click');
+        await flushPromises();
+
+        document.querySelector('[data-test-id="year-toggle-overlay-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="1900"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="month-toggle-overlay-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="Jan"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="hours-toggle-overlay-btn-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="12"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="minutes-toggle-overlay-btn-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="30"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[id="1900-01-01"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        expect(fromDateInput.attributes('value')).toBe('1900/01/01, 12:30');
+        expect(wrapper.vm.fromDate).toBe('1900-01-01T12:30:00+00:00');
+    });
+
+    it('should select a toDate without time', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        const fromDateInput = wrapper.find('.wrapper[name="sw-field--toDate"] input');
+
+        expect(fromDateInput.attributes('value')).toBe('');
+        await fromDateInput.trigger('click');
+        await flushPromises();
+
+        document.querySelector('[data-test-id="year-toggle-overlay-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="1900"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="month-toggle-overlay-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="Jan"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[id="1900-01-01"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        expect(fromDateInput.attributes('value')).toBe('1900/01/01');
+        expect(wrapper.vm.toDate).toBe('1900-01-01T23:59:59+00:00');
+    });
+
+    it('should select a toDate with time', async () => {
+        const wrapper = await createWrapper(true);
+        await flushPromises();
+
+        const fromDateInput = wrapper.find('.wrapper[name="sw-field--toDate"] input');
+
+        expect(fromDateInput.attributes('value')).toBe('');
+        await fromDateInput.trigger('click');
+        await flushPromises();
+
+        document.querySelector('[data-test-id="year-toggle-overlay-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="1900"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="month-toggle-overlay-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="Jan"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="hours-toggle-overlay-btn-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="12"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="minutes-toggle-overlay-btn-0"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[data-test-id="30"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        document.querySelector('[id="1900-01-01"]').dispatchEvent(new Event('click'));
+        await flushPromises();
+
+        expect(fromDateInput.attributes('value')).toBe('1900/01/01, 12:30');
+        expect(wrapper.vm.toDate).toBe('1900-01-01T12:30:00+00:00');
     });
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

Currently when selecting a date with one of the two datepickers in the date-range rule, it isn't displayed in the datepicker.

### 2. What does this change do, exactly?

This change adjusts the internal formatting of the return of the dapeticker components as we expectet a date like `2025-03-13T00:00` where we just append the timezone modifier `+00:00` for UTC.  
But with the switch to meteor this behavior changed as it now alsways returns the date as an string in ISO format like `2025-03-13T00:00.000Z`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a new rule (Settings > Rule builder > Create)
2. Select the Date Range rule
3. Enter some values (they should be shown correctly now) and save it
4. (Test the rule in a way to make sure it evaluates correctly)

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->
https://shopware.atlassian.net/browse/NEXT-41075

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
