### PR TITLE
fix: Consider only plugins located in custom directory

### DIFF
--- a/src/Core/Framework/Plugin/PluginEntity.php
+++ b/src/Core/Framework/Plugin/PluginEntity.php
@@ -135,6 +135,11 @@ class PluginEntity extends Entity
         $this->path = $path;
     }
 
+    public function isLocatedInCustomDirectory(): bool
+    {
+        return str_starts_with($this->path ?? '', 'custom/');
+    }
+
     public function getAuthor(): ?string
     {
         return $this->author;

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -259,7 +259,7 @@ class PluginLifecycleService
         if ($pluginBaseClass->executeComposerCommands()) {
             $this->executeComposerRequireWhenNeeded($plugin, $pluginBaseClass, $updateContext->getUpdatePluginVersion(), $shopwareContext);
         } else {
-            if ($plugin->getManagedByComposer()) {
+            if ($plugin->getManagedByComposer() && $plugin->isLocatedInCustomDirectory()) {
                 // If the plugin was previously managed by composer, but should no longer due to the update, we need to remove the composer dependency
                 $this->executeComposerRemoveCommand($plugin, $shopwareContext);
             }

--- a/src/Core/Framework/Store/Services/ExtensionLoader.php
+++ b/src/Core/Framework/Store/Services/ExtensionLoader.php
@@ -191,7 +191,7 @@ class ExtensionLoader
             'configurable' => $this->configurationService->checkConfiguration(\sprintf('%s.config', $plugin->getName()), $context),
             'updatedAt' => $plugin->getUpgradedAt(),
             'allowDisable' => true,
-            'allowUpdate' => !$plugin->getManagedByComposer() || !str_starts_with($plugin->getPath() ?? '', 'vendor'),
+            'allowUpdate' => !$plugin->getManagedByComposer() || $plugin->isLocatedInCustomDirectory(),
             'managedByComposer' => $plugin->getManagedByComposer(),
             'inAppPurchases' => $this->inAppPurchase->getByExtension($plugin->getName()),
         ];

--- a/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
+++ b/tests/unit/Core/Framework/Plugin/PluginLifecycleServiceTest.php
@@ -386,8 +386,24 @@ class PluginLifecycleServiceTest extends TestCase
         $plugin->setUpgradeVersion('1.0.1');
         $plugin->setManagedByComposer(true);
         $plugin->setComposerName('swag/mock-plugin');
+        $plugin->setPath('custom/plugins/mock-plugin');
 
         $this->commandExecutor->expects($this->once())->method('remove');
+
+        $this->pluginLifecycleService->updatePlugin($plugin, Context::createDefaultContext());
+    }
+
+    public function testUpdatePluginWithComposerCommandExecutionDisabledAfterUpdateButInstalledViaComposerDirectly(): void
+    {
+        $plugin = $this->getPluginEntityMock();
+        $plugin->setInstalledAt(new \DateTime());
+        $plugin->setActive(true);
+        $plugin->setUpgradeVersion('1.0.1');
+        $plugin->setManagedByComposer(true);
+        $plugin->setComposerName('swag/mock-plugin');
+        $plugin->setPath('vendor/shopware/mock-plugin');
+
+        $this->commandExecutor->expects($this->never())->method('remove');
 
         $this->pluginLifecycleService->updatePlugin($plugin, Context::createDefaultContext());
     }


### PR DESCRIPTION
### 1. Why is this change necessary?

If a plugin no longer executes the composer commands, it should only be removed via composer during update, if it is located in the "custom/(static-)plugins" directory.
If a plugin was directly required via composer and lives only in the "vendor" directory, it should not be considered, even if the "executeComposerCommands" flag is false.

### 2. What does this change do, exactly?

Take plugin path into account.


### 3. Describe each step to reproduce the issue or behaviour.

This issue was discovered while trying to update cloud instances. Caused by the Rufus plugin.

### 4. Please link to the relevant issues (if any).
n/a

### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [ ] I have created a [changelog file](https://github.com/shopware/platform/blob/trunk/adr/2020-08-03-implement-new-changelog.md) with all necessary information about my changes
- [ ] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfill them.
