### PR TITLE
fix: don't use deprecated monolog test class

### DIFF
--- a/tests/unit/Core/Checkout/Customer/Validation/AddressValidationFactoryTest.php
+++ b/tests/unit/Core/Checkout/Customer/Validation/AddressValidationFactoryTest.php
@@ -2,8 +2,8 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Customer\Validation;
 
-use Monolog\Test\MonologTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Customer\Validation\AddressValidationFactory;
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 #[Package('checkout')]
 #[CoversClass(AddressValidationFactory::class)]
-class AddressValidationFactoryTest extends MonologTestCase
+class AddressValidationFactoryTest extends TestCase
 {
     private AddressValidationFactory $addressValidationFactory;
 

--- a/tests/unit/Core/Checkout/Customer/Validation/AddressValidationFactoryTest.php
+++ b/tests/unit/Core/Checkout/Customer/Validation/AddressValidationFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Customer\Validation;
 
-use Monolog\Test\TestCase;
+use Monolog\Test\MonologTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 #[Package('checkout')]
 #[CoversClass(AddressValidationFactory::class)]
-class AddressValidationFactoryTest extends TestCase
+class AddressValidationFactoryTest extends MonologTestCase
 {
     private AddressValidationFactory $addressValidationFactory;
 

--- a/tests/unit/Core/Checkout/Order/Validation/OrderValidationFactoryTest.php
+++ b/tests/unit/Core/Checkout/Order/Validation/OrderValidationFactoryTest.php
@@ -2,8 +2,8 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Order\Validation;
 
-use Monolog\Test\MonologTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
 use Shopware\Core\Checkout\Order\Validation\OrderValidationFactory;
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 #[Package('checkout')]
 #[CoversClass(OrderValidationFactory::class)]
-class OrderValidationFactoryTest extends MonologTestCase
+class OrderValidationFactoryTest extends TestCase
 {
     private SalesChannelContext $salesChannelContext;
 

--- a/tests/unit/Core/Checkout/Order/Validation/OrderValidationFactoryTest.php
+++ b/tests/unit/Core/Checkout/Order/Validation/OrderValidationFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Shopware\Tests\Unit\Core\Checkout\Order\Validation;
 
-use Monolog\Test\TestCase;
+use Monolog\Test\MonologTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Shopware\Core\Checkout\Customer\Aggregate\CustomerAddress\CustomerAddressEntity;
 use Shopware\Core\Checkout\Customer\CustomerEntity;
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Constraints\NotBlank;
  */
 #[Package('checkout')]
 #[CoversClass(OrderValidationFactory::class)]
-class OrderValidationFactoryTest extends TestCase
+class OrderValidationFactoryTest extends MonologTestCase
 {
     private SalesChannelContext $salesChannelContext;
 


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfill our contribution guideline (https://developer.shopware.com/docs/resources/guidelines/code/contribution?category=shopware-platform-dev-en/contribution).

Do your changes need to be mentioned in the documentation?
Please create a second pull request at https://github.com/shopware/docs
-->

### 1. Why is this change necessary?


### 2. What does this change do, exactly?


### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
