### PR TITLE
fix: close search suggests when focus of input is lost

### DIFF
--- a/changelog/_unreleased/2025-03-17-close-search-suggests-when-focus-of-input-is-lost.md
+++ b/changelog/_unreleased/2025-03-17-close-search-suggests-when-focus-of-input-is-lost.md
@@ -1,0 +1,9 @@
+---
+title: Close search suggests when focus of input is lost
+issue: NEXT-40811
+author: Le Nguyen
+author_email: nguyenquocdaile@gmail.com
+author_github: @nguyenquocdaile
+---
+# Storefront
+* Changed _registerEvents method to close search suggests when focus of input is lost in `/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js`.

--- a/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
+++ b/src/Storefront/Resources/app/storefront/src/plugin/header/search-widget.plugin.js
@@ -72,6 +72,10 @@ export default class SearchWidgetPlugin extends Plugin {
         // add click event listener to close button
         this._closeButton.addEventListener('click', this._onCloseButtonClick.bind(this));
 
+        // add focus event listener to close button
+        this._closeButton.addEventListener('focus', () => {
+            document.querySelector(this.options.searchWidgetResultSelector).classList.add('d-none');
+        });
     }
 
     _handleSearchEvent(event) {
@@ -174,8 +178,7 @@ export default class SearchWidgetPlugin extends Plugin {
      * @private
      */
     _onCloseButtonClick() {
-        this._clearSuggestResults();
-
+        this._inputField.value = '';
         this._inputField.focus();
     }
 

--- a/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
+++ b/src/Storefront/Resources/app/storefront/test/plugin/header/search-widget.plugin.test.js
@@ -162,6 +162,27 @@ describe('SearchPlugin Tests', () => {
         expect(searchPlugin._suggest).toHaveBeenCalled();
         expect(searchPlugin.$emitter.publish).toHaveBeenCalledWith('handleInputEvent', { "value": "abcd" });
     });
+
+    test('should add d-none class to search results on close button focus', () => {
+        document.body.innerHTML = `
+            <form id="search-widget" data-search-widget="true">
+                <input type="search" name="search" autocapitalize="off" autocomplete="off">
+                <button type="submit" class="btn header-search-btn">Search</button>
+                <button type="button" class="btn header-close-btn js-search-close-btn d-none"></button>
+                <div class="search-suggest js-search-result"></div>
+            </form>
+        `;
+
+        formElement = document.getElementById('search-widget');
+        searchPlugin = new SearchPlugin(formElement);
+
+        const searchResult = document.querySelector('.js-search-result');
+        expect(searchResult.classList.contains('d-none')).toBe(false);
+
+        searchPlugin._closeButton.focus();
+
+        expect(searchResult.classList.contains('d-none')).toBe(true);
+    });
 });
 
 


### PR DESCRIPTION
PHP Version: 8.2   | Shopware Version: 6.6.9.0  | Affected area / extension: Platform(Default) 

Actual behaviour:

The search suggestions dialog box is not automatically closed when users continue to navigate, e.g. by tabbing. As soon as the keyboard focus leaves the search suggestions area of the main search field (CSS selector input.header-search-input), the keyboard focus moves behind the search suggestions dialog, especially on narrower viewports.

Expected behaviour:

The search suggestions dialog must be closed automatically after leaving the box or the input.

How to reproduce:

Enable `ACCESSIBILITY_TWEAKS` Feature-Flag

1. type into the search field until suggestions are showing
2. navigate away using tab

### Solution 

https://github.com/user-attachments/assets/a663dc3c-11a5-480b-8453-d7f745f8ae09


