### PR TITLE
fix: Raise version in composer.stub

### DIFF
--- a/changelog/_unreleased/2025-03-26-raise-version-in-composer-stub.md
+++ b/changelog/_unreleased/2025-03-26-raise-version-in-composer-stub.md
@@ -1,0 +1,8 @@
+---
+title: Raise version in composer.stub
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Raise version in `composer.stub` from `~6.6.0` to `~6.7.0` for the next major release

--- a/changelog/_unreleased/2025-03-26-raise-version-in-composer-stub.md
+++ b/changelog/_unreleased/2025-03-26-raise-version-in-composer-stub.md
@@ -5,4 +5,4 @@ author_email: 25648755+M-arcus@users.noreply.github.com
 author_github: @M-arcus
 ---
 # Core
-* Raise version in `composer.stub` from `~6.6.0` to `~6.7.0` for the next major release
+* Changed version in `composer.stub` from `~6.6.0` to `~6.7.0` for the next major release

--- a/src/Core/Framework/Plugin/Command/Scaffolding/stubs/composer.stub
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/stubs/composer.stub
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "license": "MIT",
     "require": {
-        "shopware/core": "~6.6.0"
+        "shopware/core": "~6.7.0"
     },
     "extra": {
         "shopware-plugin-class": "{{ namespace }}\\{{ className }}",


### PR DESCRIPTION
### 1. Why is this change necessary?

Created plugins can't be installed via composer due to version conflict.

### 2. What does this change do, exactly?

Raises the version number to ~6.7.0.0

### 3. Describe each step to reproduce the issue or behaviour.

Create a plugin in Shopware 6.7 RC, try to require it via composer.

### 4. Please link to the relevant issues (if any).

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
