### PR TITLE
ci: Fix warnings and deprecations in integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -402,7 +402,7 @@ jobs:
 
       - name: Run integration tests
         if: inputs.nightly == 'true'
-        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --exclude-group=needsWebserver,not-deterministic --stop-on-error --stop-on-failure
+        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --exclude-group=not-deterministic --stop-on-error --stop-on-failure
 
       - name: Install Shopware in previous major version
         if: inputs.nightly != 'true'
@@ -485,7 +485,7 @@ jobs:
 
       - name: Run integration tests in previous major version
         if: inputs.nightly == 'true'
-        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --exclude-group=needsWebserver,not-deterministic --stop-on-error --stop-on-failure
+        run: php -d memory_limit=-1 vendor/bin/phpunit --testsuite "integration" --exclude-group=not-deterministic --stop-on-error --stop-on-failure
 
       - name: Run blue-green check
         if: inputs.nightly != 'true'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1027,11 +1027,6 @@ parameters:
 
 		-
 			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 2
-			path: src/Core/Framework/Changelog/Processor/ChangelogProcessor.php
-
-		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
 			count: 1
 			path: src/Core/Framework/Changelog/Processor/ChangelogReleaseCreator.php
 

--- a/src/Core/Framework/DependencyInjection/services.xml
+++ b/src/Core/Framework/DependencyInjection/services.xml
@@ -538,6 +538,7 @@ frame-ancestors 'none';
             <argument type="service" id="filesystem"/>
             <argument>%kernel.project_dir%</argument>
             <argument>%shopware.feature.flags%</argument>
+            <argument>%kernel.environment%</argument>
         </service>
 
         <service id="Shopware\Core\Framework\Changelog\Processor\ChangelogReleaseCreator">
@@ -546,6 +547,7 @@ frame-ancestors 'none';
             <argument type="service" id="filesystem"/>
             <argument>%kernel.project_dir%</argument>
             <argument>%shopware.feature.flags%</argument>
+            <argument>%kernel.environment%</argument>
         </service>
 
         <service id="Shopware\Core\Framework\Changelog\Processor\ChangelogReleaseExporter">
@@ -554,6 +556,7 @@ frame-ancestors 'none';
             <argument type="service" id="filesystem"/>
             <argument>%kernel.project_dir%</argument>
             <argument>%shopware.feature.flags%</argument>
+            <argument>%kernel.environment%</argument>
         </service>
 
         <service id="Shopware\Core\Framework\Changelog\Processor\ChangelogValidator">
@@ -562,6 +565,7 @@ frame-ancestors 'none';
             <argument type="service" id="filesystem"/>
             <argument>%kernel.project_dir%</argument>
             <argument>%shopware.feature.flags%</argument>
+            <argument>%kernel.environment%</argument>
         </service>
 
         <service id="Shopware\Core\Framework\Changelog\ChangelogParser" public="false" />

--- a/tests/integration/Core/Content/Category/SalesChannel/CategoryRouteTest.php
+++ b/tests/integration/Core/Content/Category/SalesChannel/CategoryRouteTest.php
@@ -97,13 +97,12 @@ class CategoryRouteTest extends TestCase
         $manufacturers = $listing['aggregations']['manufacturer'];
 
         foreach ($manufacturers['entities'] as $manufacturer) {
-            static::assertEquals(['name', 'id', 'apiAlias'], array_keys($manufacturer));
+            static::assertSame(['name', 'id', 'apiAlias'], array_keys($manufacturer));
         }
 
-        $products = $listing['elements'];
-        foreach ($products as $product) {
-            static::assertEquals(['name', 'tax', 'manufacturer', 'id', 'apiAlias'], array_keys($product));
-            static::assertEquals(['name', 'id', 'apiAlias'], array_keys($product['tax']));
+        foreach ($listing['elements'] as $product) {
+            static::assertSame(['name', 'tax', 'manufacturer', 'id', 'apiAlias'], array_keys($product));
+            static::assertSame(['name', 'id', 'apiAlias'], array_keys($product['tax']));
         }
     }
 
@@ -113,8 +112,7 @@ class CategoryRouteTest extends TestCase
 
         $this->browser->request(
             'POST',
-            '/store-api/category/home',
-            []
+            '/store-api/category/home'
         );
 
         $this->assertListingCmsPage($this->ids->get('home-category'), $this->ids->get('home-cms-page'));
@@ -127,8 +125,7 @@ class CategoryRouteTest extends TestCase
         $id = $this->ids->get('folder');
         $this->browser->request(
             'POST',
-            '/store-api/category/' . $id,
-            []
+            '/store-api/category/' . $id
         );
 
         $this->assertError($id);
@@ -141,8 +138,7 @@ class CategoryRouteTest extends TestCase
         $id = $this->ids->get('link');
         $this->browser->request(
             'POST',
-            '/store-api/category/' . $id,
-            []
+            '/store-api/category/' . $id
         );
 
         $this->assertError($id);
@@ -161,8 +157,7 @@ class CategoryRouteTest extends TestCase
 
         $this->browser->request(
             'POST',
-            '/store-api/category/home',
-            []
+            '/store-api/category/home'
         );
 
         $this->assertListingCmsPage($this->ids->get('home-category'), $this->ids->get('cms-page'));
@@ -185,7 +180,7 @@ class CategoryRouteTest extends TestCase
     /**
      *  Testing CMS slot inheritance with category overrides.
      *  - EN is System Default language
-     *  - DE is parentless
+     *  - DE is without parent
      *  - AT inherits from DE
      *  Expected hierarchy: Overrides of categories (AT > DE > EN) > Templates of categories (AT > DE > EN)
      *
@@ -202,7 +197,6 @@ class CategoryRouteTest extends TestCase
         $this->browser->request(
             'POST',
             '/store-api/category/' . $this->ids->get('category'),
-            [],
         );
 
         $this->assertLandingPageCmsPage(
@@ -224,7 +218,7 @@ class CategoryRouteTest extends TestCase
     }
 
     /**
-     *  Testing CMS slot inheritance with category overrides, with multiple EN occurances in language chain.
+     *  Testing CMS slot inheritance with category overrides, with multiple EN occurrences in language chain.
      *  - EN is System Default language
      *  - DE inherits from EN
      *  Expected hierarchy: Overrides of categories (DE > EN) > Templates of categories (DE > EN)
@@ -243,7 +237,6 @@ class CategoryRouteTest extends TestCase
         $this->browser->request(
             'POST',
             '/store-api/category/' . $this->ids->get('category'),
-            [],
         );
 
         $this->assertLandingPageCmsPage(
@@ -384,23 +377,23 @@ class CategoryRouteTest extends TestCase
         static::assertIsString($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals($categoryId, $response['id'], 'CategoryId does not match');
+        static::assertSame($categoryId, $response['id'], 'CategoryId does not match');
         static::assertIsArray($response['cmsPage']);
-        static::assertEquals('product_list', $response['cmsPage']['type']);
+        static::assertSame('product_list', $response['cmsPage']['type']);
 
-        static::assertEquals($cmsPageId, $response['cmsPage']['id'], 'CmsPage.id does not match');
-        static::assertEquals($cmsPageId, $response['cmsPageId'], 'CmsPageId does not match');
+        static::assertSame($cmsPageId, $response['cmsPage']['id'], 'CmsPage.id does not match');
+        static::assertSame($cmsPageId, $response['cmsPageId'], 'CmsPageId does not match');
         static::assertCount(1, $response['cmsPage']['sections']);
 
         static::assertCount(1, $response['cmsPage']['sections'][0]['blocks']);
 
         $block = $response['cmsPage']['sections'][0]['blocks'][0];
 
-        static::assertEquals('product-listing', $block['type']);
+        static::assertSame('product-listing', $block['type']);
         static::assertCount(1, $block['slots']);
 
         $slot = $block['slots'][0];
-        static::assertEquals('product-listing', $slot['type']);
+        static::assertSame('product-listing', $slot['type']);
         static::assertArrayHasKey('listing', $slot['data']);
 
         $listing = $slot['data']['listing'];
@@ -413,27 +406,27 @@ class CategoryRouteTest extends TestCase
         static::assertIsString($this->browser->getResponse()->getContent());
         $response = \json_decode($this->browser->getResponse()->getContent(), true, 512, \JSON_THROW_ON_ERROR);
 
-        static::assertEquals($categoryId, $response['id'], 'CategoryId does not match');
+        static::assertSame($categoryId, $response['id'], 'CategoryId does not match');
         static::assertIsArray($response['cmsPage']);
-        static::assertEquals('landingpage', $response['cmsPage']['type']);
+        static::assertSame('landingpage', $response['cmsPage']['type']);
 
-        static::assertEquals($cmsPageId, $response['cmsPage']['id'], 'CmsPage.id does not match');
-        static::assertEquals($cmsPageId, $response['cmsPageId'], 'CmsPageId does not match');
+        static::assertSame($cmsPageId, $response['cmsPage']['id'], 'CmsPage.id does not match');
+        static::assertSame($cmsPageId, $response['cmsPageId'], 'CmsPageId does not match');
         static::assertCount(1, $response['cmsPage']['sections']);
 
         static::assertCount(1, $response['cmsPage']['sections'][0]['blocks']);
 
         $block = $response['cmsPage']['sections'][0]['blocks'][0];
 
-        static::assertEquals('text-teaser', $block['type']);
+        static::assertSame('text-teaser', $block['type']);
         static::assertCount(1, $block['slots']);
 
         $slot = $block['slots'][0];
-        static::assertEquals('text', $slot['type']);
+        static::assertSame('text', $slot['type']);
 
         $config = $slot['config']['content'];
-        static::assertEquals('static', $config['source']);
-        static::assertEquals($expected, $config['value']);
+        static::assertSame('static', $config['source']);
+        static::assertSame($expected, $config['value']);
     }
 
     /**
@@ -501,7 +494,7 @@ class CategoryRouteTest extends TestCase
                     ]],
                 ]],
             ],
-            'slotConfig' => $overrides['en'] ? $overrides['en']['slotConfig'] : null,
+            'slotConfig' => $overrides['en']['slotConfig'] ?? null,
             'translations' => \array_values($overrides) ?: null,
         ];
 

--- a/tests/integration/Core/Framework/Changelog/ChangelogCommandTest.php
+++ b/tests/integration/Core/Framework/Changelog/ChangelogCommandTest.php
@@ -11,6 +11,7 @@ use Shopware\Core\Framework\Changelog\Processor\ChangelogReleaseCreator;
 use Shopware\Core\Framework\Changelog\Processor\ChangelogReleaseExporter;
 use Shopware\Core\Framework\Changelog\Processor\ChangelogValidator;
 use Shopware\Core\Framework\Feature;
+use Shopware\Core\Framework\FrameworkException;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -64,19 +65,21 @@ class ChangelogCommandTest extends TestCase
     }
 
     /**
-     * @return list<array{0: string, 1: string|null, 2: list<string>}>
+     * @return list<array{string, string|null, string|null, list<string>}>
      */
     public static function provideChangeCommandFixtures(): array
     {
         return [
             [
                 __DIR__ . '/_fixture/stage/command-invalid',
-                \InvalidArgumentException::class,
+                FrameworkException::class,
+                '/Invalid file at path: .*\/tests\/integration\/Core\/Framework\/Changelog\/_fixture\/stage\/command-invalid\/changelog\/_unreleased\/1977-12-10-a-full-change.md, errors: Unknown flag _FLAG_ is assigned /',
                 [
                 ],
             ],
             [
                 __DIR__ . '/_fixture/stage/command-valid',
+                null,
                 null,
                 [
                     '# Core',
@@ -98,7 +101,7 @@ class ChangelogCommandTest extends TestCase
     }
 
     /**
-     * @return array<string, array{0: string, 1: string, 2: string|null, 3: array<string, list<string>>}>
+     * @return array<string, array{string, string, string|null, string|null, array<string, list<string>>}>
      */
     public static function provideReleaseCommandFixtures(): array
     {
@@ -107,19 +110,22 @@ class ChangelogCommandTest extends TestCase
                 __DIR__ . '/_fixture/stage/command-invalid',
                 '1.2',
                 \RuntimeException::class,
+                '/Invalid version of release \("1.2"\)\. It should be 4-digits type/',
                 [
                 ],
             ],
             'invalid-changelog' => [
                 __DIR__ . '/_fixture/stage/command-invalid',
                 '8.36.22.186',
-                \InvalidArgumentException::class,
+                FrameworkException::class,
+                '/Invalid file at path: .*\/tests\/integration\/Core\/Framework\/Changelog\/_fixture\/stage\/command-invalid\/changelog\/_unreleased\/1977-12-10-a-full-change.md, errors: Unknown flag _FLAG_ is assigned /',
                 [
                 ],
             ],
             'valid-minor-release' => [
                 __DIR__ . '/_fixture/stage/command-valid',
                 '12.13.14.15',
+                null,
                 null,
                 [
                     __DIR__ . '/_fixture/stage/command-valid/CHANGELOG.md' => [
@@ -142,6 +148,7 @@ class ChangelogCommandTest extends TestCase
             'valid-major-release' => [
                 __DIR__ . '/_fixture/stage/command-valid-minor-update',
                 '12.13.15.0',
+                null,
                 null,
                 [
                     __DIR__ . '/_fixture/stage/command-valid-minor-update/CHANGELOG.md' => [
@@ -200,8 +207,12 @@ class ChangelogCommandTest extends TestCase
      * @param list<string> $expectedOutputSnippets
      */
     #[DataProvider('provideChangeCommandFixtures')]
-    public function testChangelogChangeCommand(string $path, ?string $expectedException, array $expectedOutputSnippets): void
-    {
+    public function testChangelogChangeCommand(
+        string $path,
+        ?string $expectedException,
+        ?string $expectedExceptionMessage,
+        array $expectedOutputSnippets
+    ): void {
         self::getContainer()->get(ChangelogReleaseExporter::class)->setPlatformRoot($path);
         $cmd = self::getContainer()->get(ChangelogChangeCommand::class);
 
@@ -209,6 +220,8 @@ class ChangelogCommandTest extends TestCase
 
         if ($expectedException) {
             $this->expectException($expectedException);
+            static::assertNotNull($expectedExceptionMessage);
+            $this->expectExceptionMessageMatches($expectedExceptionMessage);
         }
 
         $cmd->run(new StringInput(''), $output);
@@ -225,7 +238,7 @@ class ChangelogCommandTest extends TestCase
      * @param array<string, list<string>> $expectedFileContents
      */
     #[DataProvider('provideReleaseCommandFixtures')]
-    public function testChangelogReleaseCommand(string $path, string $version, ?string $expectedException, array $expectedFileContents): void
+    public function testChangelogReleaseCommand(string $path, string $version, ?string $expectedException, ?string $expectedExceptionMessage, array $expectedFileContents): void
     {
         self::getContainer()->get(ChangelogReleaseCreator::class)->setPlatformRoot($path);
         $cmd = self::getContainer()->get(ChangelogReleaseCommand::class);
@@ -234,6 +247,8 @@ class ChangelogCommandTest extends TestCase
 
         if ($expectedException) {
             $this->expectException($expectedException);
+            static::assertNotNull($expectedExceptionMessage);
+            $this->expectExceptionMessageMatches($expectedExceptionMessage);
         }
 
         $cmd->run(new StringInput($version), $output);

--- a/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
+++ b/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
@@ -175,9 +175,12 @@ class FeatureTest extends TestCase
 
         $this->expectExceptionMessageMatches('/.*RANDOMFLAGTHATISNOTREGISTERDE471112.*/');
 
-        $template->render([]);
-
-        restore_error_handler();
+        try {
+            $template->render([]);
+        } catch (\Exception $e) {
+            restore_error_handler();
+            throw $e;
+        }
     }
 
     public function testTwigFeatureFlagNotRegisteredInProd(): void

--- a/tests/unit/Core/Framework/Adapter/Twig/TokenParser/FeatureFlagCallTokenParserTest.php
+++ b/tests/unit/Core/Framework/Adapter/Twig/TokenParser/FeatureFlagCallTokenParserTest.php
@@ -23,9 +23,7 @@ class FeatureFlagCallTokenParserTest extends TestCase
     public function testCodeRun(string $twigCode, bool $shouldThrow): void
     {
         // deprecation warning wouldn't be rendered otherwise
-        $this->setEnvVars(['TESTS_RUNNING' => false]);
-
-        $_SERVER['TEST_TWIG'] = false;
+        $this->setEnvVars(['TESTS_RUNNING' => false, 'TEST_TWIG' => false]);
 
         $deprecationMessage = null;
         set_error_handler(function ($errno, $errstr) use (&$deprecationMessage) {
@@ -47,8 +45,6 @@ class FeatureFlagCallTokenParserTest extends TestCase
         } else {
             static::assertNull($deprecationMessage);
         }
-
-        unset($_SERVER['TEST_TWIG']);
     }
 
     /**


### PR DESCRIPTION
### 1. Why is this change necessary?

The nightly build for the blue-green check is failing 
https://github.com/shopware/shopware/actions/runs/13889666532/job/38859393461

### 2. What does this change do, exactly?

- Fix the deprecated usage of `--exclude-group` CLI option

### 3. Describe each step to reproduce the issue or behaviour.

Run pipeline in nightly mode

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
