### PR TITLE
fix: media settings slider not working properly

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/index.js
@@ -85,9 +85,5 @@ export default {
         onLoadingChanged(loading) {
             this.isLoading = loading;
         },
-
-        onSliderChange(value) {
-            this.sliderValue = value;
-        },
     },
 };

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.html.twig
@@ -51,11 +51,9 @@
                         :help-text="$tc('sw-settings-media.3d.lightIntensity.helpText')"
                         :min="0"
                         :max="100"
-                        @input="onSliderChange"
                     />
                 </template>
             </sw-system-config>
-
         </sw-card-view>
     </template>
     {% endblock %}

--- a/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-settings-media/page/sw-settings-media/sw-settings-media.spec.js
@@ -170,14 +170,4 @@ describe('module/sw-settings-media/page/sw-settings-media', () => {
         await wrapper.vm.$nextTick();
         expect(wrapper.find('.sw-card-view').find('.sw-system-config').find('.mt-card').exists()).toBeTruthy();
     });
-
-    it('should change the slider value', async () => {
-        const wrapper = await createWrapper();
-        await flushPromises();
-
-        await wrapper.vm.$nextTick();
-        wrapper.vm.onSliderChange(50);
-
-        expect(wrapper.vm.sliderValue).toBe(50);
-    });
 });

--- a/src/Core/System/Resources/config/media.xml
+++ b/src/Core/System/Resources/config/media.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/trunk/src/Core/System/SystemConfig/Schema/config.xsd">
     <card>
-        <title>3D Files</title>
+        <title>3D files</title>
         <title lang="de-DE">3D Dateien</title>
 
         <input-field type="bool">


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the slider is broken and has a invalid value when changed

### 2. What does this change do, exactly?
Remove custom input handling and rely on v-model

### 3. Describe each step to reproduce the issue or behaviour.
Open Admin > Settings > Media and use the slider

### 4. Please link to the relevant issues (if any).
- closes #7560
- Jira issue: https://shopware.atlassian.net/browse/NEXT-41037

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
