### PR TITLE
fix: change sw-field to mt-switch in media folder settings

### DIFF
--- a/changelog/_unreleased/2025-03-16-fix-media-folder-thumbnail-settings.md
+++ b/changelog/_unreleased/2025-03-16-fix-media-folder-thumbnail-settings.md
@@ -1,0 +1,12 @@
+---
+title: fix-media-folder-thumbnail-settings
+issue: !4345
+author: Felix Schneider
+author_email: felix@wirduzen.de
+author_github: @schneider-felix
+---
+# Core
+* Changed type of `MediaFolderConfigurationEntity::mediaFolders` to be nullable
+___
+# Administration
+* Changed `sw-field` to `mt-switch` in `sw-media-modal-folder-settings`

--- a/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-folder-settings/sw-media-modal-folder-settings.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/asyncComponent/media/sw-media-modal-folder-settings/sw-media-modal-folder-settings.html.twig
@@ -106,19 +106,17 @@
                 {% block sw_media_modal_folder_settings_tab_content_thumbnails_left_container %}
                 <div class="sw-media-modal-folder-settings__thumbnails-left-container">
                     {% block sw_media_modal_folder_settings_inherit_settings_field %}
-                    <sw-field
-                        v-model:value="mediaFolder.useParentConfiguration"
-                        type="switch"
+                    <mt-switch
+                        v-model="mediaFolder.useParentConfiguration"
                         :label="$tc('global.sw-media-modal-folder-settings.labelInheritSettings')"
                         :disabled="mediaFolder.parentId === null"
-                        @update:value="onChangeInheritance"
+                        @update:model-value="onChangeInheritance"
                     />
                     {% endblock %}
 
                     {% block sw_media_modal_folder_settings_generate_thumbnails_field %}
-                    <sw-field
-                        v-model:value="configuration.createThumbnails"
-                        type="switch"
+                    <mt-switch
+                        v-model="configuration.createThumbnails"
                         :label="$tc('global.sw-media-modal-folder-settings.labelGenerateThumbnails')"
                         :disabled="mediaFolder.useParentConfiguration || disabled"
                     />

--- a/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationEntity.php
+++ b/src/Core/Content/Media/Aggregate/MediaFolderConfiguration/MediaFolderConfigurationEntity.php
@@ -15,7 +15,7 @@ class MediaFolderConfigurationEntity extends Entity
     use EntityCustomFieldsTrait;
     use EntityIdTrait;
 
-    protected MediaFolderCollection $mediaFolders;
+    protected ?MediaFolderCollection $mediaFolders = null;
 
     protected bool $createThumbnails;
 


### PR DESCRIPTION
### 1. Why is this change necessary?

In `sw-media-modal-folder-settings` there were still two leftover usages of `sw-field`. This resulted in the corresponding switch fields not showing up anymore. This is broken since 6.6 because sw-field was removed. Therefore a backport to 6.6 would be great.

### 2. What does this change do, exactly?

- Change `sw-field` to `mt-switch`
- Change type of `MediaFolderConfigurationEntity::mediaFolders` because I noticed it was incorrect

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
- relates #4345 

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
