### PR TITLE
feat: add shopware analytics in saas feature flag

### DIFF
--- a/src/Core/Framework/Resources/config/packages/feature.yaml
+++ b/src/Core/Framework/Resources/config/packages/feature.yaml
@@ -40,3 +40,8 @@ shopware:
         major: false
         toggleable: true
         description: "Experimental! Execute flows after the main unit of work has concluded"
+      - name: SHOPWARE_ANALYTICS_IN_SAAS
+        default: false
+        major: false
+        toggleable: true
+        description: "Enable Shopware Analytics in SaaS"


### PR DESCRIPTION
Adds the feature flag `SHOPWARE_ANALYTICS_IN_SAAS` which acts as a last safeguard before the official release. 