### PR TITLE
fix: Add missing dependency field to media url runtime field

### DIFF
--- a/changelog/_unreleased/2025-03-11-add-missing-dependency-field-of-url-runtime-field-to-media-defintion.md
+++ b/changelog/_unreleased/2025-03-11-add-missing-dependency-field-of-url-runtime-field-to-media-defintion.md
@@ -1,0 +1,8 @@
+---
+title: Add missing dependency field of URL runtime field to media definition
+author: Pascal Paul
+author_email: pascal.paul@pickware.de
+author_github: @pascalniklaspaul
+---
+# Core
+* Changed `MediaDefinition` to add its `private` field as a dependency of its `url` runtime field.

--- a/src/Core/Content/Media/MediaDefinition.php
+++ b/src/Core/Content/Media/MediaDefinition.php
@@ -102,7 +102,7 @@ class MediaDefinition extends EntityDefinition
             (new JsonField('config', 'config'))->addFlags(new ApiAware()),
             (new TranslatedField('alt'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::MIDDLE_SEARCH_RANKING)),
             (new TranslatedField('title'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
-            (new StringField('url', 'url'))->addFlags(new ApiAware(), new Runtime(['path', 'updatedAt'])),
+            (new StringField('url', 'url'))->addFlags(new ApiAware(), new Runtime(['path', 'private', 'updatedAt'])),
             (new StringField('path', 'path'))->addFlags(new ApiAware()),
             (new BoolField('has_file', 'hasFile'))->addFlags(new ApiAware(), new Runtime()),
             (new BoolField('private', 'private'))->addFlags(new ApiAware()),

--- a/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
+++ b/tests/integration/Core/Content/Media/DataAbstractionLayer/MediaRepositoryTest.php
@@ -567,6 +567,27 @@ class MediaRepositoryTest extends TestCase
         static::assertNull($payload['coverId']);
     }
 
+    public function testPublicMediaUrlsAreReadableWithPartialDataLoading(): void
+    {
+        $mediaId = Uuid::randomHex();
+
+        $this->mediaRepository->create(
+            [
+                [
+                    'id' => $mediaId,
+                    'private' => false,
+                    'path' => 'http://some.domain/media.png',
+                ],
+            ],
+            $this->context
+        );
+        $criteria = new Criteria([$mediaId]);
+        $criteria->addFields(['id', 'url']);
+        $media = $this->mediaRepository->search($criteria, $this->context)->get($mediaId);
+
+        static::assertSame('http://some.domain/media.png', $media?->get('url'));
+    }
+
     /**
      * @return array<string, mixed>
      */


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?

When loading the URLs of medias with partial data loading and not explicitly loading the `private` field the `MediaUrlLoader` does assume all URLs are private and thus does not add them.

### 2. What does this change do, exactly?

Adding the `private` field as a dependency field to the `url` field of `MediaDefinition`.

### 3. Describe each step to reproduce the issue or behaviour.

1. Load a media through the API using `media.url` but not `media.private` as a `Criteria.field` 
2. All URLs in the response are null, even when not private

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
