### PR TITLE
fix: grid inline edit not working on double click

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid-row/index.js
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-grid-row/index.js
@@ -37,6 +37,10 @@ Component.register('sw-grid-row', {
             from: 'swGridSetColumns',
             default: null,
         },
+        swGridColumns: {
+            from: 'swGridColumns',
+            default: null,
+        },
     },
 
     emits: ['inline-edit-finish'],
@@ -65,7 +69,6 @@ Component.register('sw-grid-row', {
 
     data() {
         return {
-            columns: [],
             isEditingActive: false,
             inlineEditingCls: 'is--inline-editing',
             id: utils.createId(),
@@ -93,8 +96,6 @@ Component.register('sw-grid-row', {
 
     methods: {
         createdComponent() {
-            this.swGridSetColumns(this.columns);
-
             this.swRegisterGridDisableInlineEditListener(this.onInlineEditCancel);
         },
 
@@ -107,7 +108,7 @@ Component.register('sw-grid-row', {
 
             // If inline editing is already enabled, or no column has
             // the property "editable" we don't have to enable it.
-            this.columns.forEach((column) => {
+            this.swGridColumns.forEach((column) => {
                 if (column.editable || isInlineEditingConfigured) {
                     isInlineEditingConfigured = true;
                 }


### PR DESCRIPTION
### 1. Why is this change necessary?
the inline edit in grid didn't work sometimes on double click


### 2. What does this change do, exactly?
uses the injected columns from the grid into the grid-row, as the check of these were not working before


### 3. Describe each step to reproduce the issue or behaviour.
1. Go to Settings > Snippets
2. double click on a row of the snippets sets grid
3. Before the fix, it didn't enable the editing unless you enter in the detail page and go back
4. After the fix it enables de inline editing directly

closes #4629

