### PR TITLE
fix: don't serialize context extensions

### DIFF
--- a/src/Core/Framework/Context.php
+++ b/src/Core/Framework/Context.php
@@ -63,6 +63,49 @@ class Context extends Struct
     }
 
     /**
+     * Extension are not serialized, as they could be anything and make problems during serialization,
+     * for symfony serializer they are exlcuded by the #[Exclude] attribute already
+     *
+     * @return array<mixed>
+     */
+    public function __serialize(): array
+    {
+        return [
+            $this->source,
+            $this->ruleIds,
+            $this->currencyId,
+            $this->languageIdChain,
+            $this->versionId,
+            $this->currencyFactor,
+            $this->considerInheritance,
+            $this->taxState,
+            $this->rounding,
+            $this->scope,
+            $this->states,
+        ];
+    }
+
+    /**
+     * @param array<mixed> $data
+     */
+    public function __unserialize(array $data): void
+    {
+        [
+            $this->source,
+            $this->ruleIds,
+            $this->currencyId,
+            $this->languageIdChain,
+            $this->versionId,
+            $this->currencyFactor,
+            $this->considerInheritance,
+            $this->taxState,
+            $this->rounding,
+            $this->scope,
+            $this->states,
+        ] = $data;
+    }
+
+    /**
      * @internal
      */
     public static function createDefaultContext(?ContextSource $source = null): self

--- a/tests/unit/Core/Framework/ContextTest.php
+++ b/tests/unit/Core/Framework/ContextTest.php
@@ -90,5 +90,40 @@ class ContextTest extends TestCase
         static::assertInstanceOf(Context::class, $deserialized);
 
         static::assertEmpty($deserialized->getVars()['extensions']);
+        static::assertEqualsCanonicalizing($context->getSource(), $deserialized->getSource());
+        static::assertEqualsCanonicalizing($context->getRounding(), $deserialized->getRounding());
+        static::assertSame($context->getRuleIds(), $deserialized->getRuleIds());
+        static::assertSame($context->getVersionId(), $deserialized->getVersionId());
+        static::assertSame($context->getScope(), $deserialized->getScope());
+        static::assertSame($context->getTaxState(), $deserialized->getTaxState());
+        static::assertSame($context->getStates(), $deserialized->getStates());
+        static::assertSame($context->getCurrencyId(), $deserialized->getCurrencyId());
+        static::assertSame($context->getCurrencyFactor(), $deserialized->getCurrencyFactor());
+        static::assertSame($context->getLanguageIdChain(), $deserialized->getLanguageIdChain());
+        static::assertSame($context->considerInheritance(), $deserialized->considerInheritance());
+    }
+
+    public function testExtensionsAreStrippedOnNativeSerialize(): void
+    {
+        $context = Context::createDefaultContext();
+
+        $context->addExtension('foo', new ArrayEntity());
+
+        $deserialized = unserialize(serialize($context));
+
+        static::assertInstanceOf(Context::class, $deserialized);
+
+        static::assertEmpty($deserialized->getVars()['extensions']);
+        static::assertEqualsCanonicalizing($context->getSource(), $deserialized->getSource());
+        static::assertEqualsCanonicalizing($context->getRounding(), $deserialized->getRounding());
+        static::assertSame($context->getRuleIds(), $deserialized->getRuleIds());
+        static::assertSame($context->getVersionId(), $deserialized->getVersionId());
+        static::assertSame($context->getScope(), $deserialized->getScope());
+        static::assertSame($context->getTaxState(), $deserialized->getTaxState());
+        static::assertSame($context->getStates(), $deserialized->getStates());
+        static::assertSame($context->getCurrencyId(), $deserialized->getCurrencyId());
+        static::assertSame($context->getCurrencyFactor(), $deserialized->getCurrencyFactor());
+        static::assertSame($context->getLanguageIdChain(), $deserialized->getLanguageIdChain());
+        static::assertSame($context->considerInheritance(), $deserialized->considerInheritance());
     }
 }


### PR DESCRIPTION
Fixes #7534

THe SwagPublisher plugin adds an extension that is not serializable: https://github.com/shopware/SwagPublisher/blob/2409e3012d8b0bb3f6098d31489b7062ae1b0e2c/src/Common/UpdateChangeContextExtension.php#L21

when we send mails the whole thing is seralized in the flow store: https://github.com/shopware/shopware/blob/4405a9e98995d0ea53203fe085f50078b32fd71b/src/Core/Content/Flow/Dispatching/Storer/MessageStorer.php#L24

There it breaks because the message includes the context, it only breaks with 6.7 as before the extensions property was not typed and therefore probably ignored during serialization, for symfony serializer we already excluded it

Alternative could be to use the symfony serializer in the flow store, however I could not make that work (there were some issues unserializing the serialized data) and it would lead to compatibility issues when an old serialized flow is unserialized