### PR TITLE
docs: set bug issue type on bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug report 🐛
 description: Errors or flaws in the code are leading to incorrect or unexpected behavior.
-labels: [Bug]
 type: Bug
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report 🐛
 description: Errors or flaws in the code are leading to incorrect or unexpected behavior.
 labels: [Bug]
+type: Bug
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/epic.yaml
+++ b/.github/ISSUE_TEMPLATE/epic.yaml
@@ -1,6 +1,5 @@
 name: Epic 
 description: A request of substantial size or complexity.
-labels: [Epic]
 type: Epic
 body:
     - type: markdown

--- a/.github/ISSUE_TEMPLATE/epic.yaml
+++ b/.github/ISSUE_TEMPLATE/epic.yaml
@@ -1,6 +1,7 @@
 name: Epic 
 description: A request of substantial size or complexity.
 labels: [Epic]
+type: Epic
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/story.yaml
+++ b/.github/ISSUE_TEMPLATE/story.yaml
@@ -1,6 +1,7 @@
 name: Story 
 description: Use this template to draft user stories.
 labels: [Story]
+type: Story
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/story.yaml
+++ b/.github/ISSUE_TEMPLATE/story.yaml
@@ -1,6 +1,5 @@
 name: Story 
 description: Use this template to draft user stories.
-labels: [Story]
 type: Story
 body:
     - type: markdown


### PR DESCRIPTION
### 1. Why is this change necessary?
We want to set the issue type "Bug" on all issues that use the "Bug report" template.

### 2. What does this change do, exactly?
As the official "Issue type preview" discussion says, we could just set the type through "type: Bug".
https://github.com/orgs/community/discussions/139933 (Issue form with `type` field)

I've also added the issue types for Epic and Story.

### 3. Describe each step to reproduce the issue or behaviour.
After the merge create a new issue with the issue type `Bug report 🐛`

### 4. Please link to the relevant issues (if any).
- closes #7459 
