### PR TITLE
fix: missing final open order transaction in state history modal

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-state-history-modal/index.ts
@@ -232,12 +232,26 @@ export default Component.wrapComponentConfig({
                 entries.push(this.createEntry(states, entry));
             });
 
+            const lastTransaction = this.order.transactions?.last();
+            if (!!lastTransaction && !knownTransactionIds.includes(lastTransaction.id)) {
+                entries.push(
+                    this.createEntry(
+                        {
+                            ...states,
+                            // @ts-expect-error - states exists
+                            order_transaction: lastTransaction?.stateMachineState,
+                        },
+                        lastTransaction,
+                    ),
+                );
+            }
+
             return entries;
         },
 
         createEntry(
             states: CombinedStates,
-            entry: Entity<'state_machine_history'> | Entity<'order'>,
+            entry: Entity<'state_machine_history'> | Entity<'order'> | Entity<'order_transaction'>,
         ): StateMachineHistoryData {
             return {
                 order: states.order,
@@ -245,8 +259,8 @@ export default Component.wrapComponentConfig({
                 delivery: states.order_delivery,
                 createdAt: 'orderDateTime' in entry ? entry.orderDateTime : entry.createdAt,
                 user: 'user' in entry ? entry.user : undefined,
-                entity: 'entityName' in entry ? entry.entityName : 'order',
-                referencedId: 'referencedId' in entry ? entry.referencedId : undefined,
+                entity: 'entityName' in entry ? entry.entityName : entry.getEntityName(),
+                referencedId: 'referencedId' in entry ? entry.referencedId : entry.id,
             };
         },
 


### PR DESCRIPTION
If there is a final order transaction with an open state (AKA no history), the line in the state history modal was missing for that.
Also, I restructured the test a bit, because collections were not correctly used.

fixes #7330 