### PR TITLE
chore: removes Kernel reloading for integration FeatureTest 

### DIFF
--- a/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
+++ b/tests/integration/Core/Framework/FeatureFlag/FeatureTest.php
@@ -6,8 +6,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Framework\Adapter\Twig\Extension\FeatureFlagExtension;
 use Shopware\Core\Framework\Feature;
-use Shopware\Core\Framework\Test\TestCaseBase\KernelLifecycleManager;
-use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -18,8 +16,6 @@ use Twig\Loader\FilesystemLoader;
  */
 class FeatureTest extends TestCase
 {
-    use KernelTestBehaviour;
-
     /**
      * @var array<string, FeatureFlagConfig>
      */
@@ -44,7 +40,6 @@ class FeatureTest extends TestCase
         self::$featureAllValue = $_SERVER['FEATURE_ALL'] ?? 'false';
         self::$appEnvValue = $_ENV['APP_ENV'] ?? $_SERVER['APP_ENV'];
         self::$features = Feature::getRegisteredFeatures();
-        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
     }
 
     protected function setUp(): void
@@ -70,8 +65,6 @@ class FeatureTest extends TestCase
 
         Feature::resetRegisteredFeatures();
         Feature::registerFeatures(self::$features);
-
-        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
     }
 
     public function testABoolGetsReturned(): void
@@ -164,7 +157,6 @@ class FeatureTest extends TestCase
 
         $_SERVER['APP_ENV'] = 'test';
         $_ENV['APP_ENV'] = 'test';
-        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
 
         $loader = new FilesystemLoader(__DIR__ . '/_fixture/');
         $twig = new Environment($loader, [
@@ -187,7 +179,6 @@ class FeatureTest extends TestCase
     {
         $_SERVER['APP_ENV'] = 'prod';
         $_ENV['APP_ENV'] = 'prod';
-        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
 
         $loader = new FilesystemLoader(__DIR__ . '/_fixture/');
         $twig = new Environment($loader, [
@@ -586,8 +577,6 @@ class FeatureTest extends TestCase
     {
         $_SERVER['APP_ENV'] = 'prod';
         $_ENV['APP_ENV'] = 'prod';
-
-        KernelLifecycleManager::bootKernel(true, self::$customCacheId);
 
         foreach ($env as $key => $value) {
             $_SERVER[$key] = $value;


### PR DESCRIPTION
### 1. Why is this change necessary?

This test provides the same results no matter Kernel is reloaded or not, on local. Let see how it behaves within our pipeline