### PR TITLE
fix: Improve tag selection in customer and orders module

### DIFF
--- a/changelog/_unreleased/2025-03-19-improve-tag-selection-in-admin.md
+++ b/changelog/_unreleased/2025-03-19-improve-tag-selection-in-admin.md
@@ -1,0 +1,8 @@
+---
+title: Improve tag selection in the administration
+issue: #7544
+---
+# Administration
+* Changed `component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.html.twig` to pass down the `disabled` property to the `sw-select-base` component to properly implement the disabled state.
+* Changed `module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig` to properly use the tag collection on `sw-entity-tag-select` with `v-model`.
+* Changed `module/sw-order/component/sw-order-general-info/index.js` to simply use `order.tags` as the tag collection, without cloning it into a new entity collection.

--- a/changelog/_unreleased/2025-03-19-improve-tag-selection-in-admin.md
+++ b/changelog/_unreleased/2025-03-19-improve-tag-selection-in-admin.md
@@ -5,4 +5,3 @@ issue: #7544
 # Administration
 * Changed `component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.html.twig` to pass down the `disabled` property to the `sw-select-base` component to properly implement the disabled state.
 * Changed `module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig` to properly use the tag collection on `sw-entity-tag-select` with `v-model`.
-* Changed `module/sw-order/component/sw-order-general-info/index.js` to simply use `order.tags` as the tag collection, without cloning it into a new entity collection.

--- a/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/select/entity/sw-entity-multi-select/sw-entity-multi-select.html.twig
@@ -5,6 +5,7 @@
     :is-loading="isLoading"
     v-bind="$attrs"
     :label="label"
+    :disabled="disabled"
     @select-expanded="onSelectExpanded"
     @select-collapsed="onSelectCollapsed"
     @clear="clearSelection"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/index.js
@@ -6,7 +6,8 @@ import template from './sw-order-general-info.html.twig';
  */
 
 const { Mixin, Store } = Shopware;
-const { Criteria } = Shopware.Data;
+const { Criteria, EntityCollection } = Shopware.Data;
+const { cloneDeep } = Shopware.Utils.object;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
@@ -188,7 +189,17 @@ export default {
 
     methods: {
         createdComponent() {
-            this.tagCollection = this.order.tags;
+            const tags = cloneDeep(this.order.tags);
+
+            this.tagCollection = new EntityCollection(
+                this.order.tags.source,
+                this.order.tags.entity,
+                Shopware.Context.api,
+                null,
+                tags,
+                tags.length,
+            );
+
             this.getLiveOrder();
             this.getTransitionOptions();
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/index.js
@@ -6,8 +6,7 @@ import template from './sw-order-general-info.html.twig';
  */
 
 const { Mixin, Store } = Shopware;
-const { Criteria, EntityCollection } = Shopware.Data;
-const { cloneDeep } = Shopware.Utils.object;
+const { Criteria } = Shopware.Data;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
@@ -189,17 +188,7 @@ export default {
 
     methods: {
         createdComponent() {
-            const tags = cloneDeep(this.order.tags);
-
-            this.tagCollection = new EntityCollection(
-                this.order.tags.source,
-                this.order.tags.entity,
-                Shopware.Context.api,
-                null,
-                tags,
-                tags.length,
-            );
-
+            this.tagCollection = this.order.tags;
             this.getLiveOrder();
             this.getTransitionOptions();
         },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
@@ -161,7 +161,7 @@
     <sw-entity-tag-select
         class="sw-order-general-info__order-tags"
         size="small"
-        :entity-collection="tagCollection"
+        v-model:entity-collection="tagCollection"
         :disabled="!acl.can('order.editor')"
         :placeholder="$tc('sw-order.generalTab.tagSelect.placeholder')"
         :always-show-placeholder="true"

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
@@ -159,9 +159,9 @@
 
     {% block sw_order_detail_base_general_info_order_tags %}
     <sw-entity-tag-select
+        v-model:entity-collection="tagCollection"
         class="sw-order-general-info__order-tags"
         size="small"
-        v-model:entity-collection="tagCollection"
         :disabled="!acl.can('order.editor')"
         :placeholder="$tc('sw-order.generalTab.tagSelect.placeholder')"
         :always-show-placeholder="true"


### PR DESCRIPTION
### 1. Why is this change necessary?
- The tag selection in the customer module gives the impression that it is not functional. In fact, it is disabled if you are not in edit mode, but the disabled state is not properly implemented.
- The tag selection in the order module does not work properly.


### 2. What does this change do, exactly?
- The entity tag selection field now properly passes down the disabled state to the `sw-select-base` component, so that the tag field is properly visualized as disabled, when not in edit mode.
- The entity tag selection field in the order module now makes use of `v-model` for passing the entity collection, so that tags can be added and removed properly.

**Disabled customer tag selection:**  

![image](https://github.com/user-attachments/assets/c761bbd0-44a0-4f58-8fe9-3168651bed28)
