### PR TITLE
fix: Add snippets for `lineItemOfType` rule types

### DIFF
--- a/changelog/_unreleased/2025-03-19-add-snippets-for-lineitemoftype-rule-types.md
+++ b/changelog/_unreleased/2025-03-19-add-snippets-for-lineitemoftype-rule-types.md
@@ -1,0 +1,8 @@
+---
+title: Add snippets for `lineItemOfType` rule types
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Administration
+* Added snippets for the `lineItemType`s of the `cartLineItemOfType` rule

--- a/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/de-DE.json
@@ -826,6 +826,14 @@
       }
     },
     "sw-condition-generic": {
+      "cartLineItemOfType": {
+        "lineItemType": {
+          "options": {
+            "product": "@:{'global.sw-condition.condition.lineItemOfTypeRule.product'}",
+            "promotion": "@:{'global.sw-condition.condition.lineItemOfTypeRule.discount_surcharge'}"
+          }
+        }
+      },
       "units": {
         "dimension": "mm",
         "weight": "kg",

--- a/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
+++ b/src/Administration/Resources/app/administration/src/app/snippet/en-GB.json
@@ -826,6 +826,14 @@
       }
     },
     "sw-condition-generic": {
+      "cartLineItemOfType": {
+        "lineItemType": {
+          "options": {
+            "product": "@:{'global.sw-condition.condition.lineItemOfTypeRule.product'}",
+            "promotion": "@:{'global.sw-condition.condition.lineItemOfTypeRule.discount_surcharge'}"
+          }
+        }
+      },
       "units": {
         "dimension": "mm",
         "weight": "kg",


### PR DESCRIPTION
### 1. Why is this change necessary?
![image](https://github.com/user-attachments/assets/fbe10f34-5f6f-49bf-933a-423051590840)

### 2. What does this change do, exactly?
![image](https://github.com/user-attachments/assets/e1ba3e6f-36e2-4090-9760-31b817cea9e2)

### 3. Describe each step to reproduce the issue or behaviour.
Configure a rule.

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
