### PR TITLE
fix: wrong position of number in pagination itemsPerPage select

### DIFF
--- a/src/Administration/Resources/app/administration/src/app/component/grid/sw-pagination/sw-pagination.scss
+++ b/src/Administration/Resources/app/administration/src/app/component/grid/sw-pagination/sw-pagination.scss
@@ -119,6 +119,11 @@ $sw-pagination-border-radius: $border-radius-default;
                 margin: 0;
             }
 
+            .mt-select-selection-list__input {
+                min-height: 0;
+                padding-bottom: 8px;
+            }
+
             .mt-label--dismissable {
                 margin: 0;
                 padding-top: 6px;


### PR DESCRIPTION
### 1. Why is this change necessary?

Countries pagination in admin settings/countries need alignment

### 2. What does this change do, exactly?

Fix it

<img width="754" alt="Bildschirmfoto 2025-03-19 um 10 21 24" src="https://github.com/user-attachments/assets/e6952d10-95fb-4880-aa55-2b44f9607115" />
<img width="538" alt="Bildschirmfoto 2025-03-19 um 10 21 27" src="https://github.com/user-attachments/assets/8270f432-3468-40a1-86e7-fc827db5667a" />
