### PR TITLE
fix: flaky PluginIntegrationTestBehaviour

### DIFF
--- a/src/Core/Framework/Test/Plugin/PluginIntegrationTestBehaviour.php
+++ b/src/Core/Framework/Test/Plugin/PluginIntegrationTestBehaviour.php
@@ -10,7 +10,6 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\Kernel;
 use SwagTestPlugin\SwagTestPlugin;
 use SwagTestSkipRebuild\SwagTestSkipRebuild;
 use SwagTestWithBundle\SwagTestWithBundle;
@@ -19,14 +18,13 @@ trait PluginIntegrationTestBehaviour
 {
     protected ClassLoader $classLoader;
 
-    protected Connection $connection;
-
     #[Before]
     public function pluginIntegrationSetUp(): void
     {
-        $this->connection = Kernel::getConnection();
-        $this->connection->beginTransaction();
-        $this->connection->executeStatement('DELETE FROM plugin');
+        $connection = static::getContainer()
+            ->get(Connection::class);
+        $connection->beginTransaction();
+        $connection->executeStatement('DELETE FROM plugin');
 
         $this->classLoader = clone KernelLifecycleManager::getClassLoader();
         KernelLifecycleManager::getClassLoader()->unregister();
@@ -39,7 +37,9 @@ trait PluginIntegrationTestBehaviour
         $this->classLoader->unregister();
         KernelLifecycleManager::getClassLoader()->register();
 
-        $this->connection->rollBack();
+        static::getContainer()
+            ->get(Connection::class)
+            ->rollBack();
     }
 
     protected function insertPlugin(PluginEntity $plugin): void
@@ -61,7 +61,9 @@ trait PluginIntegrationTestBehaviour
             'installed_at' => $installedAt ? $installedAt->format(Defaults::STORAGE_DATE_TIME_FORMAT) : null,
         ];
 
-        $this->connection->insert('plugin', $data);
+        static::getContainer()
+            ->get(Connection::class)
+            ->insert('plugin', $data);
     }
 
     protected function getNotInstalledPlugin(): PluginEntity

--- a/src/Core/Framework/Test/Plugin/PluginIntegrationTestBehaviour.php
+++ b/src/Core/Framework/Test/Plugin/PluginIntegrationTestBehaviour.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Before;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Plugin\PluginEntity;
 use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use SwagTestPlugin\SwagTestPlugin;
 use SwagTestSkipRebuild\SwagTestSkipRebuild;
@@ -16,6 +17,8 @@ use SwagTestWithBundle\SwagTestWithBundle;
 
 trait PluginIntegrationTestBehaviour
 {
+    use KernelTestBehaviour;
+
     protected ClassLoader $classLoader;
 
     #[Before]

--- a/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
@@ -400,7 +400,13 @@ class KernelPluginIntegrationTest extends TestCase
 
     private function makeKernel(KernelPluginLoader $loader): Kernel
     {
-        $kernel = KernelFactory::create('test', true, KernelLifecycleManager::getClassLoader(), $loader);
+        $kernel = KernelFactory::create(
+            'test',
+            true,
+            KernelLifecycleManager::getClassLoader(),
+            $loader,
+            static::getContainer()->get(Connection::class)
+        );
         static::assertInstanceOf(Kernel::class, $kernel);
         $this->kernel = $kernel;
 

--- a/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\Plugin;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Kernel\KernelFactory;
@@ -86,7 +87,9 @@ class KernelPluginIntegrationTest extends TestCase
     {
         $this->insertPlugin($this->getActivePlugin());
 
-        $this->connection->executeStatement('UPDATE plugin SET active = 1, installed_at = date(now())');
+        static::getContainer()
+            ->get(Connection::class)
+            ->executeStatement('UPDATE plugin SET active = 1, installed_at = date(now())');
 
         $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
         $this->kernel = $this->makeKernel($loader);

--- a/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
@@ -403,9 +403,6 @@ class KernelPluginIntegrationTest extends TestCase
         $kernel = KernelFactory::create('test', true, KernelLifecycleManager::getClassLoader(), $loader);
         static::assertInstanceOf(Kernel::class, $kernel);
         $this->kernel = $kernel;
-//        $connection = (new \ReflectionClass(KernelFactory::$kernelClass))->getProperty('connection');
-//        $connection->setAccessible(true);
-//        $connection->setValue($this->kernel, static::getContainer()->get(Connection::class));
 
         return $this->kernel;
     }

--- a/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
@@ -70,7 +70,11 @@ class KernelPluginIntegrationTest extends TestCase
     {
         $this->insertPlugin($this->getInstalledInactivePlugin());
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader(
+            $this->classLoader,
+            null,
+            static::getContainer()->get(Connection::class)
+        );
         $this->kernel = $this->makeKernel($loader);
         $this->kernel->boot();
 
@@ -91,7 +95,11 @@ class KernelPluginIntegrationTest extends TestCase
             ->get(Connection::class)
             ->executeStatement('UPDATE plugin SET active = 1, installed_at = date(now())');
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader(
+            $this->classLoader,
+            null,
+            static::getContainer()->get(Connection::class)
+        );
         $this->kernel = $this->makeKernel($loader);
         $this->kernel->boot();
 
@@ -105,7 +113,11 @@ class KernelPluginIntegrationTest extends TestCase
     {
         $this->insertPlugin($this->getInstalledInactivePlugin());
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader(
+            $this->classLoader,
+            null,
+            static::getContainer()->get(Connection::class)
+        );
         $this->kernel = $this->makeKernel($loader);
         $this->kernel->boot();
 
@@ -116,7 +128,11 @@ class KernelPluginIntegrationTest extends TestCase
     {
         $this->insertPlugin($this->getActivePlugin());
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader(
+            $this->classLoader,
+            null,
+            static::getContainer()->get(Connection::class)
+        );
         $this->kernel = $this->makeKernel($loader);
         $this->kernel->boot();
 
@@ -135,7 +151,11 @@ class KernelPluginIntegrationTest extends TestCase
         $inactive = $this->getInstalledInactivePlugin();
         $this->insertPlugin($inactive);
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader(
+            $this->classLoader,
+            null,
+            static::getContainer()->get(Connection::class)
+        );
         $this->kernel = $this->makeKernel($loader);
         $this->kernel->boot();
 
@@ -163,7 +183,11 @@ class KernelPluginIntegrationTest extends TestCase
         $inactive = $this->getInstalledInactivePluginRebuildDisabled();
         $this->insertPlugin($inactive);
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader(
+            $this->classLoader,
+            null,
+            static::getContainer()->get(Connection::class)
+        );
         $this->kernel = $this->makeKernel($loader);
         $this->kernel->boot();
 
@@ -191,7 +215,11 @@ class KernelPluginIntegrationTest extends TestCase
         $inactive = $this->getInstalledInactivePluginRebuildDisabled();
         $this->insertPlugin($inactive);
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader(
+            $this->classLoader,
+            null,
+            static::getContainer()->get(Connection::class)
+        );
         $this->kernel = $this->makeKernel($loader);
         $this->kernel->boot();
 
@@ -219,7 +247,11 @@ class KernelPluginIntegrationTest extends TestCase
         $active = $this->getActivePlugin();
         $this->insertPlugin($active);
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader(
+            $this->classLoader,
+            null,
+            static::getContainer()->get(Connection::class)
+        );
         $this->kernel = $this->makeKernel($loader);
         $this->kernel->boot();
 
@@ -254,7 +286,11 @@ class KernelPluginIntegrationTest extends TestCase
         $plugin = $this->getInstalledInactivePlugin();
         $this->insertPlugin($plugin);
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader(
+            $this->classLoader,
+            null,
+            static::getContainer()->get(Connection::class)
+        );
         $this->kernel = $this->makeKernel($loader);
         $this->kernel->boot();
 
@@ -296,7 +332,11 @@ class KernelPluginIntegrationTest extends TestCase
         $plugin = $this->getInstalledInactivePlugin();
         $this->insertPlugin($plugin);
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader(
+            $this->classLoader,
+            null,
+            static::getContainer()->get(Connection::class)
+        );
         $this->makeKernel($loader);
         $kernel = $this->kernel;
         static::assertNotNull($kernel);
@@ -365,7 +405,7 @@ class KernelPluginIntegrationTest extends TestCase
         $this->kernel = $kernel;
         $connection = (new \ReflectionClass(KernelFactory::$kernelClass))->getProperty('connection');
         $connection->setAccessible(true);
-        $connection->setValue($this->kernel, $this->connection);
+        $connection->setValue($this->kernel, static::getContainer()->get(Connection::class));
 
         return $this->kernel;
     }

--- a/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginIntegrationTest.php
@@ -403,9 +403,9 @@ class KernelPluginIntegrationTest extends TestCase
         $kernel = KernelFactory::create('test', true, KernelLifecycleManager::getClassLoader(), $loader);
         static::assertInstanceOf(Kernel::class, $kernel);
         $this->kernel = $kernel;
-        $connection = (new \ReflectionClass(KernelFactory::$kernelClass))->getProperty('connection');
-        $connection->setAccessible(true);
-        $connection->setValue($this->kernel, static::getContainer()->get(Connection::class));
+//        $connection = (new \ReflectionClass(KernelFactory::$kernelClass))->getProperty('connection');
+//        $connection->setAccessible(true);
+//        $connection->setValue($this->kernel, static::getContainer()->get(Connection::class));
 
         return $this->kernel;
     }

--- a/tests/integration/Core/Framework/Plugin/KernelPluginLoader/DbalKernelPluginLoaderTest.php
+++ b/tests/integration/Core/Framework/Plugin/KernelPluginLoader/DbalKernelPluginLoaderTest.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Tests\Integration\Core\Framework\Plugin\KernelPluginLoader;
 
+use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Plugin\KernelPluginLoader\DbalKernelPluginLoader;
 use Shopware\Core\Framework\Test\Plugin\PluginIntegrationTestBehaviour;
@@ -15,7 +16,7 @@ class DbalKernelPluginLoaderTest extends TestCase
 
     public function testLoadNoPlugins(): void
     {
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader($this->classLoader, null, static::getContainer()->get(Connection::class));
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         static::assertEmpty($loader->getPluginInfos());
@@ -27,7 +28,7 @@ class DbalKernelPluginLoaderTest extends TestCase
         $plugin = $this->getActivePlugin();
         $this->insertPlugin($plugin);
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader($this->classLoader, null, static::getContainer()->get(Connection::class));
         static::assertEmpty($loader->getPluginInfos());
     }
 
@@ -36,7 +37,7 @@ class DbalKernelPluginLoaderTest extends TestCase
         $plugin = $this->getActivePlugin();
         $this->insertPlugin($plugin);
 
-        $loader = new DbalKernelPluginLoader($this->classLoader, null, $this->connection);
+        $loader = new DbalKernelPluginLoader($this->classLoader, null, static::getContainer()->get(Connection::class));
         $loader->initializePlugins(TEST_PROJECT_DIR);
 
         static::assertNotEmpty($loader->getPluginInfos());


### PR DESCRIPTION
### 1. Why is this change necessary?

Getting connection directly from Kernel and propagating as a property through a trait does not work well for the job running integration test for framework randomly