### PR TITLE
refactor: Move review active check into store api routes

### DIFF
--- a/changelog/_unreleased/2025-03-20-move-review-active-check-into-store-api-routes.md
+++ b/changelog/_unreleased/2025-03-20-move-review-active-check-into-store-api-routes.md
@@ -1,0 +1,8 @@
+---
+title: Move review active check into store api routes
+author: Max
+author_email: max@swk-web.com
+author_github: @aragon999
+---
+# Core
+* Changed `Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewRoute::load` to throw an exception if the product reviews have been disabled for the corresponding sales channel, to make it consistent with the `Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewSaveRoute::save` method

--- a/src/Core/Content/DependencyInjection/product.xml
+++ b/src/Core/Content/DependencyInjection/product.xml
@@ -472,6 +472,7 @@
 
         <service id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewRoute" public="true">
             <argument type="service" id="product_review.repository"/>
+            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
             <argument type="service" id="event_dispatcher"/>
         </service>
 

--- a/src/Storefront/Controller/Exception/StorefrontException.php
+++ b/src/Storefront/Controller/Exception/StorefrontException.php
@@ -96,7 +96,7 @@ class StorefrontException extends HttpException
     {
         Feature::triggerDeprecationOrThrow(
             'v6.8.0.0',
-            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0', 'PluginException::reviewNotActive')
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0', 'ProductException::reviewNotActive')
         );
 
         return new self(

--- a/src/Storefront/Controller/Exception/StorefrontException.php
+++ b/src/Storefront/Controller/Exception/StorefrontException.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Storefront\Controller\Exception;
 
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\HttpException;
 use Shopware\Core\Framework\Log\Package;
 use Symfony\Component\HttpFoundation\Response;
@@ -15,6 +16,9 @@ class StorefrontException extends HttpException
     final public const UN_SUPPORT_STOREFRONT_RESPONSE = 'STOREFRONT__UN_SUPPORT_STOREFRONT_RESPONSE';
     final public const CLASS_DONT_HAVE_TWIG_INJECTED = 'STOREFRONT__CLASS_DONT_HAVE_TWIG_INJECTED';
     final public const NO_REQUEST_PROVIDED = 'STOREFRONT__NO_REQUEST_PROVIDED';
+    /**
+     * @deprecated tag:v6.8.0 - Will be replaced by `ProductException::PRODUCT_REVIEW_NOT_ACTIVE`
+     */
     final public const PRODUCT_REVIEW_NOT_ACTIVE = 'STOREFRONT__REVIEW_NOT_ACTIVE';
 
     private const CUSTOM_APP_PATH = 'custom/apps/';
@@ -85,8 +89,16 @@ class StorefrontException extends HttpException
         );
     }
 
+    /**
+     * @deprecated tag:v6.8.0 - Will be replaced by `ProductException::reviewNotActive`
+     */
     public static function reviewNotActive(): self
     {
+        Feature::triggerDeprecationOrThrow(
+            'v6.8.0.0',
+            Feature::deprecatedMethodMessage(__CLASS__, __METHOD__, 'v6.8.0.0', 'PluginException::reviewNotActive')
+        );
+
         return new self(
             Response::HTTP_FORBIDDEN,
             self::PRODUCT_REVIEW_NOT_ACTIVE,

--- a/src/Storefront/Controller/ProductController.php
+++ b/src/Storefront/Controller/ProductController.php
@@ -10,6 +10,7 @@ use Shopware\Core\Content\Product\SalesChannel\Review\AbstractProductReviewLoade
 use Shopware\Core\Content\Product\SalesChannel\Review\AbstractProductReviewSaveRoute;
 use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewsWidgetLoadedHook;
 use Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface;
+use Shopware\Core\Framework\Feature;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
@@ -117,18 +118,30 @@ class ProductController extends StorefrontController
     #[Route(path: '/product/{productId}/rating', name: 'frontend.detail.review.save', defaults: ['XmlHttpRequest' => true, '_loginRequired' => true], methods: ['POST'])]
     public function saveReview(string $productId, RequestDataBag $data, SalesChannelContext $context): Response
     {
-        try {
-            $this->productReviewSaveRoute->save($productId, $data, $context);
-        } catch (ConstraintViolationException $formViolations) {
-            return $this->forwardToRoute('frontend.product.reviews', [
-                'productId' => $productId,
-                'success' => -1,
-                'formViolations' => $formViolations,
-                'data' => $data,
-            ], ['productId' => $productId]);
-        } catch (ReviewNotActiveExeption $e) {
-            /** @deprecated tag:v6.8.0 Remove this catch, the exception is then `ProductException::reviewNotActive` */
-            throw StorefrontException::reviewNotActive();
+        if (!Feature::isActive('v6.8.0.0')) {
+            try {
+                $this->productReviewSaveRoute->save($productId, $data, $context);
+            } catch (ConstraintViolationException $formViolations) {
+                return $this->forwardToRoute('frontend.product.reviews', [
+                    'productId' => $productId,
+                    'success' => -1,
+                    'formViolations' => $formViolations,
+                    'data' => $data,
+                ], ['productId' => $productId]);
+            } catch (ReviewNotActiveExeption $e) {
+                throw StorefrontException::reviewNotActive();
+            }
+        } else {
+            try {
+                $this->productReviewSaveRoute->save($productId, $data, $context);
+            } catch (ConstraintViolationException $formViolations) {
+                return $this->forwardToRoute('frontend.product.reviews', [
+                    'productId' => $productId,
+                    'success' => -1,
+                    'formViolations' => $formViolations,
+                    'data' => $data,
+                ], ['productId' => $productId]);
+            }
         }
 
         $forwardParams = [
@@ -148,11 +161,14 @@ class ProductController extends StorefrontController
     #[Route(path: '/product/{productId}/reviews', name: 'frontend.product.reviews', defaults: ['XmlHttpRequest' => true], methods: ['GET', 'POST'])]
     public function loadReviews(string $productId, Request $request, SalesChannelContext $context): Response
     {
-        /** @deprecated tag:v6.8.0 Remove complete try catch block, the exception is then `ProductException::reviewNotActive` */
-        try {
+        if (!Feature::isActive('v6.8.0.0')) {
+            try {
+                $reviews = $this->productReviewLoader->load($request, $context, $productId, $request->get('parentId'));
+            } catch (ReviewNotActiveExeption $e) {
+                throw StorefrontException::reviewNotActive();
+            }
+        } else {
             $reviews = $this->productReviewLoader->load($request, $context, $productId, $request->get('parentId'));
-        } catch (ReviewNotActiveExeption $e) {
-            throw StorefrontException::reviewNotActive();
         }
 
         $this->hook(new ProductReviewsWidgetLoadedHook($reviews, $context));

--- a/src/Storefront/Controller/ProductController.php
+++ b/src/Storefront/Controller/ProductController.php
@@ -3,6 +3,7 @@
 namespace Shopware\Storefront\Controller;
 
 use Shopware\Core\Content\Product\Exception\ProductNotFoundException;
+use Shopware\Core\Content\Product\Exception\ReviewNotActiveExeption;
 use Shopware\Core\Content\Product\Exception\VariantNotFoundException;
 use Shopware\Core\Content\Product\SalesChannel\FindVariant\AbstractFindProductVariantRoute;
 use Shopware\Core\Content\Product\SalesChannel\Review\AbstractProductReviewLoader;
@@ -13,7 +14,6 @@ use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Storefront\Controller\Exception\StorefrontException;
 use Shopware\Storefront\Framework\Routing\RequestTransformer;
 use Shopware\Storefront\Page\Product\ProductPageLoadedHook;
@@ -43,7 +43,6 @@ class ProductController extends StorefrontController
         private readonly AbstractProductReviewSaveRoute $productReviewSaveRoute,
         private readonly SeoUrlPlaceholderHandlerInterface $seoUrlPlaceholderHandler,
         private readonly AbstractProductReviewLoader $productReviewLoader,
-        private readonly SystemConfigService $systemConfigService,
     ) {
     }
 
@@ -118,8 +117,6 @@ class ProductController extends StorefrontController
     #[Route(path: '/product/{productId}/rating', name: 'frontend.detail.review.save', defaults: ['XmlHttpRequest' => true, '_loginRequired' => true], methods: ['POST'])]
     public function saveReview(string $productId, RequestDataBag $data, SalesChannelContext $context): Response
     {
-        $this->checkReviewsActive($context);
-
         try {
             $this->productReviewSaveRoute->save($productId, $data, $context);
         } catch (ConstraintViolationException $formViolations) {
@@ -129,6 +126,9 @@ class ProductController extends StorefrontController
                 'formViolations' => $formViolations,
                 'data' => $data,
             ], ['productId' => $productId]);
+        } catch (ReviewNotActiveExeption $e) {
+            /** @deprecated tag:v6.8.0 Remove this catch, the exception is then `ProductException::reviewNotActive` */
+            throw StorefrontException::reviewNotActive();
         }
 
         $forwardParams = [
@@ -148,9 +148,12 @@ class ProductController extends StorefrontController
     #[Route(path: '/product/{productId}/reviews', name: 'frontend.product.reviews', defaults: ['XmlHttpRequest' => true], methods: ['GET', 'POST'])]
     public function loadReviews(string $productId, Request $request, SalesChannelContext $context): Response
     {
-        $this->checkReviewsActive($context);
-
-        $reviews = $this->productReviewLoader->load($request, $context, $productId, $request->get('parentId'));
+        /** @deprecated tag:v6.8.0 Remove complete try catch block, the exception is then `ProductException::reviewNotActive` */
+        try {
+            $reviews = $this->productReviewLoader->load($request, $context, $productId, $request->get('parentId'));
+        } catch (ReviewNotActiveExeption $e) {
+            throw StorefrontException::reviewNotActive();
+        }
 
         $this->hook(new ProductReviewsWidgetLoadedHook($reviews, $context));
 
@@ -158,17 +161,5 @@ class ProductController extends StorefrontController
             'reviews' => $reviews,
             'ratingSuccess' => $request->get('success'),
         ]);
-    }
-
-    /**
-     * @throws StorefrontException
-     */
-    private function checkReviewsActive(SalesChannelContext $context): void
-    {
-        $showReview = $this->systemConfigService->get('core.listing.showReview', $context->getSalesChannelId());
-
-        if (!$showReview) {
-            throw StorefrontException::reviewNotActive();
-        }
     }
 }

--- a/src/Storefront/DependencyInjection/controller.xml
+++ b/src/Storefront/DependencyInjection/controller.xml
@@ -197,7 +197,6 @@
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewSaveRoute"/>
             <argument type="service" id="Shopware\Core\Content\Seo\SeoUrlPlaceholderHandlerInterface"/>
             <argument type="service" id="Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewLoader"/>
-            <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService" />
 
             <call method="setContainer">
                 <argument type="service" id="service_container"/>

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewRouteTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewRouteTest.php
@@ -1,0 +1,119 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Product\SalesChannel\Review;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Checkout\Customer\CustomerEntity;
+use Shopware\Core\Content\Product\ProductException;
+use Shopware\Core\Content\Product\SalesChannel\Review\ProductReviewRoute;
+use Shopware\Core\Framework\Adapter\Cache\Event\AddCacheTagEvent;
+use Shopware\Core\Framework\Context;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityRepository;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\MultiFilter;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\System\SalesChannel\SalesChannelContext;
+use Shopware\Core\Test\Stub\SystemConfigService\StaticSystemConfigService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ */
+#[CoversClass(ProductReviewRoute::class)]
+class ProductReviewRouteTest extends TestCase
+{
+    private MockObject&EntityRepository $repository;
+
+    private StaticSystemConfigService $config;
+
+    private MockObject&EventDispatcherInterface $eventDispatcher;
+
+    private ProductReviewRoute $route;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(EntityRepository::class);
+        $this->config = new StaticSystemConfigService([
+            'test' => [
+                'core.listing.showReview' => true,
+                'core.basicInformation.email' => 'noreply@example.com',
+            ],
+            'testReviewNotActive' => [
+                'core.listing.showReview' => false,
+                'core.basicInformation.email' => 'noreply@example.com',
+            ],
+        ]);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $this->route = new ProductReviewRoute(
+            $this->repository,
+            $this->config,
+            $this->eventDispatcher
+        );
+    }
+
+    public function testLoad(): void
+    {
+        $productId = Uuid::randomHex();
+        $context = Context::createDefaultContext();
+        $customer = new CustomerEntity();
+        $customer->setId(Uuid::randomHex());
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->expects($this->once())->method('getCustomer')->willReturn($customer);
+        $salesChannelContext->expects($this->exactly(1))->method('getSalesChannelId')->willReturn('test');
+        $salesChannelContext->expects($this->exactly(1))->method('getContext')->willReturn($context);
+
+        $expectedCriteria = new Criteria();
+        $expectedCriteria->setTitle('product-review-route');
+        $expectedCriteria->addFilter(
+            new MultiFilter(MultiFilter::CONNECTION_AND, [
+                new MultiFilter(MultiFilter::CONNECTION_OR, [
+                    new EqualsFilter('status', true),
+                    new EqualsFilter('customerId', $customer->getId()),
+                ]),
+                new MultiFilter(MultiFilter::CONNECTION_OR, [
+                    new EqualsFilter('product.id', $productId),
+                    new EqualsFilter('product.parentId', $productId),
+                ]),
+            ])
+        );
+
+        $this->repository
+            ->expects($this->once())
+            ->method('search')
+            ->with($expectedCriteria, $context);
+
+        $event = new AddCacheTagEvent($this->route::buildName($productId));
+        $this->eventDispatcher
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($event);
+
+        $this->route->load(
+            $productId,
+            new Request(),
+            $salesChannelContext,
+            new Criteria(),
+        );
+    }
+
+    public function testLoadReviewDeactivated(): void
+    {
+        $this->expectExceptionObject(ProductException::reviewNotActive());
+
+        $salesChannelContext = $this->createMock(SalesChannelContext::class);
+        $salesChannelContext->expects($this->exactly(1))->method('getSalesChannelId')->willReturn('testReviewNotActive');
+
+        $this->route->load(
+            Uuid::randomHex(),
+            new Request(),
+            $salesChannelContext,
+            new Criteria(),
+        );
+    }
+}

--- a/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
+++ b/tests/unit/Core/Content/Product/SalesChannel/Review/ProductReviewsWidgetLoadedHookTest.php
@@ -19,7 +19,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Uuid\Uuid;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
 use Shopware\Storefront\Page\Product\ProductPageLoader;
 use Shopware\Storefront\Page\Product\QuickView\MinimalQuickViewPageLoader;
@@ -33,15 +32,12 @@ use Symfony\Component\HttpFoundation\Request;
 #[CoversClass(ProductReviewsWidgetLoadedHook::class)]
 class ProductReviewsWidgetLoadedHookTest extends TestCase
 {
-    private MockObject&SystemConfigService $systemConfigServiceMock;
-
     private MockObject&ProductReviewLoader $productReviewLoaderMock;
 
     private ProductControllerStub $controller;
 
     protected function setUp(): void
     {
-        $this->systemConfigServiceMock = $this->createMock(SystemConfigService::class);
         $this->productReviewLoaderMock = $this->createMock(ProductReviewLoader::class);
 
         $this->controller = new ProductControllerStub(
@@ -51,15 +47,12 @@ class ProductReviewsWidgetLoadedHookTest extends TestCase
             $this->createMock(AbstractProductReviewSaveRoute::class),
             $this->createMock(SeoUrlPlaceholderHandlerInterface::class),
             $this->productReviewLoaderMock,
-            $this->systemConfigServiceMock,
         );
     }
 
     public function testHookTriggeredWhenProductReviewsWidgetIsLoaded(): void
     {
         $ids = new IdsCollection();
-
-        $this->systemConfigServiceMock->method('get')->with('core.listing.showReview')->willReturn(true);
 
         $productId = Uuid::randomHex();
         $parentId = Uuid::randomHex();

--- a/tests/unit/Storefront/Controller/ProductControllerTest.php
+++ b/tests/unit/Storefront/Controller/ProductControllerTest.php
@@ -27,9 +27,7 @@ use Shopware\Core\Framework\Validation\DataBag\RequestDataBag;
 use Shopware\Core\Framework\Validation\Exception\ConstraintViolationException;
 use Shopware\Core\System\SalesChannel\NoContentResponse;
 use Shopware\Core\System\SalesChannel\SalesChannelContext;
-use Shopware\Core\System\SystemConfig\SystemConfigService;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
-use Shopware\Storefront\Controller\Exception\StorefrontException;
 use Shopware\Storefront\Controller\ProductController;
 use Shopware\Storefront\Page\Product\ProductPage;
 use Shopware\Storefront\Page\Product\ProductPageLoader;
@@ -57,8 +55,6 @@ class ProductControllerTest extends TestCase
 
     private MockObject&AbstractProductReviewSaveRoute $productReviewSaveRouteMock;
 
-    private MockObject&SystemConfigService $systemConfigServiceMock;
-
     private MockObject&ProductReviewLoader $productReviewLoaderMock;
 
     private ProductControllerStub $controller;
@@ -70,7 +66,6 @@ class ProductControllerTest extends TestCase
         $this->seoUrlPlaceholderHandlerMock = $this->createMock(SeoUrlPlaceholderHandlerInterface::class);
         $this->minimalQuickViewPageLoaderMock = $this->createMock(MinimalQuickViewPageLoader::class);
         $this->productReviewSaveRouteMock = $this->createMock(AbstractProductReviewSaveRoute::class);
-        $this->systemConfigServiceMock = $this->createMock(SystemConfigService::class);
         $this->productReviewLoaderMock = $this->createMock(ProductReviewLoader::class);
 
         $this->controller = new ProductControllerStub(
@@ -80,7 +75,6 @@ class ProductControllerTest extends TestCase
             $this->productReviewSaveRouteMock,
             $this->seoUrlPlaceholderHandlerMock,
             $this->productReviewLoaderMock,
-            $this->systemConfigServiceMock,
         );
     }
 
@@ -185,28 +179,9 @@ class ProductControllerTest extends TestCase
         static::assertInstanceOf(ProductQuickViewWidgetLoadedHook::class, $this->controller->calledHook);
     }
 
-    public function testSaveReviewDeactivated(): void
-    {
-        $ids = new IdsCollection();
-
-        $this->systemConfigServiceMock->method('get')->with('core.listing.showReview')->willReturn(false);
-
-        $requestBag = new RequestDataBag(['test' => 'test']);
-
-        $this->expectExceptionObject(StorefrontException::reviewNotActive());
-
-        $this->controller->saveReview(
-            $ids->get('productId'),
-            $requestBag,
-            $this->createMock(SalesChannelContext::class)
-        );
-    }
-
     public function testSaveReview(): void
     {
         $ids = new IdsCollection();
-
-        $this->systemConfigServiceMock->method('get')->with('core.listing.showReview')->willReturn(true);
 
         $requestBag = new RequestDataBag(['test' => 'test']);
 
@@ -260,8 +235,6 @@ class ProductControllerTest extends TestCase
     {
         $ids = new IdsCollection();
 
-        $this->systemConfigServiceMock->method('get')->with('core.listing.showReview')->willReturn(true);
-
         $requestBag = new RequestDataBag(['test' => 'test']);
 
         $violations = new ConstraintViolationException(new ConstraintViolationList(), []);
@@ -291,8 +264,6 @@ class ProductControllerTest extends TestCase
     public function testLoadReviewResults(): void
     {
         $ids = new IdsCollection();
-
-        $this->systemConfigServiceMock->method('get')->with('core.listing.showReview')->willReturn(true);
 
         $productId = Uuid::randomHex();
         $parentId = Uuid::randomHex();


### PR DESCRIPTION
### 1. Why is this change necessary?
Currently the behavior, when the reviews are not active, is not consistent. The reviews cannot be saved, if they are disabled, but can be loaded, as the check happens also in the `ProductController`

### 2. What does this change do, exactly?
Move the review active check into the corresponding review routes and remove it from the `ProductController`.

### 3. Describe each step to reproduce the issue or behaviour.
\-

### 4. Please link to the relevant issues (if any).
\-

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
