### PR TITLE
fix: updated cms block removable check

### DIFF
--- a/changelog/_unreleased/2025-03-20-fix-cms-block-removable-check.md
+++ b/changelog/_unreleased/2025-03-20-fix-cms-block-removable-check.md
@@ -1,0 +1,8 @@
+---
+title: fix cms block removable check
+author: Felix Schneider
+author_email: felix@wirduzen.de
+author_github: @schneider-felix
+---
+# Administration
+* Changed the check that decided whether a CMS block should be removable

--- a/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-cms/component/sw-cms-sidebar/index.ts
@@ -385,7 +385,7 @@ export default Shopware.Component.wrapComponentConfig({
 
         blockIsRemovable(block: Entity<'cms_block'>) {
             const cmsBlocks = this.cmsService.getCmsBlockRegistry();
-            return cmsBlocks[block.type]?.removable && this.isSystemDefaultLanguage;
+            return (cmsBlocks[block.type]?.removable !== false) && this.isSystemDefaultLanguage;
         },
 
         blockIsUnique(block: Entity<'cms_block'>) {


### PR DESCRIPTION
### 1. Why is this change necessary?

Since Shopware 6.6.7.0 CMS Elements are not removable from a layout via the Sidebar anymore because the trashcan icon does not show up. This was caused by commit 118b543 which slightly changed the check here: https://github.com/shopware/shopware/commit/118b543637997544ccaa5f01b5c2b83a962fbf81#diff-63fea23a2a713573cd708ba1a402b9caef581f1ff71cb6171e2567a87dbb9a6fL313-R354

This causes problems because this variable is `undefined` by default instead of `true`

### 2. What does this change do, exactly?

Update the condition to fix the issue outlined above.

### 3. Describe each step to reproduce the issue or behaviour.

Edit a CMS Page in the administration and try to delete an element using the "Navigator". Notice that the trashcan icon is missing.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
