### PR TITLE
fix: Show new customer address after saving admin modal

### DIFF
--- a/changelog/_unreleased/2025-03-14-fix-show-new-customer-address-after-saving-modal.md
+++ b/changelog/_unreleased/2025-03-14-fix-show-new-customer-address-after-saving-modal.md
@@ -1,0 +1,7 @@
+---
+title: Show new customer address after saving admin modal
+issue: https://github.com/shopware/shopware/issues/7350
+author_github: @En0Ma1259
+---
+# Administration
+* Added save address api call after click on modal save button `src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js`

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js
@@ -230,13 +230,11 @@ export default {
 
             Object.assign(address, this.currentAddress);
 
-            if (this.customer.addresses.has(address.id)) {
-                this.customer.addresses.remove(address.id);
-            }
+            this.customerAddressRepository.save(address).then(() => {
+                this.currentAddress = null;
 
-            this.customer.addresses.push(address);
-
-            this.currentAddress = null;
+                this.refreshList();
+            });
         },
 
         isValidAddress(address) {
@@ -279,12 +277,7 @@ export default {
         },
 
         onEditAddress(id) {
-            const currentAddress = this.addressRepository.create(Shopware.Context.api, id);
-
-            // assign values and id to new address
-            Object.assign(currentAddress, this.activeCustomer.addresses.get(id));
-
-            this.currentAddress = currentAddress;
+            this.currentAddress = this.activeCustomer.addresses.get(id);
             this.showEditAddressModal = id;
         },
 

--- a/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-customer/view/sw-customer-detail-addresses/index.js
@@ -277,7 +277,14 @@ export default {
         },
 
         onEditAddress(id) {
-            this.currentAddress = this.activeCustomer.addresses.get(id);
+            const currentAddress = this.addressRepository.create(Shopware.Context.api, id);
+            // Otherwise repository save will do a POST call instead of PATCH
+            currentAddress._isNew = false;
+
+            // assign values and id to new address
+            Object.assign(currentAddress, this.activeCustomer.addresses.get(id));
+
+            this.currentAddress = currentAddress;
             this.showEditAddressModal = id;
         },
 


### PR DESCRIPTION
**Actual behaviour:**
In the customer overview, when you create a new address using the 'Add Address' button, it is not being ~~stored~~ / displayed before saving

**Expected behaviour:**
A new address should be created.

**How to reproduce:**
- Create a new Customer from the backend
- Add new address using 'Add Address' button

Issue:
https://github.com/shopware/shopware/issues/7350
