### PR TITLE
ci: mark and close stale issues

### DIFF
--- a/.github/bin/js/package-lock.json
+++ b/.github/bin/js/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@shopware-ag/gh-project-automation": "^1.1.1"
+        "@shopware-ag/gh-project-automation": "^1.2.0"
       }
     },
     "node_modules/@actions/core": {
@@ -84,15 +84,15 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+      "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
       "optional": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
-        "@octokit/request": "^8.3.1",
-        "@octokit/request-error": "^5.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
         "@octokit/types": "^13.0.0",
         "before-after-hook": "^2.2.0",
         "universal-user-agent": "^6.0.0"
@@ -129,9 +129,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "23.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
-      "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
       "optional": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
@@ -224,18 +224,18 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
-      "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "optional": true,
       "dependencies": {
-        "@octokit/openapi-types": "^23.0.1"
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/@shopware-ag/gh-project-automation": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.1.1.tgz",
-      "integrity": "sha512-3J1+gi2I6vhR8qKSbeS6bJuFQAFaZzNcefHF5zNLAzbuJO2bxWnyGvPqktHJOT69Nw93N/ODnQ7ZI7gziAUO7Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/gh-project-automation/-/gh-project-automation-1.2.0.tgz",
+      "integrity": "sha512-zFAIXJaUFCOkT6jJrzWTIOlcvORSALJE4+SCB5QRC+wgckJXBdvhBhwX6Z4SnSe9wvta5Ken1CjUF+A5ZR64Tw==",
       "optionalDependencies": {
         "@actions/core": "^1.11.1",
         "@actions/exec": "^1.1.1",
@@ -247,12 +247,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.13.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "optional": true,
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "optional": true,
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -609,9 +609,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "optional": true
     },
     "node_modules/universal-user-agent": {

--- a/.github/bin/js/package.json
+++ b/.github/bin/js/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@shopware-ag/gh-project-automation": "^1.1.1"
+    "@shopware-ag/gh-project-automation": "^1.2.0"
   }
 }

--- a/.github/workflows/01-pr-issue-labeler.yml
+++ b/.github/workflows/01-pr-issue-labeler.yml
@@ -1,16 +1,20 @@
 name: Label Issues and PRs
 
 on:
-- pull_request
-- issues
+  pull_request:
+  issues:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
 
 jobs:
   label:
     runs-on: ubuntu-24.04
+    if: github.event_name == 'issues' || github.event_name == 'pull_request'
     steps:
-    - uses: srvaroa/labeler@0a20eccb8c94a1ee0bed5f16859aece1c45c3e55 # 1.13.0
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: srvaroa/labeler@0a20eccb8c94a1ee0bed5f16859aece1c45c3e55 # 1.13.0
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   apply-team-label:
     runs-on: ubuntu-24.04
@@ -27,11 +31,11 @@ jobs:
         with:
           scope: shopware
           identity: ReadCollaborators
-      -  uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # 3
-         id: actorTeams
-         with:
-            username: ${{ github.actor }}
-            GITHUB_TOKEN: ${{ steps.sts.outputs.token }}
+      - uses: tspascoal/get-user-teams-membership@57e9f42acd78f4d0f496b3be4368fc5f62696662 # 3
+        id: actorTeams
+        with:
+          username: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ steps.sts.outputs.token }}
       - name: debug
         if: runner.debug
         run: |
@@ -49,7 +53,7 @@ jobs:
               issue_number: issueNumber,
               labels: [teamLabel],
             });
-          
+
             if (response.status !== 200) {
               throw new Error(`Failed to add label ${teamLabel} to issue #${issueNumber}`);
             }
@@ -78,3 +82,45 @@ jobs:
           script: |
             const { setStatusInProjects } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
             await setStatusInProjects({github, core, context}, { fromStatus: "Done", toStatus: "in progress" })
+
+  mark-stale-issues:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.event.schedule == '0 1 * * *')
+    permissions:
+      contents: read
+      # TODO: Set to write when Dry Run gets disabled
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
+      - shell: bash
+        run: npm ci --prefix .github/bin/js/
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        env:
+          PROJECT_NUMBER: 27 # Framework Group
+          DRY_RUN: true
+        with:
+          script: |
+            const { markStaleIssues } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
+            await markStaleIssues({github, core, context}, process.env.PROJECT_NUMBER, process.env.DRY_RUN)
+
+  close-stale-issues:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.event.schedule == '0 1 * * *')
+    needs: [mark-stale-issues]
+    permissions:
+      contents: read
+      # TODO: Set to write when Dry Run gets disabled
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4
+      - shell: bash
+        run: npm ci --prefix .github/bin/js/
+      - uses: actions/github-script@5c56fde4671bc2d3592fb0f2c5b5bab9ddae03b1 # 7
+        env:
+          DRY_RUN: true
+        with:
+          script: |
+            const { closeStaleIssues } = await import('${{ github.workspace }}/.github/bin/js/node_modules/@shopware-ag/gh-project-automation/dist/index.mjs')
+            await closeStaleIssues({github, core, context}, process.env.DRY_RUN)


### PR DESCRIPTION
### 1. Why is this change necessary?
We want to replicate our JIRA automations on Github.

### 2. What does this change do, exactly?
This change marks the issues, that are part of the "Framework Group" Project as stale if they:
- are older than 180 days
- don't have the `DoNotClose` label
- have the `priority/low` label OR have the Status `Backlog` on the Project
- aren't part of an epic

And the second automation closes all issues that weren't updated in 30 days and have the `AboutToClose` label

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- closes #7261 

This automations are currently only implemented for the "Framework Group". For other teams/projects we can adjust the scripts.
