### PR TITLE
fix: Advanced selection modal unusable

### DIFF
--- a/changelog/_unreleased/2025-03-14-fix-advanced-selection-modal-unusable.md
+++ b/changelog/_unreleased/2025-03-14-fix-advanced-selection-modal-unusable.md
@@ -1,0 +1,6 @@
+---
+title: Fix advanced selection modal unusable
+issue: NEXT-41084
+---
+# Administration
+* Changed `sw-entity-advanced-selection-modal` component to update the `:full-page` attribute from `true` to `false` to adjust the modal's display mode.

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal/sw-entity-advanced-selection-modal.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal/sw-entity-advanced-selection-modal.html.twig
@@ -94,7 +94,7 @@
                 :items="entities"
                 :columns="entityColumns"
                 :repository="entityRepository"
-                :full-page="true"
+                :full-page="false"
                 :plain-appearance="true"
                 :compact-mode="true"
                 :show-selection="true"

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal/sw-entity-advanced-selection-modal.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-advanced-selection-modal/sw-entity-advanced-selection-modal.scss
@@ -19,6 +19,7 @@
         width: 100%;
         height: 100%;
         margin: 0;
+        border-radius: 0;
     }
 
     .sw-entity-advanced-selection-modal__filter-list-button {


### PR DESCRIPTION
Jira Ticket: https://shopware.atlassian.net/browse/NEXT-41084
 
On a product detail page under advanced pricing if you select “advanced selection” from the condition dropdown, a modal appears with a list of rules. The rule list is currently not visible, and the modal is thus unusable.

| Before | After |
|---|---|
| ![image-20250311-125350](https://github.com/user-attachments/assets/6ea9d476-8298-4e7b-a372-e631f6c62911) |<img width="904" alt="Screenshot 2025-03-14 at 09 37 31" src="https://github.com/user-attachments/assets/3c663d96-23a4-4693-b9a3-602dfb511356" /> |
