### PR TITLE
chore: Improve fetching of language information for SalesChannelContext

### DIFF
--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -182,6 +182,11 @@ Get the first order delivery with `primaryOrderDelivery` so you should replace m
 
 Get the latest order transaction with `primaryOrderTransaction` so you should replace methods like `transaction.last()`
 
+## Improved fetching of language information for SalesChannelContext
+
+The `\Shopware\Core\System\SalesChannel\Context\BaseSalesChannelContextFactory` uses the language repository directly to fetch language information.
+As a consequence the query with the title `base-context-factory::sales-channel` no longer adds the `languages` association.
+
 </details>
 
 # Administration

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -185,7 +185,8 @@ Get the latest order transaction with `primaryOrderTransaction` so you should re
 ## Improved fetching of language information for SalesChannelContext
 
 The `\Shopware\Core\System\SalesChannel\Context\BaseSalesChannelContextFactory` uses the language repository directly to fetch language information.
-As a consequence the query with the title `base-context-factory::sales-channel` no longer adds the `languages` association.
+As a consequence the query with the title `base-context-factory::sales-channel` no longer adds the `languages` association,
+which means the `salesChannel` property of the `BaseSalesChannelContext` no longer contains the current language object. 
 
 </details>
 

--- a/UPGRADE-6.8.md
+++ b/UPGRADE-6.8.md
@@ -184,7 +184,7 @@ Get the latest order transaction with `primaryOrderTransaction` so you should re
 
 ## Improved fetching of language information for SalesChannelContext
 
-The `\Shopware\Core\System\SalesChannel\Context\BaseSalesChannelContextFactory` uses the language repository directly to fetch language information.
+The `\Shopware\Core\System\SalesChannel\Context\BaseSalesChannelContextFactory` now uses the language repository directly to fetch language information.
 As a consequence the query with the title `base-context-factory::sales-channel` no longer adds the `languages` association,
 which means the `salesChannel` property of the `BaseSalesChannelContext` no longer contains the current language object. 
 

--- a/changelog/_unreleased/2025-06-11-improve-fetching-of-language-information-for-saleschannelcontext.md
+++ b/changelog/_unreleased/2025-06-11-improve-fetching-of-language-information-for-saleschannelcontext.md
@@ -1,0 +1,16 @@
+---
+title: Improve fetching of language information for SalesChannelContext
+author: Michael Telgmann
+author_github: @mitelg
+---
+
+# Core
+
+* Changed `\Shopware\Core\System\SalesChannel\Context\BaseSalesChannelContextFactory::getLanguageInfo` so it directly uses the language repository for fetching the language information.
+___
+
+# Upgrade Information
+## Improved fetching of language information for SalesChannelContext
+
+The `\Shopware\Core\System\SalesChannel\Context\BaseSalesChannelContextFactory` now uses the language repository directly to fetch language information.
+With the next major version the query with the title `base-context-factory::sales-channel` will no longer add the `languages` association.

--- a/changelog/_unreleased/2025-06-11-improve-fetching-of-language-information-for-saleschannelcontext.md
+++ b/changelog/_unreleased/2025-06-11-improve-fetching-of-language-information-for-saleschannelcontext.md
@@ -13,4 +13,5 @@ ___
 ## Improved fetching of language information for SalesChannelContext
 
 The `\Shopware\Core\System\SalesChannel\Context\BaseSalesChannelContextFactory` now uses the language repository directly to fetch language information.
-With the next major version the query with the title `base-context-factory::sales-channel` will no longer add the `languages` association.
+With the next major version the query with the title `base-context-factory::sales-channel` will no longer add the `languages` association,
+which means the `salesChannel` property of the `BaseSalesChannelContext` no longer contains the current language object. 

--- a/changelog/_unreleased/2025-06-11-improve-fetching-of-language-information-for-saleschannelcontext.md
+++ b/changelog/_unreleased/2025-06-11-improve-fetching-of-language-information-for-saleschannelcontext.md
@@ -6,12 +6,4 @@ author_github: @mitelg
 
 # Core
 
-* Changed `\Shopware\Core\System\SalesChannel\Context\BaseSalesChannelContextFactory::getLanguageInfo` so it directly uses the language repository for fetching the language information.
-___
-
-# Upgrade Information
-## Improved fetching of language information for SalesChannelContext
-
-The `\Shopware\Core\System\SalesChannel\Context\BaseSalesChannelContextFactory` now uses the language repository directly to fetch language information.
-With the next major version the query with the title `base-context-factory::sales-channel` will no longer add the `languages` association,
-which means the `salesChannel` property of the `BaseSalesChannelContext` no longer contains the current language object. 
+* Changed `\Shopware\Core\System\SalesChannel\Context\BaseSalesChannelContextFactory::getLanguageInfo` so it will directly uses the language repository for fetching the language information with the next major version.

--- a/src/Core/System/DependencyInjection/sales_channel.xml
+++ b/src/Core/System/DependencyInjection/sales_channel.xml
@@ -79,6 +79,7 @@
             <argument type="service" id="country_state.repository"/>
             <argument type="service" id="currency_country_rounding.repository"/>
             <argument type="service" id="Shopware\Core\System\SalesChannel\Context\ContextFactory"/>
+            <argument type="service" id="language.repository"/>
         </service>
 
         <service id="Shopware\Core\System\SalesChannel\Context\ContextFactory">

--- a/src/Core/System/SalesChannel/Context/BaseSalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/BaseSalesChannelContextFactory.php
@@ -10,10 +10,13 @@ use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Shipping\ShippingMethodCollection;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
 use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\PartialEntity;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\Country\Aggregate\CountryState\CountryStateCollection;
@@ -24,7 +27,6 @@ use Shopware\Core\System\Currency\Aggregate\CurrencyCountryRounding\CurrencyCoun
 use Shopware\Core\System\Currency\Aggregate\CurrencyCountryRounding\CurrencyCountryRoundingEntity;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Currency\CurrencyEntity;
-use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\SalesChannel\BaseSalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -47,6 +49,7 @@ class BaseSalesChannelContextFactory extends AbstractBaseSalesChannelContextFact
      * @param EntityRepository<ShippingMethodCollection> $shippingMethodRepository
      * @param EntityRepository<CountryStateCollection> $countryStateRepository
      * @param EntityRepository<CurrencyCountryRoundingCollection> $currencyCountryRepository
+     * @param EntityRepository<EntityCollection<PartialEntity>> $languageRepository
      */
     public function __construct(
         private readonly EntityRepository $salesChannelRepository,
@@ -59,6 +62,7 @@ class BaseSalesChannelContextFactory extends AbstractBaseSalesChannelContextFact
         private readonly EntityRepository $countryStateRepository,
         private readonly EntityRepository $currencyCountryRepository,
         private readonly ContextFactory $contextFactory,
+        private readonly EntityRepository $languageRepository,
     ) {
     }
 
@@ -73,10 +77,13 @@ class BaseSalesChannelContextFactory extends AbstractBaseSalesChannelContextFact
         $criteria->setTitle('base-context-factory::sales-channel');
         $criteria->addAssociation('currency');
         $criteria->addAssociation('domains');
-        $criteria->getAssociation('languages')
-            ->addFilter(new EqualsFilter('id', $context->getLanguageId()))
-            ->addAssociation('translationCode')
-            ->addAssociation('locale');
+
+        if (!Feature::isActive('v6.8.0.0')) {
+            $criteria->getAssociation('languages')
+                ->addFilter(new EqualsFilter('id', $context->getLanguageId()))
+                ->addAssociation('translationCode')
+                ->addAssociation('locale');
+        }
 
         $salesChannel = $this->salesChannelRepository->search($criteria, $context)->getEntities()->get($salesChannelId);
         if (!$salesChannel instanceof SalesChannelEntity) {
@@ -152,7 +159,7 @@ class BaseSalesChannelContextFactory extends AbstractBaseSalesChannelContextFact
             $shippingLocation,
             $itemRounding,
             $totalRounding,
-            $this->getLanguageInfo($salesChannel->getLanguages(), $context->getLanguageId()),
+            $this->getLanguageInfo($context),
         );
     }
 
@@ -279,19 +286,26 @@ class BaseSalesChannelContextFactory extends AbstractBaseSalesChannelContextFact
         return [$currency->getItemRounding(), $currency->getTotalRounding()];
     }
 
-    private function getLanguageInfo(?LanguageCollection $languages, string $currentLanguageId): LanguageInfo
+    private function getLanguageInfo(Context $context): LanguageInfo
     {
-        $currentLanguage = $languages?->get($currentLanguageId);
-        if ($currentLanguage === null) {
+        $currentLanguageId = $context->getLanguageId();
+        $criteria = (new Criteria([$currentLanguageId]))->addFields([
+            'name',
+            'translationCode.code',
+            'locale.code',
+        ]);
+
+        $currentLanguage = $this->languageRepository->search($criteria, $context)->getEntities()->get($currentLanguageId);
+        if (!$currentLanguage instanceof PartialEntity) {
             throw SalesChannelException::languageNotFound($currentLanguageId);
         }
 
-        $locale = $currentLanguage->getTranslationCode() ?? $currentLanguage->getLocale();
-        \assert($locale !== null, 'At least the localeId is required, so the fallback should never be null');
+        $locale = $currentLanguage->get('translationCode') ?? $currentLanguage->get('locale');
+        \assert($locale instanceof PartialEntity, 'At least the localeId is required, so the fallback should never be null');
 
         return new LanguageInfo(
-            $currentLanguage->getTranslation('name') ?? $currentLanguage->getName(),
-            $locale->getCode(),
+            $currentLanguage->get('name'),
+            $locale->get('code'),
         );
     }
 }

--- a/src/Core/System/SalesChannel/Context/BaseSalesChannelContextFactory.php
+++ b/src/Core/System/SalesChannel/Context/BaseSalesChannelContextFactory.php
@@ -27,6 +27,7 @@ use Shopware\Core\System\Currency\Aggregate\CurrencyCountryRounding\CurrencyCoun
 use Shopware\Core\System\Currency\Aggregate\CurrencyCountryRounding\CurrencyCountryRoundingEntity;
 use Shopware\Core\System\Currency\CurrencyCollection;
 use Shopware\Core\System\Currency\CurrencyEntity;
+use Shopware\Core\System\Language\LanguageCollection;
 use Shopware\Core\System\SalesChannel\BaseSalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelCollection;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
@@ -148,6 +149,12 @@ class BaseSalesChannelContextFactory extends AbstractBaseSalesChannelContextFact
             $itemRounding
         );
 
+        if (!Feature::isActive('v6.8.0.0')) {
+            $languageInfo = $this->getLanguageInfoDeprecated($salesChannel->getLanguages(), $context->getLanguageId());
+        } else {
+            $languageInfo = $this->getLanguageInfo($context);
+        }
+
         return new BaseSalesChannelContext(
             $context,
             $salesChannel,
@@ -159,7 +166,7 @@ class BaseSalesChannelContextFactory extends AbstractBaseSalesChannelContextFact
             $shippingLocation,
             $itemRounding,
             $totalRounding,
-            $this->getLanguageInfo($context),
+            $languageInfo,
         );
     }
 
@@ -306,6 +313,22 @@ class BaseSalesChannelContextFactory extends AbstractBaseSalesChannelContextFact
         return new LanguageInfo(
             $currentLanguage->get('name'),
             $locale->get('code'),
+        );
+    }
+
+    private function getLanguageInfoDeprecated(?LanguageCollection $languages, string $currentLanguageId): LanguageInfo
+    {
+        $currentLanguage = $languages?->get($currentLanguageId);
+        if ($currentLanguage === null) {
+            throw SalesChannelException::languageNotFound($currentLanguageId);
+        }
+
+        $locale = $currentLanguage->getTranslationCode() ?? $currentLanguage->getLocale();
+        \assert($locale !== null, 'At least the localeId is required, so the fallback should never be null');
+
+        return new LanguageInfo(
+            $currentLanguage->getTranslation('name') ?? $currentLanguage->getName(),
+            $locale->getCode(),
         );
     }
 }

--- a/src/Core/Test/Generator.php
+++ b/src/Core/Test/Generator.php
@@ -23,6 +23,7 @@ use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Payment\Cart\PaymentHandler\DefaultPayment;
 use Shopware\Core\Checkout\Payment\PaymentMethodEntity;
 use Shopware\Core\Checkout\Shipping\ShippingMethodEntity;
+use Shopware\Core\Defaults;
 use Shopware\Core\Framework\Context;
 use Shopware\Core\Framework\DataAbstractionLayer\Pricing\CashRoundingConfig;
 use Shopware\Core\Framework\Log\Package;
@@ -56,6 +57,7 @@ class Generator extends TestCase
     final public const CUSTOMER_ADDRESS = '08f1594313494c3e9eb57bb53486fe61';
     final public const CUSTOMER = '42d58aa78cf14851968a786a66bab93a';
     final public const LANGUAGE_INFO_NAME = 'English';
+    final public const LANGUAGE_INFO_LOCALE_ID = '0195c74c6dc97287b95616bfe6aa5fbd';
     final public const LANGUAGE_INFO_LOCALE_CODE = 'en-GB';
 
     /**
@@ -180,7 +182,7 @@ class Generator extends TestCase
 
         $areaRuleIds ??= [];
 
-        $languageInfo ??= new LanguageInfo(self::LANGUAGE_INFO_NAME, self::LANGUAGE_INFO_LOCALE_CODE);
+        $languageInfo ??= self::createLanguageInfo();
 
         $salesChannelContext = new SalesChannelContext(
             $baseContext,
@@ -267,5 +269,15 @@ class Generator extends TestCase
         $cart->addDeliveries(new DeliveryCollection([$delivery]));
 
         return $cart;
+    }
+
+    public static function createLanguageInfo(
+        ?string $id = null,
+        ?string $name = null,
+    ): LanguageInfo {
+        return new LanguageInfo(
+            $id ?? Defaults::LANGUAGE_SYSTEM,
+            $name ?? self::LANGUAGE_INFO_NAME,
+        );
     }
 }

--- a/src/Core/Test/Generator.php
+++ b/src/Core/Test/Generator.php
@@ -57,7 +57,6 @@ class Generator extends TestCase
     final public const CUSTOMER_ADDRESS = '08f1594313494c3e9eb57bb53486fe61';
     final public const CUSTOMER = '42d58aa78cf14851968a786a66bab93a';
     final public const LANGUAGE_INFO_NAME = 'English';
-    final public const LANGUAGE_INFO_LOCALE_ID = '0195c74c6dc97287b95616bfe6aa5fbd';
     final public const LANGUAGE_INFO_LOCALE_CODE = 'en-GB';
 
     /**

--- a/tests/unit/Core/Content/Product/Cms/ProductSliderCmsElementResolverTest.php
+++ b/tests/unit/Core/Content/Product/Cms/ProductSliderCmsElementResolverTest.php
@@ -26,8 +26,6 @@ class ProductSliderCmsElementResolverTest extends TestCase
 {
     use ProductSliderUnitTrait;
 
-    protected FieldConfigCollection $config;
-
     private AbstractProductSliderProcessor&MockObject $processor;
 
     private LoggerInterface&MockObject $logger;

--- a/tests/unit/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
+++ b/tests/unit/Core/Framework/DataAbstractionLayer/Cache/EntityCacheKeyGeneratorTest.php
@@ -23,10 +23,10 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting;
 use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\Currency\CurrencyEntity;
-use Shopware\Core\System\SalesChannel\Context\LanguageInfo;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\Tax\TaxCollection;
+use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\TestDefaults;
 
 /**
@@ -158,7 +158,7 @@ class DummyContext extends SalesChannelContext
             new CustomerEntity(),
             new CashRoundingConfig(2, 0.01, true),
             new CashRoundingConfig(2, 0.01, true),
-            new LanguageInfo('English', 'en-GB'),
+            Generator::createLanguageInfo(),
         );
     }
 
@@ -177,7 +177,7 @@ class DummyContext extends SalesChannelContext
     }
 
     /**
-     * @param list<string> $chain
+     * @param non-empty-list<string> $chain
      */
     public function setLanguageChain(array $chain): self
     {

--- a/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextFactoryTest.php
+++ b/tests/unit/Core/System/SalesChannel/Context/SalesChannelContextFactoryTest.php
@@ -30,11 +30,11 @@ use Shopware\Core\System\Country\CountryEntity;
 use Shopware\Core\System\Currency\CurrencyEntity;
 use Shopware\Core\System\SalesChannel\BaseSalesChannelContext;
 use Shopware\Core\System\SalesChannel\Context\AbstractBaseSalesChannelContextFactory;
-use Shopware\Core\System\SalesChannel\Context\LanguageInfo;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextFactory;
 use Shopware\Core\System\SalesChannel\Context\SalesChannelContextService;
 use Shopware\Core\System\SalesChannel\SalesChannelEntity;
 use Shopware\Core\System\Tax\TaxCollection;
+use Shopware\Core\Test\Generator;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticEntityRepository;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -84,7 +84,7 @@ class SalesChannelContextFactoryTest extends TestCase
             new ShippingLocation($country, null, null),
             new CashRoundingConfig(2, 0.01, true),
             new CashRoundingConfig(2, 0.01, true),
-            new LanguageInfo('English', 'en-GB'),
+            Generator::createLanguageInfo(),
         );
 
         /** @var StaticEntityRepository<PaymentMethodCollection> $paymentMethodRepository */


### PR DESCRIPTION
### 1. Why is this change necessary?

Instead of loading an additional association with two other associations, load only the needed language data.

### 2. What does this change do, exactly?

Use partial loading of only needed fields

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
