### PR TITLE
fix: Login scripts

### DIFF
--- a/changelog/_unreleased/2025-03-25-add-login-scripts-to-window.md
+++ b/changelog/_unreleased/2025-03-25-add-login-scripts-to-window.md
@@ -1,0 +1,8 @@
+---
+title: Add login scripts to window
+author: Sebastian Seggewiss
+author_email: s.seggewiss@shopware.com
+author_github: @seggewiss
+---
+# Administration
+* Added `_swLoginOverrides` to window object

--- a/src/Administration/Resources/app/administration/src/global.types.ts
+++ b/src/Administration/Resources/app/administration/src/global.types.ts
@@ -202,7 +202,7 @@ declare global {
         _inAppPurchases_: Record<string, string>;
         processingInactivityLogout?: boolean;
         _sw_extension_component_collection: DevtoolComponent[];
-        // Only available with Vite
+        _swLoginOverrides?: Array<() => void>;
         startApplication: () => void;
     }
 

--- a/src/Administration/Resources/app/administration/src/index.ts
+++ b/src/Administration/Resources/app/administration/src/index.ts
@@ -8,6 +8,12 @@ void import('src/core/shopware').then(async ({ ShopwareInstance }) => {
     // Set the global Shopware instance
     window.Shopware = ShopwareInstance;
 
+    if (window._swLoginOverrides) {
+        window._swLoginOverrides.forEach((script) => {
+            script();
+        });
+    }
+
     // Import the main file
     await import('src/app/main');
 


### PR DESCRIPTION
### 1. Why is this change necessary?
The twig block `administration_login_scripts` allows to apply scripts to ajdust the login. Previously the login scripts where loaded after the global Shopware object was defined. Now with the implementation of vite and the Shopware import being async, the login scripts will be loaded before the Shopware object is defined. This will break `Shopware.Component.` calls for example.

### 2. What does this change do, exactly?
This PR fixes the current approach by pushing all login scripts into a global window array and executing these functions after the Shopware object was defined.


### 3. Describe each step to reproduce the issue or behaviour.
In your plugin load a static login script with a content like this: 

```
if (window._swLoginOverrides === undefined) {
    window._swLoginOverrides = [];
}

window._swLoginOverrides.push(() => {
    // Shopware.Component....
});
```

