### PR TITLE
fix: change parameters of $t function in sw-sales-channel-detail-domains

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/index.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-sales-channel/component/sw-sales-channel-detail-domains/index.js
@@ -65,7 +65,7 @@ export default {
                 return this.$t('sw-sales-channel.detail.titleCreateDomain');
             }
 
-            return this.$t('sw-sales-channel.detail.titleEditDomain', 0, {
+            return this.$t('sw-sales-channel.detail.titleEditDomain', {
                 name: this.unicodeUriFilter(this.currentDomainBackup.url),
             });
         },


### PR DESCRIPTION
### 1. Why is this change necessary?

This resolves an issue introduced by the vuei18n update in SW6.7.

### 2. What does this change do, exactly?

Change the parameters for the `$t` function.

### 3. Describe each step to reproduce the issue or behaviour.

Just open the edit sales channel domain modal and look at the title.
<img width="1714" alt="Bildschirmfoto 2025-03-25 um 22 16 30" src="https://github.com/user-attachments/assets/ee51eccb-cd43-4059-b742-4b659d2071a7" />

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
