### PR TITLE
fix: Remove non-existing imports from admin module stub

### DIFF
--- a/changelog/_unreleased/2025-03-26-remove-non-existing-imports-from-admin-module-stub.md
+++ b/changelog/_unreleased/2025-03-26-remove-non-existing-imports-from-admin-module-stub.md
@@ -1,0 +1,8 @@
+---
+title: Remove non-existing imports from admin module stub
+author: Marcus Müller
+author_email: 25648755+M-arcus@users.noreply.github.com
+author_github: @M-arcus
+---
+# Core
+* Remove non-existing `swag-example-list`, `swag-example-detail` and `swag-example-create` imports from admin module stub

--- a/changelog/_unreleased/2025-03-26-remove-non-existing-imports-from-admin-module-stub.md
+++ b/changelog/_unreleased/2025-03-26-remove-non-existing-imports-from-admin-module-stub.md
@@ -5,4 +5,4 @@ author_email: 25648755+M-arcus@users.noreply.github.com
 author_github: @M-arcus
 ---
 # Core
-* Remove non-existing `swag-example-list`, `swag-example-detail` and `swag-example-create` imports from admin module stub
+* Removed non-existing `swag-example-list`, `swag-example-detail` and `swag-example-create` imports from admin module stub

--- a/src/Core/Framework/Plugin/Command/Scaffolding/stubs/js-module.stub
+++ b/src/Core/Framework/Plugin/Command/Scaffolding/stubs/js-module.stub
@@ -1,7 +1,4 @@
 // <plugin root>/src/Resources/app/administration/src/module/swag-example/index.js
-import './page/swag-example-list';
-import './page/swag-example-detail';
-import './page/swag-example-create';
 import deDE from './snippet/de-DE';
 import enGB from './snippet/en-GB';
 


### PR DESCRIPTION
### 1. Why is this change necessary?

```
x Build failed in 9ms
Could not resolve "./page/swag-example-list" from "../../../../../acme/my-test-plugin/src/Resources/app/administration/src/module/swag-example/index.js"
file: /var/www/html/vendor/acme/my-test-plugin/src/Resources/app/administration/src/module/swag-example/index.js
    at getRollupError (file:///var/www/html/vendor/shopware/administration/Resources/app/administration/node_modules/rollup/dist/es/shared/parseAst.js:397:41)
    at error (file:///var/www/html/vendor/shopware/administration/Resources/app/administration/node_modules/rollup/dist/es/shared/parseAst.js:393:42)
    at ModuleLoader.handleInvalidResolvedId (file:///var/www/html/vendor/shopware/administration/Resources/app/administration/node_modules/rollup/dist/es/shared/node-entry.js:21111:24)
    at file:///var/www/html/vendor/shopware/administration/Resources/app/administration/node_modules/rollup/dist/es/shared/node-entry.js:21071:26 {
  code: 'UNRESOLVED_IMPORT',
  exporter: './page/swag-example-list',
  id: '/var/www/html/vendor/acme/my-test-plugin/src/Resources/app/administration/src/module/swag-example/index.js',
  watchFiles: [
    '/var/www/html/vendor/acme/my-test-plugin/src/Resources/app/administration/src/main.js',
    '/var/www/html/vendor/acme/my-test-plugin/src/Resources/app/administration/src/module/swag-example/index.js'
  ]
}
```

### 2. What does this change do, exactly?

It removes the imports because they do not exist.

### 3. Describe each step to reproduce the issue or behavior.

1. `bin/console plugin:create`
2. require that plugin
3. install it
4. `bin/build.js`

### 4. Please link to the relevant issues (if any).
<!-- Examples:
- closes #123  - closes the issue #123 when the PR is merged
- relates #123 - relates to the issue #123

In case of issue existing only on Jira, link to the Jira issue.
- Jira issue: https://shopware.atlassian.net/browse/NEXT-123
-->

### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
