### PR TITLE
Fix: Accessibility issue in footer #collapseFooterTitle

### DIFF
--- a/changelog/_unreleased/2025-04-20-Accessibility-issue-in-footer-collapseFooterTitle.md
+++ b/changelog/_unreleased/2025-04-20-Accessibility-issue-in-footer-collapseFooterTitle.md
@@ -1,0 +1,17 @@
+---
+title: Accessibility issue in footer #collapseFooterTitle
+issue:
+flag: ACCESSIBILITY_TWEAKS
+author: Jürgen Hörmann 
+author_email: juergen@sfxonline.de
+author_github: @jhit
+---
+
+# Storefront
+* The elements in the footer-navigation are not accessible for screen readers. The `id="collapseFooter{{ loop.index }}"` 
+  and respective `class="footer-column-headline ..."` elements are missing the `role` attribute. When using accessibility 
+  validation tools they will raise errors like this: [Elements must only use supported ARIA attributes](
+  https://dequeuniversity.com/rules/axe/4.10/aria-allowed-attrThis). This change affects the following template
+  * `src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig`
+
+

--- a/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
+++ b/src/Storefront/Resources/views/storefront/layout/footer/footer.html.twig
@@ -71,7 +71,8 @@
                                     <div class="footer-column-headline footer-headline js-collapse-footer-column-trigger"
                                          data-bs-target="#collapseFooterTitle{{ loop.index }}"
                                          aria-expanded="true"
-                                         aria-controls="collapseFooter{{ loop.index }}">
+                                         aria-controls="collapseFooter{{ loop.index }}"
+                                         role="listitem">
 
                                         {% if root.category.type == 'folder' %}
                                             {{ root.category.translated.name }}
@@ -103,7 +104,8 @@
                                 {% block layout_footer_navigation_information_content %}
                                     <div id="collapseFooter{{ loop.index }}"
                                          class="footer-column-content collapse js-footer-column-content"
-                                         aria-labelledby="collapseFooterTitle{{ loop.index }}">
+                                         aria-labelledby="collapseFooterTitle{{ loop.index }}"
+                                         role="listitem">
                                         <div class="footer-column-content-inner">
                                             {% block layout_footer_navigation_information_links %}
                                                 <ul class="list-unstyled">


### PR DESCRIPTION
When testing for usability I get this error:

Elements must only use supported ARIA attributes
https://dequeuniversity.com/rules/axe/4.10/aria-allowed-attr

on div[data-bs-target="#collapseFooterTitle1"]

adding the role="listitem" fixes this issue. This issue is already fixed in 6.7.0 trunk

<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?
Shopware 6.6.10 should comply with the BFSG. 

### 2. What does this change do, exactly?
Solve two accessibility issues in the footer 

### 3. Describe each step to reproduce the issue or behaviour.
Test any Shopware 6.6.10 Shop with a accessibility test tool.

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
