### PR TITLE
feat: new config to toggle salutation field for registration

### DIFF
--- a/changelog/_unreleased/2025-03-25-new-config-to-toogle-salutaion-field-on-registration.md
+++ b/changelog/_unreleased/2025-03-25-new-config-to-toogle-salutaion-field-on-registration.md
@@ -4,7 +4,7 @@ issue: https://github.com/shopware/shopware/issues/7480
 author_github: @En0Ma1259
 ---
 # Core
-* Added new `hideSalutation` config to toggle salutation field on registration form
+* Added new `showSalutation` config to toggle salutation field on registration form
 ___
 # Storefront
-* Added check for new config `hideSalutation` in `src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig`
+* Added check for new config `showSalutation` in `src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig`

--- a/changelog/_unreleased/2025-03-25-new-config-to-toogle-salutaion-field-on-registration.md
+++ b/changelog/_unreleased/2025-03-25-new-config-to-toogle-salutaion-field-on-registration.md
@@ -1,0 +1,10 @@
+---
+title: New config to toggle salutation field on registration
+issue: https://github.com/shopware/shopware/issues/7480
+author_github: @En0Ma1259
+---
+# Core
+* Added new `hideSalutation` config to toggle salutation field on registration form
+___
+# Storefront
+* Added check for new config `hideSalutation` in `src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig`

--- a/src/Core/Migration/V6_7/Migration1742897274RegistrationSalutationToggleConfig.php
+++ b/src/Core/Migration/V6_7/Migration1742897274RegistrationSalutationToggleConfig.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Migration\V6_7;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+class Migration1742897274RegistrationSalutationToggleConfig extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1742897274;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $config = $connection->fetchAllAssociativeIndexed(
+            'SELECT `configuration_value` FROM `system_config` WHERE `configuration_key` = ? and `sales_channel_id` is null',
+            ['core.loginRegistration.showSalutation']
+        );
+
+        if (!empty($config)) {
+            return;
+        }
+
+        $connection->insert('system_config', [
+            'id' => Uuid::randomBytes(),
+            'configuration_key' => 'core.loginRegistration.showSalutation',
+            'configuration_value' => json_encode(['_value' => true]),
+            'sales_channel_id' => null,
+            'created_at' => (new \DateTime())->format(Defaults::STORAGE_DATE_TIME_FORMAT),
+        ]);
+    }
+}

--- a/src/Core/System/Resources/config/loginRegistration.xml
+++ b/src/Core/System/Resources/config/loginRegistration.xml
@@ -26,9 +26,9 @@
         </input-field>
 
         <input-field type="bool">
-            <name>hideSalutation</name>
-            <label>Hide salutation</label>
-            <label lang="de-DE">Anrede ausblenden</label>
+            <name>showSalutation</name>
+            <label>Show salutation</label>
+            <label lang="de-DE">Anrede anzeigen</label>
         </input-field>
 
         <input-field type="bool">

--- a/src/Core/System/Resources/config/loginRegistration.xml
+++ b/src/Core/System/Resources/config/loginRegistration.xml
@@ -26,6 +26,12 @@
         </input-field>
 
         <input-field type="bool">
+            <name>hideSalutation</name>
+            <label>Hide salutation</label>
+            <label lang="de-DE">Anrede ausblenden</label>
+        </input-field>
+
+        <input-field type="bool">
             <name>showTitleField</name>
             <label>Show title</label>
             <label lang="de-DE">Titel anzeigen</label>

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -89,49 +89,53 @@
     {% endblock %}
 
     {% block component_address_personal_fields_salutation_title %}
-        <div class="row g-2">
-            {% block component_address_personal_fields_salutation %}
-                {% set salutationOptions %}
-                    {% for salutation in page.salutations %}
-                        <option {% if salutation.id == data.get('salutationId') %}
-                            selected="selected"
-                        {% endif %}
-                            value="{{ salutation.id }}">
-                            {{ salutation.translated.displayName }}
-                        </option>
-                    {% endfor %}
-                {% endset %}
+        {% if not config('core.loginRegistration.hideSalutation') or config('core.loginRegistration.showTitleField') %}
+            <div class="row g-2">
+                {% block component_address_personal_fields_salutation %}
+                    {% if not config('core.loginRegistration.hideSalutation') %}
+                        {% set salutationOptions %}
+                            {% for salutation in page.salutations %}
+                                <option {% if salutation.id == data.get('salutationId') %}
+                                    selected="selected"
+                                {% endif %}
+                                    value="{{ salutation.id }}">
+                                    {{ salutation.translated.displayName }}
+                                </option>
+                            {% endfor %}
+                        {% endset %}
 
-                {% sw_include '@Storefront/storefront/component/form/form-select.html.twig' with {
-                    label: 'account.personalSalutationLabel'|trans|sw_sanitize,
-                    id: idPrefix ~ prefix ~ 'personalSalutation',
-                    name: prefix ? prefix ~ '[salutationId]' : 'salutationId',
-                    options: salutationOptions,
-                    violationPath: '/salutationId',
-                    additionalClass: 'col-md-3 col-sm-6',
-                } %}
-            {% endblock %}
-
-            {% block component_address_personal_fields_title %}
-                {% if config('core.loginRegistration.showTitleField') %}
-                    {% if formViolations.getViolations("/#{prefix}/title") is not empty %}
-                        {% set violationPath = "/#{prefix}/title" %}
-                    {% elseif formViolations.getViolations("/title") is not empty %}
-                        {% set violationPath = "/title" %}
+                        {% sw_include '@Storefront/storefront/component/form/form-select.html.twig' with {
+                            label: 'account.personalSalutationLabel'|trans|sw_sanitize,
+                            id: idPrefix ~ prefix ~ 'personalSalutation',
+                            name: prefix ? prefix ~ '[salutationId]' : 'salutationId',
+                            options: salutationOptions,
+                            violationPath: '/salutationId',
+                            additionalClass: 'col-md-3 col-sm-6',
+                        } %}
                     {% endif %}
+                {% endblock %}
 
-                    {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
-                        label: 'account.personalTitleLabel'|trans|sw_sanitize,
-                        id: idPrefix ~ prefix ~ 'personalTitle',
-                        name: prefix ? prefix ~ '[title]' : 'title',
-                        value: data.get('title'),
-                        autocomplete: 'section-personal honorific-prefix',
-                        violationPath: violationPath,
-                        additionalClass: 'col-md-3 col-sm-6',
-                    } %}
-                {% endif %}
-            {% endblock %}
-        </div>
+                {% block component_address_personal_fields_title %}
+                    {% if config('core.loginRegistration.showTitleField') %}
+                        {% if formViolations.getViolations("/#{prefix}/title") is not empty %}
+                            {% set violationPath = "/#{prefix}/title" %}
+                        {% elseif formViolations.getViolations("/title") is not empty %}
+                            {% set violationPath = "/title" %}
+                        {% endif %}
+
+                        {% sw_include '@Storefront/storefront/component/form/form-input.html.twig' with {
+                            label: 'account.personalTitleLabel'|trans|sw_sanitize,
+                            id: idPrefix ~ prefix ~ 'personalTitle',
+                            name: prefix ? prefix ~ '[title]' : 'title',
+                            value: data.get('title'),
+                            autocomplete: 'section-personal honorific-prefix',
+                            violationPath: violationPath,
+                            additionalClass: 'col-md-3 col-sm-6',
+                        } %}
+                    {% endif %}
+                {% endblock %}
+            </div>
+        {% endif %}
     {% endblock %}
 
     {% block component_address_personal_fields_name %}

--- a/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
+++ b/src/Storefront/Resources/views/storefront/component/address/address-personal.html.twig
@@ -89,10 +89,10 @@
     {% endblock %}
 
     {% block component_address_personal_fields_salutation_title %}
-        {% if not config('core.loginRegistration.hideSalutation') or config('core.loginRegistration.showTitleField') %}
+        {% if config('core.loginRegistration.showSalutation') or config('core.loginRegistration.showTitleField') %}
             <div class="row g-2">
                 {% block component_address_personal_fields_salutation %}
-                    {% if not config('core.loginRegistration.hideSalutation') %}
+                    {% if config('core.loginRegistration.showSalutation') %}
                         {% set salutationOptions %}
                             {% for salutation in page.salutations %}
                                 <option {% if salutation.id == data.get('salutationId') %}

--- a/tests/migration/Core/V6_7/Migration1742897274RegistrationSalutationToggleConfigTest.php
+++ b/tests/migration/Core/V6_7/Migration1742897274RegistrationSalutationToggleConfigTest.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Tests\Migration\Core\V6_7;
+
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Core\Framework\Log\Package;
+use Shopware\Core\Framework\Test\TestCaseBase\KernelTestBehaviour;
+use Shopware\Core\Framework\Uuid\Uuid;
+use Shopware\Core\Migration\V6_7\Migration1742897274RegistrationSalutationToggleConfig;
+
+/**
+ * @internal
+ */
+#[Package('framework')]
+#[CoversClass(Migration1742897274RegistrationSalutationToggleConfig::class)]
+class Migration1742897274RegistrationSalutationToggleConfigTest extends TestCase
+{
+    use KernelTestBehaviour;
+
+    public function testMigration(): void
+    {
+        $connection = self::getContainer()->get(Connection::class);
+
+        $connection->delete('system_config', ['configuration_key' => 'core.loginRegistration.showSalutation']);
+
+        $migration = new Migration1742897274RegistrationSalutationToggleConfig();
+        $migration->update($connection);
+        $migration->update($connection);
+
+        $newConfiguration = $connection->fetchAllKeyValue(
+            'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = ?',
+            ['core.loginRegistration.showSalutation']
+        );
+        $id = array_key_first($newConfiguration);
+
+        static::assertCount(1, $newConfiguration);
+        static::assertEquals('{"_value": true}', $newConfiguration[$id]);
+
+        $connection->update(
+            'system_config',
+            [
+                'configuration_value' => '{"_value": false}',
+            ],
+            ['id' => Uuid::fromHexToBytes((string) $id)]
+        );
+
+        $migration->update($connection);
+
+        $newConfiguration = $connection->fetchAllKeyValue(
+            'SELECT LOWER(HEX(`id`)), `configuration_value` FROM `system_config` WHERE `configuration_key` = ?',
+            ['core.loginRegistration.showSalutation']
+        );
+        $id = array_key_first($newConfiguration);
+
+        static::assertCount(1, $newConfiguration);
+        static::assertEquals('{"_value": false}', $newConfiguration[$id]);
+    }
+}


### PR DESCRIPTION
User story

As a U.S. merchant
I want to hide the salutation field
so that customers don't be bothered with a salutation field
Acceptance criteria

    Add a toggle "Show salutation field" to Settings > Log-in & sign-up
    A system config is toggling the visibility of the salutation field in the storefront

fixes https://github.com/shopware/shopware/issues/7480