### PR TITLE
fix: added link to sw-gtc-checkbox

### DIFF
--- a/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-checkbox.check.js
+++ b/src/Administration/Resources/app/administration/eslint-rules/deprecation-rules/no-deprecated-component-usage-checks/mt-checkbox.check.js
@@ -28,16 +28,6 @@ const handleMtCheckbox = (context, node) => {
             attr.key?.argument?.name === 'checked';
     });
 
-    // Check if the mt-checkbox has the slot "label"
-    const labelSlot = node.children.find((child) => {
-        return child.type === 'VElement' &&
-            child.name === 'template' &&
-            child.startTag?.attributes.find((attr) => {
-                return attr.key?.name?.name === 'slot'
-                    && attr.key?.argument?.name === 'label'
-            });
-    });
-
     // Check if the mt-checkbox has the slot "hint"
     const hintSlot = node.children.find((child) => {
         return child.type === 'VElement' &&
@@ -130,31 +120,6 @@ const handleMtCheckbox = (context, node) => {
                 if (context.options.includes('disableFix')) return;
 
                 yield fixer.replaceText(valueAttributeExpression.key.argument, 'checked');
-            }
-        });
-    }
-
-    if (labelSlot) {
-        context.report({
-            node: labelSlot,
-            message: `[${mtComponentName}] The "label" slot is deprecated. Use the "label" prop instead.`,
-            *fix(fixer)  {
-                if (context.options.includes('disableFix')) return;
-
-                const labelSlot = node.children.find((child) => {
-                    return child.type === 'VElement' &&
-                        child.name === 'template' &&
-                        child.startTag?.attributes.find((attr) => {
-                            return attr.key?.name?.name === 'slot'
-                                && attr.key?.argument?.name === 'label'
-                        });
-                });
-
-                const labelSlotValueRaw = labelSlot.children[0].value;
-                // Remove \n and multiple spaces from the string
-                const labelSlotValue = labelSlotValueRaw.replace(/\n/g, '').replace(/\s+/g, ' ');
-
-                yield fixer.replaceText(labelSlot, `<!-- Slot "label" was removed and should be replaced with "label" prop. Previous value was: ${labelSlotValue} -->`);
             }
         });
     }
@@ -419,80 +384,6 @@ const mtCheckboxInvalidTests = [
             </template>`,
         errors: [{
             message: '[mt-checkbox] The "v-model" directive is deprecated. Use "v-model:checked" instead.',
-        }]
-    },
-    {
-        name: '"mt-checkbox" wrong slot "label" usage should be replaced with "label" prop [shorthandSyntax]',
-        filename: 'test.html.twig',
-        code: `
-            <template>
-                <mt-checkbox>
-                    <template #label>
-                        Hello Shopware
-                    </template>
-                </mt-checkbox>
-            </template>`,
-        output: `
-            <template>
-                <mt-checkbox>
-                    <!-- Slot "label" was removed and should be replaced with "label" prop. Previous value was:  Hello Shopware  -->
-                </mt-checkbox>
-            </template>`,
-        errors: [{
-            message: '[mt-checkbox] The "label" slot is deprecated. Use the "label" prop instead.',
-        }]
-    },
-    {
-        name: '"mt-checkbox" wrong slot "label" usage should be replaced with "label" prop [shorthandSyntax, disableFix]',
-        filename: 'test.html.twig',
-        options: ['disableFix'],
-        code: `
-            <template>
-                <mt-checkbox>
-                    <template #label>
-                        Hello Shopware
-                    </template>
-                </mt-checkbox>
-            </template>`,
-        errors: [{
-            message: '[mt-checkbox] The "label" slot is deprecated. Use the "label" prop instead.',
-        }]
-    },
-    {
-        name: '"mt-checkbox" wrong slot "label" usage should be replaced with "label" prop',
-        filename: 'test.html.twig',
-        code: `
-            <template>
-                <mt-checkbox>
-                    <template v-slot:label>
-                        Hello Shopware
-                    </template>
-                </mt-checkbox>
-            </template>`,
-        output: `
-            <template>
-                <mt-checkbox>
-                    <!-- Slot "label" was removed and should be replaced with "label" prop. Previous value was:  Hello Shopware  -->
-                </mt-checkbox>
-            </template>`,
-        errors: [{
-            message: '[mt-checkbox] The "label" slot is deprecated. Use the "label" prop instead.',
-        }]
-    },
-    {
-        name: '"mt-checkbox" wrong slot "label" usage should be replaced with "label" prop [disableFix]',
-        filename: 'test.html.twig',
-        options: ['disableFix'],
-        code: `
-            <template>
-                <mt-checkbox>
-                    <template v-slot:label>
-                        Hello Shopware
-                    </template>
-                </mt-checkbox>
-            </template>`,
-        errors: [{
-            message: '[mt-checkbox] The "label" slot is deprecated. Use the "label" prop instead.',
         }]
     },
     {

--- a/src/Administration/Resources/app/administration/package-lock.json
+++ b/src/Administration/Resources/app/administration/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@shopware-ag/meteor-admin-sdk": "5.7.7",
-        "@shopware-ag/meteor-component-library": "4.7.1",
+        "@shopware-ag/meteor-component-library": "4.8.0",
         "@shopware-ag/meteor-icon-kit": "5.4.0",
         "@swc/core": "1.10.7",
         "@types/fs-extra": "^11.0.4",
@@ -4983,9 +4983,9 @@
       }
     },
     "node_modules/@shopware-ag/meteor-component-library": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.7.1.tgz",
-      "integrity": "sha512-azmKiBx2TFJ0KIH6POlUd0JDcVvuangbf3t5odLJJ9n1zDr4dqVuRXrMx2W+nrjfSvpTRwZFOFPw1K4MTqRVQg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@shopware-ag/meteor-component-library/-/meteor-component-library-4.8.0.tgz",
+      "integrity": "sha512-fkxZogOYpV5dNJtfSCI0mynq3/poWGJFeNV3wFDnhpd8lnPApF0px8zYM3EKesXn0ja6gi1TZ1sDN8C+QbhjTQ==",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.9",
         "@floating-ui/dom": "^1.4.3",

--- a/src/Administration/Resources/app/administration/package.json
+++ b/src/Administration/Resources/app/administration/package.json
@@ -49,7 +49,7 @@
   ],
   "dependencies": {
     "@shopware-ag/meteor-admin-sdk": "5.7.7",
-    "@shopware-ag/meteor-component-library": "4.7.1",
+    "@shopware-ag/meteor-component-library": "4.8.0",
     "@shopware-ag/meteor-icon-kit": "5.4.0",
     "@swc/core": "1.10.7",
     "@types/fs-extra": "^11.0.4",

--- a/src/Administration/Resources/app/administration/src/app/component/form/sw-gtc-checkbox/sw-gtc-checkbox.html.twig
+++ b/src/Administration/Resources/app/administration/src/app/component/form/sw-gtc-checkbox/sw-gtc-checkbox.html.twig
@@ -3,9 +3,19 @@
     {% block sw_gtc_checkbox_input %}
     <mt-checkbox
         :checked="value"
-        :label="$tc('global.sw-gtc-checkbox.url')"
         @update:checked="onChange"
-    />
+    >
+        <template #label>
+            {{ $tc('global.sw-gtc-checkbox.label') }}
+            <mt-link
+                class="sw-external-link"
+                type="external"
+                :href="$tc('global.sw-gtc-checkbox.url')"
+            >
+                {{ $tc('global.sw-gtc-checkbox.link') }}
+            </mt-link>
+        </template>
+    </mt-checkbox>
     {% endblock %}
 </div>
 {% endblock %}

--- a/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
+++ b/src/Administration/Resources/app/administration/test/_setup/prepare_environment.js
@@ -37,7 +37,8 @@ import {
     MtTabs,
     MtTextField,
     MtTextarea,
-    MtToast, MtTextEditor,
+    MtToast,
+    MtTextEditor,
 } from '@shopware-ag/meteor-component-library';
 import {createI18n} from "vue-i18n";
 import aclService from './_mocks_/acl.service.mock';


### PR DESCRIPTION
### 1. Why is this change necessary?

After switching to the meteor components terms and conditions checkbox is missing link to the GTC page.

### 2. What does this change do, exactly?

Adds missing markup.

### 3. Describe each step to reproduce the issue or behaviour.

Open installation popup in extensions store.

### 4. Please link to the relevant issues (if any).
- closes https://github.com/shopware/shopware/issues/7471
- requires https://github.com/shopware/meteor/pull/609 to be merged first

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
