### PR TITLE
Fix line-break on btn-link-inline buttons

### DIFF
--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/abstract/variables/_bootstrap.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/abstract/variables/_bootstrap.scss
@@ -86,6 +86,7 @@ $form-label-margin-bottom: 3px !default;
 $btn-padding-y: 2px !default;
 $btn-padding-x: 12px !default;
 $btn-line-height: 2.125rem !default;
+$btn-white-space: nowrap !default;
 
 $btn-padding-y-sm: 2px !default;
 $btn-padding-x-sm: 12px !default;

--- a/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_button.scss
+++ b/src/Storefront/Resources/app/storefront/src/scss/skin/shopware/component/_button.scss
@@ -10,7 +10,6 @@ https://getbootstrap.com/docs/5.2/components/buttons
     --#{$prefix}btn-disabled-color: #{$btn-link-disabled-color};
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
 }
 
 // custom add to cart button, used e.g. in product-box and product detail buybox
@@ -47,6 +46,8 @@ https://getbootstrap.com/docs/5.2/components/buttons
     --#{$prefix}btn-border-width: 0;
     text-decoration: underline;
     vertical-align: baseline;
+    text-align: left;
+    white-space: normal;
 
     &:hover {
         text-decoration: underline;


### PR DESCRIPTION
### 1. Why is this change necessary?

Button links like "Prices including VAT plus shipping" are not producing line breaks and might clip through their parent container.

### 2. What does this change do, exactly?

Fix the button styling so it behaves like regular text link.
