### PR TITLE
fix: flow builder action labelled as unknown

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/index.js
@@ -167,6 +167,7 @@ export default {
                 'sequences',
                 'appActions',
                 'getSelectedAppAction',
+                'hasAvailableAction',
             ],
         ),
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-flow/component/sw-flow-sequence-action/index.js
@@ -528,10 +528,6 @@ export default {
             return actions;
         },
 
-        hasAvailableAction(actionName) {
-            return this.availableActions.includes(actionName);
-        },
-
         isValidAction(actionName) {
             return actionName && this.hasAvailableAction(actionName);
         },


### PR DESCRIPTION
### 1. Why is this change necessary?
Fixes the issue when creating an ‘add tag’-action with the entity 'customer' in the Flow Builder, the action will be displayed as “unknown action”. 
The actions are generalized `action.add.customer.tag` and `action.add.order.tag` getting replaced with `action.add.entity.tag`. The second one is then filtered out because it gets recognized as a duplicate.

### 2. What does this change do, exactly?
Puts the `hasAvailableAction` in the mapState so the function works correctly


### 3. Describe each step to reproduce the issue or behaviour.
1. Create a Flow in the Flow Builder
2. Use Checkout-Order-placed
3. Add action addTag for the Order and Customer Entity
4. Only the Customer Entity is displayed as Unknown

In case of issue existing only on Jira, link to the Jira issue.
--> https://shopware.atlassian.net/browse/NEXT-40925

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
