### PR TITLE
fix: Add/Remove order tags admin

### DIFF
--- a/changelog/_unreleased/2025-03-21-fix-add-remove-order-tags.md
+++ b/changelog/_unreleased/2025-03-21-fix-add-remove-order-tags.md
@@ -1,0 +1,12 @@
+---
+title: Fix add/remove order tags
+issue: https://github.com/shopware/shopware/issues/7473
+author_github: @En0Ma1259
+---
+# Core
+* Added new `sync` method to `Shopware\Core\Framework\DataAbstractionLayer\VersionManager`
+* Changed `Shopware\Core\Framework\Api\Sync\SyncService` constructor type `Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface` to `Shopware\Core\Framework\DataAbstractionLayer\VersionManager`. Now calling `VersionManager::sync` in `SyncService::sync` 
+___
+# Administration
+* Changed use sync call for admin order saves
+* Changed saving and removing tags not in separat calls, but on saving order

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/index.js
@@ -6,8 +6,7 @@ import template from './sw-order-general-info.html.twig';
  */
 
 const { Mixin, Store } = Shopware;
-const { Criteria, EntityCollection } = Shopware.Data;
-const { cloneDeep } = Shopware.Utils.object;
+const { Criteria } = Shopware.Data;
 
 // eslint-disable-next-line sw-deprecation-rules/private-feature-declarations
 export default {
@@ -189,17 +188,6 @@ export default {
 
     methods: {
         createdComponent() {
-            const tags = cloneDeep(this.order.tags);
-
-            this.tagCollection = new EntityCollection(
-                this.order.tags.source,
-                this.order.tags.entity,
-                Shopware.Context.api,
-                null,
-                tags,
-                tags.length,
-            );
-
             this.getLiveOrder();
             this.getTransitionOptions();
         },
@@ -212,16 +200,8 @@ export default {
             });
         },
 
-        onTagAdd(item) {
-            this.orderTagRepository.assign(item.id).then(() => {
-                this.tagCollection.add(item);
-            });
-        },
-
-        onTagRemove(item) {
-            this.orderTagRepository.delete(item.id).then(() => {
-                this.tagCollection.remove(item.id);
-            });
+        setTagCollection(tags) {
+            this.order.tags = tags;
         },
 
         getAllStates() {

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-general-info/sw-order-general-info.html.twig
@@ -159,14 +159,13 @@
 
     {% block sw_order_detail_base_general_info_order_tags %}
     <sw-entity-tag-select
-        v-model:entity-collection="tagCollection"
+        v-model:entity-collection="order.tags"
         class="sw-order-general-info__order-tags"
         size="small"
         :disabled="!acl.can('order.editor')"
         :placeholder="$tc('sw-order.generalTab.tagSelect.placeholder')"
         :always-show-placeholder="true"
-        @item-add="onTagAdd"
-        @item-remove="onTagRemove"
+        @update:entity-collection="setTagCollection"
     />
     {% endblock %}
 </div>

--- a/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/page/sw-order-detail/index.js
@@ -108,7 +108,9 @@ export default {
         },
 
         orderRepository() {
-            return this.repositoryFactory.create('order');
+            return this.repositoryFactory.create('order', null, {
+                useSync: true,
+            });
         },
 
         automaticPromotions() {

--- a/src/Core/Framework/Api/Sync/SyncService.php
+++ b/src/Core/Framework/Api/Sync/SyncService.php
@@ -14,7 +14,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Indexing\EntityIndexerRegistry;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
+use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteContext;
 use Shopware\Core\Framework\Log\Package;
 use Shopware\Core\Framework\Struct\ArrayEntity;
@@ -27,7 +27,7 @@ class SyncService implements SyncServiceInterface
      * @internal
      */
     public function __construct(
-        private readonly EntityWriterInterface $writer,
+        private readonly VersionManager $versionManager,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly DefinitionInstanceRegistry $registry,
         private readonly EntitySearcherInterface $searcher,
@@ -55,7 +55,7 @@ class SyncService implements SyncServiceInterface
             $context->addState($behavior->getIndexingBehavior());
         }
 
-        $result = $this->writer->sync($operations, WriteContext::createFromContext($context));
+        $result = $this->versionManager->sync($operations, WriteContext::createFromContext($context));
 
         $writes = EntityWrittenContainerEvent::createWithWrittenEvents($result->getWritten(), $context, []);
         $deletes = EntityWrittenContainerEvent::createWithDeletedEvents($result->getDeleted(), $context, []);

--- a/src/Core/Framework/DataAbstractionLayer/VersionManager.php
+++ b/src/Core/Framework/DataAbstractionLayer/VersionManager.php
@@ -227,6 +227,26 @@ class VersionManager
     }
 
     /**
+     * @param list<SyncOperation> $operations
+     */
+    public function sync(array $operations, WriteContext $context): WriteResult
+    {
+        $result = $this->entityWriter->sync($operations, $context);
+        if ($context->getContext()->hasState(self::DISABLE_AUDIT_LOG)) {
+            return $result;
+        }
+
+        if ($context->getContext()->getVersionId() === Defaults::LIVE_VERSION) {
+            return $result;
+        }
+
+        $this->writeAuditLog($result->getWritten(), $context);
+        $this->writeAuditLog($result->getDeleted(), $context);
+
+        return $result;
+    }
+
+    /**
      * @return array<string, array<EntityWriteResult>>
      */
     private function cloneEntity(
@@ -470,7 +490,7 @@ class VersionManager
                 continue;
             }
 
-            $definition = $this->registry->getByEntityName($items[0]->getEntityName());
+            $definition = $this->registry->getByEntityName($items[array_key_first($items)]->getEntityName());
             $entityName = $definition->getEntityName();
 
             if (!$definition->isVersionAware()) {

--- a/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
+++ b/src/Core/Framework/DependencyInjection/data-abstraction-layer.xml
@@ -650,7 +650,7 @@
         </service>
 
         <service id="Shopware\Core\Framework\Api\Sync\SyncService" public="true">
-            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter"/>
+            <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\VersionManager"/>
             <argument type="service" id="event_dispatcher"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry"/>
             <argument type="service" id="Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearcherInterface"/>

--- a/tests/unit/Core/Framework/Api/Sync/SyncServiceTest.php
+++ b/tests/unit/Core/Framework/Api/Sync/SyncServiceTest.php
@@ -22,9 +22,8 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\IdSearchResult;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Parser\AggregationParser;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder;
+use Shopware\Core\Framework\DataAbstractionLayer\VersionManager;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriteGatewayInterface;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriter;
-use Shopware\Core\Framework\DataAbstractionLayer\Write\EntityWriterInterface;
 use Shopware\Core\Framework\DataAbstractionLayer\Write\WriteResult;
 use Shopware\Core\Test\Stub\DataAbstractionLayer\StaticDefinitionInstanceRegistry;
 use Shopware\Core\Test\Stub\Framework\IdsCollection;
@@ -50,7 +49,7 @@ class SyncServiceTest extends TestCase
             ]
         );
 
-        $writer = $this->createMock(EntityWriterInterface::class);
+        $writer = $this->createMock(VersionManager::class);
         $writer
             ->expects($this->once())
             ->method('sync')
@@ -126,7 +125,7 @@ class SyncServiceTest extends TestCase
             ->with($registry->get(ProductCategoryDefinition::class), $criteria);
 
         $service = new SyncService(
-            $this->createMock(EntityWriter::class),
+            $this->createMock(VersionManager::class),
             new EventDispatcher(),
             $registry,
             $searcher,
@@ -144,7 +143,7 @@ class SyncServiceTest extends TestCase
 
     public function testWildcardDeleteForMappingEntities(): void
     {
-        $writer = $this->createMock(EntityWriterInterface::class);
+        $writer = $this->createMock(VersionManager::class);
         $writer
             ->expects($this->once())
             ->method('sync')


### PR DESCRIPTION
In the admin in the order details, the Tags-Field does not work like expected.

Add a Tag → field stays blank
Reload → added Tag is displayed
Remove Tag → “X” over the Tag is not aligned correctly, Tag is still displayed
Remove Tag again → error message

Also, it is weird that you don’t have to save after adding/removing tags, but that is not new in 6.7