### PR TITLE
fix: use router.currentRoute in tracingInterceptor

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.js
@@ -376,7 +376,7 @@ function tracingInterceptor(client) {
      */
     if (process.env.NODE_ENV !== 'test') {
         client.interceptors.request.use((config) => {
-            const currentRoute = Shopware?.Application?.view?.router?.history?.current?.name;
+            const currentRoute = Shopware?.Application?.view?.router?.currentRoute?.value?.name;
 
             if (currentRoute) {
                 config.headers['shopware-admin-active-route'] = currentRoute;

--- a/src/Administration/Resources/app/administration/src/core/factory/http.factory.spec.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/http.factory.spec.js
@@ -134,8 +134,8 @@ describe('core/factory/http.factory.js', () => {
     it('should add current vue route, as http header to trace', async () => {
         Shopware.Application.view = {
             router: {
-                history: {
-                    current: {
+                currentRoute: {
+                    value: {
                         name: 'sw-dashboard-index',
                     },
                 },


### PR DESCRIPTION
### 1. Why is this change necessary?
Shopware?.Application?.view?.router?.history?.current?.name no longer seems to be valid

### 2. What does this change do, exactly?
Use valid value to determine the current route

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
