### PR TITLE
fix: HTML quirks mode in the Storefront

### DIFF
--- a/changelog/_unreleased/2025-03-25-Fix-html-quirks-mode.md
+++ b/changelog/_unreleased/2025-03-25-Fix-html-quirks-mode.md
@@ -1,0 +1,6 @@
+---
+title: Fix HTML quirks mode in the Storefront
+issue: #4654
+---
+# Storefront
+* Changed `src/Storefront/Resources/views/storefront/base.html.twig` by moving the `isHMRMode` below the doctype declaration, so no empty lines are generated before the doctype declaration.

--- a/src/Storefront/Resources/views/storefront/base.html.twig
+++ b/src/Storefront/Resources/views/storefront/base.html.twig
@@ -1,17 +1,14 @@
 {# @sw-package framework #}
-
-{# Set variable to "true" to enable HMR (hot page reloading) mode #}
-{% set isHMRMode = app.request.headers.get('hot-reload-mode') and app.environment == 'dev' %}
-
-{% block base_doctype %}
-<!DOCTYPE html>
-{% endblock %}
+{% block base_doctype %}<!DOCTYPE html>{% endblock %}
 
 {% block base_html %}
 <html lang="{{ context.languageInfo.localeCode }}"
       itemscope="itemscope"
       itemtype="https://schema.org/WebPage">
 {% endblock %}
+
+{# Set variable to "true" to enable HMR (hot page reloading) mode #}
+{% set isHMRMode = app.request.headers.get('hot-reload-mode') and app.environment == 'dev' %}
 
 {% block base_head %}
     {% sw_include '@Storefront/storefront/layout/meta.html.twig' %}


### PR DESCRIPTION
### 1. Why is this change necessary?

The HTML output creates an empty line before the doctype declaration, which can lead to quirks mode in certain browsers.

### 2. What does this change do, exactly?

The variable declaration of `isHMRMode` was moved after the doctype declaration, so no empty line at the beginning of the document is created by Twig.


