### PR TITLE
fix: import export profile creation from existing file

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-import-export/service/importExport.service.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-import-export/service/importExport.service.ts
@@ -104,7 +104,7 @@ export default class ImportExportService extends ApiService {
 
         return this.httpClient
             .post('/_action/import-export/mapping-from-template', formData, {
-                headers: this.getBasicHeaders(),
+                headers: this.getBasicHeaders({ 'Content-Type': 'multipart/form-data' }),
             })
             .then((response) => {
                 if (!response.data) {


### PR DESCRIPTION
### 1. Why is this change necessary?
The file is not being sent with the other data and will therefore not be recognized / will be empty.

### 2. What does this change do, exactly?
Adds an `additionalHeader` content-type to the request of the "mapping-from-template" route.

### 3. Describe each step to reproduce the issue or behaviour.
1. Go the import-export
2. Create an export of for examply customers
3. Go under Profiles and "Add new profile"
4. Fill out the fields and click on "next"
5. Upload the csv file
6. Gets an error every time

### 4. Please link to the relevant issues (if any).

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-41148


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfill them.
