### PR TITLE
chore: split core integration tests for faster execution

### DIFF
--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -16,13 +16,16 @@ echo \json_encode([
         'test' => [
             ['path' => 'Core/Checkout'],
             ['path' => 'Core/Content'],
-            ['path' => 'Core/Framework'],
+            ['path' => '{Core/Framework/Adapter,Core/Framework/Api,Core/Framework/App,Core/Framework/Cache,Core/Framework/Changelog,Core/Framework/CustomField}'],
+            ['path' => '{Core/Framework/DataAbstractionLayer,Core/Framework/DemoData,Core/Framework/DependencyInjection,Core/Framework/FeatureFlag,Core/Framework/Increment,Core/Framework/Language,Core/Framework/Log,Core/Framework/MessageQueue}'],
+            ['path' => '{Core/Framework/Migration,Core/Framework/Plugin,Core/Framework/RateLimiter,Core/Framework/Routing,Core/Framework/Rule,Core/Framework/Script,Core/Framework/Seo,Core/Framework/Store,Core/Framework/Telemetry,Core/Framework/TestCaseBase}'],
+            ['path' => '{Core/Framework/Translation,Core/Framework/Update,Core/Framework/Util,Core/Framework/Webhook,Core/Framework/AdditionalPermissionValidationTest.php,Core/Framework/ApiRoutesHaveASchemaTest.php,Core/Framework/KernelTest.php,Core/Framework/ServiceDefinitionTest.php}'],
             ['path' => 'Storefront'],
             ['path' => '{Administration,Elasticsearch}'],
             ['path' => '{Core/Installer,Core/Maintenance,Core/System}'],
             ['testsuite' => 'migration'],
             ['testsuite' => 'devops']
-            ],
+        ],
         'php' => $php,
         'db' => $db,
     ]

--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -17,7 +17,7 @@ echo \json_encode([
             ['path' => 'Core/Checkout'],
             ['path' => 'Core/Content'],
             ['path' => '{Core/Framework/Adapter,Core/Framework/Api,Core/Framework/App,Core/Framework/Cache,Core/Framework/Changelog,Core/Framework/CustomField}'],
-            ['path' => '{Core/Framework/DataAbstractionLayer,Core/Framework/DemoData,Core/Framework/DependencyInjection,Core/Framework/FeatureFlag,Core/Framework/Increment,Core/Framework/Language,Core/Framework/Log,Core/Framework/MessageQueue}'],
+            ['path' => '{Core/Framework/DataAbstractionLayer,Core/Framework/Demodata,Core/Framework/DependencyInjection,Core/Framework/FeatureFlag,Core/Framework/Increment,Core/Framework/Language,Core/Framework/Log,Core/Framework/MessageQueue}'],
             ['path' => '{Core/Framework/Migration,Core/Framework/Plugin,Core/Framework/RateLimiter,Core/Framework/Routing,Core/Framework/Rule,Core/Framework/Script,Core/Framework/Seo,Core/Framework/Store,Core/Framework/Telemetry,Core/Framework/TestCaseBase}'],
             ['path' => '{Core/Framework/Translation,Core/Framework/Update,Core/Framework/Util,Core/Framework/Webhook,Core/Framework/AdditionalPermissionValidationTest.php,Core/Framework/ApiRoutesHaveASchemaTest.php,Core/Framework/KernelTest.php,Core/Framework/ServiceDefinitionTest.php}'],
             ['path' => 'Storefront'],

--- a/.github/bin/generate-phpunit-matrix.php
+++ b/.github/bin/generate-phpunit-matrix.php
@@ -16,10 +16,9 @@ echo \json_encode([
         'test' => [
             ['path' => 'Core/Checkout'],
             ['path' => 'Core/Content'],
-            ['path' => '{Core/Framework/Adapter,Core/Framework/Api,Core/Framework/App,Core/Framework/Cache,Core/Framework/Changelog,Core/Framework/CustomField}'],
-            ['path' => '{Core/Framework/DataAbstractionLayer,Core/Framework/Demodata,Core/Framework/DependencyInjection,Core/Framework/FeatureFlag,Core/Framework/Increment,Core/Framework/Language,Core/Framework/Log,Core/Framework/MessageQueue}'],
-            ['path' => '{Core/Framework/Migration,Core/Framework/Plugin,Core/Framework/RateLimiter,Core/Framework/Routing,Core/Framework/Rule,Core/Framework/Script,Core/Framework/Seo,Core/Framework/Store,Core/Framework/Telemetry,Core/Framework/TestCaseBase}'],
-            ['path' => '{Core/Framework/Translation,Core/Framework/Update,Core/Framework/Util,Core/Framework/Webhook,Core/Framework/AdditionalPermissionValidationTest.php,Core/Framework/ApiRoutesHaveASchemaTest.php,Core/Framework/KernelTest.php,Core/Framework/ServiceDefinitionTest.php}'],
+            ['testsuite' => 'core-framework-batch1'],
+            ['testsuite' => 'core-framework-batch2'],
+            ['testsuite' => 'core-framework-batch3'],
             ['path' => 'Storefront'],
             ['path' => '{Administration,Elasticsearch}'],
             ['path' => '{Core/Installer,Core/Maintenance,Core/System}'],

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,7 +34,7 @@ jobs:
           shopware-repository: ${{ github.repository }}
       - name: Run PHPUnit
         run: |
-          ./vendor/bin/phpunit --group=redis
+          ./vendor/bin/phpunit --group=redis --testsuite migration,unit,integration,devops
 
   admin:
     uses: ./.github/workflows/admin.yml

--- a/composer.json
+++ b/composer.json
@@ -371,7 +371,7 @@
             "export PROJECT_ROOT=\"$PWD\"; \"$PROJECT_ROOT\"/bin/install-extension-npm"
         ],
         "init:testdb": [
-            "FORCE_INSTALL=true vendor/bin/phpunit --group=none"
+            "FORCE_INSTALL=true vendor/bin/phpunit --group=none --testsuite migration,unit,integration,devops"
         ],
         "lint": [
             "@stylelint",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -110,6 +110,49 @@
         <testsuite name="integration">
             <directory>tests/integration</directory>
         </testsuite>
+
+        <!-- Framework is split in sub suites to improve the pipeline efficiency -->
+        <testsuite name="core-framework-batch1">
+            <file>tests/integration/Core/Framework/AdditionalPermissionValidationTest.php</file>
+            <file>tests/integration/Core/Framework/ApiRoutesHaveASchemaTest.php</file>
+            <file>tests/integration/Core/Framework/KernelTest.php</file>
+            <file>tests/integration/Core/Framework/ServiceDefinitionTest.php</file>
+            <directory>tests/integration/Core/Framework/Adapter</directory>
+            <directory>tests/integration/Core/Framework/Api</directory>
+            <directory>tests/integration/Core/Framework/App</directory>
+            <directory>tests/integration/Core/Framework/Cache</directory>
+            <directory>tests/integration/Core/Framework/Changelog</directory>
+            <directory>tests/integration/Core/Framework/CustomField</directory>
+        </testsuite>
+
+        <testsuite name="core-framework-batch2">
+            <directory>tests/integration/Core/Framework/DataAbstractionLayer</directory>
+            <directory>tests/integration/Core/Framework/Demodata</directory>
+            <directory>tests/integration/Core/Framework/DependencyInjection</directory>
+            <directory>tests/integration/Core/Framework/FeatureFlag</directory>
+            <directory>tests/integration/Core/Framework/Increment</directory>
+            <directory>tests/integration/Core/Framework/Language</directory>
+            <directory>tests/integration/Core/Framework/Log</directory>
+            <directory>tests/integration/Core/Framework/MessageQueue</directory>
+            <directory>tests/integration/Core/Framework/Migration</directory>
+        </testsuite>
+
+        <testsuite name="core-framework-batch3">
+            <directory>tests/integration/Core/Framework/Plugin</directory>
+            <directory>tests/integration/Core/Framework/RateLimiter</directory>
+            <directory>tests/integration/Core/Framework/Routing</directory>
+            <directory>tests/integration/Core/Framework/Rule</directory>
+            <directory>tests/integration/Core/Framework/Script</directory>
+            <directory>tests/integration/Core/Framework/Seo</directory>
+            <directory>tests/integration/Core/Framework/Store</directory>
+            <directory>tests/integration/Core/Framework/Telemetry</directory>
+            <directory>tests/integration/Core/Framework/TestCaseBase</directory>
+            <directory>tests/integration/Core/Framework/Translation</directory>
+            <directory>tests/integration/Core/Framework/Update</directory>
+            <directory>tests/integration/Core/Framework/Util</directory>
+            <directory>tests/integration/Core/Framework/Webhook</directory>
+        </testsuite>
+
         <testsuite name="devops">
             <directory>tests/devops</directory>
         </testsuite>


### PR DESCRIPTION
### 1. Why is this change necessary?

Integration tests for Core are getting slower, it's a lottery between 12 minutes and 30 minutes.

### 2. What does this change do, exactly?

Split in subgroup the Core tests for integration suite

The initial commit is a 'raw' split and we might describe them into suites instead of path for better exposing, as the risk is to skip new tests that would not be added here, while it would be more readable in phpunit.xml.dist

After this change, seeing the pipeline as on first commits:

<img width="317" alt="Screenshot 2025-03-18 at 11 19 46" src="https://github.com/user-attachments/assets/68570ce5-35ca-409a-99ad-5d9581d59fce" />

Which would be less readable than naming sub suites for Core, introduced in late commits:

<img width="800" alt="Screenshot 2025-03-18 at 15 30 38" src="https://github.com/user-attachments/assets/4bcc9bea-8aa8-44a5-bc0f-f75af765e3cc" />

**Important note:**

Since phpunit upgrade to 11, it is now expected to specify the test suite in use and not run phpunit without anything.

Example:
 `vendor/bin/phpunit --group=none` or similar would trigger many warnings, as integration tests are present in different suites (`integration` and `core-framework-batch1`, `core-framework-batch2`, `core-framework-batch3`). 
`vendor/bin/phpunit --group=none --testsuite migration,unit,integration,devops` will work as expected

All known commands hidden in composer have been fixed to prevent such warnings, beware if you would use custom local commands

