### PR TITLE
fix: wishlist were not marked as noindex for robots

### DIFF
--- a/changelog/_unreleased/2025-03-14-set-wishlistpage-to-noindex.md
+++ b/changelog/_unreleased/2025-03-14-set-wishlistpage-to-noindex.md
@@ -1,0 +1,10 @@
+---
+title: Set WishlistPage to noindex
+issue: NEXT-40843
+author: tinect
+author_email: s.koenig@tinect.de
+author_github: tinect
+---
+# Storefront
+* Changed robots in `WishlistPage` and `GuestWishlistPage` to `noindex,follow`
+

--- a/src/Storefront/Page/Wishlist/GuestWishlistPageLoader.php
+++ b/src/Storefront/Page/Wishlist/GuestWishlistPageLoader.php
@@ -26,6 +26,8 @@ class GuestWishlistPageLoader
     public function load(Request $request, SalesChannelContext $context): GuestWishlistPage
     {
         $page = $this->genericPageLoader->load($request, $context);
+        $page->getMetaInformation()?->setRobots('noindex,follow');
+
         $page = GuestWishlistPage::createFrom($page);
 
         $this->eventDispatcher->dispatch(new GuestWishlistPageLoadedEvent($page, $context, $request));

--- a/src/Storefront/Page/Wishlist/WishlistPageLoader.php
+++ b/src/Storefront/Page/Wishlist/WishlistPageLoader.php
@@ -53,6 +53,8 @@ class WishlistPageLoader
         $this->eventDispatcher->dispatch(new WishListPageProductCriteriaEvent($criteria, $context, $request));
 
         $page = $this->genericLoader->load($request, $context);
+        $page->getMetaInformation()?->setRobots('noindex,follow');
+
         $page = WishlistPage::createFrom($page);
 
         try {


### PR DESCRIPTION
### 1. Why is this change necessary?
make the page noindex on default

### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.
check meta `robots` on wishlist.

### 4. Please link to the relevant issues (if any).
closes #7089

- Jira issue: https://shopware.atlassian.net/browse/NEXT-40843

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
