### PR TITLE
feat: add Hooks for FooterPagelet and HeaderPagelet

### DIFF
--- a/src/Core/DevOps/Resources/generated/script-hooks-reference.md
+++ b/src/Core/DevOps/Resources/generated/script-hooks-reference.md
@@ -437,6 +437,30 @@ All available Hooks that can be used to load additional data.
 | **Available Services** | [repository](./data-loading-script-services-reference.md#RepositoryFacade)<br>[config](./miscellaneous-script-services-reference.md#SystemConfigFacade)<br>[store](./data-loading-script-services-reference.md#SalesChannelRepositoryFacade)<br>[request](./miscellaneous-script-services-reference.md#RequestFacade)<br> |
 | **Stoppable**          | `false`                  |
 
+#### footer-pagelet-loaded
+
+| <!-- -->               | <!-- -->                                |
+|:-----------------------|:----------------------------------------|
+| **Name**               | footer-pagelet-loaded                         |
+| **Since**              | 6.7.0.0                        |
+| **Class**              | `Shopware\Storefront\Pagelet\Footer\FooterPageletLoadedHook`                      |
+| **Description**        | Triggered when the FooterPagelet is loaded<br>                  |
+| **Available Data**     | page: [`Shopware\Storefront\Pagelet\Footer\FooterPagelet`](https://github.com/shopware/platform/blob/trunk/src/Storefront/Pagelet/Footer/FooterPagelet.php)<br>context: [`Shopware\Core\Framework\Context`](https://github.com/shopware/platform/blob/trunk/src/Core/Framework/Context.php)<br>salesChannelContext: [`Shopware\Core\System\SalesChannel\SalesChannelContext`](https://github.com/shopware/platform/blob/trunk/src/Core/System/SalesChannel/SalesChannelContext.php)<br>        |
+| **Available Services** | [repository](./data-loading-script-services-reference.md#RepositoryFacade)<br>[config](./miscellaneous-script-services-reference.md#SystemConfigFacade)<br>[store](./data-loading-script-services-reference.md#SalesChannelRepositoryFacade)<br>[request](./miscellaneous-script-services-reference.md#RequestFacade)<br> |
+| **Stoppable**          | `false`                  |
+
+#### header-pagelet-loaded
+
+| <!-- -->               | <!-- -->                                |
+|:-----------------------|:----------------------------------------|
+| **Name**               | header-pagelet-loaded                         |
+| **Since**              | 6.7.0.0                        |
+| **Class**              | `Shopware\Storefront\Pagelet\Header\HeaderPageletLoadedHook`                      |
+| **Description**        | Triggered when the HeaderPagelet is loaded<br>                  |
+| **Available Data**     | page: [`Shopware\Storefront\Pagelet\Header\HeaderPagelet`](https://github.com/shopware/platform/blob/trunk/src/Storefront/Pagelet/Header/HeaderPagelet.php)<br>context: [`Shopware\Core\Framework\Context`](https://github.com/shopware/platform/blob/trunk/src/Core/Framework/Context.php)<br>salesChannelContext: [`Shopware\Core\System\SalesChannel\SalesChannelContext`](https://github.com/shopware/platform/blob/trunk/src/Core/System/SalesChannel/SalesChannelContext.php)<br>        |
+| **Available Services** | [repository](./data-loading-script-services-reference.md#RepositoryFacade)<br>[config](./miscellaneous-script-services-reference.md#SystemConfigFacade)<br>[store](./data-loading-script-services-reference.md#SalesChannelRepositoryFacade)<br>[request](./miscellaneous-script-services-reference.md#RequestFacade)<br> |
+| **Stoppable**          | `false`                  |
+
 #### menu-offcanvas-pagelet-loaded
 
 | <!-- -->               | <!-- -->                                |

--- a/src/Storefront/Controller/NavigationController.php
+++ b/src/Storefront/Controller/NavigationController.php
@@ -6,7 +6,9 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Storefront\Page\Navigation\NavigationPageLoadedHook;
 use Shopware\Storefront\Page\Navigation\NavigationPageLoaderInterface;
+use Shopware\Storefront\Pagelet\Footer\FooterPageletLoadedHook;
 use Shopware\Storefront\Pagelet\Footer\FooterPageletLoaderInterface;
+use Shopware\Storefront\Pagelet\Header\HeaderPageletLoadedHook;
 use Shopware\Storefront\Pagelet\Header\HeaderPageletLoaderInterface;
 use Shopware\Storefront\Pagelet\Menu\Offcanvas\MenuOffcanvasPageletLoadedHook;
 use Shopware\Storefront\Pagelet\Menu\Offcanvas\MenuOffcanvasPageletLoaderInterface;
@@ -75,6 +77,8 @@ class NavigationController extends StorefrontController
     {
         $header = $this->headerLoader->load($request, $context);
 
+        $this->hook(new HeaderPageletLoadedHook($header, $context));
+
         return $this->renderStorefront('@Storefront/storefront/layout/header.html.twig', ['header' => $header]);
     }
 
@@ -82,6 +86,8 @@ class NavigationController extends StorefrontController
     public function footer(Request $request, SalesChannelContext $context): Response
     {
         $footer = $this->footerLoader->load($request, $context);
+
+        $this->hook(new FooterPageletLoadedHook($footer, $context));
 
         return $this->renderStorefront('@Storefront/storefront/layout/footer.html.twig', ['footer' => $footer]);
     }

--- a/src/Storefront/Pagelet/Footer/FooterPageletLoadedHook.php
+++ b/src/Storefront/Pagelet/Footer/FooterPageletLoadedHook.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Pagelet\Footer;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Script\Execution\Awareness\SalesChannelContextAwareTrait;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\Page\PageLoadedHook;
+
+/**
+ * Triggered when the FooterPagelet is loaded
+ *
+ * @hook-use-case data_loading
+ *
+ * @since 6.7.0.0
+ *
+ * @final
+ *
+ * @codeCoverageIgnore
+ */
+#[Package('framework')]
+class FooterPageletLoadedHook extends PageLoadedHook
+{
+    use SalesChannelContextAwareTrait;
+
+    final public const HOOK_NAME = 'footer-pagelet-loaded';
+
+    public function __construct(
+        private readonly FooterPagelet $page,
+        SalesChannelContext $context
+    ) {
+        parent::__construct($context->getContext());
+        $this->salesChannelContext = $context;
+    }
+
+    public function getName(): string
+    {
+        return self::HOOK_NAME;
+    }
+
+    public function getPage(): FooterPagelet
+    {
+        return $this->page;
+    }
+}

--- a/src/Storefront/Pagelet/Header/HeaderPageletLoadedHook.php
+++ b/src/Storefront/Pagelet/Header/HeaderPageletLoadedHook.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Storefront\Pagelet\Header;
+
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Script\Execution\Awareness\SalesChannelContextAwareTrait;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Storefront\Page\PageLoadedHook;
+
+/**
+ * Triggered when the HeaderPagelet is loaded
+ *
+ * @hook-use-case data_loading
+ *
+ * @since 6.7.0.0
+ *
+ * @final
+ *
+ * @codeCoverageIgnore
+ */
+#[Package('framework')]
+class HeaderPageletLoadedHook extends PageLoadedHook
+{
+    use SalesChannelContextAwareTrait;
+
+    final public const HOOK_NAME = 'header-pagelet-loaded';
+
+    public function __construct(
+        private readonly HeaderPagelet $page,
+        SalesChannelContext $context
+    ) {
+        parent::__construct($context->getContext());
+        $this->salesChannelContext = $context;
+    }
+
+    public function getName(): string
+    {
+        return self::HOOK_NAME;
+    }
+
+    public function getPage(): HeaderPagelet
+    {
+        return $this->page;
+    }
+}

--- a/tests/unit/Storefront/Controller/NavigationControllerTest.php
+++ b/tests/unit/Storefront/Controller/NavigationControllerTest.php
@@ -5,12 +5,24 @@ namespace Shopware\Tests\Unit\Storefront\Controller;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Payment\PaymentMethodCollection;
+use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Category\Tree\Tree;
 use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\Currency\CurrencyCollection;
+use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\Language\LanguageCollection;
+use Shopware\Core\System\Language\LanguageEntity;
 use Shopware\Core\Test\Generator;
 use Shopware\Storefront\Controller\NavigationController;
 use Shopware\Storefront\Page\Navigation\NavigationPage;
 use Shopware\Storefront\Page\Navigation\NavigationPageLoaderInterface;
+use Shopware\Storefront\Pagelet\Footer\FooterPagelet;
+use Shopware\Storefront\Pagelet\Footer\FooterPageletLoadedHook;
 use Shopware\Storefront\Pagelet\Footer\FooterPageletLoaderInterface;
+use Shopware\Storefront\Pagelet\Header\HeaderPagelet;
+use Shopware\Storefront\Pagelet\Header\HeaderPageletLoadedHook;
 use Shopware\Storefront\Pagelet\Header\HeaderPageletLoaderInterface;
 use Shopware\Storefront\Pagelet\Menu\Offcanvas\MenuOffcanvasPageletLoaderInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -81,18 +93,30 @@ class NavigationControllerTest extends TestCase
     {
         $request = new Request();
         $context = Generator::generateSalesChannelContext();
+        $headerPagelet = new HeaderPagelet(new Tree(null, []), new LanguageCollection(), new CurrencyCollection(), new LanguageEntity(), new CurrencyEntity());
+
+        $this->headerLoader->expects($this->once())->method('load')->with($request, $context)->willReturn($headerPagelet);
 
         $this->controller->header($request, $context);
         static::assertSame('@Storefront/storefront/layout/header.html.twig', $this->controller->renderStorefrontView);
+
+        static::assertInstanceOf(HeaderPageletLoadedHook::class, $this->controller->calledHook);
+        static::assertSame($headerPagelet, $this->controller->calledHook->getPage());
     }
 
     public function testFooterRendersStorefront(): void
     {
         $request = new Request();
         $context = Generator::generateSalesChannelContext();
+        $footerPagelet = new FooterPagelet(null, new CategoryCollection(), new PaymentMethodCollection(), new ShippingMethodCollection());
+
+        $this->footerLoader->expects($this->once())->method('load')->with($request, $context)->willReturn($footerPagelet);
 
         $this->controller->footer($request, $context);
         static::assertSame('@Storefront/storefront/layout/footer.html.twig', $this->controller->renderStorefrontView);
+
+        static::assertInstanceOf(FooterPageletLoadedHook::class, $this->controller->calledHook);
+        static::assertSame($footerPagelet, $this->controller->calledHook->getPage());
     }
 }
 


### PR DESCRIPTION
As part of the ESI feature, footer and header are not manipulatable via App Scripting anymore for all pages. Therefore, we now add new hooks to add these extension points again.