### PR TITLE
fix: Sitemap build evaluates category rules [6.6.x]

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1551,11 +1551,6 @@ parameters:
 			path: src/Core/Content/Sitemap/Service/ConfigHandler.php
 
 		-
-			message: "#^Throwing new exceptions within classes are not allowed\\. Please use domain exception pattern\\. See https\\://github\\.com/shopware/platform/blob/v6\\.4\\.20\\.0/adr/2022\\-02\\-24\\-domain\\-exceptions\\.md$#"
-			count: 2
-			path: src/Core/Content/Sitemap/Service/SitemapExporter.php
-
-		-
 			message: "#^Method Shopware\\\\Core\\\\Content\\\\Sitemap\\\\Service\\\\SitemapHandleInterface\\:\\:write\\(\\) has parameter \\$urls with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Core/Content/Sitemap/Service/SitemapHandleInterface.php

--- a/src/Core/Content/DependencyInjection/sitemap.xml
+++ b/src/Core/Content/DependencyInjection/sitemap.xml
@@ -60,7 +60,6 @@
             <argument type="service" id="Shopware\Core\Content\Category\CategoryDefinition"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory"/>
             <argument type="service" id="router"/>
-            <argument type="service" id="sales_channel.category.repository"/>
 
             <tag name="shopware.sitemap_url_provider"/>
         </service>

--- a/src/Core/Content/DependencyInjection/sitemap.xml
+++ b/src/Core/Content/DependencyInjection/sitemap.xml
@@ -11,6 +11,7 @@
             <argument type="service" id="shopware.filesystem.sitemap"/>
             <argument type="service" id="Shopware\Core\Content\Sitemap\Service\SitemapHandleFactoryInterface"/>
             <argument type="service" id="event_dispatcher"/>
+            <argument type="service" id="Shopware\Core\Checkout\Cart\CartRuleLoader"/>
         </service>
 
         <service id="Shopware\Core\Content\Sitemap\Service\SitemapLister">
@@ -59,6 +60,7 @@
             <argument type="service" id="Shopware\Core\Content\Category\CategoryDefinition"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory"/>
             <argument type="service" id="router"/>
+            <argument type="service" id="sales_channel.category.repository"/>
 
             <tag name="shopware.sitemap_url_provider"/>
         </service>

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Sitemap\Provider;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
+use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
@@ -12,9 +13,12 @@ use Shopware\Core\Content\Sitemap\Struct\UrlResult;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -25,13 +29,16 @@ class CategoryUrlProvider extends AbstractUrlProvider
 
     /**
      * @internal
+     *
+     * @param SalesChannelRepository<CategoryCollection> $categoryRepository
      */
     public function __construct(
         private readonly ConfigHandler $configHandler,
         private readonly Connection $connection,
         private readonly CategoryDefinition $definition,
         private readonly IteratorFactory $iteratorFactory,
-        private readonly RouterInterface $router
+        private readonly RouterInterface $router,
+        private readonly SalesChannelRepository $categoryRepository,
     ) {
     }
 
@@ -57,9 +64,19 @@ class CategoryUrlProvider extends AbstractUrlProvider
         if (empty($categories)) {
             return new UrlResult([], null);
         }
+
         $keys = FetchModeHelper::keyPair($categories);
 
-        $seoUrls = $this->getSeoUrls(array_values($keys), 'frontend.navigation.page', $context, $this->connection);
+        // Load categories from the repository to allow decorators and event listeners to modify the result.
+        /** @var EntityCollection<CategoryEntity> $categoryEntities */
+        $categoryEntities = $this->categoryRepository->search(new Criteria(array_values($keys)), $context);
+        $activeCategories = array_filter(
+            $categories,
+            fn (array $category) => $categoryEntities->get($category['id'])?->getActive() ?? true
+        );
+        $activeCategoryIds = array_column($activeCategories, 'id');
+
+        $seoUrls = $this->getSeoUrls($activeCategoryIds, 'frontend.navigation.page', $context, $this->connection);
 
         /** @var array<string, array{seo_path_info: string}> $seoUrls */
         $seoUrls = FetchModeHelper::groupUnique($seoUrls);
@@ -67,7 +84,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
         $urls = [];
         $url = new Url();
 
-        foreach ($categories as $category) {
+        foreach ($activeCategories as $category) {
             $lastMod = $category['updated_at'] ?: $category['created_at'];
 
             $lastMod = (new \DateTime($lastMod))->format(Defaults::STORAGE_DATE_TIME_FORMAT);

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -14,7 +14,6 @@ use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -68,8 +68,8 @@ class CategoryUrlProvider extends AbstractUrlProvider
         $keys = FetchModeHelper::keyPair($categories);
 
         // Load categories from the repository to allow decorators and event listeners to modify the result.
-        /** @var EntitySearchResult<CategoryEntity> $categoryEntities */
         $categoryEntities = $this->categoryRepository->search(new Criteria(array_values($keys)), $context);
+        \assert($categoryEntities->first() === null || $categoryEntities->first() instanceof CategoryEntity);
         $activeCategories = array_filter(
             $categories,
             fn (array $category) => $categoryEntities->get($category['id'])?->getActive() ?? true

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -13,8 +13,8 @@ use Shopware\Core\Content\Sitemap\Struct\UrlResult;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
-use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
@@ -68,7 +68,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
         $keys = FetchModeHelper::keyPair($categories);
 
         // Load categories from the repository to allow decorators and event listeners to modify the result.
-        /** @var EntityCollection<CategoryEntity> $categoryEntities */
+        /** @var EntitySearchResult<CategoryEntity> $categoryEntities */
         $categoryEntities = $this->categoryRepository->search(new Criteria(array_values($keys)), $context);
         $activeCategories = array_filter(
             $categories,

--- a/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
+++ b/src/Core/Content/Sitemap/Provider/CategoryUrlProvider.php
@@ -4,7 +4,6 @@ namespace Shopware\Core\Content\Sitemap\Provider;
 
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
-use Shopware\Core\Content\Category\CategoryCollection;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
@@ -13,11 +12,9 @@ use Shopware\Core\Content\Sitemap\Struct\UrlResult;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\DataAbstractionLayer\Doctrine\FetchModeHelper;
-use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -28,16 +25,13 @@ class CategoryUrlProvider extends AbstractUrlProvider
 
     /**
      * @internal
-     *
-     * @param SalesChannelRepository<CategoryCollection> $categoryRepository
      */
     public function __construct(
         private readonly ConfigHandler $configHandler,
         private readonly Connection $connection,
         private readonly CategoryDefinition $definition,
         private readonly IteratorFactory $iteratorFactory,
-        private readonly RouterInterface $router,
-        private readonly SalesChannelRepository $categoryRepository,
+        private readonly RouterInterface $router
     ) {
     }
 
@@ -51,11 +45,6 @@ class CategoryUrlProvider extends AbstractUrlProvider
         return 'category';
     }
 
-    /**
-     * {@inheritdoc}
-     *
-     * @throws \Exception
-     */
     public function getUrls(SalesChannelContext $context, int $limit, ?int $offset = null): UrlResult
     {
         $categories = $this->getCategories($context, $limit, $offset);
@@ -66,16 +55,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
 
         $keys = FetchModeHelper::keyPair($categories);
 
-        // Load categories from the repository to allow decorators and event listeners to modify the result.
-        $categoryEntities = $this->categoryRepository->search(new Criteria(array_values($keys)), $context);
-        \assert($categoryEntities->first() === null || $categoryEntities->first() instanceof CategoryEntity);
-        $activeCategories = array_filter(
-            $categories,
-            fn (array $category) => $categoryEntities->get($category['id'])?->getActive() ?? true
-        );
-        $activeCategoryIds = array_column($activeCategories, 'id');
-
-        $seoUrls = $this->getSeoUrls($activeCategoryIds, 'frontend.navigation.page', $context, $this->connection);
+        $seoUrls = $this->getSeoUrls(array_values($keys), 'frontend.navigation.page', $context, $this->connection);
 
         /** @var array<string, array{seo_path_info: string}> $seoUrls */
         $seoUrls = FetchModeHelper::groupUnique($seoUrls);
@@ -83,7 +63,7 @@ class CategoryUrlProvider extends AbstractUrlProvider
         $urls = [];
         $url = new Url();
 
-        foreach ($activeCategories as $category) {
+        foreach ($categories as $category) {
             $lastMod = $category['updated_at'] ?: $category['created_at'];
 
             $lastMod = (new \DateTime($lastMod))->format(Defaults::STORAGE_DATE_TIME_FORMAT);
@@ -105,8 +85,9 @@ class CategoryUrlProvider extends AbstractUrlProvider
         }
 
         $keys = array_keys($keys);
-        /** @var int|null $nextOffset */
+
         $nextOffset = array_pop($keys);
+        \assert(\is_int($nextOffset) || $nextOffset === null);
 
         return new UrlResult($urls, $nextOffset);
     }

--- a/src/Core/Content/Sitemap/Service/SitemapExporter.php
+++ b/src/Core/Content/Sitemap/Service/SitemapExporter.php
@@ -4,6 +4,7 @@ namespace Shopware\Core\Content\Sitemap\Service;
 
 use League\Flysystem\FilesystemOperator;
 use Psr\Cache\CacheItemPoolInterface;
+use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Content\Sitemap\Event\SitemapGeneratedEvent;
 use Shopware\Core\Content\Sitemap\Exception\AlreadyLockedException;
 use Shopware\Core\Content\Sitemap\Provider\AbstractUrlProvider;
@@ -25,9 +26,9 @@ class SitemapExporter implements SitemapExporterInterface
     private array $sitemapHandles = [];
 
     /**
-     * @internal
-     *
      * @param iterable<AbstractUrlProvider> $urlProvider
+     *
+     * @internal
      */
     public function __construct(
         private readonly iterable $urlProvider,
@@ -35,7 +36,8 @@ class SitemapExporter implements SitemapExporterInterface
         private readonly int $batchSize,
         private readonly FilesystemOperator $filesystem,
         private readonly SitemapHandleFactoryInterface $sitemapHandleFactory,
-        private readonly EventDispatcherInterface $dispatcher
+        private readonly EventDispatcherInterface $dispatcher,
+        private readonly CartRuleLoader $ruleLoader,
     ) {
     }
 
@@ -44,6 +46,7 @@ class SitemapExporter implements SitemapExporterInterface
      */
     public function generate(SalesChannelContext $context, bool $force = false, ?string $lastProvider = null, ?int $offset = null): SitemapGenerationResult
     {
+        $this->refreshContextRules($context);
         $this->lock($context, $force);
 
         try {
@@ -91,6 +94,21 @@ class SitemapExporter implements SitemapExporterInterface
     private function unlock(SalesChannelContext $salesChannelContext): void
     {
         $this->cache->deleteItem($this->generateCacheKeyForSalesChannel($salesChannelContext));
+    }
+
+    /**
+     * Ensure that the rules are loaded for the current context in case that the SalesChannelContext was created from
+     * Factory and is missing the attached rules.
+     */
+    private function refreshContextRules(SalesChannelContext $salesChannelContext): SalesChannelContext
+    {
+        if (\count($salesChannelContext->getRuleIds()) > 0) {
+            return $salesChannelContext;
+        }
+
+        $this->ruleLoader->loadByToken($salesChannelContext, $salesChannelContext->getToken());
+
+        return $salesChannelContext;
     }
 
     private function generateCacheKeyForSalesChannel(SalesChannelContext $salesChannelContext): string

--- a/src/Core/Content/Sitemap/Service/SitemapExporter.php
+++ b/src/Core/Content/Sitemap/Service/SitemapExporter.php
@@ -6,15 +6,14 @@ use League\Flysystem\FilesystemOperator;
 use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Content\Sitemap\Event\SitemapGeneratedEvent;
-use Shopware\Core\Content\Sitemap\Exception\AlreadyLockedException;
 use Shopware\Core\Content\Sitemap\Provider\AbstractUrlProvider;
+use Shopware\Core\Content\Sitemap\SitemapException;
 use Shopware\Core\Content\Sitemap\Struct\SitemapGenerationResult;
 use Shopware\Core\Content\Sitemap\Struct\Url;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\SystemConfig\Exception\InvalidDomainException;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[Package('discovery')]
@@ -84,7 +83,7 @@ class SitemapExporter implements SitemapExporterInterface
         $key = $this->generateCacheKeyForSalesChannel($salesChannelContext);
         $item = $this->cache->getItem($key);
         if ($item->isHit() && !$force) {
-            throw new AlreadyLockedException($salesChannelContext);
+            throw SitemapException::sitemapAlreadyLocked($salesChannelContext);
         }
 
         $item->set(true);
@@ -154,7 +153,7 @@ class SitemapExporter implements SitemapExporterInterface
         }
 
         if (empty($sitemapHandles)) {
-            throw new InvalidDomainException('Empty domain');
+            throw SitemapException::invalidDomain();
         }
 
         $this->sitemapHandles = $sitemapHandles;

--- a/src/Core/Content/Sitemap/SitemapException.php
+++ b/src/Core/Content/Sitemap/SitemapException.php
@@ -4,12 +4,17 @@ namespace Shopware\Core\Content\Sitemap;
 
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Symfony\Component\HttpFoundation\Response;
 
 #[Package('discovery')]
 class SitemapException extends HttpException
 {
     public const FILE_NOT_READABLE = 'CONTENT__FILE_IS_NOT_READABLE';
+
+    public const SITEMAP_ALREADY_LOCKED = 'CONTENT__SITEMAP_ALREADY_LOCKED';
+
+    public const INVALID_DOMAIN = 'CONTENT__INVALID_DOMAIN';
 
     public static function fileNotReadable(string $path): self
     {
@@ -18,6 +23,28 @@ class SitemapException extends HttpException
             self::FILE_NOT_READABLE,
             'File is not readable at {{ path }}.',
             ['path' => $path]
+        );
+    }
+
+    public static function sitemapAlreadyLocked(SalesChannelContext $context): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::SITEMAP_ALREADY_LOCKED,
+            'Cannot acquire lock for sales channel {{salesChannelId}} and language {{languageId}}',
+            [
+                'salesChannelId' => $context->getSalesChannelId(),
+                'languageId' => $context->getLanguageId(),
+            ],
+        );
+    }
+
+    public static function invalidDomain(): self
+    {
+        return new self(
+            Response::HTTP_BAD_REQUEST,
+            self::INVALID_DOMAIN,
+            'Invalid domain',
         );
     }
 }

--- a/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -15,6 +15,7 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
 use Symfony\Component\Routing\RouterInterface;
@@ -97,6 +98,7 @@ class CategoryUrlProviderTest extends TestCase
             static::getContainer()->get(CategoryDefinition::class),
             static::getContainer()->get(IteratorFactory::class),
             static::getContainer()->get(RouterInterface::class),
+            static::getContainer()->get('sales_channel.product.repository'),
         );
     }
 

--- a/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -97,7 +97,7 @@ class CategoryUrlProviderTest extends TestCase
             static::getContainer()->get(CategoryDefinition::class),
             static::getContainer()->get(IteratorFactory::class),
             static::getContainer()->get(RouterInterface::class),
-            static::getContainer()->get('sales_channel.product.repository'),
+            static::getContainer()->get('sales_channel.category.repository'),
         );
     }
 

--- a/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -2,22 +2,18 @@
 
 namespace Shopware\Tests\Integration\Core\Content\Sitemap\Provider;
 
-use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Category\CategoryDefinition;
 use Shopware\Core\Content\Category\CategoryEntity;
 use Shopware\Core\Content\Sitemap\Provider\CategoryUrlProvider;
-use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
 use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
-use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
-use Symfony\Component\Routing\RouterInterface;
 
 /**
  * @internal
@@ -91,14 +87,7 @@ class CategoryUrlProviderTest extends TestCase
 
     private function getCategoryUrlProvider(): CategoryUrlProvider
     {
-        return new CategoryUrlProvider(
-            static::getContainer()->get(ConfigHandler::class),
-            static::getContainer()->get(Connection::class),
-            static::getContainer()->get(CategoryDefinition::class),
-            static::getContainer()->get(IteratorFactory::class),
-            static::getContainer()->get(RouterInterface::class),
-            static::getContainer()->get('sales_channel.category.repository'),
-        );
+        return $this->getContainer()->get(CategoryUrlProvider::class);
     }
 
     private function createRootCategoryData(): string

--- a/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/integration/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -15,7 +15,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Test\Seo\StorefrontSalesChannelTestHelper;
 use Shopware\Core\Framework\Test\TestCaseBase\IntegrationTestBehaviour;
 use Shopware\Core\Framework\Uuid\Uuid;
-use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Framework\Seo\SeoUrlRoute\ProductPageSeoUrlRoute;
 use Symfony\Component\Routing\RouterInterface;

--- a/tests/integration/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/integration/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -9,11 +9,11 @@ use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
-use Shopware\Core\Content\Sitemap\Exception\AlreadyLockedException;
 use Shopware\Core\Content\Sitemap\Provider\AbstractUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\SitemapExporter;
 use Shopware\Core\Content\Sitemap\Service\SitemapHandleFactoryInterface;
 use Shopware\Core\Content\Sitemap\Service\SitemapHandleInterface;
+use Shopware\Core\Content\Sitemap\SitemapException;
 use Shopware\Core\Content\Sitemap\Struct\Url;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
 use Shopware\Core\Defaults;
@@ -77,7 +77,7 @@ class SitemapExporterTest extends TestCase
 
         $exporter = $this->createSitemapExporter($cache);
 
-        $this->expectException(AlreadyLockedException::class);
+        $this->expectException(SitemapException::class);
         $exporter->generate($this->context);
     }
 

--- a/tests/integration/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/integration/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -4,9 +4,11 @@ namespace Shopware\Tests\Integration\Core\Content\Sitemap\Service;
 
 use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Content\Sitemap\Exception\AlreadyLockedException;
 use Shopware\Core\Content\Sitemap\Provider\AbstractUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\SitemapExporter;
@@ -61,14 +63,7 @@ class SitemapExporterTest extends TestCase
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache->method('getItem')->willReturn($this->createCacheItem('', true, false));
 
-        $exporter = new SitemapExporter(
-            [],
-            $cache,
-            10,
-            $this->createMock(FilesystemOperator::class),
-            $this->createMock(SitemapHandleFactoryInterface::class),
-            $this->createMock(EventDispatcher::class)
-        );
+        $exporter = $this->sitemapExporter($cache);
 
         $result = $exporter->generate($this->context);
 
@@ -80,14 +75,7 @@ class SitemapExporterTest extends TestCase
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache->method('getItem')->willReturn($this->createCacheItem('', true, true));
 
-        $exporter = new SitemapExporter(
-            [],
-            $cache,
-            10,
-            $this->createMock(FilesystemOperator::class),
-            $this->createMock(SitemapHandleFactoryInterface::class),
-            $this->createMock(EventDispatcher::class)
-        );
+        $exporter = $this->sitemapExporter($cache);
 
         $this->expectException(AlreadyLockedException::class);
         $exporter->generate($this->context);
@@ -98,14 +86,7 @@ class SitemapExporterTest extends TestCase
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache->method('getItem')->willReturn($this->createCacheItem('', true, true));
 
-        $exporter = new SitemapExporter(
-            [],
-            $cache,
-            10,
-            $this->createMock(FilesystemOperator::class),
-            $this->createMock(SitemapHandleFactoryInterface::class),
-            $this->createMock(EventDispatcher::class)
-        );
+        $exporter = $this->sitemapExporter($cache);
 
         $result = $exporter->generate($this->context, true);
 
@@ -140,14 +121,7 @@ class SitemapExporterTest extends TestCase
             return true;
         });
 
-        $exporter = new SitemapExporter(
-            [],
-            $cache,
-            10,
-            $this->createMock(FilesystemOperator::class),
-            $this->createMock(SitemapHandleFactoryInterface::class),
-            $this->createMock(EventDispatcher::class)
-        );
+        $exporter = $this->sitemapExporter($cache);
 
         $result = $exporter->generate($this->context);
 
@@ -241,14 +215,7 @@ class SitemapExporterTest extends TestCase
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache->method('getItem')->willReturn($this->createCacheItem('', true, false));
 
-        $exporter = new SitemapExporter(
-            [$handler],
-            $cache,
-            10,
-            $this->createMock(FilesystemOperator::class),
-            $factory,
-            $this->createMock(EventDispatcher::class)
-        );
+        $exporter = $this->sitemapExporter($cache,[$handler], $factory);
 
         $salesChannel = Generator::generateSalesChannelContext();
         $salesChannel->getSalesChannel()->setDomains(new SalesChannelDomainCollection([
@@ -306,5 +273,24 @@ class SitemapExporterTest extends TestCase
         if (!$result->isFinish()) {
             $this->generateSitemap($salesChannelContext, $force, $result->getProvider(), $result->getOffset());
         }
+    }
+
+    /**
+     * @param iterable<AbstractUrlProvider>|null $urlProvider
+     */
+    private function sitemapExporter(
+        CacheItemPoolInterface&MockObject $cache,
+        ?iterable $urlProvider = null,
+        (SitemapHandleFactoryInterface&MockObject)|null $sitemapHandleFactory = null,
+    ): SitemapExporter {
+        return new SitemapExporter(
+            $urlProvider ?? [],
+            $cache,
+            10,
+            $this->createMock(FilesystemOperator::class),
+            $sitemapHandleFactory ?? $this->createMock(SitemapHandleFactoryInterface::class),
+            $this->createMock(EventDispatcher::class),
+            $this->createMock(CartRuleLoader::class)
+        );
     }
 }

--- a/tests/integration/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/integration/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -63,7 +63,7 @@ class SitemapExporterTest extends TestCase
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache->method('getItem')->willReturn($this->createCacheItem('', true, false));
 
-        $exporter = $this->sitemapExporter($cache);
+        $exporter = $this->createSitemapExporter($cache);
 
         $result = $exporter->generate($this->context);
 
@@ -75,7 +75,7 @@ class SitemapExporterTest extends TestCase
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache->method('getItem')->willReturn($this->createCacheItem('', true, true));
 
-        $exporter = $this->sitemapExporter($cache);
+        $exporter = $this->createSitemapExporter($cache);
 
         $this->expectException(AlreadyLockedException::class);
         $exporter->generate($this->context);
@@ -86,7 +86,7 @@ class SitemapExporterTest extends TestCase
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache->method('getItem')->willReturn($this->createCacheItem('', true, true));
 
-        $exporter = $this->sitemapExporter($cache);
+        $exporter = $this->createSitemapExporter($cache);
 
         $result = $exporter->generate($this->context, true);
 
@@ -121,7 +121,7 @@ class SitemapExporterTest extends TestCase
             return true;
         });
 
-        $exporter = $this->sitemapExporter($cache);
+        $exporter = $this->createSitemapExporter($cache);
 
         $result = $exporter->generate($this->context);
 
@@ -215,7 +215,7 @@ class SitemapExporterTest extends TestCase
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache->method('getItem')->willReturn($this->createCacheItem('', true, false));
 
-        $exporter = $this->sitemapExporter($cache, [$handler], $factory);
+        $exporter = $this->createSitemapExporter($cache, [$handler], $factory);
 
         $salesChannel = Generator::generateSalesChannelContext();
         $salesChannel->getSalesChannel()->setDomains(new SalesChannelDomainCollection([
@@ -278,7 +278,7 @@ class SitemapExporterTest extends TestCase
     /**
      * @param iterable<AbstractUrlProvider>|null $urlProvider
      */
-    private function sitemapExporter(
+    private function createSitemapExporter(
         CacheItemPoolInterface&MockObject $cache,
         ?iterable $urlProvider = null,
         (SitemapHandleFactoryInterface&MockObject)|null $sitemapHandleFactory = null,

--- a/tests/integration/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/integration/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -215,7 +215,7 @@ class SitemapExporterTest extends TestCase
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache->method('getItem')->willReturn($this->createCacheItem('', true, false));
 
-        $exporter = $this->sitemapExporter($cache,[$handler], $factory);
+        $exporter = $this->sitemapExporter($cache, [$handler], $factory);
 
         $salesChannel = Generator::generateSalesChannelContext();
         $salesChannel->getSalesChannel()->setDomains(new SalesChannelDomainCollection([

--- a/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
+++ b/tests/unit/Core/Content/Sitemap/Provider/CategoryUrlProviderTest.php
@@ -1,0 +1,154 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Sitemap\Provider;
+
+use Doctrine\DBAL\Cache\ArrayResult;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Category\CategoryEntity;
+use Shopware\Core\Content\Product\ProductEntity;
+use Shopware\Core\Content\Sitemap\Provider\CategoryUrlProvider;
+use Shopware\Core\Content\Sitemap\Service\ConfigHandler;
+use Shopware\Core\Content\Sitemap\Struct\Url;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IterableQuery;
+use Shopware\Core\Framework\DataAbstractionLayer\Dbal\Common\IteratorFactory;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Plugin\Exception\DecorationPatternException;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Test\Generator;
+use Shopware\Core\Test\Stub\Framework\IdsCollection;
+use Shopware\Core\Test\TestDefaults;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @internal
+ */
+#[Package('discovery')]
+#[CoversClass(CategoryUrlProvider::class)]
+class CategoryUrlProviderTest extends TestCase
+{
+    private readonly ConfigHandler&MockObject $configHandler;
+
+    private readonly Connection&MockObject $connection;
+
+    private readonly CategoryDefinition&MockObject $definition;
+
+    private readonly IteratorFactory&MockObject $iteratorFactory;
+
+    private readonly RouterInterface&MockObject $router;
+
+    private readonly IdsCollection $ids;
+
+    protected function setUp(): void
+    {
+        $this->configHandler = $this->createMock(ConfigHandler::class);
+        $this->connection = $this->createMock(Connection::class);
+        $this->definition = $this->createMock(CategoryDefinition::class);
+        $this->iteratorFactory = $this->createMock(IteratorFactory::class);
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->ids = new IdsCollection();
+
+        $this->initServices();
+    }
+
+    public function testGetDecorated(): void
+    {
+        static::expectException(DecorationPatternException::class);
+        $this->getCategoryUrlProvider()->getDecorated();
+    }
+
+    public function testGetName(): void
+    {
+        $name = $this->getCategoryUrlProvider()->getName();
+        static::assertSame('category', $name);
+    }
+
+    public function testGetCategoryUrls(): void
+    {
+        $context = Generator::generateSalesChannelContext();
+
+        $provider = $this->getCategoryUrlProvider();
+        $urlResult = $provider->getUrls($context, 100, 50);
+
+        $urls = $urlResult->getUrls();
+        static::assertCount(2, $urls);
+
+        $url = array_shift($urls);
+        static::assertInstanceOf(Url::class, $url);
+        static::assertSame($this->ids->get('category-1'), $url->getIdentifier());
+        static::assertSame('category/1/detail', $url->getLoc());
+
+        $url = array_shift($urls);
+        static::assertInstanceOf(Url::class, $url);
+        static::assertSame($this->ids->get('category-2'), $url->getIdentifier());
+        static::assertSame('category/2/detail', $url->getLoc());
+    }
+
+    private function initServices(): void
+    {
+        $this->connection->method('fetchAllAssociative')->willReturn([
+            [
+                'foreign_key' => $this->ids->get('category-1'),
+                'seo_path_info' => 'category/1/detail',
+            ],
+        ]);
+
+        $this->router->method('generate')->willReturn('category/2/detail');
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('executeQuery')->willReturn(new Result(new ArrayResult([
+            [
+                'increment' => 1,
+                'id' => $this->ids->get('category-1'),
+                'created_at' => '2021-01-01 00:00:00',
+                'updated_at' => null,
+            ],
+            [
+                'increment' => 2,
+                'id' => $this->ids->get('category-2'),
+                'created_at' => '2021-01-01 00:00:00',
+                'updated_at' => null,
+            ],
+        ]), $this->connection));
+
+        $query = $this->createMock(IterableQuery::class);
+        $query->method('getQuery')->willReturn($queryBuilder);
+
+        $this->iteratorFactory->method('createIterator')
+            ->willReturn($query);
+
+        $this->configHandler->method('get')->willReturn([
+            [
+                'resource' => CategoryEntity::class,
+                'salesChannelId' => TestDefaults::SALES_CHANNEL,
+                'identifier' => $this->ids->get('category-1'),
+            ],
+            [
+                'resource' => CategoryEntity::class,
+                'salesChannelId' => Uuid::randomHex(),
+                'identifier' => $this->ids->get('category-2'),
+            ],
+            [
+                'resource' => ProductEntity::class,
+                'salesChannelId' => Uuid::randomHex(),
+                'identifier' => $this->ids->get('product-3'),
+            ],
+        ]);
+    }
+
+    private function getCategoryUrlProvider(): CategoryUrlProvider
+    {
+        return new CategoryUrlProvider(
+            $this->configHandler,
+            $this->connection,
+            $this->definition,
+            $this->iteratorFactory,
+            $this->router
+        );
+    }
+}

--- a/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -4,6 +4,7 @@ namespace Shopware\Tests\Unit\Core\Content\Sitemap\Service;
 
 use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
@@ -67,38 +68,17 @@ class SitemapExporterTest extends TestCase
         $cacheItemPoolInterface = $this->createMock(CacheItemPoolInterface::class);
         $cacheItemPoolInterface->method('getItem')->willReturn(new CacheItem());
 
-        $exporter = new SitemapExporter(
-            [
-                $customerUrlProvider,
-            ],
-            $cacheItemPoolInterface,
-            10,
-            $this->createMock(FilesystemOperator::class),
-            $sitemapHandlerFactory,
-            $this->createMock(EventDispatcher::class),
-            $this->createMock(CartRuleLoader::class)
-        );
+        $exporter = $this->sitemapExporter($cacheItemPoolInterface, [$customerUrlProvider], $sitemapHandlerFactory);
 
         $languageId = Uuid::randomHex();
-        $salesChannel = new SalesChannelEntity();
-        $salesChannel->setId('testSalesChannel');
-        $salesChannel->setLanguageId($languageId);
+        $salesChannel = $this->salesChannel('testSalesChannel', $languageId);
 
-        $domainA = new SalesChannelDomainEntity();
-        $domainA->setId('testDomainA');
-        $domainA->setUrl('https://test.com/');
-        $domainA->setLanguageId($languageId);
-
-        $domainB = new SalesChannelDomainEntity();
-        $domainB->setId('testDomainB');
-        $domainB->setUrl('https://test.com');
-        $domainB->setLanguageId($languageId);
+        $domainA = $this->salesChannelDomain('testDomainA', 'https://test.com/', $languageId);
+        $domainB = $this->salesChannelDomain('testDomainB', 'https://test.com', $languageId);
 
         $salesChannel->setDomains(new SalesChannelDomainCollection([$domainA, $domainB]));
 
-        $salesChannelContext = $this->createMock(SalesChannelContext::class);
-        $salesChannelContext->method('getSalesChannel')->willReturn($salesChannel);
-        $salesChannelContext->method('getLanguageId')->willReturn($languageId);
+        $salesChannelContext = $this->mockSalesChannelContext($salesChannel);
 
         $expectedUrls = [];
         foreach ($urls as $url) {
@@ -110,5 +90,78 @@ class SitemapExporterTest extends TestCase
         $sitemapHandler1->expects(static::once())->method('write')->with($expectedUrls);
         $sitemapHandler2->expects(static::once())->method('write')->with($expectedUrls);
         $exporter->generate($salesChannelContext);
+    }
+
+    public function testDoesNotRefreshSalesChannelWithRules(): void
+    {
+        $salesChannel = $this->salesChannel('salesChannelWithRules');
+        $salesChannelRules = array_map(fn () => Uuid::randomHex(), range(0, 2));
+
+        $domain = $this->salesChannelDomain('testDomain', 'https://test.com', $salesChannel->getLanguageId());
+        $salesChannel->setDomains(new SalesChannelDomainCollection([$domain]));
+
+        $salesChannelContext = $this->mockSalesChannelContext($salesChannel);
+        $salesChannelContext->expects(static::once())->method('getRuleIds')->willReturn($salesChannelRules);
+
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->method('getItem')->willReturn(new CacheItem());
+
+        $cartRuleLoader = $this->createMock(CartRuleLoader::class);
+        $exporter = $this->sitemapExporter($cache, cartRuleLoader: $cartRuleLoader);
+        $exporter->generate($salesChannelContext);
+
+        $salesChannelContext->expects(static::never())->method('getToken');
+        $cartRuleLoader->expects(static::never())->method('loadByToken');
+    }
+
+    private function sitemapExporter(
+        CacheItemPoolInterface&MockObject $cache,
+        ?iterable $urlProvider = null,
+        (SitemapHandleFactoryInterface&MockObject)|null $sitemapHandleFactory = null,
+        ?CartRuleLoader $cartRuleLoader = null
+    ): SitemapExporter {
+        return new SitemapExporter(
+            $urlProvider ?? [],
+            $cache,
+            10,
+            $this->createMock(FilesystemOperator::class),
+            $sitemapHandleFactory ?? $this->createMock(SitemapHandleFactoryInterface::class),
+            $this->createMock(EventDispatcher::class),
+            $cartRuleLoader ?? $this->createMock(CartRuleLoader::class)
+        );
+    }
+
+    private function salesChannel(
+        string $salesChannelId,
+        ?string $languageId = null
+    ): SalesChannelEntity {
+        $salesChannel = new SalesChannelEntity();
+        $salesChannel->setId($salesChannelId);
+        $salesChannel->setLanguageId($languageId ?? Uuid::randomHex());
+
+        return $salesChannel;
+    }
+
+    private function salesChannelDomain(
+        string $domainId,
+        string $domainUrl,
+        ?string $languageId = null
+    ): SalesChannelDomainEntity {
+        $salesChannelDomain = new SalesChannelDomainEntity();
+        $salesChannelDomain->setId($domainId);
+        $salesChannelDomain->setUrl($domainUrl);
+        $salesChannelDomain->setLanguageId($languageId ?? Uuid::randomHex());
+
+        return $salesChannelDomain;
+    }
+
+    private function mockSalesChannelContext(
+        SalesChannelEntity $salesChannel,
+    ): SalesChannelContext&MockObject {
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->method('getSalesChannel')->willReturn($salesChannel);
+        $salesChannelContext->method('getLanguageId')->willReturn($salesChannel->getLanguageId());
+
+        return $salesChannelContext;
     }
 }

--- a/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -6,6 +6,7 @@ use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
+use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Content\Sitemap\Provider\CustomUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\SitemapExporter;
 use Shopware\Core\Content\Sitemap\Service\SitemapHandleFactoryInterface;
@@ -74,7 +75,8 @@ class SitemapExporterTest extends TestCase
             10,
             $this->createMock(FilesystemOperator::class),
             $sitemapHandlerFactory,
-            $this->createMock(EventDispatcher::class)
+            $this->createMock(EventDispatcher::class),
+            $this->createMock(CartRuleLoader::class)
         );
 
         $languageId = Uuid::randomHex();

--- a/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -69,13 +69,13 @@ class SitemapExporterTest extends TestCase
         $cacheItemPoolInterface = $this->createMock(CacheItemPoolInterface::class);
         $cacheItemPoolInterface->method('getItem')->willReturn(new CacheItem());
 
-        $exporter = $this->sitemapExporter($cacheItemPoolInterface, [$customerUrlProvider], $sitemapHandlerFactory);
+        $exporter = $this->createSitemapExporter($cacheItemPoolInterface, [$customerUrlProvider], $sitemapHandlerFactory);
 
         $languageId = Uuid::randomHex();
-        $salesChannel = $this->salesChannel('testSalesChannel', $languageId);
+        $salesChannel = $this->createSalesChannel('testSalesChannel', $languageId);
 
-        $domainA = $this->salesChannelDomain('testDomainA', 'https://test.com/', $languageId);
-        $domainB = $this->salesChannelDomain('testDomainB', 'https://test.com', $languageId);
+        $domainA = $this->createSalesChannelDomain('testDomainA', 'https://test.com/', $languageId);
+        $domainB = $this->createSalesChannelDomain('testDomainB', 'https://test.com', $languageId);
 
         $salesChannel->setDomains(new SalesChannelDomainCollection([$domainA, $domainB]));
 
@@ -95,10 +95,10 @@ class SitemapExporterTest extends TestCase
 
     public function testDoesNotRefreshSalesChannelWithRules(): void
     {
-        $salesChannel = $this->salesChannel('salesChannelWithRules');
+        $salesChannel = $this->createSalesChannel('salesChannelWithRules');
         $salesChannelRules = array_map(fn () => Uuid::randomHex(), range(0, 2));
 
-        $domain = $this->salesChannelDomain('testDomain', 'https://test.com', $salesChannel->getLanguageId());
+        $domain = $this->createSalesChannelDomain('testDomain', 'https://test.com', $salesChannel->getLanguageId());
         $salesChannel->setDomains(new SalesChannelDomainCollection([$domain]));
 
         $salesChannelContext = $this->mockSalesChannelContext($salesChannel);
@@ -108,7 +108,7 @@ class SitemapExporterTest extends TestCase
         $cache->method('getItem')->willReturn(new CacheItem());
 
         $cartRuleLoader = $this->createMock(CartRuleLoader::class);
-        $exporter = $this->sitemapExporter($cache, cartRuleLoader: $cartRuleLoader);
+        $exporter = $this->createSitemapExporter($cache, cartRuleLoader: $cartRuleLoader);
         $exporter->generate($salesChannelContext);
 
         $salesChannelContext->expects(static::never())->method('getToken');
@@ -118,7 +118,7 @@ class SitemapExporterTest extends TestCase
     /**
      * @param iterable<AbstractUrlProvider>|null $urlProvider
      */
-    private function sitemapExporter(
+    private function createSitemapExporter(
         CacheItemPoolInterface&MockObject $cache,
         ?iterable $urlProvider = null,
         (SitemapHandleFactoryInterface&MockObject)|null $sitemapHandleFactory = null,
@@ -135,7 +135,7 @@ class SitemapExporterTest extends TestCase
         );
     }
 
-    private function salesChannel(
+    private function createSalesChannel(
         string $salesChannelId,
         ?string $languageId = null
     ): SalesChannelEntity {
@@ -146,7 +146,7 @@ class SitemapExporterTest extends TestCase
         return $salesChannel;
     }
 
-    private function salesChannelDomain(
+    private function createSalesChannelDomain(
         string $domainId,
         string $domainUrl,
         ?string $languageId = null

--- a/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
+use Shopware\Core\Content\Sitemap\Provider\AbstractUrlProvider;
 use Shopware\Core\Content\Sitemap\Provider\CustomUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\SitemapExporter;
 use Shopware\Core\Content\Sitemap\Service\SitemapHandleFactoryInterface;
@@ -114,7 +115,10 @@ class SitemapExporterTest extends TestCase
         $cartRuleLoader->expects(static::never())->method('loadByToken');
     }
 
-    private function sitemapExporter(
+    /**
+     * @param iterable<AbstractUrlProvider>|null $urlProvider
+     */
+    private function sitkitemapExporter(
         CacheItemPoolInterface&MockObject $cache,
         ?iterable $urlProvider = null,
         (SitemapHandleFactoryInterface&MockObject)|null $sitemapHandleFactory = null,

--- a/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -118,7 +118,7 @@ class SitemapExporterTest extends TestCase
     /**
      * @param iterable<AbstractUrlProvider>|null $urlProvider
      */
-    private function sitkitemapExporter(
+    private function sitemapExporter(
         CacheItemPoolInterface&MockObject $cache,
         ?iterable $urlProvider = null,
         (SitemapHandleFactoryInterface&MockObject)|null $sitemapHandleFactory = null,

--- a/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
+++ b/tests/unit/Core/Content/Sitemap/Service/SitemapExporterTest.php
@@ -6,6 +6,7 @@ use League\Flysystem\FilesystemOperator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Shopware\Core\Checkout\Cart\CartRuleLoader;
 use Shopware\Core\Content\Sitemap\Provider\AbstractUrlProvider;
@@ -13,13 +14,17 @@ use Shopware\Core\Content\Sitemap\Provider\CustomUrlProvider;
 use Shopware\Core\Content\Sitemap\Service\SitemapExporter;
 use Shopware\Core\Content\Sitemap\Service\SitemapHandleFactoryInterface;
 use Shopware\Core\Content\Sitemap\Service\SitemapHandleInterface;
+use Shopware\Core\Content\Sitemap\SitemapException;
 use Shopware\Core\Content\Sitemap\Struct\Url;
 use Shopware\Core\Content\Sitemap\Struct\UrlResult;
+use Shopware\Core\Framework\Api\Context\SystemSource;
+use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainCollection;
 use Shopware\Core\System\SalesChannel\Aggregate\SalesChannelDomain\SalesChannelDomainEntity;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
+use Shopware\Core\Test\Generator;
 use Symfony\Component\Cache\CacheItem;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -79,7 +84,7 @@ class SitemapExporterTest extends TestCase
 
         $salesChannel->setDomains(new SalesChannelDomainCollection([$domainA, $domainB]));
 
-        $salesChannelContext = $this->mockSalesChannelContext($salesChannel);
+        $salesChannelContext = $this->createSalesChannelContext($salesChannel, []);
 
         $expectedUrls = [];
         foreach ($urls as $url) {
@@ -96,23 +101,51 @@ class SitemapExporterTest extends TestCase
     public function testDoesNotRefreshSalesChannelWithRules(): void
     {
         $salesChannel = $this->createSalesChannel('salesChannelWithRules');
-        $salesChannelRules = array_map(fn () => Uuid::randomHex(), range(0, 2));
+        $rules = array_map(fn () => Uuid::randomHex(), range(0, 2));
 
         $domain = $this->createSalesChannelDomain('testDomain', 'https://test.com', $salesChannel->getLanguageId());
         $salesChannel->setDomains(new SalesChannelDomainCollection([$domain]));
 
-        $salesChannelContext = $this->mockSalesChannelContext($salesChannel);
-        $salesChannelContext->expects(static::once())->method('getRuleIds')->willReturn($salesChannelRules);
+        $salesChannelContext = $this->createSalesChannelContext($salesChannel, $rules);
 
         $cache = $this->createMock(CacheItemPoolInterface::class);
         $cache->method('getItem')->willReturn(new CacheItem());
 
         $cartRuleLoader = $this->createMock(CartRuleLoader::class);
-        $exporter = $this->createSitemapExporter($cache, cartRuleLoader: $cartRuleLoader);
+        $exporter = $this->createSitemapExporter(cache: $cache, cartRuleLoader: $cartRuleLoader);
         $exporter->generate($salesChannelContext);
 
-        $salesChannelContext->expects(static::never())->method('getToken');
         $cartRuleLoader->expects(static::never())->method('loadByToken');
+    }
+
+    public function testGenerateThrowsExceptionINoSitemapHandlesCreated(): void
+    {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->method('getItem')->willReturn(new CacheItemMock());
+
+        $exporter = $this->createSitemapExporter($cache);
+
+        $salesChannel = $this->createSalesChannel('testSalesChannel');
+        $salesChannelContext = $this->createSalesChannelContext($salesChannel, []);
+
+        $this->expectException(SitemapException::class);
+        $this->expectExceptionMessage('Invalid domain');
+        $exporter->generate($salesChannelContext, true);
+    }
+
+    public function testGenerateThrowsExceptionIfSitemapIsAlreadyLocked(): void
+    {
+        $cache = $this->createMock(CacheItemPoolInterface::class);
+        $cache->method('getItem')->willReturn(new CacheItemMock());
+
+        $exporter = $this->createSitemapExporter($cache);
+
+        $salesChannel = $this->createSalesChannel('testSalesChannel');
+        $salesChannelContext = $this->createSalesChannelContext($salesChannel, []);
+
+        $this->expectException(SitemapException::class);
+        $this->expectExceptionMessage('Cannot acquire lock for sales channel testSalesChannel and language ' . $salesChannel->getLanguageId());
+        $exporter->generate($salesChannelContext);
     }
 
     /**
@@ -159,13 +192,56 @@ class SitemapExporterTest extends TestCase
         return $salesChannelDomain;
     }
 
-    private function mockSalesChannelContext(
-        SalesChannelEntity $salesChannel,
-    ): SalesChannelContext&MockObject {
-        $salesChannelContext = $this->createMock(SalesChannelContext::class);
-        $salesChannelContext->method('getSalesChannel')->willReturn($salesChannel);
-        $salesChannelContext->method('getLanguageId')->willReturn($salesChannel->getLanguageId());
+    /**
+     * @param array<string> $ruleIds
+     */
+    private function createSalesChannelContext(SalesChannelEntity $salesChannel, array $ruleIds): SalesChannelContext
+    {
+        $context = new Context(
+            source: new SystemSource(),
+            ruleIds: $ruleIds,
+            languageIdChain: [$salesChannel->getLanguageId()],
+        );
 
-        return $salesChannelContext;
+        return Generator::generateSalesChannelContext(
+            baseContext: $context,
+            salesChannel: $salesChannel,
+        );
+    }
+}
+
+/**
+ * @internal
+ */
+class CacheItemMock implements CacheItemInterface
+{
+    public function getKey(): string
+    {
+        return Uuid::randomHex();
+    }
+
+    public function get(): mixed
+    {
+        return null;
+    }
+
+    public function isHit(): bool
+    {
+        return true;
+    }
+
+    public function set(mixed $value): static
+    {
+        return $this;
+    }
+
+    public function expiresAt(?\DateTimeInterface $expiration): static
+    {
+        return $this;
+    }
+
+    public function expiresAfter(\DateInterval|int|null $time): static
+    {
+        return $this;
     }
 }

--- a/tests/unit/Core/Content/Sitemap/SitemapExceptionTest.php
+++ b/tests/unit/Core/Content/Sitemap/SitemapExceptionTest.php
@@ -3,39 +3,40 @@
 namespace Shopware\Tests\Unit\Core\Content\Sitemap;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Core\Content\Sitemap\SitemapException;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Test\Generator;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @internal
  */
+#[Package('discovery')]
 #[CoversClass(SitemapException::class)]
 class SitemapExceptionTest extends TestCase
 {
-    #[DataProvider('exceptionProvider')]
-    public function testExceptions(
-        SitemapException $exceptionFunction,
-        int $statusCode,
-        string $errorCode,
-        string $message
-    ): void {
-        static::assertSame($statusCode, $exceptionFunction->getStatusCode());
-        static::assertSame($errorCode, $exceptionFunction->getErrorCode());
-        static::assertSame($message, $exceptionFunction->getMessage());
+    public function testFileNotReadable(): void
+    {
+        $exception = SitemapException::fileNotReadable('/path/to/file');
+        static::assertSame(Response::HTTP_INTERNAL_SERVER_ERROR, $exception->getStatusCode());
+        static::assertSame('CONTENT__FILE_IS_NOT_READABLE', $exception->getErrorCode());
+        static::assertSame('File is not readable at /path/to/file.', $exception->getMessage());
     }
 
-    /**
-     * @return iterable<array<string, mixed>>
-     */
-    public static function exceptionProvider(): iterable
+    public function testSitemapAlreadyLocked(): void
     {
-        yield [
-            'exceptionFunction' => SitemapException::fileNotReadable('foo'),
-            'statusCode' => Response::HTTP_INTERNAL_SERVER_ERROR,
-            'errorCode' => 'CONTENT__FILE_IS_NOT_READABLE',
-            'message' => 'File is not readable at foo.',
-        ];
+        $exception = SitemapException::sitemapAlreadyLocked(Generator::generateSalesChannelContext());
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame('CONTENT__SITEMAP_ALREADY_LOCKED', $exception->getErrorCode());
+        static::assertSame('Cannot acquire lock for sales channel 98432def39fc4624b33213a56b8c944d and language 2fbb5fe2e29a4d70aa5854ce7ce3e20b', $exception->getMessage());
+    }
+
+    public function testInvalidDomain(): void
+    {
+        $exception = SitemapException::invalidDomain();
+        static::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+        static::assertSame('CONTENT__INVALID_DOMAIN', $exception->getErrorCode());
+        static::assertSame('Invalid domain', $exception->getMessage());
     }
 }


### PR DESCRIPTION
When the sitemap is generated, evaluate rules that may be attached to categories. This fix prevents the sitemap to contain URLs that lead to 404 do to rules preventing the category from being available.

https://shopware.atlassian.net/browse/NEXT-40976