### PR TITLE
ci: add dependabot for 6.6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,20 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    target-branch: trunk
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci(deps): "
+    labels:
+      - "domain/product-ops"
+    groups:
+      all:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    target-branch: 6.6.x
     directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
We also need it for 6.6.x. The config is only loaded from the default branch