### PR TITLE
fix: Prevent CmsDataResolver merging same criteria results on different entities

### DIFF
--- a/changelog/_unreleased/2025-03-24-fix-cmsdataresolver-same-criteria-different-entities.md
+++ b/changelog/_unreleased/2025-03-24-fix-cmsdataresolver-same-criteria-different-entities.md
@@ -1,0 +1,9 @@
+---
+title: Fix CmsDataResolver same Criteria different Entities
+author: Fayti1703
+author_email: fayti1703@protonmail.com
+author_github: @Fayti1703
+---
+# Core
+* Changed `CmsSlotsDataResolver` to correctly resolve the search results if multiple entity types are searched with the same criteria.
+___

--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
@@ -190,7 +190,7 @@ class CmsSlotsDataResolver
                     $result = $repository->search($criteria, $context->getContext());
                 }
 
-                $searchResults[$criteriaHash] = $result;
+                $searchResults[$definitionClass][$criteriaHash] = $result;
             }
         }
 
@@ -318,7 +318,7 @@ class CmsSlotsDataResolver
             return;
         }
 
-        foreach ($criteriaObjects[$slot->getUniqueIdentifier()] as $criterias) {
+        foreach ($criteriaObjects[$slot->getUniqueIdentifier()] as $definition => $criterias) {
             foreach ($criterias as $key => $criteria) {
                 if (!$criteria->hasExtension('criteriaHash')) {
                     continue;
@@ -327,11 +327,11 @@ class CmsSlotsDataResolver
                 /** @var ArrayEntity $hashArrayEntity */
                 $hashArrayEntity = $criteria->getExtension('criteriaHash');
                 $hash = $hashArrayEntity->get('hash');
-                if (!isset($searchResults[$hash])) {
+                if (!isset($searchResults[$definition][$hash])) {
                     continue;
                 }
 
-                $result->add($key, $searchResults[$hash]);
+                $result->add($key, $searchResults[$definition][$hash]);
             }
         }
     }

--- a/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
+++ b/src/Core/Content/Cms/DataResolver/CmsSlotsDataResolver.php
@@ -114,7 +114,7 @@ class CmsSlotsDataResolver
      *
      * @param array<CriteriaCollection> $criteriaList
      * @param array<EntitySearchResult<TEntityCollection>> $identifierResult
-     * @param array<EntitySearchResult<TEntityCollection>> $criteriaResult
+     * @param array<array<EntitySearchResult<TEntityCollection>>> $criteriaResult
      */
     private function enrichCmsSlots(
         CmsSlotCollection $slots,
@@ -172,7 +172,7 @@ class CmsSlotsDataResolver
     /**
      * @param array<string, array<string, Criteria>> $searches
      *
-     * @return array<string, EntitySearchResult<EntityCollection>>
+     * @return array<string, array<string, EntitySearchResult<EntityCollection>>>
      */
     private function fetchByCriteria(array $searches, SalesChannelContext $context): array
     {
@@ -310,7 +310,7 @@ class CmsSlotsDataResolver
      * @template TEntityCollection of EntityCollection
      *
      * @param array<string, CriteriaCollection> $criteriaObjects
-     * @param array<string, EntitySearchResult<TEntityCollection>> $searchResults
+     * @param array<string, array<EntitySearchResult<TEntityCollection>>> $searchResults
      */
     private function mapSearchResults(ElementDataCollection $result, CmsSlotEntity $slot, array $criteriaObjects, array $searchResults): void
     {

--- a/src/Core/Content/Cms/Extension/CmsSlotsDataEnrichExtension.php
+++ b/src/Core/Content/Cms/Extension/CmsSlotsDataEnrichExtension.php
@@ -60,7 +60,7 @@ final class CmsSlotsDataEnrichExtension extends Extension
          *
          * @description The fetched slot data which was searched by the criteria list
          *
-         * @var array<EntitySearchResult<TEntityCollection>>
+         * @var array<array<string, EntitySearchResult<TEntityCollection>>>
          */
         public readonly array $criteriaResult,
         /**

--- a/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsMultiDataResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsMultiDataResolverTest.php
@@ -1,0 +1,107 @@
+<?php
+declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\DataResolver;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Content\Category\CategoryCollection;
+use Shopware\Core\Content\Category\CategoryDefinition;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotCollection;
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\DataResolver\CmsSlotsDataResolver;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Content\Product\ProductCollection;
+use Shopware\Core\Content\Product\ProductDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\DefinitionInstanceRegistry;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+use Shopware\Core\Framework\Extensions\ExtensionDispatcher;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository;
+use Shopware\Core\Test\Generator;
+use Shopware\Tests\Unit\Core\Content\Cms\DataResolver\Fixtures\MultiCmsElementResolver;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\HttpFoundation\Request;
+
+#[Package('discovery')]
+#[CoversClass(CmsSlotsDataResolver::class)]
+class CmsSlotsMultiDataResolverTest extends TestCase
+{
+    private DefinitionInstanceRegistry $registry;
+
+    private ExtensionDispatcher $extensions;
+
+    protected function setUp(): void
+    {
+        $this->registry = new DefinitionInstanceRegistry(new ContainerBuilder(), [], []);
+        $dispatcher = $this->createMock(EventDispatcher::class);
+        $this->extensions = new ExtensionDispatcher($dispatcher);
+    }
+
+    public function testMultipleDefinitionCriteriaWithSameHashResolveCorrectly(): void
+    {
+        $slots = new CmsSlotCollection([
+            (new CmsSlotEntity())->assign([
+                'id' => 'slot-1',
+                'slot' => 'first',
+                'type' => 'first',
+            ]),
+            (new CmsSlotEntity())->assign([
+                'id' => 'slot-2',
+                'slot' => 'second',
+                'type' => 'second',
+            ]),
+        ]);
+
+        $firstResolver = $this->createResolver('first', ProductDefinition::class);
+        $secondResolver = $this->createResolver('second', CategoryDefinition::class);
+
+        $productDefinition = new ProductDefinition();
+        $categoryDefinition = new CategoryDefinition();
+        $this->registry->register($productDefinition);
+        $this->registry->register($categoryDefinition);
+
+        $productRepository = $this->createRepositoryMock($productDefinition);
+        $categoryRepository = $this->createRepositoryMock($categoryDefinition);
+
+        $resolver = new CmsSlotsDataResolver(
+            [$firstResolver, $secondResolver],
+            ['product' => $productRepository, 'category' => $categoryRepository],
+            $this->registry,
+            $this->extensions
+        );
+
+        $context = Generator::generateSalesChannelContext();
+        $resolverContext = new ResolverContext($context, new Request());
+
+        $resolver->resolve($slots, $resolverContext);
+
+        /** @var EntitySearchResult $firstData */
+        $firstData = $slots->getSlot('first')->getData();
+        static::assertInstanceOf(EntitySearchResult::class, $firstData);
+        static::assertInstanceOf(ProductCollection::class, $firstData->getEntities());
+
+        /** @var EntitySearchResult $secondData */
+        $secondData = $slots->getSlot('second')->getData();
+        static::assertInstanceOf(EntitySearchResult::class, $secondData);
+        static::assertInstanceOf(CategoryCollection::class, $secondData->getEntities());
+    }
+
+    private function createResolver(string $type, string $definition): MultiCmsElementResolver
+    {
+        return new MultiCmsElementResolver($type, $definition);
+    }
+
+    private function createRepositoryMock(EntityDefinition $definition): SalesChannelRepository
+    {
+        $repository = static::createStub(SalesChannelRepository::class);
+        $collection = new ($definition->getCollectionClass())();
+        $result = static::createStub(EntitySearchResult::class);
+        $result->method('getEntities')->willReturn($collection);
+        $repository->method('search')->willReturn($result);
+
+        return $repository;
+    }
+}

--- a/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsMultiDataResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsMultiDataResolverTest.php
@@ -81,13 +81,17 @@ class CmsSlotsMultiDataResolverTest extends TestCase
 
         $resolver->resolve($slots, $resolverContext);
 
-        /** @var EntitySearchResult $firstData */
-        $firstData = $slots->getSlot('first')->getData();
+        /** @var CmsSlotEntity $firstSlot */
+        $firstSlot = $slots->getSlot('first');
+        /** @var EntitySearchResult<ProductCollection> $firstData */
+        $firstData = $firstSlot->getData();
         static::assertInstanceOf(EntitySearchResult::class, $firstData);
         static::assertInstanceOf(ProductCollection::class, $firstData->getEntities());
 
-        /** @var EntitySearchResult $secondData */
-        $secondData = $slots->getSlot('second')->getData();
+        /** @var CmsSlotEntity $secondSlot */
+        $secondSlot = $slots->getSlot('second');
+        /** @var EntitySearchResult<ProductCollection> $secondData */
+        $secondData = $secondSlot->getData();
         static::assertInstanceOf(EntitySearchResult::class, $secondData);
         static::assertInstanceOf(CategoryCollection::class, $secondData->getEntities());
     }

--- a/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsMultiDataResolverTest.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/CmsSlotsMultiDataResolverTest.php
@@ -25,6 +25,9 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @internal
+ */
 #[Package('discovery')]
 #[CoversClass(CmsSlotsDataResolver::class)]
 class CmsSlotsMultiDataResolverTest extends TestCase

--- a/tests/unit/Core/Content/Cms/DataResolver/Fixtures/MultiCmsElementResolver.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/Fixtures/MultiCmsElementResolver.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Unit\Core\Content\Cms\DataResolver\Fixtures;
+
+use Shopware\Core\Content\Cms\Aggregate\CmsSlot\CmsSlotEntity;
+use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
+use Shopware\Core\Content\Cms\DataResolver\Element\CmsElementResolverInterface;
+use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
+use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+
+class MultiCmsElementResolver implements CmsElementResolverInterface
+{
+    public function __construct(
+        private readonly string $type,
+        private readonly string $entity
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function collect(CmsSlotEntity $slot, ResolverContext $resolverContext): ?CriteriaCollection
+    {
+        $criteriaCollection = new CriteriaCollection();
+        $criteria = new Criteria();
+        $criteria->setLimit(1);
+        $criteriaCollection->add('fetch', $this->entity, $criteria);
+
+        return $criteriaCollection;
+    }
+
+    public function enrich(CmsSlotEntity $slot, ResolverContext $resolverContext, ElementDataCollection $result): void
+    {
+        $slot->setData($result->get('fetch'));
+    }
+}

--- a/tests/unit/Core/Content/Cms/DataResolver/Fixtures/MultiCmsElementResolver.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/Fixtures/MultiCmsElementResolver.php
@@ -9,6 +9,9 @@ use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
 
+/**
+ * @internal
+ */
 class MultiCmsElementResolver implements CmsElementResolverInterface
 {
     public function __construct(

--- a/tests/unit/Core/Content/Cms/DataResolver/Fixtures/MultiCmsElementResolver.php
+++ b/tests/unit/Core/Content/Cms/DataResolver/Fixtures/MultiCmsElementResolver.php
@@ -7,7 +7,10 @@ use Shopware\Core\Content\Cms\DataResolver\CriteriaCollection;
 use Shopware\Core\Content\Cms\DataResolver\Element\CmsElementResolverInterface;
 use Shopware\Core\Content\Cms\DataResolver\Element\ElementDataCollection;
 use Shopware\Core\Content\Cms\DataResolver\ResolverContext\ResolverContext;
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Criteria;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
 
 /**
  * @internal
@@ -37,6 +40,8 @@ class MultiCmsElementResolver implements CmsElementResolverInterface
 
     public function enrich(CmsSlotEntity $slot, ResolverContext $resolverContext, ElementDataCollection $result): void
     {
-        $slot->setData($result->get('fetch'));
+        /** @var EntitySearchResult<EntityCollection<Entity>> $fetchResult */
+        $fetchResult = $result->get('fetch');
+        $slot->setData($fetchResult);
     }
 }


### PR DESCRIPTION
### 1. Why is this change necessary?

If two `CmsElementResolver`s try to load entities from two different `EntityDefinition`s using the same `Criteria` (not the same object, but with the same settings), they currently get the same result. This is very surprising, since one resolver might be looking for products and the other for categories.

### 2. What does this change do, exactly?

It adds one more level to the `$searchResults` array build and access to give different fetched EntityDefinitions different key paths.

### 3. Describe each step to reproduce the issue or behaviour.

1. Create a Plugin with two `CmsElementResolver`s. 
2. In the first, return a criteria collection with `$criteriaCollection->add('fetch', ProductDefinition::class, (new Criteria())->setLimit(1))`.
3. In the first, return a criteria collection with `$criteriaCollection->add('fetch', CategoryDefinition::class, (new Criteria())->setLimit(1))`.
4. Dump the resulting `ElementDataCollections`
5. Observe that both get the same results, despite searching for different entity types.

### 4. Please link to the relevant issues (if any).

Closes #3822.

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [x] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
