### PR TITLE
fix: customer addresses are not correctly updated in order create

### DIFF
--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-create-initial-modal/index.ts
@@ -243,9 +243,6 @@ export default Component.wrapComponentConfig({
                 .cancelCart({
                     salesChannelId: this.salesChannelId,
                     contextToken: this.cart.token,
-                })
-                .then(() => {
-                    Store.get('swOrder').setCustomer(null);
                 });
         },
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/index.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/index.ts
@@ -102,6 +102,14 @@ export default Component.wrapComponentConfig({
         },
     },
 
+    watch: {
+        'customer.id': {
+            handler(): void {
+                void this.getCustomerAddresses();
+            },
+        },
+    },
+
     created() {
         this.createdComponent();
     },

--- a/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/sw-order-customer-address-select.spec.js
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/component/sw-order-customer-address-select/sw-order-customer-address-select.spec.js
@@ -172,4 +172,20 @@ describe('src/module/sw-order/component/sw-order-customer-address-select', () =>
         expect(addresses[0].hidden).toBe(false);
         expect(addresses[1].hidden).toBe(true);
     });
+
+    it('should reload addresses on customer change', async () => {
+        const wrapper = await createWrapper();
+        await flushPromises();
+
+        const spyGetCustomerAddresses = jest.spyOn(wrapper.vm, 'getCustomerAddresses');
+
+        await wrapper.setProps({
+            customer: {
+                ...customerData,
+                id: '456',
+            },
+        });
+
+        expect(spyGetCustomerAddresses).toHaveBeenCalledTimes(1);
+    });
 });

--- a/src/Administration/Resources/app/administration/src/module/sw-order/store/order.store.ts
+++ b/src/Administration/Resources/app/administration/src/module/sw-order/store/order.store.ts
@@ -202,7 +202,8 @@ const swOrderStore = Shopware.Store.register({
                 throw new Error('Invalid context token');
             }
 
-            return Service('cartStoreService').cancelCart(salesChannelId, contextToken);
+            return Service('cartStoreService').cancelCart(salesChannelId, contextToken)
+                .then(() => this.setCustomer(null));
         },
 
         updateCustomerContext({


### PR DESCRIPTION
Two changes:
- When selecting a customer in the create address modal, the addresses were never reloaded, so the previous customers addresses were still showing
- When cancelling a cart, the customer was not always reset, resulting the same customer being selected on the next order creation.

fixes #7759 