### PR TITLE
refactor: use dbal connection instead repository

### DIFF
--- a/src/Core/Framework/DependencyInjection/webhook.xml
+++ b/src/Core/Framework/DependencyInjection/webhook.xml
@@ -77,7 +77,6 @@
 
         <service id="Shopware\Core\Framework\Webhook\Subscriber\RetryWebhookMessageFailedSubscriber">
             <argument type="service" id="Doctrine\DBAL\Connection"/>
-            <argument type="service" id="webhook_event_log.repository"/>
             <argument type="service" id="Shopware\Core\Framework\Webhook\Service\RelatedWebhooks"/>
 
             <tag name="kernel.event_subscriber"/>


### PR DESCRIPTION
**Backport:** https://github.com/shopware/shopware/pull/7431

### 1. Why is this change necessary?

When a webhook failed and there was no log entry, the queue will be blocked for ever.

```
13:44:43 CRITICAL  [console] Error thrown while running command "'messenger:consum' --all -vvv". Message: "Expected command for "webhook_event_log" to be "Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand". (Got: Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand)Hint: Use POST method to create new entities."
[
  "exception" => Shopware\Core\Framework\DataAbstractionLayer\Write\Command\WriteTypeIntendException^ {
    #message: "Expected command for "webhook_event_log" to be "Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand". (Got: Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand)Hint: Use POST method to create new entities."
    #code: 0
    #file: "./vendor/shopware/core/Framework/DataAbstractionLayer/Write/Command/WriteCommandQueue.php"
    #line: 140
    -statusCode: 400
    -headers: []
    #parameters: [
      "definition" => "webhook_event_log",
      "expectedClass" => "Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand",
      "actualClass" => "Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand"
    ]
  "command" => "'messenger:consum' --all -vvv",
  "message" => "Expected command for "webhook_event_log" to be "Shopware\Core\Framework\DataAbstractionLayer\Write\Command\UpdateCommand". (Got: Shopware\Core\Framework\DataAbstractionLayer\Write\Command\InsertCommand)Hint: Use POST method to create new entities."
]
```


### 2. What does this change do, exactly?

Use dbal connection, we don't care if the log entry exists or not


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
